### PR TITLE
Refactor TextSemanticsNodeMapper to commonize the text wireframe logic

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapper.kt
@@ -9,6 +9,9 @@ package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.text.font.GenericFontFamily
+import androidx.compose.ui.text.style.TextAlign
+import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.utils.BackgroundInfo
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -21,6 +24,11 @@ internal abstract class AbstractSemanticsNodeMapper(
     private val semanticsUtils: SemanticsUtils = SemanticsUtils()
 ) : SemanticsNodeMapper {
 
+    protected val defaultTextStyle = MobileSegment.TextStyle(
+        size = DEFAULT_FONT_SIZE,
+        color = DEFAULT_TEXT_COLOR,
+        family = DEFAULT_FONT_FAMILY
+    )
     protected fun resolveId(semanticsNode: SemanticsNode, currentIndex: Int = 0): Long {
         // Use semantics node intrinsic id as the higher endian of Long type and the index of
         // the wireframe inside the node as the lower endian to generate a unique id.
@@ -63,6 +71,41 @@ internal abstract class AbstractSemanticsNodeMapper(
         )
     }
 
+    protected fun resolveTextLayoutInfoToTextStyle(
+        parentContext: UiContext,
+        textLayoutInfo: TextLayoutInfo
+    ): MobileSegment.TextStyle {
+        return MobileSegment.TextStyle(
+            family = when (val value = textLayoutInfo.fontFamily) {
+                is GenericFontFamily -> value.name
+                else -> DEFAULT_FONT_FAMILY
+            },
+            size = textLayoutInfo.fontSize,
+            color = convertColor(textLayoutInfo.color.toLong()) ?: parentContext.parentContentColor
+                ?: DEFAULT_TEXT_COLOR
+        )
+    }
+
+    protected fun resolveTextAlign(textLayoutInfo: TextLayoutInfo): MobileSegment.TextPosition {
+        val align = when (textLayoutInfo.textAlign) {
+            TextAlign.Start,
+            TextAlign.Left -> MobileSegment.Horizontal.LEFT
+
+            TextAlign.End,
+            TextAlign.Right -> MobileSegment.Horizontal.RIGHT
+
+            TextAlign.Justify,
+            TextAlign.Center -> MobileSegment.Horizontal.CENTER
+
+            else -> MobileSegment.Horizontal.LEFT
+        }
+        return MobileSegment.TextPosition(
+            alignment = MobileSegment.Alignment(
+                horizontal = align
+            )
+        )
+    }
+
     protected fun convertColor(color: Long): String? {
         return if (color == UNSPECIFIED_COLOR) {
             null
@@ -81,5 +124,8 @@ internal abstract class AbstractSemanticsNodeMapper(
         private const val COMPOSE_COLOR_SHIFT = 32
         private const val MAX_ALPHA = 255
         private const val SEMANTICS_ID_BIT_SHIFT = 32
+        private const val DEFAULT_FONT_SIZE = 12L
+        private const val DEFAULT_FONT_FAMILY = "Roboto, sans-serif"
+        protected const val DEFAULT_TEXT_COLOR = "#000000FF"
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextLayoutInfo.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextLayoutInfo.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
+
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
+
+internal data class TextLayoutInfo(
+    val text: String,
+    val color: ULong,
+    val fontSize: Long,
+    val fontFamily: FontFamily?,
+    val textAlign: TextAlign? = TextAlign.Start
+)

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapper.kt
@@ -6,39 +6,39 @@
 
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorProducer
-import androidx.compose.ui.semantics.SemanticsActions
-import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
-import androidx.compose.ui.semantics.getOrNull
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.TextLayoutResult
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.GenericFontFamily
-import androidx.compose.ui.text.style.TextAlign
 import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWireframe
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
-import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection
-import com.datadog.android.sessionreplay.compose.internal.reflection.getSafe
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
 
-internal class TextSemanticsNodeMapper(
+internal open class TextSemanticsNodeMapper(
     colorStringFormatter: ColorStringFormatter,
-    semanticsUtils: SemanticsUtils = SemanticsUtils()
+    private val semanticsUtils: SemanticsUtils = SemanticsUtils()
 ) : AbstractSemanticsNodeMapper(colorStringFormatter, semanticsUtils) {
+
     override fun map(
         semanticsNode: SemanticsNode,
         parentContext: UiContext,
         asyncJobStatusCallback: AsyncJobStatusCallback
     ): SemanticsWireframe {
-        val text = resolveText(semanticsNode.config)
-        val textStyle = resolveTextStyle(semanticsNode, parentContext) ?: defaultTextStyle
+        val textWireframe = resolveTextWireFrame(parentContext, semanticsNode)
+        return SemanticsWireframe(
+            wireframes = listOfNotNull(textWireframe),
+            parentContext
+        )
+    }
+
+    protected fun resolveTextWireFrame(
+        parentContext: UiContext,
+        semanticsNode: SemanticsNode
+    ): MobileSegment.Wireframe.TextWireframe? {
+        val textLayoutInfo = semanticsUtils.resolveTextLayoutInfo(semanticsNode)
+        val capturedText = textLayoutInfo?.text
         val bounds = resolveBounds(semanticsNode)
-        val textWireframe = text?.let {
+        return capturedText?.let { text ->
             MobileSegment.Wireframe.TextWireframe(
                 id = semanticsNode.id.toLong(),
                 x = bounds.x,
@@ -46,112 +46,18 @@ internal class TextSemanticsNodeMapper(
                 width = bounds.width,
                 height = bounds.height,
                 text = text,
-                textStyle = textStyle,
-                textPosition = resolveTextAlign(semanticsNode)
-            )
-        }
-        return SemanticsWireframe(
-            wireframes = listOfNotNull(textWireframe),
-            parentContext
-        )
-    }
-
-    private fun resolveTextAlign(semanticsNode: SemanticsNode): MobileSegment.TextPosition? {
-        return resolveSemanticsTextStyle(semanticsNode)?.let {
-            val align = when (it.textAlign) {
-                TextAlign.Start,
-                TextAlign.Left -> MobileSegment.Horizontal.LEFT
-
-                TextAlign.End,
-                TextAlign.Right -> MobileSegment.Horizontal.RIGHT
-
-                TextAlign.Justify,
-                TextAlign.Center -> MobileSegment.Horizontal.CENTER
-
-                else -> MobileSegment.Horizontal.LEFT
-            }
-            MobileSegment.TextPosition(
-                alignment = MobileSegment.Alignment(
-                    horizontal = align
-                )
+                textStyle = resolveTextStyle(parentContext, textLayoutInfo),
+                textPosition = resolveTextAlign(textLayoutInfo)
             )
         }
     }
 
-    private fun resolveTextStyle(semanticsNode: SemanticsNode, parentContext: UiContext): MobileSegment.TextStyle? {
-        return resolveSemanticsTextStyle(semanticsNode)?.let { textStyle ->
-            val color = resolveModifierColor(semanticsNode) ?: textStyle.color
-            MobileSegment.TextStyle(
-                family = when (val value = textStyle.fontFamily) {
-                    is GenericFontFamily -> value.name
-                    else -> DEFAULT_FONT_FAMILY
-                },
-                size = textStyle.fontSize.value.toLong(),
-                color = convertColor(color.value.toLong()) ?: parentContext.parentContentColor
-                    ?: DEFAULT_TEXT_COLOR
-            )
-        }
-    }
-
-    private fun resolveModifierColor(semanticsNode: SemanticsNode): Color? {
-        val modifier = semanticsNode.layoutInfo.getModifierInfo().firstOrNull {
-            ComposeReflection.TextStringSimpleElement?.isInstance(it.modifier) ?: false
-        }?.modifier
-        return if (modifier != null && ComposeReflection.TextStringSimpleElement?.isInstance(modifier) == true) {
-            val colorProducer = ComposeReflection.ColorProducerField?.getSafe(modifier) as? ColorProducer
-            return colorProducer?.invoke()
-        } else {
-            null
-        }
-    }
-
-    private fun resolveSemanticsTextStyle(semanticsNode: SemanticsNode): TextStyle? {
-        val textLayoutResults = mutableListOf<TextLayoutResult>()
-        semanticsNode.config.getOrNull(SemanticsActions.GetTextLayoutResult)?.action?.invoke(textLayoutResults)
-        return textLayoutResults.firstOrNull()?.layoutInput?.style
-    }
-
-    private fun resolveText(semanticsConfiguration: SemanticsConfiguration): String? {
-        return semanticsConfiguration.firstOrNull {
-            it.key.name == KEY_CONFIG_TEXT
-        }?.let {
-            return resolveAnnotatedString(it.value)
-        }
-    }
-
-    private fun resolveAnnotatedString(value: Any?): String {
-        return if (value is AnnotatedString) {
-            if (value.paragraphStyles.isEmpty() &&
-                value.spanStyles.isEmpty() &&
-                value.getStringAnnotations(0, value.text.length).isEmpty()
-            ) {
-                value.text
-            } else {
-                // Save space if we there is text only in the object
-                value.toString()
-            }
-        } else if (value is Collection<*>) {
-            val sb = StringBuilder()
-            value.forEach {
-                resolveAnnotatedString(it).let {
-                    sb.append(it)
-                }
-            }
-            sb.toString()
-        } else {
-            value.toString()
-        }
-    }
-
-    companion object {
-        private const val KEY_CONFIG_TEXT = "Text"
-        private const val DEFAULT_FONT_FAMILY = "Roboto, sans-serif"
-        private const val DEFAULT_TEXT_COLOR = "#000000FF"
-        private const val DEFAULT_FONT_SIZE = 12L
-        private val defaultTextStyle = MobileSegment.TextStyle(
-            size = DEFAULT_FONT_SIZE,
-            color = DEFAULT_TEXT_COLOR,
-            family = DEFAULT_FONT_FAMILY
-        )
+    protected fun resolveTextStyle(
+        parentContext: UiContext,
+        textLayoutInfo: TextLayoutInfo?
+    ): MobileSegment.TextStyle {
+        return textLayoutInfo?.let {
+            resolveTextLayoutInfoToTextStyle(parentContext, it)
+        } ?: defaultTextStyle
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/StringUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/StringUtils.kt
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.utils
+
+import androidx.compose.ui.text.AnnotatedString
+
+internal fun resolveAnnotatedString(value: Any?): String {
+    return if (value is AnnotatedString) {
+        if (value.paragraphStyles.isEmpty() &&
+            value.spanStyles.isEmpty() &&
+            value.getStringAnnotations(0, value.text.length).isEmpty()
+        ) {
+            value.text
+        } else {
+            // Save space if we there is text only in the object
+            value.toString()
+        }
+    } else if (value is Collection<*>) {
+        val sb = StringBuilder()
+        value.forEach {
+            sb.append(resolveAnnotatedString(it))
+        }
+        sb.toString()
+    } else {
+        value.toString()
+    }
+}

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapperTest.kt
@@ -37,7 +37,7 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(SessionReplayComposeForgeConfigurator::class)
-internal class ButtonSemanticsNodeMapperTest : AbstractCompositionGroupMapperTest() {
+internal class ButtonSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest() {
 
     private lateinit var testedButtonSemanticsNodeMapper: ButtonSemanticsNodeMapper
 

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ContainerSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ContainerSemanticsNodeMapperTest.kt
@@ -37,7 +37,7 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(SessionReplayComposeForgeConfigurator::class)
-internal class ContainerSemanticsNodeMapperTest : AbstractCompositionGroupMapperTest() {
+internal class ContainerSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest() {
 
     private lateinit var testedContainerSemanticsNodeMapper: ContainerSemanticsNodeMapper
 

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RadioButtonSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RadioButtonSemanticsNodeMapperTest.kt
@@ -38,7 +38,7 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(SessionReplayComposeForgeConfigurator::class)
-internal class RadioButtonSemanticsNodeMapperTest : AbstractCompositionGroupMapperTest() {
+internal class RadioButtonSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest() {
 
     private lateinit var testedRadioButtonSemanticsNodeMapper: RadioButtonSemanticsNodeMapper
 

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TabSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TabSemanticsNodeMapperTest.kt
@@ -35,7 +35,7 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(SessionReplayComposeForgeConfigurator::class)
-internal class TabSemanticsNodeMapperTest : AbstractCompositionGroupMapperTest() {
+internal class TabSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest() {
 
     private lateinit var testedTabSemanticsNodeMapper: TabSemanticsNodeMapper
 

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapperTest.kt
@@ -7,21 +7,17 @@
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.semantics.AccessibilityAction
-import androidx.compose.ui.semantics.SemanticsActions
-import androidx.compose.ui.semantics.SemanticsConfiguration
-import androidx.compose.ui.semantics.SemanticsPropertyKey
-import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.text.TextLayoutInput
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
+import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
+import com.datadog.android.sessionreplay.utils.ColorStringFormatter
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
@@ -47,12 +43,9 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(SessionReplayComposeForgeConfigurator::class)
-internal class TextSemanticsNodeMapperTest : AbstractCompositionGroupMapperTest() {
+internal class TextSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest() {
 
-    private lateinit var testedTextSemanticsNodeMapper: TextSemanticsNodeMapper
-
-    @Mock
-    private lateinit var mockSemanticsConfiguration: SemanticsConfiguration
+    private lateinit var testedTextSemanticsNodeMapper: StubTextSemanticsNodeMapper
 
     @Mock
     private lateinit var mockTextLayoutInput: TextLayoutInput
@@ -66,21 +59,14 @@ internal class TextSemanticsNodeMapperTest : AbstractCompositionGroupMapperTest(
     @StringForgery(regex = "#[0-9A-F]{8}")
     lateinit var fakeTextColorHexString: String
 
-    private var stubTextLayoutResultAction: ((MutableList<TextLayoutResult>) -> Boolean) = { list ->
-        list.add(mockTextLayoutResult)
-        true
-    }
-
-    var fakeTextAlign: TextAlign = TextAlign.Left
-
     @LongForgery(min = 0xffffffff)
     var fakeTextColor: Long = 0x12346778L
 
     @Forgery
     lateinit var fakeUiContext: UiContext
 
-    @StringForgery
-    lateinit var fakeText: String
+    @Forgery
+    lateinit var fakeTextLayoutInfo: TextLayoutInfo
 
     @IntForgery(min = 0, max = 100)
     private var fakeFontSize = 0
@@ -88,17 +74,15 @@ internal class TextSemanticsNodeMapperTest : AbstractCompositionGroupMapperTest(
     @BeforeEach
     override fun `set up`(forge: Forge) {
         super.`set up`(forge)
-        fakeTextAlign = generateFakeTextAlign(forge = forge)
         mockColorStringFormatter(fakeTextColor, fakeTextColorHexString)
 
         whenever(mockTextLayoutInput.style) doReturn TextStyle(
             color = Color(fakeTextColor shr 32),
             fontFamily = FontFamily.Default,
-            fontSize = fakeFontSize.sp,
-            textAlign = fakeTextAlign
+            fontSize = fakeFontSize.sp
         )
         whenever(mockTextLayoutResult.layoutInput) doReturn mockTextLayoutInput
-        testedTextSemanticsNodeMapper = TextSemanticsNodeMapper(
+        testedTextSemanticsNodeMapper = StubTextSemanticsNodeMapper(
             colorStringFormatter = mockColorStringFormatter,
             semanticsUtils = mockSemanticsUtils
         )
@@ -107,13 +91,9 @@ internal class TextSemanticsNodeMapperTest : AbstractCompositionGroupMapperTest(
     @Test
     fun `M return the correct wireframe W map`() {
         // Given
-        val map: Map<SemanticsPropertyKey<*>, Any?> = mapOf(SemanticsPropertyKey<String>(name = "Text") to fakeText)
-        val mockNode = mockSemanticsNodeWithBound {
-            whenever(mockSemanticsConfiguration.iterator()) doReturn map.iterator()
-            whenever(mockSemanticsConfiguration.getOrNull(SemanticsActions.GetTextLayoutResult)) doReturn
-                AccessibilityAction("", stubTextLayoutResultAction)
-            whenever(config) doReturn mockSemanticsConfiguration
-        }
+        val mockNode = mockSemanticsNodeWithBound {}
+
+        whenever(mockSemanticsUtils.resolveTextLayoutInfo(mockNode)) doReturn fakeTextLayoutInfo
         whenever(mockSemanticsUtils.resolveInnerBounds(mockNode)) doReturn rectToBounds(
             fakeBounds,
             fakeDensity
@@ -130,44 +110,31 @@ internal class TextSemanticsNodeMapperTest : AbstractCompositionGroupMapperTest(
             y = (fakeBounds.top / fakeDensity).toLong(),
             width = (fakeBounds.size.width / fakeDensity).toLong(),
             height = (fakeBounds.size.height / fakeDensity).toLong(),
-            text = fakeText,
-            textStyle = MobileSegment.TextStyle(
-                family = DEFAULT_FONT_FAMILY,
-                size = fakeFontSize.toLong(),
-                color = fakeTextColorHexString
+            text = fakeTextLayoutInfo.text,
+            textStyle = testedTextSemanticsNodeMapper.stubResolveTextStyle(
+                fakeUiContext,
+                fakeTextLayoutInfo
             ),
-            textPosition = MobileSegment.TextPosition(
-                alignment = resolveTextAlign(fakeTextAlign)
-            )
+            textPosition = testedTextSemanticsNodeMapper.stubResolveTextAlign(fakeTextLayoutInfo)
         )
 
         assertThat(actual.wireframes).contains(expected)
     }
 
-    private fun resolveTextAlign(textAlign: TextAlign): MobileSegment.Alignment {
-        val align = when (textAlign) {
-            TextAlign.Start,
-            TextAlign.Left -> MobileSegment.Horizontal.LEFT
+    class StubTextSemanticsNodeMapper(
+        colorStringFormatter: ColorStringFormatter,
+        semanticsUtils: SemanticsUtils = SemanticsUtils()
+    ) : TextSemanticsNodeMapper(colorStringFormatter, semanticsUtils) {
 
-            TextAlign.End,
-            TextAlign.Right -> MobileSegment.Horizontal.RIGHT
-
-            TextAlign.Justify,
-            TextAlign.Center -> MobileSegment.Horizontal.CENTER
-
-            else -> MobileSegment.Horizontal.CENTER
+        fun stubResolveTextAlign(textLayoutInfo: TextLayoutInfo): MobileSegment.TextPosition {
+            return super.resolveTextAlign(textLayoutInfo = textLayoutInfo)
         }
-        return MobileSegment.Alignment(
-            horizontal = align
-        )
-    }
 
-    private fun generateFakeTextAlign(forge: Forge): TextAlign {
-        val index = forge.anInt(0, TextAlign.values().size)
-        return TextAlign.values()[index]
-    }
-
-    companion object {
-        private const val DEFAULT_FONT_FAMILY = "Roboto, sans-serif"
+        fun stubResolveTextStyle(
+            parentContext: UiContext,
+            textLayoutInfo: TextLayoutInfo?
+        ): MobileSegment.TextStyle {
+            return super.resolveTextStyle(parentContext, textLayoutInfo)
+        }
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/StringUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/StringUtilsTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.utils
+
+import androidx.compose.ui.text.AnnotatedString
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class StringUtilsTest {
+    @Test
+    fun `M return null W resolveAnnotatedString with null value`() {
+        // When
+        val result = resolveAnnotatedString(null)
+
+        // Then
+        assertThat("null").isEqualTo(result)
+    }
+
+    @Test
+    fun `M return correct text W resolveAnnotatedString with plain AnnotatedString`(
+        @StringForgery(StringForgeryType.ALPHABETICAL) fakeSimpleText: String
+    ) {
+        // Given
+        val annotatedString = AnnotatedString(fakeSimpleText)
+
+        // When
+        val result = resolveAnnotatedString(annotatedString)
+
+        // Then
+        assertThat(fakeSimpleText).isEqualTo(result)
+    }
+
+    @Test
+    fun `M return empty text W resolveAnnotatedString with empty collection`() {
+        // When
+        val result = resolveAnnotatedString(emptyList<Any>())
+
+        // Then
+        assertThat("").isEqualTo(result)
+    }
+
+    @Test
+    fun `M return correct text W resolveAnnotatedString with collection of plain strings`(
+        @StringForgery(StringForgeryType.ALPHABETICAL) fakeSimpleTextA: String,
+        @StringForgery(StringForgeryType.ALPHABETICAL) fakeSimpleTextB: String,
+        @StringForgery(StringForgeryType.ALPHABETICAL) fakeSimpleTextC: String
+    ) {
+        // When
+        val result =
+            resolveAnnotatedString(listOf(fakeSimpleTextA, fakeSimpleTextB, fakeSimpleTextC))
+
+        // Then
+        assertThat(fakeSimpleTextA + fakeSimpleTextB + fakeSimpleTextC).isEqualTo(result)
+    }
+
+    @Test
+    fun `M return correct text W resolveAnnotatedString with mixed collection`(
+        @StringForgery(StringForgeryType.ALPHABETICAL) fakeSimpleTextA: String,
+        @StringForgery(StringForgeryType.ALPHABETICAL) fakeSimpleTextB: String,
+        @StringForgery(StringForgeryType.ALPHABETICAL) fakeSimpleTextC: String,
+        @StringForgery(StringForgeryType.ALPHABETICAL) fakeSimpleTextD: String
+    ) {
+        // Given
+        val collection = listOf(
+            fakeSimpleTextA,
+            AnnotatedString(fakeSimpleTextB),
+            listOf(fakeSimpleTextC, AnnotatedString(fakeSimpleTextD))
+        )
+
+        // When
+        val result = resolveAnnotatedString(collection)
+
+        // Then
+        assertThat(fakeSimpleTextA + fakeSimpleTextB + fakeSimpleTextC + fakeSimpleTextD)
+            .isEqualTo(result)
+    }
+
+    @Test
+    fun `M return correct text W resolveAnnotatedString with other object type`(
+        @IntForgery fakeNumber: Int
+    ) {
+        // When
+        val result = resolveAnnotatedString(fakeNumber)
+
+        // Then
+        assertThat(fakeNumber.toString()).isEqualTo(result)
+    }
+}

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/SessionReplayComposeForgeConfigurator.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/SessionReplayComposeForgeConfigurator.kt
@@ -30,6 +30,7 @@ class SessionReplayComposeForgeConfigurator : BaseConfigurator() {
         // Compose Specifics
         forge.addFactory(UIContextForgeryFactory())
         forge.addFactory(ComposeWireframeForgeryFactory())
+        forge.addFactory(TextLayoutInfoForgeryFactory())
         forge.addFactory(MappingContextForgeryFactory())
         forge.addFactory(SystemInformationForgeryFactory())
         forge.addFactory(GlobalBoundsForgeryFactory())

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/TextLayoutInfoForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/TextLayoutInfoForgeryFactory.kt
@@ -1,0 +1,33 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.test.elmyr
+
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
+import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.TextLayoutInfo
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class TextLayoutInfoForgeryFactory : ForgeryFactory<TextLayoutInfo> {
+    override fun getForgery(forge: Forge): TextLayoutInfo {
+        return TextLayoutInfo(
+            text = forge.aString(),
+            color = forge.aLong().toULong(),
+            fontSize = forge.aSmallInt().toLong(),
+            fontFamily = forge.anElementFrom(
+                listOf(
+                    FontFamily.Serif,
+                    FontFamily.SansSerif,
+                    FontFamily.Cursive,
+                    FontFamily.Monospace,
+                    FontFamily.Default
+                )
+            ),
+            textAlign = forge.anElementFrom(TextAlign.values())
+        )
+    }
+}


### PR DESCRIPTION
### What does this PR do?

For the other semantics node mapper, we are probably going to reuse the part of the logic of resolving the text in current `TextSemanticsNodeMapper`, so in this PR, some functions are moved to `AbstractSemanticsNodeMapper` or `SemanticUtils` so it can be directly used by others.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

