### PR TITLE
RUM-7467: Apply contrasting color to semantics component

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-compose/build.gradle.kts
@@ -26,6 +26,7 @@ plugins {
     id("com.github.ben-manes.versions")
 
     // Tests
+    id("de.mobilej.unmock")
     id("org.jetbrains.kotlinx.kover")
 
     // Internal Generation
@@ -75,6 +76,11 @@ dependencies {
     testImplementation(testFixtures(project(":dd-sdk-android-core")))
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
+    unmock(libs.robolectric)
+}
+
+unMock {
+    keep("android.graphics.Color")
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RadioButtonSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RadioButtonSemanticsNodeMapper.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWireframe
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
+import com.datadog.android.sessionreplay.compose.internal.utils.ColorUtils
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -18,7 +19,8 @@ import com.datadog.android.sessionreplay.utils.ColorStringFormatter
 
 internal class RadioButtonSemanticsNodeMapper(
     colorStringFormatter: ColorStringFormatter,
-    semanticsUtils: SemanticsUtils = SemanticsUtils()
+    semanticsUtils: SemanticsUtils = SemanticsUtils(),
+    private val colorUtils: ColorUtils = ColorUtils()
 ) : AbstractSemanticsNodeMapper(
     colorStringFormatter,
     semanticsUtils
@@ -28,9 +30,11 @@ internal class RadioButtonSemanticsNodeMapper(
         parentContext: UiContext,
         asyncJobStatusCallback: AsyncJobStatusCallback
     ): SemanticsWireframe {
-        var wireframeIndex = 0
-        val boxWireframe = resolveBoxWireframe(semanticsNode, wireframeIndex++)
-        val dotWireframe = resolveDotWireframe(semanticsNode, wireframeIndex)
+        val color = parentContext.parentContentColor?.takeIf { colorUtils.isDarkColor(it) }?.let {
+            DEFAULT_COLOR_WHITE
+        } ?: DEFAULT_COLOR_BLACK
+        val boxWireframe = resolveBoxWireframe(semanticsNode, 0, color)
+        val dotWireframe = resolveDotWireframe(semanticsNode, 1, color)
         return SemanticsWireframe(
             uiContext = null,
             wireframes = listOfNotNull(boxWireframe, dotWireframe)
@@ -39,7 +43,8 @@ internal class RadioButtonSemanticsNodeMapper(
 
     private fun resolveBoxWireframe(
         semanticsNode: SemanticsNode,
-        wireframeIndex: Int
+        wireframeIndex: Int,
+        color: String
     ): MobileSegment.Wireframe {
         val globalBounds = resolveBounds(semanticsNode)
         return MobileSegment.Wireframe.ShapeWireframe(
@@ -52,7 +57,7 @@ internal class RadioButtonSemanticsNodeMapper(
                 cornerRadius = globalBounds.width / 2
             ),
             border = MobileSegment.ShapeBorder(
-                color = DEFAULT_COLOR_BLACK,
+                color = color,
                 width = BOX_BORDER_WIDTH
             )
         )
@@ -60,7 +65,8 @@ internal class RadioButtonSemanticsNodeMapper(
 
     private fun resolveDotWireframe(
         semanticsNode: SemanticsNode,
-        wireframeIndex: Int
+        wireframeIndex: Int,
+        color: String
     ): MobileSegment.Wireframe? {
         val selected = semanticsNode.config.getOrNull(SemanticsProperties.Selected) ?: false
         val globalBounds = resolveBounds(semanticsNode)
@@ -72,7 +78,7 @@ internal class RadioButtonSemanticsNodeMapper(
                 width = globalBounds.width - DOT_PADDING_DP * 2,
                 height = globalBounds.height - DOT_PADDING_DP * 2,
                 shapeStyle = MobileSegment.ShapeStyle(
-                    backgroundColor = DEFAULT_COLOR_BLACK,
+                    backgroundColor = color,
                     cornerRadius = (globalBounds.width - DOT_PADDING_DP * 2) / 2
                 )
             )
@@ -84,6 +90,7 @@ internal class RadioButtonSemanticsNodeMapper(
     companion object {
         private const val DOT_PADDING_DP = 4
         private const val DEFAULT_COLOR_BLACK = "#000000FF"
+        private const val DEFAULT_COLOR_WHITE = "#FFFFFFFF"
         private const val BOX_BORDER_WIDTH = 1L
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/ColorUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/ColorUtils.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.compose.internal.utils
 import android.graphics.Color
 import com.datadog.android.api.InternalLogger
 import java.util.Locale
+import kotlin.math.pow
 
 internal class ColorUtils(
     private val logger: InternalLogger = InternalLogger.UNBOUND
@@ -26,6 +27,30 @@ internal class ColorUtils(
             )
             null
         }
+    }
+
+    // Luma formula: L=0.2126×R+0.7152×G+0.0722×B
+    @Suppress("MagicNumber")
+    internal fun isDarkColor(hexColor: String): Boolean {
+        return parseColorSafe(hexColor)?.let {
+            val red = Color.red(it) / 255.0
+            val green = Color.green(it) / 255.0
+            val blue = Color.blue(it) / 255.0
+
+            // Linearize the RGB components
+            val r = linearize(red)
+            val g = linearize(green)
+            val b = linearize(blue)
+
+            // Calculate luminance
+            val luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+            luminance <= 0.5
+        } ?: false
+    }
+
+    @Suppress("MagicNumber")
+    private fun linearize(channel: Double): Double {
+        return if (channel <= 0.03928) channel / 12.92 else ((channel + 0.055) / 1.055).pow(2.4)
     }
 
     internal companion object {

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/ColorUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/ColorUtilsTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.utils
+
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ColorUtilsTest {
+
+    private val testedColorUtils = ColorUtils()
+
+    private val lightColors = listOf(
+        PURE_WHITE_HEX,
+        BRIGHT_GREEN_HEX,
+        BRIGHT_YELLOW_HEX,
+        LIGHT_GRAY_HEX,
+        VERY_LIGHT_GRAY_HEX
+    )
+
+    private val darkColors = listOf(
+        PURE_BLACK_HEX,
+        BRIGHT_RED_HEX,
+        BRIGHT_BLUE_HEX,
+        NEUTRAL_GRAY_HEX,
+        DARK_INDIGO_HEX
+    )
+
+    @Test
+    fun `M return true W isDarkColor { color is dark }`(forge: Forge) {
+        // Given
+        val color = forge.anElementFrom(darkColors)
+
+        // When
+        val result = testedColorUtils.isDarkColor(color)
+
+        // Then
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `M return false W isDarkColor { color is light }`(forge: Forge) {
+        // Given
+        val color = forge.anElementFrom(lightColors)
+
+        // When
+        val result = testedColorUtils.isDarkColor(color)
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    companion object {
+        // light colors
+        private const val PURE_WHITE_HEX = "#FFFFFFFF"
+        private const val BRIGHT_GREEN_HEX = "#FF00FF00"
+        private const val BRIGHT_YELLOW_HEX = "#FFFFFF00"
+        private const val LIGHT_GRAY_HEX = "#FFC0C0C0"
+        private const val VERY_LIGHT_GRAY_HEX = "#FFF5F5F5"
+
+        // dark colors
+        private const val PURE_BLACK_HEX = "#FF000000"
+        private const val BRIGHT_RED_HEX = "#FFFF0000"
+        private const val BRIGHT_BLUE_HEX = "#FF0000FF"
+        private const val NEUTRAL_GRAY_HEX = "#FF808080"
+        private const val DARK_INDIGO_HEX = "#FF4B0082"
+    }
+}

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/JetpackComposeActivity.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/JetpackComposeActivity.kt
@@ -9,10 +9,14 @@ package com.datadog.android.sample.compose
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
+import androidx.compose.material.darkColors
+import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
@@ -20,7 +24,6 @@ import androidx.navigation.compose.rememberNavController
 import com.datadog.android.compose.ExperimentalTrackingApi
 import com.datadog.android.compose.NavigationViewTrackingEffect
 import com.datadog.android.rum.tracking.AcceptAllNavDestinations
-import com.google.accompanist.appcompattheme.AppCompatTheme
 
 /**
  * An activity to showcase Jetpack Compose instrumentation.
@@ -30,7 +33,13 @@ class JetpackComposeActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            AppCompatTheme {
+            MaterialTheme(
+                colors = if (isSystemInDarkTheme()) {
+                    darkColors()
+                } else {
+                    lightColors()
+                }
+            ) {
                 AppScaffold()
             }
         }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/ToggleSample.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/ToggleSample.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.android.sample.compose
 
-import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Checkbox
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.RadioButton
 import androidx.compose.material.Switch
 import androidx.compose.material.Text
@@ -90,13 +91,16 @@ private fun SampleButtonContainer(
             .fillMaxWidth()
             .padding(4.dp)
             .clip(RoundedCornerShape(4.dp))
-            .background(color = Color.Gray),
+            .border(
+                width = 1.dp,
+                color = Color.Gray
+            ),
         verticalAlignment = Alignment.CenterVertically
     ) {
         content.invoke()
         Text(
             title,
-            color = Color.Black,
+            color = MaterialTheme.colors.onBackground,
             modifier = Modifier.padding(8.dp)
         )
     }


### PR DESCRIPTION
### What does this PR do?

In semantics tree we are not able to retrieve the complex color of some components including:
* Checkbox
* Switch
* RadioButton.

Therefore we need to assume a contrasting color based on the background color to make them as much visible as possible.

The core function judges if the background is a bright one or dark one by [ Luma forumla ](https://en.wikipedia.org/wiki/Luma_(video)), based on that, we can give the content a black color or white color.

###  Demo

The components turn white in dark mode:

<img width="384" alt="image" src="https://github.com/user-attachments/assets/90aa9fc1-8e79-452d-9c2e-52ec1eb2d004" />


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

