### PR TITLE
RUM-7191 Implemented the basic logic for time-to-network-settle view metric

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -601,6 +601,9 @@ datadog:
       # endregion
       # region Java Collections
       - "java.util.ArrayList.forEach(kotlin.Function1)"
+      - "java.util.HashSet.add(kotlin.String)"
+      - "java.util.HashSet.clear()"
+      - "java.util.HashSet.remove(kotlin.String)"
       - "java.util.LinkedList.add(android.view.View)"
       - "java.util.LinkedList.add(com.datadog.android.privacy.TrackingConsentProviderCallback)"
       - "java.util.LinkedList.add(com.datadog.android.sessionreplay.internal.recorder.Node)"

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -547,7 +547,7 @@ data class com.datadog.android.rum.model.ActionEvent
     companion object 
       fun fromJson(kotlin.String): Type
 data class com.datadog.android.rum.model.ErrorEvent
-  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ErrorEventSession, ErrorEventSource? = null, ErrorEventView, Usr? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Action? = null, Container? = null, Error, Context? = null)
+  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ErrorEventSession, ErrorEventSource? = null, ErrorEventView, Usr? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Action? = null, Container? = null, Error, Freeze? = null, Context? = null)
   val type: kotlin.String
   fun toJson(): com.google.gson.JsonElement
   companion object 
@@ -639,11 +639,17 @@ data class com.datadog.android.rum.model.ErrorEvent
       fun fromJson(kotlin.String): Container
       fun fromJsonObject(com.google.gson.JsonObject): Container
   data class Error
-    constructor(kotlin.String? = null, kotlin.String, ErrorSource, kotlin.String? = null, kotlin.collections.List<Cause>? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.String? = null, Category? = null, Handling? = null, kotlin.String? = null, SourceType? = null, Resource? = null, kotlin.collections.List<Thread>? = null, kotlin.collections.List<BinaryImage>? = null, kotlin.Boolean? = null, Meta? = null, kotlin.Long? = null)
+    constructor(kotlin.String? = null, kotlin.String, ErrorSource, kotlin.String? = null, kotlin.collections.List<Cause>? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.String? = null, Category? = null, Handling? = null, kotlin.String? = null, SourceType? = null, Resource? = null, kotlin.collections.List<Thread>? = null, kotlin.collections.List<BinaryImage>? = null, kotlin.Boolean? = null, Meta? = null, Csp? = null, kotlin.Long? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Error
       fun fromJsonObject(com.google.gson.JsonObject): Error
+  data class Freeze
+    constructor(kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Freeze
+      fun fromJsonObject(com.google.gson.JsonObject): Freeze
   data class Cellular
     constructor(kotlin.String? = null, kotlin.String? = null)
     fun toJson(): com.google.gson.JsonElement
@@ -704,6 +710,12 @@ data class com.datadog.android.rum.model.ErrorEvent
     companion object 
       fun fromJson(kotlin.String): Meta
       fun fromJsonObject(com.google.gson.JsonObject): Meta
+  data class Csp
+    constructor(Disposition? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Csp
+      fun fromJsonObject(com.google.gson.JsonObject): Csp
   data class Provider
     constructor(kotlin.String? = null, kotlin.String? = null, ProviderType? = null)
     fun toJson(): com.google.gson.JsonElement
@@ -851,6 +863,13 @@ data class com.datadog.android.rum.model.ErrorEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Method
+  enum Disposition
+    constructor(kotlin.String)
+    - ENFORCE
+    - REPORT
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Disposition
   enum ProviderType
     constructor(kotlin.String)
     - AD
@@ -963,7 +982,7 @@ data class com.datadog.android.rum.model.LongTaskEvent
       fun fromJson(kotlin.String): Container
       fun fromJsonObject(com.google.gson.JsonObject): Container
   data class LongTask
-    constructor(kotlin.String? = null, kotlin.Long, kotlin.Boolean? = null)
+    constructor(kotlin.String? = null, kotlin.Number? = null, EntryType? = null, kotlin.Long, kotlin.Long? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Boolean? = null, kotlin.collections.List<Script>? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): LongTask
@@ -998,6 +1017,12 @@ data class com.datadog.android.rum.model.LongTaskEvent
     companion object 
       fun fromJson(kotlin.String): ContainerView
       fun fromJsonObject(com.google.gson.JsonObject): ContainerView
+  data class Script
+    constructor(kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Long? = null, kotlin.String? = null, InvokerType? = null, kotlin.String? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Script
+      fun fromJsonObject(com.google.gson.JsonObject): Script
   enum LongTaskEventSource
     constructor(kotlin.String)
     - ANDROID
@@ -1062,6 +1087,13 @@ data class com.datadog.android.rum.model.LongTaskEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): DeviceType
+  enum EntryType
+    constructor(kotlin.String)
+    - LONG_TASK
+    - LONG_ANIMATION_FRAME
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): EntryType
   enum Plan
     constructor(kotlin.Number)
     - PLAN_1
@@ -1081,6 +1113,17 @@ data class com.datadog.android.rum.model.LongTaskEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): SessionPrecondition
+  enum InvokerType
+    constructor(kotlin.String)
+    - USER_CALLBACK
+    - EVENT_LISTENER
+    - RESOLVE_PROMISE
+    - REJECT_PROMISE
+    - CLASSIC_SCRIPT
+    - MODULE_SCRIPT
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): InvokerType
 data class com.datadog.android.rum.model.ResourceEvent
   constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ResourceEventSession, ResourceEventSource? = null, ResourceEventView, Usr? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Action? = null, Container? = null, Resource)
   val type: kotlin.String
@@ -1174,7 +1217,7 @@ data class com.datadog.android.rum.model.ResourceEvent
       fun fromJson(kotlin.String): Container
       fun fromJsonObject(com.google.gson.JsonObject): Container
   data class Resource
-    constructor(kotlin.String? = null, ResourceType, Method? = null, kotlin.String, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, Redirect? = null, Dns? = null, Connect? = null, Ssl? = null, FirstByte? = null, Download? = null, Provider? = null, Graphql? = null)
+    constructor(kotlin.String? = null, ResourceType, Method? = null, kotlin.String, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, RenderBlockingStatus? = null, Worker? = null, Redirect? = null, Dns? = null, Connect? = null, Ssl? = null, FirstByte? = null, Download? = null, kotlin.String? = null, Provider? = null, Graphql? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Resource
@@ -1209,6 +1252,12 @@ data class com.datadog.android.rum.model.ResourceEvent
     companion object 
       fun fromJson(kotlin.String): ContainerView
       fun fromJsonObject(com.google.gson.JsonObject): ContainerView
+  data class Worker
+    constructor(kotlin.Long, kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Worker
+      fun fromJsonObject(com.google.gson.JsonObject): Worker
   data class Redirect
     constructor(kotlin.Long, kotlin.Long)
     fun toJson(): com.google.gson.JsonElement
@@ -1351,6 +1400,13 @@ data class com.datadog.android.rum.model.ResourceEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Method
+  enum RenderBlockingStatus
+    constructor(kotlin.String)
+    - BLOCKING
+    - NON_BLOCKING
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): RenderBlockingStatus
   enum Plan
     constructor(kotlin.Number)
     - PLAN_1
@@ -1397,6 +1453,229 @@ data class com.datadog.android.rum.model.ResourceEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): OperationType
+data class com.datadog.android.rum.model.RumVitalEvent
+  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, RumVitalEventSession, RumVitalEventSource? = null, RumVitalEventView, Usr? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Container? = null, RumVitalEventVital)
+  val type: kotlin.String
+  fun toJson(): com.google.gson.JsonElement
+  companion object 
+    fun fromJson(kotlin.String): RumVitalEvent
+    fun fromJsonObject(com.google.gson.JsonObject): RumVitalEvent
+  data class Application
+    constructor(kotlin.String)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Application
+      fun fromJsonObject(com.google.gson.JsonObject): Application
+  data class RumVitalEventSession
+    constructor(kotlin.String, RumVitalEventSessionType, kotlin.Boolean? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): RumVitalEventSession
+      fun fromJsonObject(com.google.gson.JsonObject): RumVitalEventSession
+  data class RumVitalEventView
+    constructor(kotlin.String, kotlin.String? = null, kotlin.String, kotlin.String? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): RumVitalEventView
+      fun fromJsonObject(com.google.gson.JsonObject): RumVitalEventView
+  data class Usr
+    constructor(kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Usr
+      fun fromJsonObject(com.google.gson.JsonObject): Usr
+  data class Connectivity
+    constructor(Status, kotlin.collections.List<Interface>? = null, EffectiveType? = null, Cellular? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Connectivity
+      fun fromJsonObject(com.google.gson.JsonObject): Connectivity
+  data class Display
+    constructor(Viewport? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Display
+      fun fromJsonObject(com.google.gson.JsonObject): Display
+  data class Synthetics
+    constructor(kotlin.String, kotlin.String, kotlin.Boolean? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Synthetics
+      fun fromJsonObject(com.google.gson.JsonObject): Synthetics
+  data class CiTest
+    constructor(kotlin.String)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): CiTest
+      fun fromJsonObject(com.google.gson.JsonObject): CiTest
+  data class Os
+    constructor(kotlin.String, kotlin.String, kotlin.String? = null, kotlin.String)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Os
+      fun fromJsonObject(com.google.gson.JsonObject): Os
+  data class Device
+    constructor(DeviceType, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Device
+      fun fromJsonObject(com.google.gson.JsonObject): Device
+  data class Dd
+    constructor(DdSession? = null, Configuration? = null, kotlin.String? = null, DdVital? = null)
+    val formatVersion: kotlin.Long
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Dd
+      fun fromJsonObject(com.google.gson.JsonObject): Dd
+  data class Context
+    constructor(kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Context
+      fun fromJsonObject(com.google.gson.JsonObject): Context
+  data class Container
+    constructor(ContainerView, RumVitalEventSource)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Container
+      fun fromJsonObject(com.google.gson.JsonObject): Container
+  data class RumVitalEventVital
+    constructor(RumVitalEventVitalType, kotlin.String, kotlin.String? = null, kotlin.String? = null, kotlin.Number? = null, Custom? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): RumVitalEventVital
+      fun fromJsonObject(com.google.gson.JsonObject): RumVitalEventVital
+  data class Cellular
+    constructor(kotlin.String? = null, kotlin.String? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Cellular
+      fun fromJsonObject(com.google.gson.JsonObject): Cellular
+  data class Viewport
+    constructor(kotlin.Number, kotlin.Number)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Viewport
+      fun fromJsonObject(com.google.gson.JsonObject): Viewport
+  data class DdSession
+    constructor(Plan? = null, SessionPrecondition? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): DdSession
+      fun fromJsonObject(com.google.gson.JsonObject): DdSession
+  data class Configuration
+    constructor(kotlin.Number, kotlin.Number? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Configuration
+      fun fromJsonObject(com.google.gson.JsonObject): Configuration
+  data class DdVital
+    constructor(kotlin.Boolean? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): DdVital
+      fun fromJsonObject(com.google.gson.JsonObject): DdVital
+  data class ContainerView
+    constructor(kotlin.String)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ContainerView
+      fun fromJsonObject(com.google.gson.JsonObject): ContainerView
+  data class Custom
+    constructor(kotlin.collections.MutableMap<kotlin.String, kotlin.Number> = mutableMapOf())
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Custom
+      fun fromJsonObject(com.google.gson.JsonObject): Custom
+  enum RumVitalEventSource
+    constructor(kotlin.String)
+    - ANDROID
+    - IOS
+    - BROWSER
+    - FLUTTER
+    - REACT_NATIVE
+    - ROKU
+    - UNITY
+    - KOTLIN_MULTIPLATFORM
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): RumVitalEventSource
+  enum RumVitalEventSessionType
+    constructor(kotlin.String)
+    - USER
+    - SYNTHETICS
+    - CI_TEST
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): RumVitalEventSessionType
+  enum Status
+    constructor(kotlin.String)
+    - CONNECTED
+    - NOT_CONNECTED
+    - MAYBE
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Status
+  enum Interface
+    constructor(kotlin.String)
+    - BLUETOOTH
+    - CELLULAR
+    - ETHERNET
+    - WIFI
+    - WIMAX
+    - MIXED
+    - OTHER
+    - UNKNOWN
+    - NONE
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Interface
+  enum EffectiveType
+    constructor(kotlin.String)
+    - SLOW_2G
+    - `2G`
+    - `3G`
+    - `4G`
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): EffectiveType
+  enum DeviceType
+    constructor(kotlin.String)
+    - MOBILE
+    - DESKTOP
+    - TABLET
+    - TV
+    - GAMING_CONSOLE
+    - BOT
+    - OTHER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): DeviceType
+  enum RumVitalEventVitalType
+    constructor(kotlin.String)
+    - DURATION
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): RumVitalEventVitalType
+  enum Plan
+    constructor(kotlin.Number)
+    - PLAN_1
+    - PLAN_2
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Plan
+  enum SessionPrecondition
+    constructor(kotlin.String)
+    - USER_APP_LAUNCH
+    - INACTIVITY_TIMEOUT
+    - MAX_DURATION
+    - BACKGROUND_LAUNCH
+    - PREWARM
+    - FROM_NON_INTERACTIVE_SESSION
+    - EXPLICIT_STOP
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): SessionPrecondition
 data class com.datadog.android.rum.model.ViewEvent
   constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ViewEventSession, ViewEventSource? = null, ViewEventView, Usr? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Container? = null, Context? = null, Privacy? = null)
   val type: kotlin.String
@@ -1417,7 +1696,7 @@ data class com.datadog.android.rum.model.ViewEvent
       fun fromJson(kotlin.String): ViewEventSession
       fun fromJsonObject(com.google.gson.JsonObject): ViewEventSession
   data class ViewEventView
