### PR TITLE
Move ImageSemanticsMapper reflection functions into ReflectionUtils

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/api/dd-sdk-android-session-replay-compose.api
+++ b/features/dd-sdk-android-session-replay-compose/api/dd-sdk-android-session-replay-compose.api
@@ -10,7 +10,7 @@ public final class com/datadog/android/sessionreplay/compose/ComposeExtensionSup
 public abstract interface annotation class com/datadog/android/sessionreplay/compose/ExperimentalSessionReplayApi : java/lang/annotation/Annotation {
 }
 
-public final class com/datadog/android/sessionreplay/compose/internal/ModifierExtKt {
+public final class com/datadog/android/sessionreplay/compose/ModifierExtKt {
 	public static final fun sessionReplayHide (Landroidx/compose/ui/Modifier;Z)Landroidx/compose/ui/Modifier;
 	public static final fun sessionReplayImagePrivacy (Landroidx/compose/ui/Modifier;Lcom/datadog/android/sessionreplay/ImagePrivacy;)Landroidx/compose/ui/Modifier;
 	public static final fun sessionReplayTextAndInputPrivacy (Landroidx/compose/ui/Modifier;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;)Landroidx/compose/ui/Modifier;

--- a/features/dd-sdk-android-session-replay-compose/consumer-rules.pro
+++ b/features/dd-sdk-android-session-replay-compose/consumer-rules.pro
@@ -41,7 +41,7 @@
 -keep class androidx.compose.ui.graphics.AndroidImageBitmap {
      <fields>;
 }
--keep class coil.compose.ContentPainterModifier {
+-keep class coil.compose.ContentPainterElement {
      <fields>;
 }
 -keep class coil.compose.AsyncImagePainter {

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/data/BitmapInfo.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/data/BitmapInfo.kt
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.data
+
+import android.graphics.Bitmap
+
+internal data class BitmapInfo(
+    val bitmap: Bitmap,
+    val isContextualImage: Boolean
+)

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ImageSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ImageSemanticsNodeMapper.kt
@@ -6,22 +6,9 @@
 
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
-import android.graphics.Bitmap
-import androidx.compose.ui.graphics.painter.BitmapPainter
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.graphics.vector.VectorPainter
 import androidx.compose.ui.semantics.SemanticsNode
 import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWireframe
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
-import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection
-import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.BitmapField
-import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.ContentPainterModifierClass
-import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.ImageField
-import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.PainterElementClass
-import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.PainterField
-import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.PainterFieldOfAsyncImagePainter
-import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.PainterFieldOfContentPainter
-import com.datadog.android.sessionreplay.compose.internal.reflection.getSafe
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
@@ -37,7 +24,7 @@ internal class ImageSemanticsNodeMapper(
         asyncJobStatusCallback: AsyncJobStatusCallback
     ): SemanticsWireframe {
         val bounds = resolveBounds(semanticsNode)
-        val bitmapInfo = resolveSemanticsPainter(semanticsNode)
+        val bitmapInfo = semanticsUtils.resolveSemanticsPainter(semanticsNode)
         val containerFrames = resolveModifierWireframes(semanticsNode).toMutableList()
         val imagePrivacy =
             semanticsUtils.getImagePrivacyOverride(semanticsNode) ?: parentContext.imagePrivacy
@@ -65,73 +52,4 @@ internal class ImageSemanticsNodeMapper(
             uiContext = null
         )
     }
-
-    private fun resolveSemanticsPainter(
-        semanticsNode: SemanticsNode
-    ): BitmapInfo? {
-        var isContextualImage = false
-        var painter = tryParseLocalImagePainter(semanticsNode)
-        if (painter == null) {
-            painter = tryParseAsyncImagePainter(semanticsNode)
-            if (painter != null) {
-                isContextualImage = true
-            }
-        }
-        // TODO RUM-6535: support more painters.
-        if (ComposeReflection.AsyncImagePainterClass?.isInstance(painter) == true) {
-            isContextualImage = true
-            painter = PainterFieldOfAsyncImagePainter?.getSafe(painter) as? Painter
-        }
-        val bitmap = when (painter) {
-            is BitmapPainter -> tryParseBitmapPainterToBitmap(painter)
-            is VectorPainter -> tryParseVectorPainterToBitmap(painter)
-            else -> {
-                null
-            }
-        }
-
-        val newBitmap = bitmap?.let {
-            @Suppress("UnsafeThirdPartyFunctionCall") // isMutable is always false
-            it.copy(Bitmap.Config.ARGB_8888, false)
-        }
-        return newBitmap?.let {
-            BitmapInfo(it, isContextualImage)
-        }
-    }
-
-    private fun tryParseVectorPainterToBitmap(vectorPainter: VectorPainter): Bitmap? {
-        val vector = ComposeReflection.VectorField?.getSafe(vectorPainter)
-        val cacheDrawScope = ComposeReflection.CacheDrawScopeField?.getSafe(vector)
-        val mCachedImage = ComposeReflection.CachedImageField?.getSafe(cacheDrawScope)
-        return mCachedImage?.let {
-            BitmapField?.getSafe(it) as? Bitmap
-        }
-    }
-
-    private fun tryParseBitmapPainterToBitmap(bitmapPainter: BitmapPainter): Bitmap? {
-        val image = ImageField?.getSafe(bitmapPainter)
-        return image?.let {
-            BitmapField?.getSafe(image) as? Bitmap
-        }
-    }
-
-    private fun tryParseLocalImagePainter(semanticsNode: SemanticsNode): Painter? {
-        val modifier = semanticsNode.layoutInfo.getModifierInfo().firstOrNull {
-            PainterElementClass?.isInstance(it.modifier) == true
-        }?.modifier
-        return modifier?.let { PainterField?.getSafe(it) as? Painter }
-    }
-
-    private fun tryParseAsyncImagePainter(semanticsNode: SemanticsNode): Painter? {
-        val modifier = semanticsNode.layoutInfo.getModifierInfo().firstOrNull {
-            ContentPainterModifierClass?.isInstance(it.modifier) == true
-        }?.modifier
-        val asyncPainter = PainterFieldOfContentPainter?.getSafe(modifier)
-        return PainterFieldOfAsyncImagePainter?.getSafe(asyncPainter) as? Painter
-    }
-
-    private data class BitmapInfo(
-        val bitmap: Bitmap,
-        val isContextualImage: Boolean
-    )
 }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
@@ -64,8 +64,8 @@ internal object ComposeReflection {
     val AndroidImageBitmapClass = getClassSafe("androidx.compose.ui.graphics.AndroidImageBitmap")
     val BitmapField = AndroidImageBitmapClass?.getDeclaredFieldSafe("bitmap")
 
-    val ContentPainterModifierClass = getClassSafe("coil.compose.ContentPainterModifier")
-    val PainterFieldOfContentPainter = ContentPainterModifierClass?.getDeclaredFieldSafe("painter")
+    val ContentPainterElementClass = getClassSafe("coil.compose.ContentPainterElement")
+    val PainterFieldOfContentPainter = ContentPainterElementClass?.getDeclaredFieldSafe("painter")
 
     val AsyncImagePainterClass = getClassSafe("coil.compose.AsyncImagePainter")
     val PainterFieldOfAsyncImagePainter = AsyncImagePainterClass?.getDeclaredFieldSafe("_painter")


### PR DESCRIPTION
### What does this PR do?

This is a follow up commit of this [PR](https://github.com/DataDog/dd-sdk-android/pull/2415) 
Move ImageSemanticsMapper reflection functions into ReflectionUtils


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

