### PR TITLE
RUM-7489 Handle readOnly additionalProperties

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/TypeDefinition.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/TypeDefinition.kt
@@ -102,7 +102,7 @@ sealed class TypeDefinition {
         val name: String,
         val properties: List<TypeProperty>,
         override val description: String = "",
-        val additionalProperties: TypeDefinition? = null,
+        val additionalProperties: TypeProperty? = null,
         val parentType: OneOfClass? = null
     ) : TypeDefinition() {
 
@@ -144,7 +144,8 @@ sealed class TypeDefinition {
         }
 
         override fun matches(other: TypeDefinition): Boolean {
-            return (other is Class) && (other.properties == properties) &&
+            return (other is Class) &&
+                (other.properties == properties) &&
                 (other.additionalProperties == additionalProperties)
         }
 

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/generator/ClassJsonElementDeserializerGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/generator/ClassJsonElementDeserializerGenerator.kt
@@ -317,7 +317,7 @@ class ClassJsonElementDeserializerGenerator(
 
     @Suppress("FunctionMaxLength")
     private fun FunSpec.Builder.appendAdditionalPropertiesDeserialization(
-        additionalProperties: TypeDefinition,
+        additionalProperties: TypeProperty,
         hasKnownProperties: Boolean,
         rootTypeName: String
     ) {
@@ -325,7 +325,7 @@ class ClassJsonElementDeserializerGenerator(
             "val %L = mutableMapOf<%T, %T>()",
             Identifier.PARAM_ADDITIONAL_PROPS,
             STRING,
-            additionalProperties.additionalPropertyTypeName(rootTypeName)
+            additionalProperties.type.additionalPropertyTypeName(rootTypeName)
         )
         beginControlFlow(
             "for (entry in %L.entrySet())",
@@ -339,14 +339,14 @@ class ClassJsonElementDeserializerGenerator(
             )
         }
 
-        if (additionalProperties is TypeDefinition.Class) {
+        if (additionalProperties.type is TypeDefinition.Class) {
             addStatement(
                 "%L[entry.key] = entry.value",
                 Identifier.PARAM_ADDITIONAL_PROPS
             )
         } else {
             appendDeserializedProperty(
-                propertyType = additionalProperties,
+                propertyType = additionalProperties.type,
                 assignee = "${Identifier.PARAM_ADDITIONAL_PROPS}[entry.key]",
                 getter = "entry.value",
                 nullable = false,

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/TestDefinitions.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/TestDefinitions.kt
@@ -160,7 +160,12 @@ val Comment = TypeDefinition.Class(
                         false
                     )
                 ),
-                additionalProperties = TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)
+                additionalProperties = TypeProperty(
+                    name = "",
+                    type = TypeDefinition.Primitive(JsonPrimitiveType.INTEGER),
+                    optional = true,
+                    readOnly = true
+                )
             ),
             true
         ),
@@ -169,7 +174,12 @@ val Comment = TypeDefinition.Class(
             TypeDefinition.Class(
                 name = "Flags",
                 properties = listOf(),
-                additionalProperties = TypeDefinition.Primitive(JsonPrimitiveType.BOOLEAN)
+                additionalProperties = TypeProperty(
+                    name = "",
+                    type = TypeDefinition.Primitive(JsonPrimitiveType.BOOLEAN),
+                    optional = true,
+                    readOnly = false
+                )
             ),
             true
         ),
@@ -178,7 +188,12 @@ val Comment = TypeDefinition.Class(
             TypeDefinition.Class(
                 name = "Tags",
                 properties = listOf(),
-                additionalProperties = TypeDefinition.Primitive(JsonPrimitiveType.STRING)
+                additionalProperties = TypeProperty(
+                    name = "",
+                    type = TypeDefinition.Primitive(JsonPrimitiveType.STRING),
+                    optional = true,
+                    readOnly = false
+                )
             ),
             true
         )
@@ -200,7 +215,12 @@ val Company = TypeDefinition.Class(
                         false
                     )
                 ),
-                additionalProperties = TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)
+                additionalProperties = TypeProperty(
+                    name = "",
+                    type = TypeDefinition.Primitive(JsonPrimitiveType.INTEGER),
+                    optional = true,
+                    readOnly = false
+                )
             ),
             true
         ),
@@ -220,12 +240,22 @@ val Company = TypeDefinition.Class(
                         true
                     )
                 ),
-                additionalProperties = TypeDefinition.Class("?", emptyList())
+                additionalProperties = TypeProperty(
+                    name = "",
+                    type = TypeDefinition.Class("?", emptyList()),
+                    optional = true,
+                    readOnly = false
+                )
             ),
             true
         )
     ),
