### PR TITLE
Add Navigation view tracking in benchmark Compose application

### DIFF
--- a/sample/benchmark/build.gradle.kts
+++ b/sample/benchmark/build.gradle.kts
@@ -94,6 +94,7 @@ dependencies {
     implementation(project(":features:dd-sdk-android-session-replay"))
     implementation(project(":features:dd-sdk-android-session-replay-material"))
     implementation(project(":features:dd-sdk-android-session-replay-compose"))
+    implementation(project(":integrations:dd-sdk-android-compose"))
     implementation(project(":tools:benchmark"))
 
     testImplementation(libs.bundles.jUnit5)

--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/compose/MainView.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/compose/MainView.kt
@@ -30,12 +30,16 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.datadog.android.BuildConfig
+import com.datadog.android.compose.ExperimentalTrackingApi
+import com.datadog.android.compose.NavigationViewTrackingEffect
+import com.datadog.android.rum.tracking.AcceptAllNavDestinations
 
 @Composable
 internal fun MainView() {
     AppScaffold()
 }
 
+@OptIn(ExperimentalTrackingApi::class)
 @Composable
 internal fun AppScaffold() {
     val navController = rememberNavController()
@@ -53,6 +57,11 @@ internal fun AppScaffold() {
             BottomNavigationBar(navHostController = navController)
         }
     ) { padding ->
+        NavigationViewTrackingEffect(
+            navController = navController,
+            trackArguments = true,
+            destinationPredicate = AcceptAllNavDestinations()
+        )
         NavHost(
             navController = navController,
             startDestination = Screen.Text.route,


### PR DESCRIPTION
### What does this PR do?

In Benchmark application, prior to this PR we don't send any `view` type Rum event when navigating between compose view, this leads to Rum session `has_replay` is always false even if in local it's already true. And on the player side we don't have a replay for the session for very long time.

Adding Navigation view tracking for compose can make the Rum view event sent correctly, and `has_replay` attribute will be earlier refreshed to true.


### Demo

| Before | After |
| --- | --- |
|<img width="773" alt="image" src="https://github.com/user-attachments/assets/d5e5984f-3108-41ba-b60c-ab87aed8e45d"> |.<img width="779" alt="image" src="https://github.com/user-attachments/assets/27709771-27d4-4a0a-a635-be011df14255">|


Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

