### PR TITLE
RUM-7302: Align log levels for sr already enabled

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
@@ -106,10 +106,17 @@ object SessionReplay {
     private fun isAlreadyRegistered() =
         currentRegisteredCore?.get()?.isCoreActive() == true
 
-    private fun logAlreadyRegisteredWarning(internalLogger: InternalLogger) =
+    private fun logAlreadyRegisteredWarning(internalLogger: InternalLogger) {
         internalLogger.log(
-            level = InternalLogger.Level.WARN,
-            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER),
             messageBuilder = { IS_ALREADY_REGISTERED_WARNING }
         )
+
+        internalLogger.log(
+            level = InternalLogger.Level.DEBUG,
+            targets = listOf(InternalLogger.Target.TELEMETRY),
+            messageBuilder = { IS_ALREADY_REGISTERED_WARNING }
+        )
+    }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayTest.kt
@@ -156,8 +156,14 @@ internal class SessionReplayTest {
 
         // Then
         mockInternalLogger.verifyLog(
-            level = InternalLogger.Level.WARN,
-            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER),
+            message = IS_ALREADY_REGISTERED_WARNING
+        )
+
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.DEBUG,
+            targets = listOf(InternalLogger.Target.TELEMETRY),
             message = IS_ALREADY_REGISTERED_WARNING
         )
         assertThat(SessionReplay.currentRegisteredCore?.get()).isEqualTo(mockCore1)


### PR DESCRIPTION
### What does this PR do?
Aligns the log levels with iOS for the error we output when a user tries to enable session replay twice (either on the same core or on different cores) - "Session Replay is already enabled"

### Motivation
On iOS they output an error to the user and debug to the telemetry. 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

