### PR TITLE
RUM-6535: Add backwards compatibility for Coil AsyncImage

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/consumer-rules.pro
+++ b/features/dd-sdk-android-session-replay-compose/consumer-rules.pro
@@ -44,6 +44,9 @@
 -keep class coil.compose.ContentPainterElement {
      <fields>;
 }
+-keep class coil.compose.ContentPainterModifier {
+     <fields>;
+}
 -keep class coil.compose.AsyncImagePainter {
      <fields>;
 }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 
+@Suppress("StringLiteralDuplication")
 internal object ComposeReflection {
     val WrappedCompositionClass = getClassSafe("androidx.compose.ui.platform.WrappedComposition")
 
@@ -64,8 +65,13 @@ internal object ComposeReflection {
     val AndroidImageBitmapClass = getClassSafe("androidx.compose.ui.graphics.AndroidImageBitmap")
     val BitmapField = AndroidImageBitmapClass?.getDeclaredFieldSafe("bitmap")
 
+    val ContentPainterModifierClass = getClassSafe("coil.compose.ContentPainterModifier")
+    val PainterFieldOfContentPainterModifier =
+        ContentPainterModifierClass?.getDeclaredFieldSafe("painter")
+
     val ContentPainterElementClass = getClassSafe("coil.compose.ContentPainterElement")
-    val PainterFieldOfContentPainter = ContentPainterElementClass?.getDeclaredFieldSafe("painter")
+    val PainterFieldOfContentPainterElement =
+        ContentPainterElementClass?.getDeclaredFieldSafe("painter")
 
     val AsyncImagePainterClass = getClassSafe("coil.compose.AsyncImagePainter")
     val PainterFieldOfAsyncImagePainter = AsyncImagePainterClass?.getDeclaredFieldSafe("_painter")


### PR DESCRIPTION
### What does this PR do?

`Coil` has done a migration on the painter class in this [PR](https://github.com/coil-kt/coil/commit/f0aa7aa2163f1221355b8cadb97411badd620794), which causes our reflection not able to retrieve the bitmap painter, This PR is to add the support before the migration.

### Motivation

RUM-6535

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

