### PR TITLE
RUM-7643 Correctly handle TTNS when resource was stopped with error

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -129,6 +129,8 @@ internal sealed class RumRawEvent {
 
     internal data class ErrorSent(
         val viewId: String,
+        val resourceId: String? = null,
+        val resourceEndTimestampInNanos: Long? = null,
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 
@@ -151,6 +153,7 @@ internal sealed class RumRawEvent {
 
     internal data class ErrorDropped(
         val viewId: String,
+        val resourceId: String? = null,
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -574,7 +574,14 @@ internal class DatadogRumMonitor(
                 )
             )
 
-            is StorageEvent.Error -> handleEvent(RumRawEvent.ErrorSent(viewId))
+            is StorageEvent.Error -> handleEvent(
+                RumRawEvent.ErrorSent(
+                    viewId,
+                    event.resourceId,
+                    event.resourceStopTimestampInNanos
+                )
+            )
+
             is StorageEvent.LongTask -> handleEvent(RumRawEvent.LongTaskSent(viewId, false))
             is StorageEvent.FrozenFrame -> handleEvent(RumRawEvent.LongTaskSent(viewId, true))
             is StorageEvent.View -> {
@@ -587,7 +594,7 @@ internal class DatadogRumMonitor(
         when (event) {
             is StorageEvent.Action -> handleEvent(RumRawEvent.ActionDropped(viewId))
             is StorageEvent.Resource -> handleEvent(RumRawEvent.ResourceDropped(viewId, event.resourceId))
-            is StorageEvent.Error -> handleEvent(RumRawEvent.ErrorDropped(viewId))
+            is StorageEvent.Error -> handleEvent(RumRawEvent.ErrorDropped(viewId, event.resourceId))
             is StorageEvent.LongTask -> handleEvent(RumRawEvent.LongTaskDropped(viewId, false))
             is StorageEvent.FrozenFrame -> handleEvent(RumRawEvent.LongTaskDropped(viewId, true))
             is StorageEvent.View -> {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/StorageEvent.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/StorageEvent.kt
@@ -15,8 +15,9 @@ internal sealed class StorageEvent {
         val type: ActionEvent.ActionEventActionType,
         val eventEndTimestampInNanos: Long
     ) : StorageEvent()
+
     data class Resource(val resourceId: String, val resourceStopTimestampInNanos: Long) : StorageEvent()
-    object Error : StorageEvent()
+    data class Error(val resourceId: String? = null, val resourceStopTimestampInNanos: Long? = null) : StorageEvent()
     object LongTask : StorageEvent()
     object FrozenFrame : StorageEvent()
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -1235,9 +1235,6 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
-        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
-            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
-        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1316,9 +1313,6 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
-        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
-            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
-        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1395,9 +1389,6 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
-        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
-            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
-        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1493,9 +1484,6 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
-        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
-            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
-        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1592,9 +1580,6 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
-        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
-            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
-        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1688,9 +1673,6 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
-        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
-            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
-        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1785,9 +1767,6 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
-        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
-            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
-        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1867,9 +1846,6 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
-        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
-            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
-        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -1949,9 +1925,6 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
-        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
-            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
-        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -2030,9 +2003,6 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
-        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
-            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
-        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -2112,9 +2082,6 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
-        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
-            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
-        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -2199,9 +2166,6 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
-        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
-            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
-        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -2286,9 +2250,6 @@ internal class RumResourceScopeTest {
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
-        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
-            InternalResourceContext(testedScope.resourceId, mockEvent.eventTime.nanoTime)
-        )
         assertThat(result).isEqualTo(null)
     }
 
@@ -2920,7 +2881,10 @@ internal class RumResourceScopeTest {
 
         // Then
         verify(rumMonitor.mockInstance as AdvancedRumMonitor)
-            .eventSent(fakeParentContext.viewId.orEmpty(), StorageEvent.Error)
+            .eventSent(
+                fakeParentContext.viewId.orEmpty(),
+                StorageEvent.Error(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+            )
     }
 
     @Test
@@ -2949,7 +2913,10 @@ internal class RumResourceScopeTest {
 
         // Then
         verify(rumMonitor.mockInstance as AdvancedRumMonitor)
-            .eventDropped(fakeParentContext.viewId.orEmpty(), StorageEvent.Error)
+            .eventDropped(
+                fakeParentContext.viewId.orEmpty(),
+                StorageEvent.Error(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+            )
     }
 
     @Test
@@ -2980,7 +2947,10 @@ internal class RumResourceScopeTest {
 
         // Then
         verify(rumMonitor.mockInstance as AdvancedRumMonitor)
-            .eventDropped(fakeParentContext.viewId.orEmpty(), StorageEvent.Error)
+            .eventDropped(
+                fakeParentContext.viewId.orEmpty(),
+                StorageEvent.Error(testedScope.resourceId, mockEvent.eventTime.nanoTime)
+            )
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -7430,6 +7430,64 @@ internal class RumViewScopeTest {
     // region NetworkSettledTime
 
     @Test
+    fun `M mark the resource as stopped W handleEvent(ErrorSent) { resource information present }`(
+        @StringForgery resourceId: String,
+        @LongForgery(0) resourceStopTimestampInNanos: Long
+    ) {
+        // Given
+        fakeEvent = RumRawEvent.ErrorSent(testedScope.viewId, resourceId, resourceStopTimestampInNanos)
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
+            InternalResourceContext(
+                resourceId,
+                resourceStopTimestampInNanos
+            )
+        )
+    }
+
+    @Test
+    fun `M mark the resource as dropped W handleEvent(ErrorDropped) { resource information present }`(
+        @StringForgery resourceId: String
+    ) {
+        // Given
+        fakeEvent = RumRawEvent.ErrorDropped(testedScope.viewId, resourceId)
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        verify(mockNetworkSettledMetricResolver).resourceWasDropped(resourceId)
+    }
+
+    @Test
+    fun `M not interact with networkSettledMetricResolver W handleEvent(ErrorSent) { resource info not present }`() {
+        // Given
+        fakeEvent = RumRawEvent.ErrorSent(testedScope.viewId)
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        verify(mockNetworkSettledMetricResolver, never()).resourceWasStopped(any())
+    }
+
+    @Test
+    fun `M not interact with networkSettledMetricResolver W handleEvent(ErrorDropped) { resource info not present }`() {
+        // Given
+        fakeEvent = RumRawEvent.ErrorSent(testedScope.viewId)
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        verify(mockNetworkSettledMetricResolver, never()).resourceWasDropped(any())
+    }
+
+    @Test
     fun `M notify the networkSettledMetricResolver W view was stopped`() {
         // When
         testedScope.handleEvent(
@@ -7476,9 +7534,9 @@ internal class RumViewScopeTest {
         verify(mockNetworkSettledMetricResolver).viewWasCreated(fakeEventTime.nanoTime)
     }
 
-    // endregion
+// endregion
 
-    // region InteractionToNextViewTime
+// region InteractionToNextViewTime
 
     @Test
     fun `M notify the interactionToNextViewMetricResolver W view was created`() {
@@ -7526,9 +7584,9 @@ internal class RumViewScopeTest {
         verify(mockInteractionToNextViewMetricResolver, never()).onActionSent(any())
     }
 
-    // endregion
+// endregion
 
-    // region Vitals
+// region Vitals
 
     @Test
     fun `M send View update W onVitalUpdate()+handleEvent(KeepAlive) {CPU}`(
@@ -8142,9 +8200,9 @@ internal class RumViewScopeTest {
         verify(mockFrameRateVitalMonitor).unregister(testedScope.frameRateVitalListener)
     }
 
-    // endregion
+// endregion
 
-    // region Cross-platform performance metrics
+// region Cross-platform performance metrics
 
     @Test
     fun `M send update W handleEvent(UpdatePerformanceMetric+KeepAlive) { FlutterBuildTime }`(
@@ -8329,9 +8387,9 @@ internal class RumViewScopeTest {
         assertThat(result).isSameAs(testedScope)
     }
 
-    // endregion
+// endregion
 
-    // region Feature Flags
+// region Feature Flags
 
     @Test
     fun `M send event W handleEvent(AddFeatureFlagEvaluation) on active view`(
@@ -8471,9 +8529,9 @@ internal class RumViewScopeTest {
         }
     }
 
-    // endregion
+// endregion
 
-    // region Feature Flags Batch
+// region Feature Flags Batch
 
     @Test
     fun `M send event W handleEvent(AddFeatureFlagEvaluations) on active view`(
@@ -8630,9 +8688,9 @@ internal class RumViewScopeTest {
         }
     }
 
-    // endregion
+// endregion
 
-    // region Stopping Sessions
+// region Stopping Sessions
 
     @Test
     fun `M set view to inactive and send update W handleEvent { StopSession }`() {
@@ -8658,9 +8716,9 @@ internal class RumViewScopeTest {
         }
     }
 
-    // endregion
+// endregion
 
-    // region write notification
+// region write notification
 
     @Test
     fun `M notify about success W handleEvent(AddError+non-fatal) { write succeeded }`(
@@ -8688,7 +8746,7 @@ internal class RumViewScopeTest {
 
         // Then
         verify(rumMonitor.mockInstance as AdvancedRumMonitor)
-            .eventSent(testedScope.viewId, StorageEvent.Error)
+            .eventSent(testedScope.viewId, StorageEvent.Error())
     }
 
     @Test
@@ -8718,7 +8776,7 @@ internal class RumViewScopeTest {
 
         // Then
         verify(rumMonitor.mockInstance as AdvancedRumMonitor)
-            .eventDropped(testedScope.viewId, StorageEvent.Error)
+            .eventDropped(testedScope.viewId, StorageEvent.Error())
     }
 
     @Test
@@ -8750,7 +8808,7 @@ internal class RumViewScopeTest {
 
         // Then
         verify(rumMonitor.mockInstance as AdvancedRumMonitor)
-            .eventDropped(testedScope.viewId, StorageEvent.Error)
+            .eventDropped(testedScope.viewId, StorageEvent.Error())
     }
 
     @Test
@@ -8779,7 +8837,7 @@ internal class RumViewScopeTest {
 
         // Then
         verify(rumMonitor.mockInstance as AdvancedRumMonitor, never())
-            .eventSent(testedScope.viewId, StorageEvent.Error)
+            .eventSent(testedScope.viewId, StorageEvent.Error())
     }
 
     @Test
@@ -8809,7 +8867,7 @@ internal class RumViewScopeTest {
 
         // Then
         verify(rumMonitor.mockInstance as AdvancedRumMonitor, never())
-            .eventDropped(testedScope.viewId, StorageEvent.Error)
+            .eventDropped(testedScope.viewId, StorageEvent.Error())
     }
 
     @Test
@@ -8841,7 +8899,7 @@ internal class RumViewScopeTest {
 
         // Then
         verify(rumMonitor.mockInstance as AdvancedRumMonitor, never())
-            .eventDropped(testedScope.viewId, StorageEvent.Error)
+            .eventDropped(testedScope.viewId, StorageEvent.Error())
     }
 
     @Test
@@ -9030,9 +9088,9 @@ internal class RumViewScopeTest {
             .eventDropped(testedScope.viewId, StorageEvent.FrozenFrame)
     }
 
-    // endregion
+// endregion
 
-    // region Misc
+// region Misc
 
     @ParameterizedTest
     @MethodSource("brokenTimeRawEventData")
@@ -9077,9 +9135,9 @@ internal class RumViewScopeTest {
         )
     }
 
-    // endregion
+// endregion
 
-    // region Global Attributes
+// region Global Attributes
 
     @Test
     fun `M update the global attributes W handleEvent(StopView)`(
@@ -9544,7 +9602,7 @@ internal class RumViewScopeTest {
         assertThat(result).isNull()
     }
 
-    // endregion
+// endregion
 
     @Test
     fun `M produce event safe for serialization W handleEvent()`(
@@ -9622,7 +9680,7 @@ internal class RumViewScopeTest {
         }
     }
 
-    // region Internal
+// region Internal
 
     private fun mockEvent(): RumRawEvent {
         val event: RumRawEvent = mock()
@@ -9659,7 +9717,7 @@ internal class RumViewScopeTest {
         ).thenReturn(fakeReplayRecordsCount)
     }
 
-    // endregion
+// endregion
 
     data class RumRawEventData(val event: RumRawEvent, val viewKey: RumScopeKey)
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -1428,7 +1428,7 @@ internal class DatadogRumMonitorTest {
     fun `M delegate event to rootScope W eventSent {error}`(
         @StringForgery viewId: String
     ) {
-        testedMonitor.eventSent(viewId, StorageEvent.Error)
+        testedMonitor.eventSent(viewId, StorageEvent.Error())
         Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
@@ -1516,7 +1516,7 @@ internal class DatadogRumMonitorTest {
     fun `M delegate event to rootScope W eventDropped {error}`(
         @StringForgery viewId: String
     ) {
-        testedMonitor.eventDropped(viewId, StorageEvent.Error)
+        testedMonitor.eventDropped(viewId, StorageEvent.Error())
         Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {


### PR DESCRIPTION
### What does this PR do?

Currently if a resource was stopped with an error we are computing the TTNS metric no matter if the error event was persisted or not. To align with the the approach we took for the normal resource stop we will have to make sure that the TTNS metric will only be computed when the error event was persisted.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

