### PR TITLE
RUM-7195: Support interop view from Compose

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AndroidComposeViewMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AndroidComposeViewMapper.kt
@@ -8,6 +8,7 @@
 
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
+import androidx.annotation.UiThread
 import androidx.compose.ui.platform.AndroidComposeView
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -31,6 +32,7 @@ internal class AndroidComposeViewMapper(
     viewBoundsResolver,
     drawableToColorMapper
 ) {
+    @UiThread
     override fun map(
         view: AndroidComposeView,
         mappingContext: MappingContext,

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapper.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
+import androidx.annotation.UiThread
 import androidx.compose.ui.platform.ComposeView
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
@@ -31,6 +32,7 @@ internal class ComposeViewMapper(
     viewBoundsResolver,
     drawableToColorMapper
 ) {
+    @UiThread
     override fun map(
         view: ComposeView,
         mappingContext: MappingContext,

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapper.kt
@@ -50,6 +50,7 @@ internal class RootSemanticsNodeMapper(
     )
 ) {
 
+    @UiThread
     internal fun createComposeWireframes(
         semanticsNode: SemanticsNode,
         density: Float,
@@ -69,18 +70,21 @@ internal class RootSemanticsNodeMapper(
                     textAndInputPrivacy = mappingContext.textAndInputPrivacy,
                     imageWireframeHelper = mappingContext.imageWireframeHelper
                 ),
-                asyncJobStatusCallback = asyncJobStatusCallback
+                asyncJobStatusCallback = asyncJobStatusCallback,
+                mappingContext = mappingContext
             )
         }
         return wireframes
     }
 
+    @UiThread
     private fun createComposerWireframes(
         semanticsNode: SemanticsNode,
         touchPrivacyManager: TouchPrivacyManager,
         wireframes: MutableList<MobileSegment.Wireframe>,
         parentUiContext: UiContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        mappingContext: MappingContext
     ) {
         // If Hidden node is detected, add placeholder wireframe and return
         if (semanticsUtils.isNodeHidden(semanticsNode)) {
@@ -93,6 +97,16 @@ internal class RootSemanticsNodeMapper(
             }
             return
         }
+
+        val interopView = semanticsUtils.getInteropView(semanticsNode)
+
+        if (interopView != null) {
+            val interopViewWireframes =
+                mappingContext.interopViewCallback.map(interopView, mappingContext)
+            wireframes.addAll(interopViewWireframes)
+            return
+        }
+
         val mapper = getSemanticsNodeMapper(semanticsNode)
         updateTouchOverrideAreas(
             touchPrivacyManager = touchPrivacyManager,
@@ -119,7 +133,8 @@ internal class RootSemanticsNodeMapper(
                     touchPrivacyManager = touchPrivacyManager,
                     wireframes = wireframes,
                     parentUiContext = currentUiContext,
-                    asyncJobStatusCallback = asyncJobStatusCallback
+                    asyncJobStatusCallback = asyncJobStatusCallback,
+                    mappingContext = mappingContext
                 )
             }
         }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
@@ -23,6 +23,7 @@ internal object ComposeReflection {
     val OwnerField = WrappedCompositionClass?.getDeclaredFieldSafe("owner")
 
     val LayoutNodeClass = getClassSafe("androidx.compose.ui.node.LayoutNode")
+    val GetInteropViewMethod = LayoutNodeClass?.getDeclaredMethodSafe("getInteropView")
 
     val SemanticsNodeClass = getClassSafe("androidx.compose.ui.semantics.SemanticsNode")
     val LayoutNodeField = SemanticsNodeClass?.getDeclaredFieldSafe("layoutNode")

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/ReflectionUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/ReflectionUtils.kt
@@ -27,6 +27,7 @@ import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeRefl
 import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.ContentPainterElementClass
 import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.ContentPainterModifierClass
 import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.GetInnerLayerCoordinatorMethod
+import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.GetInteropViewMethod
 import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.ImageField
 import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.LayoutField
 import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.LayoutNodeField
@@ -165,5 +166,9 @@ internal class ReflectionUtils {
         val layout = LayoutField?.getSafe(paragraph)
         val staticLayout = StaticLayoutField?.getSafe(layout) as? StaticLayout
         return staticLayout?.text?.toString()
+    }
+
+    fun getInteropView(semanticsNode: SemanticsNode): View? {
+        return GetInteropViewMethod?.invoke(semanticsNode.layoutInfo) as? View
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
@@ -273,4 +273,8 @@ internal class SemanticsUtils(private val reflectionUtils: ReflectionUtils = Ref
     internal fun isNodeHidden(semanticsNode: SemanticsNode): Boolean {
         return semanticsNode.config.getOrNull(SessionReplayHidePropertyKey) ?: false
     }
+
+    internal fun getInteropView(semanticsNode: SemanticsNode): View? {
+        return reflectionUtils.getInteropView(semanticsNode)
+    }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapperTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
+import android.view.View
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
@@ -233,6 +234,27 @@ class RootSemanticsNodeMapperTest {
             eq(mockSemanticsNode),
             any(),
             eq(mockAsyncJobStatusCallback)
+        )
+    }
+
+    @Test
+    fun `M call interop callback W semantics node has interop view`() {
+        val mockSemanticsNode = mockSemanticsNode(null)
+        val mockView = mock<View>()
+        whenever(mockSemanticsUtils.getInteropView(mockSemanticsNode)) doReturn mockView
+
+        // When
+        testedRootSemanticsNodeMapper.createComposeWireframes(
+            mockSemanticsNode,
+            fakeMappingContext.systemInformation.screenDensity,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback
+        )
+
+        // Then
+        verify(fakeMappingContext.interopViewCallback).map(
+            eq(mockView),
+            eq(fakeMappingContext)
         )
     }
 

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/MappingContextForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/MappingContextForgeryFactory.kt
@@ -19,7 +19,8 @@ internal class MappingContextForgeryFactory : ForgeryFactory<MappingContext> {
             hasOptionSelectorParent = forge.aBool(),
             imagePrivacy = forge.getForgery(),
             textAndInputPrivacy = forge.getForgery(),
-            touchPrivacyManager = mock()
+            touchPrivacyManager = mock(),
+            interopViewCallback = mock()
         )
     }
 }

--- a/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/forge/MappingContextForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/forge/MappingContextForgeryFactory.kt
@@ -19,7 +19,8 @@ internal class MappingContextForgeryFactory : ForgeryFactory<MappingContext> {
             textAndInputPrivacy = forge.getForgery(),
             imagePrivacy = forge.getForgery(),
             hasOptionSelectorParent = forge.aBool(),
-            touchPrivacyManager = mock()
+            touchPrivacyManager = mock(),
+            interopViewCallback = mock()
         )
     }
 }

