### PR TITLE
Fix consumer-rules pro for Compose Session Replay

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/consumer-rules.pro
+++ b/features/dd-sdk-android-session-replay-compose/consumer-rules.pro
@@ -20,25 +20,25 @@
 -keep class androidx.compose.ui.node.LayoutNode {
      *;
 }
--keepclassmembers class androidx.compose.ui.semantics.SemanticsNode {
+-keep class androidx.compose.ui.semantics.SemanticsNode {
      <fields>;
 }
--keepclassmembers class androidx.compose.ui.draw.PainterElement {
+-keep class androidx.compose.ui.draw.PainterElement {
      <fields>;
 }
--keepclassmembers class androidx.compose.ui.graphics.vector.VectorPainter {
+-keep class androidx.compose.ui.graphics.vector.VectorPainter {
      <fields>;
 }
--keepclassmembers class androidx.compose.ui.graphics.painter.BitmapPainter {
+-keep class androidx.compose.ui.graphics.painter.BitmapPainter {
      <fields>;
 }
--keepclassmembers class androidx.compose.ui.graphics.vector.VectorComponent {
+-keep class androidx.compose.ui.graphics.vector.VectorComponent {
      <fields>;
 }
--keepclassmembers class androidx.compose.ui.graphics.vector.DrawCache {
+-keep class androidx.compose.ui.graphics.vector.DrawCache {
      <fields>;
 }
--keepclassmembers class androidx.compose.ui.graphics.AndroidImageBitmap {
+-keep class androidx.compose.ui.graphics.AndroidImageBitmap {
      <fields>;
 }
 -keep class coil.compose.ContentPainterModifier {
@@ -47,10 +47,10 @@
 -keep class coil.compose.AsyncImagePainter {
      <fields>;
 }
--keepclassmembers class androidx.compose.foundation.layout.PaddingElement{
+-keep class androidx.compose.foundation.layout.PaddingElement{
     <fields>;
 }
--keepclassmembers class "androidx.compose.ui.graphics.GraphicsLayerElement"{
+-keep class androidx.compose.ui.graphics.GraphicsLayerElement{
     <fields>;
 }
 

--- a/sample/benchmark/build.gradle.kts
+++ b/sample/benchmark/build.gradle.kts
@@ -65,6 +65,8 @@ android {
             isMinifyEnabled = true
             signingConfigs.findByName("release")?.let {
                 signingConfig = it
+            } ?: kotlin.run {
+                signingConfig = signingConfigs.findByName("debug")
             }
         }
     }


### PR DESCRIPTION
### What does this PR do?

`keepclassmembers` can not keep the class itself, which leads to class not found exception during the release mode runtime, so we need to change it to `keep`

### Motivation

Images are missing in the session replay of release benchmark app

https://mobile-integration.datadoghq.com/rum/replay/sessions/baff0c73-9b05-4dd6-8fb2-512b5c8d2a36?applicationId=63e67473-c075-4f15-8891-04e96212f22e&seed=c459ac50-a643-4203-abc3-2e550084b1f0&ts=1731925605609

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

