### PR TITLE
Fix internal telemetry on invalid loading time usage

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -251,33 +251,18 @@ internal open class RumViewScope(
 
     @WorkerThread
     private fun onAddViewLoadingTime(event: RumRawEvent.AddViewLoadingTime, writer: DataWriter<Any>) {
-        val internalLogger = sdkCore.internalLogger
         val canUpdateViewLoadingTime = !stopped && (viewLoadingTime == null || event.overwrite)
-        if (stopped) {
-            internalLogger.log(
-                InternalLogger.Level.WARN,
-                InternalLogger.Target.USER,
-                { NO_ACTIVE_VIEW_FOR_LOADING_TIME_WARNING_MESSAGE }
-            )
-            internalLogger.logApiUsage {
-                InternalTelemetryEvent.ApiUsage.AddViewLoadingTime(
-                    overwrite = event.overwrite,
-                    noView = false,
-                    noActiveView = true
-                )
-            }
-        }
 
         if (canUpdateViewLoadingTime) {
-            updateViewLoadingTime(event, internalLogger, writer)
+            updateViewLoadingTime(event, writer)
         }
     }
 
     private fun updateViewLoadingTime(
         event: RumRawEvent.AddViewLoadingTime,
-        internalLogger: InternalLogger,
         writer: DataWriter<Any>
     ) {
+        val internalLogger = sdkCore.internalLogger
         val viewName = key.name
         val previousViewLoadingTime = viewLoadingTime
         val newLoadingTime = event.eventTime.nanoTime - startedNanos
@@ -1382,8 +1367,6 @@ internal open class RumViewScope(
             "view: %s was 0. In order to keep the view we forced it to 1ns."
         internal const val NEGATIVE_DURATION_WARNING_MESSAGE = "The computed duration for the " +
             "view: %s was negative. In order to keep the view we forced it to 1ns."
-        internal const val NO_ACTIVE_VIEW_FOR_LOADING_TIME_WARNING_MESSAGE =
-            "No active view found to add the loading time."
         internal const val ADDING_VIEW_LOADING_TIME_DEBUG_MESSAGE_FORMAT =
             "View loading time %dns added to the view %s"
         internal const val OVERWRITING_VIEW_LOADING_TIME_WARNING_MESSAGE_FORMAT =

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -7419,19 +7419,6 @@ internal class RumViewScopeTest {
 
         // Then
         assertThat(testedScope.viewLoadingTime).isNull()
-        mockInternalLogger.verifyLog(
-            InternalLogger.Level.WARN,
-            InternalLogger.Target.USER,
-            RumViewScope.NO_ACTIVE_VIEW_FOR_LOADING_TIME_WARNING_MESSAGE
-        )
-        mockInternalLogger.verifyApiUsage(
-            InternalTelemetryEvent.ApiUsage.AddViewLoadingTime(
-                noActiveView = true,
-                noView = false,
-                overwrite = fakeOverwrite
-            ),
-            15f
-        )
         verifyNoInteractions(mockWriter)
     }
 


### PR DESCRIPTION
### What does this PR do?

The way our telemetry was set up, we could send warnings when there shouldn't have been : 
- if a previous RumViewScope was stopped but kept to wait for children event to be sent, it would always send a warning saying there's no active view, even if an actual active view would actually handle the event. 