### PR TITLE
RUM-7870: Remove non-critical Compose reflection error from telemetry

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
@@ -81,22 +81,39 @@ internal object ComposeReflection {
     val PainterFieldOfContentPainterModifier =
         ContentPainterModifierClass?.getDeclaredFieldSafe("painter")
 
-    val ContentPainterElementClass = getClassSafe("coil.compose.ContentPainterElement")
+    val ContentPainterElementClass = getClassSafe(
+        "coil.compose.ContentPainterElement",
+        isCritical = false
+    )
     val PainterFieldOfContentPainterElement =
         ContentPainterElementClass?.getDeclaredFieldSafe("painter")
 
-    val AsyncImagePainterClass = getClassSafe("coil.compose.AsyncImagePainter")
+    val AsyncImagePainterClass = getClassSafe(
+        "coil.compose.AsyncImagePainter",
+        isCritical = false
+    )
     val PainterFieldOfAsyncImagePainter = AsyncImagePainterClass?.getDeclaredFieldSafe("_painter")
 
     // Region of MultiParagraph text
-    val ParagraphInfoListField =
-        MultiParagraph::class.java.getDeclaredFieldSafe("paragraphInfoList")
+    val ParagraphInfoListField = MultiParagraph::class.java.getDeclaredFieldSafe(
+        "paragraphInfoList",
+        isCritical = false
+    )
     val ParagraphInfoClass = getClassSafe("androidx.compose.ui.text.ParagraphInfo")
-    val ParagraphField = ParagraphInfoClass?.getDeclaredFieldSafe("paragraph")
+    val ParagraphField = ParagraphInfoClass?.getDeclaredFieldSafe(
+        "paragraph",
+        isCritical = false
+    )
     val AndroidParagraphClass = getClassSafe("androidx.compose.ui.text.AndroidParagraph")
-    val LayoutField = AndroidParagraphClass?.getDeclaredFieldSafe("layout")
+    val LayoutField = AndroidParagraphClass?.getDeclaredFieldSafe(
+        "layout",
+        isCritical = false
+    )
     val TextLayoutClass = getClassSafe("androidx.compose.ui.text.android.TextLayout")
-    val StaticLayoutField = TextLayoutClass?.getDeclaredFieldSafe("layout")
+    val StaticLayoutField = TextLayoutClass?.getDeclaredFieldSafe(
+        "layout",
+        isCritical = false
+    )
 }
 
 internal fun Field.accessible(): Field {
@@ -128,49 +145,70 @@ internal fun Field.getSafe(target: Any?): Any? {
     }
 }
 
-internal fun getClassSafe(className: String): Class<*>? {
+internal fun getClassSafe(className: String, isCritical: Boolean = true): Class<*>? {
     return try {
         Class.forName(className)
     } catch (e: LinkageError) {
-        logReflectionException(className, LOG_TYPE_CLASS, LOG_REASON_LINKAGE_ERROR, e)
+        if (isCritical) {
+            logReflectionException(className, LOG_TYPE_CLASS, LOG_REASON_LINKAGE_ERROR, e)
+        }
         null
     } catch (e: ExceptionInInitializerError) {
-        logReflectionException(className, LOG_TYPE_CLASS, LOG_REASON_INITIALIZATION_ERROR, e)
+        if (isCritical) {
+            logReflectionException(className, LOG_TYPE_CLASS, LOG_REASON_INITIALIZATION_ERROR, e)
+        }
         null
     } catch (e: ClassNotFoundException) {
-        logNoSuchException(className, LOG_TYPE_CLASS, e)
+        if (isCritical) {
+            logNoSuchException(className, LOG_TYPE_CLASS, e)
+        }
         null
     }
 }
 
 @Suppress("TooGenericExceptionCaught")
-internal fun Class<*>.getDeclaredFieldSafe(fieldName: String): Field? {
+internal fun Class<*>.getDeclaredFieldSafe(fieldName: String, isCritical: Boolean = true): Field? {
     return try {
         getDeclaredField(fieldName).accessible()
     } catch (e: SecurityException) {
-        logSecurityException(fieldName, LOG_TYPE_FIELD, e)
+        if (isCritical) {
+            logSecurityException(fieldName, LOG_TYPE_FIELD, e)
+        }
         null
     } catch (e: NullPointerException) {
-        logNullPointerException(fieldName, LOG_TYPE_FIELD, e)
+        if (isCritical) {
+            logNullPointerException(fieldName, LOG_TYPE_FIELD, e)
+        }
         null
     } catch (e: NoSuchFieldException) {
-        logNoSuchException(fieldName, LOG_TYPE_FIELD, e)
+        if (isCritical) {
+            logNoSuchException(fieldName, LOG_TYPE_FIELD, e)
+        }
         null
     }
 }
 
 @Suppress("TooGenericExceptionCaught")
-internal fun Class<*>.getDeclaredMethodSafe(methodName: String): Method? {
+internal fun Class<*>.getDeclaredMethodSafe(
+    methodName: String,
+    isCritical: Boolean = true
+): Method? {
     return try {
         getDeclaredMethod(methodName).accessible()
     } catch (e: SecurityException) {
-        logSecurityException(methodName, LOG_TYPE_METHOD, e)
+        if (isCritical) {
+            logSecurityException(methodName, LOG_TYPE_METHOD, e)
+        }
         null
     } catch (e: NullPointerException) {
-        logNullPointerException(methodName, LOG_TYPE_METHOD, e)
+        if (isCritical) {
+            logNullPointerException(methodName, LOG_TYPE_METHOD, e)
+        }
         null
     } catch (e: NoSuchMethodException) {
-        logNoSuchException(methodName, LOG_TYPE_METHOD, e)
+        if (isCritical) {
+            logNoSuchException(methodName, LOG_TYPE_METHOD, e)
+        }
         null
     }
 }


### PR DESCRIPTION
### What does this PR do?

In Compose Session Replay, we setup some telemetry to monitor if the reflection is broken on client side, in the current version we noticed that some telemetries are false alert, so we need to remove them.

![image](https://github.com/user-attachments/assets/187f620d-4ecf-453c-be76-9554303e2791)

In this PR, we remove following reflection telemetry:
* paragraphInfoList
* ContentPainterModifier
* AsyncImagePainter
* ContentPainterElement
* layout
* paragraph

### Motivation

RUM-7870


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

