### PR TITLE
RUM-7567: Apply hide view override on semantics node

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/ModifierExt.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/ModifierExt.kt
@@ -59,7 +59,7 @@ fun Modifier.sessionReplayTouchPrivacy(touchPrivacy: TouchPrivacy): Modifier {
     }
 }
 
-private val SessionReplayHidePropertyKey: SemanticsPropertyKey<Boolean> = SemanticsPropertyKey(
+internal val SessionReplayHidePropertyKey: SemanticsPropertyKey<Boolean> = SemanticsPropertyKey(
     name = "_dd_session_replay_hide"
 )
 

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeHiddenMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeHiddenMapper.kt
@@ -1,0 +1,44 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
+
+import androidx.compose.ui.semantics.SemanticsNode
+import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWireframe
+import com.datadog.android.sessionreplay.compose.internal.data.UiContext
+import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
+import com.datadog.android.sessionreplay.utils.ColorStringFormatter
+
+internal class ComposeHiddenMapper(
+    colorStringFormatter: ColorStringFormatter,
+    semanticsUtils: SemanticsUtils = SemanticsUtils()
+) : AbstractSemanticsNodeMapper(colorStringFormatter, semanticsUtils) {
+    override fun map(
+        semanticsNode: SemanticsNode,
+        parentContext: UiContext,
+        asyncJobStatusCallback: AsyncJobStatusCallback
+    ): SemanticsWireframe? {
+        val id = resolveId(semanticsNode)
+        val viewGlobalBounds = resolveBounds(semanticsNode)
+        return SemanticsWireframe(
+            wireframes = MobileSegment.Wireframe.PlaceholderWireframe(
+                id = id,
+                x = viewGlobalBounds.x,
+                y = viewGlobalBounds.y,
+                width = viewGlobalBounds.width,
+                height = viewGlobalBounds.height,
+                label = HIDDEN_VIEW_PLACEHOLDER_TEXT
+            ).let { listOf(it) },
+            uiContext = parentContext
+        )
+    }
+
+    internal companion object {
+        internal const val HIDDEN_VIEW_PLACEHOLDER_TEXT = "Hidden"
+    }
+}

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapper.kt
@@ -43,6 +43,10 @@ internal class RootSemanticsNodeMapper(
     private val containerSemanticsNodeMapper: ContainerSemanticsNodeMapper = ContainerSemanticsNodeMapper(
         colorStringFormatter,
         semanticsUtils
+    ),
+    private val composeHiddenMapper: ComposeHiddenMapper = ComposeHiddenMapper(
+        colorStringFormatter,
+        semanticsUtils
     )
 ) {
 
@@ -78,6 +82,17 @@ internal class RootSemanticsNodeMapper(
         parentUiContext: UiContext,
         asyncJobStatusCallback: AsyncJobStatusCallback
     ) {
+        // If Hidden node is detected, add placeholder wireframe and return
+        if (semanticsUtils.isNodeHidden(semanticsNode)) {
+            composeHiddenMapper.map(
+                semanticsNode,
+                parentUiContext,
+                asyncJobStatusCallback
+            )?.let {
+                wireframes.addAll(it.wireframes)
+            }
+            return
+        }
         val mapper = getSemanticsNodeMapper(semanticsNode)
         updateTouchOverrideAreas(
             touchPrivacyManager = touchPrivacyManager,

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
@@ -25,6 +25,7 @@ import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.TouchPrivacy
 import com.datadog.android.sessionreplay.compose.ImagePrivacySemanticsPropertyKey
+import com.datadog.android.sessionreplay.compose.SessionReplayHidePropertyKey
 import com.datadog.android.sessionreplay.compose.TextInputSemanticsPropertyKey
 import com.datadog.android.sessionreplay.compose.TouchSemanticsPropertyKey
 import com.datadog.android.sessionreplay.compose.internal.data.BitmapInfo
@@ -261,5 +262,9 @@ internal class SemanticsUtils(private val reflectionUtils: ReflectionUtils = Ref
 
     internal fun getTouchPrivacyOverride(semanticsNode: SemanticsNode): TouchPrivacy? {
         return semanticsNode.config.getOrNull(TouchSemanticsPropertyKey)
+    }
+
+    internal fun isNodeHidden(semanticsNode: SemanticsNode): Boolean {
+        return semanticsNode.config.getOrNull(SessionReplayHidePropertyKey) ?: false
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeHiddenNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeHiddenNodeMapperTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
+
+import androidx.compose.ui.semantics.SemanticsNode
+import com.datadog.android.sessionreplay.compose.internal.data.UiContext
+import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(SessionReplayComposeForgeConfigurator::class)
+internal class ComposeHiddenNodeMapperTest : AbstractSemanticsNodeMapperTest() {
+
+    private lateinit var testedComposeHiddenNodeMapper: ComposeHiddenMapper
+
+    @Mock
+    private lateinit var mockSemanticsNode: SemanticsNode
+
+    @Mock
+    private lateinit var mockAsyncJobStatusCallback: AsyncJobStatusCallback
+
+    @Forgery
+    lateinit var fakeUiContext: UiContext
+
+    @BeforeEach
+    override fun `set up`(forge: Forge) {
+        super.`set up`(forge)
+        testedComposeHiddenNodeMapper = ComposeHiddenMapper(
+            colorStringFormatter = mockColorStringFormatter,
+            semanticsUtils = mockSemanticsUtils
+        )
+    }
+
+    private fun mockSemanticsNode(): SemanticsNode {
+        return mockSemanticsNodeWithBound {
+            whenever(mockSemanticsNode.layoutInfo).doReturn(mockLayoutInfo)
+        }
+    }
+
+    @Test
+    fun `M return the correct wireframe W map`() {
+        // Given
+        val mockSemanticsNode = mockSemanticsNode()
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode)) doReturn rectToBounds(
+            fakeBounds,
+            fakeDensity
+        )
+
+        // When
+        val actual = testedComposeHiddenNodeMapper.map(
+            mockSemanticsNode,
+            fakeUiContext,
+            mockAsyncJobStatusCallback
+        )
+
+        // Then
+        val expected = MobileSegment.Wireframe.PlaceholderWireframe(
+            id = (fakeSemanticsId.toLong() shl 32),
+            x = (fakeBounds.left / fakeDensity).toLong(),
+            y = (fakeBounds.top / fakeDensity).toLong(),
+            width = (fakeBounds.size.width / fakeDensity).toLong(),
+            height = (fakeBounds.size.height / fakeDensity).toLong(),
+            label = "Hidden"
+        )
+        assertThat(actual?.wireframes).contains(expected)
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Show hide placeholder wireframe when user calls `.sessionReplayHide(hide = true) ` on the composable modifier.

### Motivation

RUM-7567

### Demo
 
A demo about how it looks like:
<img width="281" alt="image" src="https://github.com/user-attachments/assets/9b69e54e-c18c-47ec-bb72-6f1f2dbca97e">


Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