-    additionalProperties = TypeDefinition.Class("?", emptyList())
+    additionalProperties = TypeProperty(
+        name = "",
+        type = TypeDefinition.Class("?", emptyList()),
+        optional = true,
+        readOnly = false
+    )
 )
 
 val Conflict = TypeDefinition.Class(
@@ -789,7 +819,12 @@ val AdditionalPropsMerged = TypeDefinition.Class(
                     TypeProperty("notes", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
                     TypeProperty("source", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true)
                 ),
-                additionalProperties = TypeDefinition.Class("?", emptyList())
+                additionalProperties = TypeProperty(
+                    name = "",
+                    type = TypeDefinition.Class("?", emptyList()),
+                    optional = true,
+                    readOnly = false
+                )
             ),
             true
         ),
@@ -812,7 +847,12 @@ val AdditionalPropsSingleMerge = TypeDefinition.Class(
                     TypeProperty("notes", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
                     TypeProperty("source", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true)
                 ),
-                additionalProperties = TypeDefinition.Class("?", emptyList())
+                additionalProperties = TypeProperty(
+                    name = "",
+                    type = TypeDefinition.Class("?", emptyList()),
+                    optional = true,
+                    readOnly = false
+                )
             ),
             true
         ),

--- a/buildSrc/src/test/kotlin/com/example/model/Comment.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Comment.kt
@@ -11,6 +11,7 @@ import kotlin.Array
 import kotlin.Boolean
 import kotlin.Long
 import kotlin.String
+import kotlin.collections.Map
 import kotlin.collections.MutableMap
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.Throws
@@ -89,7 +90,7 @@ public data class Comment(
 
     public data class Ratings(
         public val global: Long,
-        public val additionalProperties: MutableMap<String, Long> = mutableMapOf(),
+        public val additionalProperties: Map<String, Long> = mapOf(),
     ) {
         public fun toJson(): JsonElement {
             val json = JsonObject()

--- a/buildSrc/src/test/resources/input/additional_props.json
+++ b/buildSrc/src/test/resources/input/additional_props.json
@@ -14,9 +14,12 @@
         }
       },
       "additionalProperties": {
-        "type": "integer"
+        "type": "integer",
+        "readOnly": true
       },
-      "required": [ "global"]
+      "required": [
+        "global"
+      ]
     },
     "flags": {
       "additionalProperties": {
@@ -24,8 +27,9 @@
       }
     },
     "tags": {
-      "additionalProperties":  {
-        "type": "string"
+      "additionalProperties": {
+        "type": "string",
+        "readOnly": false
       }
     }
   },

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -1490,7 +1490,7 @@ data class com.datadog.android.rum.model.ViewEvent
       fun fromJson(kotlin.String): Privacy
       fun fromJsonObject(com.google.gson.JsonObject): Privacy
   data class CustomTimings
-    constructor(kotlin.collections.MutableMap<kotlin.String, kotlin.Long> = mutableMapOf())
+    constructor(kotlin.collections.Map<kotlin.String, kotlin.Long> = mapOf())
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): CustomTimings

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -14,7 +14,6 @@ import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
-import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.GlobalRumMonitor

--- a/features/dd-sdk-android-trace/api/apiSurface
+++ b/features/dd-sdk-android-trace/api/apiSurface
@@ -38,13 +38,13 @@ data class com.datadog.android.trace.model.SpanEvent
     fun fromJson(kotlin.String): SpanEvent
     fun fromJsonObject(com.google.gson.JsonObject): SpanEvent
   data class Metrics
-    constructor(kotlin.Long? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.Number> = mutableMapOf())
+    constructor(kotlin.Long? = null, kotlin.collections.Map<kotlin.String, kotlin.Number> = mapOf())
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Metrics
       fun fromJsonObject(com.google.gson.JsonObject): Metrics
   data class Meta
-    constructor(kotlin.String, Dd, Span, Tracer, Usr, Network? = null, Device, Os, kotlin.collections.MutableMap<kotlin.String, kotlin.String> = mutableMapOf())
+    constructor(kotlin.String, Dd, Span, Tracer, Usr, Network? = null, Device, Os, kotlin.collections.Map<kotlin.String, kotlin.String> = mapOf())
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Meta


### PR DESCRIPTION
### What does this PR do?

Make sure that the `readOnly` setting on additional properties is taken into account when converting Json Schema into a Kotlin data class.