### PR TITLE
Fix cache misses due to wrong drawable

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolver.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolver.kt
@@ -160,7 +160,8 @@ internal class ResourceResolver(
 
         if (handledBitmap == null) {
             tryToDrawNewBitmap(
-                drawable = copiedDrawable,
+                originalDrawable = drawable,
+                copiedDrawable = copiedDrawable,
                 drawableWidth = drawableWidth,
                 drawableHeight = drawableHeight,
                 displayMetrics = displayMetrics,
@@ -244,12 +245,14 @@ internal class ResourceResolver(
         val key = customResourceIdCacheKey
             ?: bitmapCachesManager.generateResourceKeyFromDrawable(drawable)
             ?: return
+
         bitmapCachesManager.putInResourceCache(key, resourceId)
     }
 
     @WorkerThread
     private fun tryToDrawNewBitmap(
-        drawable: Drawable,
+        originalDrawable: Drawable,
+        copiedDrawable: Drawable,
         drawableWidth: Int,
         drawableHeight: Int,
         displayMetrics: DisplayMetrics,
@@ -257,7 +260,7 @@ internal class ResourceResolver(
         resolveResourceCallback: ResolveResourceCallback
     ) {
         drawableUtils.createBitmapOfApproxSizeFromDrawable(
-            drawable = drawable,
+            drawable = copiedDrawable,
             drawableWidth = drawableWidth,
             drawableHeight = drawableHeight,
             displayMetrics = displayMetrics,
@@ -273,7 +276,7 @@ internal class ResourceResolver(
                     }
 
                     resolveResourceHash(
-                        drawable = drawable,
+                        drawable = originalDrawable,
                         bitmap = bitmap,
                         compressedBitmapBytes = compressedBitmapBytes,
                         shouldCacheBitmap = true,
@@ -339,6 +342,7 @@ internal class ResourceResolver(
         val cacheKey = key
             ?: bitmapCachesManager.generateResourceKeyFromDrawable(drawable)
             ?: return null
+
         return bitmapCachesManager.getFromResourceCache(cacheKey)
     }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolverTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolverTest.kt
@@ -1037,4 +1037,60 @@ internal class ResourceResolverTest {
         applicationId = fakeApplicationid.toString(),
         bitmapCachesManager = mockBitmapCachesManager
     )
+
+    @Test
+    fun `M use original drawable for cache write W resolveResourceId() { cache miss }`(
+        @Mock mockCopiedDrawable: Drawable
+    ) {
+        // Given
+        whenever(mockDrawableCopier.copy(mockDrawable, mockResources)).thenReturn(mockCopiedDrawable)
+
+        // When
+        testedResourceResolver.resolveResourceId(
+            resources = mockResources,
+            applicationContext = mockApplicationContext,
+            displayMetrics = mockDisplayMetrics,
+            originalDrawable = mockDrawable,
+            drawableCopier = mockDrawableCopier,
+            drawableWidth = mockDrawable.intrinsicWidth,
+            drawableHeight = mockDrawable.intrinsicHeight,
+            customResourceIdCacheKey = null,
+            resourceResolverCallback = mockSerializerCallback
+        )
+
+        // Then
+        verify(mockBitmapCachesManager, times(2)).generateResourceKeyFromDrawable(mockDrawable)
+    }
+
+    @Test
+    fun `M use copy of the drawable for creating the bitmap W resolveResourceId() { cache miss }`(
+        @Mock mockCopiedDrawable: Drawable
+    ) {
+        // Given
+        whenever(mockDrawableCopier.copy(mockDrawable, mockResources)).thenReturn(mockCopiedDrawable)
+
+        // When
+        testedResourceResolver.resolveResourceId(
+            resources = mockResources,
+            applicationContext = mockApplicationContext,
+            displayMetrics = mockDisplayMetrics,
+            originalDrawable = mockDrawable,
+            drawableCopier = mockDrawableCopier,
+            drawableWidth = mockDrawable.intrinsicWidth,
+            drawableHeight = mockDrawable.intrinsicHeight,
+            customResourceIdCacheKey = null,
+            resourceResolverCallback = mockSerializerCallback
+        )
+
+        // Then
+        verify(mockDrawableUtils).createBitmapOfApproxSizeFromDrawable(
+            drawable = eq(mockCopiedDrawable),
+            drawableWidth = any(),
+            drawableHeight = any(),
+            displayMetrics = any(),
+            requestedSizeInBytes = any(),
+            config = any(),
+            bitmapCreationCallback = any()
+        )
+    }
 }


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where the `ResourcesLruCache` was being missed due to the wrong drawable being used. 

We are copying the drawable before creating the bitmap, and were using the copied drawable as the cache key for the new resourceId. However we query the cache with the original drawable. In this pr the original drawable is passed in to use as the basis for the key when writing to the cache.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

