### PR TITLE
RUM-7291: Integrate benchmark profiler in compose mapper

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-compose/build.gradle.kts
@@ -56,6 +56,7 @@ android {
 
 dependencies {
     api(project(":features:dd-sdk-android-session-replay"))
+    implementation(project(":dd-sdk-android-internal"))
     implementation(libs.kotlin)
     implementation(libs.gson)
 

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/BenchmarkExt.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/BenchmarkExt.kt
@@ -1,0 +1,32 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.utils
+
+import com.datadog.android.internal.profiler.BenchmarkSpan
+import com.datadog.android.internal.profiler.withinBenchmarkSpan
+
+private const val ATTRIBUTE_CONTAINER = "attribute.container"
+private const val ATTRIBUTE_TYPE_KEY = "attribute.type"
+private const val ATTRIBUTE_TYPE_COMPOSE_VALUE = "compose"
+
+/**
+ * A wrap function of [withinComposeBenchmarkSpan] dedicated to session replay span recording.
+ */
+internal inline fun <T : Any?> withinComposeBenchmarkSpan(
+    spanName: String,
+    isContainer: Boolean = false,
+    block: BenchmarkSpan.() -> T
+): T {
+    return withinBenchmarkSpan(
+        spanName,
+        mapOf(
+            ATTRIBUTE_CONTAINER to isContainer.toString(),
+            ATTRIBUTE_TYPE_KEY to ATTRIBUTE_TYPE_COMPOSE_VALUE
+        ),
+        block
+    )
+}


### PR DESCRIPTION
### What does this PR do?

Integrate benchmark profiler to measure the span of Compose Session Replay


### Motivation

RUM-7291

### Demo

Compose part start from `RootNode` span, each component span is name with its mapper:

<img width="1571" alt="image" src="https://github.com/user-attachments/assets/5ece66bf-7076-481b-9e11-71f87bf637c3">


Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

