### PR TITLE
[RUM-6286] Poor performance method detekt rule support

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -99,6 +99,8 @@ datadog:
       - "com.datadog.android.api.feature.FeatureScope.withWriteContext"
     mainThreadSwitchingCalls:
       - "android.widget.LinearLayout.post"
+  PoorPerformanceMethodsUsage:
+    active: true
   TodoWithoutTask:
     active: true
     deprecatedPrefixes:

--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/DatadogProvider.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/DatadogProvider.kt
@@ -9,6 +9,7 @@ package com.datadog.tools.detekt
 import com.datadog.tools.detekt.rules.sdk.CheckInternal
 import com.datadog.tools.detekt.rules.sdk.InvalidStringFormat
 import com.datadog.tools.detekt.rules.sdk.PackageNameVisibility
+import com.datadog.tools.detekt.rules.sdk.PoorPerformanceMethodsUsage
 import com.datadog.tools.detekt.rules.sdk.RequireInternal
 import com.datadog.tools.detekt.rules.sdk.ThreadSafety
 import com.datadog.tools.detekt.rules.sdk.ThrowingInternalException
@@ -38,7 +39,8 @@ class DatadogProvider : RuleSetProvider {
                 ThrowingInternalException(),
                 TodoWithoutTask(config),
                 UnsafeCallOnNullableType(),
-                UnsafeThirdPartyFunctionCall(config)
+                UnsafeThirdPartyFunctionCall(config),
+                PoorPerformanceMethodsUsage()
             )
         )
     }

--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/sdk/PoorPerformanceMethodsUsage.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/sdk/PoorPerformanceMethodsUsage.kt
@@ -1,0 +1,90 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.tools.detekt.rules.sdk
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtAnnotatedExpression
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+
+/**
+ * A rule to detect methods that could cause performance issues.
+ * Full list of detected methods listed in [PoorPerformanceMethodsUsage.POOR_PERFORMANCE_METHODS_NAMES]
+ * @active
+ */
+class PoorPerformanceMethodsUsage : Rule() {
+
+    override val issue: Issue = Issue(
+        ISSUE_ID,
+        severity = Severity.Performance,
+        description = "This rule reports when method that might cause performance impact is used",
+        debt = Debt.TWENTY_MINS
+    )
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        val referencedName = expression.getCallNameExpression()?.getReferencedName()
+        if (referencedName !in POOR_PERFORMANCE_METHODS_NAMES) return
+
+        val functionAnnotations = expression.getStrictParentOfType<KtNamedFunction>()
+            ?.getAnnotationEntries() ?: emptyList()
+
+        val expressionAnnotations = expression.getStrictParentOfType<KtAnnotatedExpression>()
+            ?.annotationEntries ?: emptyList()
+
+        val applicableAnnotations = (functionAnnotations + expressionAnnotations)
+            .filter { it.shortName?.asString() == SUPPRESSION_ANNOTATION_NAME }
+
+        val suppressedIssues = applicableAnnotations
+            .map { annotation -> annotation.arguments }
+            .flatten()
+
+        if (ISSUE_ID !in suppressedIssues) {
+            reportPotentialPerformanceImpact(
+                expression,
+                "Potential performance issue detected for method: $referencedName"
+            )
+        }
+    }
+
+    private val KtAnnotationEntry.arguments: List<String>
+        get() = valueArguments
+            .mapNotNull { argument ->
+                when (val expression = argument.getArgumentExpression()) {
+                    is KtStringTemplateExpression -> expression.entries.joinToString("") { it.text }
+                    else -> throw IllegalArgumentException(
+                        """
+                            Complex arguments are not supported. 
+                            Please use @${SUPPRESSION_ANNOTATION_NAME}("methodName") or
+                             @${SUPPRESSION_ANNOTATION_NAME}("firstMethod", "secondMethod") 
+                        """.trimIndent()
+                    )
+                }
+            }
+
+    private fun reportPotentialPerformanceImpact(
+        expression: KtCallExpression,
+        message: String
+    ) {
+        report(CodeSmell(issue, Entity.from(expression), message))
+    }
+
+    companion object {
+        private const val ISSUE_ID = "PotentiallyPoorPerformanceMethodUsage"
+        private const val SUPPRESSION_ANNOTATION_NAME = "Suppress"
+        private val POOR_PERFORMANCE_METHODS_NAMES = setOf(
+            "joinToString"
+        )
+    }
+}

--- a/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/sdk/PoorPerformanceMethodsUsageTest.kt
+++ b/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/sdk/PoorPerformanceMethodsUsageTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.tools.detekt.rules.sdk
+
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
+import org.junit.Test
+
+class PoorPerformanceMethodsUsageTest {
+
+    @Test
+    fun `detekt joinToString method call`() {
+        val code =
+            """
+            fun test() {
+                listOf(1).joinToString()
+            }
+            """.trimIndent()
+
+        val findings = PoorPerformanceMethodsUsage().lint(code)
+
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `detekt ignores joinToString method call with Suppress annotation on parent function`() {
+        val code =
+            """
+            @Suppress("AnotherSuppressedRule", "PotentiallyPoorPerformanceMethodUsage")
+            fun test() {
+                listOf(1).joinToString()
+            }
+            """.trimIndent()
+
+        val findings = PoorPerformanceMethodsUsage().lint(code)
+
+        assertThat(findings).hasSize(0)
+    }
+
+    @Test
+    fun `detekt ignores joinToString method call with Suppress annotation on expression`() {
+        val code =
+            """
+            fun test() {
+                @Suppress("PotentiallyPoorPerformanceMethodUsage")
+                listOf(1).joinToString()
+            }
+            """.trimIndent()
+
+        val findings = PoorPerformanceMethodsUsage().lint(code)
+
+        assertThat(findings).hasSize(0)
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This PR contains detekt rule targeting to detect potential performance impact with usage of some method from kotlin std lib or our android-sdk

### Motivation

This is the continuation of [RUM-6256](https://github.com/DataDog/dd-sdk-android/pull/2273) which improved md5 computation. In this PR we are trying to build detekt rule that will notify dev team ahead before performance impact occur

### Additional Notes

Work in progress

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)



[RUM-6256]: https://datadoghq.atlassian.net/browse/RUM-6256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