### PR TITLE
RUM-7337: Adjust Webview Replay storage configuration limits

### DIFF
--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayFeature.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayFeature.kt
@@ -37,7 +37,7 @@ internal class WebViewReplayFeature(
     }
 
     override val storageConfiguration: FeatureStorageConfiguration =
-        FeatureStorageConfiguration.DEFAULT
+        STORAGE_CONFIGURATION
 
     override fun onStop() {
         dataWriter = NoOpDataWriter()
@@ -55,5 +55,18 @@ internal class WebViewReplayFeature(
 
     companion object {
         internal const val WEB_REPLAY_FEATURE_NAME = "web-replay"
+
+        /**
+         * Storage configuration with the following parameters:
+         * max item size = 10 MB,
+         * max items per batch = 500,
+         * max batch size = 10 MB, SR intake batch limit is 10MB
+         * old batch threshold = 18 hours.
+         */
+        internal val STORAGE_CONFIGURATION: FeatureStorageConfiguration =
+            FeatureStorageConfiguration.DEFAULT.copy(
+                maxItemSize = 10 * 1024 * 1024,
+                maxBatchSize = 10 * 1024 * 1024
+            )
     }
 }

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayFeatureTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayFeatureTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.webview.internal.replay
+
+import android.content.Context
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.api.net.RequestFactory
+import com.datadog.android.api.storage.NoOpDataWriter
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.webview.internal.storage.WebViewDataWriter
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class WebViewReplayFeatureTest {
+
+    private lateinit var testedFeature: WebViewReplayFeature
+
+    @Mock
+    lateinit var mockRequestFactory: RequestFactory
+
+    @Mock
+    lateinit var mockSdkCore: FeatureSdkCore
+
+    @Mock
+    lateinit var mockAppContext: Context
+
+    @BeforeEach
+    fun `set up`() {
+        testedFeature = WebViewReplayFeature(mockSdkCore, mockRequestFactory)
+        whenever(mockSdkCore.internalLogger) doReturn mock()
+    }
+
+    @Test
+    fun `M provide feature name W name()`() {
+        // Then
+        assertThat(testedFeature.name)
+            .isEqualTo(WebViewReplayFeature.WEB_REPLAY_FEATURE_NAME)
+    }
+
+    @Test
+    fun `M provide correct storage configuration W storageConfiguration()`() {
+        // Then
+        assertThat(testedFeature.storageConfiguration)
+            .isEqualTo(WebViewReplayFeature.STORAGE_CONFIGURATION)
+    }
+
+    @Test
+    fun `M unregister writer W onStop()`() {
+        // Given
+        testedFeature.onInitialize(mockAppContext)
+
+        // When
+        testedFeature.onStop()
+
+        // Then
+        assertThat(testedFeature.initialized).isFalse
+        assertThat(testedFeature.dataWriter)
+            .isInstanceOf(NoOpDataWriter::class.java)
+    }
+
+    @Test
+    fun `M initialize writer W initialize()`() {
+        // When
+        testedFeature.onInitialize(mockAppContext)
+
+        // Then
+        assertThat(testedFeature.dataWriter)
+            .isInstanceOf(WebViewDataWriter::class.java)
+        assertThat(testedFeature.initialized).isTrue
+    }
+}


### PR DESCRIPTION
### What does this PR do?
`WebviewReplayFeature` was using the default storage configuration. As a result, events sent by the browser sdk that were larger than 512kb were being rejected rather than written to batch files. This pr adjusts the size limits to align with session replay - 10mb per item and 10mb per batch. 

I also added unit tests for `WebviewReplayFeature` as there didn't seem to be any.

### Motivation
Support ticket where the customer couldn't see their webviews.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

