### PR TITLE
RUM-7527: Remove unused Datadog GlobalTracer class

### DIFF
--- a/features/dd-sdk-android-trace/src/main/java/com/datadog/trace/api/GlobalTracer.java
+++ b/features/dd-sdk-android-trace/src/main/java/com/datadog/trace/api/GlobalTracer.java
@@ -5,12 +5,21 @@ import com.datadog.trace.api.internal.InternalTracer;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import kotlin.Deprecated;
+import kotlin.DeprecationLevel;
+import kotlin.ReplaceWith;
+
 /**
  * A global reference to the registered Datadog tracer.
  *
  * <p>OpenTracing's GlobalTracer cannot be cast to its DDTracer implementation, so this class exists
  * to provide a global window to datadog-specific features.
  */
+@Deprecated(
+        message = "Use [io.opentracing.util.GlobalTracer] instead, this class will be removed soon",
+        replaceWith = @ReplaceWith(expression = "GlobalTracer", imports = "io.opentracing.util"),
+        level = DeprecationLevel.ERROR
+)
 public class GlobalTracer {
   private static final Tracer NO_OP =
       new Tracer() {

--- a/features/dd-sdk-android-trace/src/main/java/com/datadog/trace/api/profiling/Profiling.java
+++ b/features/dd-sdk-android-trace/src/main/java/com/datadog/trace/api/profiling/Profiling.java
@@ -1,9 +1,5 @@
 package com.datadog.trace.api.profiling;
 
-import com.datadog.trace.api.GlobalTracer;
-import com.datadog.trace.api.Tracer;
-import com.datadog.trace.api.internal.InternalTracer;
-
 public interface Profiling {
 
   /**

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -433,7 +433,7 @@ open class DatadogInterceptor internal constructor(
     /**
      * A Builder for the [DatadogInterceptor].
      * @param tracedHostsWithHeaderType a list of all the hosts and header types that you want to
-     * be automatically tracked by this interceptor. If registering a [com.datadog.trace.api.GlobalTracer],
+     * be automatically tracked by this interceptor. If registering a [io.opentracing.util.GlobalTracer],
      * the tracer must be configured with [AndroidTracer.Builder.setTracingHeaderTypes] containing all the necessary
      * header types configured for OkHttp tracking.
      * If no hosts are provided (via this argument or global configuration


### PR DESCRIPTION
### What does this PR do?

Remove unused Datadog `GlobalTracer` class to avoid confusion with opentracing `GlobalTracer`

### Motivation

RUM-7527


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

