### PR TITLE
RUM-7174 Introduce the setNetworkSettledInitialResourceIdentifier API

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -82,7 +82,7 @@ data class com.datadog.android.rum.RumConfiguration
     fun setVitalsUpdateFrequency(com.datadog.android.rum.configuration.VitalsUpdateFrequency): Builder
     fun useCustomEndpoint(String): Builder
     fun setSessionListener(RumSessionListener): Builder
-    fun setNetworkSettledInitialResourceIdentifier(com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier): Builder
+    fun setInitialResourceIdentifier(com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier): Builder
     fun build(): RumConfiguration
 enum com.datadog.android.rum.RumErrorSource
   - NETWORK
@@ -167,16 +167,6 @@ interface com.datadog.android.rum.event.ViewEventMapper : com.datadog.android.ev
   override fun map(com.datadog.android.rum.model.ViewEvent): com.datadog.android.rum.model.ViewEvent
 data class com.datadog.android.rum.internal.domain.event.ResourceTiming
   constructor(Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L)
-interface com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
-  fun validate(NetworkSettledResourceContext): Boolean
-data class com.datadog.android.rum.internal.metric.networksettled.NetworkSettledResourceContext
-  constructor(String, Long, Long?)
-class com.datadog.android.rum.internal.metric.networksettled.TimeBasedInitialResourceIdentifier : InitialResourceIdentifier
-  constructor(Long = DEFAULT_TIME_THRESHOLD_MS)
-  override fun validate(NetworkSettledResourceContext): Boolean
-  override fun equals(Any?): Boolean
-  override fun hashCode(): Int
-  companion object 
 interface com.datadog.android.rum.internal.monitor.AdvancedNetworkRumMonitor : com.datadog.android.rum.RumMonitor
   fun waitForResourceTiming(Any)
   fun addResourceTiming(Any, com.datadog.android.rum.internal.domain.event.ResourceTiming)
@@ -185,6 +175,16 @@ interface com.datadog.android.rum.internal.monitor.AdvancedNetworkRumMonitor : c
   fun stopResource(com.datadog.android.rum.resource.ResourceId, Int?, Long?, com.datadog.android.rum.RumResourceKind, Map<String, Any?>)
   fun stopResourceWithError(com.datadog.android.rum.resource.ResourceId, Int?, String, com.datadog.android.rum.RumErrorSource, Throwable, Map<String, Any?> = emptyMap())
   fun stopResourceWithError(com.datadog.android.rum.resource.ResourceId, Int?, String, com.datadog.android.rum.RumErrorSource, String, String?, Map<String, Any?> = emptyMap())
+interface com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
+  fun validate(NetworkSettledResourceContext): Boolean
+data class com.datadog.android.rum.metric.networksettled.NetworkSettledResourceContext
+  constructor(String, Long, Long?)
+class com.datadog.android.rum.metric.networksettled.TimeBasedInitialResourceIdentifier : InitialResourceIdentifier
+  constructor(Long = DEFAULT_TIME_THRESHOLD_MS)
+  override fun validate(NetworkSettledResourceContext): Boolean
+  override fun equals(Any?): Boolean
+  override fun hashCode(): Int
+  companion object 
 fun android.content.Context.getAssetAsRumResource(String, Int = AssetManager.ACCESS_STREAMING, com.datadog.android.api.SdkCore = Datadog.getInstance()): java.io.InputStream
 fun android.content.Context.getRawResAsRumResource(Int, com.datadog.android.api.SdkCore = Datadog.getInstance()): java.io.InputStream
 fun java.io.InputStream.asRumResource(String, com.datadog.android.api.SdkCore = Datadog.getInstance()): java.io.InputStream

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -82,6 +82,7 @@ data class com.datadog.android.rum.RumConfiguration
     fun setVitalsUpdateFrequency(com.datadog.android.rum.configuration.VitalsUpdateFrequency): Builder
     fun useCustomEndpoint(String): Builder
     fun setSessionListener(RumSessionListener): Builder
+    fun setNetworkSettledInitialResourceIdentifier(com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier): Builder
     fun build(): RumConfiguration
 enum com.datadog.android.rum.RumErrorSource
   - NETWORK
@@ -166,6 +167,16 @@ interface com.datadog.android.rum.event.ViewEventMapper : com.datadog.android.ev
   override fun map(com.datadog.android.rum.model.ViewEvent): com.datadog.android.rum.model.ViewEvent
 data class com.datadog.android.rum.internal.domain.event.ResourceTiming
   constructor(Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L)
