### PR TITLE
RUM-7091: Add TextField semantics mapper for Session Replay Compose

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
@@ -31,6 +32,9 @@ internal class RootSemanticsNodeMapper(
     ),
     // Text doesn't have a role in semantics, so it should be a fallback mapper.
     private val textSemanticsNodeMapper: TextSemanticsNodeMapper = TextSemanticsNodeMapper(
+        colorStringFormatter
+    ),
+    private val textFieldSemanticsNodeMapper: TextFieldSemanticsNodeMapper = TextFieldSemanticsNodeMapper(
         colorStringFormatter
     ),
     private val containerSemanticsNodeMapper: ContainerSemanticsNodeMapper = ContainerSemanticsNodeMapper(
@@ -95,7 +99,9 @@ internal class RootSemanticsNodeMapper(
         semanticsNode: SemanticsNode
     ): SemanticsNodeMapper {
         val role = semanticsNode.config.getOrNull(SemanticsProperties.Role)
-        return semanticsNodeMapper[role] ?: if (isTextNode(semanticsNode)) {
+        return semanticsNodeMapper[role] ?: if (isTextFieldNode(semanticsNode)) {
+            textFieldSemanticsNodeMapper
+        } else if (isTextNode(semanticsNode)) {
             textSemanticsNodeMapper
         } else {
             containerSemanticsNodeMapper
@@ -105,6 +111,10 @@ internal class RootSemanticsNodeMapper(
     private fun isTextNode(semanticsNode: SemanticsNode): Boolean {
         // Some text semantics nodes don't have an explicit `Role` but the text exists in the config
         return semanticsNode.config.getOrNull(SemanticsProperties.Text)?.isNotEmpty() == true
+    }
+
+    private fun isTextFieldNode(semanticsNode: SemanticsNode): Boolean {
+        return semanticsNode.config.contains(SemanticsActions.SetText)
     }
 
     companion object {

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapper.kt
@@ -1,0 +1,109 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
+
+import androidx.compose.ui.semantics.SemanticsConfiguration
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWireframe
+import com.datadog.android.sessionreplay.compose.internal.data.UiContext
+import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
+import com.datadog.android.sessionreplay.compose.internal.utils.resolveAnnotatedString
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
+import com.datadog.android.sessionreplay.utils.ColorStringFormatter
+
+internal class TextFieldSemanticsNodeMapper(
+    colorStringFormatter: ColorStringFormatter,
+    private val semanticsUtils: SemanticsUtils = SemanticsUtils()
+) : AbstractSemanticsNodeMapper(colorStringFormatter, semanticsUtils) {
+    override fun map(
+        semanticsNode: SemanticsNode,
+        parentContext: UiContext,
+        asyncJobStatusCallback: AsyncJobStatusCallback
+    ): SemanticsWireframe {
+        var index = 0
+        val shapeWireframe = resolveTextFieldShapeWireframe(parentContext, semanticsNode, index++)
+        val editTextWireframe = resolveEditTextWireframe(parentContext, semanticsNode, index)
+        return SemanticsWireframe(
+            wireframes = listOfNotNull(shapeWireframe, editTextWireframe),
+            uiContext = null
+        )
+    }
+
+    private fun resolveTextFieldShapeWireframe(
+        parentContext: UiContext,
+        semanticsNode: SemanticsNode,
+        index: Int
+    ): MobileSegment.Wireframe {
+        val color = semanticsUtils.resolveBackgroundColor(semanticsNode)?.let {
+            convertColor(it)
+        }
+        val globalBounds = semanticsUtils.resolveInnerBounds(semanticsNode)
+        val shape = semanticsUtils.resolveBackgroundShape(semanticsNode)
+        val cornerRadius = shape?.let {
+            semanticsUtils.resolveCornerRadius(it, globalBounds, parentContext.composeDensity)
+        }
+        return MobileSegment.Wireframe.ShapeWireframe(
+            id = resolveId(semanticsNode, index),
+            x = globalBounds.x,
+            y = globalBounds.y,
+            width = globalBounds.width,
+            height = globalBounds.height,
+            shapeStyle = color?.let {
+                MobileSegment.ShapeStyle(
+                    backgroundColor = it,
+                    cornerRadius = cornerRadius
+                )
+            }
+        )
+    }
+
+    private fun resolveEditTextWireframe(
+        parentContext: UiContext,
+        semanticsNode: SemanticsNode,
+        index: Int
+    ): MobileSegment.Wireframe? {
+        val globalBounds = semanticsUtils.resolveInnerBounds(semanticsNode)
+        val editText = resolveEditText(semanticsNode.config)
+        val textLayoutInfo = semanticsUtils.resolveTextLayoutInfo(semanticsNode)
+        val textStyle = textLayoutInfo?.let {
+            resolveTextLayoutInfoToTextStyle(parentContext, it)
+        } ?: defaultTextStyle
+        return editText?.let {
+            MobileSegment.Wireframe.TextWireframe(
+                id = resolveId(semanticsNode, index),
+                x = globalBounds.x,
+                y = globalBounds.y,
+                width = globalBounds.width,
+                height = globalBounds.height,
+                text = it,
+                textStyle = textStyle,
+                textPosition = MobileSegment.TextPosition(
+                    padding = MobileSegment.Padding(
+                        left = (EDIT_TEXT_START_PADDING * parentContext.composeDensity.density).toLong()
+                    ),
+                    alignment = MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.LEFT,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                )
+            )
+        }
+    }
+
+    private fun resolveEditText(semanticsConfiguration: SemanticsConfiguration): String? {
+        return semanticsConfiguration.getOrNull(SemanticsProperties.EditableText)?.let {
+            resolveAnnotatedString(it)
+        }
+    }
+
+    companion object {
+        private const val EDIT_TEXT_START_PADDING = 4L
+    }
+}

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
@@ -35,6 +35,7 @@ internal object ComposeReflection {
 
     val BackgroundElementClass = getClassSafe("androidx.compose.foundation.BackgroundElement")
     val ColorField = BackgroundElementClass?.getDeclaredFieldSafe("color")
+    val ShapeField = BackgroundElementClass?.getDeclaredFieldSafe("shape")
 
     val PaddingElementClass = getClassSafe("androidx.compose.foundation.layout.PaddingElement")
     val StartField = PaddingElementClass?.getDeclaredFieldSafe("start")

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
@@ -106,6 +106,16 @@ internal class SemanticsUtils {
         }
     }
 
+    internal fun resolveBackgroundShape(semanticsNode: SemanticsNode): Shape? {
+        val backgroundModifierInfo =
+            semanticsNode.layoutInfo.getModifierInfo().firstOrNull { modifierInfo ->
+                ComposeReflection.BackgroundElementClass?.isInstance(modifierInfo.modifier) == true
+            }
+        return backgroundModifierInfo?.let {
+            ComposeReflection.ShapeField?.getSafe(it.modifier) as? Shape
+        }
+    }
+
     private fun shrinkInnerBounds(
         modifier: Modifier,
         currentBounds: GlobalBounds

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapperTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
+
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.semantics.SemanticsConfiguration
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.GenericFontFamily
+import com.datadog.android.sessionreplay.compose.internal.data.UiContext
+import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.FloatForgery
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(SessionReplayComposeForgeConfigurator::class)
+internal class TextFieldSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest() {
+
+    private lateinit var testedTextFieldSemanticsNodeMapper: TextFieldSemanticsNodeMapper
+
+    @Mock
+    private lateinit var mockSemanticsNode: SemanticsNode
+
+    @Mock
+    private lateinit var mockAsyncJobStatusCallback: AsyncJobStatusCallback
+
+    @Mock
+    private lateinit var mockShape: Shape
+
+    @Mock
+    private lateinit var mockSemanticsConfiguration: SemanticsConfiguration
+
+    @LongForgery(min = 0xffffffff)
+    var fakeBackgroundColor: Long = 0L
+
+    @FloatForgery
+    var fakeCornerRadius: Float = 0f
+
+    @StringForgery(regex = "#[0-9A-F]{8}")
+    lateinit var fakeBackgroundColorHexString: String
+
+    @StringForgery(regex = "#[0-9A-F]{8}")
+    lateinit var fakeTextColorHexString: String
+
+    @Forgery
+    lateinit var fakeUiContext: UiContext
+
+    @Forgery
+    lateinit var fakeTextLayoutInfo: TextLayoutInfo
+
+    @StringForgery
+    lateinit var fakeEditText: String
+
+    @BeforeEach
+    override fun `set up`(forge: Forge) {
+        super.`set up`(forge)
+        mockColorStringFormatter(fakeBackgroundColor, fakeBackgroundColorHexString)
+        mockColorStringFormatter(fakeTextLayoutInfo.color.toLong(), fakeTextColorHexString)
+        whenever(mockDensity.density) doReturn fakeDensity
+        testedTextFieldSemanticsNodeMapper = TextFieldSemanticsNodeMapper(
+            colorStringFormatter = mockColorStringFormatter,
+            semanticsUtils = mockSemanticsUtils
+        )
+    }
+
+    @Test
+    fun `M return the correct wireframe W map`() {
+        // Given
+        val mockSemanticsNode = mockSemanticsNode()
+        val innerBounds = rectToBounds(fakeBounds, fakeDensity)
+        whenever(mockSemanticsNode.config) doReturn mockSemanticsConfiguration
+        whenever(mockSemanticsConfiguration.getOrNull(SemanticsProperties.EditableText)) doReturn AnnotatedString(
+            fakeEditText
+        )
+        whenever(mockSemanticsUtils.resolveTextLayoutInfo(mockSemanticsNode)) doReturn fakeTextLayoutInfo
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode)) doReturn innerBounds
+        whenever(mockSemanticsUtils.resolveBackgroundColor(mockSemanticsNode)) doReturn fakeBackgroundColor
+        whenever(mockSemanticsUtils.resolveBackgroundShape(mockSemanticsNode)) doReturn mockShape
+        whenever(
+            mockSemanticsUtils.resolveCornerRadius(
+                eq(mockShape),
+                any(),
+                any()
+            )
+        ) doReturn fakeCornerRadius
+        whenever(
+            mockSemanticsUtils.resolveCornerRadius(
+                mockShape,
+                fakeGlobalBounds,
+                mockDensity
+            )
+        ) doReturn fakeCornerRadius
+
+        // When
+        val actual = testedTextFieldSemanticsNodeMapper.map(
+            mockSemanticsNode,
+            fakeUiContext,
+            mockAsyncJobStatusCallback
+        )
+
+        // Then
+        val expectedShapeWireframe = MobileSegment.Wireframe.ShapeWireframe(
+            id = (fakeSemanticsId.toLong() shl 32),
+            x = (fakeBounds.left / fakeDensity).toLong(),
+            y = (fakeBounds.top / fakeDensity).toLong(),
+            width = (fakeBounds.size.width / fakeDensity).toLong(),
+            height = (fakeBounds.size.height / fakeDensity).toLong(),
+            shapeStyle = MobileSegment.ShapeStyle(
+                backgroundColor = fakeBackgroundColorHexString,
+                cornerRadius = fakeCornerRadius
+            )
+        )
+
+        val expectedTextWireframe = MobileSegment.Wireframe.TextWireframe(
+            id = (fakeSemanticsId.toLong() shl 32) + 1,
+            x = (fakeBounds.left / fakeDensity).toLong(),
+            y = (fakeBounds.top / fakeDensity).toLong(),
+            width = (fakeBounds.size.width / fakeDensity).toLong(),
+            height = (fakeBounds.size.height / fakeDensity).toLong(),
+            text = fakeEditText,
+            textStyle = MobileSegment.TextStyle(
+                family = (fakeTextLayoutInfo.fontFamily as GenericFontFamily).name,
+                size = fakeTextLayoutInfo.fontSize,
+                color = fakeTextColorHexString
+            ),
+            textPosition = MobileSegment.TextPosition(
+                padding = MobileSegment.Padding(
+                    left = (4 * fakeUiContext.composeDensity.density).toLong()
+                ),
+                alignment = MobileSegment.Alignment(
+                    horizontal = MobileSegment.Horizontal.LEFT,
+                    vertical = MobileSegment.Vertical.CENTER
+                )
+            )
+        )
+
+        assertThat(actual.wireframes).contains(expectedShapeWireframe, expectedTextWireframe)
+    }
+
+    private fun mockSemanticsNode(): SemanticsNode {
+        return mockSemanticsNodeWithBound {
+            whenever(mockSemanticsNode.layoutInfo).doReturn(mockLayoutInfo)
+        }
+    }
+}

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/InputSample.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/InputSample.kt
@@ -1,0 +1,55 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sample.compose
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun InputSample() {
+    Column(
+        modifier = Modifier.fillMaxSize()
+            .padding(16.dp)
+    ) {
+        var input1 by remember { mutableStateOf("Input of Text Field") }
+        TextField(
+            value = input1,
+            onValueChange = { input1 = it },
+            label = { Text("TextField") }
+        )
+
+        var input2 by remember { mutableStateOf("Input of Outlined Text Field") }
+        OutlinedTextField(
+            value = input2,
+            textStyle = TextStyle(
+                color = Color.Red
+            ),
+            onValueChange = { input2 = it },
+            label = { Text("OutlinedTextField") }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+internal fun PreviewInputSample() {
+    InputSample()
+}

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/SampleSelectionScreen.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/SampleSelectionScreen.kt
@@ -27,6 +27,7 @@ internal fun SampleSelectionScreen(
     onTypographyClicked: () -> Unit,
     onLegacyClicked: () -> Unit,
     onImageClicked: () -> Unit,
+    onInputClicked: () -> Unit,
     onToggleClicked: () -> Unit,
     onSelectorsClicked: () -> Unit,
     onTabsClicked: () -> Unit
@@ -47,6 +48,10 @@ internal fun SampleSelectionScreen(
         StyledButton(
             text = "Image Sample",
             onClick = onImageClicked
+        )
+        StyledButton(
+            text = "Input Sample",
+            onClick = onInputClicked
         )
         StyledButton(
             text = "Toggle Buttons Sample",
@@ -91,6 +96,9 @@ internal fun NavGraphBuilder.selectionNavigation(navController: NavHostControlle
             onImageClicked = {
                 navController.navigate(SampleScreen.Image.navigationRoute)
             },
+            onInputClicked = {
+                navController.navigate(SampleScreen.Input.navigationRoute)
+            },
             onToggleClicked = {
                 navController.navigate(SampleScreen.Toggle.navigationRoute)
             },
@@ -112,6 +120,10 @@ internal fun NavGraphBuilder.selectionNavigation(navController: NavHostControlle
 
     composable(SampleScreen.Image.navigationRoute) {
         ImageSample()
+    }
+
+    composable(SampleScreen.Input.navigationRoute) {
+        InputSample()
     }
 
     composable(SampleScreen.Toggle.navigationRoute) {
@@ -138,6 +150,7 @@ internal sealed class SampleScreen(
     object Root : SampleScreen(COMPOSE_ROOT)
     object Typography : SampleScreen("$COMPOSE_ROOT/typography")
     object Image : SampleScreen("$COMPOSE_ROOT/image")
+    object Input : SampleScreen("$COMPOSE_ROOT/input")
     object Toggle : SampleScreen("$COMPOSE_ROOT/toggle")
     object Tabs : SampleScreen("$COMPOSE_ROOT/tabs")
     object Selectors : SampleScreen("$COMPOSE_ROOT/selectors")
@@ -156,6 +169,8 @@ private fun PreviewSampleSelectionScreen() {
         onLegacyClicked = {
         },
         onImageClicked = {
+        },
+        onInputClicked = {
         },
         onToggleClicked = {
         },


### PR DESCRIPTION
### What does this PR do?

Add TextField semantics mapper for Session Replay Compose, with this PR, following compose components can be supported:
* TextField
* OutlineTextField

Known issue of this mapper:
* TextField hint text color might not be correct,
* OutlineTextField can have the correct outline

### Motivation

RUM-7091

### Demo

| Sample App |.  Session Replay |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/b0cea05b-6216-45a7-a709-0fe76312264d" alt="Screenshot_20241121_095512" width="600">| ![ezgif-7-7d88bddb00](https://github.com/user-attachments/assets/4c2b81ad-3875-4ae9-b2f8-a3fe753881b6) |



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

