### PR TITLE
Fix TextFieldSemanticsNodeMapper flaky test

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapperTest.kt
@@ -149,7 +149,8 @@ internal class TextFieldSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTes
             height = (fakeBounds.size.height / fakeDensity).toLong(),
             text = fakeEditText,
             textStyle = MobileSegment.TextStyle(
-                family = (fakeTextLayoutInfo.fontFamily as GenericFontFamily).name,
+                family = (fakeTextLayoutInfo.fontFamily as? GenericFontFamily)?.name
+                    ?: DEFAULT_FONT_FAMILY,
                 size = fakeTextLayoutInfo.fontSize,
                 color = fakeTextColorHexString
             ),
@@ -171,5 +172,9 @@ internal class TextFieldSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTes
         return mockSemanticsNodeWithBound {
             whenever(mockSemanticsNode.layoutInfo).doReturn(mockLayoutInfo)
         }
+    }
+
+    companion object {
+        private const val DEFAULT_FONT_FAMILY = "Roboto, sans-serif"
     }
 }


### PR DESCRIPTION
### What does this PR do?

Fix TextFieldSemanticsNodeMapper flaky test, it's possible that the random font family in `fakeTextLayoutInfo` is not GenericFontFamily, so this PR covers the corner case.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