+interface com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
+  fun validate(NetworkSettledResourceContext): Boolean
+data class com.datadog.android.rum.internal.metric.networksettled.NetworkSettledResourceContext
+  constructor(String, Long, Long?)
+class com.datadog.android.rum.internal.metric.networksettled.TimeBasedInitialResourceIdentifier : InitialResourceIdentifier
+  constructor(Long = DEFAULT_TIME_THRESHOLD_MS)
+  override fun validate(NetworkSettledResourceContext): Boolean
+  override fun equals(Any?): Boolean
+  override fun hashCode(): Int
+  companion object 
 interface com.datadog.android.rum.internal.monitor.AdvancedNetworkRumMonitor : com.datadog.android.rum.RumMonitor
   fun waitForResourceTiming(Any)
   fun addResourceTiming(Any, com.datadog.android.rum.internal.domain.event.ResourceTiming)

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -104,6 +104,7 @@ public final class com/datadog/android/rum/RumConfiguration$Builder {
 	public final fun setActionEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setErrorEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setLongTaskEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
+	public final fun setNetworkSettledInitialResourceIdentifier (Lcom/datadog/android/rum/internal/metric/networksettled/InitialResourceIdentifier;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setResourceEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setSessionListener (Lcom/datadog/android/rum/RumSessionListener;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setSessionSampleRate (F)Lcom/datadog/android/rum/RumConfiguration$Builder;
@@ -285,6 +286,32 @@ public abstract class com/datadog/android/rum/internal/instrumentation/gestures/
 	public fun <init> ()V
 	public fun onFling (Landroid/view/MotionEvent;Landroid/view/MotionEvent;FF)Z
 	public fun onScroll (Landroid/view/MotionEvent;Landroid/view/MotionEvent;FF)Z
+}
+
+public abstract interface class com/datadog/android/rum/internal/metric/networksettled/InitialResourceIdentifier {
+	public abstract fun validate (Lcom/datadog/android/rum/internal/metric/networksettled/NetworkSettledResourceContext;)Z
+}
+
+public final class com/datadog/android/rum/internal/metric/networksettled/NetworkSettledResourceContext {
+	public fun <init> (Ljava/lang/String;JLjava/lang/Long;)V
+	public final fun copy (Ljava/lang/String;JLjava/lang/Long;)Lcom/datadog/android/rum/internal/metric/networksettled/NetworkSettledResourceContext;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/internal/metric/networksettled/NetworkSettledResourceContext;Ljava/lang/String;JLjava/lang/Long;ILjava/lang/Object;)Lcom/datadog/android/rum/internal/metric/networksettled/NetworkSettledResourceContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/internal/metric/networksettled/TimeBasedInitialResourceIdentifier : com/datadog/android/rum/internal/metric/networksettled/InitialResourceIdentifier {
+	public static final field Companion Lcom/datadog/android/rum/internal/metric/networksettled/TimeBasedInitialResourceIdentifier$Companion;
+	public fun <init> ()V
+	public fun <init> (J)V
+	public synthetic fun <init> (JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun validate (Lcom/datadog/android/rum/internal/metric/networksettled/NetworkSettledResourceContext;)Z
+}
+
+public final class com/datadog/android/rum/internal/metric/networksettled/TimeBasedInitialResourceIdentifier$Companion {
 }
 
 public abstract interface class com/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor : com/datadog/android/rum/RumMonitor {

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -103,8 +103,8 @@ public final class com/datadog/android/rum/RumConfiguration$Builder {
 	public final fun disableUserInteractionTracking ()Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setActionEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setErrorEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
+	public final fun setInitialResourceIdentifier (Lcom/datadog/android/rum/metric/networksettled/InitialResourceIdentifier;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setLongTaskEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
-	public final fun setNetworkSettledInitialResourceIdentifier (Lcom/datadog/android/rum/internal/metric/networksettled/InitialResourceIdentifier;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setResourceEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setSessionListener (Lcom/datadog/android/rum/RumSessionListener;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setSessionSampleRate (F)Lcom/datadog/android/rum/RumConfiguration$Builder;
@@ -288,32 +288,6 @@ public abstract class com/datadog/android/rum/internal/instrumentation/gestures/
 	public fun onScroll (Landroid/view/MotionEvent;Landroid/view/MotionEvent;FF)Z
 }
 
-public abstract interface class com/datadog/android/rum/internal/metric/networksettled/InitialResourceIdentifier {
-	public abstract fun validate (Lcom/datadog/android/rum/internal/metric/networksettled/NetworkSettledResourceContext;)Z
-}
-
-public final class com/datadog/android/rum/internal/metric/networksettled/NetworkSettledResourceContext {
-	public fun <init> (Ljava/lang/String;JLjava/lang/Long;)V
-	public final fun copy (Ljava/lang/String;JLjava/lang/Long;)Lcom/datadog/android/rum/internal/metric/networksettled/NetworkSettledResourceContext;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/internal/metric/networksettled/NetworkSettledResourceContext;Ljava/lang/String;JLjava/lang/Long;ILjava/lang/Object;)Lcom/datadog/android/rum/internal/metric/networksettled/NetworkSettledResourceContext;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/datadog/android/rum/internal/metric/networksettled/TimeBasedInitialResourceIdentifier : com/datadog/android/rum/internal/metric/networksettled/InitialResourceIdentifier {
-	public static final field Companion Lcom/datadog/android/rum/internal/metric/networksettled/TimeBasedInitialResourceIdentifier$Companion;
-	public fun <init> ()V
-	public fun <init> (J)V
-	public synthetic fun <init> (JILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun validate (Lcom/datadog/android/rum/internal/metric/networksettled/NetworkSettledResourceContext;)Z
-}
-
-public final class com/datadog/android/rum/internal/metric/networksettled/TimeBasedInitialResourceIdentifier$Companion {
-}
-
 public abstract interface class com/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor : com/datadog/android/rum/RumMonitor {
 	public abstract fun addResourceTiming (Ljava/lang/Object;Lcom/datadog/android/rum/internal/domain/event/ResourceTiming;)V
 	public abstract fun notifyInterceptorInstantiated ()V
@@ -328,6 +302,32 @@ public final class com/datadog/android/rum/internal/monitor/AdvancedNetworkRumMo
 	public static synthetic fun startResource$default (Lcom/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor;Lcom/datadog/android/rum/resource/ResourceId;Lcom/datadog/android/rum/RumResourceMethod;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun stopResourceWithError$default (Lcom/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor;Lcom/datadog/android/rum/resource/ResourceId;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun stopResourceWithError$default (Lcom/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor;Lcom/datadog/android/rum/resource/ResourceId;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;ILjava/lang/Object;)V
+}
+
+public abstract interface class com/datadog/android/rum/metric/networksettled/InitialResourceIdentifier {
+	public abstract fun validate (Lcom/datadog/android/rum/metric/networksettled/NetworkSettledResourceContext;)Z
+}
+
+public final class com/datadog/android/rum/metric/networksettled/NetworkSettledResourceContext {
+	public fun <init> (Ljava/lang/String;JLjava/lang/Long;)V
+	public final fun copy (Ljava/lang/String;JLjava/lang/Long;)Lcom/datadog/android/rum/metric/networksettled/NetworkSettledResourceContext;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/metric/networksettled/NetworkSettledResourceContext;Ljava/lang/String;JLjava/lang/Long;ILjava/lang/Object;)Lcom/datadog/android/rum/metric/networksettled/NetworkSettledResourceContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/metric/networksettled/TimeBasedInitialResourceIdentifier : com/datadog/android/rum/metric/networksettled/InitialResourceIdentifier {
+	public static final field Companion Lcom/datadog/android/rum/metric/networksettled/TimeBasedInitialResourceIdentifier$Companion;
+	public fun <init> ()V
+	public fun <init> (J)V
+	public synthetic fun <init> (JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun validate (Lcom/datadog/android/rum/metric/networksettled/NetworkSettledResourceContext;)Z
+}
+
+public final class com/datadog/android/rum/metric/networksettled/TimeBasedInitialResourceIdentifier$Companion {
 }
 
 public final class com/datadog/android/rum/model/ActionEvent {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
@@ -126,7 +126,7 @@ object Rum {
             trackFrustrations = rumFeature.trackFrustrations,
             sessionListener = rumFeature.sessionListener,
             executorService = sdkCore.createSingleThreadExecutorService("rum-pipeline"),
-            networkSettledResourceIdentifier = rumFeature.networkSettledInitialResourceIdentifier
+            initialResourceIdentifier = rumFeature.initialResourceIdentifier
         )
     }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
@@ -125,7 +125,8 @@ object Rum {
             backgroundTrackingEnabled = rumFeature.backgroundEventTracking,
             trackFrustrations = rumFeature.trackFrustrations,
             sessionListener = rumFeature.sessionListener,
-            executorService = sdkCore.createSingleThreadExecutorService("rum-pipeline")
+            executorService = sdkCore.createSingleThreadExecutorService("rum-pipeline"),
+            networkSettledResourceIdentifier = rumFeature.networkSettledInitialResourceIdentifier
         )
     }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
@@ -13,9 +13,9 @@ import com.datadog.android.rum.configuration.VitalsUpdateFrequency
 import com.datadog.android.rum.event.ViewEventMapper
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.instrumentation.MainLooperLongTaskStrategy
-import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
-import com.datadog.android.rum.internal.metric.networksettled.TimeBasedInitialResourceIdentifier
 import com.datadog.android.rum.internal.tracking.NoOpInteractionPredicate
+import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
+import com.datadog.android.rum.metric.networksettled.TimeBasedInitialResourceIdentifier
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
@@ -265,8 +265,8 @@ data class RumConfiguration internal constructor(
          * a threshold of 100ms.
          * @param initialResourceIdentifier the [InitialResourceIdentifier] to use.
          */
-        fun setNetworkSettledInitialResourceIdentifier(initialResourceIdentifier: InitialResourceIdentifier): Builder {
-            rumConfig = rumConfig.copy(networkSettledInitialResourceIdentifier = initialResourceIdentifier)
+        fun setInitialResourceIdentifier(initialResourceIdentifier: InitialResourceIdentifier): Builder {
+            rumConfig = rumConfig.copy(initialResourceIdentifier = initialResourceIdentifier)
             return this
         }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
@@ -13,6 +13,8 @@ import com.datadog.android.rum.configuration.VitalsUpdateFrequency
 import com.datadog.android.rum.event.ViewEventMapper
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.instrumentation.MainLooperLongTaskStrategy
+import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
+import com.datadog.android.rum.internal.metric.networksettled.TimeBasedInitialResourceIdentifier
 import com.datadog.android.rum.internal.tracking.NoOpInteractionPredicate
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
@@ -254,6 +256,17 @@ data class RumConfiguration internal constructor(
          */
         fun setSessionListener(sessionListener: RumSessionListener): Builder {
             rumConfig = rumConfig.copy(sessionListener = sessionListener)
+            return this
+        }
+
+        /**
+         * Sets the identifier strategy for initial network resources used to compute the time to network settled
+         * in a RUM View event. By default, the SDK uses a [TimeBasedInitialResourceIdentifier] with
+         * a threshold of 100ms.
+         * @param initialResourceIdentifier the [InitialResourceIdentifier] to use.
+         */
+        fun setNetworkSettledInitialResourceIdentifier(initialResourceIdentifier: InitialResourceIdentifier): Builder {
+            rumConfig = rumConfig.copy(networkSettledInitialResourceIdentifier = initialResourceIdentifier)
             return this
         }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -50,9 +50,6 @@ import com.datadog.android.rum.internal.instrumentation.MainLooperLongTaskStrate
 import com.datadog.android.rum.internal.instrumentation.UserActionTrackingStrategyApi29
 import com.datadog.android.rum.internal.instrumentation.UserActionTrackingStrategyLegacy
 import com.datadog.android.rum.internal.instrumentation.gestures.DatadogGesturesTracker
-import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
-import com.datadog.android.rum.internal.metric.networksettled.NoOpInitialResourceIdentifier
-import com.datadog.android.rum.internal.metric.networksettled.TimeBasedInitialResourceIdentifier
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
 import com.datadog.android.rum.internal.net.RumRequestFactory
@@ -70,6 +67,9 @@ import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalObserver
 import com.datadog.android.rum.internal.vitals.VitalReader
 import com.datadog.android.rum.internal.vitals.VitalReaderRunnable
+import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
+import com.datadog.android.rum.metric.networksettled.NoOpInitialResourceIdentifier
+import com.datadog.android.rum.metric.networksettled.TimeBasedInitialResourceIdentifier
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
@@ -130,7 +130,7 @@ internal class RumFeature(
     private var anrDetectorExecutorService: ExecutorService? = null
     internal var anrDetectorRunnable: ANRDetectorRunnable? = null
     internal lateinit var appContext: Context
-    internal var networkSettledInitialResourceIdentifier: InitialResourceIdentifier = NoOpInitialResourceIdentifier()
+    internal var initialResourceIdentifier: InitialResourceIdentifier = NoOpInitialResourceIdentifier()
 
     private val lateCrashEventHandler by lazy { lateCrashReporterFactory(sdkCore as InternalSdkCore) }
 
@@ -140,7 +140,7 @@ internal class RumFeature(
 
     override fun onInitialize(appContext: Context) {
         this.appContext = appContext
-        networkSettledInitialResourceIdentifier = configuration.networkSettledInitialResourceIdentifier
+        initialResourceIdentifier = configuration.initialResourceIdentifier
         dataWriter = createDataWriter(
             configuration,
             sdkCore as InternalSdkCore
@@ -534,7 +534,7 @@ internal class RumFeature(
         val trackNonFatalAnrs: Boolean,
         val vitalsMonitorUpdateFrequency: VitalsUpdateFrequency,
         val sessionListener: RumSessionListener,
-        val networkSettledInitialResourceIdentifier: InitialResourceIdentifier,
+        val initialResourceIdentifier: InitialResourceIdentifier,
         val additionalConfig: Map<String, Any>
     )
 
@@ -578,7 +578,7 @@ internal class RumFeature(
             trackNonFatalAnrs = isTrackNonFatalAnrsEnabledByDefault(),
             vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.AVERAGE,
             sessionListener = NoOpRumSessionListener(),
-            networkSettledInitialResourceIdentifier = TimeBasedInitialResourceIdentifier(),
+            initialResourceIdentifier = TimeBasedInitialResourceIdentifier(),
             additionalConfig = emptyMap()
         )
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -50,6 +50,9 @@ import com.datadog.android.rum.internal.instrumentation.MainLooperLongTaskStrate
 import com.datadog.android.rum.internal.instrumentation.UserActionTrackingStrategyApi29
 import com.datadog.android.rum.internal.instrumentation.UserActionTrackingStrategyLegacy
 import com.datadog.android.rum.internal.instrumentation.gestures.DatadogGesturesTracker
+import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
+import com.datadog.android.rum.internal.metric.networksettled.NoOpInitialResourceIdentifier
+import com.datadog.android.rum.internal.metric.networksettled.TimeBasedInitialResourceIdentifier
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
 import com.datadog.android.rum.internal.net.RumRequestFactory
@@ -127,6 +130,7 @@ internal class RumFeature(
     private var anrDetectorExecutorService: ExecutorService? = null
     internal var anrDetectorRunnable: ANRDetectorRunnable? = null
     internal lateinit var appContext: Context
+    internal var networkSettledInitialResourceIdentifier: InitialResourceIdentifier = NoOpInitialResourceIdentifier()
 
     private val lateCrashEventHandler by lazy { lateCrashReporterFactory(sdkCore as InternalSdkCore) }
 
@@ -136,7 +140,7 @@ internal class RumFeature(
 
     override fun onInitialize(appContext: Context) {
         this.appContext = appContext
-
+        networkSettledInitialResourceIdentifier = configuration.networkSettledInitialResourceIdentifier
         dataWriter = createDataWriter(
             configuration,
             sdkCore as InternalSdkCore
@@ -530,6 +534,7 @@ internal class RumFeature(
         val trackNonFatalAnrs: Boolean,
         val vitalsMonitorUpdateFrequency: VitalsUpdateFrequency,
         val sessionListener: RumSessionListener,
+        val networkSettledInitialResourceIdentifier: InitialResourceIdentifier,
         val additionalConfig: Map<String, Any>
     )
 
@@ -573,6 +578,7 @@ internal class RumFeature(
             trackNonFatalAnrs = isTrackNonFatalAnrsEnabledByDefault(),
             vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.AVERAGE,
             sessionListener = NoOpRumSessionListener(),
+            networkSettledInitialResourceIdentifier = TimeBasedInitialResourceIdentifier(),
             additionalConfig = emptyMap()
         )
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
@@ -18,8 +18,8 @@ import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
-import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.internal.vitals.VitalMonitor
+import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
 import java.util.concurrent.TimeUnit
 
 @Suppress("LongParameterList")
@@ -35,7 +35,7 @@ internal class RumApplicationScope(
     private val frameRateVitalMonitor: VitalMonitor,
     private val sessionEndedMetricDispatcher: SessionMetricDispatcher,
     private val sessionListener: RumSessionListener?,
-    private val networkSettledResourceIdentifier: InitialResourceIdentifier
+    private val initialResourceIdentifier: InitialResourceIdentifier
 ) : RumScope, RumViewChangedListener {
 
     private var rumContext = RumContext(applicationId = applicationId)
@@ -55,7 +55,7 @@ internal class RumApplicationScope(
             frameRateVitalMonitor,
             sessionListener,
             false,
-            networkSettledResourceIdentifier
+            initialResourceIdentifier
         )
     )
 
@@ -148,7 +148,7 @@ internal class RumApplicationScope(
             frameRateVitalMonitor,
             sessionListener,
             true,
-            networkSettledResourceIdentifier
+            initialResourceIdentifier
         )
         childScopes.add(newSession)
         if (event !is RumRawEvent.StartView) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
@@ -18,6 +18,7 @@ import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
+import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import java.util.concurrent.TimeUnit
 
@@ -33,7 +34,8 @@ internal class RumApplicationScope(
     private val memoryVitalMonitor: VitalMonitor,
     private val frameRateVitalMonitor: VitalMonitor,
     private val sessionEndedMetricDispatcher: SessionMetricDispatcher,
-    private val sessionListener: RumSessionListener?
+    private val sessionListener: RumSessionListener?,
+    private val networkSettledResourceIdentifier: InitialResourceIdentifier
 ) : RumScope, RumViewChangedListener {
 
     private var rumContext = RumContext(applicationId = applicationId)
@@ -52,7 +54,8 @@ internal class RumApplicationScope(
             memoryVitalMonitor,
             frameRateVitalMonitor,
             sessionListener,
-            false
+            false,
+            networkSettledResourceIdentifier
         )
     )
 
@@ -144,7 +147,8 @@ internal class RumApplicationScope(
             memoryVitalMonitor,
             frameRateVitalMonitor,
             sessionListener,
-            true
+            true,
+            networkSettledResourceIdentifier
         )
         childScopes.add(newSession)
         if (event !is RumRawEvent.StartView) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -15,9 +15,9 @@ import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
-import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.internal.utils.percent
 import com.datadog.android.rum.internal.vitals.VitalMonitor
+import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
 import java.security.SecureRandom
 import java.util.UUID
 import java.util.concurrent.TimeUnit

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -15,6 +15,7 @@ import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
+import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.internal.utils.percent
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import java.security.SecureRandom
@@ -37,6 +38,7 @@ internal class RumSessionScope(
     frameRateVitalMonitor: VitalMonitor,
     private val sessionListener: RumSessionListener?,
     applicationDisplayed: Boolean,
+    networkSettledResourceIdentifier: InitialResourceIdentifier,
     private val sessionInactivityNanos: Long = DEFAULT_SESSION_INACTIVITY_NS,
     private val sessionMaxDurationNanos: Long = DEFAULT_SESSION_MAX_DURATION_NS
 ) : RumScope {
@@ -66,7 +68,8 @@ internal class RumSessionScope(
         memoryVitalMonitor,
         frameRateVitalMonitor,
         applicationDisplayed,
-        sampleRate
+        sampleRate,
+        networkSettledResourceIdentifier
     )
 
     init {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -21,10 +21,10 @@ import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.metric.SessionEndedMetric
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.interactiontonextview.InteractionToNextViewMetricResolver
-import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.internal.metric.networksettled.NetworkSettledMetricResolver
 import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalMonitor
+import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
@@ -42,7 +42,7 @@ internal class RumViewManagerScope(
     private val frameRateVitalMonitor: VitalMonitor,
     internal var applicationDisplayed: Boolean,
     internal val sampleRate: Float,
-    internal val networkSettledResourceIdentifier: InitialResourceIdentifier,
+    internal val initialResourceIdentifier: InitialResourceIdentifier,
     private val interactionToNextViewMetricResolver: InteractionToNextViewMetricResolver =
         InteractionToNextViewMetricResolver(internalLogger = sdkCore.internalLogger)
 ) : RumScope {
@@ -206,7 +206,7 @@ internal class RumViewManagerScope(
             trackFrustrations,
             sampleRate,
             interactionToNextViewMetricResolver,
-            networkSettledResourceIdentifier
+            initialResourceIdentifier
         )
         applicationDisplayed = true
         childrenScopes.add(viewScope)
@@ -271,7 +271,7 @@ internal class RumViewManagerScope(
             sampleRate = sampleRate,
             interactionToNextViewMetricResolver = interactionToNextViewMetricResolver,
             networkSettledMetricResolver = NetworkSettledMetricResolver(
-                networkSettledResourceIdentifier,
+                initialResourceIdentifier,
                 sdkCore.internalLogger
             )
         )
@@ -299,7 +299,7 @@ internal class RumViewManagerScope(
             sampleRate = sampleRate,
             interactionToNextViewMetricResolver = interactionToNextViewMetricResolver,
             networkSettledMetricResolver = NetworkSettledMetricResolver(
-                networkSettledResourceIdentifier,
+                initialResourceIdentifier,
                 sdkCore.internalLogger
             )
         )

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -21,6 +21,8 @@ import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.metric.SessionEndedMetric
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.interactiontonextview.InteractionToNextViewMetricResolver
+import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
+import com.datadog.android.rum.internal.metric.networksettled.NetworkSettledMetricResolver
 import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import java.util.Locale
@@ -40,6 +42,7 @@ internal class RumViewManagerScope(
     private val frameRateVitalMonitor: VitalMonitor,
     internal var applicationDisplayed: Boolean,
     internal val sampleRate: Float,
+    internal val networkSettledResourceIdentifier: InitialResourceIdentifier,
     private val interactionToNextViewMetricResolver: InteractionToNextViewMetricResolver =
         InteractionToNextViewMetricResolver(internalLogger = sdkCore.internalLogger)
 ) : RumScope {
@@ -202,7 +205,8 @@ internal class RumViewManagerScope(
             frameRateVitalMonitor,
             trackFrustrations,
             sampleRate,
-            interactionToNextViewMetricResolver
+            interactionToNextViewMetricResolver,
+            networkSettledResourceIdentifier
         )
         applicationDisplayed = true
         childrenScopes.add(viewScope)
@@ -265,7 +269,11 @@ internal class RumViewManagerScope(
             type = RumViewScope.RumViewType.BACKGROUND,
             trackFrustrations = trackFrustrations,
             sampleRate = sampleRate,
-            interactionToNextViewMetricResolver = interactionToNextViewMetricResolver
+            interactionToNextViewMetricResolver = interactionToNextViewMetricResolver,
+            networkSettledMetricResolver = NetworkSettledMetricResolver(
+                networkSettledResourceIdentifier,
+                sdkCore.internalLogger
+            )
         )
     }
 
@@ -289,7 +297,11 @@ internal class RumViewManagerScope(
             type = RumViewScope.RumViewType.APPLICATION_LAUNCH,
             trackFrustrations = trackFrustrations,
             sampleRate = sampleRate,
-            interactionToNextViewMetricResolver = interactionToNextViewMetricResolver
+            interactionToNextViewMetricResolver = interactionToNextViewMetricResolver,
+            networkSettledMetricResolver = NetworkSettledMetricResolver(
+                networkSettledResourceIdentifier,
+                sdkCore.internalLogger
+            )
         )
     }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -27,7 +27,6 @@ import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.interactiontonextview.InteractionToNextViewMetricResolver
 import com.datadog.android.rum.internal.metric.interactiontonextview.InternalInteractionContext
-import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.internal.metric.networksettled.NetworkSettledMetricResolver
 import com.datadog.android.rum.internal.monitor.StorageEvent
 import com.datadog.android.rum.internal.utils.hasUserData
@@ -35,6 +34,7 @@ import com.datadog.android.rum.internal.utils.newRumEventWriteOperation
 import com.datadog.android.rum.internal.vitals.VitalInfo
 import com.datadog.android.rum.internal.vitals.VitalListener
 import com.datadog.android.rum.internal.vitals.VitalMonitor
+import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/InitialResourceIdentifier.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/InitialResourceIdentifier.kt
@@ -8,8 +8,17 @@ package com.datadog.android.rum.internal.metric.networksettled
 
 import com.datadog.tools.annotation.NoOpImplementation
 
+/**
+ * Interface for identifying initial network resources.
+ */
 @NoOpImplementation
-internal interface InitialResourceIdentifier {
+interface InitialResourceIdentifier {
+    /**
+     * Validates whether the given network resource context meets the criteria for an initial resource.
+     *
+     * @param context The context of the network resource to validate.
+     * @return `true` if the context meets the criteria, `false` otherwise.
+     */
     fun validate(
         context: NetworkSettledResourceContext
     ): Boolean

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/NetworkSettledMetricResolver.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/NetworkSettledMetricResolver.kt
@@ -7,6 +7,9 @@
 package com.datadog.android.rum.internal.metric.networksettled
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
+import com.datadog.android.rum.metric.networksettled.NetworkSettledResourceContext
+import com.datadog.android.rum.metric.networksettled.TimeBasedInitialResourceIdentifier
 
 internal class NetworkSettledMetricResolver(
     private val initialResourceIdentifier: InitialResourceIdentifier = TimeBasedInitialResourceIdentifier(),

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/NetworkSettledResourceContext.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/NetworkSettledResourceContext.kt
@@ -6,7 +6,14 @@
 
 package com.datadog.android.rum.internal.metric.networksettled
 
-internal data class NetworkSettledResourceContext(
+/**
+ * Represents the context of a network resource that has settled.
+ *
+ * @property resourceId The unique identifier of the network resource.
+ * @property eventCreatedAtNanos The timestamp (in nanoseconds) when the event was created.
+ * @property viewCreatedTimestamp The timestamp (in nanoseconds) when the view was created, or null if not applicable.
+ */
+data class NetworkSettledResourceContext(
     internal val resourceId: String,
     internal val eventCreatedAtNanos: Long,
     internal val viewCreatedTimestamp: Long?

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/TimeBasedInitialResourceIdentifier.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/networksettled/TimeBasedInitialResourceIdentifier.kt
@@ -8,9 +8,17 @@ package com.datadog.android.rum.internal.metric.networksettled
 
 import java.util.concurrent.TimeUnit
 
-internal class TimeBasedInitialResourceIdentifier(
-    private val timeThresholdInNanoSeconds: Long = TimeUnit.MILLISECONDS.toNanos(DEFAULT_TIME_THRESHOLD_MS)
+/**
+ * An [InitialResourceIdentifier] that validates the initial resource based on the time elapsed.
+ * The resource is considered initial if the time elapsed between creation of the view and the start of the resource
+ * is less than the provided threshold in milliseconds.By default, the threshold is set to 100 milliseconds.
+ * @param timeThresholdInMilliseconds The threshold in milliseconds.
+ */
+class TimeBasedInitialResourceIdentifier(
+    timeThresholdInMilliseconds: Long = DEFAULT_TIME_THRESHOLD_MS
 ) : InitialResourceIdentifier {
+    private val timeThresholdInNanoSeconds: Long = TimeUnit.MILLISECONDS.toNanos(timeThresholdInMilliseconds)
+
     override fun validate(
         context: NetworkSettledResourceContext
     ): Boolean {
@@ -18,6 +26,23 @@ internal class TimeBasedInitialResourceIdentifier(
             context.eventCreatedAtNanos - viewCreatedTimestamp < timeThresholdInNanoSeconds
         } ?: false
     }
+
+    // region Object
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as TimeBasedInitialResourceIdentifier
+
+        return timeThresholdInNanoSeconds == other.timeThresholdInNanoSeconds
+    }
+
+    override fun hashCode(): Int {
+        return timeThresholdInNanoSeconds.hashCode()
+    }
+
+    // endregion
 
     companion object {
         internal const val DEFAULT_TIME_THRESHOLD_MS = 100L

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -43,8 +43,8 @@ import com.datadog.android.rum.internal.domain.scope.RumSessionScope
 import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
 import com.datadog.android.rum.internal.domain.scope.RumViewScope
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
-import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.internal.vitals.VitalMonitor
+import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.resource.ResourceId
 import com.datadog.android.telemetry.internal.TelemetryEventHandler
 import java.util.Locale
@@ -72,7 +72,7 @@ internal class DatadogRumMonitor(
     frameRateVitalMonitor: VitalMonitor,
     sessionListener: RumSessionListener,
     internal val executorService: ExecutorService,
-    internal val networkSettledResourceIdentifier: InitialResourceIdentifier
+    internal val initialResourceIdentifier: InitialResourceIdentifier
 ) : RumMonitor, AdvancedRumMonitor {
 
     internal var rootScope: RumScope = RumApplicationScope(
@@ -87,7 +87,7 @@ internal class DatadogRumMonitor(
         frameRateVitalMonitor,
         sessionEndedMetricDispatcher = sessionEndedMetricDispatcher,
         CombinedRumSessionListener(sessionListener, telemetryEventHandler),
-        networkSettledResourceIdentifier
+        initialResourceIdentifier
     )
 
     internal val keepAliveRunnable = Runnable {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -43,6 +43,7 @@ import com.datadog.android.rum.internal.domain.scope.RumSessionScope
 import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
 import com.datadog.android.rum.internal.domain.scope.RumViewScope
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
+import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.resource.ResourceId
 import com.datadog.android.telemetry.internal.TelemetryEventHandler
@@ -70,7 +71,8 @@ internal class DatadogRumMonitor(
     memoryVitalMonitor: VitalMonitor,
     frameRateVitalMonitor: VitalMonitor,
     sessionListener: RumSessionListener,
-    internal val executorService: ExecutorService
+    internal val executorService: ExecutorService,
+    internal val networkSettledResourceIdentifier: InitialResourceIdentifier
 ) : RumMonitor, AdvancedRumMonitor {
 
     internal var rootScope: RumScope = RumApplicationScope(
@@ -84,7 +86,8 @@ internal class DatadogRumMonitor(
         memoryVitalMonitor,
         frameRateVitalMonitor,
         sessionEndedMetricDispatcher = sessionEndedMetricDispatcher,
-        CombinedRumSessionListener(sessionListener, telemetryEventHandler)
+        CombinedRumSessionListener(sessionListener, telemetryEventHandler),
+        networkSettledResourceIdentifier
     )
 
     internal val keepAliveRunnable = Runnable {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/metric/networksettled/InitialResourceIdentifier.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/metric/networksettled/InitialResourceIdentifier.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.rum.internal.metric.networksettled
+package com.datadog.android.rum.metric.networksettled
 
 import com.datadog.tools.annotation.NoOpImplementation
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/metric/networksettled/NetworkSettledResourceContext.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/metric/networksettled/NetworkSettledResourceContext.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.rum.internal.metric.networksettled
+package com.datadog.android.rum.metric.networksettled
 
 /**
  * Represents the context of a network resource that has settled.

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/metric/networksettled/TimeBasedInitialResourceIdentifier.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/metric/networksettled/TimeBasedInitialResourceIdentifier.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.rum.internal.metric.networksettled
+package com.datadog.android.rum.metric.networksettled
 
 import java.util.concurrent.TimeUnit
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
@@ -15,6 +15,8 @@ import com.datadog.android.rum.event.ViewEventMapper
 import com.datadog.android.rum.internal.NoOpRumSessionListener
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.instrumentation.MainLooperLongTaskStrategy
+import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
+import com.datadog.android.rum.internal.metric.networksettled.TimeBasedInitialResourceIdentifier
 import com.datadog.android.rum.internal.tracking.NoOpInteractionPredicate
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
@@ -99,7 +101,8 @@ internal class RumConfigurationBuilderTest {
                 trackNonFatalAnrs = true,
                 vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.AVERAGE,
                 sessionListener = NoOpRumSessionListener(),
-                additionalConfig = emptyMap()
+                additionalConfig = emptyMap(),
+                networkSettledInitialResourceIdentifier = TimeBasedInitialResourceIdentifier()
             )
         )
     }
@@ -523,5 +526,20 @@ internal class RumConfigurationBuilderTest {
         // Then
         assertThat(rumConfiguration.featureConfiguration.sessionListener)
             .isSameAs(mockSessionListener)
+    }
+
+    @Test
+    fun `M use a custom initialResourceIdentifier W setInitialResourceIdentifierStrategy()`() {
+        // Given
+        val customInitialResourceIdentifier = mock<InitialResourceIdentifier>()
+
+        // When
+        val rumConfiguration = testedBuilder
+            .setNetworkSettledInitialResourceIdentifier(customInitialResourceIdentifier)
+            .build()
+
+        // Then
+        assertThat(rumConfiguration.featureConfiguration.networkSettledInitialResourceIdentifier)
+            .isSameAs(customInitialResourceIdentifier)
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
@@ -15,9 +15,9 @@ import com.datadog.android.rum.event.ViewEventMapper
 import com.datadog.android.rum.internal.NoOpRumSessionListener
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.instrumentation.MainLooperLongTaskStrategy
-import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
-import com.datadog.android.rum.internal.metric.networksettled.TimeBasedInitialResourceIdentifier
 import com.datadog.android.rum.internal.tracking.NoOpInteractionPredicate
+import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
+import com.datadog.android.rum.metric.networksettled.TimeBasedInitialResourceIdentifier
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
@@ -102,7 +102,7 @@ internal class RumConfigurationBuilderTest {
                 vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.AVERAGE,
                 sessionListener = NoOpRumSessionListener(),
                 additionalConfig = emptyMap(),
-                networkSettledInitialResourceIdentifier = TimeBasedInitialResourceIdentifier()
+                initialResourceIdentifier = TimeBasedInitialResourceIdentifier()
             )
         )
     }
@@ -535,11 +535,11 @@ internal class RumConfigurationBuilderTest {
 
         // When
         val rumConfiguration = testedBuilder
-            .setNetworkSettledInitialResourceIdentifier(customInitialResourceIdentifier)
+            .setInitialResourceIdentifier(customInitialResourceIdentifier)
             .build()
 
         // Then
-        assertThat(rumConfiguration.featureConfiguration.networkSettledInitialResourceIdentifier)
+        assertThat(rumConfiguration.featureConfiguration.initialResourceIdentifier)
             .isSameAs(customInitialResourceIdentifier)
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
@@ -108,8 +108,8 @@ internal class RumTest {
             }
             assertThat((lastValue.requestFactory as RumRequestFactory).customEndpointUrl)
                 .isEqualTo(fakeRumConfiguration.featureConfiguration.customEndpointUrl)
-            assertThat(lastValue.networkSettledInitialResourceIdentifier).isSameAs(
-                fakeRumConfiguration.featureConfiguration.networkSettledInitialResourceIdentifier
+            assertThat(lastValue.initialResourceIdentifier).isSameAs(
+                fakeRumConfiguration.featureConfiguration.initialResourceIdentifier
             )
         }
     }
@@ -155,8 +155,8 @@ internal class RumTest {
 
         assertThat(telemetrySampler.getSampleRate())
             .isEqualTo(fakeRumConfiguration.featureConfiguration.telemetrySampleRate)
-        assertThat(monitor.networkSettledResourceIdentifier)
-            .isSameAs(fakeRumConfiguration.featureConfiguration.networkSettledInitialResourceIdentifier)
+        assertThat(monitor.initialResourceIdentifier)
+            .isSameAs(fakeRumConfiguration.featureConfiguration.initialResourceIdentifier)
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
@@ -108,6 +108,9 @@ internal class RumTest {
             }
             assertThat((lastValue.requestFactory as RumRequestFactory).customEndpointUrl)
                 .isEqualTo(fakeRumConfiguration.featureConfiguration.customEndpointUrl)
+            assertThat(lastValue.networkSettledInitialResourceIdentifier).isSameAs(
+                fakeRumConfiguration.featureConfiguration.networkSettledInitialResourceIdentifier
+            )
         }
     }
 
@@ -152,6 +155,8 @@ internal class RumTest {
 
         assertThat(telemetrySampler.getSampleRate())
             .isEqualTo(fakeRumConfiguration.featureConfiguration.telemetrySampleRate)
+        assertThat(monitor.networkSettledResourceIdentifier)
+            .isSameAs(fakeRumConfiguration.featureConfiguration.networkSettledInitialResourceIdentifier)
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -19,8 +19,8 @@ import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
-import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.internal.vitals.VitalMonitor
+import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.tools.unit.forge.exhaustiveAttributes
 import fr.xgouchet.elmyr.Forge

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -19,6 +19,7 @@ import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
+import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.tools.unit.forge.exhaustiveAttributes
@@ -110,6 +111,9 @@ internal class RumApplicationScopeTest {
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
+    @Mock
+    lateinit var mockNetworkSettledResourceIdentifier: InitialResourceIdentifier
+
     @BeforeEach
     fun `set up`() {
         whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
@@ -127,7 +131,8 @@ internal class RumApplicationScopeTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockDispatcher,
-            mockSessionListener
+            mockSessionListener,
+            mockNetworkSettledResourceIdentifier
         )
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -16,8 +16,8 @@ import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
-import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.internal.vitals.VitalMonitor
+import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -16,6 +16,7 @@ import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
+import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
@@ -109,6 +110,9 @@ internal class RumSessionScopeTest {
 
     @Mock
     lateinit var mockSessionReplayFeatureScope: FeatureScope
+
+    @Mock
+    lateinit var mockNetworkSettledResourceIdentifier: InitialResourceIdentifier
 
     @BeforeEach
     fun `set up`(forge: Forge) {
@@ -1273,6 +1277,7 @@ internal class RumSessionScopeTest {
             mockFrameRateVitalMonitor,
             mockSessionListener,
             applicationDisplayed = false,
+            networkSettledResourceIdentifier = mockNetworkSettledResourceIdentifier,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -25,9 +25,9 @@ import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
-import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalMonitor
+import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.android.rum.utils.verifyApiUsage
@@ -147,7 +147,7 @@ internal class RumViewManagerScopeTest {
             mockFrameRateVitalMonitor,
             applicationDisplayed = false,
             sampleRate = fakeSampleRate,
-            networkSettledResourceIdentifier = mockNetworkSettledResourceIdentifier
+            initialResourceIdentifier = mockNetworkSettledResourceIdentifier
         )
     }
 
@@ -510,7 +510,7 @@ internal class RumViewManagerScopeTest {
             frameRateVitalMonitor = mockFrameRateVitalMonitor,
             applicationDisplayed = false,
             sampleRate = fakeSampleRate,
-            networkSettledResourceIdentifier = mockNetworkSettledResourceIdentifier
+            initialResourceIdentifier = mockNetworkSettledResourceIdentifier
         )
         testedScope.applicationDisplayed = true
         val fakeEvent = forge.validBackgroundEvent()
@@ -540,7 +540,7 @@ internal class RumViewManagerScopeTest {
             frameRateVitalMonitor = mockFrameRateVitalMonitor,
             applicationDisplayed = false,
             sampleRate = fakeSampleRate,
-            networkSettledResourceIdentifier = mockNetworkSettledResourceIdentifier
+            initialResourceIdentifier = mockNetworkSettledResourceIdentifier
         )
         testedScope.childrenScopes.add(mockChildScope)
         whenever(mockChildScope.isActive()) doReturn true
@@ -573,7 +573,7 @@ internal class RumViewManagerScopeTest {
             frameRateVitalMonitor = mockFrameRateVitalMonitor,
             applicationDisplayed = false,
             sampleRate = fakeSampleRate,
-            networkSettledResourceIdentifier = mockNetworkSettledResourceIdentifier
+            initialResourceIdentifier = mockNetworkSettledResourceIdentifier
         )
         testedScope.applicationDisplayed = true
         val fakeEvent = forge.validBackgroundEvent()
@@ -639,7 +639,7 @@ internal class RumViewManagerScopeTest {
             frameRateVitalMonitor = mockFrameRateVitalMonitor,
             applicationDisplayed = true,
             sampleRate = fakeSampleRate,
-            networkSettledResourceIdentifier = mockNetworkSettledResourceIdentifier
+            initialResourceIdentifier = mockNetworkSettledResourceIdentifier
         )
         testedScope.childrenScopes.add(mockChildScope)
         whenever(mockChildScope.isActive()) doReturn true
@@ -673,7 +673,7 @@ internal class RumViewManagerScopeTest {
             frameRateVitalMonitor = mockFrameRateVitalMonitor,
             applicationDisplayed = false,
             sampleRate = fakeSampleRate,
-            networkSettledResourceIdentifier = mockNetworkSettledResourceIdentifier
+            initialResourceIdentifier = mockNetworkSettledResourceIdentifier
         )
         testedScope.stopped = true
         val fakeEvent = forge.applicationStartedEvent()

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -25,6 +25,7 @@ import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
+import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.model.ActionEvent
@@ -114,6 +115,9 @@ internal class RumViewManagerScopeTest {
     @Forgery
     lateinit var fakeTime: TimeInfo
 
+    @Mock
+    lateinit var mockNetworkSettledResourceIdentifier: InitialResourceIdentifier
+
     @BoolForgery
     var fakeTrackFrustrations: Boolean = true
 
@@ -142,7 +146,8 @@ internal class RumViewManagerScopeTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             applicationDisplayed = false,
-            sampleRate = fakeSampleRate
+            sampleRate = fakeSampleRate,
+            networkSettledResourceIdentifier = mockNetworkSettledResourceIdentifier
         )
     }
 
@@ -504,7 +509,8 @@ internal class RumViewManagerScopeTest {
             memoryVitalMonitor = mockMemoryVitalMonitor,
             frameRateVitalMonitor = mockFrameRateVitalMonitor,
             applicationDisplayed = false,
-            sampleRate = fakeSampleRate
+            sampleRate = fakeSampleRate,
+            networkSettledResourceIdentifier = mockNetworkSettledResourceIdentifier
         )
         testedScope.applicationDisplayed = true
         val fakeEvent = forge.validBackgroundEvent()
@@ -533,7 +539,8 @@ internal class RumViewManagerScopeTest {
             memoryVitalMonitor = mockMemoryVitalMonitor,
             frameRateVitalMonitor = mockFrameRateVitalMonitor,
             applicationDisplayed = false,
-            sampleRate = fakeSampleRate
+            sampleRate = fakeSampleRate,
+            networkSettledResourceIdentifier = mockNetworkSettledResourceIdentifier
         )
         testedScope.childrenScopes.add(mockChildScope)
         whenever(mockChildScope.isActive()) doReturn true
@@ -565,7 +572,8 @@ internal class RumViewManagerScopeTest {
             memoryVitalMonitor = mockMemoryVitalMonitor,
             frameRateVitalMonitor = mockFrameRateVitalMonitor,
             applicationDisplayed = false,
-            sampleRate = fakeSampleRate
+            sampleRate = fakeSampleRate,
+            networkSettledResourceIdentifier = mockNetworkSettledResourceIdentifier
         )
         testedScope.applicationDisplayed = true
         val fakeEvent = forge.validBackgroundEvent()
@@ -630,7 +638,8 @@ internal class RumViewManagerScopeTest {
             memoryVitalMonitor = mockMemoryVitalMonitor,
             frameRateVitalMonitor = mockFrameRateVitalMonitor,
             applicationDisplayed = true,
-            sampleRate = fakeSampleRate
+            sampleRate = fakeSampleRate,
+            networkSettledResourceIdentifier = mockNetworkSettledResourceIdentifier
         )
         testedScope.childrenScopes.add(mockChildScope)
         whenever(mockChildScope.isActive()) doReturn true
@@ -663,7 +672,8 @@ internal class RumViewManagerScopeTest {
             memoryVitalMonitor = mockMemoryVitalMonitor,
             frameRateVitalMonitor = mockFrameRateVitalMonitor,
             applicationDisplayed = false,
-            sampleRate = fakeSampleRate
+            sampleRate = fakeSampleRate,
+            networkSettledResourceIdentifier = mockNetworkSettledResourceIdentifier
         )
         testedScope.stopped = true
         val fakeEvent = forge.applicationStartedEvent()

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -7397,6 +7397,35 @@ internal class RumViewScopeTest {
     }
 
     @Test
+    fun `M not notify networkSettledMetricResolver W view was stopped { different key }`(
+        @Forgery fakeOtherKey: RumScopeKey
+    ) {
+        // Given
+        assumeFalse(fakeOtherKey == fakeKey)
+
+        // When
+        testedScope.handleEvent(RumRawEvent.StopView(fakeOtherKey, emptyMap()), mockWriter)
+
+        // Then
+        verify(mockNetworkSettledMetricResolver, never()).viewWasStopped()
+    }
+
+    @Test
+    fun `M not notify networkSettledMetricResolver W view was stopped { already stopped }`() {
+        // Given
+        testedScope.stopped = true
+
+        // When
+        testedScope.handleEvent(
+            RumRawEvent.StopView(fakeKey, emptyMap()),
+            mockWriter
+        )
+
+        // Then
+        verify(mockNetworkSettledMetricResolver, never()).viewWasStopped()
+    }
+
+    @Test
     fun `M notify the networkSettledMetricMetricResolver W view was created`() {
         // Then
         verify(mockNetworkSettledMetricResolver).viewWasCreated(fakeEventTime.nanoTime)
@@ -8928,7 +8957,8 @@ internal class RumViewScopeTest {
             mockFeaturesContextResolver,
             trackFrustrations = fakeTrackFrustrations,
             sampleRate = fakeSampleRate,
-            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver
+            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver,
+            networkSettledMetricResolver = mockNetworkSettledMetricResolver
         )
 
         // When
@@ -8994,7 +9024,8 @@ internal class RumViewScopeTest {
             featuresContextResolver = mockFeaturesContextResolver,
             trackFrustrations = fakeTrackFrustrations,
             sampleRate = fakeSampleRate,
-            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver
+            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver,
+            networkSettledMetricResolver = mockNetworkSettledMetricResolver
         )
 
         // When
@@ -9048,7 +9079,8 @@ internal class RumViewScopeTest {
             featuresContextResolver = mockFeaturesContextResolver,
             trackFrustrations = fakeTrackFrustrations,
             sampleRate = fakeSampleRate,
-            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver
+            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver,
+            networkSettledMetricResolver = mockNetworkSettledMetricResolver
         )
 
         // When
@@ -9108,7 +9140,8 @@ internal class RumViewScopeTest {
             featuresContextResolver = mockFeaturesContextResolver,
             trackFrustrations = fakeTrackFrustrations,
             sampleRate = fakeSampleRate,
-            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver
+            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver,
+            networkSettledMetricResolver = mockNetworkSettledMetricResolver
         )
         testedScope.handleEvent(
             RumRawEvent.StartResource(key, url, method, emptyMap()),
@@ -9174,7 +9207,8 @@ internal class RumViewScopeTest {
             featuresContextResolver = mockFeaturesContextResolver,
             trackFrustrations = fakeTrackFrustrations,
             sampleRate = fakeSampleRate,
-            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver
+            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver,
+            networkSettledMetricResolver = mockNetworkSettledMetricResolver
         )
         testedScope.handleEvent(
             RumRawEvent.StartAction(type, name, forge.aBool(), emptyMap()),
@@ -9250,7 +9284,8 @@ internal class RumViewScopeTest {
             featuresContextResolver = mockFeaturesContextResolver,
             trackFrustrations = fakeTrackFrustrations,
             sampleRate = fakeSampleRate,
-            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver
+            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver,
+            networkSettledMetricResolver = mockNetworkSettledMetricResolver
         )
         testedScope.handleEvent(
             RumRawEvent.StartResource(key, url, method, emptyMap()),
@@ -9326,7 +9361,8 @@ internal class RumViewScopeTest {
             featuresContextResolver = mockFeaturesContextResolver,
             trackFrustrations = fakeTrackFrustrations,
             sampleRate = fakeSampleRate,
-            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver
+            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver,
+            networkSettledMetricResolver = mockNetworkSettledMetricResolver
         )
         testedScope.handleEvent(
             RumRawEvent.StartAction(type, name, forge.aBool(), emptyMap()),
@@ -9383,7 +9419,8 @@ internal class RumViewScopeTest {
             featuresContextResolver = mockFeaturesContextResolver,
             trackFrustrations = fakeTrackFrustrations,
             sampleRate = fakeSampleRate,
-            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver
+            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver,
+            networkSettledMetricResolver = mockNetworkSettledMetricResolver
         )
 
         // When
@@ -9446,7 +9483,8 @@ internal class RumViewScopeTest {
             featuresContextResolver = mockFeaturesContextResolver,
             trackFrustrations = fakeTrackFrustrations,
             sampleRate = fakeSampleRate,
-            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver
+            interactionToNextViewMetricResolver = mockInteractionToNextViewMetricResolver,
+            networkSettledMetricResolver = mockNetworkSettledMetricResolver
         )
 
         // When

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/networksettled/TimeBasedInitialResourceIdentifierTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/networksettled/TimeBasedInitialResourceIdentifierTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.rum.internal.metric.networksettled
 
 import com.datadog.android.rum.utils.forge.Configurator
+import com.datadog.tools.unit.ObjectTest
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -16,30 +17,51 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import java.util.concurrent.TimeUnit
 
 @Extensions(
     ExtendWith(ForgeExtension::class)
 )
 @ForgeConfiguration(Configurator::class)
-internal class TimeRequestBasedValidatorTest {
+internal class TimeBasedInitialResourceIdentifierTest : ObjectTest<TimeBasedInitialResourceIdentifier>() {
 
     private lateinit var testedValidator: TimeBasedInitialResourceIdentifier
 
     @Forgery
     lateinit var fakeNetworkSettledResourceContext: NetworkSettledResourceContext
 
-    private var fakeIntervalThreshold: Long = 0L
+    private var fakeIntervalThresholdInMs: Long = 0L
+    private var fakeIntervalThresholdInNanos: Long = 0L
     private var fakeViewCreatedTimestamp: Long = 0L
 
     @BeforeEach
     fun `set up`(forge: Forge) {
         fakeViewCreatedTimestamp = forge.aTinyPositiveLong()
-        fakeIntervalThreshold = forge.aTinyPositiveLong()
+        fakeIntervalThresholdInMs = forge.aTinyPositiveLong()
+        fakeIntervalThresholdInNanos = TimeUnit.MILLISECONDS.toNanos(fakeIntervalThresholdInMs)
         fakeNetworkSettledResourceContext =
             fakeNetworkSettledResourceContext.copy(
                 viewCreatedTimestamp = fakeViewCreatedTimestamp
             )
-        testedValidator = TimeBasedInitialResourceIdentifier(fakeIntervalThreshold)
+        testedValidator = TimeBasedInitialResourceIdentifier(fakeIntervalThresholdInMs)
+    }
+
+    override fun createInstance(forge: Forge): TimeBasedInitialResourceIdentifier {
+        return TimeBasedInitialResourceIdentifier(fakeIntervalThresholdInMs)
+    }
+
+    override fun createEqualInstance(
+        source: TimeBasedInitialResourceIdentifier,
+        forge: Forge
+    ): TimeBasedInitialResourceIdentifier {
+        return TimeBasedInitialResourceIdentifier(fakeIntervalThresholdInMs)
+    }
+
+    override fun createUnequalInstance(
+        source: TimeBasedInitialResourceIdentifier,
+        forge: Forge
+    ): TimeBasedInitialResourceIdentifier? {
+        return TimeBasedInitialResourceIdentifier(fakeIntervalThresholdInMs + forge.aTinyPositiveLong())
     }
 
     // region Tests
@@ -62,7 +84,7 @@ internal class TimeRequestBasedValidatorTest {
         fakeNetworkSettledResourceContext =
             fakeNetworkSettledResourceContext.copy(
                 eventCreatedAtNanos =
-                fakeViewCreatedTimestamp + fakeIntervalThreshold + forge.aTinyPositiveLong()
+                fakeViewCreatedTimestamp + fakeIntervalThresholdInNanos + forge.aTinyPositiveLong()
             )
 
         // When
@@ -78,7 +100,7 @@ internal class TimeRequestBasedValidatorTest {
         fakeNetworkSettledResourceContext =
             fakeNetworkSettledResourceContext.copy(
                 eventCreatedAtNanos =
-                fakeViewCreatedTimestamp + forge.aLong(min = 0, max = fakeIntervalThreshold)
+                fakeViewCreatedTimestamp + forge.aLong(min = 0, max = fakeIntervalThresholdInNanos)
             )
 
         // When

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -41,6 +41,7 @@ import com.datadog.android.rum.internal.domain.scope.RumSessionScope
 import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
 import com.datadog.android.rum.internal.domain.scope.RumViewScope
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
+import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.resource.ResourceId
 import com.datadog.android.rum.utils.forge.Configurator
@@ -163,6 +164,9 @@ internal class DatadogRumMonitorTest {
     @Forgery
     lateinit var fakeTimeInfo: TimeInfo
 
+    @Mock
+    lateinit var mockNetworkSettledResourceIdentifier: InitialResourceIdentifier
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         whenever(mockExecutorService.submit(any())) doAnswer {
@@ -189,7 +193,8 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
-            mockExecutorService
+            mockExecutorService,
+            mockNetworkSettledResourceIdentifier
         )
         testedMonitor.rootScope = mockScope
     }
@@ -211,7 +216,8 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
-            mockExecutorService
+            mockExecutorService,
+            mockNetworkSettledResourceIdentifier
         )
 
         val rootScope = testedMonitor.rootScope
@@ -270,7 +276,8 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
-            mockExecutorService
+            mockExecutorService,
+            mockNetworkSettledResourceIdentifier
         )
         val completableFuture = CompletableFuture<String>()
         testedMonitor.start()
@@ -307,7 +314,8 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
-            mockExecutorService
+            mockExecutorService,
+            mockNetworkSettledResourceIdentifier
         )
 
         val completableFuture = CompletableFuture<String>()
@@ -1639,7 +1647,8 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
-            mockExecutor
+            mockExecutor,
+            mockNetworkSettledResourceIdentifier
         )
 
         // When
@@ -1684,7 +1693,8 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
-            mockExecutorService
+            mockExecutorService,
+            mockNetworkSettledResourceIdentifier
         )
 
         // When
@@ -1716,7 +1726,8 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
-            mockExecutorService
+            mockExecutorService,
+            mockNetworkSettledResourceIdentifier
         )
         whenever(mockExecutorService.isShutdown).thenReturn(true)
 
@@ -1900,7 +1911,8 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
-            mockExecutorService
+            mockExecutorService,
+            mockNetworkSettledResourceIdentifier
         )
         testedMonitor.startView(key, name, attributes)
         // When

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -41,8 +41,8 @@ import com.datadog.android.rum.internal.domain.scope.RumSessionScope
 import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
 import com.datadog.android.rum.internal.domain.scope.RumViewScope
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
-import com.datadog.android.rum.internal.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.internal.vitals.VitalMonitor
+import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.resource.ResourceId
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.android.rum.utils.verifyLog

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/metric/networksettled/NetworkSettledMetricResolverTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/metric/networksettled/NetworkSettledMetricResolverTest.kt
@@ -4,9 +4,11 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.rum.internal.metric.networksettled
+package com.datadog.android.rum.metric.networksettled
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.rum.internal.metric.networksettled.InternalResourceContext
+import com.datadog.android.rum.internal.metric.networksettled.NetworkSettledMetricResolver
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.android.rum.utils.verifyLog
 import fr.xgouchet.elmyr.Forge

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/metric/networksettled/TimeBasedInitialResourceIdentifierTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/metric/networksettled/TimeBasedInitialResourceIdentifierTest.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.rum.internal.metric.networksettled
+package com.datadog.android.rum.metric.networksettled
 
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.tools.unit.ObjectTest

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
@@ -48,7 +48,7 @@ internal class ConfigurationRumForgeryFactory :
             vitalsMonitorUpdateFrequency = forge.aValueFrom(VitalsUpdateFrequency::class.java),
             sessionListener = mock(),
             additionalConfig = forge.aMap { aString() to aString() },
-            networkSettledInitialResourceIdentifier = mock()
+            initialResourceIdentifier = mock()
         )
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
@@ -47,7 +47,8 @@ internal class ConfigurationRumForgeryFactory :
             trackNonFatalAnrs = forge.aBool(),
             vitalsMonitorUpdateFrequency = forge.aValueFrom(VitalsUpdateFrequency::class.java),
             sessionListener = mock(),
-            additionalConfig = forge.aMap { aString() to aString() }
+            additionalConfig = forge.aMap { aString() to aString() },
+            networkSettledInitialResourceIdentifier = mock()
         )
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/NetworkSettledResourceContextFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/NetworkSettledResourceContextFactory.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.rum.utils.forge
 
-import com.datadog.android.rum.internal.metric.networksettled.NetworkSettledResourceContext
+import com.datadog.android.rum.metric.networksettled.NetworkSettledResourceContext
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 import java.util.UUID


### PR DESCRIPTION

### What does this PR do?

Following the RFC we are introducing the `setNetworkSettledInitialResourceIdentifier` API as part of the `RumConfiguration#Builder` in order to provide external control on which resource started in a view will be take part
in the `time-to-network-settled` metric computation. The default identifier being used is a `TimeBasedResourceIdentifier` with a default threshold set to `100ms`. This could be re - used by our users in the Configuration `Builder` by changing the `time interval` to their internal needs.

In addition to this this PR contain a small but very important fix in the `RumViewScope` where we make sure the `NetworkSettledMetricResolver` is notified for the `view stopped` only if the event was sent for the current view and only once.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

