### PR TITLE
Improve the log message when exception happen during Upload

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadStatus.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadStatus.kt
@@ -117,6 +117,8 @@ internal sealed class UploadStatus(
 
             if (throwable != null) {
                 append(" (")
+                append(throwable.javaClass.name)
+                append(": ")
                 append(throwable.message)
                 append(")")
             }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadStatusTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadStatusTest.kt
@@ -106,12 +106,13 @@ internal class UploadStatusTest {
         )
 
         // Then
+        val throwable = status.throwable!!
         mockLogger.verifyLog(
             InternalLogger.Level.WARN,
             listOf(InternalLogger.Target.USER),
             "Batch [$fakeByteSize bytes] ($fakeContext) failed " +
-                "because of a network error (${status.throwable!!.message}); we will retry later." +
-                " This request was attempted $fakeRequestAttempts time(s)."
+                "because of a network error (${throwable.javaClass.name}: ${throwable.message}); " +
+                "we will retry later. This request was attempted $fakeRequestAttempts time(s)."
         )
         verifyNoMoreInteractions(mockLogger)
     }
@@ -130,12 +131,13 @@ internal class UploadStatusTest {
         )
 
         // Then
+        val throwable = status.throwable!!
         mockLogger.verifyLog(
             InternalLogger.Level.WARN,
             listOf(InternalLogger.Target.USER),
             "Batch $fakeRequestId [$fakeByteSize bytes] ($fakeContext) failed " +
-                "because of a network error (${status.throwable!!.message}); we will retry later." +
-                " This request was attempted $fakeRequestAttempts time(s)."
+                "because of a network error (${throwable.javaClass.name}: ${throwable.message}); " +
+                "we will retry later. This request was attempted $fakeRequestAttempts time(s)."
         )
         verifyNoMoreInteractions(mockLogger)
     }
@@ -153,12 +155,13 @@ internal class UploadStatusTest {
         )
 
         // Then
+        val throwable = status.throwable!!
         mockLogger.verifyLog(
             InternalLogger.Level.WARN,
             listOf(InternalLogger.Target.USER),
             "Batch [$fakeByteSize bytes] ($fakeContext) failed " +
-                "because of a DNS error (${status.throwable!!.message}); we will retry later." +
-                " This request was attempted $fakeRequestAttempts time(s)."
+                "because of a DNS error (${throwable.javaClass.name}: ${throwable.message}); " +
+                "we will retry later. This request was attempted $fakeRequestAttempts time(s)."
         )
         verifyNoMoreInteractions(mockLogger)
     }
@@ -177,12 +180,13 @@ internal class UploadStatusTest {
         )
 
         // Then
+        val throwable = status.throwable!!
         mockLogger.verifyLog(
             InternalLogger.Level.WARN,
             listOf(InternalLogger.Target.USER),
             "Batch $fakeRequestId [$fakeByteSize bytes] ($fakeContext) failed " +
-                "because of a DNS error (${status.throwable!!.message}); we will retry later." +
-                " This request was attempted $fakeRequestAttempts time(s)."
+                "because of a DNS error (${throwable.javaClass.name}: ${throwable.message}); " +
+                "we will retry later. This request was attempted $fakeRequestAttempts time(s)."
 
         )
         verifyNoMoreInteractions(mockLogger)
@@ -488,12 +492,13 @@ internal class UploadStatusTest {
         )
 
         // Then
+        val throwable = status.throwable!!
         mockLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.USER),
             "Batch [$fakeByteSize bytes] ($fakeContext) failed " +
-                "because of an unknown error (${status.throwable!!.message}); we will retry later." +
-                " This request was attempted $fakeRequestAttempts time(s)."
+                "because of an unknown error (${throwable.javaClass.name}: ${throwable.message}); " +
+                "we will retry later. This request was attempted $fakeRequestAttempts time(s)."
         )
     }
 
@@ -511,12 +516,13 @@ internal class UploadStatusTest {
         )
 
         // Then
+        val throwable = status.throwable!!
         mockLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.USER),
             "Batch $fakeRequestId [$fakeByteSize bytes] ($fakeContext) failed " +
-                "because of an unknown error (${status.throwable!!.message}); we will retry later." +
-                " This request was attempted $fakeRequestAttempts time(s)."
+                "because of an unknown error (${throwable.javaClass.name}: ${throwable.message}); " +
+                "we will retry later. This request was attempted $fakeRequestAttempts time(s)."
         )
     }
 
@@ -533,13 +539,13 @@ internal class UploadStatusTest {
         )
 
         // Then
+        val throwable = status.throwable!!
         mockLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.USER),
             "Batch [$fakeByteSize bytes] ($fakeContext) failed " +
-                "because of an error when creating the request (${status.throwable!!.message});" +
-                " the batch was dropped." +
-                " This request was attempted $fakeRequestAttempts time(s)."
+                "because of an error when creating the request (${throwable.javaClass.name}: ${throwable.message}); " +
+                "the batch was dropped. This request was attempted $fakeRequestAttempts time(s)."
         )
     }
 
@@ -557,13 +563,13 @@ internal class UploadStatusTest {
         )
 
         // Then
+        val throwable = status.throwable!!
         mockLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.USER),
             "Batch $fakeRequestId [$fakeByteSize bytes] ($fakeContext) failed " +
-                "because of an error when creating the request (${status.throwable!!.message});" +
-                " the batch was dropped." +
-                " This request was attempted $fakeRequestAttempts time(s)."
+                "because of an error when creating the request (${throwable.javaClass.name}: ${throwable.message}); " +
+                "the batch was dropped. This request was attempted $fakeRequestAttempts time(s)."
         )
     }
 


### PR DESCRIPTION
### What does this PR do?

Improve the log message when exception happen during Upload. Right now we only print the error message but not the error type which makes it harder to investigate when an unknown error appears