### PR TITLE
Fix crash while using recycled bitmap in Session Replay

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/wrappers/BitmapWrapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/wrappers/BitmapWrapper.kt
@@ -36,6 +36,7 @@ internal class BitmapWrapper(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     internal fun createScaledBitmap(
         src: Bitmap,
         dstWidth: Int,
@@ -51,6 +52,16 @@ internal class BitmapWrapper(
             logger.log(
                 level = InternalLogger.Level.ERROR,
                 target = InternalLogger.Target.MAINTAINER,
+                { FAILED_TO_CREATE_SCALED_BITMAP },
+                e
+            )
+            null
+        } catch (e: RuntimeException) {
+            // It's still possible that RuntimeException is thrown after checking the bitmap
+            // is not recycled.
+            logger.log(
+                level = InternalLogger.Level.ERROR,
+                target = InternalLogger.Target.USER,
                 { FAILED_TO_CREATE_SCALED_BITMAP },
                 e
             )


### PR DESCRIPTION
### What does this PR do?

A client reported SDK crash with stack trace:
```
Fatal Exception: java.lang.RuntimeException: Canvas: trying to use a recycled bitmap android.graphics.Bitmap@cad0e02
       at android.graphics.BaseCanvas.throwIfCannotDraw(BaseCanvas.java:83)
       at android.graphics.BaseCanvas.drawBitmap(BaseCanvas.java:174)
       at android.graphics.Canvas.drawBitmap(Canvas.java:1580)
       at android.graphics.Bitmap.createBitmap(Bitmap.java:1008)
       at android.graphics.Bitmap.createScaledBitmap(Bitmap.java:841)
       at com.datadog.android.sessionreplay.internal.recorder.wrappers.BitmapWrapper.createScaledBitmap$dd_sdk_android_session_replay_release(BitmapWrapper.java:46)
       at com.datadog.android.sessionreplay.internal.utils.DrawableUtils.createScaledBitmap$dd_sdk_android_session_replay_release(DrawableUtils.java:93)
       at com.datadog.android.sessionreplay.internal.utils.DrawableUtils.createScaledBitmap$dd_sdk_android_session_replay_release$default(DrawableUtils.java:84)
       at com.datadog.android.sessionreplay.internal.recorder.resources.ResourceResolver.tryToGetBitmapFromBitmapDrawable(ResourceResolver.java:231)
       at com.datadog.android.sessionreplay.internal.recorder.resources.ResourceResolver.createBitmap(ResourceResolver.java:112)
       at com.datadog.android.sessionreplay.internal.recorder.resources.ResourceResolver.resolveResourceId$lambda$0(ResourceResolver.java:76)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
       at java.lang.Thread.run(Thread.java:1012)
```

The reason is probably after checking the bitmap is not recycled, GC happened just before we really use the bitmap, so the it throws this `RuntimeException`.

The fix is that we catch the exception and return null, just ignore this bitmap instead of crashing the app.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