--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -66,8 +66,10 @@ class com.datadog.android.sessionreplay.internal.recorder.resources.DefaultDrawa
   override fun copy(android.graphics.drawable.Drawable, android.content.res.Resources): android.graphics.drawable.Drawable?
 interface com.datadog.android.sessionreplay.internal.recorder.resources.DrawableCopier
   fun copy(android.graphics.drawable.Drawable, android.content.res.Resources): android.graphics.drawable.Drawable?
+interface com.datadog.android.sessionreplay.recorder.InteropViewCallback
+  fun map(android.view.View, MappingContext): List<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
 data class com.datadog.android.sessionreplay.recorder.MappingContext
-  constructor(SystemInformation, com.datadog.android.sessionreplay.utils.ImageWireframeHelper, com.datadog.android.sessionreplay.TextAndInputPrivacy, com.datadog.android.sessionreplay.ImagePrivacy, com.datadog.android.sessionreplay.internal.TouchPrivacyManager, Boolean = false)
+  constructor(SystemInformation, com.datadog.android.sessionreplay.utils.ImageWireframeHelper, com.datadog.android.sessionreplay.TextAndInputPrivacy, com.datadog.android.sessionreplay.ImagePrivacy, com.datadog.android.sessionreplay.internal.TouchPrivacyManager, Boolean = false, InteropViewCallback)
 interface com.datadog.android.sessionreplay.recorder.OptionSelectorDetector
   fun isOptionSelector(android.view.ViewGroup): Boolean
 data class com.datadog.android.sessionreplay.recorder.SystemInformation

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -1414,21 +1414,27 @@ public final class com/datadog/android/sessionreplay/model/ResourceMetadata$Comp
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/sessionreplay/model/ResourceMetadata;
 }
 
