### PR TITLE
Fix the way we are recording the last interaction for ITNV metric

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -179,7 +179,7 @@ interface com.datadog.android.rum.internal.monitor.AdvancedNetworkRumMonitor : c
 interface com.datadog.android.rum.metric.interactiontonextview.LastInteractionIdentifier
   fun validate(PreviousViewLastInteractionContext): Boolean
 data class com.datadog.android.rum.metric.interactiontonextview.PreviousViewLastInteractionContext
-  constructor(com.datadog.android.rum.RumActionType, Long, Long?)
+  constructor(com.datadog.android.rum.model.ActionEvent.ActionEventActionType, Long, Long?)
 class com.datadog.android.rum.metric.interactiontonextview.TimeBasedInteractionIdentifier : LastInteractionIdentifier
   constructor(Long = DEFAULT_TIME_THRESHOLD_MS)
   override fun validate(PreviousViewLastInteractionContext): Boolean

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -310,14 +310,14 @@ public abstract interface class com/datadog/android/rum/metric/interactiontonext
 }
 
 public final class com/datadog/android/rum/metric/interactiontonextview/PreviousViewLastInteractionContext {
-	public fun <init> (Lcom/datadog/android/rum/RumActionType;JLjava/lang/Long;)V
-	public final fun component1 ()Lcom/datadog/android/rum/RumActionType;
+	public fun <init> (Lcom/datadog/android/rum/model/ActionEvent$ActionEventActionType;JLjava/lang/Long;)V
+	public final fun component1 ()Lcom/datadog/android/rum/model/ActionEvent$ActionEventActionType;
 	public final fun component2 ()J
 	public final fun component3 ()Ljava/lang/Long;
-	public final fun copy (Lcom/datadog/android/rum/RumActionType;JLjava/lang/Long;)Lcom/datadog/android/rum/metric/interactiontonextview/PreviousViewLastInteractionContext;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/metric/interactiontonextview/PreviousViewLastInteractionContext;Lcom/datadog/android/rum/RumActionType;JLjava/lang/Long;ILjava/lang/Object;)Lcom/datadog/android/rum/metric/interactiontonextview/PreviousViewLastInteractionContext;
+	public final fun copy (Lcom/datadog/android/rum/model/ActionEvent$ActionEventActionType;JLjava/lang/Long;)Lcom/datadog/android/rum/metric/interactiontonextview/PreviousViewLastInteractionContext;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/metric/interactiontonextview/PreviousViewLastInteractionContext;Lcom/datadog/android/rum/model/ActionEvent$ActionEventActionType;JLjava/lang/Long;ILjava/lang/Object;)Lcom/datadog/android/rum/metric/interactiontonextview/PreviousViewLastInteractionContext;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getActionType ()Lcom/datadog/android/rum/RumActionType;
+	public final fun getActionType ()Lcom/datadog/android/rum/model/ActionEvent$ActionEventActionType;
 	public final fun getCurrentViewCreationTimestamp ()Ljava/lang/Long;
 	public final fun getEventCreatedAtNanos ()J
 	public fun hashCode ()I

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -16,6 +16,7 @@ import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
+import com.datadog.android.rum.model.ActionEvent
 
 internal sealed class RumRawEvent {
 
@@ -119,6 +120,8 @@ internal sealed class RumRawEvent {
     internal data class ActionSent(
         val viewId: String,
         val frustrationCount: Int,
+        val type: ActionEvent.ActionEventActionType,
+        val eventEndTimestampInNanos: Long,
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/interactiontonextview/ActionTypeInteractionValidator.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/interactiontonextview/ActionTypeInteractionValidator.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.rum.internal.metric.interactiontonextview
 
-import com.datadog.android.rum.RumActionType
+import com.datadog.android.rum.model.ActionEvent
 
 internal class ActionTypeInteractionValidator : InteractionIngestionValidator {
     override fun validate(
@@ -17,10 +17,10 @@ internal class ActionTypeInteractionValidator : InteractionIngestionValidator {
 
     companion object {
         private val ALLOWED_TYPES = setOf(
-            RumActionType.TAP,
-            RumActionType.SWIPE,
-            RumActionType.CLICK,
-            RumActionType.BACK
+            ActionEvent.ActionEventActionType.TAP,
+            ActionEvent.ActionEventActionType.SWIPE,
+            ActionEvent.ActionEventActionType.CLICK,
+            ActionEvent.ActionEventActionType.BACK
         )
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/interactiontonextview/InternalInteractionContext.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/interactiontonextview/InternalInteractionContext.kt
@@ -6,10 +6,10 @@
 
 package com.datadog.android.rum.internal.metric.interactiontonextview
 
-import com.datadog.android.rum.RumActionType
+import com.datadog.android.rum.model.ActionEvent
 
 internal data class InternalInteractionContext(
     internal val viewId: String,
-    internal val actionType: RumActionType,
+    internal val actionType: ActionEvent.ActionEventActionType,
     internal val eventCreatedAtNanos: Long
 )

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -560,7 +560,9 @@ internal class DatadogRumMonitor(
             is StorageEvent.Action -> handleEvent(
                 RumRawEvent.ActionSent(
                     viewId,
-                    event.frustrationCount
+                    event.frustrationCount,
+                    event.type,
+                    event.eventEndTimestampInNanos
                 )
             )
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/StorageEvent.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/StorageEvent.kt
@@ -6,9 +6,16 @@
 
 package com.datadog.android.rum.internal.monitor
 
+import com.datadog.android.rum.model.ActionEvent
+
 internal sealed class StorageEvent {
     object View : StorageEvent()
-    data class Action(val frustrationCount: Int) : StorageEvent()
+    data class Action(
+        val frustrationCount: Int,
+        val type: ActionEvent.ActionEventActionType,
+        val eventEndTimestampInNanos: Long
+    ) : StorageEvent()
+
     object Resource : StorageEvent()
     object Error : StorageEvent()
     object LongTask : StorageEvent()

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/metric/interactiontonextview/PreviousViewLastInteractionContext.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/metric/interactiontonextview/PreviousViewLastInteractionContext.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.rum.metric.interactiontonextview
 
-import com.datadog.android.rum.RumActionType
+import com.datadog.android.rum.model.ActionEvent
 
 /**
  * Represents the context of the last interaction in the previous view.
@@ -16,7 +16,7 @@ import com.datadog.android.rum.RumActionType
  * or null if not applicable.
  */
 data class PreviousViewLastInteractionContext(
-    val actionType: RumActionType,
+    val actionType: ActionEvent.ActionEventActionType,
     val eventCreatedAtNanos: Long,
     val currentViewCreationTimestamp: Long?
 )

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
@@ -11,6 +11,7 @@ import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.internal.domain.Time
+import com.datadog.android.rum.model.ActionEvent
 import com.datadog.tools.unit.forge.aThrowable
 import com.datadog.tools.unit.forge.exhaustiveAttributes
 import fr.xgouchet.elmyr.Forge
@@ -234,7 +235,12 @@ internal fun Forge.silentOrphanEvent(): RumRawEvent {
             RumRawEvent.ResetSession(),
             RumRawEvent.KeepAlive(),
             RumRawEvent.StopView(getForgery(), emptyMap()),
-            RumRawEvent.ActionSent(fakeId, aPositiveInt()),
+            RumRawEvent.ActionSent(
+                fakeId,
+                aPositiveInt(),
+                aValueFrom(ActionEvent.ActionEventActionType::class.java),
+                aPositiveLong()
+            ),
             RumRawEvent.ErrorSent(fakeId),
             RumRawEvent.LongTaskSent(fakeId),
             RumRawEvent.ResourceSent(fakeId),

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/interactiontonextview/ActionTypeInteractionValidatorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/interactiontonextview/ActionTypeInteractionValidatorTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.rum.internal.metric.interactiontonextview
 
-import com.datadog.android.rum.RumActionType
+import com.datadog.android.rum.model.ActionEvent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
@@ -63,22 +63,22 @@ internal class ActionTypeInteractionValidatorTest {
             return listOf(
                 InternalInteractionContext(
                     "viewId",
-                    RumActionType.TAP,
+                    ActionEvent.ActionEventActionType.TAP,
                     System.nanoTime()
                 ),
                 InternalInteractionContext(
                     "viewId",
-                    RumActionType.CLICK,
+                    ActionEvent.ActionEventActionType.CLICK,
                     System.nanoTime()
                 ),
                 InternalInteractionContext(
                     "viewId",
-                    RumActionType.SWIPE,
+                    ActionEvent.ActionEventActionType.SWIPE,
                     System.nanoTime()
                 ),
                 InternalInteractionContext(
                     "viewId",
-                    RumActionType.BACK,
+                    ActionEvent.ActionEventActionType.BACK,
                     System.nanoTime()
                 )
             )
@@ -89,12 +89,12 @@ internal class ActionTypeInteractionValidatorTest {
             return listOf(
                 InternalInteractionContext(
                     "viewId",
-                    RumActionType.CUSTOM,
+                    ActionEvent.ActionEventActionType.CUSTOM,
                     System.nanoTime()
                 ),
                 InternalInteractionContext(
                     "viewId",
-                    RumActionType.SCROLL,
+                    ActionEvent.ActionEventActionType.SCROLL,
                     System.nanoTime()
                 )
             )

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -44,6 +44,7 @@ import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.metric.interactiontonextview.LastInteractionIdentifier
 import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
+import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.resource.ResourceId
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.android.rum.utils.verifyLog
@@ -1384,9 +1385,11 @@ internal class DatadogRumMonitorTest {
     @Test
     fun `M delegate event to rootScope W eventSent {action}`(
         @StringForgery viewId: String,
-        @IntForgery(0) frustrationCount: Int
+        @IntForgery(0) frustrationCount: Int,
+        @LongForgery(0) eventEndTimestamp: Long,
+        @Forgery actionType: ActionEvent.ActionEventActionType
     ) {
-        testedMonitor.eventSent(viewId, StorageEvent.Action(frustrationCount))
+        testedMonitor.eventSent(viewId, StorageEvent.Action(frustrationCount, actionType, eventEndTimestamp))
         Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
@@ -1395,6 +1398,8 @@ internal class DatadogRumMonitorTest {
             val event = firstValue as RumRawEvent.ActionSent
             assertThat(event.viewId).isEqualTo(viewId)
             assertThat(event.frustrationCount).isEqualTo(frustrationCount)
+            assertThat(event.type).isEqualTo(actionType)
+            assertThat(event.eventEndTimestampInNanos).isEqualTo(eventEndTimestamp)
         }
         verifyNoMoreInteractions(mockScope, mockWriter)
     }
@@ -1468,9 +1473,11 @@ internal class DatadogRumMonitorTest {
     @Test
     fun `M delegate event to rootScope W eventDropped {action}`(
         @StringForgery viewId: String,
-        @IntForgery(0) frustrationCount: Int
+        @IntForgery(0) frustrationCount: Int,
+        @LongForgery(0) eventEndTimestamp: Long,
+        @Forgery actionType: ActionEvent.ActionEventActionType
     ) {
-        testedMonitor.eventDropped(viewId, StorageEvent.Action(frustrationCount))
+        testedMonitor.eventDropped(viewId, StorageEvent.Action(frustrationCount, actionType, eventEndTimestamp))
         Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ActionSentForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ActionSentForgeryFactory.kt
@@ -6,18 +6,19 @@
 
 package com.datadog.android.rum.utils.forge
 
-import com.datadog.android.rum.internal.metric.interactiontonextview.InternalInteractionContext
+import com.datadog.android.rum.internal.domain.scope.RumRawEvent
 import com.datadog.android.rum.model.ActionEvent
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 import java.util.UUID
 
-internal class InternalInteractionContextFactory : ForgeryFactory<InternalInteractionContext> {
-    override fun getForgery(forge: Forge): InternalInteractionContext {
-        return InternalInteractionContext(
+internal class ActionSentForgeryFactory : ForgeryFactory<RumRawEvent.ActionSent> {
+    override fun getForgery(forge: Forge): RumRawEvent.ActionSent {
+        return RumRawEvent.ActionSent(
             viewId = forge.getForgery<UUID>().toString(),
-            actionType = forge.aValueFrom(ActionEvent.ActionEventActionType::class.java),
-            eventCreatedAtNanos = forge.aPositiveLong()
+            frustrationCount = forge.anInt(min = 0),
+            type = forge.aValueFrom(ActionEvent.ActionEventActionType::class.java),
+            eventEndTimestampInNanos = forge.aPositiveLong()
         )
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
@@ -63,5 +63,8 @@ internal class Configurator : BaseConfigurator() {
         forge.addFactory(InternalTelemetryErrorLogForgeryFactory())
         forge.addFactory(InternalTelemetryConfigurationForgeryFactory())
         forge.addFactory(InternalTelemetryApiUsageForgeryFactory())
+
+        // RumRawEvent
+        forge.addFactory(ActionSentForgeryFactory())
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/PreviousViewLastActionContextFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/PreviousViewLastActionContextFactory.kt
@@ -6,15 +6,15 @@
 
 package com.datadog.android.rum.utils.forge
 
-import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.metric.interactiontonextview.PreviousViewLastInteractionContext
+import com.datadog.android.rum.model.ActionEvent
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
 internal class PreviousViewLastActionContextFactory : ForgeryFactory<PreviousViewLastInteractionContext> {
     override fun getForgery(forge: Forge): PreviousViewLastInteractionContext {
         return PreviousViewLastInteractionContext(
-            actionType = forge.aValueFrom(RumActionType::class.java),
+            actionType = forge.aValueFrom(ActionEvent.ActionEventActionType::class.java),
             eventCreatedAtNanos = forge.aPositiveLong(),
             currentViewCreationTimestamp = forge.aNullable { forge.aPositiveLong() }
         )


### PR DESCRIPTION
### What does this PR do?

The interval we consider for the interaction-to-next-view metric is the moment the last action finished on the previous view until the moment the new view was created. Based on the last discussion we decided to completely rely on the RUM ActionEvents that were sent as potential last interactions meaning that we had to do several changes in the `RumActionScope` by reporting more information in the `ActionSent` event to the `RumViewScope`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

