### PR TITLE
[RUM-3845] Trying to get from Thread.sleep(SHORT_SLEEP_MS) in unit tests at DatadogEventListenerTest

### DIFF
--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogEventListener.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogEventListener.kt
@@ -74,27 +74,27 @@ internal constructor(
     override fun callStart(call: Call) {
         super.callStart(call)
         sendWaitForResourceTimingEvent()
-        callStart = System.nanoTime()
+        callStart = sdkCore.time.deviceTimeNs
     }
 
     /** @inheritdoc */
     override fun dnsStart(call: Call, domainName: String) {
         super.dnsStart(call, domainName)
         sendWaitForResourceTimingEvent()
-        dnsStart = System.nanoTime()
+        dnsStart = sdkCore.time.deviceTimeNs
     }
 
     /** @inheritdoc */
     override fun dnsEnd(call: Call, domainName: String, inetAddressList: List<InetAddress>) {
         super.dnsEnd(call, domainName, inetAddressList)
-        dnsEnd = System.nanoTime()
+        dnsEnd = sdkCore.time.deviceTimeNs
     }
 
     /** @inheritdoc */
     override fun connectStart(call: Call, inetSocketAddress: InetSocketAddress, proxy: Proxy) {
         super.connectStart(call, inetSocketAddress, proxy)
         sendWaitForResourceTimingEvent()
-        connStart = System.nanoTime()
+        connStart = sdkCore.time.deviceTimeNs
     }
 
     /** @inheritdoc */
@@ -105,33 +105,33 @@ internal constructor(
         protocol: Protocol?
     ) {
         super.connectEnd(call, inetSocketAddress, proxy, protocol)
-        connEnd = System.nanoTime()
+        connEnd = sdkCore.time.deviceTimeNs
     }
 
     /** @inheritdoc */
     override fun secureConnectStart(call: Call) {
         super.secureConnectStart(call)
         sendWaitForResourceTimingEvent()
-        sslStart = System.nanoTime()
+        sslStart = sdkCore.time.deviceTimeNs
     }
 
     /** @inheritdoc */
     override fun secureConnectEnd(call: Call, handshake: Handshake?) {
         super.secureConnectEnd(call, handshake)
-        sslEnd = System.nanoTime()
+        sslEnd = sdkCore.time.deviceTimeNs
     }
 
     /** @inheritdoc */
     override fun responseHeadersStart(call: Call) {
         super.responseHeadersStart(call)
         sendWaitForResourceTimingEvent()
-        headersStart = System.nanoTime()
+        headersStart = sdkCore.time.deviceTimeNs
     }
 
     /** @inheritdoc */
     override fun responseHeadersEnd(call: Call, response: Response) {
         super.responseHeadersEnd(call, response)
-        headersEnd = System.nanoTime()
+        headersEnd = sdkCore.time.deviceTimeNs
         if (response.code >= HttpURLConnection.HTTP_BAD_REQUEST) {
             sendTiming()
         }
@@ -141,13 +141,13 @@ internal constructor(
     override fun responseBodyStart(call: Call) {
         super.responseBodyStart(call)
         sendWaitForResourceTimingEvent()
-        bodyStart = System.nanoTime()
+        bodyStart = sdkCore.time.deviceTimeNs
     }
 
     /** @inheritdoc */
     override fun responseBodyEnd(call: Call, byteCount: Long) {
         super.responseBodyEnd(call, byteCount)
-        bodyEnd = System.nanoTime()
+        bodyEnd = sdkCore.time.deviceTimeNs
     }
 
     /** @inheritdoc */

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogEventListenerTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogEventListenerTest.kt
@@ -47,7 +47,6 @@ import org.mockito.quality.Strictness
 import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.Proxy
-import java.util.concurrent.TimeUnit
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -58,7 +57,7 @@ import java.util.concurrent.TimeUnit
 @ForgeConfiguration(OkHttpIntegrationForgeConfigurator::class)
 internal class DatadogEventListenerTest {
 
-    lateinit var testedListener: EventListener
+    private lateinit var testedListener: EventListener
 
     @Mock
     lateinit var mockCall: Call
@@ -160,9 +159,9 @@ internal class DatadogEventListenerTest {
             assertThat(timing.sslDuration).isLessThan(timing.connectDuration)
 
             // All durations are consistent
-            assertThat(timing.dnsDuration).isLessThan(SHORT_SLEEP_NS + MARGIN_NS)
-            assertThat(timing.connectDuration).isLessThan((SHORT_SLEEP_NS * 3) + MARGIN_NS)
-            assertThat(timing.firstByteDuration).isLessThan(SHORT_SLEEP_NS + MARGIN_NS)
+            assertThat(timing.dnsDuration).isEqualTo(SHORT_SLEEP_NS)
+            assertThat(timing.connectDuration).isEqualTo(SHORT_SLEEP_NS * 3)
+            assertThat(timing.firstByteDuration).isEqualTo(SHORT_SLEEP_NS)
         }
     }
 
@@ -211,10 +210,10 @@ internal class DatadogEventListenerTest {
             assertThat(timing.sslDuration).isLessThan(timing.connectDuration)
 
             // All durations are consistent
-            assertThat(timing.dnsDuration).isLessThan(SHORT_SLEEP_NS + MARGIN_NS)
-            assertThat(timing.connectDuration).isLessThan((SHORT_SLEEP_NS * 3) + MARGIN_NS)
-            assertThat(timing.firstByteDuration).isLessThan(SHORT_SLEEP_NS + MARGIN_NS)
-            assertThat(timing.downloadDuration).isLessThan(SHORT_SLEEP_NS + MARGIN_NS)
+            assertThat(timing.dnsDuration).isEqualTo(SHORT_SLEEP_NS)
+            assertThat(timing.connectDuration).isEqualTo(SHORT_SLEEP_NS * 3)
+            assertThat(timing.firstByteDuration).isEqualTo(SHORT_SLEEP_NS)
+            assertThat(timing.downloadDuration).isEqualTo(SHORT_SLEEP_NS)
         }
     }
 
@@ -244,9 +243,8 @@ internal class DatadogEventListenerTest {
             assertThat(timing.firstByteStart).isEqualTo(0L)
             assertThat(timing.firstByteDuration).isEqualTo(0L)
 
-            assertThat(timing.downloadStart).isGreaterThanOrEqualTo(SHORT_SLEEP_NS)
-            assertThat(timing.downloadDuration).isGreaterThanOrEqualTo(SHORT_SLEEP_NS)
-                .isLessThan(SHORT_SLEEP_NS + MARGIN_NS)
+            assertThat(timing.downloadStart).isEqualTo(SHORT_SLEEP_NS)
+            assertThat(timing.downloadDuration).isEqualTo(SHORT_SLEEP_NS)
         }
     }
 
@@ -297,10 +295,10 @@ internal class DatadogEventListenerTest {
             assertThat(timing.sslDuration).isLessThan(timing.connectDuration)
 
             // All durations are consistent
-            assertThat(timing.dnsDuration).isLessThan(SHORT_SLEEP_NS + MARGIN_NS)
-            assertThat(timing.connectDuration).isLessThan((SHORT_SLEEP_NS * 3) + MARGIN_NS)
-            assertThat(timing.firstByteDuration).isLessThan(SHORT_SLEEP_NS + MARGIN_NS)
-            assertThat(timing.downloadDuration).isLessThan(SHORT_SLEEP_NS + MARGIN_NS)
+            assertThat(timing.dnsDuration).isEqualTo(SHORT_SLEEP_NS)
+            assertThat(timing.connectDuration).isEqualTo(SHORT_SLEEP_NS * 3)
+            assertThat(timing.firstByteDuration).isEqualTo(SHORT_SLEEP_NS)
+            assertThat(timing.downloadDuration).isEqualTo(SHORT_SLEEP_NS)
         }
     }
 
@@ -379,14 +377,7 @@ internal class DatadogEventListenerTest {
     }
 
     companion object {
-        private const val SHORT_SLEEP_MS = 5L
-
-        private val SHORT_SLEEP_NS = TimeUnit.MILLISECONDS.toNanos(SHORT_SLEEP_MS)
-
-        // Because the threading can be random sometimes, we need a margin for our timing assertions
-        // If the tests turn flaky again, we can increase this value
-        // TODO RUM-3845 let the DatdogEventListener use the SDKCore's time info to have more reliable assertions
-        private val MARGIN_NS = TimeUnit.MILLISECONDS.toNanos(60)
+        private const val SHORT_SLEEP_NS = 5000000L
 
         val rumMonitor = GlobalRumMonitorTestConfiguration()
 


### PR DESCRIPTION
### What does this PR do?

In this PR we are trying to get rid of `Thread.sleep `instructions inside `DatadogEventListenerTest.kt`.
To do so we use `sdkCore.time.deviceTimeNs` at DatadogEventListener.kt instead of `System.nanoTime()` method which let us mock time values 

### Motivation

This approach makes this test independent from CI machine time and should increase test stability

### Additional Notes

This is a WIP PR so changes could be non-final. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