-    constructor(kotlin.String, kotlin.String? = null, kotlin.String, kotlin.String? = null, kotlin.Long? = null, LoadingType? = null, kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.String? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.String? = null, kotlin.Long? = null, kotlin.String? = null, kotlin.Number? = null, kotlin.String? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, CustomTimings? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, Action, Error, Crash? = null, LongTask? = null, FrozenFrame? = null, Resource, Frustration? = null, kotlin.collections.List<InForegroundPeriod>? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, FlutterBuildTime? = null, FlutterBuildTime? = null, FlutterBuildTime? = null)
+    constructor(kotlin.String, kotlin.String? = null, kotlin.String, kotlin.String? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, LoadingType? = null, kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.String? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.String? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.String? = null, kotlin.Number? = null, kotlin.Long? = null, kotlin.String? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, CustomTimings? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, Action, Error, Crash? = null, LongTask? = null, FrozenFrame? = null, Resource, Frustration? = null, kotlin.collections.List<InForegroundPeriod>? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, FlutterBuildTime? = null, FlutterBuildTime? = null, FlutterBuildTime? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): ViewEventView

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -1211,8 +1211,8 @@ public final class com/datadog/android/rum/model/ActionEvent$Viewport$Companion 
 
 public final class com/datadog/android/rum/model/ErrorEvent {
 	public static final field Companion Lcom/datadog/android/rum/model/ErrorEvent$Companion;
-	public fun <init> (JLcom/datadog/android/rum/model/ErrorEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSession;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSource;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventView;Lcom/datadog/android/rum/model/ErrorEvent$Usr;Lcom/datadog/android/rum/model/ErrorEvent$Connectivity;Lcom/datadog/android/rum/model/ErrorEvent$Display;Lcom/datadog/android/rum/model/ErrorEvent$Synthetics;Lcom/datadog/android/rum/model/ErrorEvent$CiTest;Lcom/datadog/android/rum/model/ErrorEvent$Os;Lcom/datadog/android/rum/model/ErrorEvent$Device;Lcom/datadog/android/rum/model/ErrorEvent$Dd;Lcom/datadog/android/rum/model/ErrorEvent$Context;Lcom/datadog/android/rum/model/ErrorEvent$Action;Lcom/datadog/android/rum/model/ErrorEvent$Container;Lcom/datadog/android/rum/model/ErrorEvent$Error;Lcom/datadog/android/rum/model/ErrorEvent$Context;)V
-	public synthetic fun <init> (JLcom/datadog/android/rum/model/ErrorEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSession;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSource;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventView;Lcom/datadog/android/rum/model/ErrorEvent$Usr;Lcom/datadog/android/rum/model/ErrorEvent$Connectivity;Lcom/datadog/android/rum/model/ErrorEvent$Display;Lcom/datadog/android/rum/model/ErrorEvent$Synthetics;Lcom/datadog/android/rum/model/ErrorEvent$CiTest;Lcom/datadog/android/rum/model/ErrorEvent$Os;Lcom/datadog/android/rum/model/ErrorEvent$Device;Lcom/datadog/android/rum/model/ErrorEvent$Dd;Lcom/datadog/android/rum/model/ErrorEvent$Context;Lcom/datadog/android/rum/model/ErrorEvent$Action;Lcom/datadog/android/rum/model/ErrorEvent$Container;Lcom/datadog/android/rum/model/ErrorEvent$Error;Lcom/datadog/android/rum/model/ErrorEvent$Context;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (JLcom/datadog/android/rum/model/ErrorEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSession;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSource;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventView;Lcom/datadog/android/rum/model/ErrorEvent$Usr;Lcom/datadog/android/rum/model/ErrorEvent$Connectivity;Lcom/datadog/android/rum/model/ErrorEvent$Display;Lcom/datadog/android/rum/model/ErrorEvent$Synthetics;Lcom/datadog/android/rum/model/ErrorEvent$CiTest;Lcom/datadog/android/rum/model/ErrorEvent$Os;Lcom/datadog/android/rum/model/ErrorEvent$Device;Lcom/datadog/android/rum/model/ErrorEvent$Dd;Lcom/datadog/android/rum/model/ErrorEvent$Context;Lcom/datadog/android/rum/model/ErrorEvent$Action;Lcom/datadog/android/rum/model/ErrorEvent$Container;Lcom/datadog/android/rum/model/ErrorEvent$Error;Lcom/datadog/android/rum/model/ErrorEvent$Freeze;Lcom/datadog/android/rum/model/ErrorEvent$Context;)V
+	public synthetic fun <init> (JLcom/datadog/android/rum/model/ErrorEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSession;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSource;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventView;Lcom/datadog/android/rum/model/ErrorEvent$Usr;Lcom/datadog/android/rum/model/ErrorEvent$Connectivity;Lcom/datadog/android/rum/model/ErrorEvent$Display;Lcom/datadog/android/rum/model/ErrorEvent$Synthetics;Lcom/datadog/android/rum/model/ErrorEvent$CiTest;Lcom/datadog/android/rum/model/ErrorEvent$Os;Lcom/datadog/android/rum/model/ErrorEvent$Device;Lcom/datadog/android/rum/model/ErrorEvent$Dd;Lcom/datadog/android/rum/model/ErrorEvent$Context;Lcom/datadog/android/rum/model/ErrorEvent$Action;Lcom/datadog/android/rum/model/ErrorEvent$Container;Lcom/datadog/android/rum/model/ErrorEvent$Error;Lcom/datadog/android/rum/model/ErrorEvent$Freeze;Lcom/datadog/android/rum/model/ErrorEvent$Context;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
 	public final fun component10 ()Lcom/datadog/android/rum/model/ErrorEvent$Usr;
 	public final fun component11 ()Lcom/datadog/android/rum/model/ErrorEvent$Connectivity;
@@ -1227,7 +1227,8 @@ public final class com/datadog/android/rum/model/ErrorEvent {
 	public final fun component2 ()Lcom/datadog/android/rum/model/ErrorEvent$Application;
 	public final fun component20 ()Lcom/datadog/android/rum/model/ErrorEvent$Container;
 	public final fun component21 ()Lcom/datadog/android/rum/model/ErrorEvent$Error;
-	public final fun component22 ()Lcom/datadog/android/rum/model/ErrorEvent$Context;
+	public final fun component22 ()Lcom/datadog/android/rum/model/ErrorEvent$Freeze;
+	public final fun component23 ()Lcom/datadog/android/rum/model/ErrorEvent$Context;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
@@ -1235,8 +1236,8 @@ public final class com/datadog/android/rum/model/ErrorEvent {
 	public final fun component7 ()Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSession;
 	public final fun component8 ()Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSource;
 	public final fun component9 ()Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventView;
-	public final fun copy (JLcom/datadog/android/rum/model/ErrorEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSession;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSource;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventView;Lcom/datadog/android/rum/model/ErrorEvent$Usr;Lcom/datadog/android/rum/model/ErrorEvent$Connectivity;Lcom/datadog/android/rum/model/ErrorEvent$Display;Lcom/datadog/android/rum/model/ErrorEvent$Synthetics;Lcom/datadog/android/rum/model/ErrorEvent$CiTest;Lcom/datadog/android/rum/model/ErrorEvent$Os;Lcom/datadog/android/rum/model/ErrorEvent$Device;Lcom/datadog/android/rum/model/ErrorEvent$Dd;Lcom/datadog/android/rum/model/ErrorEvent$Context;Lcom/datadog/android/rum/model/ErrorEvent$Action;Lcom/datadog/android/rum/model/ErrorEvent$Container;Lcom/datadog/android/rum/model/ErrorEvent$Error;Lcom/datadog/android/rum/model/ErrorEvent$Context;)Lcom/datadog/android/rum/model/ErrorEvent;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ErrorEvent;JLcom/datadog/android/rum/model/ErrorEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSession;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSource;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventView;Lcom/datadog/android/rum/model/ErrorEvent$Usr;Lcom/datadog/android/rum/model/ErrorEvent$Connectivity;Lcom/datadog/android/rum/model/ErrorEvent$Display;Lcom/datadog/android/rum/model/ErrorEvent$Synthetics;Lcom/datadog/android/rum/model/ErrorEvent$CiTest;Lcom/datadog/android/rum/model/ErrorEvent$Os;Lcom/datadog/android/rum/model/ErrorEvent$Device;Lcom/datadog/android/rum/model/ErrorEvent$Dd;Lcom/datadog/android/rum/model/ErrorEvent$Context;Lcom/datadog/android/rum/model/ErrorEvent$Action;Lcom/datadog/android/rum/model/ErrorEvent$Container;Lcom/datadog/android/rum/model/ErrorEvent$Error;Lcom/datadog/android/rum/model/ErrorEvent$Context;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ErrorEvent;
+	public final fun copy (JLcom/datadog/android/rum/model/ErrorEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSession;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSource;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventView;Lcom/datadog/android/rum/model/ErrorEvent$Usr;Lcom/datadog/android/rum/model/ErrorEvent$Connectivity;Lcom/datadog/android/rum/model/ErrorEvent$Display;Lcom/datadog/android/rum/model/ErrorEvent$Synthetics;Lcom/datadog/android/rum/model/ErrorEvent$CiTest;Lcom/datadog/android/rum/model/ErrorEvent$Os;Lcom/datadog/android/rum/model/ErrorEvent$Device;Lcom/datadog/android/rum/model/ErrorEvent$Dd;Lcom/datadog/android/rum/model/ErrorEvent$Context;Lcom/datadog/android/rum/model/ErrorEvent$Action;Lcom/datadog/android/rum/model/ErrorEvent$Container;Lcom/datadog/android/rum/model/ErrorEvent$Error;Lcom/datadog/android/rum/model/ErrorEvent$Freeze;Lcom/datadog/android/rum/model/ErrorEvent$Context;)Lcom/datadog/android/rum/model/ErrorEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ErrorEvent;JLcom/datadog/android/rum/model/ErrorEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSession;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSource;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventView;Lcom/datadog/android/rum/model/ErrorEvent$Usr;Lcom/datadog/android/rum/model/ErrorEvent$Connectivity;Lcom/datadog/android/rum/model/ErrorEvent$Display;Lcom/datadog/android/rum/model/ErrorEvent$Synthetics;Lcom/datadog/android/rum/model/ErrorEvent$CiTest;Lcom/datadog/android/rum/model/ErrorEvent$Os;Lcom/datadog/android/rum/model/ErrorEvent$Device;Lcom/datadog/android/rum/model/ErrorEvent$Dd;Lcom/datadog/android/rum/model/ErrorEvent$Context;Lcom/datadog/android/rum/model/ErrorEvent$Action;Lcom/datadog/android/rum/model/ErrorEvent$Container;Lcom/datadog/android/rum/model/ErrorEvent$Error;Lcom/datadog/android/rum/model/ErrorEvent$Freeze;Lcom/datadog/android/rum/model/ErrorEvent$Context;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ErrorEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ErrorEvent;
@@ -1254,6 +1255,7 @@ public final class com/datadog/android/rum/model/ErrorEvent {
 	public final fun getDisplay ()Lcom/datadog/android/rum/model/ErrorEvent$Display;
 	public final fun getError ()Lcom/datadog/android/rum/model/ErrorEvent$Error;
 	public final fun getFeatureFlags ()Lcom/datadog/android/rum/model/ErrorEvent$Context;
+	public final fun getFreeze ()Lcom/datadog/android/rum/model/ErrorEvent$Freeze;
 	public final fun getOs ()Lcom/datadog/android/rum/model/ErrorEvent$Os;
 	public final fun getService ()Ljava/lang/String;
 	public final fun getSession ()Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSession;
@@ -1548,6 +1550,28 @@ public final class com/datadog/android/rum/model/ErrorEvent$Context$Companion {
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ErrorEvent$Context;
 }
 
+public final class com/datadog/android/rum/model/ErrorEvent$Csp {
+	public static final field Companion Lcom/datadog/android/rum/model/ErrorEvent$Csp$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/datadog/android/rum/model/ErrorEvent$Disposition;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/ErrorEvent$Disposition;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/rum/model/ErrorEvent$Disposition;
+	public final fun copy (Lcom/datadog/android/rum/model/ErrorEvent$Disposition;)Lcom/datadog/android/rum/model/ErrorEvent$Csp;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ErrorEvent$Csp;Lcom/datadog/android/rum/model/ErrorEvent$Disposition;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ErrorEvent$Csp;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Csp;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ErrorEvent$Csp;
+	public final fun getDisposition ()Lcom/datadog/android/rum/model/ErrorEvent$Disposition;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/ErrorEvent$Csp$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Csp;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ErrorEvent$Csp;
+}
+
 public final class com/datadog/android/rum/model/ErrorEvent$Dd {
 	public static final field Companion Lcom/datadog/android/rum/model/ErrorEvent$Dd$Companion;
 	public fun <init> ()V
@@ -1669,6 +1693,20 @@ public final class com/datadog/android/rum/model/ErrorEvent$Display$Companion {
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ErrorEvent$Display;
 }
 
+public final class com/datadog/android/rum/model/ErrorEvent$Disposition : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/rum/model/ErrorEvent$Disposition$Companion;
+	public static final field ENFORCE Lcom/datadog/android/rum/model/ErrorEvent$Disposition;
+	public static final field REPORT Lcom/datadog/android/rum/model/ErrorEvent$Disposition;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Disposition;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Disposition;
+	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$Disposition;
+}
+
+public final class com/datadog/android/rum/model/ErrorEvent$Disposition$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Disposition;
+}
+
 public final class com/datadog/android/rum/model/ErrorEvent$EffectiveType : java/lang/Enum {
 	public static final field 2G Lcom/datadog/android/rum/model/ErrorEvent$EffectiveType;
 	public static final field 3G Lcom/datadog/android/rum/model/ErrorEvent$EffectiveType;
@@ -1687,8 +1725,8 @@ public final class com/datadog/android/rum/model/ErrorEvent$EffectiveType$Compan
 
 public final class com/datadog/android/rum/model/ErrorEvent$Error {
 	public static final field Companion Lcom/datadog/android/rum/model/ErrorEvent$Error$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$ErrorSource;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$Category;Lcom/datadog/android/rum/model/ErrorEvent$Handling;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$SourceType;Lcom/datadog/android/rum/model/ErrorEvent$Resource;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/rum/model/ErrorEvent$Meta;Ljava/lang/Long;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$ErrorSource;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$Category;Lcom/datadog/android/rum/model/ErrorEvent$Handling;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$SourceType;Lcom/datadog/android/rum/model/ErrorEvent$Resource;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/rum/model/ErrorEvent$Meta;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$ErrorSource;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$Category;Lcom/datadog/android/rum/model/ErrorEvent$Handling;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$SourceType;Lcom/datadog/android/rum/model/ErrorEvent$Resource;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/rum/model/ErrorEvent$Meta;Lcom/datadog/android/rum/model/ErrorEvent$Csp;Ljava/lang/Long;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$ErrorSource;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$Category;Lcom/datadog/android/rum/model/ErrorEvent$Handling;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$SourceType;Lcom/datadog/android/rum/model/ErrorEvent$Resource;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/rum/model/ErrorEvent$Meta;Lcom/datadog/android/rum/model/ErrorEvent$Csp;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Lcom/datadog/android/rum/model/ErrorEvent$Handling;
 	public final fun component11 ()Ljava/lang/String;
@@ -1698,7 +1736,8 @@ public final class com/datadog/android/rum/model/ErrorEvent$Error {
 	public final fun component15 ()Ljava/util/List;
 	public final fun component16 ()Ljava/lang/Boolean;
 	public final fun component17 ()Lcom/datadog/android/rum/model/ErrorEvent$Meta;
-	public final fun component18 ()Ljava/lang/Long;
+	public final fun component18 ()Lcom/datadog/android/rum/model/ErrorEvent$Csp;
+	public final fun component19 ()Ljava/lang/Long;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Lcom/datadog/android/rum/model/ErrorEvent$ErrorSource;
 	public final fun component4 ()Ljava/lang/String;
@@ -1707,14 +1746,15 @@ public final class com/datadog/android/rum/model/ErrorEvent$Error {
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Lcom/datadog/android/rum/model/ErrorEvent$Category;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$ErrorSource;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$Category;Lcom/datadog/android/rum/model/ErrorEvent$Handling;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$SourceType;Lcom/datadog/android/rum/model/ErrorEvent$Resource;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/rum/model/ErrorEvent$Meta;Ljava/lang/Long;)Lcom/datadog/android/rum/model/ErrorEvent$Error;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ErrorEvent$Error;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$ErrorSource;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$Category;Lcom/datadog/android/rum/model/ErrorEvent$Handling;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$SourceType;Lcom/datadog/android/rum/model/ErrorEvent$Resource;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/rum/model/ErrorEvent$Meta;Ljava/lang/Long;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ErrorEvent$Error;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$ErrorSource;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$Category;Lcom/datadog/android/rum/model/ErrorEvent$Handling;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$SourceType;Lcom/datadog/android/rum/model/ErrorEvent$Resource;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/rum/model/ErrorEvent$Meta;Lcom/datadog/android/rum/model/ErrorEvent$Csp;Ljava/lang/Long;)Lcom/datadog/android/rum/model/ErrorEvent$Error;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ErrorEvent$Error;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$ErrorSource;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$Category;Lcom/datadog/android/rum/model/ErrorEvent$Handling;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$SourceType;Lcom/datadog/android/rum/model/ErrorEvent$Resource;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/rum/model/ErrorEvent$Meta;Lcom/datadog/android/rum/model/ErrorEvent$Csp;Ljava/lang/Long;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ErrorEvent$Error;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Error;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ErrorEvent$Error;
 	public final fun getBinaryImages ()Ljava/util/List;
 	public final fun getCategory ()Lcom/datadog/android/rum/model/ErrorEvent$Category;
 	public final fun getCauses ()Ljava/util/List;
+	public final fun getCsp ()Lcom/datadog/android/rum/model/ErrorEvent$Csp;
 	public final fun getFingerprint ()Ljava/lang/String;
 	public final fun getHandling ()Lcom/datadog/android/rum/model/ErrorEvent$Handling;
 	public final fun getHandlingStack ()Ljava/lang/String;
@@ -1854,6 +1894,26 @@ public final class com/datadog/android/rum/model/ErrorEvent$ErrorSource : java/l
 
 public final class com/datadog/android/rum/model/ErrorEvent$ErrorSource$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$ErrorSource;
+}
+
+public final class com/datadog/android/rum/model/ErrorEvent$Freeze {
+	public static final field Companion Lcom/datadog/android/rum/model/ErrorEvent$Freeze$Companion;
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lcom/datadog/android/rum/model/ErrorEvent$Freeze;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ErrorEvent$Freeze;JILjava/lang/Object;)Lcom/datadog/android/rum/model/ErrorEvent$Freeze;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Freeze;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ErrorEvent$Freeze;
+	public final fun getDuration ()J
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/ErrorEvent$Freeze$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Freeze;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ErrorEvent$Freeze;
 }
 
 public final class com/datadog/android/rum/model/ErrorEvent$Handling : java/lang/Enum {
@@ -2623,6 +2683,20 @@ public final class com/datadog/android/rum/model/LongTaskEvent$EffectiveType$Com
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$EffectiveType;
 }
 
+public final class com/datadog/android/rum/model/LongTaskEvent$EntryType : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/rum/model/LongTaskEvent$EntryType$Companion;
+	public static final field LONG_ANIMATION_FRAME Lcom/datadog/android/rum/model/LongTaskEvent$EntryType;
+	public static final field LONG_TASK Lcom/datadog/android/rum/model/LongTaskEvent$EntryType;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$EntryType;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$EntryType;
+	public static fun values ()[Lcom/datadog/android/rum/model/LongTaskEvent$EntryType;
+}
+
+public final class com/datadog/android/rum/model/LongTaskEvent$EntryType$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$EntryType;
+}
+
 public final class com/datadog/android/rum/model/LongTaskEvent$Interface : java/lang/Enum {
 	public static final field BLUETOOTH Lcom/datadog/android/rum/model/LongTaskEvent$Interface;
 	public static final field CELLULAR Lcom/datadog/android/rum/model/LongTaskEvent$Interface;
@@ -2644,20 +2718,52 @@ public final class com/datadog/android/rum/model/LongTaskEvent$Interface$Compani
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$Interface;
 }
 
+public final class com/datadog/android/rum/model/LongTaskEvent$InvokerType : java/lang/Enum {
+	public static final field CLASSIC_SCRIPT Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;
+	public static final field Companion Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType$Companion;
+	public static final field EVENT_LISTENER Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;
+	public static final field MODULE_SCRIPT Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;
+	public static final field REJECT_PROMISE Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;
+	public static final field RESOLVE_PROMISE Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;
+	public static final field USER_CALLBACK Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;
+	public static fun values ()[Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;
+}
+
+public final class com/datadog/android/rum/model/LongTaskEvent$InvokerType$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;
+}
+
 public final class com/datadog/android/rum/model/LongTaskEvent$LongTask {
 	public static final field Companion Lcom/datadog/android/rum/model/LongTaskEvent$LongTask$Companion;
-	public fun <init> (Ljava/lang/String;JLjava/lang/Boolean;)V
-	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/LongTaskEvent$EntryType;JLjava/lang/Long;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/LongTaskEvent$EntryType;JLjava/lang/Long;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()J
-	public final fun component3 ()Ljava/lang/Boolean;
-	public final fun copy (Ljava/lang/String;JLjava/lang/Boolean;)Lcom/datadog/android/rum/model/LongTaskEvent$LongTask;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/LongTaskEvent$LongTask;Ljava/lang/String;JLjava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/rum/model/LongTaskEvent$LongTask;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Number;
+	public final fun component3 ()Lcom/datadog/android/rum/model/LongTaskEvent$EntryType;
+	public final fun component4 ()J
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6 ()Ljava/lang/Number;
+	public final fun component7 ()Ljava/lang/Number;
+	public final fun component8 ()Ljava/lang/Number;
+	public final fun component9 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/LongTaskEvent$EntryType;JLjava/lang/Long;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/util/List;)Lcom/datadog/android/rum/model/LongTaskEvent$LongTask;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/LongTaskEvent$LongTask;Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/LongTaskEvent$EntryType;JLjava/lang/Long;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/util/List;ILjava/lang/Object;)Lcom/datadog/android/rum/model/LongTaskEvent$LongTask;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$LongTask;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/LongTaskEvent$LongTask;
+	public final fun getBlockingDuration ()Ljava/lang/Long;
 	public final fun getDuration ()J
+	public final fun getEntryType ()Lcom/datadog/android/rum/model/LongTaskEvent$EntryType;
+	public final fun getFirstUiEventTimestamp ()Ljava/lang/Number;
 	public final fun getId ()Ljava/lang/String;
+	public final fun getRenderStart ()Ljava/lang/Number;
+	public final fun getScripts ()Ljava/util/List;
+	public final fun getStartTime ()Ljava/lang/Number;
+	public final fun getStyleAndLayoutStart ()Ljava/lang/Number;
 	public fun hashCode ()I
 	public final fun isFrozenFrame ()Ljava/lang/Boolean;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
@@ -2798,6 +2904,48 @@ public final class com/datadog/android/rum/model/LongTaskEvent$Plan : java/lang/
 
 public final class com/datadog/android/rum/model/LongTaskEvent$Plan$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$Plan;
+}
+
+public final class com/datadog/android/rum/model/LongTaskEvent$Script {
+	public static final field Companion Lcom/datadog/android/rum/model/LongTaskEvent$Script$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Long;
+	public final fun component10 ()Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun component5 ()Ljava/lang/Number;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/Long;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$Script;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/LongTaskEvent$Script;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/LongTaskEvent$Script;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$Script;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/LongTaskEvent$Script;
+	public final fun getDuration ()Ljava/lang/Long;
+	public final fun getExecutionStart ()Ljava/lang/Number;
+	public final fun getForcedStyleAndLayoutDuration ()Ljava/lang/Long;
+	public final fun getInvoker ()Ljava/lang/String;
+	public final fun getInvokerType ()Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;
+	public final fun getPauseDuration ()Ljava/lang/Long;
+	public final fun getSourceCharPosition ()Ljava/lang/Long;
+	public final fun getSourceFunctionName ()Ljava/lang/String;
+	public final fun getSourceUrl ()Ljava/lang/String;
+	public final fun getStartTime ()Ljava/lang/Number;
+	public final fun getWindowAttribution ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/LongTaskEvent$Script$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$Script;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/LongTaskEvent$Script;
 }
 
 public final class com/datadog/android/rum/model/LongTaskEvent$SessionPrecondition : java/lang/Enum {
@@ -3603,45 +3751,71 @@ public final class com/datadog/android/rum/model/ResourceEvent$Redirect$Companio
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ResourceEvent$Redirect;
 }
 
+public final class com/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus : java/lang/Enum {
+	public static final field BLOCKING Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus;
+	public static final field Companion Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus$Companion;
+	public static final field NON_BLOCKING Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus;
+	public static fun values ()[Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus;
+}
+
+public final class com/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus;
+}
+
 public final class com/datadog/android/rum/model/ResourceEvent$Resource {
 	public static final field Companion Lcom/datadog/android/rum/model/ResourceEvent$Resource$Companion;
-	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;Lcom/datadog/android/rum/model/ResourceEvent$Method;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ResourceEvent$Redirect;Lcom/datadog/android/rum/model/ResourceEvent$Dns;Lcom/datadog/android/rum/model/ResourceEvent$Connect;Lcom/datadog/android/rum/model/ResourceEvent$Ssl;Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;Lcom/datadog/android/rum/model/ResourceEvent$Download;Lcom/datadog/android/rum/model/ResourceEvent$Provider;Lcom/datadog/android/rum/model/ResourceEvent$Graphql;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;Lcom/datadog/android/rum/model/ResourceEvent$Method;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ResourceEvent$Redirect;Lcom/datadog/android/rum/model/ResourceEvent$Dns;Lcom/datadog/android/rum/model/ResourceEvent$Connect;Lcom/datadog/android/rum/model/ResourceEvent$Ssl;Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;Lcom/datadog/android/rum/model/ResourceEvent$Download;Lcom/datadog/android/rum/model/ResourceEvent$Provider;Lcom/datadog/android/rum/model/ResourceEvent$Graphql;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;Lcom/datadog/android/rum/model/ResourceEvent$Method;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus;Lcom/datadog/android/rum/model/ResourceEvent$Worker;Lcom/datadog/android/rum/model/ResourceEvent$Redirect;Lcom/datadog/android/rum/model/ResourceEvent$Dns;Lcom/datadog/android/rum/model/ResourceEvent$Connect;Lcom/datadog/android/rum/model/ResourceEvent$Ssl;Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;Lcom/datadog/android/rum/model/ResourceEvent$Download;Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$Provider;Lcom/datadog/android/rum/model/ResourceEvent$Graphql;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;Lcom/datadog/android/rum/model/ResourceEvent$Method;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus;Lcom/datadog/android/rum/model/ResourceEvent$Worker;Lcom/datadog/android/rum/model/ResourceEvent$Redirect;Lcom/datadog/android/rum/model/ResourceEvent$Dns;Lcom/datadog/android/rum/model/ResourceEvent$Connect;Lcom/datadog/android/rum/model/ResourceEvent$Ssl;Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;Lcom/datadog/android/rum/model/ResourceEvent$Download;Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$Provider;Lcom/datadog/android/rum/model/ResourceEvent$Graphql;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Lcom/datadog/android/rum/model/ResourceEvent$Connect;
-	public final fun component11 ()Lcom/datadog/android/rum/model/ResourceEvent$Ssl;
-	public final fun component12 ()Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;
-	public final fun component13 ()Lcom/datadog/android/rum/model/ResourceEvent$Download;
-	public final fun component14 ()Lcom/datadog/android/rum/model/ResourceEvent$Provider;
-	public final fun component15 ()Lcom/datadog/android/rum/model/ResourceEvent$Graphql;
+	public final fun component10 ()Ljava/lang/Long;
+	public final fun component11 ()Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus;
+	public final fun component12 ()Lcom/datadog/android/rum/model/ResourceEvent$Worker;
+	public final fun component13 ()Lcom/datadog/android/rum/model/ResourceEvent$Redirect;
+	public final fun component14 ()Lcom/datadog/android/rum/model/ResourceEvent$Dns;
+	public final fun component15 ()Lcom/datadog/android/rum/model/ResourceEvent$Connect;
+	public final fun component16 ()Lcom/datadog/android/rum/model/ResourceEvent$Ssl;
+	public final fun component17 ()Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;
+	public final fun component18 ()Lcom/datadog/android/rum/model/ResourceEvent$Download;
+	public final fun component19 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;
+	public final fun component20 ()Lcom/datadog/android/rum/model/ResourceEvent$Provider;
+	public final fun component21 ()Lcom/datadog/android/rum/model/ResourceEvent$Graphql;
 	public final fun component3 ()Lcom/datadog/android/rum/model/ResourceEvent$Method;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/Long;
 	public final fun component6 ()Ljava/lang/Long;
 	public final fun component7 ()Ljava/lang/Long;
-	public final fun component8 ()Lcom/datadog/android/rum/model/ResourceEvent$Redirect;
-	public final fun component9 ()Lcom/datadog/android/rum/model/ResourceEvent$Dns;
-	public final fun copy (Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;Lcom/datadog/android/rum/model/ResourceEvent$Method;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ResourceEvent$Redirect;Lcom/datadog/android/rum/model/ResourceEvent$Dns;Lcom/datadog/android/rum/model/ResourceEvent$Connect;Lcom/datadog/android/rum/model/ResourceEvent$Ssl;Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;Lcom/datadog/android/rum/model/ResourceEvent$Download;Lcom/datadog/android/rum/model/ResourceEvent$Provider;Lcom/datadog/android/rum/model/ResourceEvent$Graphql;)Lcom/datadog/android/rum/model/ResourceEvent$Resource;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ResourceEvent$Resource;Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;Lcom/datadog/android/rum/model/ResourceEvent$Method;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ResourceEvent$Redirect;Lcom/datadog/android/rum/model/ResourceEvent$Dns;Lcom/datadog/android/rum/model/ResourceEvent$Connect;Lcom/datadog/android/rum/model/ResourceEvent$Ssl;Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;Lcom/datadog/android/rum/model/ResourceEvent$Download;Lcom/datadog/android/rum/model/ResourceEvent$Provider;Lcom/datadog/android/rum/model/ResourceEvent$Graphql;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ResourceEvent$Resource;
+	public final fun component8 ()Ljava/lang/Long;
+	public final fun component9 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;Lcom/datadog/android/rum/model/ResourceEvent$Method;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus;Lcom/datadog/android/rum/model/ResourceEvent$Worker;Lcom/datadog/android/rum/model/ResourceEvent$Redirect;Lcom/datadog/android/rum/model/ResourceEvent$Dns;Lcom/datadog/android/rum/model/ResourceEvent$Connect;Lcom/datadog/android/rum/model/ResourceEvent$Ssl;Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;Lcom/datadog/android/rum/model/ResourceEvent$Download;Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$Provider;Lcom/datadog/android/rum/model/ResourceEvent$Graphql;)Lcom/datadog/android/rum/model/ResourceEvent$Resource;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ResourceEvent$Resource;Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;Lcom/datadog/android/rum/model/ResourceEvent$Method;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus;Lcom/datadog/android/rum/model/ResourceEvent$Worker;Lcom/datadog/android/rum/model/ResourceEvent$Redirect;Lcom/datadog/android/rum/model/ResourceEvent$Dns;Lcom/datadog/android/rum/model/ResourceEvent$Connect;Lcom/datadog/android/rum/model/ResourceEvent$Ssl;Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;Lcom/datadog/android/rum/model/ResourceEvent$Download;Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$Provider;Lcom/datadog/android/rum/model/ResourceEvent$Graphql;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ResourceEvent$Resource;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$Resource;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ResourceEvent$Resource;
 	public final fun getConnect ()Lcom/datadog/android/rum/model/ResourceEvent$Connect;
+	public final fun getDecodedBodySize ()Ljava/lang/Long;
 	public final fun getDns ()Lcom/datadog/android/rum/model/ResourceEvent$Dns;
 	public final fun getDownload ()Lcom/datadog/android/rum/model/ResourceEvent$Download;
 	public final fun getDuration ()Ljava/lang/Long;
+	public final fun getEncodedBodySize ()Ljava/lang/Long;
 	public final fun getFirstByte ()Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;
 	public final fun getGraphql ()Lcom/datadog/android/rum/model/ResourceEvent$Graphql;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getMethod ()Lcom/datadog/android/rum/model/ResourceEvent$Method;
+	public final fun getProtocol ()Ljava/lang/String;
 	public final fun getProvider ()Lcom/datadog/android/rum/model/ResourceEvent$Provider;
 	public final fun getRedirect ()Lcom/datadog/android/rum/model/ResourceEvent$Redirect;
+	public final fun getRenderBlockingStatus ()Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus;
 	public final fun getSize ()Ljava/lang/Long;
 	public final fun getSsl ()Lcom/datadog/android/rum/model/ResourceEvent$Ssl;
 	public final fun getStatusCode ()Ljava/lang/Long;
+	public final fun getTransferSize ()Ljava/lang/Long;
 	public final fun getType ()Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;
 	public final fun getUrl ()Ljava/lang/String;
+	public final fun getWorker ()Lcom/datadog/android/rum/model/ResourceEvent$Worker;
 	public fun hashCode ()I
 	public final fun setUrl (Ljava/lang/String;)V
 	public final fun toJson ()Lcom/google/gson/JsonElement;
@@ -3895,6 +4069,754 @@ public final class com/datadog/android/rum/model/ResourceEvent$Viewport {
 public final class com/datadog/android/rum/model/ResourceEvent$Viewport$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$Viewport;
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ResourceEvent$Viewport;
+}
+
+public final class com/datadog/android/rum/model/ResourceEvent$Worker {
+	public static final field Companion Lcom/datadog/android/rum/model/ResourceEvent$Worker$Companion;
+	public fun <init> (JJ)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun copy (JJ)Lcom/datadog/android/rum/model/ResourceEvent$Worker;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ResourceEvent$Worker;JJILjava/lang/Object;)Lcom/datadog/android/rum/model/ResourceEvent$Worker;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$Worker;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ResourceEvent$Worker;
+	public final fun getDuration ()J
+	public final fun getStart ()J
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/ResourceEvent$Worker$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$Worker;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ResourceEvent$Worker;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Companion;
+	public fun <init> (JLcom/datadog/android/rum/model/RumVitalEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSession;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventView;Lcom/datadog/android/rum/model/RumVitalEvent$Usr;Lcom/datadog/android/rum/model/RumVitalEvent$Connectivity;Lcom/datadog/android/rum/model/RumVitalEvent$Display;Lcom/datadog/android/rum/model/RumVitalEvent$Synthetics;Lcom/datadog/android/rum/model/RumVitalEvent$CiTest;Lcom/datadog/android/rum/model/RumVitalEvent$Os;Lcom/datadog/android/rum/model/RumVitalEvent$Device;Lcom/datadog/android/rum/model/RumVitalEvent$Dd;Lcom/datadog/android/rum/model/RumVitalEvent$Context;Lcom/datadog/android/rum/model/RumVitalEvent$Container;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;)V
+	public synthetic fun <init> (JLcom/datadog/android/rum/model/RumVitalEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSession;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventView;Lcom/datadog/android/rum/model/RumVitalEvent$Usr;Lcom/datadog/android/rum/model/RumVitalEvent$Connectivity;Lcom/datadog/android/rum/model/RumVitalEvent$Display;Lcom/datadog/android/rum/model/RumVitalEvent$Synthetics;Lcom/datadog/android/rum/model/RumVitalEvent$CiTest;Lcom/datadog/android/rum/model/RumVitalEvent$Os;Lcom/datadog/android/rum/model/RumVitalEvent$Device;Lcom/datadog/android/rum/model/RumVitalEvent$Dd;Lcom/datadog/android/rum/model/RumVitalEvent$Context;Lcom/datadog/android/rum/model/RumVitalEvent$Container;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component10 ()Lcom/datadog/android/rum/model/RumVitalEvent$Usr;
+	public final fun component11 ()Lcom/datadog/android/rum/model/RumVitalEvent$Connectivity;
+	public final fun component12 ()Lcom/datadog/android/rum/model/RumVitalEvent$Display;
+	public final fun component13 ()Lcom/datadog/android/rum/model/RumVitalEvent$Synthetics;
+	public final fun component14 ()Lcom/datadog/android/rum/model/RumVitalEvent$CiTest;
+	public final fun component15 ()Lcom/datadog/android/rum/model/RumVitalEvent$Os;
+	public final fun component16 ()Lcom/datadog/android/rum/model/RumVitalEvent$Device;
+	public final fun component17 ()Lcom/datadog/android/rum/model/RumVitalEvent$Dd;
+	public final fun component18 ()Lcom/datadog/android/rum/model/RumVitalEvent$Context;
+	public final fun component19 ()Lcom/datadog/android/rum/model/RumVitalEvent$Container;
+	public final fun component2 ()Lcom/datadog/android/rum/model/RumVitalEvent$Application;
+	public final fun component20 ()Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSession;
+	public final fun component8 ()Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;
+	public final fun component9 ()Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventView;
+	public final fun copy (JLcom/datadog/android/rum/model/RumVitalEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSession;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventView;Lcom/datadog/android/rum/model/RumVitalEvent$Usr;Lcom/datadog/android/rum/model/RumVitalEvent$Connectivity;Lcom/datadog/android/rum/model/RumVitalEvent$Display;Lcom/datadog/android/rum/model/RumVitalEvent$Synthetics;Lcom/datadog/android/rum/model/RumVitalEvent$CiTest;Lcom/datadog/android/rum/model/RumVitalEvent$Os;Lcom/datadog/android/rum/model/RumVitalEvent$Device;Lcom/datadog/android/rum/model/RumVitalEvent$Dd;Lcom/datadog/android/rum/model/RumVitalEvent$Context;Lcom/datadog/android/rum/model/RumVitalEvent$Container;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;)Lcom/datadog/android/rum/model/RumVitalEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent;JLcom/datadog/android/rum/model/RumVitalEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSession;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventView;Lcom/datadog/android/rum/model/RumVitalEvent$Usr;Lcom/datadog/android/rum/model/RumVitalEvent$Connectivity;Lcom/datadog/android/rum/model/RumVitalEvent$Display;Lcom/datadog/android/rum/model/RumVitalEvent$Synthetics;Lcom/datadog/android/rum/model/RumVitalEvent$CiTest;Lcom/datadog/android/rum/model/RumVitalEvent$Os;Lcom/datadog/android/rum/model/RumVitalEvent$Device;Lcom/datadog/android/rum/model/RumVitalEvent$Dd;Lcom/datadog/android/rum/model/RumVitalEvent$Context;Lcom/datadog/android/rum/model/RumVitalEvent$Container;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent;
+	public final fun getApplication ()Lcom/datadog/android/rum/model/RumVitalEvent$Application;
+	public final fun getBuildId ()Ljava/lang/String;
+	public final fun getBuildVersion ()Ljava/lang/String;
+	public final fun getCiTest ()Lcom/datadog/android/rum/model/RumVitalEvent$CiTest;
+	public final fun getConnectivity ()Lcom/datadog/android/rum/model/RumVitalEvent$Connectivity;
+	public final fun getContainer ()Lcom/datadog/android/rum/model/RumVitalEvent$Container;
+	public final fun getContext ()Lcom/datadog/android/rum/model/RumVitalEvent$Context;
+	public final fun getDate ()J
+	public final fun getDd ()Lcom/datadog/android/rum/model/RumVitalEvent$Dd;
+	public final fun getDevice ()Lcom/datadog/android/rum/model/RumVitalEvent$Device;
+	public final fun getDisplay ()Lcom/datadog/android/rum/model/RumVitalEvent$Display;
+	public final fun getOs ()Lcom/datadog/android/rum/model/RumVitalEvent$Os;
+	public final fun getService ()Ljava/lang/String;
+	public final fun getSession ()Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSession;
+	public final fun getSource ()Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;
+	public final fun getSynthetics ()Lcom/datadog/android/rum/model/RumVitalEvent$Synthetics;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUsr ()Lcom/datadog/android/rum/model/RumVitalEvent$Usr;
+	public final fun getVersion ()Ljava/lang/String;
+	public final fun getView ()Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventView;
+	public final fun getVital ()Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Application {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Application$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Application;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$Application;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$Application;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Application;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Application;
+	public final fun getId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Application$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Application;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Application;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Cellular {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Cellular$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Cellular;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$Cellular;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$Cellular;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Cellular;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Cellular;
+	public final fun getCarrierName ()Ljava/lang/String;
+	public final fun getTechnology ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Cellular$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Cellular;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Cellular;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$CiTest {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$CiTest$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$CiTest;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$CiTest;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$CiTest;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$CiTest;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$CiTest;
+	public final fun getTestExecutionId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$CiTest$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$CiTest;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$CiTest;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Configuration {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Configuration$Companion;
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;)V
+	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Number;
+	public final fun component2 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/RumVitalEvent$Configuration;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$Configuration;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$Configuration;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Configuration;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Configuration;
+	public final fun getSessionReplaySampleRate ()Ljava/lang/Number;
+	public final fun getSessionSampleRate ()Ljava/lang/Number;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Configuration$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Configuration;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Configuration;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Connectivity {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Connectivity$Companion;
+	public fun <init> (Lcom/datadog/android/rum/model/RumVitalEvent$Status;Ljava/util/List;Lcom/datadog/android/rum/model/RumVitalEvent$EffectiveType;Lcom/datadog/android/rum/model/RumVitalEvent$Cellular;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/RumVitalEvent$Status;Ljava/util/List;Lcom/datadog/android/rum/model/RumVitalEvent$EffectiveType;Lcom/datadog/android/rum/model/RumVitalEvent$Cellular;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/rum/model/RumVitalEvent$Status;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lcom/datadog/android/rum/model/RumVitalEvent$EffectiveType;
+	public final fun component4 ()Lcom/datadog/android/rum/model/RumVitalEvent$Cellular;
+	public final fun copy (Lcom/datadog/android/rum/model/RumVitalEvent$Status;Ljava/util/List;Lcom/datadog/android/rum/model/RumVitalEvent$EffectiveType;Lcom/datadog/android/rum/model/RumVitalEvent$Cellular;)Lcom/datadog/android/rum/model/RumVitalEvent$Connectivity;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$Connectivity;Lcom/datadog/android/rum/model/RumVitalEvent$Status;Ljava/util/List;Lcom/datadog/android/rum/model/RumVitalEvent$EffectiveType;Lcom/datadog/android/rum/model/RumVitalEvent$Cellular;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$Connectivity;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Connectivity;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Connectivity;
+	public final fun getCellular ()Lcom/datadog/android/rum/model/RumVitalEvent$Cellular;
+	public final fun getEffectiveType ()Lcom/datadog/android/rum/model/RumVitalEvent$EffectiveType;
+	public final fun getInterfaces ()Ljava/util/List;
+	public final fun getStatus ()Lcom/datadog/android/rum/model/RumVitalEvent$Status;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Connectivity$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Connectivity;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Connectivity;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Container {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Container$Companion;
+	public fun <init> (Lcom/datadog/android/rum/model/RumVitalEvent$ContainerView;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;)V
+	public final fun component1 ()Lcom/datadog/android/rum/model/RumVitalEvent$ContainerView;
+	public final fun component2 ()Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;
+	public final fun copy (Lcom/datadog/android/rum/model/RumVitalEvent$ContainerView;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;)Lcom/datadog/android/rum/model/RumVitalEvent$Container;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$Container;Lcom/datadog/android/rum/model/RumVitalEvent$ContainerView;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$Container;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Container;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Container;
+	public final fun getSource ()Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;
+	public final fun getView ()Lcom/datadog/android/rum/model/RumVitalEvent$ContainerView;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Container$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Container;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Container;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$ContainerView {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$ContainerView$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$ContainerView;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$ContainerView;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$ContainerView;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$ContainerView;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$ContainerView;
+	public final fun getId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$ContainerView$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$ContainerView;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$ContainerView;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Context {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Context$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;)Lcom/datadog/android/rum/model/RumVitalEvent$Context;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$Context;Ljava/util/Map;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$Context;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Context;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Context;
+	public final fun getAdditionalProperties ()Ljava/util/Map;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Context$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Context;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Context;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Custom {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Custom$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;)Lcom/datadog/android/rum/model/RumVitalEvent$Custom;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$Custom;Ljava/util/Map;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Custom;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Custom;
+	public final fun getAdditionalProperties ()Ljava/util/Map;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Custom$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Custom;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Custom;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Dd {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Dd$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/datadog/android/rum/model/RumVitalEvent$DdSession;Lcom/datadog/android/rum/model/RumVitalEvent$Configuration;Ljava/lang/String;Lcom/datadog/android/rum/model/RumVitalEvent$DdVital;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/RumVitalEvent$DdSession;Lcom/datadog/android/rum/model/RumVitalEvent$Configuration;Ljava/lang/String;Lcom/datadog/android/rum/model/RumVitalEvent$DdVital;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/rum/model/RumVitalEvent$DdSession;
+	public final fun component2 ()Lcom/datadog/android/rum/model/RumVitalEvent$Configuration;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/datadog/android/rum/model/RumVitalEvent$DdVital;
+	public final fun copy (Lcom/datadog/android/rum/model/RumVitalEvent$DdSession;Lcom/datadog/android/rum/model/RumVitalEvent$Configuration;Ljava/lang/String;Lcom/datadog/android/rum/model/RumVitalEvent$DdVital;)Lcom/datadog/android/rum/model/RumVitalEvent$Dd;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$Dd;Lcom/datadog/android/rum/model/RumVitalEvent$DdSession;Lcom/datadog/android/rum/model/RumVitalEvent$Configuration;Ljava/lang/String;Lcom/datadog/android/rum/model/RumVitalEvent$DdVital;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$Dd;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Dd;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Dd;
+	public final fun getBrowserSdkVersion ()Ljava/lang/String;
+	public final fun getConfiguration ()Lcom/datadog/android/rum/model/RumVitalEvent$Configuration;
+	public final fun getFormatVersion ()J
+	public final fun getSession ()Lcom/datadog/android/rum/model/RumVitalEvent$DdSession;
+	public final fun getVital ()Lcom/datadog/android/rum/model/RumVitalEvent$DdVital;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Dd$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Dd;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Dd;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$DdSession {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$DdSession$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/datadog/android/rum/model/RumVitalEvent$Plan;Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/RumVitalEvent$Plan;Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/rum/model/RumVitalEvent$Plan;
+	public final fun component2 ()Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition;
+	public final fun copy (Lcom/datadog/android/rum/model/RumVitalEvent$Plan;Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition;)Lcom/datadog/android/rum/model/RumVitalEvent$DdSession;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$DdSession;Lcom/datadog/android/rum/model/RumVitalEvent$Plan;Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$DdSession;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$DdSession;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$DdSession;
+	public final fun getPlan ()Lcom/datadog/android/rum/model/RumVitalEvent$Plan;
+	public final fun getSessionPrecondition ()Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$DdSession$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$DdSession;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$DdSession;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$DdVital {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$DdVital$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/Boolean;)Lcom/datadog/android/rum/model/RumVitalEvent$DdVital;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$DdVital;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$DdVital;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$DdVital;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$DdVital;
+	public final fun getComputedValue ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$DdVital$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$DdVital;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$DdVital;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Device {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Device$Companion;
+	public fun <init> (Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Device;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$Device;Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$Device;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Device;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Device;
+	public final fun getArchitecture ()Ljava/lang/String;
+	public final fun getBrand ()Ljava/lang/String;
+	public final fun getModel ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Device$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Device;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Device;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$DeviceType : java/lang/Enum {
+	public static final field BOT Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType;
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType$Companion;
+	public static final field DESKTOP Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType;
+	public static final field GAMING_CONSOLE Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType;
+	public static final field MOBILE Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType;
+	public static final field OTHER Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType;
+	public static final field TABLET Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType;
+	public static final field TV Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType;
+	public static fun values ()[Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$DeviceType$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$DeviceType;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Display {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Display$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/datadog/android/rum/model/RumVitalEvent$Viewport;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/RumVitalEvent$Viewport;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/rum/model/RumVitalEvent$Viewport;
+	public final fun copy (Lcom/datadog/android/rum/model/RumVitalEvent$Viewport;)Lcom/datadog/android/rum/model/RumVitalEvent$Display;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$Display;Lcom/datadog/android/rum/model/RumVitalEvent$Viewport;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$Display;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Display;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Display;
+	public final fun getViewport ()Lcom/datadog/android/rum/model/RumVitalEvent$Viewport;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Display$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Display;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Display;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$EffectiveType : java/lang/Enum {
+	public static final field 2G Lcom/datadog/android/rum/model/RumVitalEvent$EffectiveType;
+	public static final field 3G Lcom/datadog/android/rum/model/RumVitalEvent$EffectiveType;
+	public static final field 4G Lcom/datadog/android/rum/model/RumVitalEvent$EffectiveType;
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$EffectiveType$Companion;
+	public static final field SLOW_2G Lcom/datadog/android/rum/model/RumVitalEvent$EffectiveType;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$EffectiveType;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$EffectiveType;
+	public static fun values ()[Lcom/datadog/android/rum/model/RumVitalEvent$EffectiveType;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$EffectiveType$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$EffectiveType;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Interface : java/lang/Enum {
+	public static final field BLUETOOTH Lcom/datadog/android/rum/model/RumVitalEvent$Interface;
+	public static final field CELLULAR Lcom/datadog/android/rum/model/RumVitalEvent$Interface;
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Interface$Companion;
+	public static final field ETHERNET Lcom/datadog/android/rum/model/RumVitalEvent$Interface;
+	public static final field MIXED Lcom/datadog/android/rum/model/RumVitalEvent$Interface;
+	public static final field NONE Lcom/datadog/android/rum/model/RumVitalEvent$Interface;
+	public static final field OTHER Lcom/datadog/android/rum/model/RumVitalEvent$Interface;
+	public static final field UNKNOWN Lcom/datadog/android/rum/model/RumVitalEvent$Interface;
+	public static final field WIFI Lcom/datadog/android/rum/model/RumVitalEvent$Interface;
+	public static final field WIMAX Lcom/datadog/android/rum/model/RumVitalEvent$Interface;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Interface;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Interface;
+	public static fun values ()[Lcom/datadog/android/rum/model/RumVitalEvent$Interface;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Interface$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Interface;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Os {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Os$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Os;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$Os;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$Os;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Os;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Os;
+	public final fun getBuild ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getVersion ()Ljava/lang/String;
+	public final fun getVersionMajor ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Os$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Os;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Os;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Plan : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Plan$Companion;
+	public static final field PLAN_1 Lcom/datadog/android/rum/model/RumVitalEvent$Plan;
+	public static final field PLAN_2 Lcom/datadog/android/rum/model/RumVitalEvent$Plan;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Plan;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Plan;
+	public static fun values ()[Lcom/datadog/android/rum/model/RumVitalEvent$Plan;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Plan$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Plan;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$RumVitalEventSession {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSession$Companion;
+	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSessionType;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSessionType;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSessionType;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSessionType;Ljava/lang/Boolean;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSession;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSession;Ljava/lang/String;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSessionType;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSession;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSession;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSession;
+	public final fun getHasReplay ()Ljava/lang/Boolean;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getType ()Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSessionType;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$RumVitalEventSession$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSession;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSession;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$RumVitalEventSessionType : java/lang/Enum {
+	public static final field CI_TEST Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSessionType;
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSessionType$Companion;
+	public static final field SYNTHETICS Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSessionType;
+	public static final field USER Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSessionType;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSessionType;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSessionType;
+	public static fun values ()[Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSessionType;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$RumVitalEventSessionType$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSessionType;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource : java/lang/Enum {
+	public static final field ANDROID Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;
+	public static final field BROWSER Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource$Companion;
+	public static final field FLUTTER Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;
+	public static final field IOS Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;
+	public static final field KOTLIN_MULTIPLATFORM Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;
+	public static final field REACT_NATIVE Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;
+	public static final field ROKU Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;
+	public static final field UNITY Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;
+	public static fun values ()[Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$RumVitalEventView {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventView$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventView;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventView;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventView;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventView;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventView;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getReferrer ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun setName (Ljava/lang/String;)V
+	public final fun setReferrer (Ljava/lang/String;)V
+	public final fun setUrl (Ljava/lang/String;)V
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$RumVitalEventView$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventView;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventView;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital$Companion;
+	public fun <init> (Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/RumVitalEvent$Custom;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/RumVitalEvent$Custom;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Number;
+	public final fun component6 ()Lcom/datadog/android/rum/model/RumVitalEvent$Custom;
+	public final fun copy (Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/RumVitalEvent$Custom;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/RumVitalEvent$Custom;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;
+	public final fun getCustom ()Lcom/datadog/android/rum/model/RumVitalEvent$Custom;
+	public final fun getDetails ()Ljava/lang/String;
+	public final fun getDuration ()Ljava/lang/Number;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType$Companion;
+	public static final field DURATION Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;
+	public static fun values ()[Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$SessionPrecondition : java/lang/Enum {
+	public static final field BACKGROUND_LAUNCH Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition;
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition$Companion;
+	public static final field EXPLICIT_STOP Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition;
+	public static final field FROM_NON_INTERACTIVE_SESSION Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition;
+	public static final field INACTIVITY_TIMEOUT Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition;
+	public static final field MAX_DURATION Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition;
+	public static final field PREWARM Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition;
+	public static final field USER_APP_LAUNCH Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition;
+	public static fun values ()[Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$SessionPrecondition$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$SessionPrecondition;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Status : java/lang/Enum {
+	public static final field CONNECTED Lcom/datadog/android/rum/model/RumVitalEvent$Status;
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Status$Companion;
+	public static final field MAYBE Lcom/datadog/android/rum/model/RumVitalEvent$Status;
+	public static final field NOT_CONNECTED Lcom/datadog/android/rum/model/RumVitalEvent$Status;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Status;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Status;
+	public static fun values ()[Lcom/datadog/android/rum/model/RumVitalEvent$Status;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Status$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Status;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Synthetics {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Synthetics$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/datadog/android/rum/model/RumVitalEvent$Synthetics;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$Synthetics;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$Synthetics;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Synthetics;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Synthetics;
+	public final fun getInjected ()Ljava/lang/Boolean;
+	public final fun getResultId ()Ljava/lang/String;
+	public final fun getTestId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Synthetics$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Synthetics;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Synthetics;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Usr {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Usr$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/datadog/android/rum/model/RumVitalEvent$Usr;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$Usr;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$Usr;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Usr;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Usr;
+	public final fun getAdditionalProperties ()Ljava/util/Map;
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Usr$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Usr;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Usr;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Viewport {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Viewport$Companion;
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;)V
+	public final fun component1 ()Ljava/lang/Number;
+	public final fun component2 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/RumVitalEvent$Viewport;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$Viewport;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$Viewport;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Viewport;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Viewport;
+	public final fun getHeight ()Ljava/lang/Number;
+	public final fun getWidth ()Ljava/lang/Number;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$Viewport$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Viewport;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$Viewport;
 }
 
 public final class com/datadog/android/rum/model/ViewEvent {
@@ -4855,52 +5777,56 @@ public final class com/datadog/android/rum/model/ViewEvent$ViewEventSource$Compa
 
 public final class com/datadog/android/rum/model/ViewEvent$ViewEventView {
 	public static final field Companion Lcom/datadog/android/rum/model/ViewEvent$ViewEventView$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lcom/datadog/android/rum/model/ViewEvent$LoadingType;JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ViewEvent$CustomTimings;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/rum/model/ViewEvent$Action;Lcom/datadog/android/rum/model/ViewEvent$Error;Lcom/datadog/android/rum/model/ViewEvent$Crash;Lcom/datadog/android/rum/model/ViewEvent$LongTask;Lcom/datadog/android/rum/model/ViewEvent$FrozenFrame;Lcom/datadog/android/rum/model/ViewEvent$Resource;Lcom/datadog/android/rum/model/ViewEvent$Frustration;Ljava/util/List;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lcom/datadog/android/rum/model/ViewEvent$LoadingType;JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ViewEvent$CustomTimings;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/rum/model/ViewEvent$Action;Lcom/datadog/android/rum/model/ViewEvent$Error;Lcom/datadog/android/rum/model/ViewEvent$Crash;Lcom/datadog/android/rum/model/ViewEvent$LongTask;Lcom/datadog/android/rum/model/ViewEvent$FrozenFrame;Lcom/datadog/android/rum/model/ViewEvent$Resource;Lcom/datadog/android/rum/model/ViewEvent$Frustration;Ljava/util/List;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ViewEvent$LoadingType;JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ViewEvent$CustomTimings;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/rum/model/ViewEvent$Action;Lcom/datadog/android/rum/model/ViewEvent$Error;Lcom/datadog/android/rum/model/ViewEvent$Crash;Lcom/datadog/android/rum/model/ViewEvent$LongTask;Lcom/datadog/android/rum/model/ViewEvent$FrozenFrame;Lcom/datadog/android/rum/model/ViewEvent$Resource;Lcom/datadog/android/rum/model/ViewEvent$Frustration;Ljava/util/List;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ViewEvent$LoadingType;JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ViewEvent$CustomTimings;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/rum/model/ViewEvent$Action;Lcom/datadog/android/rum/model/ViewEvent$Error;Lcom/datadog/android/rum/model/ViewEvent$Crash;Lcom/datadog/android/rum/model/ViewEvent$LongTask;Lcom/datadog/android/rum/model/ViewEvent$FrozenFrame;Lcom/datadog/android/rum/model/ViewEvent$Resource;Lcom/datadog/android/rum/model/ViewEvent$Frustration;Ljava/util/List;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/Long;
 	public final fun component11 ()Ljava/lang/Long;
-	public final fun component12 ()Ljava/lang/Long;
-	public final fun component13 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/Long;
 	public final fun component14 ()Ljava/lang/Long;
 	public final fun component15 ()Ljava/lang/String;
-	public final fun component16 ()Ljava/lang/Number;
-	public final fun component17 ()Ljava/lang/String;
-	public final fun component18 ()Ljava/lang/Long;
-	public final fun component19 ()Ljava/lang/Long;
+	public final fun component16 ()Ljava/lang/Long;
+	public final fun component17 ()Ljava/lang/Long;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/lang/Number;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component20 ()Ljava/lang/Long;
-	public final fun component21 ()Ljava/lang/Long;
+	public final fun component21 ()Ljava/lang/String;
 	public final fun component22 ()Ljava/lang/Long;
-	public final fun component23 ()Lcom/datadog/android/rum/model/ViewEvent$CustomTimings;
-	public final fun component24 ()Ljava/lang/Boolean;
-	public final fun component25 ()Ljava/lang/Boolean;
-	public final fun component26 ()Lcom/datadog/android/rum/model/ViewEvent$Action;
-	public final fun component27 ()Lcom/datadog/android/rum/model/ViewEvent$Error;
-	public final fun component28 ()Lcom/datadog/android/rum/model/ViewEvent$Crash;
-	public final fun component29 ()Lcom/datadog/android/rum/model/ViewEvent$LongTask;
+	public final fun component23 ()Ljava/lang/Long;
+	public final fun component24 ()Ljava/lang/Long;
+	public final fun component25 ()Ljava/lang/Long;
+	public final fun component26 ()Ljava/lang/Long;
+	public final fun component27 ()Lcom/datadog/android/rum/model/ViewEvent$CustomTimings;
+	public final fun component28 ()Ljava/lang/Boolean;
+	public final fun component29 ()Ljava/lang/Boolean;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun component30 ()Lcom/datadog/android/rum/model/ViewEvent$FrozenFrame;
-	public final fun component31 ()Lcom/datadog/android/rum/model/ViewEvent$Resource;
-	public final fun component32 ()Lcom/datadog/android/rum/model/ViewEvent$Frustration;
-	public final fun component33 ()Ljava/util/List;
-	public final fun component34 ()Ljava/lang/Number;
-	public final fun component35 ()Ljava/lang/Number;
-	public final fun component36 ()Ljava/lang/Number;
-	public final fun component37 ()Ljava/lang/Number;
+	public final fun component30 ()Lcom/datadog/android/rum/model/ViewEvent$Action;
+	public final fun component31 ()Lcom/datadog/android/rum/model/ViewEvent$Error;
+	public final fun component32 ()Lcom/datadog/android/rum/model/ViewEvent$Crash;
+	public final fun component33 ()Lcom/datadog/android/rum/model/ViewEvent$LongTask;
+	public final fun component34 ()Lcom/datadog/android/rum/model/ViewEvent$FrozenFrame;
+	public final fun component35 ()Lcom/datadog/android/rum/model/ViewEvent$Resource;
+	public final fun component36 ()Lcom/datadog/android/rum/model/ViewEvent$Frustration;
+	public final fun component37 ()Ljava/util/List;
 	public final fun component38 ()Ljava/lang/Number;
 	public final fun component39 ()Ljava/lang/Number;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun component40 ()Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;
-	public final fun component41 ()Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;
-	public final fun component42 ()Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;
+	public final fun component40 ()Ljava/lang/Number;
+	public final fun component41 ()Ljava/lang/Number;
+	public final fun component42 ()Ljava/lang/Number;
+	public final fun component43 ()Ljava/lang/Number;
+	public final fun component44 ()Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;
+	public final fun component45 ()Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;
+	public final fun component46 ()Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;
 	public final fun component5 ()Ljava/lang/Long;
-	public final fun component6 ()Lcom/datadog/android/rum/model/ViewEvent$LoadingType;
-	public final fun component7 ()J
-	public final fun component8 ()Ljava/lang/Long;
-	public final fun component9 ()Ljava/lang/Long;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lcom/datadog/android/rum/model/ViewEvent$LoadingType;JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ViewEvent$CustomTimings;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/rum/model/ViewEvent$Action;Lcom/datadog/android/rum/model/ViewEvent$Error;Lcom/datadog/android/rum/model/ViewEvent$Crash;Lcom/datadog/android/rum/model/ViewEvent$LongTask;Lcom/datadog/android/rum/model/ViewEvent$FrozenFrame;Lcom/datadog/android/rum/model/ViewEvent$Resource;Lcom/datadog/android/rum/model/ViewEvent$Frustration;Ljava/util/List;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;)Lcom/datadog/android/rum/model/ViewEvent$ViewEventView;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewEvent$ViewEventView;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Lcom/datadog/android/rum/model/ViewEvent$LoadingType;JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ViewEvent$CustomTimings;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/rum/model/ViewEvent$Action;Lcom/datadog/android/rum/model/ViewEvent$Error;Lcom/datadog/android/rum/model/ViewEvent$Crash;Lcom/datadog/android/rum/model/ViewEvent$LongTask;Lcom/datadog/android/rum/model/ViewEvent$FrozenFrame;Lcom/datadog/android/rum/model/ViewEvent$Resource;Lcom/datadog/android/rum/model/ViewEvent$Frustration;Ljava/util/List;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;IILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewEvent$ViewEventView;
+	public final fun component6 ()Ljava/lang/Long;
+	public final fun component7 ()Ljava/lang/Long;
+	public final fun component8 ()Lcom/datadog/android/rum/model/ViewEvent$LoadingType;
+	public final fun component9 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ViewEvent$LoadingType;JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ViewEvent$CustomTimings;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/rum/model/ViewEvent$Action;Lcom/datadog/android/rum/model/ViewEvent$Error;Lcom/datadog/android/rum/model/ViewEvent$Crash;Lcom/datadog/android/rum/model/ViewEvent$LongTask;Lcom/datadog/android/rum/model/ViewEvent$FrozenFrame;Lcom/datadog/android/rum/model/ViewEvent$Resource;Lcom/datadog/android/rum/model/ViewEvent$Frustration;Ljava/util/List;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;)Lcom/datadog/android/rum/model/ViewEvent$ViewEventView;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewEvent$ViewEventView;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ViewEvent$LoadingType;JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ViewEvent$CustomTimings;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/rum/model/ViewEvent$Action;Lcom/datadog/android/rum/model/ViewEvent$Error;Lcom/datadog/android/rum/model/ViewEvent$Crash;Lcom/datadog/android/rum/model/ViewEvent$LongTask;Lcom/datadog/android/rum/model/ViewEvent$FrozenFrame;Lcom/datadog/android/rum/model/ViewEvent$Resource;Lcom/datadog/android/rum/model/ViewEvent$Frustration;Ljava/util/List;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;IILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewEvent$ViewEventView;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$ViewEventView;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewEvent$ViewEventView;
@@ -4910,6 +5836,7 @@ public final class com/datadog/android/rum/model/ViewEvent$ViewEventView {
 	public final fun getCrash ()Lcom/datadog/android/rum/model/ViewEvent$Crash;
 	public final fun getCumulativeLayoutShift ()Ljava/lang/Number;
 	public final fun getCumulativeLayoutShiftTargetSelector ()Ljava/lang/String;
+	public final fun getCumulativeLayoutShiftTime ()Ljava/lang/Long;
 	public final fun getCustomTimings ()Lcom/datadog/android/rum/model/ViewEvent$CustomTimings;
 	public final fun getDomComplete ()Ljava/lang/Long;
 	public final fun getDomContentLoaded ()Ljava/lang/Long;
@@ -4928,6 +5855,8 @@ public final class com/datadog/android/rum/model/ViewEvent$ViewEventView {
 	public final fun getInForegroundPeriods ()Ljava/util/List;
 	public final fun getInteractionToNextPaint ()Ljava/lang/Long;
 	public final fun getInteractionToNextPaintTargetSelector ()Ljava/lang/String;
+	public final fun getInteractionToNextPaintTime ()Ljava/lang/Long;
+	public final fun getInteractionToNextViewTime ()Ljava/lang/Long;
 	public final fun getJsRefreshRate ()Lcom/datadog/android/rum/model/ViewEvent$FlutterBuildTime;
 	public final fun getLargestContentfulPaint ()Ljava/lang/Long;
 	public final fun getLargestContentfulPaintTargetSelector ()Ljava/lang/String;
@@ -4938,6 +5867,7 @@ public final class com/datadog/android/rum/model/ViewEvent$ViewEventView {
 	public final fun getMemoryAverage ()Ljava/lang/Number;
 	public final fun getMemoryMax ()Ljava/lang/Number;
 	public final fun getName ()Ljava/lang/String;
+	public final fun getNetworkSettledTime ()Ljava/lang/Long;
 	public final fun getReferrer ()Ljava/lang/String;
 	public final fun getRefreshRateAverage ()Ljava/lang/Number;
 	public final fun getRefreshRateMin ()Ljava/lang/Number;

--- a/features/dd-sdk-android-rum/src/main/json/rum/_common-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/_common-schema.json
@@ -28,13 +28,11 @@
     },
     "service": {
       "type": "string",
-      "description": "The service name for this application",
-      "readOnly": true
+      "description": "The service name for this application"
     },
     "version": {
       "type": "string",
-      "description": "The version for this application",
-      "readOnly": true
+      "description": "The version for this application"
     },
     "build_version": {
       "type": "string",

--- a/features/dd-sdk-android-rum/src/main/json/rum/error-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/error-schema.json
@@ -314,9 +314,35 @@
               },
               "readOnly": true
             },
+            "csp": {
+              "type": "object",
+              "description": "Content Security Violation properties",
+              "properties": {
+                "disposition": {
+                  "type": "string",
+                  "description": "In the context of CSP errors, indicates how the violated policy is configured to be treated by the user agent.",
+                  "enum": ["enforce", "report"],
+                  "readOnly": true
+                }
+              },
+              "readOnly": true
+            },
             "time_since_app_start": {
               "type": "integer",
               "description": "Time since application start when error happened (in milliseconds)",
+              "readOnly": true
+            }
+          },
+          "readOnly": true
+        },
+        "freeze": {
+          "type": "object",
+          "description": "Properties of App Hang and ANR errors",
+          "required": ["duration"],
+          "properties": {
+            "duration": {
+              "type": "integer",
+              "description": "Duration of the main thread freeze (in ns)",
               "readOnly": true
             }
           },

--- a/features/dd-sdk-android-rum/src/main/json/rum/long_task-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/long_task-schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "rum/long_task-schema.json",
+  "$comment": "Long animation frames are ingested as long tasks",
   "title": "RumLongTaskEvent",
   "type": "object",
   "description": "Schema of all properties of a Long Task event",
@@ -30,19 +31,133 @@
           "properties": {
             "id": {
               "type": "string",
-              "description": "UUID of the long task",
+              "description": "UUID of the long task or long animation frame",
               "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+              "readOnly": true
+            },
+            "start_time": {
+              "type": "number",
+              "description": "Start time of the long animation frame",
+              "minimum": 0,
+              "readOnly": true
+            },
+            "entry_type": {
+              "type": "string",
+              "description": "Type of the event: long task or long animation frame",
+              "enum": ["long-task", "long-animation-frame"],
               "readOnly": true
             },
             "duration": {
               "type": "integer",
-              "description": "Duration in ns of the long task",
+              "description": "Duration in ns of the long task or long animation frame",
+              "minimum": 0,
+              "readOnly": true
+            },
+            "blocking_duration": {
+              "type": "integer",
+              "description": "Duration in ns for which the animation frame was being blocked",
+              "minimum": 0,
+              "readOnly": true
+            },
+            "render_start": {
+              "type": "number",
+              "description": "Start time of the rendering cycle, which includes requestAnimationFrame callbacks, style and layout calculation, resize observer and intersection observer callbacks",
+              "minimum": 0,
+              "readOnly": true
+            },
+            "style_and_layout_start": {
+              "type": "number",
+              "description": "Start time of the time period spent in style and layout calculations",
+              "minimum": 0,
+              "readOnly": true
+            },
+            "first_ui_event_timestamp": {
+              "type": "number",
+              "description": "Start time of of the first UI event (mouse/keyboard and so on) to be handled during the course of this frame",
               "minimum": 0,
               "readOnly": true
             },
             "is_frozen_frame": {
               "type": "boolean",
               "description": "Whether this long task is considered a frozen frame",
+              "readOnly": true
+            },
+            "scripts": {
+              "type": "array",
+              "description": "A list of long scripts that were executed over the course of the long frame",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "duration": {
+                    "type": "integer",
+                    "description": "Duration in ns between startTime and when the subsequent microtask queue has finished processing",
+                    "minimum": 0,
+                    "readOnly": true
+                  },
+                  "pause_duration": {
+                    "type": "integer",
+                    "description": "Duration in ns of the total time spent in 'pausing' synchronous operations (alert, synchronous XHR)",
+                    "minimum": 0,
+                    "readOnly": true
+                  },
+                  "forced_style_and_layout_duration": {
+                    "type": "integer",
+                    "description": "Duration in ns of the the total time spent processing forced layout and style inside this function",
+                    "minimum": 0,
+                    "readOnly": true
+                  },
+                  "start_time": {
+                    "type": "number",
+                    "description": "Time the entry function was invoked",
+                    "minimum": 0,
+                    "readOnly": true
+                  },
+                  "execution_start": {
+                    "type": "number",
+                    "description": "Time after compilation",
+                    "minimum": 0,
+                    "readOnly": true
+                  },
+                  "source_url": {
+                    "type": "string",
+                    "description": "The script resource name where available (or empty if not found)",
+                    "readOnly": true
+                  },
+                  "source_function_name": {
+                    "type": "string",
+                    "description": "The script function name where available (or empty if not found)",
+                    "readOnly": true
+                  },
+                  "source_char_position": {
+                    "type": "integer",
+                    "description": "The script character position where available (or -1 if not found)",
+                    "readOnly": true
+                  },
+                  "invoker": {
+                    "type": "string",
+                    "description": "Information about the invoker of the script",
+                    "readOnly": true
+                  },
+                  "invoker_type": {
+                    "type": "string",
+                    "description": "Type of the invoker of the script",
+                    "enum": [
+                      "user-callback",
+                      "event-listener",
+                      "resolve-promise",
+                      "reject-promise",
+                      "classic-script",
+                      "module-script"
+                    ],
+                    "readOnly": true
+                  },
+                  "window_attribution": {
+                    "type": "string",
+                    "description": "The container (the top-level document, or an <iframe>) the long animation frame occurred in",
+                    "readOnly": true
+                  }
+                }
+              },
               "readOnly": true
             }
           },

--- a/features/dd-sdk-android-rum/src/main/json/rum/resource-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/resource-schema.json
@@ -69,6 +69,50 @@
               "minimum": 0,
               "readOnly": true
             },
+            "encoded_body_size": {
+              "type": "integer",
+              "description": "Size in octet of the resource before removing any applied content encodings",
+              "minimum": 0,
+              "readOnly": true
+            },
+            "decoded_body_size": {
+              "type": "integer",
+              "description": "Size in octet of the resource after removing any applied encoding",
+              "minimum": 0,
+              "readOnly": true
+            },
+            "transfer_size": {
+              "type": "integer",
+              "description": "Size in octet of the fetched resource",
+              "minimum": 0,
+              "readOnly": true
+            },
+            "render_blocking_status": {
+              "type": "string",
+              "description": "Render blocking status of the resource",
+              "enum": ["blocking", "non-blocking"],
+              "readOnly": true
+            },
+            "worker": {
+              "type": "object",
+              "description": "Worker phase properties",
+              "required": ["duration", "start"],
+              "properties": {
+                "duration": {
+                  "type": "integer",
+                  "description": "Duration in nanoseconds of the resource worker phase",
+                  "minimum": 0,
+                  "readOnly": true
+                },
+                "start": {
+                  "type": "integer",
+                  "description": "Duration in nanoseconds between start of the request and start of the worker phase",
+                  "minimum": 0,
+                  "readOnly": true
+                }
+              },
+              "readOnly": true
+            },
             "redirect": {
               "type": "object",
               "description": "Redirect phase properties",
@@ -187,6 +231,11 @@
                   "readOnly": true
                 }
               },
+              "readOnly": true
+            },
+            "protocol": {
+              "type": "string",
+              "description": "Network protocol used to fetch the resource (e.g., 'http/1.1', 'h2')",
               "readOnly": true
             },
             "provider": {

--- a/features/dd-sdk-android-rum/src/main/json/rum/view-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/view-schema.json
@@ -31,6 +31,18 @@
               "minimum": 0,
               "readOnly": true
             },
+            "network_settled_time": {
+              "type": "integer",
+              "description": "Duration in ns from the moment the view was started until all the initial network requests settled",
+              "minimum": 0,
+              "readOnly": true
+            },
+            "interaction_to_next_view_time": {
+              "type": "integer",
+              "description": "Duration in ns to from the last interaction on previous view to the moment the current view was displayed",
+              "minimum": 0,
+              "readOnly": true
+            },
             "loading_type": {
               "type": "string",
               "description": "Type of the loading of the view",
@@ -92,6 +104,12 @@
               "minimum": 0,
               "readOnly": true
             },
+            "interaction_to_next_paint_time": {
+              "type": "integer",
+              "description": "Duration in ns between start of the view and start of the INP",
+              "minimum": 0,
+              "readOnly": true
+            },
             "interaction_to_next_paint_target_selector": {
               "type": "string",
               "description": "CSS selector path of the interacted element corresponding to INP",
@@ -100,6 +118,12 @@
             "cumulative_layout_shift": {
               "type": "number",
               "description": "Total layout shift score that occurred on the view",
+              "minimum": 0,
+              "readOnly": true
+            },
+            "cumulative_layout_shift_time": {
+              "type": "integer",
+              "description": "Duration in ns between start of the view and start of the largest layout shift contributing to CLS",
               "minimum": 0,
               "readOnly": true
             },

--- a/features/dd-sdk-android-rum/src/main/json/rum/vital-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/vital-schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/vital-schema.json",
+  "title": "RumVitalEvent",
+  "type": "object",
+  "description": "Schema of all properties of a Vital event",
+  "allOf": [
+    {
+      "$ref": "_common-schema.json"
+    },
+    {
+      "$ref": "_view-container-schema.json"
+    },
+    {
+      "required": ["type", "vital"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "RUM event type",
+          "const": "vital",
+          "readOnly": true
+        },
+        "vital": {
+          "type": "object",
+          "description": "Vital properties",
+          "required": ["id", "type"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Type of the vital",
+              "enum": ["duration"],
+              "readOnly": true
+            },
+            "id": {
+              "type": "string",
+              "description": "UUID of the vital",
+              "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+              "readOnly": true
+            },
+            "name": {
+              "type": "string",
+              "description": "Name of the vital, as it is also used as facet path for its value, it must contain only letters, digits, or the characters - _ . @ $",
+              "readOnly": true
+            },
+            "details": {
+              "type": "string",
+              "description": "Details of the vital. It can be used as a secondary identifier (URL, React component name...)",
+              "readOnly": true
+            },
+            "duration": {
+              "type": "number",
+              "description": "Duration of the vital in nanoseconds",
+              "readOnly": true
+            },
+            "custom": {
+              "type": "object",
+              "description": "User custom vital.",
+              "additionalProperties": {
+                "type": "number",
+                "minimum": 0,
+                "readOnly": true
+              },
+              "readOnly": true
+            }
+          },
+          "readOnly": true
+        },
+        "_dd": {
+          "type": "object",
+          "description": "Internal properties",
+          "properties": {
+            "vital": {
+              "type": "object",
+              "description": "Internal vital properties",
+              "properties": {
+                "computed_value": {
+                  "type": "boolean",
+                  "description": "Whether the value of the vital is computed by the SDK (as opposed to directly provided by the customer)",
+                  "readOnly": true
+                }
+              },
+              "readOnly": true
+            }
+          },
+          "readOnly": true
+        }
+      }
+    }
+  ]
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/InitialResourceIdentifier.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/InitialResourceIdentifier.kt
@@ -1,0 +1,16 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.metric.networksettled
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+@NoOpImplementation
+internal interface InitialResourceIdentifier {
+    fun validate(
+        context: NetworkSettledResourceContext
+    ): Boolean
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/InternalResourceContext.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/InternalResourceContext.kt
@@ -1,0 +1,12 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.metric.networksettled
+
+internal data class InternalResourceContext(
+    internal val resourceId: String,
+    internal val eventCreatedAtNanos: Long
+)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/NetworkSettledMetricResolver.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/NetworkSettledMetricResolver.kt
@@ -1,0 +1,98 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.metric.networksettled
+
+import com.datadog.android.api.InternalLogger
+
+internal class NetworkSettledMetricResolver(
+    private val initialResourceIdentifier: InitialResourceIdentifier = TimeBasedInitialResourceIdentifier(),
+    private val internalLogger: InternalLogger
+) {
+    private val resourceStartedTimestamps = HashSet<String>()
+
+    @Volatile
+    private var networkSettleMaxValue: Long? = null
+
+    @Volatile
+    private var viewCreatedTimestamp: Long? = null
+
+    @Volatile
+    private var lastComputedMetric: Long? = null
+
+    @Volatile
+    private var viewWasStopped: Boolean = false
+
+    fun viewWasCreated(eventTimestampInNanos: Long) {
+        viewCreatedTimestamp = eventTimestampInNanos
+    }
+
+    fun resourceWasStarted(context: InternalResourceContext) {
+        if (viewWasStopped) return
+        // check if the resource was is a network settled valid resource
+        if (initialResourceIdentifier.validate(
+                NetworkSettledResourceContext(
+                    context.resourceId,
+                    context.eventCreatedAtNanos,
+                    viewCreatedTimestamp
+                )
+            )
+        ) {
+            // check if we have a view created entry for this resource
+            resourceStartedTimestamps.add(context.resourceId)
+        }
+    }
+
+    fun resourceWasStopped(context: InternalResourceContext) {
+        if (viewWasStopped) return
+        val currentViewCreatedTimestamp = viewCreatedTimestamp
+        val currentNetworkSettleMaxValue = networkSettleMaxValue ?: 0L
+        val resourceStartedTimestamp = resourceStartedTimestamps.remove(context.resourceId)
+        // check if we have a start timestamp for this resource
+        if (currentViewCreatedTimestamp != null && resourceStartedTimestamp) {
+            val networkToSettledDuration = context.eventCreatedAtNanos - currentViewCreatedTimestamp
+            if (networkToSettledDuration > currentNetworkSettleMaxValue) {
+                networkSettleMaxValue = networkToSettledDuration
+            }
+        }
+    }
+
+    fun viewWasStopped() {
+        viewWasStopped = true
+        // clear all the resources for this view
+        resourceStartedTimestamps.clear()
+    }
+
+    fun resolveMetric(): Long? {
+        if (viewWasStopped) {
+            return lastComputedMetric
+        }
+        lastComputedMetric = computeMetric()
+        return lastComputedMetric
+    }
+
+    @Suppress("ReturnCount")
+    private fun computeMetric(): Long? {
+        if (viewCreatedTimestamp == null) {
+            internalLogger.log(
+                InternalLogger.Level.DEBUG,
+                InternalLogger.Target.MAINTAINER,
+                { "[ViewNetworkSettledMetric] There was no view created yet for this resource" }
+            )
+            return null
+        }
+        if (resourceStartedTimestamps.size > 0) {
+            // not all resources were stopped
+            internalLogger.log(
+                InternalLogger.Level.DEBUG,
+                InternalLogger.Target.MAINTAINER,
+                { "[ViewNetworkSettledMetric] Not all the initial resources were stopped for this view" }
+            )
+            return null
+        }
+        return networkSettleMaxValue
+    }
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/NetworkSettledResourceContext.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/NetworkSettledResourceContext.kt
@@ -1,0 +1,13 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.metric.networksettled
+
+internal data class NetworkSettledResourceContext(
+    internal val resourceId: String,
+    internal val eventCreatedAtNanos: Long,
+    internal val viewCreatedTimestamp: Long?
+)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/TimeBasedInitialResourceIdentifier.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/TimeBasedInitialResourceIdentifier.kt
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.metric.networksettled
+
+import java.util.concurrent.TimeUnit
+
+internal class TimeBasedInitialResourceIdentifier(
+    private val timeThresholdInNanoSeconds: Long = TimeUnit.MILLISECONDS.toNanos(DEFAULT_TIME_THRESHOLD_MS)
+) : InitialResourceIdentifier {
+    override fun validate(
+        context: NetworkSettledResourceContext
+    ): Boolean {
+        return context.viewCreatedTimestamp?.let { viewCreatedTimestamp ->
+            context.eventCreatedAtNanos - viewCreatedTimestamp < timeThresholdInNanoSeconds
+        } ?: false
+    }
+
+    companion object {
+        internal const val DEFAULT_TIME_THRESHOLD_MS = 100L
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
@@ -254,6 +254,18 @@ internal class ViewEventAssert(actual: ViewEvent) :
         return this
     }
 
+    fun hasNetworkSettledTime(
+        expected: Long?
+    ): ViewEventAssert {
+        assertThat(actual.view.networkSettledTime)
+            .overridingErrorMessage(
+                "Expected event to have networkSettledTime $expected" +
+                    " but was ${actual.view.networkSettledTime}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
     fun hasLoadingType(
         expected: ViewEvent.LoadingType?
     ): ViewEventAssert {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -15,7 +15,6 @@ import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
-import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
@@ -27,6 +26,8 @@ import com.datadog.android.rum.internal.FeaturesContextResolver
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
+import com.datadog.android.rum.internal.metric.networksettled.InternalResourceContext
+import com.datadog.android.rum.internal.metric.networksettled.NetworkSettledMetricResolver
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.internal.monitor.StorageEvent
 import com.datadog.android.rum.model.ErrorEvent
@@ -141,6 +142,9 @@ internal class RumResourceScopeTest {
     @Mock
     lateinit var mockFeaturesContextResolver: FeaturesContextResolver
 
+    @Mock
+    lateinit var mockNetworkSettledMetricResolver: NetworkSettledMetricResolver
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         val isValidSource = forge.aBool()
@@ -208,7 +212,16 @@ internal class RumResourceScopeTest {
             fakeServerOffset,
             mockResolver,
             mockFeaturesContextResolver,
-            fakeSampleRate
+            fakeSampleRate,
+            mockNetworkSettledMetricResolver
+        )
+    }
+
+    @Test
+    fun `M notify the NetworkSettledMetricsResolver W initialized()`() {
+        // Then
+        verify(mockNetworkSettledMetricResolver).resourceWasStarted(
+            InternalResourceContext(testedScope.resourceId, fakeEventTime.nanoTime)
         )
     }
 
@@ -301,6 +314,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -371,6 +387,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -394,7 +413,8 @@ internal class RumResourceScopeTest {
             fakeServerOffset,
             mockResolver,
             mockFeaturesContextResolver,
-            fakeSampleRate
+            fakeSampleRate,
+            mockNetworkSettledMetricResolver
         )
         doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(brokenUrl)
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
@@ -455,6 +475,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -530,6 +553,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -600,6 +626,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -633,7 +662,8 @@ internal class RumResourceScopeTest {
             fakeServerOffset,
             mockResolver,
             mockFeaturesContextResolver,
-            fakeSampleRate
+            fakeSampleRate,
+            mockNetworkSettledMetricResolver
         )
 
         // When
@@ -688,6 +718,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -749,6 +782,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -801,6 +837,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -822,6 +861,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -871,7 +913,8 @@ internal class RumResourceScopeTest {
             fakeServerOffset,
             mockResolver,
             mockFeaturesContextResolver,
-            fakeSampleRate
+            fakeSampleRate,
+            mockNetworkSettledMetricResolver
         )
         whenever(rumMonitor.mockInstance.getAttributes()) doReturn emptyMap()
 
@@ -927,6 +970,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -998,6 +1044,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1071,6 +1120,9 @@ internal class RumResourceScopeTest {
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(resultTiming).isEqualTo(testedScope)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1144,6 +1196,9 @@ internal class RumResourceScopeTest {
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(resultTiming).isEqualTo(testedScope)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1219,6 +1274,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1297,6 +1355,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1373,6 +1434,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1414,7 +1478,8 @@ internal class RumResourceScopeTest {
             fakeServerOffset,
             mockResolver,
             mockFeaturesContextResolver,
-            fakeSampleRate
+            fakeSampleRate,
+            mockNetworkSettledMetricResolver
         )
 
         // When
@@ -1467,6 +1532,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1510,7 +1578,8 @@ internal class RumResourceScopeTest {
             fakeServerOffset,
             mockResolver,
             mockFeaturesContextResolver,
-            fakeSampleRate
+            fakeSampleRate,
+            mockNetworkSettledMetricResolver
         )
 
         // When
@@ -1562,6 +1631,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1585,7 +1657,8 @@ internal class RumResourceScopeTest {
             fakeServerOffset,
             mockResolver,
             mockFeaturesContextResolver,
-            fakeSampleRate
+            fakeSampleRate,
+            mockNetworkSettledMetricResolver
         )
         doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(brokenUrl)
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
@@ -1654,6 +1727,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1678,7 +1754,8 @@ internal class RumResourceScopeTest {
             fakeServerOffset,
             mockResolver,
             mockFeaturesContextResolver,
-            fakeSampleRate
+            fakeSampleRate,
+            mockNetworkSettledMetricResolver
         )
         doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(brokenUrl)
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
@@ -1747,6 +1824,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1826,6 +1906,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1905,6 +1988,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1983,6 +2069,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -2062,6 +2151,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -2146,6 +2238,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -2230,6 +2325,9 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -2251,6 +2349,9 @@ internal class RumResourceScopeTest {
 
         verify(mockParentScope, atMost(1)).getRumContext()
         verifyNoMoreInteractions(mockWriter, mockParentScope)
+        verify(mockNetworkSettledMetricResolver, never()).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isSameAs(testedScope)
     }
 
@@ -2275,6 +2376,9 @@ internal class RumResourceScopeTest {
 
         verify(mockParentScope, atMost(1)).getRumContext()
         verifyNoMoreInteractions(mockWriter, mockParentScope)
+        verify(mockNetworkSettledMetricResolver, never()).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isSameAs(testedScope)
     }
 
@@ -2302,6 +2406,9 @@ internal class RumResourceScopeTest {
 
         verify(mockParentScope, atMost(1)).getRumContext()
         verifyNoMoreInteractions(mockWriter, mockParentScope)
+        verify(mockNetworkSettledMetricResolver, never()).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(result).isSameAs(testedScope)
     }
 
@@ -2326,6 +2433,9 @@ internal class RumResourceScopeTest {
         verify(mockParentScope, atMost(1)).getRumContext()
         verifyNoMoreInteractions(mockWriter, mockParentScope)
         assertThat(resultWaitForTiming).isEqualTo(testedScope)
+        verify(mockNetworkSettledMetricResolver, never()).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(resultStop).isSameAs(testedScope)
     }
 
@@ -2389,6 +2499,9 @@ internal class RumResourceScopeTest {
         }
         verifyNoMoreInteractions(mockWriter)
         verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(resultWaitForTiming).isSameAs(testedScope)
         assertThat(resultStop).isEqualTo(null)
     }
@@ -2458,6 +2571,9 @@ internal class RumResourceScopeTest {
         verify(mockParentScope, never()).handleEvent(any(), any())
         assertThat(resultWaitForTiming).isEqualTo(testedScope)
         assertThat(resultTiming).isEqualTo(testedScope)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(resultStop).isEqualTo(null)
     }
 
@@ -2526,6 +2642,9 @@ internal class RumResourceScopeTest {
         verifyNoMoreInteractions(mockWriter)
         verify(mockParentScope, never()).handleEvent(any(), any())
         assertThat(resultWaitForTiming).isEqualTo(testedScope)
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+        )
         assertThat(resultStop).isEqualTo(testedScope)
         assertThat(resultTiming).isEqualTo(null)
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/networksettled/NetworkSettledMetricResolverTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/networksettled/NetworkSettledMetricResolverTest.kt
@@ -1,0 +1,432 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.metric.networksettled
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.rum.utils.forge.Configurator
+import com.datadog.android.rum.utils.verifyLog
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import java.util.UUID
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class NetworkSettledMetricResolverTest {
+
+    private lateinit var testedMetric: NetworkSettledMetricResolver
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @Mock
+    lateinit var mockInitialResourceIdentifier: InitialResourceIdentifier
+
+    private var fakeViewStartTime: Long = System.nanoTime()
+
+    // region SetUp
+
+    @BeforeEach
+    fun `set up`() {
+        fakeViewStartTime = System.nanoTime()
+        testedMetric = NetworkSettledMetricResolver(mockInitialResourceIdentifier, mockInternalLogger)
+        testedMetric.viewWasCreated(fakeViewStartTime)
+        whenever(mockInitialResourceIdentifier.validate(any())).thenReturn(true)
+    }
+
+    // endregion
+
+    // region metric computation
+
+    @Test
+    fun `M return the correct metric W resolveMetric(){ resources stopped in random order }`(forge: Forge) {
+        // Given
+        val startTimestamps = forge.forgeStartTimestamps()
+        val stopTimestamps = startTimestamps.mapToStopTimestamps(forge)
+        val settledIntervals = stopTimestamps.mapToSettledIntervals()
+        val expectedMetricValue = settledIntervals.max()
+        val fakeResourcesIds = forge.aList(size = startTimestamps.size) {
+            forge.getForgery<UUID>().toString()
+        }
+        fakeResourcesIds.forEachIndexed { index, id ->
+            testedMetric.resourceWasStarted(
+                InternalResourceContext(id, startTimestamps[index])
+            )
+            testedMetric.resourceWasStopped(
+                InternalResourceContext(id, stopTimestamps[index])
+            )
+        }
+
+        // When
+        val metricValue = testedMetric.resolveMetric()
+
+        // Then
+        assertThat(metricValue).isEqualTo(expectedMetricValue)
+    }
+
+    @Test
+    fun `M return the correct metric W resolveMetric(){ only one resource registered }`(forge: Forge) {
+        // Given
+        val startTimestamp = System.nanoTime()
+        val stopTimestamp = startTimestamp + forge.aLong(min = 1, max = 1000)
+        val fakeResourceId = forge.getForgery<UUID>().toString()
+        testedMetric.resourceWasStarted(InternalResourceContext(fakeResourceId, startTimestamp))
+        testedMetric.resourceWasStopped(InternalResourceContext(fakeResourceId, stopTimestamp))
+
+        // When
+        val metricValue = testedMetric.resolveMetric()
+
+        // Then
+        assertThat(metricValue).isEqualTo(stopTimestamp - fakeViewStartTime)
+    }
+
+    @Test
+    fun `M return null W resolveMetric(){ no resources registered }`() {
+        // When
+        val metricValue = testedMetric.resolveMetric()
+
+        // Then
+        assertThat(metricValue).isNull()
+    }
+
+    @Test
+    fun `M return null W resolveMetric(){ view not created }`(forge: Forge) {
+        // Given
+        testedMetric = NetworkSettledMetricResolver(mockInitialResourceIdentifier, mockInternalLogger)
+        val startTimestamp = System.nanoTime()
+        val stopTimestamp = startTimestamp + forge.aLong(min = 1, max = 1000)
+        val fakeResourceId = forge.getForgery<UUID>().toString()
+        testedMetric.resourceWasStarted(InternalResourceContext(fakeResourceId, startTimestamp))
+        testedMetric.resourceWasStopped(InternalResourceContext(fakeResourceId, stopTimestamp))
+
+        // When
+        val metricValue = testedMetric.resolveMetric()
+
+        // Then
+        assertThat(metricValue).isNull()
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.DEBUG,
+            InternalLogger.Target.MAINTAINER,
+            "[ViewNetworkSettledMetric] There was no view created yet for this resource"
+        )
+    }
+
+    @Test
+    fun `M pass the viewCreatedTimestamp to validator W resourceWasStarted()`(forge: Forge) {
+        // Given
+        testedMetric = NetworkSettledMetricResolver(mockInitialResourceIdentifier, mockInternalLogger)
+        val startTimestamp = System.nanoTime()
+        val expectedViewCreatedTimestamp: Long?
+        if (forge.aBool()) {
+            testedMetric.viewWasCreated(fakeViewStartTime)
+            expectedViewCreatedTimestamp = fakeViewStartTime
+        } else {
+            expectedViewCreatedTimestamp = null
+        }
+        val fakeResourceId = forge.getForgery<UUID>().toString()
+
+        // When
+        testedMetric.resourceWasStarted(InternalResourceContext(fakeResourceId, startTimestamp))
+
+        // Then
+        verify(mockInitialResourceIdentifier).validate(
+            NetworkSettledResourceContext(
+                fakeResourceId,
+                startTimestamp,
+                expectedViewCreatedTimestamp
+            )
+        )
+    }
+
+    @Test
+    fun `M return null W resolveMetric(){ not all resources settled }`(forge: Forge) {
+        // Given
+        val startTimestamps = forge.forgeStartTimestamps(size = forge.anInt(min = 4, max = 10))
+        val stopTimestamps = startTimestamps.mapToStopTimestamps(forge)
+        val fakeResourcesIds = forge.aList(size = startTimestamps.size) {
+            forge.getForgery<UUID>().toString()
+        }
+        fakeResourcesIds.forEachIndexed { index, id ->
+            testedMetric.resourceWasStarted(
+                InternalResourceContext(id, startTimestamps[index])
+            )
+        }
+        fakeResourcesIds.take(forge.anInt(min = 1, max = fakeResourcesIds.size / 2))
+            .forEachIndexed { index, fakeResourceContext ->
+                testedMetric.resourceWasStopped(
+                    InternalResourceContext(fakeResourceContext, stopTimestamps[index])
+                )
+            }
+
+        // When
+        val metricValue = testedMetric.resolveMetric()
+
+        // Then
+        assertThat(metricValue).isNull()
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.DEBUG,
+            InternalLogger.Target.MAINTAINER,
+            "[ViewNetworkSettledMetric] Not all the initial resources were stopped for this view"
+        )
+    }
+
+    @Test
+    fun `M return null W resolveMetric(){ view was stopped, not all resources settled }`(forge: Forge) {
+        // Given
+        val startTimestamps = forge.forgeStartTimestamps(size = forge.anInt(min = 4, max = 10))
+        val stopTimestamps = startTimestamps.mapToStopTimestamps(forge)
+        val fakeResourcesIds = forge.aList(size = startTimestamps.size) {
+            forge.getForgery<UUID>().toString()
+        }
+        fakeResourcesIds.forEachIndexed { index, id ->
+            testedMetric.resourceWasStarted(
+                InternalResourceContext(id, startTimestamps[index])
+            )
+        }
+        val stoppedResourcesBeforeViewStopped =
+            fakeResourcesIds.take(forge.anInt(min = 1, max = fakeResourcesIds.size / 2))
+        val stoppedResourcesAfterViewStopped =
+            fakeResourcesIds.takeLast(fakeResourcesIds.size / 2)
+        stoppedResourcesBeforeViewStopped.forEachIndexed { index, fakeResourceContext ->
+            testedMetric.resourceWasStopped(InternalResourceContext(fakeResourceContext, stopTimestamps[index]))
+        }
+        testedMetric.viewWasStopped()
+        stoppedResourcesAfterViewStopped.forEachIndexed { index, fakeResourceContext ->
+            testedMetric.resourceWasStopped(InternalResourceContext(fakeResourceContext, stopTimestamps[index]))
+        }
+
+        // When
+        val metricValue = testedMetric.resolveMetric()
+
+        // Then
+        assertThat(metricValue).isNull()
+    }
+
+    @Test
+    fun `M return last value W resolveMetric(){ view was stopped, all resources settled }`(forge: Forge) {
+        // Given
+        val startTimestamps = forge.forgeStartTimestamps()
+        val stopTimestamps = startTimestamps.mapToStopTimestamps(forge)
+        val settledIntervals = stopTimestamps.mapToSettledIntervals()
+        val expectedMetricValue = settledIntervals.max()
+        val fakeResourcesIds = forge.aList(size = startTimestamps.size) {
+            forge.getForgery<UUID>().toString()
+        }
+        fakeResourcesIds.forEachIndexed { index, id ->
+            testedMetric.resourceWasStarted(
+                InternalResourceContext(id, startTimestamps[index])
+            )
+            testedMetric.resourceWasStopped(
+                InternalResourceContext(id, stopTimestamps[index])
+            )
+        }
+        testedMetric.resolveMetric()
+
+        // When
+        testedMetric.viewWasStopped()
+        val afterViewStoppedMetricValue = testedMetric.resolveMetric()
+
+        // Then
+        assertThat(afterViewStoppedMetricValue).isEqualTo(expectedMetricValue)
+    }
+
+    @Test
+    fun `M return null W resolveMetric(){ no resource was validated }`(forge: Forge) {
+        // Given
+        val startTimestamps = forge.forgeStartTimestamps()
+        whenever(mockInitialResourceIdentifier.validate(any())).thenReturn(false)
+        val stopTimestamps = startTimestamps.mapToStopTimestamps(forge)
+        val fakeResourcesIds = forge.aList(size = startTimestamps.size) {
+            forge.getForgery<UUID>().toString()
+        }
+        fakeResourcesIds.forEachIndexed { index, id ->
+            testedMetric.resourceWasStarted(
+                InternalResourceContext(id, startTimestamps[index])
+            )
+            testedMetric.resourceWasStopped(
+                InternalResourceContext(id, stopTimestamps[index])
+            )
+        }
+        // When
+        val metricValue = testedMetric.resolveMetric()
+
+        // Then
+        assertThat(metricValue).isNull()
+    }
+
+    @Test
+    fun `M return null W resolveMetric(){ resource was stopped with a different id }`(forge: Forge) {
+        // Given
+        val startTimestamp = System.nanoTime()
+        val stopTimestamp = startTimestamp + forge.aLong(min = 1, max = 1000)
+        val fakeResourceContext = forge.getForgery<InternalResourceContext>()
+        val fakeDifferentResourceContext = forge.getForgery<InternalResourceContext>()
+        testedMetric.resourceWasStarted(InternalResourceContext(fakeResourceContext.resourceId, startTimestamp))
+        testedMetric.resourceWasStopped(
+            InternalResourceContext(
+                fakeDifferentResourceContext.resourceId,
+                stopTimestamp
+            )
+        )
+
+        // When
+        val metricValue = testedMetric.resolveMetric()
+
+        // Then
+        assertThat(metricValue).isNull()
+    }
+
+    // endregion
+
+    // region thread visibility
+
+    @Test
+    fun `M return the correct metric W resolveMetric(){ resource started in one Thread and continued in another }`(
+        forge: Forge
+    ) {
+        // Given
+        val startTimestamp = System.nanoTime()
+        val stopTimestamp = startTimestamp + forge.aLong(min = 1, max = 1000)
+        val fakeResourceContext = forge.getForgery<InternalResourceContext>()
+        val thread1 = Thread {
+            testedMetric.resourceWasStarted(
+                InternalResourceContext(
+                    fakeResourceContext.resourceId,
+                    startTimestamp
+                )
+            )
+        }
+        thread1.start()
+        thread1.join()
+        val thread2 = Thread {
+            testedMetric.resourceWasStopped(
+                InternalResourceContext(
+                    fakeResourceContext.resourceId,
+                    stopTimestamp
+                )
+            )
+        }
+        thread2.start()
+        thread2.join()
+
+        // When
+        val metricValue = testedMetric.resolveMetric()
+
+        // Then
+        assertThat(metricValue).isEqualTo(stopTimestamp - fakeViewStartTime)
+    }
+
+    @Test
+    fun `M return the correct metric W resolveMetric(){ view stopped in one thread and metric requested in another }`(
+        forge: Forge
+    ) {
+        // Given
+        val startTimestamp = System.nanoTime()
+        val stopTimestamp = startTimestamp + forge.aLong(min = 1, max = 1000)
+        val fakeResourceContext = forge.getForgery<InternalResourceContext>()
+        val thread1 = Thread {
+            testedMetric.resourceWasStarted(
+                InternalResourceContext(
+                    fakeResourceContext.resourceId,
+                    startTimestamp
+                )
+            )
+        }
+        thread1.start()
+        thread1.join()
+        val thread2 = Thread {
+            testedMetric.viewWasStopped()
+        }
+        thread2.start()
+        thread2.join()
+        testedMetric.resourceWasStopped(
+            InternalResourceContext(
+                fakeResourceContext.resourceId,
+                stopTimestamp
+            )
+        )
+
+        // When
+        val metricValue = testedMetric.resolveMetric()
+
+        // Then
+        assertThat(metricValue).isNull()
+    }
+
+    @Test
+    fun `M return the correct metric W resolveMetric(){ metric computed in one thread, stopped in another}`(
+        forge: Forge
+    ) {
+        // Given
+        val startTimestamp = System.nanoTime()
+        val stopTimestamp = startTimestamp + forge.aLong(min = 1, max = 1000)
+        val fakeResourceContext = forge.getForgery<InternalResourceContext>()
+        val thread1 = Thread {
+            testedMetric.resourceWasStarted(
+                InternalResourceContext(
+                    fakeResourceContext.resourceId,
+                    startTimestamp
+                )
+            )
+            testedMetric.resourceWasStopped(
+                InternalResourceContext(
+                    fakeResourceContext.resourceId,
+                    stopTimestamp
+                )
+            )
+            testedMetric.resolveMetric()
+        }
+        thread1.start()
+        thread1.join()
+        val thread2 = Thread {
+            testedMetric.viewWasStopped()
+        }
+        thread2.start()
+        thread2.join()
+
+        // When
+        val metricValue = testedMetric.resolveMetric()
+
+        // Then
+        assertThat(metricValue).isEqualTo(stopTimestamp - fakeViewStartTime)
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun Forge.forgeStartTimestamps(size: Int = anInt(min = 1, max = 10)) = aList(size = size) {
+        System.nanoTime() + aLong(min = 1, max = 1000)
+    }
+
+    private fun List<Long>.mapToSettledIntervals(): List<Long> {
+        return map { it - fakeViewStartTime }
+    }
+
+    private fun List<Long>.mapToStopTimestamps(forge: Forge): List<Long> {
+        // just to avoid overloads we are using small offsets here
+        return map { it + forge.aLong(min = 1, max = 1000) }
+    }
+
+    // endregion
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/networksettled/TimeRequestBasedValidatorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/networksettled/TimeRequestBasedValidatorTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.metric.networksettled
+
+import com.datadog.android.rum.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+
+@Extensions(
+    ExtendWith(ForgeExtension::class)
+)
+@ForgeConfiguration(Configurator::class)
+internal class TimeRequestBasedValidatorTest {
+
+    private lateinit var testedValidator: TimeBasedInitialResourceIdentifier
+
+    @Forgery
+    lateinit var fakeNetworkSettledResourceContext: NetworkSettledResourceContext
+
+    private var fakeIntervalThreshold: Long = 0L
+    private var fakeViewCreatedTimestamp: Long = 0L
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        fakeViewCreatedTimestamp = forge.aTinyPositiveLong()
+        fakeIntervalThreshold = forge.aTinyPositiveLong()
+        fakeNetworkSettledResourceContext =
+            fakeNetworkSettledResourceContext.copy(
+                viewCreatedTimestamp = fakeViewCreatedTimestamp
+            )
+        testedValidator = TimeBasedInitialResourceIdentifier(fakeIntervalThreshold)
+    }
+
+    // region Tests
+
+    @Test
+    fun `M return false W viewCreatedTimestamp is null`() {
+        // Given
+        fakeNetworkSettledResourceContext = fakeNetworkSettledResourceContext.copy(viewCreatedTimestamp = null)
+
+        // When
+        val result = testedValidator.validate(fakeNetworkSettledResourceContext)
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `M return false W resource started after the threshold`(forge: Forge) {
+        // Given
+        fakeNetworkSettledResourceContext =
+            fakeNetworkSettledResourceContext.copy(
+                eventCreatedAtNanos =
+                fakeViewCreatedTimestamp + fakeIntervalThreshold + forge.aTinyPositiveLong()
+            )
+
+        // When
+        val result = testedValidator.validate(fakeNetworkSettledResourceContext)
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `M return true W resource started before the threshold`(forge: Forge) {
+        // Given
+        fakeNetworkSettledResourceContext =
+            fakeNetworkSettledResourceContext.copy(
+                eventCreatedAtNanos =
+                fakeViewCreatedTimestamp + forge.aLong(min = 0, max = fakeIntervalThreshold)
+            )
+
+        // When
+        val result = testedValidator.validate(fakeNetworkSettledResourceContext)
+
+        // Then
+        assertThat(result).isTrue()
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun Forge.aTinyPositiveLong(): Long {
+        return aLong(min = 1, max = 100000)
+    }
+
+    // endregion
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
@@ -45,6 +45,8 @@ internal class Configurator : BaseConfigurator() {
         forge.addFactory(ViewEventMetaForgeryFactory())
         forge.addFactory(RumScopeKeyForgeryFactory())
         forge.addFactory(ResourceIdForgeryFactory())
+        forge.addFactory(InternalResourceContextFactory())
+        forge.addFactory(NetworkSettledResourceContextFactory())
 
         // Telemetry schema models
         forge.addFactory(TelemetryDebugEventForgeryFactory())

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/InternalResourceContextFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/InternalResourceContextFactory.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.utils.forge
+
+import com.datadog.android.rum.internal.metric.networksettled.InternalResourceContext
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.util.UUID
+
+internal class InternalResourceContextFactory : ForgeryFactory<InternalResourceContext> {
+
+    override fun getForgery(forge: Forge): InternalResourceContext {
+        return InternalResourceContext(
+            resourceId = forge.getForgery<UUID>().toString(),
+            eventCreatedAtNanos = forge.aPositiveLong()
+        )
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/NetworkSettledResourceContextFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/NetworkSettledResourceContextFactory.kt
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.utils.forge
+
+import com.datadog.android.rum.internal.metric.networksettled.NetworkSettledResourceContext
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.util.UUID
+
+internal class NetworkSettledResourceContextFactory : ForgeryFactory<NetworkSettledResourceContext> {
+
+    override fun getForgery(forge: Forge): NetworkSettledResourceContext {
+        return NetworkSettledResourceContext(
+            resourceId = forge.getForgery<UUID>().toString(),
+            eventCreatedAtNanos = forge.aPositiveLong(),
+            viewCreatedTimestamp = forge.aNullable { aPositiveLong() }
+        )
+    }
+}


### PR DESCRIPTION
### What does this PR do?

In this PR we are adding the logic for resolving the newly introduced `Time To Network Settled` out-of-the-box view loading metric.
**Start**: Begins with RUM ViewScope initialization.
**End**: Tied to the end of the last resource load that commenced in the initial 100ms window or defined by the given strategy in the configuration. In case the application went into background or a new view started by the time the initial resources finished loading we will not report this metric for that specific view. In general this could be phrased as:
in case the view was stopped before all the resources were loaded we will not report this metric.

```mermaid
gantt
    title Timeline for Time-to-Network-Settled
    dateFormat  HH:mm:ss
    section Time-to-Network-Settled
    View Becomes Visible: des1, 00:00:00, 00:00:00:100  
    Network request :done, des2, 00:00:01, 00:00:02
    Network request :done, des3, 00:00:01, 00:00:04
    Network request :done, des4, 00:00:03, 00:00:06
    100ms limit: after des4, 00:00:04
    Time-to-Network-Settled Interval :active, des5, 00:00:00, 00:00:06
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

