### PR TITLE
RUM-7342: Apply Global privacy level to semantics node mapper

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/data/UiContext.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/data/UiContext.kt
@@ -7,13 +7,15 @@
 package com.datadog.android.sessionreplay.compose.internal.data
 
 import androidx.compose.ui.unit.Density
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.ImagePrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.utils.ImageWireframeHelper
 
 internal data class UiContext(
     val parentContentColor: String?,
     val density: Float,
-    val privacy: SessionReplayPrivacy,
+    val textAndInputPrivacy: TextAndInputPrivacy,
+    val imagePrivacy: ImagePrivacy,
     val isInUserInputLayout: Boolean = false,
     val imageWireframeHelper: ImageWireframeHelper
 ) {

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AndroidComposeViewMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AndroidComposeViewMapper.kt
@@ -10,7 +10,6 @@ package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
 import androidx.compose.ui.platform.AndroidComposeView
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
 import com.datadog.android.sessionreplay.recorder.mapper.BaseWireframeMapper
@@ -40,13 +39,10 @@ internal class AndroidComposeViewMapper(
     ): List<MobileSegment.Wireframe> {
         val density =
             mappingContext.systemInformation.screenDensity.let { if (it == 0.0f) 1.0f else it }
-        // TODO RUM-6192: Apply FGM for compose
-        val privacy = SessionReplayPrivacy.ALLOW
         return rootSemanticsNodeMapper.createComposeWireframes(
             view.semanticsOwner.unmergedRootSemanticsNode,
             density,
             mappingContext,
-            privacy,
             asyncJobStatusCallback
         )
     }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapper.kt
@@ -8,7 +8,6 @@ package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
 import androidx.compose.ui.platform.ComposeView
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -40,14 +39,11 @@ internal class ComposeViewMapper(
     ): List<MobileSegment.Wireframe> {
         val density =
             mappingContext.systemInformation.screenDensity.let { if (it == 0.0f) 1.0f else it }
-        // TODO RUM-6192: Apply FGM for compose
-        val privacy = SessionReplayPrivacy.ALLOW
         return semanticsUtils.findRootSemanticsNode(view)?.let { node ->
             rootSemanticsNodeMapper.createComposeWireframes(
                 node,
                 density,
                 mappingContext,
-                privacy,
                 asyncJobStatusCallback
             )
         } ?: emptyList()

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ImageSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ImageSemanticsNodeMapper.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.VectorPainter
 import androidx.compose.ui.semantics.SemanticsNode
-import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWireframe
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection
@@ -45,8 +44,7 @@ internal class ImageSemanticsNodeMapper(
                 bitmap = bitmapInfo.bitmap,
                 density = parentContext.density,
                 isContextualImage = bitmapInfo.isContextualImage,
-                // TODO RUM-6192: Apply FGM here
-                imagePrivacy = ImagePrivacy.MASK_NONE,
+                imagePrivacy = parentContext.imagePrivacy,
                 asyncJobStatusCallback = asyncJobStatusCallback,
                 clipping = null,
                 shapeStyle = null,

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapper.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.compose.internal.utils.withinComposeBenchmarkSpan
@@ -47,7 +46,6 @@ internal class RootSemanticsNodeMapper(
         semanticsNode: SemanticsNode,
         density: Float,
         mappingContext: MappingContext,
-        privacy: SessionReplayPrivacy,
         asyncJobStatusCallback: AsyncJobStatusCallback
     ): List<MobileSegment.Wireframe> {
         val wireframes = mutableListOf<MobileSegment.Wireframe>()
@@ -58,7 +56,8 @@ internal class RootSemanticsNodeMapper(
                 parentUiContext = UiContext(
                     parentContentColor = null,
                     density = density,
-                    privacy = privacy,
+                    imagePrivacy = mappingContext.imagePrivacy,
+                    textAndInputPrivacy = mappingContext.textAndInputPrivacy,
                     imageWireframeHelper = mappingContext.imageWireframeHelper
                 ),
                 asyncJobStatusCallback = asyncJobStatusCallback

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapper.kt
@@ -14,6 +14,7 @@ import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWirefram
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.compose.internal.utils.resolveAnnotatedString
+import com.datadog.android.sessionreplay.compose.internal.utils.transformCapturedText
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
@@ -70,7 +71,9 @@ internal class TextFieldSemanticsNodeMapper(
         index: Int
     ): MobileSegment.Wireframe? {
         val globalBounds = semanticsUtils.resolveInnerBounds(semanticsNode)
-        val editText = resolveEditText(semanticsNode.config)
+        val editText = resolveEditText(semanticsNode.config)?.let {
+            transformCapturedText(it, parentContext.textAndInputPrivacy, true)
+        }
         val textLayoutInfo = semanticsUtils.resolveTextLayoutInfo(semanticsNode)
         val textStyle = textLayoutInfo?.let {
             resolveTextLayoutInfoToTextStyle(parentContext, it)

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapper.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.semantics.SemanticsNode
 import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWireframe
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
+import com.datadog.android.sessionreplay.compose.internal.utils.transformCapturedText
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
@@ -36,7 +37,9 @@ internal open class TextSemanticsNodeMapper(
         semanticsNode: SemanticsNode
     ): MobileSegment.Wireframe.TextWireframe? {
         val textLayoutInfo = semanticsUtils.resolveTextLayoutInfo(semanticsNode)
-        val capturedText = textLayoutInfo?.text
+        val capturedText = textLayoutInfo?.text?.let {
+            transformCapturedText(it, parentContext.textAndInputPrivacy)
+        }
         val bounds = resolveBounds(semanticsNode)
         return capturedText?.let { text ->
             MobileSegment.Wireframe.TextWireframe(

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/StringUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/StringUtils.kt
@@ -7,25 +7,46 @@
 package com.datadog.android.sessionreplay.compose.internal.utils
 
 import androidx.compose.ui.text.AnnotatedString
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
+import com.datadog.android.sessionreplay.internal.recorder.obfuscator.StringObfuscator
 
-internal fun resolveAnnotatedString(value: Any?): String {
-    return if (value is AnnotatedString) {
-        if (value.paragraphStyles.isEmpty() &&
-            value.spanStyles.isEmpty() &&
-            value.getStringAnnotations(0, value.text.length).isEmpty()
-        ) {
-            value.text
-        } else {
-            // Save space if we there is text only in the object
-            value.toString()
-        }
-    } else if (value is Collection<*>) {
-        val sb = StringBuilder()
-        value.forEach {
-            sb.append(resolveAnnotatedString(it))
-        }
-        sb.toString()
+private const val FIXED_INPUT_MASK = "***"
+
+internal fun transformCapturedText(
+    originalText: String,
+    textAndInputPrivacy: TextAndInputPrivacy,
+    isInput: Boolean = false
+): String = when (textAndInputPrivacy) {
+    TextAndInputPrivacy.MASK_SENSITIVE_INPUTS -> originalText
+    TextAndInputPrivacy.MASK_ALL_INPUTS -> if (isInput) {
+        FIXED_INPUT_MASK
     } else {
+        originalText
+    }
+
+    TextAndInputPrivacy.MASK_ALL -> if (isInput) {
+        FIXED_INPUT_MASK
+    } else {
+        StringObfuscator.getStringObfuscator().obfuscate(originalText)
+    }
+}
+
+internal fun resolveAnnotatedString(value: Any?): String = if (value is AnnotatedString) {
+    if (value.paragraphStyles.isEmpty() &&
+        value.spanStyles.isEmpty() &&
+        value.getStringAnnotations(0, value.text.length).isEmpty()
+    ) {
+        value.text
+    } else {
+        // Save space if we there is text only in the object
         value.toString()
     }
+} else if (value is Collection<*>) {
+    val sb = StringBuilder()
+    value.forEach {
+        sb.append(resolveAnnotatedString(it))
+    }
+    sb.toString()
+} else {
+    value.toString()
 }

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AndroidComposeViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AndroidComposeViewMapperTest.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
 import com.datadog.android.sessionreplay.recorder.MappingContext
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -114,7 +113,6 @@ class AndroidComposeViewMapperTest {
             mockSemanticsNode,
             fakeMappingContext.systemInformation.screenDensity,
             fakeMappingContext,
-            SessionReplayPrivacy.ALLOW,
             mockAsyncJobStatusCallback
         )
     }

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapperTest.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -112,7 +111,6 @@ class ComposeViewMapperTest {
             mockSemanticsNode,
             fakeMappingContext.systemInformation.screenDensity,
             fakeMappingContext,
-            SessionReplayPrivacy.ALLOW,
             mockAsyncJobStatusCallback
         )
     }

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapperTest.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -76,9 +75,6 @@ class RootSemanticsNodeMapperTest {
     @Forgery
     private lateinit var fakeMappingContext: MappingContext
 
-    @Forgery
-    private lateinit var fakePrivacy: SessionReplayPrivacy
-
     private lateinit var testedRootSemanticsNodeMapper: RootSemanticsNodeMapper
 
     @BeforeEach
@@ -107,7 +103,6 @@ class RootSemanticsNodeMapperTest {
             mockSemanticsNode,
             fakeMappingContext.systemInformation.screenDensity,
             fakeMappingContext,
-            fakePrivacy,
             mockAsyncJobStatusCallback
         )
 
@@ -129,7 +124,6 @@ class RootSemanticsNodeMapperTest {
             mockSemanticsNode,
             fakeMappingContext.systemInformation.screenDensity,
             fakeMappingContext,
-            fakePrivacy,
             mockAsyncJobStatusCallback
         )
 
@@ -151,7 +145,6 @@ class RootSemanticsNodeMapperTest {
             mockSemanticsNode,
             fakeMappingContext.systemInformation.screenDensity,
             fakeMappingContext,
-            fakePrivacy,
             mockAsyncJobStatusCallback
         )
 
@@ -173,7 +166,6 @@ class RootSemanticsNodeMapperTest {
             mockSemanticsNode,
             fakeMappingContext.systemInformation.screenDensity,
             fakeMappingContext,
-            fakePrivacy,
             mockAsyncJobStatusCallback
         )
 
@@ -195,7 +187,6 @@ class RootSemanticsNodeMapperTest {
             mockSemanticsNode,
             fakeMappingContext.systemInformation.screenDensity,
             fakeMappingContext,
-            fakePrivacy,
             mockAsyncJobStatusCallback
         )
 

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapperTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.GenericFontFamily
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -140,14 +141,19 @@ internal class TextFieldSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTes
                 cornerRadius = fakeCornerRadius
             )
         )
-
+        val expectedText =
+            if (fakeUiContext.textAndInputPrivacy == TextAndInputPrivacy.MASK_SENSITIVE_INPUTS) {
+                fakeEditText
+            } else {
+                "***"
+            }
         val expectedTextWireframe = MobileSegment.Wireframe.TextWireframe(
             id = (fakeSemanticsId.toLong() shl 32) + 1,
             x = (fakeBounds.left / fakeDensity).toLong(),
             y = (fakeBounds.top / fakeDensity).toLong(),
             width = (fakeBounds.size.width / fakeDensity).toLong(),
             height = (fakeBounds.size.height / fakeDensity).toLong(),
-            text = fakeEditText,
+            text = expectedText,
             textStyle = MobileSegment.TextStyle(
                 family = (fakeTextLayoutInfo.fontFamily as? GenericFontFamily)?.name
                     ?: DEFAULT_FONT_FAMILY,

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapperTest.kt
@@ -12,9 +12,11 @@ import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.sp
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
+import com.datadog.android.sessionreplay.internal.recorder.obfuscator.StringObfuscator
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
@@ -103,14 +105,18 @@ internal class TextSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest() {
             fakeUiContext,
             mockAsyncJobStatusCallback
         )
-
+        val expectedText = if (fakeUiContext.textAndInputPrivacy == TextAndInputPrivacy.MASK_ALL) {
+            StringObfuscator.getStringObfuscator().obfuscate(fakeTextLayoutInfo.text)
+        } else {
+            fakeTextLayoutInfo.text
+        }
         val expected = MobileSegment.Wireframe.TextWireframe(
             id = fakeSemanticsId.toLong(),
             x = (fakeBounds.left / fakeDensity).toLong(),
             y = (fakeBounds.top / fakeDensity).toLong(),
             width = (fakeBounds.size.width / fakeDensity).toLong(),
             height = (fakeBounds.size.height / fakeDensity).toLong(),
-            text = fakeTextLayoutInfo.text,
+            text = expectedText,
             textStyle = testedTextSemanticsNodeMapper.stubResolveTextStyle(
                 fakeUiContext,
                 fakeTextLayoutInfo

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/UIContextForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/UIContextForgeryFactory.kt
@@ -6,7 +6,8 @@
 
 package com.datadog.android.sessionreplay.compose.test.elmyr
 
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.ImagePrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
@@ -17,7 +18,8 @@ internal class UIContextForgeryFactory : ForgeryFactory<UiContext> {
         return UiContext(
             parentContentColor = forge.anAlphabeticalString(),
             density = forge.aFloat(0.01f, 100f),
-            privacy = forge.aValueFrom(SessionReplayPrivacy::class.java),
+            imagePrivacy = forge.aValueFrom(ImagePrivacy::class.java),
+            textAndInputPrivacy = forge.aValueFrom(TextAndInputPrivacy::class.java),
             isInUserInputLayout = forge.aBool(),
             imageWireframeHelper = mock()
         )

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
@@ -55,7 +55,6 @@ internal class DefaultImageWireframeHelper(
             return createContentPlaceholderWireframe(
                 id = id,
                 globalBounds = globalBounds,
-                density = density,
                 label = MASK_ALL_CONTENT_LABEL
             )
         }
@@ -65,7 +64,6 @@ internal class DefaultImageWireframeHelper(
             return createContentPlaceholderWireframe(
                 id = id,
                 globalBounds = globalBounds,
-                density = density,
                 label = MASK_CONTEXTUAL_CONTENT_LABEL
             )
         }
@@ -309,15 +307,14 @@ internal class DefaultImageWireframeHelper(
     private fun createContentPlaceholderWireframe(
         id: Long,
         globalBounds: GlobalBounds,
-        density: Float,
         label: String
     ): MobileSegment.Wireframe.PlaceholderWireframe {
         return MobileSegment.Wireframe.PlaceholderWireframe(
             id,
-            globalBounds.x.densityNormalized(density),
-            globalBounds.y.densityNormalized(density),
-            globalBounds.width.densityNormalized(density),
-            globalBounds.height.densityNormalized(density),
+            globalBounds.x,
+            globalBounds.y,
+            globalBounds.width,
+            globalBounds.height,
             label = label
         )
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -98,7 +98,7 @@ openTelemetry = "1.4.0"
 # Only for internal benchmark use
 openTelemetryBenchmark = "1.40.0"
 re2j = "1.7"
-material3Android = "1.3.1"
+material3Android = "1.1.2"
 
 
 [libraries]
@@ -155,7 +155,7 @@ androidXComposeRuntime = { module = "androidx.compose.runtime:runtime" }
 androidXComposeUi = { module = "androidx.compose.ui:ui" }
 androidXComposeUiTooling = { module = "androidx.compose.ui:ui-tooling" }
 androidXComposeMaterial = { module = "androidx.compose.material:material" }
-material3Android = { group = "androidx.compose.material3", name = "material3-android", version.ref = "material3Android" }
+material3Android = { group = "androidx.compose.material3", name = "material3", version.ref = "material3Android" }
 
 # DD-TRACE-OT
 openTracingApi = { module = "io.opentracing:opentracing-api", version.ref = "openTracing" }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/InputSample.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/InputSample.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
@@ -38,12 +39,22 @@ internal fun InputSample() {
 
         var input2 by remember { mutableStateOf("Input of Outlined Text Field") }
         OutlinedTextField(
+            modifier = Modifier.padding(top = 8.dp),
             value = input2,
             textStyle = TextStyle(
                 color = Color.Red
             ),
             onValueChange = { input2 = it },
             label = { Text("OutlinedTextField") }
+        )
+
+        var input3 by remember { mutableStateOf("Input of Password Field") }
+        TextField(
+            modifier = Modifier.padding(top = 8.dp),
+            value = input3,
+            onValueChange = { input3 = it },
+            label = { Text("Passowrd") },
+            visualTransformation = PasswordVisualTransformation()
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?

Apply Global privacy level to semantics node mapper, there are following major changes:
* Remove legacy privacy in UiContext, replace it by input privacy and image privacy
* Text and TextField semantics node mapper applied with input privacy
* Image semantics node mapper applied with image privacy

Besides, in sample app, material3 lib version is downgraded to align with compose bom version

### Motivation

RUM-7342

### Additional Notes

| | Selection screen| Typography screen | Input screen| 
| --- | --- | --- | --- |
| MASK_ALL | <img width="282" alt="Screenshot 2024-11-22 at 09 33 05" src="https://github.com/user-attachments/assets/2560489c-c3f5-4e6a-91d2-93e5353d907a"> | <img width="282" alt="Screenshot 2024-11-22 at 09 33 27" src="https://github.com/user-attachments/assets/05b26efc-21f4-4c0f-aec1-db1fc7fe1a45"> | <img width="282" alt="Screenshot 2024-11-22 at 09 34 02" src="https://github.com/user-attachments/assets/a4d57246-7f17-448a-a7ba-1d35baf0ca23">|
| MASK_ALL_INPUTS | <img width="284" alt="Screenshot 2024-11-22 at 09 36 49" src="https://github.com/user-attachments/assets/02ea1122-2925-4e0c-bf28-24804d2b73dc"> | <img width="283" alt="Screenshot 2024-11-22 at 09 37 08" src="https://github.com/user-attachments/assets/83384478-4786-4b21-8a07-0dbbb0488d03"> | <img width="280" alt="Screenshot 2024-11-22 at 09 40 08" src="https://github.com/user-attachments/assets/6696b7c8-3d4b-4ac7-baba-ad4c479fef26"> |
| MASK_SENSITIVE_INPUTS | <img width="282" alt="Screenshot 2024-11-22 at 09 42 11" src="https://github.com/user-attachments/assets/1bcbb9a8-bbd6-4447-8ba4-7caeb2e2c3f0"> |  <img width="280" alt="Screenshot 2024-11-22 at 09 42 28" src="https://github.com/user-attachments/assets/c1144819-8f82-4a85-8e90-94f49b86ac40">| <img width="282" alt="Screenshot 2024-11-22 at 09 42 50" src="https://github.com/user-attachments/assets/646c3ed8-5276-4673-9362-02e7d5327380">|

|  MASK_ALL | MASK_LARGE_ONLY| MASK_NONE|
| --- | --- | --- |
|<img width="283" alt="Screenshot 2024-11-22 at 09 44 49" src="https://github.com/user-attachments/assets/dd500882-9990-4fa2-86ea-3625dca289dd">|<img width="281" alt="Screenshot 2024-11-22 at 14 09 48" src="https://github.com/user-attachments/assets/2643b87f-6479-4711-ba2e-f1610f504642">| <img width="283" alt="Screenshot 2024-11-22 at 14 07 44" src="https://github.com/user-attachments/assets/3d0a4b03-e2d2-40f7-9fce-23984af143cb">|



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

