### PR TITLE
RUM-7215: Add AndroidComposeViewMapper to support popup

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/ComposeExtensionSupport.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/ComposeExtensionSupport.kt
@@ -4,12 +4,17 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
+@file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+
 package com.datadog.android.sessionreplay.compose
 
+import androidx.compose.ui.platform.AndroidComposeView
 import androidx.compose.ui.platform.ComposeView
 import com.datadog.android.sessionreplay.ExtensionSupport
 import com.datadog.android.sessionreplay.MapperTypeWrapper
-import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.SemanticsWireframeMapper
+import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.AndroidComposeViewMapper
+import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.ComposeViewMapper
+import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.RootSemanticsNodeMapper
 import com.datadog.android.sessionreplay.recorder.OptionSelectorDetector
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
 import com.datadog.android.sessionreplay.utils.DefaultColorStringFormatter
@@ -30,16 +35,28 @@ class ComposeExtensionSupport : ExtensionSupport {
     private val colorStringFormatter: ColorStringFormatter = DefaultColorStringFormatter
     private val viewBoundsResolver: ViewBoundsResolver = DefaultViewBoundsResolver
     private val drawableToColorMapper: DrawableToColorMapper = DrawableToColorMapper.getDefault()
+    private val rootSemanticsNodeMapper = RootSemanticsNodeMapper(colorStringFormatter)
 
     override fun getCustomViewMappers(): List<MapperTypeWrapper<*>> {
         return listOf(
             MapperTypeWrapper(
                 ComposeView::class.java,
-                SemanticsWireframeMapper(
+                ComposeViewMapper(
                     viewIdentifierResolver,
                     colorStringFormatter,
                     viewBoundsResolver,
-                    drawableToColorMapper
+                    drawableToColorMapper,
+                    rootSemanticsNodeMapper = rootSemanticsNodeMapper
+                )
+            ),
+            MapperTypeWrapper(
+                AndroidComposeView::class.java,
+                AndroidComposeViewMapper(
+                    viewIdentifierResolver,
+                    colorStringFormatter,
+                    viewBoundsResolver,
+                    drawableToColorMapper,
+                    rootSemanticsNodeMapper
                 )
             )
         )

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AndroidComposeViewMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AndroidComposeViewMapper.kt
@@ -1,0 +1,53 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+@file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+
+package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
+
+import androidx.compose.ui.platform.AndroidComposeView
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.recorder.MappingContext
+import com.datadog.android.sessionreplay.recorder.mapper.BaseWireframeMapper
+import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
+import com.datadog.android.sessionreplay.utils.ColorStringFormatter
+import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
+import com.datadog.android.sessionreplay.utils.ViewBoundsResolver
+import com.datadog.android.sessionreplay.utils.ViewIdentifierResolver
+
+internal class AndroidComposeViewMapper(
+    viewIdentifierResolver: ViewIdentifierResolver,
+    colorStringFormatter: ColorStringFormatter,
+    viewBoundsResolver: ViewBoundsResolver,
+    drawableToColorMapper: DrawableToColorMapper,
+    private val rootSemanticsNodeMapper: RootSemanticsNodeMapper
+) : BaseWireframeMapper<AndroidComposeView>(
+    viewIdentifierResolver,
+    colorStringFormatter,
+    viewBoundsResolver,
+    drawableToColorMapper
+) {
+    override fun map(
+        view: AndroidComposeView,
+        mappingContext: MappingContext,
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
+    ): List<MobileSegment.Wireframe> {
+        val density =
+            mappingContext.systemInformation.screenDensity.let { if (it == 0.0f) 1.0f else it }
+        // TODO RUM-6192: Apply FGM for compose
+        val privacy = SessionReplayPrivacy.ALLOW
+        return rootSemanticsNodeMapper.createComposeWireframes(
+            view.semanticsOwner.unmergedRootSemanticsNode,
+            density,
+            mappingContext,
+            privacy,
+            asyncJobStatusCallback
+        )
+    }
+}

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapper.kt
@@ -1,0 +1,55 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
+
+import androidx.compose.ui.platform.ComposeView
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.recorder.MappingContext
+import com.datadog.android.sessionreplay.recorder.mapper.BaseWireframeMapper
+import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
+import com.datadog.android.sessionreplay.utils.ColorStringFormatter
+import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
+import com.datadog.android.sessionreplay.utils.ViewBoundsResolver
+import com.datadog.android.sessionreplay.utils.ViewIdentifierResolver
+
+internal class ComposeViewMapper(
+    viewIdentifierResolver: ViewIdentifierResolver,
+    colorStringFormatter: ColorStringFormatter,
+    viewBoundsResolver: ViewBoundsResolver,
+    drawableToColorMapper: DrawableToColorMapper,
+    private val semanticsUtils: SemanticsUtils = SemanticsUtils(),
+    private val rootSemanticsNodeMapper: RootSemanticsNodeMapper
+) : BaseWireframeMapper<ComposeView>(
+    viewIdentifierResolver,
+    colorStringFormatter,
+    viewBoundsResolver,
+    drawableToColorMapper
+) {
+    override fun map(
+        view: ComposeView,
+        mappingContext: MappingContext,
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
+    ): List<MobileSegment.Wireframe> {
+        val density =
+            mappingContext.systemInformation.screenDensity.let { if (it == 0.0f) 1.0f else it }
+        // TODO RUM-6192: Apply FGM for compose
+        val privacy = SessionReplayPrivacy.ALLOW
+        return semanticsUtils.findRootSemanticsNode(view)?.let { node ->
+            rootSemanticsNodeMapper.createComposeWireframes(
+                node,
+                density,
+                mappingContext,
+                privacy,
+                asyncJobStatusCallback
+            )
+        } ?: emptyList()
+    }
+}

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/ComposeExtensionSupportTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/ComposeExtensionSupportTest.kt
@@ -8,7 +8,7 @@ package com.datadog.android.sessionreplay.compose
 
 import androidx.compose.ui.platform.ComposeView
 import com.datadog.android.sessionreplay.ExtensionSupport
-import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.SemanticsWireframeMapper
+import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.ComposeViewMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -41,7 +41,7 @@ class ComposeExtensionSupportTest {
 
         // Then
         val composeMapper = customMappers.firstOrNull { it.supportsView(mockView) }?.getUnsafeMapper()
-        assertThat(composeMapper).isInstanceOf(SemanticsWireframeMapper::class.java)
+        assertThat(composeMapper).isInstanceOf(ComposeViewMapper::class.java)
     }
 
     @Test

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapperTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
+
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsConfiguration
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
+import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
+import com.datadog.android.sessionreplay.recorder.MappingContext
+import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
+import com.datadog.android.sessionreplay.utils.ColorStringFormatter
+import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
+import com.datadog.android.sessionreplay.utils.ViewBoundsResolver
+import com.datadog.android.sessionreplay.utils.ViewIdentifierResolver
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(SessionReplayComposeForgeConfigurator::class)
+class ComposeViewMapperTest {
+
+    @Mock
+    private lateinit var mockRootSemanticsNodeMapper: RootSemanticsNodeMapper
+
+    @Mock
+    private lateinit var mockViewIdentifierResolver: ViewIdentifierResolver
+
+    @Mock
+    private lateinit var mockColorStringFormatter: ColorStringFormatter
+
+    @Mock
+    private lateinit var mockViewBoundsResolver: ViewBoundsResolver
+
+    @Mock
+    private lateinit var mockDrawableToColorMapper: DrawableToColorMapper
+
+    @Mock
+    private lateinit var mockView: ComposeView
+
+    @Mock
+    private lateinit var mockAsyncJobStatusCallback: AsyncJobStatusCallback
+
+    @Mock
+    private lateinit var mockInternalLogger: InternalLogger
+
+    @Mock
+    private lateinit var mockSemanticsUtils: SemanticsUtils
+
+    @Mock
+    private lateinit var mockSemanticsConfiguration: SemanticsConfiguration
+
+    @Forgery
+    private lateinit var fakeMappingContext: MappingContext
+
+    private lateinit var testedComposeViewMapper: ComposeViewMapper
+
+    @BeforeEach
+    fun `set up`() {
+        testedComposeViewMapper = ComposeViewMapper(
+            mockViewIdentifierResolver,
+            mockColorStringFormatter,
+            mockViewBoundsResolver,
+            mockDrawableToColorMapper,
+            mockSemanticsUtils,
+            mockRootSemanticsNodeMapper
+        )
+    }
+
+    @Test
+    fun `M invoke rootSemanticsNodeMapper createComposeWireframes W map`() {
+        // Given
+        val mockSemanticsNode = mockSemanticsNode(null)
+        whenever(mockSemanticsUtils.findRootSemanticsNode(mockView)).thenReturn(mockSemanticsNode)
+
+        // When
+        testedComposeViewMapper.map(
+            mockView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
+
+        // Then
+        verify(mockRootSemanticsNodeMapper).createComposeWireframes(
+            mockSemanticsNode,
+            fakeMappingContext.systemInformation.screenDensity,
+            fakeMappingContext,
+            SessionReplayPrivacy.ALLOW,
+            mockAsyncJobStatusCallback
+        )
+    }
+
+    private fun mockSemanticsNode(role: Role?): SemanticsNode {
+        return mock {
+            whenever(mockSemanticsConfiguration.getOrNull(SemanticsProperties.Role)) doReturn role
+            whenever(it.config) doReturn mockSemanticsConfiguration
+        }
+    }
+}

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapperTest.kt
@@ -1,0 +1,216 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
+
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsConfiguration
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
+import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
+import com.datadog.android.sessionreplay.recorder.MappingContext
+import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
+import com.datadog.android.sessionreplay.utils.ColorStringFormatter
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(SessionReplayComposeForgeConfigurator::class)
+class RootSemanticsNodeMapperTest {
+
+    @Mock
+    private lateinit var mockContainerSemanticsNodeMapper: ContainerSemanticsNodeMapper
+
+    @Mock
+    private lateinit var mockTextSemanticsNodeMapper: TextSemanticsNodeMapper
+
+    @Mock
+    private lateinit var mockColorStringFormatter: ColorStringFormatter
+
+    @Mock
+    private lateinit var mockAsyncJobStatusCallback: AsyncJobStatusCallback
+
+    @Mock
+    private lateinit var mockSemanticsUtils: SemanticsUtils
+
+    @Mock
+    private lateinit var mockRadioButtonSemanticsNodeMapper: RadioButtonSemanticsNodeMapper
+
+    @Mock
+    private lateinit var mockTabSemanticsNodeMapper: TabSemanticsNodeMapper
+
+    @Mock
+    private lateinit var mockButtonSemanticsNodeMapper: ButtonSemanticsNodeMapper
+
+    @Mock
+    private lateinit var mockImageSemanticsNodeMapper: ImageSemanticsNodeMapper
+
+    @Mock
+    private lateinit var mockSemanticsConfiguration: SemanticsConfiguration
+
+    @Forgery
+    private lateinit var fakeMappingContext: MappingContext
+
+    @Forgery
+    private lateinit var fakePrivacy: SessionReplayPrivacy
+
+    private lateinit var testedRootSemanticsNodeMapper: RootSemanticsNodeMapper
+
+    @BeforeEach
+    fun `set up`() {
+        testedRootSemanticsNodeMapper = RootSemanticsNodeMapper(
+            colorStringFormatter = mockColorStringFormatter,
+            semanticsUtils = mockSemanticsUtils,
+            semanticsNodeMapper = mapOf(
+                Role.RadioButton to mockRadioButtonSemanticsNodeMapper,
+                Role.Tab to mockTabSemanticsNodeMapper,
+                Role.Button to mockButtonSemanticsNodeMapper,
+                Role.Image to mockImageSemanticsNodeMapper
+            ),
+            textSemanticsNodeMapper = mockTextSemanticsNodeMapper,
+            containerSemanticsNodeMapper = mockContainerSemanticsNodeMapper
+        )
+    }
+
+    @Test
+    fun `M use ContainerSemanticsNodeMapper W map { role is missing }`() {
+        // Given
+        val mockSemanticsNode = mockSemanticsNode(null)
+
+        // When
+        testedRootSemanticsNodeMapper.createComposeWireframes(
+            mockSemanticsNode,
+            fakeMappingContext.systemInformation.screenDensity,
+            fakeMappingContext,
+            fakePrivacy,
+            mockAsyncJobStatusCallback
+        )
+
+        // Then
+        verify(mockContainerSemanticsNodeMapper).map(
+            eq(mockSemanticsNode),
+            any(),
+            eq(mockAsyncJobStatusCallback)
+        )
+    }
+
+    @Test
+    fun `M use ButtonSemanticsNodeMapper W map { role is Button }`() {
+        // Given
+        val mockSemanticsNode = mockSemanticsNode(Role.Button)
+
+        // When
+        testedRootSemanticsNodeMapper.createComposeWireframes(
+            mockSemanticsNode,
+            fakeMappingContext.systemInformation.screenDensity,
+            fakeMappingContext,
+            fakePrivacy,
+            mockAsyncJobStatusCallback
+        )
+
+        // Then
+        verify(mockButtonSemanticsNodeMapper).map(
+            eq(mockSemanticsNode),
+            any(),
+            eq(mockAsyncJobStatusCallback)
+        )
+    }
+
+    @Test
+    fun `M use RadioButtonSemanticsNodeMapper W map { role is RadioButton }`() {
+        // Given
+        val mockSemanticsNode = mockSemanticsNode(Role.RadioButton)
+
+        // When
+        testedRootSemanticsNodeMapper.createComposeWireframes(
+            mockSemanticsNode,
+            fakeMappingContext.systemInformation.screenDensity,
+            fakeMappingContext,
+            fakePrivacy,
+            mockAsyncJobStatusCallback
+        )
+
+        // Then
+        verify(mockRadioButtonSemanticsNodeMapper).map(
+            eq(mockSemanticsNode),
+            any(),
+            eq(mockAsyncJobStatusCallback)
+        )
+    }
+
+    @Test
+    fun `M use TabSemanticsNodeMapper W map { role is Tab }`() {
+        // Given
+        val mockSemanticsNode = mockSemanticsNode(Role.Tab)
+
+        // When
+        testedRootSemanticsNodeMapper.createComposeWireframes(
+            mockSemanticsNode,
+            fakeMappingContext.systemInformation.screenDensity,
+            fakeMappingContext,
+            fakePrivacy,
+            mockAsyncJobStatusCallback
+        )
+
+        // Then
+        verify(mockTabSemanticsNodeMapper).map(
+            eq(mockSemanticsNode),
+            any(),
+            eq(mockAsyncJobStatusCallback)
+        )
+    }
+
+    @Test
+    fun `M use ImageSemanticsNodeMapper W map { role is Image }`() {
+        // Given
+        val mockSemanticsNode = mockSemanticsNode(Role.Image)
+
+        // When
+        testedRootSemanticsNodeMapper.createComposeWireframes(
+            mockSemanticsNode,
+            fakeMappingContext.systemInformation.screenDensity,
+            fakeMappingContext,
+            fakePrivacy,
+            mockAsyncJobStatusCallback
+        )
+
+        // Then
+        verify(mockImageSemanticsNodeMapper).map(
+            eq(mockSemanticsNode),
+            any(),
+            eq(mockAsyncJobStatusCallback)
+        )
+    }
+
+    private fun mockSemanticsNode(role: Role?): SemanticsNode {
+        return mock {
+            whenever(mockSemanticsConfiguration.getOrNull(SemanticsProperties.Role)) doReturn role
+            whenever(it.config) doReturn mockSemanticsConfiguration
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR do?

In Jetpack compose, if the composable content is added by `setContent{  }` in the activity, then the wrapper view is `ComposeView`, but for the pop up like bottom sheet dialog or Drop down menu, they use `AndroidComposeView` as the wrapper in a separated `DecorView`.

So we need to support `AndroidComposeView` mapping otherwise the Session Replay can not resolve any content in the popup decor view.

In this PR, a small refactor is done in order to share the common logic between `ComposeViewMapper` and `AndroidComposeViewMapper`, here is the structure change:

![image](https://github.com/user-attachments/assets/23713f42-1cca-4639-bdea-6e6f5bd7f0e7)
 

### Motivation

RUM-7215

### Replay Demo

Known issue in demo:
Drop down menu doesn't have the correct position in replay

https://mobile-integration.datadoghq.com/rum/replay/sessions/26a23f05-aa91-427e-9f77-4b3457ac4ba2?applicationId=38030dde-f9f9-4e52-9443-b9804a030080&seed=029b6a93-9744-4fa8-84fe-b166b9a163fe&ts=1731675244745

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

