### PR TITLE
RUM-7081: Decouple Compose reflection functions and report to Telemetry

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/ReflectionUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/ReflectionUtils.kt
@@ -1,0 +1,100 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.utils
+
+import android.view.View
+import androidx.compose.runtime.Composition
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorProducer
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsOwner
+import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection
+import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.CompositionField
+import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.GetInnerLayerCoordinatorMethod
+import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.LayoutNodeField
+import com.datadog.android.sessionreplay.compose.internal.reflection.getSafe
+
+@Suppress("TooManyFunctions")
+internal class ReflectionUtils {
+
+    fun getComposition(view: View): Composition? {
+        return CompositionField?.getSafe(view) as? Composition
+    }
+
+    fun isBackgroundElement(modifier: Modifier): Boolean {
+        return ComposeReflection.BackgroundElementClass?.isInstance(modifier) == true
+    }
+
+    fun isPaddingElement(modifier: Modifier): Boolean {
+        return ComposeReflection.PaddingElementClass?.isInstance(modifier) == true
+    }
+
+    fun isTextStringSimpleElement(modifier: Modifier): Boolean {
+        return ComposeReflection.TextStringSimpleElement?.isInstance(modifier) == true
+    }
+
+    fun isWrappedCompositionClass(composition: Composition): Boolean {
+        return ComposeReflection.WrappedCompositionClass?.isInstance(composition) == true
+    }
+
+    fun isAndroidComposeView(any: Any): Boolean {
+        return ComposeReflection.AndroidComposeViewClass?.isInstance(any) == true
+    }
+
+    fun getOwner(composition: Composition): Any? {
+        return ComposeReflection.OwnerField?.getSafe(composition)
+    }
+
+    fun getSemanticsOwner(any: Any): SemanticsOwner? {
+        return ComposeReflection.SemanticsOwner?.getSafe(any) as? SemanticsOwner
+    }
+
+    fun isGraphicsLayerElement(modifier: Modifier): Boolean {
+        return ComposeReflection.GraphicsLayerElementClass?.isInstance(modifier) == true
+    }
+
+    fun getColorProducerColor(modifier: Modifier): Color? {
+        return (ComposeReflection.ColorProducerField?.getSafe(modifier) as? ColorProducer)?.invoke()
+    }
+
+    fun getPlaceable(semanticsNode: SemanticsNode): Placeable? {
+        val layoutNode = LayoutNodeField?.getSafe(semanticsNode)
+        val innerLayerCoordinator = layoutNode?.let { GetInnerLayerCoordinatorMethod?.invoke(it) }
+        return innerLayerCoordinator as? Placeable
+    }
+
+    fun getTopPadding(modifier: Modifier): Float {
+        return ComposeReflection.TopField?.getSafe(modifier) as? Float ?: 0.0f
+    }
+
+    fun getStartPadding(modifier: Modifier): Float {
+        return ComposeReflection.StartField?.getSafe(modifier) as? Float ?: 0.0f
+    }
+
+    fun getBottomPadding(modifier: Modifier): Float {
+        return ComposeReflection.BottomField?.getSafe(modifier) as? Float ?: 0.0f
+    }
+
+    fun getEndPadding(modifier: Modifier): Float {
+        return ComposeReflection.EndField?.getSafe(modifier) as? Float ?: 0.0f
+    }
+
+    fun getColor(modifier: Modifier): Long? {
+        return ComposeReflection.ColorField?.getSafe(modifier) as? Long
+    }
+
+    fun getShape(modifier: Modifier): Shape? {
+        return ComposeReflection.ShapeField?.getSafe(modifier) as? Shape
+    }
+
+    fun getClipShape(modifier: Modifier): Shape? {
+        return ComposeReflection.ClipShapeField?.getSafe(modifier) as? Shape
+    }
+}

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
@@ -8,51 +8,43 @@ package com.datadog.android.sessionreplay.compose.internal.utils
 
 import android.view.View
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composition
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsNode
-import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.text.TextLayoutInput
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.Density
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.TextLayoutInfo
-import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection
-import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.CompositionField
-import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.GetInnerLayerCoordinatorMethod
-import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.LayoutNodeField
-import com.datadog.android.sessionreplay.compose.internal.reflection.getSafe
 import com.datadog.android.sessionreplay.utils.GlobalBounds
 
 @Suppress("TooManyFunctions")
