### PR TITLE
fix: Don't warn about missing view on PerformanceMetric events

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -333,7 +333,8 @@ internal class RumViewManagerScope(
             RumRawEvent.LongTaskDropped::class.java,
             RumRawEvent.LongTaskSent::class.java,
             RumRawEvent.ResourceDropped::class.java,
-            RumRawEvent.ResourceSent::class.java
+            RumRawEvent.ResourceSent::class.java,
+            RumRawEvent.UpdatePerformanceMetric::class.java
         )
 
         internal const val RUM_BACKGROUND_VIEW_ID = "com.datadog.background.view"


### PR DESCRIPTION
### What does this PR do?

PerformanceMetric events are triggered automatically by some of the cross platform frameworks, and can result in log spam as views transition or if no view is active.  Fix it so that the performance metric event is considered a silent orphaned event type.

refs: RUM-6138

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

