### PR TITLE
RUM-7341: Add Compose FGM override API

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/api/apiSurface
+++ b/features/dd-sdk-android-session-replay-compose/api/apiSurface
@@ -4,3 +4,7 @@ class com.datadog.android.sessionreplay.compose.ComposeExtensionSupport : com.da
   override fun getCustomDrawableMapper(): List<com.datadog.android.sessionreplay.utils.DrawableToColorMapper>
   override fun name(): String
 annotation com.datadog.android.sessionreplay.compose.ExperimentalSessionReplayApi
+fun androidx.compose.ui.Modifier.sessionReplayHide(Boolean): androidx.compose.ui.Modifier
+fun androidx.compose.ui.Modifier.sessionReplayImagePrivacy(com.datadog.android.sessionreplay.ImagePrivacy): androidx.compose.ui.Modifier
+fun androidx.compose.ui.Modifier.sessionReplayTextAndInputPrivacy(com.datadog.android.sessionreplay.TextAndInputPrivacy): androidx.compose.ui.Modifier
+fun androidx.compose.ui.Modifier.sessionReplayTouchPrivacy(com.datadog.android.sessionreplay.TouchPrivacy): androidx.compose.ui.Modifier

--- a/features/dd-sdk-android-session-replay-compose/api/dd-sdk-android-session-replay-compose.api
+++ b/features/dd-sdk-android-session-replay-compose/api/dd-sdk-android-session-replay-compose.api
@@ -10,3 +10,10 @@ public final class com/datadog/android/sessionreplay/compose/ComposeExtensionSup
 public abstract interface annotation class com/datadog/android/sessionreplay/compose/ExperimentalSessionReplayApi : java/lang/annotation/Annotation {
 }
 
