### PR TITLE
Improve telemetry on invalid view duration

### DIFF
--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -315,6 +315,7 @@ class SampleApplication : Application() {
                 event.context?.additionalProperties?.put(ATTR_IS_MAPPED, true)
                 event
             }
+            .trackBackgroundEvents(true)
             .build()
     }
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/service/LogsForegroundService.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/service/LogsForegroundService.kt
@@ -105,17 +105,17 @@ class LogsForegroundService : Service() {
                 sendRumErrorPendingIntent
             )
             .addAction(
-                android.R.drawable.ic_menu_call,
+                R.drawable.ic_baseline_action_24,
                 "Send RUM Action",
                 sendRumActionPendingIntent
             )
             .addAction(
-                android.R.drawable.ic_media_play,
+                R.drawable.ic_baseline_start_res_24,
                 "Start RUM Resource",
                 startRumResourcePendingIntent
             )
             .addAction(
-                android.R.drawable.ic_media_pause,
+                R.drawable.ic_baseline_end_res_24,
                 "Stop RUM Resource",
                 stopRumResourcePendingIntent
             )

--- a/sample/kotlin/src/main/res/drawable/ic_baseline_action_24.xml
+++ b/sample/kotlin/src/main/res/drawable/ic_baseline_action_24.xml
@@ -1,0 +1,16 @@
+<!--
+  ~ Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+  ~ This product includes software developed at Datadog (https://www.datadoghq.com/).
+  ~ Copyright 2016-Present Datadog, Inc.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M13 5C15.21 5 17 6.79 17 9C17 10.5 16.2 11.77 15 12.46V11.24C15.61 10.69 16 9.89 16 9C16 7.34 14.66 6 13 6S10 7.34 10 9C10 9.89 10.39 10.69 11 11.24V12.46C9.8 11.77 9 10.5 9 9C9 6.79 10.79 5 13 5M20 20.5C19.97 21.32 19.32 21.97 18.5 22H13C12.62 22 12.26 21.85 12 21.57L8 17.37L8.74 16.6C8.93 16.39 9.2 16.28 9.5 16.28H9.7L12 18V9C12 8.45 12.45 8 13 8S14 8.45 14 9V13.47L15.21 13.6L19.15 15.79C19.68 16.03 20 16.56 20 17.14V20.5M20 2H4C2.9 2 2 2.9 2 4V12C2 13.11 2.9 14 4 14H8V12L4 12L4 4H20L20 12H18V14H20V13.96L20.04 14C21.13 14 22 13.09 22 12V4C22 2.9 21.11 2 20 2Z"/>
+</vector>

--- a/sample/kotlin/src/main/res/drawable/ic_baseline_end_res_24.xml
+++ b/sample/kotlin/src/main/res/drawable/ic_baseline_end_res_24.xml
@@ -1,0 +1,16 @@
+<!--
+  ~ Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+  ~ This product includes software developed at Datadog (https://www.datadoghq.com/).
+  ~ Copyright 2016-Present Datadog, Inc.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M14.59,6L12,8.59L9.41,6L8,7.41L10.59,10L8,12.59L9.41,14L12,11.41L14.59,14L16,12.59L13.41,10L16,7.41L14.59,6M17,3A2,2 0 0,1 19,5V15A2,2 0 0,1 17,17H13V19H14A1,1 0 0,1 15,20H22V22H15A1,1 0 0,1 14,23H10A1,1 0 0,1 9,22H2V20H9A1,1 0 0,1 10,19H11V17H7C5.89,17 5,16.1 5,15V5A2,2 0 0,1 7,3H17Z"/>
+</vector>

--- a/sample/kotlin/src/main/res/drawable/ic_baseline_start_res_24.xml
+++ b/sample/kotlin/src/main/res/drawable/ic_baseline_start_res_24.xml
@@ -1,0 +1,16 @@
+<!--
+  ~ Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+  ~ This product includes software developed at Datadog (https://www.datadoghq.com/).
+  ~ Copyright 2016-Present Datadog, Inc.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M16,11V9H13V6H11V9H8V11H11V14H13V11H16M17,3A2,2 0 0,1 19,5V15A2,2 0 0,1 17,17H13V19H14A1,1 0 0,1 15,20H22V22H15A1,1 0 0,1 14,23H10A1,1 0 0,1 9,22H2V20H9A1,1 0 0,1 10,19H11V17H7C5.89,17 5,16.1 5,15V5A2,2 0 0,1 7,3H17Z"/>
+</vector>


### PR DESCRIPTION
### What does this PR do?

In order to get a better signal from our telemetry, we update the logs when a view ends with a duration less than or equal to zero: 

- We distinguish negative and nul duration
- We add additional attributes to get more insights
- We exclude legitimate nul duration cases for background crashes.