-internal class SemanticsUtils {
+internal class SemanticsUtils(private val reflectionUtils: ReflectionUtils = ReflectionUtils()) {
 
     internal fun findRootSemanticsNode(view: View): SemanticsNode? {
-        val composition = CompositionField?.getSafe(view) as? Composition
-        if (ComposeReflection.WrappedCompositionClass?.isInstance(composition) == true) {
-            val owner = ComposeReflection.OwnerField?.getSafe(composition)
-            if (ComposeReflection.AndroidComposeViewClass?.isInstance(owner) == true) {
-                val semanticsOwner = ComposeReflection.SemanticsOwner?.getSafe(owner) as? SemanticsOwner
-                val rootNode = semanticsOwner?.unmergedRootSemanticsNode
-                return rootNode
+        reflectionUtils.apply {
+            getComposition(view)?.takeIf { isWrappedCompositionClass(it) }?.let { composition ->
+                getOwner(composition)?.takeIf { isAndroidComposeView(it) }?.let { owner ->
+                    val semanticsOwner = reflectionUtils.getSemanticsOwner(owner)
+                    return semanticsOwner?.unmergedRootSemanticsNode
+                }
             }
         }
         return null
     }
 
-    internal fun resolveOuterBounds(semanticsNode: SemanticsNode): GlobalBounds {
+    private fun resolveOuterBounds(semanticsNode: SemanticsNode): GlobalBounds {
         var currentBounds = resolveInnerBounds(semanticsNode)
         semanticsNode.layoutInfo.getModifierInfo().filter {
-            (ComposeReflection.PaddingElementClass?.isInstance(it.modifier) == true)
+            reflectionUtils.isPaddingElement(it.modifier)
         }.forEach {
-            val top = ComposeReflection.TopField?.getSafe(it.modifier) as? Float ?: 0.0f
-            val start = ComposeReflection.StartField?.getSafe(it.modifier) as? Float ?: 0.0f
-            val end = ComposeReflection.EndField?.getSafe(it.modifier) as? Float ?: 0.0f
-            val bottom = ComposeReflection.BottomField?.getSafe(it.modifier) as? Float ?: 0.0f
+            val top = reflectionUtils.getTopPadding(it.modifier)
+            val start = reflectionUtils.getStartPadding(it.modifier)
+            val end = reflectionUtils.getEndPadding(it.modifier)
+            val bottom = reflectionUtils.getBottomPadding(it.modifier)
             currentBounds = GlobalBounds(
                 x = currentBounds.x - start.toLong(),
                 y = currentBounds.y - top.toLong(),
@@ -79,15 +71,15 @@ internal class SemanticsUtils {
         // -> background(): retrieve the color and use `currentBackgroundInfo` to generate wireframes,
         //                  then reset `currentBackgroundInfo`.
         semanticsNode.layoutInfo.getModifierInfo().forEach { modifierInfo ->
-            if (ComposeReflection.BackgroundElementClass?.isInstance(modifierInfo.modifier) == true) {
-                val color = ComposeReflection.ColorField?.getSafe(modifierInfo.modifier) as? Long
+            if (reflectionUtils.isBackgroundElement(modifierInfo.modifier)) {
+                val color = reflectionUtils.getColor(modifierInfo.modifier)
                 currentBackgroundInfo = currentBackgroundInfo.copy(globalBounds = currentBounds, color = color)
                 backgroundInfoList.add(currentBackgroundInfo)
                 currentBackgroundInfo = BackgroundInfo()
-            } else if (ComposeReflection.PaddingElementClass?.isInstance(modifierInfo.modifier) == true) {
+            } else if (reflectionUtils.isPaddingElement(modifierInfo.modifier)) {
                 currentBounds = shrinkInnerBounds(modifierInfo.modifier, currentBounds)
                 currentBackgroundInfo = currentBackgroundInfo.copy(globalBounds = currentBounds)
-            } else if (ComposeReflection.GraphicsLayerElementClass?.isInstance(modifierInfo.modifier) == true) {
+            } else if (reflectionUtils.isGraphicsLayerElement(modifierInfo.modifier)) {
                 val cornerRadius =
                     resolveClipShape(modifierInfo.modifier, currentBounds, density) ?: 0f
                 currentBackgroundInfo = currentBackgroundInfo.copy(cornerRadius = cornerRadius)
@@ -99,31 +91,26 @@ internal class SemanticsUtils {
     internal fun resolveBackgroundColor(semanticsNode: SemanticsNode): Long? {
         val backgroundModifierInfo =
             semanticsNode.layoutInfo.getModifierInfo().firstOrNull { modifierInfo ->
-                ComposeReflection.BackgroundElementClass?.isInstance(modifierInfo.modifier) == true
+                reflectionUtils.isBackgroundElement(modifierInfo.modifier)
             }
-        return backgroundModifierInfo?.let {
-            ComposeReflection.ColorField?.getSafe(it.modifier) as? Long
-        }
+        return backgroundModifierInfo?.let { reflectionUtils.getColor(it.modifier) }
     }
 
     internal fun resolveBackgroundShape(semanticsNode: SemanticsNode): Shape? {
-        val backgroundModifierInfo =
-            semanticsNode.layoutInfo.getModifierInfo().firstOrNull { modifierInfo ->
-                ComposeReflection.BackgroundElementClass?.isInstance(modifierInfo.modifier) == true
-            }
-        return backgroundModifierInfo?.let {
-            ComposeReflection.ShapeField?.getSafe(it.modifier) as? Shape
-        }
+        val backgroundModifier = semanticsNode.layoutInfo.getModifierInfo().firstOrNull {
+            reflectionUtils.isBackgroundElement(it.modifier)
+        }?.modifier
+        return backgroundModifier?.let { reflectionUtils.getShape(it) }
     }
 
     private fun shrinkInnerBounds(
         modifier: Modifier,
         currentBounds: GlobalBounds
     ): GlobalBounds {
-        val top = ComposeReflection.TopField?.getSafe(modifier) as? Float ?: 0.0f
-        val start = ComposeReflection.StartField?.getSafe(modifier) as? Float ?: 0.0f
-        val end = ComposeReflection.EndField?.getSafe(modifier) as? Float ?: 0.0f
-        val bottom = ComposeReflection.BottomField?.getSafe(modifier) as? Float ?: 0.0f
+        val top = reflectionUtils.getTopPadding(modifier)
+        val start = reflectionUtils.getStartPadding(modifier)
+        val end = reflectionUtils.getEndPadding(modifier)
+        val bottom = reflectionUtils.getBottomPadding(modifier)
         return GlobalBounds(
             x = currentBounds.x + start.toLong(),
             y = currentBounds.y + top.toLong(),
@@ -150,9 +137,7 @@ internal class SemanticsUtils {
     }
 
     private fun resolveInnerSize(semanticsNode: SemanticsNode): Size? {
-        val layoutNode = LayoutNodeField?.getSafe(semanticsNode)
-        val innerLayerCoordinator = layoutNode?.let { GetInnerLayerCoordinatorMethod?.invoke(it) }
-        val placeable = innerLayerCoordinator as? Placeable
+        val placeable = reflectionUtils.getPlaceable(semanticsNode)
         val height = placeable?.height
         val width = placeable?.width
         return if (height != null && width != null) {
@@ -167,9 +152,8 @@ internal class SemanticsUtils {
         currentBounds: GlobalBounds,
         density: Density
     ): Float? {
-        val shape = ComposeReflection.ClipShapeField?.getSafe(modifier) as? Shape
-        return shape?.let {
-            resolveCornerRadius(it, currentBounds, density)
+        return reflectionUtils.getClipShape(modifier)?.let { shape ->
+            resolveCornerRadius(shape, currentBounds, density)
         }
     }
 
@@ -198,15 +182,28 @@ internal class SemanticsUtils {
             textLayoutResults
         )
         val layoutInput = textLayoutResults.firstOrNull()?.layoutInput
+        val modifierColor = resolveModifierColor(semanticsNode)
         return layoutInput?.let {
-            convertTextLayoutInfo(it)
+            convertTextLayoutInfo(it, modifierColor)
         }
     }
 
-    private fun convertTextLayoutInfo(layoutInput: TextLayoutInput): TextLayoutInfo {
+    private fun resolveModifierColor(semanticsNode: SemanticsNode): Color? {
+        val modifier = semanticsNode.layoutInfo.getModifierInfo().firstOrNull {
+            reflectionUtils.isTextStringSimpleElement(it.modifier)
+        }?.modifier
+        return modifier?.let {
+            reflectionUtils.getColorProducerColor(it)
+        }
+    }
+
+    private fun convertTextLayoutInfo(
+        layoutInput: TextLayoutInput,
+        modifierColor: Color?
+    ): TextLayoutInfo {
         return TextLayoutInfo(
             text = resolveAnnotatedString(layoutInput.text),
-            color = layoutInput.style.color.value,
+            color = modifierColor?.value ?: layoutInput.style.color.value,
             textAlign = layoutInput.style.textAlign,
             fontSize = layoutInput.style.fontSize.value.toLong(),
             fontFamily = layoutInput.style.fontFamily

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtilsTest.kt
@@ -1,0 +1,389 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.utils
+
+import android.view.View
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composition
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.LayoutInfo
+import androidx.compose.ui.layout.ModifierInfo
+import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.semantics.AccessibilityAction
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsConfiguration
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsOwner
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextLayoutInput
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.TextUnitType
+import androidx.compose.ui.unit.dp
+import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.TextLayoutInfo
+import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
+import com.datadog.android.sessionreplay.utils.GlobalBounds
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.FloatForgery
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(SessionReplayComposeForgeConfigurator::class)
+class SemanticsUtilsTest {
+
+    private lateinit var testedSemanticsUtils: SemanticsUtils
+
+    @Mock
+    private lateinit var mockReflectionUtils: ReflectionUtils
+
+    @Mock
+    private lateinit var mockView: View
+
+    @Mock
+    private lateinit var mockSemanticsNode: SemanticsNode
+
+    @Mock
+    private lateinit var mockLayoutInfo: LayoutInfo
+
+    @Mock
+    private lateinit var mockModifierInfo: ModifierInfo
+
+    @Mock
+    private lateinit var mockModifier: Modifier
+
+    private var fakeOffset: Offset = Offset(0f, 0f)
+
+    @FloatForgery(min = 1f, max = 10f)
+    private var fakeDensity: Float = 0f
+
+    @Mock
+    private lateinit var mockConfig: SemanticsConfiguration
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        testedSemanticsUtils = SemanticsUtils(reflectionUtils = mockReflectionUtils)
+        whenever(mockSemanticsNode.layoutInfo) doReturn mockLayoutInfo
+        whenever(mockLayoutInfo.getModifierInfo()) doReturn listOf(mockModifierInfo)
+        whenever(mockModifierInfo.modifier) doReturn mockModifier
+        whenever(mockLayoutInfo.density) doReturn Density(fakeDensity)
+        whenever(mockSemanticsNode.config) doReturn mockConfig
+        fakeOffset = Offset(x = forge.aFloat(), y = forge.aFloat())
+    }
+
+    @Test
+    fun `M return root semantics W findRootSemanticsNode`() {
+        // Given
+        val mockComposition = mock<Composition>()
+        val mockOwner = mock<Any>()
+        val mockSemanticsOwner = mock<SemanticsOwner>()
+        whenever(mockReflectionUtils.getComposition(mockView)) doReturn mockComposition
+        whenever(mockReflectionUtils.isWrappedCompositionClass(mockComposition)) doReturn true
+        whenever(mockReflectionUtils.getOwner(mockComposition)) doReturn mockOwner
+        whenever(mockReflectionUtils.isAndroidComposeView(mockOwner)) doReturn true
+        whenever(mockReflectionUtils.getSemanticsOwner(mockOwner)) doReturn mockSemanticsOwner
+        whenever(mockSemanticsOwner.unmergedRootSemanticsNode) doReturn mockSemanticsNode
+
+        // When
+        val result = testedSemanticsUtils.findRootSemanticsNode(mockView)
+
+        // Then
+        assertThat(result).isEqualTo(mockSemanticsNode)
+    }
+
+    @Test
+    fun `M return shape W resolveBackgroundShape`() {
+        // Given
+        val mockShape = mock<Shape>()
+        whenever(mockReflectionUtils.isBackgroundElement(mockModifier)) doReturn true
+        whenever(mockReflectionUtils.getShape(mockModifier)) doReturn mockShape
+
+        // When
+        val result = testedSemanticsUtils.resolveBackgroundShape(mockSemanticsNode)
+
+        // Then
+        assertThat(result).isEqualTo(mockShape)
+    }
+
+    @Test
+    fun `M return inner bounds W resolveInnerBounds`() {
+        // Given
+        val placeable = mock<Placeable>()
+        whenever(mockReflectionUtils.getPlaceable(mockSemanticsNode)) doReturn placeable
+        whenever(mockSemanticsNode.positionInRoot) doReturn fakeOffset
+
+        // When
+        val result = testedSemanticsUtils.resolveInnerBounds(mockSemanticsNode)
+        val expected = GlobalBounds(
+            x = (fakeOffset.x / fakeDensity).toLong(),
+            y = (fakeOffset.y / fakeDensity).toLong(),
+            width = (placeable.width / fakeDensity).toLong(),
+            height = (placeable.width / fakeDensity).toLong()
+        )
+
+        // Then
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `M return corner radius W resolveCornerRadius`(
+        @Forgery fakeBounds: GlobalBounds,
+        @IntForgery fakeCornerSizeValue: Int
+    ) {
+        // Given
+        val mockShape = mock<RoundedCornerShape>()
+        val fakeDensity = Density(fakeDensity)
+        val fakeCornerSize = CornerSize(fakeCornerSizeValue.dp)
+        whenever(mockShape.topStart) doReturn fakeCornerSize
+
+        // When
+        val size = Size(
+            fakeBounds.width.toFloat() * fakeDensity.density,
+            fakeBounds.height.toFloat() * fakeDensity.density
+        )
+        val expected = fakeCornerSize.toPx(size, fakeDensity) / fakeDensity.density
+        val result = testedSemanticsUtils.resolveCornerRadius(mockShape, fakeBounds, fakeDensity)
+
+        // Then
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `M return color W resolveBackgroundColor`(forge: Forge) {
+        // Given
+        val fakeColorValue = forge.aLong()
+        whenever(mockReflectionUtils.isBackgroundElement(mockModifier)) doReturn true
+        whenever(mockReflectionUtils.getColor(mockModifier)) doReturn fakeColorValue
+
+        // When
+        val result = testedSemanticsUtils.resolveBackgroundColor(mockSemanticsNode)
+
+        // Then
+        assertThat(result).isEqualTo(fakeColorValue)
+    }
+
+    @Test
+    fun `M return TextLayoutInfo W resolveTextLayoutInfo modifier color is null`(forge: Forge) {
+        // Given
+        val fakeText = AnnotatedString(forge.aString())
+        val fakeColorValue = forge.aLong().toULong()
+        val fakeFontSize = forge.aFloat()
+        val fakeFontFamily = forge.anElementFrom(
+            listOf(
+                FontFamily.Serif,
+                FontFamily.SansSerif,
+                FontFamily.Cursive,
+                FontFamily.Monospace,
+                FontFamily.Default
+            )
+        )
+        val fakeTextAlign = forge.anElementFrom(TextAlign.values())
+        val mockResult = mock<AccessibilityAction<(MutableList<TextLayoutResult>) -> Boolean>>()
+        val mockAction = mock<(MutableList<TextLayoutResult>) -> Boolean>()
+        val textLayoutResult: TextLayoutResult = mock()
+        val textLayoutResults = mutableListOf<TextLayoutResult>()
+        val mockTextLayoutInput = mock<TextLayoutInput>()
+        val mockTextStyle = mock<TextStyle>()
+        whenever(mockConfig.getOrNull(SemanticsActions.GetTextLayoutResult)) doReturn mockResult
+        whenever(mockResult.action) doReturn mockAction
+        whenever(textLayoutResult.layoutInput) doReturn mockTextLayoutInput
+        doAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            (invocation.arguments[0] as MutableList<TextLayoutResult>).add(textLayoutResult)
+            true
+        }.whenever(mockAction).invoke(textLayoutResults)
+        whenever(mockTextLayoutInput.style) doReturn mockTextStyle
+        whenever(mockTextLayoutInput.text) doReturn fakeText
+        whenever(mockTextStyle.color) doReturn Color(fakeColorValue)
+        whenever(mockTextStyle.textAlign) doReturn fakeTextAlign
+        whenever(mockTextStyle.fontSize) doReturn TextUnit(fakeFontSize, TextUnitType.Sp)
+        whenever(mockTextStyle.fontFamily) doReturn fakeFontFamily
+
+        // When
+        val result = testedSemanticsUtils.resolveTextLayoutInfo(mockSemanticsNode)
+
+        // Then
+        val expected = TextLayoutInfo(
+            text = resolveAnnotatedString(fakeText),
+            color = fakeColorValue,
+            textAlign = fakeTextAlign,
+            fontSize = fakeFontSize.toLong(),
+            fontFamily = fakeFontFamily
+        )
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `M return TextLayoutInfo W resolveTextLayoutInfo modifier color is not null`(forge: Forge) {
+        // Given
+        val fakeText = AnnotatedString(forge.aString())
+        val fakeColorValue = forge.aLong().toULong()
+        val fakeModifierColorValue = forge.aLong().toULong()
+        val fakeFontSize = forge.aFloat()
+        val fakeFontFamily = forge.anElementFrom(
+            listOf(
+                FontFamily.Serif,
+                FontFamily.SansSerif,
+                FontFamily.Cursive,
+                FontFamily.Monospace,
+                FontFamily.Default
+            )
+        )
+        val fakeTextAlign = forge.anElementFrom(TextAlign.values())
+        val mockResult = mock<AccessibilityAction<(MutableList<TextLayoutResult>) -> Boolean>>()
+        val mockAction = mock<(MutableList<TextLayoutResult>) -> Boolean>()
+        val textLayoutResult: TextLayoutResult = mock()
+        val textLayoutResults = mutableListOf<TextLayoutResult>()
+        val mockTextLayoutInput = mock<TextLayoutInput>()
+        val mockTextStyle = mock<TextStyle>()
+        whenever(mockConfig.getOrNull(SemanticsActions.GetTextLayoutResult)) doReturn mockResult
+        whenever(mockResult.action) doReturn mockAction
+        whenever(textLayoutResult.layoutInput) doReturn mockTextLayoutInput
+        doAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            (invocation.arguments[0] as MutableList<TextLayoutResult>).add(textLayoutResult)
+            true
+        }.whenever(mockAction).invoke(textLayoutResults)
+        whenever(mockTextLayoutInput.style) doReturn mockTextStyle
+        whenever(mockTextLayoutInput.text) doReturn fakeText
+        whenever(mockTextStyle.color) doReturn Color(fakeColorValue)
+        whenever(mockTextStyle.textAlign) doReturn fakeTextAlign
+        whenever(mockTextStyle.fontSize) doReturn TextUnit(fakeFontSize, TextUnitType.Sp)
+        whenever(mockTextStyle.fontFamily) doReturn fakeFontFamily
+        whenever(mockReflectionUtils.isTextStringSimpleElement(mockModifier)) doReturn true
+        whenever(mockReflectionUtils.getColorProducerColor(mockModifier)) doReturn Color(
+            fakeModifierColorValue
+        )
+
+        // When
+        val result = testedSemanticsUtils.resolveTextLayoutInfo(mockSemanticsNode)
+
+        // Then
+        val expected = TextLayoutInfo(
+            text = resolveAnnotatedString(fakeText),
+            color = fakeModifierColorValue,
+            textAlign = fakeTextAlign,
+            fontSize = fakeFontSize.toLong(),
+            fontFamily = fakeFontFamily
+        )
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `M return backgroundInfo W resolveBackgroundInfo`(
+        forge: Forge,
+        @LongForgery fakeColorValue: Long,
+        @IntForgery fakeCornerSizeValue: Int
+    ) {
+        // Given
+        val leftPos = forge.aSmallInt()
+        val rightPos = forge.anInt(leftPos, 0x2000)
+        val topPos = forge.aSmallInt()
+        val bottomPos = forge.anInt(topPos, 0x2000)
+        val fakeRect = Rect(
+            left = leftPos.toFloat(),
+            top = topPos.toFloat(),
+            right = rightPos.toFloat(),
+            bottom = bottomPos.toFloat()
+        )
+        val mockShape = mock<RoundedCornerShape>()
+        val mockPaddingModifier = mock<Modifier>()
+        val mockBackgroundModifier = mock<Modifier>()
+        val mockShapeModifier = mock<Modifier>()
+        val mockPaddingModifierInfo = mock<ModifierInfo>()
+        val mockBackgroundModifierInfo = mock<ModifierInfo>()
+        val mockShapeModifierInfo = mock<ModifierInfo>()
+        val fakeDensity = Density(fakeDensity)
+        val fakeBounds = rectToBounds(fakeRect, fakeDensity.density)
+        val fakeCornerSize = CornerSize(fakeCornerSizeValue.dp)
+        val topPadding: Float = forge.aSmallInt().toFloat()
+        val startPadding: Float = forge.aSmallInt().toFloat()
+        val endPadding: Float = forge.aSmallInt().toFloat()
+        val bottomPadding: Float = forge.aSmallInt().toFloat()
+        whenever(mockShape.topStart) doReturn fakeCornerSize
+        whenever(mockShapeModifierInfo.modifier) doReturn mockShapeModifier
+        whenever(mockBackgroundModifierInfo.modifier) doReturn mockBackgroundModifier
+        whenever(mockPaddingModifierInfo.modifier) doReturn mockPaddingModifier
+        whenever(mockReflectionUtils.getColor(mockBackgroundModifier)) doReturn fakeColorValue
+        whenever(mockReflectionUtils.getClipShape(mockShapeModifier)) doReturn mockShape
+        whenever(mockReflectionUtils.getTopPadding(mockPaddingModifier)) doReturn topPadding
+        whenever(mockReflectionUtils.getStartPadding(mockPaddingModifier)) doReturn startPadding
+        whenever(mockReflectionUtils.getBottomPadding(mockPaddingModifier)) doReturn bottomPadding
+        whenever(mockReflectionUtils.getEndPadding(mockPaddingModifier)) doReturn endPadding
+        whenever(mockReflectionUtils.isPaddingElement(mockPaddingModifier)) doReturn true
+        whenever(mockReflectionUtils.isBackgroundElement(mockBackgroundModifier)) doReturn true
+        whenever(mockReflectionUtils.isGraphicsLayerElement(mockShapeModifier)) doReturn true
+        whenever(mockLayoutInfo.getModifierInfo()) doReturn listOf(
+            mockShapeModifierInfo,
+            mockPaddingModifierInfo,
+            mockBackgroundModifierInfo
+        )
+        whenever(mockSemanticsNode.boundsInRoot) doReturn fakeRect
+        whenever(mockSemanticsNode.positionInRoot) doReturn Offset(fakeRect.left, fakeRect.top)
+        val size = Size(
+            fakeBounds.width.toFloat() * fakeDensity.density,
+            fakeBounds.height.toFloat() * fakeDensity.density
+        )
+        val cornerRadius = fakeCornerSize.toPx(size, fakeDensity) / fakeDensity.density
+
+        // When
+        val result = testedSemanticsUtils.resolveBackgroundInfo(mockSemanticsNode)
+        val expected = BackgroundInfo(
+            color = fakeColorValue,
+            globalBounds = GlobalBounds(
+                x = fakeBounds.x,
+                y = fakeBounds.y,
+                width = fakeBounds.width,
+                height = fakeBounds.height
+
+            ),
+            cornerRadius = cornerRadius
+        )
+
+        // Then
+        assertThat(result).containsExactly(expected)
+    }
+
+    private fun rectToBounds(rect: Rect, density: Float): GlobalBounds {
+        val width = ((rect.right - rect.left) / density).toLong()
+        val height = ((rect.bottom - rect.top) / density).toLong()
+        val x = (rect.left / density).toLong()
+        val y = (rect.top / density).toLong()
+        return GlobalBounds(x, y, width, height)
+    }
+}


### PR DESCRIPTION
### What does this PR do?

* Decouple Compose reflection functions from `SemanticsUtils` to `ReflectionUtils`.
* Add Unit test to `SemanticsUtils`
* Clean up `ComposeReflection` so they can have unified logs and report to Telemetry.
* 

### Motivation

RUM-7081

###  Demo

RUM Telemetry result:
<img width="1282" alt="image" src="https://github.com/user-attachments/assets/01a6c6fc-fa03-49ec-a2ab-702489667324">

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

