### PR TITLE
RUM-7476: Apply touch privacy override in RootSemanticsMapper

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapper.kt
@@ -6,14 +6,18 @@
 
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
+import androidx.annotation.UiThread
+import androidx.compose.ui.graphics.toAndroidRectF
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.core.graphics.toRect
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.compose.internal.utils.withinComposeBenchmarkSpan
+import com.datadog.android.sessionreplay.internal.TouchPrivacyManager
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -53,6 +57,7 @@ internal class RootSemanticsNodeMapper(
             createComposerWireframes(
                 semanticsNode = semanticsNode,
                 wireframes = wireframes,
+                touchPrivacyManager = mappingContext.touchPrivacyManager,
                 parentUiContext = UiContext(
                     parentContentColor = null,
                     density = density,
@@ -68,11 +73,16 @@ internal class RootSemanticsNodeMapper(
 
     private fun createComposerWireframes(
         semanticsNode: SemanticsNode,
+        touchPrivacyManager: TouchPrivacyManager,
         wireframes: MutableList<MobileSegment.Wireframe>,
         parentUiContext: UiContext,
         asyncJobStatusCallback: AsyncJobStatusCallback
     ) {
         val mapper = getSemanticsNodeMapper(semanticsNode)
+        updateTouchOverrideAreas(
+            touchPrivacyManager = touchPrivacyManager,
+            semanticsNode = semanticsNode
+        )
         withinComposeBenchmarkSpan(
             mapper::class.java.simpleName,
             isContainer = mapper is ContainerSemanticsNodeMapper
@@ -89,7 +99,13 @@ internal class RootSemanticsNodeMapper(
             }
             val children = semanticsNode.children
             children.forEach {
-                createComposerWireframes(it, wireframes, currentUiContext, asyncJobStatusCallback)
+                createComposerWireframes(
+                    semanticsNode = it,
+                    touchPrivacyManager = touchPrivacyManager,
+                    wireframes = wireframes,
+                    parentUiContext = currentUiContext,
+                    asyncJobStatusCallback = asyncJobStatusCallback
+                )
             }
         }
     }
@@ -114,6 +130,17 @@ internal class RootSemanticsNodeMapper(
 
     private fun isTextFieldNode(semanticsNode: SemanticsNode): Boolean {
         return semanticsNode.config.contains(SemanticsActions.SetText)
+    }
+
+    @UiThread
+    private fun updateTouchOverrideAreas(
+        semanticsNode: SemanticsNode,
+        touchPrivacyManager: TouchPrivacyManager
+    ) {
+        semanticsUtils.getTouchPrivacyOverride(semanticsNode)?.let { touchPrivacy ->
+            val viewArea = semanticsNode.boundsInRoot.toAndroidRectF().toRect()
+            touchPrivacyManager.addTouchOverrideArea(viewArea, touchPrivacy)
+        }
     }
 
     companion object {

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/MappingContextForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/MappingContextForgeryFactory.kt
@@ -18,7 +18,8 @@ internal class MappingContextForgeryFactory : ForgeryFactory<MappingContext> {
             imageWireframeHelper = mock(),
             hasOptionSelectorParent = forge.aBool(),
             imagePrivacy = forge.getForgery(),
-            textAndInputPrivacy = forge.getForgery()
+            textAndInputPrivacy = forge.getForgery(),
+            touchPrivacyManager = mock()
         )
     }
 }

--- a/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/forge/MappingContextForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/forge/MappingContextForgeryFactory.kt
@@ -18,7 +18,8 @@ internal class MappingContextForgeryFactory : ForgeryFactory<MappingContext> {
             imageWireframeHelper = mock(),
             textAndInputPrivacy = forge.getForgery(),
             imagePrivacy = forge.getForgery(),
-            hasOptionSelectorParent = forge.aBool()
+            hasOptionSelectorParent = forge.aBool(),
+            touchPrivacyManager = mock()
         )
     }
 }

--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -55,6 +55,9 @@ enum com.datadog.android.sessionreplay.TextAndInputPrivacy : PrivacyLevel
 enum com.datadog.android.sessionreplay.TouchPrivacy : PrivacyLevel
   - SHOW
   - HIDE
+class com.datadog.android.sessionreplay.internal.TouchPrivacyManager
+  constructor(com.datadog.android.sessionreplay.TouchPrivacy)
+  fun addTouchOverrideArea(android.graphics.Rect, com.datadog.android.sessionreplay.TouchPrivacy)
 interface com.datadog.android.sessionreplay.internal.recorder.obfuscator.StringObfuscator
   fun obfuscate(String): String
   companion object 
@@ -64,7 +67,7 @@ class com.datadog.android.sessionreplay.internal.recorder.resources.DefaultDrawa
 interface com.datadog.android.sessionreplay.internal.recorder.resources.DrawableCopier
   fun copy(android.graphics.drawable.Drawable, android.content.res.Resources): android.graphics.drawable.Drawable?
 data class com.datadog.android.sessionreplay.recorder.MappingContext
-  constructor(SystemInformation, com.datadog.android.sessionreplay.utils.ImageWireframeHelper, com.datadog.android.sessionreplay.TextAndInputPrivacy, com.datadog.android.sessionreplay.ImagePrivacy, Boolean = false)
+  constructor(SystemInformation, com.datadog.android.sessionreplay.utils.ImageWireframeHelper, com.datadog.android.sessionreplay.TextAndInputPrivacy, com.datadog.android.sessionreplay.ImagePrivacy, com.datadog.android.sessionreplay.internal.TouchPrivacyManager, Boolean = false)
 interface com.datadog.android.sessionreplay.recorder.OptionSelectorDetector
   fun isOptionSelector(android.view.ViewGroup): Boolean
 data class com.datadog.android.sessionreplay.recorder.SystemInformation

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -108,6 +108,11 @@ public final class com/datadog/android/sessionreplay/TouchPrivacy : java/lang/En
 	public static fun values ()[Lcom/datadog/android/sessionreplay/TouchPrivacy;
 }
 
+public final class com/datadog/android/sessionreplay/internal/TouchPrivacyManager {
+	public fun <init> (Lcom/datadog/android/sessionreplay/TouchPrivacy;)V
+	public final fun addTouchOverrideArea (Landroid/graphics/Rect;Lcom/datadog/android/sessionreplay/TouchPrivacy;)V
+}
+
 public abstract interface class com/datadog/android/sessionreplay/internal/recorder/obfuscator/StringObfuscator {
 	public static final field Companion Lcom/datadog/android/sessionreplay/internal/recorder/obfuscator/StringObfuscator$Companion;
 	public abstract fun obfuscate (Ljava/lang/String;)Ljava/lang/String;
@@ -1410,21 +1415,23 @@ public final class com/datadog/android/sessionreplay/model/ResourceMetadata$Comp
 }
 
 public final class com/datadog/android/sessionreplay/recorder/MappingContext {
-	public fun <init> (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Z)V
-	public synthetic fun <init> (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Lcom/datadog/android/sessionreplay/internal/TouchPrivacyManager;Z)V
+	public synthetic fun <init> (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Lcom/datadog/android/sessionreplay/internal/TouchPrivacyManager;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/datadog/android/sessionreplay/recorder/SystemInformation;
 	public final fun component2 ()Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;
 	public final fun component3 ()Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
 	public final fun component4 ()Lcom/datadog/android/sessionreplay/ImagePrivacy;
-	public final fun component5 ()Z
-	public final fun copy (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Z)Lcom/datadog/android/sessionreplay/recorder/MappingContext;
-	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/recorder/MappingContext;Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;ZILjava/lang/Object;)Lcom/datadog/android/sessionreplay/recorder/MappingContext;
+	public final fun component5 ()Lcom/datadog/android/sessionreplay/internal/TouchPrivacyManager;
+	public final fun component6 ()Z
+	public final fun copy (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Lcom/datadog/android/sessionreplay/internal/TouchPrivacyManager;Z)Lcom/datadog/android/sessionreplay/recorder/MappingContext;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/recorder/MappingContext;Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Lcom/datadog/android/sessionreplay/internal/TouchPrivacyManager;ZILjava/lang/Object;)Lcom/datadog/android/sessionreplay/recorder/MappingContext;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHasOptionSelectorParent ()Z
 	public final fun getImagePrivacy ()Lcom/datadog/android/sessionreplay/ImagePrivacy;
 	public final fun getImageWireframeHelper ()Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;
 	public final fun getSystemInformation ()Lcom/datadog/android/sessionreplay/recorder/SystemInformation;
 	public final fun getTextAndInputPrivacy ()Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
+	public final fun getTouchPrivacyManager ()Lcom/datadog/android/sessionreplay/internal/TouchPrivacyManager;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/TouchPrivacyManager.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/TouchPrivacyManager.kt
@@ -10,9 +10,14 @@ import android.graphics.Point
 import android.graphics.Rect
 import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
+import com.datadog.android.lint.InternalApi
 import com.datadog.android.sessionreplay.TouchPrivacy
 
-internal class TouchPrivacyManager(
+/**
+ * Manager to handle touch privacy area.
+ */
+@InternalApi
+class TouchPrivacyManager(
     private val globalTouchPrivacy: TouchPrivacy
 ) {
     // areas on screen where overrides are applied
@@ -25,8 +30,11 @@ internal class TouchPrivacyManager(
     // the overrides when they are no longer needed.
     private val nextOverrideAreas = HashMap<Rect, TouchPrivacy>()
 
+    /**
+     * Adds touch area with [TouchPrivacy] override.
+     */
     @UiThread
-    internal fun addTouchOverrideArea(bounds: Rect, touchPrivacy: TouchPrivacy) {
+    fun addTouchOverrideArea(bounds: Rect, touchPrivacy: TouchPrivacy) {
         nextOverrideAreas[bounds] = touchPrivacy
     }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
@@ -182,12 +182,12 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
                             viewIdentifierResolver = viewIdentifierResolver
                         ),
                         viewUtilsInternal = ViewUtilsInternal(),
-                        internalLogger = internalLogger,
-                        touchPrivacyManager = touchPrivacyManager
+                        internalLogger = internalLogger
                     ),
                     ComposedOptionSelectorDetector(
                         customOptionSelectorDetectors + DefaultOptionSelectorDetector()
                     ),
+                    touchPrivacyManager,
                     internalLogger = internalLogger
                 ),
                 recordedDataQueueHandler = recordedDataQueueHandler,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
@@ -13,6 +13,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.R
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
+import com.datadog.android.sessionreplay.internal.TouchPrivacyManager
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -25,6 +26,7 @@ internal class SnapshotProducer(
     private val imageWireframeHelper: ImageWireframeHelper,
     private val treeViewTraversal: TreeViewTraversal,
     private val optionSelectorDetector: OptionSelectorDetector,
+    private val touchPrivacyManager: TouchPrivacyManager,
     private val internalLogger: InternalLogger
 ) {
 
@@ -42,7 +44,8 @@ internal class SnapshotProducer(
                 systemInformation = systemInformation,
                 imageWireframeHelper = imageWireframeHelper,
                 textAndInputPrivacy = textAndInputPrivacy,
-                imagePrivacy = imagePrivacy
+                imagePrivacy = imagePrivacy,
+                touchPrivacyManager = touchPrivacyManager
             ),
             LinkedList(),
             recordedDataQueueRefs

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversal.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversal.kt
@@ -16,7 +16,6 @@ import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.sessionreplay.MapperTypeWrapper
 import com.datadog.android.sessionreplay.R
 import com.datadog.android.sessionreplay.TouchPrivacy
-import com.datadog.android.sessionreplay.internal.TouchPrivacyManager
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
 import com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.Companion.INVALID_PRIVACY_LEVEL_ERROR
 import com.datadog.android.sessionreplay.internal.recorder.mapper.HiddenViewMapper
@@ -35,8 +34,7 @@ internal class TreeViewTraversal(
     private val hiddenViewMapper: HiddenViewMapper,
     private val decorViewMapper: WireframeMapper<View>,
     private val viewUtilsInternal: ViewUtilsInternal,
-    private val internalLogger: InternalLogger,
-    private val touchPrivacyManager: TouchPrivacyManager
+    private val internalLogger: InternalLogger
 ) {
 
     @Suppress("ReturnCount")
@@ -59,7 +57,7 @@ internal class TreeViewTraversal(
 
         // try to resolve from the exhaustive type mappers
         var mapper = findMapperForView(view)
-        updateTouchOverrideAreas(view)
+        updateTouchOverrideAreas(view, mappingContext)
 
         if (isHidden(view)) {
             traversalStrategy = TraversalStrategy.STOP_AND_RETURN_NODE
@@ -123,7 +121,7 @@ internal class TreeViewTraversal(
         view.getTag(R.id.datadog_hidden) == true
 
     @UiThread
-    private fun updateTouchOverrideAreas(view: View) {
+    private fun updateTouchOverrideAreas(view: View, mappingContext: MappingContext) {
         val touchPrivacy = view.getTag(R.id.datadog_touch_privacy)
 
         if (touchPrivacy != null) {
@@ -144,7 +142,7 @@ internal class TreeViewTraversal(
 
             try {
                 val privacyLevel = TouchPrivacy.valueOf(touchPrivacy.toString().uppercase(Locale.US))
-                touchPrivacyManager.addTouchOverrideArea(viewArea, privacyLevel)
+                mappingContext.touchPrivacyManager.addTouchOverrideArea(viewArea, privacyLevel)
             } catch (e: IllegalArgumentException) {
                 internalLogger.log(
                     InternalLogger.Level.ERROR,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/MappingContext.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/MappingContext.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.recorder
 
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
+import com.datadog.android.sessionreplay.internal.TouchPrivacyManager
 import com.datadog.android.sessionreplay.utils.ImageWireframeHelper
 
 /**
@@ -18,6 +19,7 @@ import com.datadog.android.sessionreplay.utils.ImageWireframeHelper
  * @param imageWireframeHelper a helper tool to capture images within a View
  * @param textAndInputPrivacy the text and input privacy level to use when building the wireframes
  * @param imagePrivacy the image recording configuration to use when building the wireframes
+ * @param touchPrivacyManager the manager to handle touch privacy area.
  * @param hasOptionSelectorParent tells if one of the parents of the current [android.view.View]
  * is an option selector type (e.g. time picker, date picker, drop - down list)
  */
@@ -26,5 +28,6 @@ data class MappingContext(
     val imageWireframeHelper: ImageWireframeHelper,
     val textAndInputPrivacy: TextAndInputPrivacy,
     val imagePrivacy: ImagePrivacy,
+    val touchPrivacyManager: TouchPrivacyManager,
     val hasOptionSelectorParent: Boolean = false
 )

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/MappingContextForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/MappingContextForgeryFactory.kt
@@ -18,7 +18,8 @@ internal class MappingContextForgeryFactory : ForgeryFactory<MappingContext> {
             imageWireframeHelper = mock(),
             hasOptionSelectorParent = forge.aBool(),
             textAndInputPrivacy = forge.getForgery(),
-            imagePrivacy = forge.getForgery()
+            imagePrivacy = forge.getForgery(),
+            touchPrivacyManager = mock()
         )
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducerTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.R
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.android.sessionreplay.internal.TouchPrivacyManager
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
 import com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.Companion.INVALID_PRIVACY_LEVEL_ERROR
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -68,6 +69,9 @@ internal class SnapshotProducerTest {
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
+    @Mock
+    lateinit var mockTouchPrivacyManager: TouchPrivacyManager
+
     @Forgery
     lateinit var fakeSystemInformation: SystemInformation
 
@@ -86,6 +90,7 @@ internal class SnapshotProducerTest {
             mockImageWireframeHelper,
             mockTreeViewTraversal,
             mockOptionSelectorDetector,
+            mockTouchPrivacyManager,
             mockInternalLogger
         )
     }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversalTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversalTest.kt
@@ -95,8 +95,7 @@ internal class TreeViewTraversalTest {
             hiddenViewMapper = mockHiddenViewMapper,
             decorViewMapper = mockDecorViewMapper,
             viewUtilsInternal = mockViewUtilsInternal,
-            internalLogger = mockInternalLogger,
-            touchPrivacyManager = mockTouchPrivacyManager
+            internalLogger = mockInternalLogger
         )
     }
 
@@ -136,8 +135,7 @@ internal class TreeViewTraversalTest {
             hiddenViewMapper = mockHiddenViewMapper,
             decorViewMapper = mockDecorViewMapper,
             viewUtilsInternal = mockViewUtilsInternal,
-            internalLogger = mockInternalLogger,
-            touchPrivacyManager = mockTouchPrivacyManager
+            internalLogger = mockInternalLogger
         )
 
         // When
@@ -171,8 +169,7 @@ internal class TreeViewTraversalTest {
             hiddenViewMapper = mockHiddenViewMapper,
             decorViewMapper = mockDecorViewMapper,
             viewUtilsInternal = mockViewUtilsInternal,
-            internalLogger = mockInternalLogger,
-            touchPrivacyManager = mockTouchPrivacyManager
+            internalLogger = mockInternalLogger
         )
 
         // When
@@ -207,8 +204,7 @@ internal class TreeViewTraversalTest {
             hiddenViewMapper = mockHiddenViewMapper,
             decorViewMapper = mockDecorViewMapper,
             viewUtilsInternal = mockViewUtilsInternal,
-            internalLogger = mockInternalLogger,
-            touchPrivacyManager = mockTouchPrivacyManager
+            internalLogger = mockInternalLogger
         )
 
         // When
@@ -258,8 +254,7 @@ internal class TreeViewTraversalTest {
             hiddenViewMapper = mockHiddenViewMapper,
             decorViewMapper = mockDecorViewMapper,
             viewUtilsInternal = mockViewUtilsInternal,
-            internalLogger = mockInternalLogger,
-            touchPrivacyManager = mockTouchPrivacyManager
+            internalLogger = mockInternalLogger
         )
 
         // When
@@ -293,8 +288,7 @@ internal class TreeViewTraversalTest {
             hiddenViewMapper = mockHiddenViewMapper,
             decorViewMapper = mockDecorViewMapper,
             viewUtilsInternal = mockViewUtilsInternal,
-            internalLogger = mockInternalLogger,
-            touchPrivacyManager = mockTouchPrivacyManager
+            internalLogger = mockInternalLogger
         )
 
         // When
@@ -329,8 +323,7 @@ internal class TreeViewTraversalTest {
             hiddenViewMapper = mockHiddenViewMapper,
             decorViewMapper = mockDecorViewMapper,
             viewUtilsInternal = mockViewUtilsInternal,
-            internalLogger = mockInternalLogger,
-            touchPrivacyManager = mockTouchPrivacyManager
+            internalLogger = mockInternalLogger
         )
 
         // When
@@ -467,8 +460,7 @@ internal class TreeViewTraversalTest {
             hiddenViewMapper = mockHiddenViewMapper,
             decorViewMapper = mockDecorViewMapper,
             viewUtilsInternal = mockViewUtilsInternal,
-            internalLogger = mockInternalLogger,
-            touchPrivacyManager = mockTouchPrivacyManager
+            internalLogger = mockInternalLogger
         )
 
         // When

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -257,11 +257,7 @@ class SampleApplication : Application() {
             TextAndInputPrivacy.MASK_SENSITIVE_INPUTS
         }
 
-        val touchPrivacy = if (shouldMaskAll) {
-            TouchPrivacy.HIDE
-        } else {
-            TouchPrivacy.SHOW
-        }
+        val touchPrivacy = TouchPrivacy.SHOW
 
         GlobalRumMonitor.get().addAttribute("imagePrivacy", imagePrivacy)
         GlobalRumMonitor.get().addAttribute("textAndInputPrivacy", textAndInputPrivacy)

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/FineGrainedMaskingSample.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/FineGrainedMaskingSample.kt
@@ -203,6 +203,4 @@ internal fun PreviewFineGrainedMaskingSample() {
 }
 
 private const val FAKE_TEXT =
-    "\"Beyond the silver mountains, a hidden village thrives under perpetual starlight. " +
-        "Mystical creatures guard ancient secrets, while the villagers weave dreams " +
-        "into reality, crafting magic from whispers and moonbeams.\""
+    "\"Beyond the silver mountains, a hidden village thrives under perpetual starlight. "


### PR DESCRIPTION
### What does this PR do?

* Apply touch privacy override in `RootSemanticsMapper`
* Move `TouchPrivacyManger` into `MappingContext` so that RootSemanticsMapper can have access

### Motivation

RUM-7476


### Demo
![ezgif-5-d1a1f1cc6c](https://github.com/user-attachments/assets/33ff7dd0-4443-43e0-a10a-e4c51995148c)



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