+public final class com/datadog/android/sessionreplay/compose/internal/ModifierExtKt {
+	public static final fun sessionReplayHide (Landroidx/compose/ui/Modifier;Z)Landroidx/compose/ui/Modifier;
+	public static final fun sessionReplayImagePrivacy (Landroidx/compose/ui/Modifier;Lcom/datadog/android/sessionreplay/ImagePrivacy;)Landroidx/compose/ui/Modifier;
+	public static final fun sessionReplayTextAndInputPrivacy (Landroidx/compose/ui/Modifier;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;)Landroidx/compose/ui/Modifier;
+	public static final fun sessionReplayTouchPrivacy (Landroidx/compose/ui/Modifier;Lcom/datadog/android/sessionreplay/TouchPrivacy;)Landroidx/compose/ui/Modifier;
+}
+

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/ModifierExt.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/ModifierExt.kt
@@ -1,0 +1,83 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import androidx.compose.ui.semantics.semantics
+import com.datadog.android.sessionreplay.ImagePrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
+import com.datadog.android.sessionreplay.TouchPrivacy
+
+/**
+ * Allows setting a view to be "hidden" in the hierarchy in Session Replay.
+ *
+ * @param hide pass `true` to hide the composable, or `false` to remove the override
+ */
+fun Modifier.sessionReplayHide(hide: Boolean): Modifier {
+    return this.semantics {
+        this.hide = hide
+    }
+}
+
+/**
+ * Allows overriding the image privacy for a view in Session Replay.
+ *
+ * @param imagePrivacy the new privacy level to use for the composable.
+ */
+fun Modifier.sessionReplayImagePrivacy(imagePrivacy: ImagePrivacy): Modifier {
+    return this.semantics {
+        this.imagePrivacy = imagePrivacy
+    }
+}
+
+/**
+ * Allows overriding the text and input privacy for a view in Session Replay.
+ *
+ * @param textAndInputPrivacy the new privacy level to use for the composable.
+ */
+fun Modifier.sessionReplayTextAndInputPrivacy(textAndInputPrivacy: TextAndInputPrivacy): Modifier {
+    return this.semantics {
+        this.textInputPrivacy = textAndInputPrivacy
+    }
+}
+
+/**
+ * Allows overriding the touch privacy for a view in Session Replay.
+ *
+ * @param touchPrivacy the new privacy level to use for the composable
+ * or null to remove the override.
+ */
+fun Modifier.sessionReplayTouchPrivacy(touchPrivacy: TouchPrivacy): Modifier {
+    return this.semantics {
+        this.touchPrivacy = touchPrivacy
+    }
+}
+
+private val SessionReplayHidePropertyKey: SemanticsPropertyKey<Boolean> = SemanticsPropertyKey(
+    name = "_dd_session_replay_hide"
+)
+
+internal val ImagePrivacySemanticsPropertyKey: SemanticsPropertyKey<ImagePrivacy> =
+    SemanticsPropertyKey(
+        name = "_dd_session_replay_image_privacy"
+    )
+
+internal val TextInputSemanticsPropertyKey: SemanticsPropertyKey<TextAndInputPrivacy> =
+    SemanticsPropertyKey(
+        name = "_dd_session_replay_text_input_privacy"
+    )
+
+internal val TouchSemanticsPropertyKey: SemanticsPropertyKey<TouchPrivacy> = SemanticsPropertyKey(
+    name = "_dd_session_replay_touch_privacy"
+)
+
+private var SemanticsPropertyReceiver.hide by SessionReplayHidePropertyKey
+private var SemanticsPropertyReceiver.imagePrivacy by ImagePrivacySemanticsPropertyKey
+private var SemanticsPropertyReceiver.textInputPrivacy by TextInputSemanticsPropertyKey
+private var SemanticsPropertyReceiver.touchPrivacy by TouchSemanticsPropertyKey

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ContainerSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ContainerSemanticsNodeMapper.kt
@@ -26,10 +26,16 @@ internal class ContainerSemanticsNodeMapper(
         val backgroundColor = semanticsUtils.resolveBackgroundColor(semanticsNode)?.let {
             convertColor(it)
         }
+        val textAndInputPrivacy = semanticsUtils.getTextAndInputPrivacyOverride(semanticsNode)
+            ?: parentContext.textAndInputPrivacy
+        val imagePrivacy = semanticsUtils.getImagePrivacyOverride(semanticsNode)
+            ?: parentContext.imagePrivacy
         return SemanticsWireframe(
             wireframes = wireframes,
             uiContext = parentContext.copy(
-                parentContentColor = backgroundColor ?: parentContext.parentContentColor
+                parentContentColor = backgroundColor ?: parentContext.parentContentColor,
+                imagePrivacy = imagePrivacy,
+                textAndInputPrivacy = textAndInputPrivacy
             )
         )
     }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ImageSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ImageSemanticsNodeMapper.kt
@@ -22,11 +22,13 @@ import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeRefl
 import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.PainterFieldOfAsyncImagePainter
 import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.PainterFieldOfContentPainter
 import com.datadog.android.sessionreplay.compose.internal.reflection.getSafe