+public abstract interface class com/datadog/android/sessionreplay/recorder/InteropViewCallback {
+	public abstract fun map (Landroid/view/View;Lcom/datadog/android/sessionreplay/recorder/MappingContext;)Ljava/util/List;
+}
+
 public final class com/datadog/android/sessionreplay/recorder/MappingContext {
-	public fun <init> (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Lcom/datadog/android/sessionreplay/internal/TouchPrivacyManager;Z)V
-	public synthetic fun <init> (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Lcom/datadog/android/sessionreplay/internal/TouchPrivacyManager;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Lcom/datadog/android/sessionreplay/internal/TouchPrivacyManager;ZLcom/datadog/android/sessionreplay/recorder/InteropViewCallback;)V
+	public synthetic fun <init> (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Lcom/datadog/android/sessionreplay/internal/TouchPrivacyManager;ZLcom/datadog/android/sessionreplay/recorder/InteropViewCallback;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/datadog/android/sessionreplay/recorder/SystemInformation;
 	public final fun component2 ()Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;
 	public final fun component3 ()Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
 	public final fun component4 ()Lcom/datadog/android/sessionreplay/ImagePrivacy;
 	public final fun component5 ()Lcom/datadog/android/sessionreplay/internal/TouchPrivacyManager;
 	public final fun component6 ()Z
-	public final fun copy (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Lcom/datadog/android/sessionreplay/internal/TouchPrivacyManager;Z)Lcom/datadog/android/sessionreplay/recorder/MappingContext;
-	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/recorder/MappingContext;Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Lcom/datadog/android/sessionreplay/internal/TouchPrivacyManager;ZILjava/lang/Object;)Lcom/datadog/android/sessionreplay/recorder/MappingContext;
+	public final fun component7 ()Lcom/datadog/android/sessionreplay/recorder/InteropViewCallback;
+	public final fun copy (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Lcom/datadog/android/sessionreplay/internal/TouchPrivacyManager;ZLcom/datadog/android/sessionreplay/recorder/InteropViewCallback;)Lcom/datadog/android/sessionreplay/recorder/MappingContext;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/recorder/MappingContext;Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Lcom/datadog/android/sessionreplay/internal/TouchPrivacyManager;ZLcom/datadog/android/sessionreplay/recorder/InteropViewCallback;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/recorder/MappingContext;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHasOptionSelectorParent ()Z
 	public final fun getImagePrivacy ()Lcom/datadog/android/sessionreplay/ImagePrivacy;
 	public final fun getImageWireframeHelper ()Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;
+	public final fun getInteropViewCallback ()Lcom/datadog/android/sessionreplay/recorder/InteropViewCallback;
 	public final fun getSystemInformation ()Lcom/datadog/android/sessionreplay/recorder/SystemInformation;
 	public final fun getTextAndInputPrivacy ()Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
 	public final fun getTouchPrivacyManager ()Lcom/datadog/android/sessionreplay/internal/TouchPrivacyManager;

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
@@ -15,6 +15,7 @@ import com.datadog.android.sessionreplay.R
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.internal.TouchPrivacyManager
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
+import com.datadog.android.sessionreplay.internal.recorder.callback.DefaultInteropViewCallback
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
 import com.datadog.android.sessionreplay.recorder.OptionSelectorDetector
@@ -45,7 +46,11 @@ internal class SnapshotProducer(
                 imageWireframeHelper = imageWireframeHelper,
                 textAndInputPrivacy = textAndInputPrivacy,
                 imagePrivacy = imagePrivacy,
-                touchPrivacyManager = touchPrivacyManager
+                touchPrivacyManager = touchPrivacyManager,
+                interopViewCallback = DefaultInteropViewCallback(
+                    treeViewTraversal,
+                    recordedDataQueueRefs
+                )
             ),
             LinkedList(),
             recordedDataQueueRefs

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/DefaultInteropViewCallback.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/DefaultInteropViewCallback.kt
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.callback
+
+import android.view.View
+import androidx.annotation.UiThread
+import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
+import com.datadog.android.sessionreplay.internal.recorder.TreeViewTraversal
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.recorder.InteropViewCallback
+import com.datadog.android.sessionreplay.recorder.MappingContext
+
+internal class DefaultInteropViewCallback(
+    private val treeViewTraversal: TreeViewTraversal,
+    private val recordedDataQueueRefs: RecordedDataQueueRefs
+) : InteropViewCallback {
+
+    @UiThread
+    override fun map(view: View, mappingContext: MappingContext): List<MobileSegment.Wireframe> {
+        return treeViewTraversal.traverse(
+            view,
+            mappingContext,
+            recordedDataQueueRefs
+        ).mappedWireframes
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/InteropViewCallback.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/InteropViewCallback.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder
+
+import android.view.View
+import androidx.annotation.UiThread
+import com.datadog.android.sessionreplay.model.MobileSegment
+
+/**
+ * Interface to define the callback for Jetpack Compose semantics tree to call
+ * when there is an interop view to map.
+ */
+interface InteropViewCallback {
+
+    /**
+     * Called when an interop view needs to be mapped.
+     */
+    @UiThread
+    fun map(view: View, mappingContext: MappingContext): List<MobileSegment.Wireframe>
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/MappingContext.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/MappingContext.kt
@@ -22,6 +22,8 @@ import com.datadog.android.sessionreplay.utils.ImageWireframeHelper
  * @param touchPrivacyManager the manager to handle touch privacy area.
  * @param hasOptionSelectorParent tells if one of the parents of the current [android.view.View]
  * is an option selector type (e.g. time picker, date picker, drop - down list)
+ * @param interopViewCallback the callback for Jetpack Compose semantics tree to call
+ * when there is an interop view to map.
  */
 data class MappingContext(
     val systemInformation: SystemInformation,
@@ -29,5 +31,6 @@ data class MappingContext(
     val textAndInputPrivacy: TextAndInputPrivacy,
     val imagePrivacy: ImagePrivacy,
     val touchPrivacyManager: TouchPrivacyManager,
-    val hasOptionSelectorParent: Boolean = false
+    val hasOptionSelectorParent: Boolean = false,
+    val interopViewCallback: InteropViewCallback
 )

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/MappingContextForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/MappingContextForgeryFactory.kt
@@ -19,7 +19,8 @@ internal class MappingContextForgeryFactory : ForgeryFactory<MappingContext> {
             hasOptionSelectorParent = forge.aBool(),
             textAndInputPrivacy = forge.getForgery(),
             imagePrivacy = forge.getForgery(),
-            touchPrivacyManager = mock()
+            touchPrivacyManager = mock(),
+            interopViewCallback = mock()
         )
     }
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/SampleSelectionScreen.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/SampleSelectionScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -31,10 +33,11 @@ internal fun SampleSelectionScreen(
     onToggleClicked: () -> Unit,
     onSelectorsClicked: () -> Unit,
     onFgmClicked: () -> Unit,
-    onTabsClicked: () -> Unit
+    onTabsClicked: () -> Unit,
+    onInteropViewClicked: () -> Unit
 ) {
     Column(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
@@ -74,6 +77,10 @@ internal fun SampleSelectionScreen(
             text = "Legacy Sample",
             onClick = onLegacyClicked
         )
+        StyledButton(
+            text = "InteropView",
+            onClick = onInteropViewClicked
+        )
     }
 }
 
@@ -92,6 +99,7 @@ private fun StyledButton(
     )
 }
 
+@Suppress("LongMethod")
 internal fun NavGraphBuilder.selectionNavigation(navController: NavHostController) {
     composable(SampleScreen.Root.navigationRoute) {
         SampleSelectionScreen(
@@ -118,6 +126,9 @@ internal fun NavGraphBuilder.selectionNavigation(navController: NavHostControlle
             },
             onLegacyClicked = {
                 navController.navigate(SampleScreen.Legacy.navigationRoute)
+            },
+            onInteropViewClicked = {
+                navController.navigate(SampleScreen.InteropView.navigationRoute)
             }
         )
     }
@@ -150,6 +161,10 @@ internal fun NavGraphBuilder.selectionNavigation(navController: NavHostControlle
         TabsSample()
     }
 
+    composable(SampleScreen.InteropView.navigationRoute) {
+        InteropViewSample()
+    }
+
     activity(SampleScreen.Legacy.navigationRoute) {
         activityClass = LegacyComposeActivity::class
     }
@@ -168,6 +183,7 @@ internal sealed class SampleScreen(
     object Selectors : SampleScreen("$COMPOSE_ROOT/selectors")
     object FGM : SampleScreen("$COMPOSE_ROOT/fgm")
     object Legacy : SampleScreen("$COMPOSE_ROOT/legacy")
+    object InteropView : SampleScreen("$COMPOSE_ROOT/interop_view")
 
     companion object {
         private const val COMPOSE_ROOT = "compose"
@@ -194,6 +210,8 @@ private fun PreviewSampleSelectionScreen() {
         onFgmClicked = {
         },
         onTabsClicked = {
+        },
+        onInteropViewClicked = {
         }
     )
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/WebViewSample.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/WebViewSample.kt
@@ -1,0 +1,79 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sample.compose
+
+import android.annotation.SuppressLint
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.ImageView
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.datadog.android.rum.ExperimentalRumApi
+import com.datadog.android.rum.GlobalRumMonitor
+import com.datadog.android.sample.R
+import com.datadog.android.webview.WebViewTracking
+
+private val webViewTrackingHosts = listOf(
+    "datadoghq.dev"
+)
+
+@OptIn(ExperimentalRumApi::class)
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+internal fun InteropViewSample() {
+    Column {
+        Text(
+            text = "ImageView"
+        )
+        AndroidView(
+            modifier = Modifier.height(120.dp),
+            factory = { context ->
+                ImageView(context).apply {
+                    setImageResource(R.drawable.ic_dd_icon_red)
+                }
+            },
+            update = {
+            }
+        )
+        Text(
+            text = "WebView"
+        )
+        AndroidView(
+            modifier = Modifier.height(240.dp),
+            factory = { context ->
+                WebView(context).apply {
+                    settings.javaScriptEnabled = true
+                    webViewClient = object : WebViewClient() {
+                        override fun onPageFinished(view: WebView?, url: String?) {
+                            super.onPageFinished(view, url)
+                            GlobalRumMonitor.get().addViewLoadingTime(overwrite = false)
+                        }
+                    }
+                    WebViewTracking.enable(this, webViewTrackingHosts)
+                    settings.loadWithOverviewMode = true
+                    settings.useWideViewPort = true
+                    settings.setSupportZoom(true)
+                }
+            },
+            update = { webView ->
+                webView.loadUrl("https://datadoghq.dev/browser-sdk-test-playground/webview-support/#click_event")
+            }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+internal fun PreviewAndroidViewSample() {
+    InteropViewSample()
+}


### PR DESCRIPTION
### What does this PR do?

A callback `InteropViewCallback` is added inside `mappingContext` so that in semantics tree, whenever an interop view is seen in the semantics node, this callback can be called to map in the way of how we are doing in the `TreeViewTraversal`.

with this PR, `AndroidView` can be seen in Session Replay, WebView embedded with `AndroidView` can be seen as well.

### Motivation

RUM-7195

### Dem
![ezgif-4-b418e69d8b](https://github.com/user-attachments/assets/f927a6e2-49cf-4c20-bb69-b955649b7836)
o


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