+import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
 
 internal class ImageSemanticsNodeMapper(
-    colorStringFormatter: ColorStringFormatter
+    colorStringFormatter: ColorStringFormatter,
+    private val semanticsUtils: SemanticsUtils
 ) : AbstractSemanticsNodeMapper(colorStringFormatter) {
 
     override fun map(
@@ -37,6 +39,8 @@ internal class ImageSemanticsNodeMapper(
         val bounds = resolveBounds(semanticsNode)
         val bitmapInfo = resolveSemanticsPainter(semanticsNode)
         val containerFrames = resolveModifierWireframes(semanticsNode).toMutableList()
+        val imagePrivacy =
+            semanticsUtils.getImagePrivacyOverride(semanticsNode) ?: parentContext.imagePrivacy
         val imageWireframe = if (bitmapInfo != null) {
             parentContext.imageWireframeHelper.createImageWireframeByBitmap(
                 id = semanticsNode.id.toLong(),
@@ -44,7 +48,7 @@ internal class ImageSemanticsNodeMapper(
                 bitmap = bitmapInfo.bitmap,
                 density = parentContext.density,
                 isContextualImage = bitmapInfo.isContextualImage,
-                imagePrivacy = parentContext.imagePrivacy,
+                imagePrivacy = imagePrivacy,
                 asyncJobStatusCallback = asyncJobStatusCallback,
                 clipping = null,
                 shapeStyle = null,

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapper.kt
@@ -27,7 +27,7 @@ internal class RootSemanticsNodeMapper(
         Role.RadioButton to RadioButtonSemanticsNodeMapper(colorStringFormatter, semanticsUtils),
         Role.Tab to TabSemanticsNodeMapper(colorStringFormatter, semanticsUtils),
         Role.Button to ButtonSemanticsNodeMapper(colorStringFormatter, semanticsUtils),
-        Role.Image to ImageSemanticsNodeMapper(colorStringFormatter)
+        Role.Image to ImageSemanticsNodeMapper(colorStringFormatter, semanticsUtils)
     ),
     // Text doesn't have a role in semantics, so it should be a fallback mapper.
     private val textSemanticsNodeMapper: TextSemanticsNodeMapper = TextSemanticsNodeMapper(

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
 import androidx.compose.ui.semantics.SemanticsNode
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWireframe
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
@@ -25,20 +26,23 @@ internal open class TextSemanticsNodeMapper(
         parentContext: UiContext,
         asyncJobStatusCallback: AsyncJobStatusCallback
     ): SemanticsWireframe {
-        val textWireframe = resolveTextWireFrame(parentContext, semanticsNode)
+        val textAndInputPrivacy = semanticsUtils.getTextAndInputPrivacyOverride(semanticsNode)
+            ?: parentContext.textAndInputPrivacy
+        val textWireframe = resolveTextWireFrame(parentContext, semanticsNode, textAndInputPrivacy)
         return SemanticsWireframe(
             wireframes = listOfNotNull(textWireframe),
-            parentContext
+            parentContext.copy(textAndInputPrivacy = textAndInputPrivacy)
         )
     }
 
     protected fun resolveTextWireFrame(
         parentContext: UiContext,
-        semanticsNode: SemanticsNode
+        semanticsNode: SemanticsNode,
+        textAndInputPrivacy: TextAndInputPrivacy
     ): MobileSegment.Wireframe.TextWireframe? {
         val textLayoutInfo = semanticsUtils.resolveTextLayoutInfo(semanticsNode)
         val capturedText = textLayoutInfo?.text?.let {
-            transformCapturedText(it, parentContext.textAndInputPrivacy)
+            transformCapturedText(it, textAndInputPrivacy)
         }
         val bounds = resolveBounds(semanticsNode)
         return capturedText?.let { text ->

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
@@ -18,6 +18,12 @@ import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.text.TextLayoutInput
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.Density
+import com.datadog.android.sessionreplay.ImagePrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
+import com.datadog.android.sessionreplay.TouchPrivacy
+import com.datadog.android.sessionreplay.compose.ImagePrivacySemanticsPropertyKey
+import com.datadog.android.sessionreplay.compose.TextInputSemanticsPropertyKey
+import com.datadog.android.sessionreplay.compose.TouchSemanticsPropertyKey
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.TextLayoutInfo
 import com.datadog.android.sessionreplay.utils.GlobalBounds
 
@@ -208,5 +214,17 @@ internal class SemanticsUtils(private val reflectionUtils: ReflectionUtils = Ref
             fontSize = layoutInput.style.fontSize.value.toLong(),
             fontFamily = layoutInput.style.fontFamily
         )
+    }
+
+    internal fun getImagePrivacyOverride(semanticsNode: SemanticsNode): ImagePrivacy? {
+        return semanticsNode.config.getOrNull(ImagePrivacySemanticsPropertyKey)
+    }
+
+    internal fun getTextAndInputPrivacyOverride(semanticsNode: SemanticsNode): TextAndInputPrivacy? {
+        return semanticsNode.config.getOrNull(TextInputSemanticsPropertyKey)
+    }
+
+    internal fun getTouchPrivacyOverride(semanticsNode: SemanticsNode): TouchPrivacy? {
+        return semanticsNode.config.getOrNull(TouchSemanticsPropertyKey)
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ContainerSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ContainerSemanticsNodeMapperTest.kt
@@ -7,6 +7,8 @@
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
 import androidx.compose.ui.semantics.SemanticsNode
+import com.datadog.android.sessionreplay.ImagePrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.utils.BackgroundInfo
 import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
@@ -106,6 +108,27 @@ internal class ContainerSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTes
                 parentContentColor = fakeBackgroundColorHexString
             )
         )
+    }
+
+    @Test
+    fun `M pass down the override privacy W map() { privacy is overridden }`(forge: Forge) {
+        // Given
+        val fakeImagePrivacy = forge.aValueFrom(ImagePrivacy::class.java)
+        val fakeTextInputPrivacy = forge.aValueFrom(TextAndInputPrivacy::class.java)
+        val mockSemanticsNode = mockSemanticsNode()
+        whenever(mockSemanticsUtils.getImagePrivacyOverride(mockSemanticsNode)) doReturn fakeImagePrivacy
+        whenever(mockSemanticsUtils.getTextAndInputPrivacyOverride(mockSemanticsNode)) doReturn fakeTextInputPrivacy
+
+        // When
+        val result = testedContainerSemanticsNodeMapper.map(
+            mockSemanticsNode,
+            fakeUiContext,
+            mockAsyncJobStatusCallback
+        )
+
+        // Then
+        assertThat(result.uiContext?.imagePrivacy).isEqualTo(fakeImagePrivacy)
+        assertThat(result.uiContext?.textAndInputPrivacy).isEqualTo(fakeTextInputPrivacy)
     }
 
     private fun mockSemanticsNode(): SemanticsNode {

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapperTest.kt
@@ -174,6 +174,47 @@ internal class TextFieldSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTes
         assertThat(actual.wireframes).contains(expectedShapeWireframe, expectedTextWireframe)
     }
 
+    @Test
+    fun `M pass down the override privacy W map() { privacy is overridden }`(forge: Forge) {
+        // Given
+        val mockSemanticsNode = mockSemanticsNodeWithBound {}
+        val fakeTextInputPrivacy = forge.aValueFrom(TextAndInputPrivacy::class.java)
+        val innerBounds = rectToBounds(fakeBounds, fakeDensity)
+        whenever(mockSemanticsNode.config) doReturn mockSemanticsConfiguration
+        whenever(mockSemanticsConfiguration.getOrNull(SemanticsProperties.EditableText)) doReturn AnnotatedString(
+            fakeEditText
+        )
+        whenever(mockSemanticsUtils.resolveTextLayoutInfo(mockSemanticsNode)) doReturn fakeTextLayoutInfo
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode)) doReturn innerBounds
+        whenever(mockSemanticsUtils.resolveBackgroundColor(mockSemanticsNode)) doReturn fakeBackgroundColor
+        whenever(mockSemanticsUtils.resolveBackgroundShape(mockSemanticsNode)) doReturn mockShape
+        whenever(
+            mockSemanticsUtils.resolveCornerRadius(
+                eq(mockShape),
+                any(),
+                any()
+            )
+        ) doReturn fakeCornerRadius
+        whenever(
+            mockSemanticsUtils.resolveCornerRadius(
+                mockShape,
+                fakeGlobalBounds,
+                mockDensity
+            )
+        ) doReturn fakeCornerRadius
+        whenever(mockSemanticsUtils.getTextAndInputPrivacyOverride(mockSemanticsNode)) doReturn fakeTextInputPrivacy
+
+        // When
+        val result = testedTextFieldSemanticsNodeMapper.map(
+            mockSemanticsNode,
+            fakeUiContext,
+            mockAsyncJobStatusCallback
+        )
+
+        // Then
+        assertThat(result.uiContext?.textAndInputPrivacy).isEqualTo(fakeTextInputPrivacy)
+    }
+
     private fun mockSemanticsNode(): SemanticsNode {
         return mockSemanticsNodeWithBound {
             whenever(mockSemanticsNode.layoutInfo).doReturn(mockLayoutInfo)

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/FineGrainedMaskingSample.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/FineGrainedMaskingSample.kt
@@ -1,0 +1,208 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sample.compose
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.datadog.android.sample.R
+import com.datadog.android.sessionreplay.ImagePrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
+import com.datadog.android.sessionreplay.TouchPrivacy
+import com.datadog.android.sessionreplay.compose.sessionReplayImagePrivacy
+import com.datadog.android.sessionreplay.compose.sessionReplayTextAndInputPrivacy
+import com.datadog.android.sessionreplay.compose.sessionReplayTouchPrivacy
+
+@Composable
+internal fun FineGrainedMaskingSample() {
+    Column(modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+        ImagePrivacySample()
+        TextAndInputPrivacySample()
+        TouchPrivacySample()
+    }
+}
+
+@Composable
+private fun ImagePrivacySample() {
+    Row(modifier = Modifier.fillMaxWidth().wrapContentHeight()) {
+        SampleItem(
+            modifier = Modifier.weight(1f),
+            title = "MASK_NONE"
+        ) {
+            Image(
+                modifier = Modifier
+                    .sessionReplayImagePrivacy(imagePrivacy = ImagePrivacy.MASK_NONE),
+                painter = painterResource(R.drawable.ic_dd_icon_red),
+                contentDescription = "red dog1"
+            )
+        }
+        SampleItem(
+            modifier = Modifier.weight(1f),
+            title = "MASK_LARGE_ONLY"
+        ) {
+            Image(
+                modifier = Modifier
+                    .sessionReplayImagePrivacy(imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY),
+                painter = painterResource(R.drawable.ic_dd_icon_red),
+                contentDescription = "red dog2"
+            )
+        }
+        SampleItem(
+            modifier = Modifier.weight(1f),
+            title = "MASK_ALL"
+        ) {
+            Image(
+                modifier = Modifier
+                    .sessionReplayImagePrivacy(imagePrivacy = ImagePrivacy.MASK_ALL),
+                painter = painterResource(R.drawable.ic_dd_icon_red),
+                contentDescription = "red dog3"
+            )
+        }
+    }
+}
+
+@Composable
+private fun TextAndInputPrivacySample() {
+    Row {
+        SampleItem(
+            modifier = Modifier.wrapContentSize().weight(1f),
+            title = "MASK_SENSITIVE_INPUTS"
+        ) {
+            Text(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .sessionReplayTextAndInputPrivacy(textAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS),
+                text = FAKE_TEXT
+            )
+        }
+        SampleItem(
+            modifier = Modifier.wrapContentSize().weight(1f),
+            title = "MASK_ALL_INPUTS"
+        ) {
+            Text(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .sessionReplayTextAndInputPrivacy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL_INPUTS),
+                text = FAKE_TEXT
+            )
+        }
+        SampleItem(
+            modifier = Modifier.wrapContentSize().weight(1f),
+            title = "MASK_ALL"
+        ) {
+            Text(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .sessionReplayTextAndInputPrivacy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL),
+                text = FAKE_TEXT
+            )
+        }
+    }
+}
+
+@Composable
+private fun TouchPrivacySample() {
+    var hideClickTimes by remember {
+        mutableStateOf(0)
+    }
+    var showClickTimes by remember {
+        mutableStateOf(0)
+    }
+    Row {
+        SampleItem(
+            modifier = Modifier.wrapContentSize().weight(1f)
+                .sessionReplayTouchPrivacy(touchPrivacy = TouchPrivacy.SHOW)
+                .clickable {
+                    showClickTimes++
+                },
+            title = "Touch Privacy: Show"
+        ) {
+            Text(
+                text = if (showClickTimes == 0) {
+                    "Click Me!"
+                } else {
+                    "You've clicked $showClickTimes times"
+                }
+            )
+        }
+        SampleItem(
+            modifier = Modifier.wrapContentSize().weight(1f)
+                .sessionReplayTouchPrivacy(touchPrivacy = TouchPrivacy.HIDE)
+                .clickable {
+                    hideClickTimes++
+                },
+            title = "Touch Privacy: Hide"
+        ) {
+            Text(
+                modifier = Modifier
+                    .sessionReplayTouchPrivacy(touchPrivacy = TouchPrivacy.HIDE),
+                text = if (hideClickTimes == 0) {
+                    "Click Me!"
+                } else {
+                    "You've clicked $hideClickTimes times"
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun SampleItem(
+    modifier: Modifier = Modifier,
+    title: String,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Column(
+        modifier.border(
+            width = 1.dp,
+            color = Color.Black
+        ).height(280.dp)
+    ) {
+        Text(
+            modifier = Modifier.padding(16.dp).height(48.dp),
+            text = title,
+            textAlign = TextAlign.Center
+        )
+        Divider(modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp))
+        content.invoke(this)
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+internal fun PreviewFineGrainedMaskingSample() {
+    FineGrainedMaskingSample()
+}
+
+private const val FAKE_TEXT =
+    "\"Beyond the silver mountains, a hidden village thrives under perpetual starlight. " +
+        "Mystical creatures guard ancient secrets, while the villagers weave dreams " +
+        "into reality, crafting magic from whispers and moonbeams.\""

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/SampleSelectionScreen.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/SampleSelectionScreen.kt
@@ -30,6 +30,7 @@ internal fun SampleSelectionScreen(
     onInputClicked: () -> Unit,
     onToggleClicked: () -> Unit,
     onSelectorsClicked: () -> Unit,
+    onFgmClicked: () -> Unit,
     onTabsClicked: () -> Unit
 ) {
     Column(
@@ -64,6 +65,10 @@ internal fun SampleSelectionScreen(
         StyledButton(
             text = "Selectors Sample",
             onClick = onSelectorsClicked
+        )
+        StyledButton(
+            text = "Fine Grained Masking Privacy Sample",
+            onClick = onFgmClicked
         )
         StyledButton(
             text = "Legacy Sample",
@@ -108,6 +113,9 @@ internal fun NavGraphBuilder.selectionNavigation(navController: NavHostControlle
             onSelectorsClicked = {
                 navController.navigate(SampleScreen.Selectors.navigationRoute)
             },
+            onFgmClicked = {
+                navController.navigate(SampleScreen.FGM.navigationRoute)
+            },
             onLegacyClicked = {
                 navController.navigate(SampleScreen.Legacy.navigationRoute)
             }
@@ -134,6 +142,10 @@ internal fun NavGraphBuilder.selectionNavigation(navController: NavHostControlle
         SelectorSample()
     }
 
+    composable(SampleScreen.FGM.navigationRoute) {
+        FineGrainedMaskingSample()
+    }
+
     composable(SampleScreen.Tabs.navigationRoute) {
         TabsSample()
     }
@@ -154,6 +166,7 @@ internal sealed class SampleScreen(
     object Toggle : SampleScreen("$COMPOSE_ROOT/toggle")
     object Tabs : SampleScreen("$COMPOSE_ROOT/tabs")
     object Selectors : SampleScreen("$COMPOSE_ROOT/selectors")
+    object FGM : SampleScreen("$COMPOSE_ROOT/fgm")
     object Legacy : SampleScreen("$COMPOSE_ROOT/legacy")
 
     companion object {
@@ -177,6 +190,8 @@ private fun PreviewSampleSelectionScreen() {
         onTypographyClicked = {
         },
         onSelectorsClicked = {
+        },
+        onFgmClicked = {
         },
         onTabsClicked = {
         }


### PR DESCRIPTION
### What does this PR do?

* Add Session Replay FGM override APIs for 
   * ImagePrivacy
   * TextAndInputPrivacy
   * TouchPrivacy
* Implement `ImagePrivacy` and `TextAndInputPrivacy` in the semantics mapper.


### Motivation

RUM-7341

### Additional Notes

Touch Privacy will be applied in following commit

### Demo

In each grid, the title of the grid means the override privacy of the content:

| Sampe App| Global configuration is Mask all | Global configuration is Mask none|
| --- | --- | --- |
|<img width="283" alt="Screenshot 2024-11-27 at 13 01 32" src="https://github.com/user-attachments/assets/4101394b-af8b-4235-bc64-ba0f6f87b323">  |<img width="280" alt="Screenshot 2024-11-27 at 10 48 17" src="https://github.com/user-attachments/assets/2bfc63a1-6724-457c-b964-eb60568eeb45">   |<img width="282" alt="Screenshot 2024-11-27 at 10 51 12" src="https://github.com/user-attachments/assets/c19a1865-a2de-4a79-bda2-62e808401deb"> |




### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

