### PR TITLE
RUM-7116: Add RadioButton color

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/consumer-rules.pro
+++ b/features/dd-sdk-android-session-replay-compose/consumer-rules.pro
@@ -20,6 +20,9 @@
 -keep class androidx.compose.material.CheckboxKt$CheckboxImpl$1$1 {
      <fields>;
 }
+-keep class androidx.compose.material.RadioButtonKt$RadioButton$2$1 {
+     <fields>;
+}
 -keep class androidx.compose.ui.draw.DrawBehindElement {
      <fields>;
 }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SwitchSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SwitchSemanticsNodeMapper.kt
@@ -15,6 +15,8 @@ import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWirefram
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.utils.ColorUtils
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
+import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils.Companion.DEFAULT_COLOR_BLACK
+import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils.Companion.DEFAULT_COLOR_WHITE
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
@@ -174,7 +176,5 @@ internal class SwitchSemanticsNodeMapper(
         const val CORNER_RADIUS_DP = 20
         const val THUMB_DIAMETER_DP = 20
         const val BORDER_WIDTH_DP = 1L
-        const val DEFAULT_COLOR_BLACK = "#000000FF"
-        const val DEFAULT_COLOR_WHITE = "#FFFFFFFF"
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
@@ -40,15 +40,18 @@ internal object ComposeReflection {
     val ColorField = BackgroundElementClass?.getDeclaredFieldSafe("color")
     val ShapeField = BackgroundElementClass?.getDeclaredFieldSafe("shape")
 
-    val CheckDrawingCacheClass = getClassSafe("androidx.compose.material.CheckDrawingCache")
-    val CheckboxKtClass = getClassSafe("androidx.compose.material.CheckboxKt\$CheckboxImpl\$1\$1")
     val DrawBehindElementClass = getClassSafe("androidx.compose.ui.draw.DrawBehindElement")
+    val CheckboxKtClass = getClassSafe("androidx.compose.material.CheckboxKt\$CheckboxImpl\$1\$1")
+    val RadioButtonKtClass = getClassSafe("androidx.compose.material.RadioButtonKt\$RadioButton\$2\$1")
+    val CheckDrawingCacheClass = getClassSafe("androidx.compose.material.CheckDrawingCache")
+
     val BorderColorField = CheckboxKtClass?.getDeclaredFieldSafe("\$borderColor\$delegate")
     val BoxColorField = CheckboxKtClass?.getDeclaredFieldSafe("\$boxColor\$delegate")
     val CheckCacheField = CheckboxKtClass?.getDeclaredFieldSafe("\$checkCache")
     val CheckColorField = CheckboxKtClass?.getDeclaredFieldSafe("\$checkColor\$delegate")
     val CheckPathField = CheckDrawingCacheClass?.getDeclaredFieldSafe("checkPath")
     val OnDrawField = DrawBehindElementClass?.getDeclaredFieldSafe("onDraw")
+    val RadioColorField = RadioButtonKtClass?.getDeclaredFieldSafe("\$radioColor")
 
     val PaddingElementClass = getClassSafe("androidx.compose.foundation.layout.PaddingElement")
     val StartField = PaddingElementClass?.getDeclaredFieldSafe("start")

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/ReflectionUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/ReflectionUtils.kt
@@ -186,6 +186,10 @@ internal class ReflectionUtils {
         return ComposeReflection.BoxColorField?.getSafe(onDrawInstance) as? AnimationState<*, *>
     }
 
+    fun getRadioColor(onDrawInstance: Any): AnimationState<*, *>? {
+        return ComposeReflection.RadioColorField?.getSafe(onDrawInstance) as? AnimationState<*, *>
+    }
+
     fun getCheckColor(onDrawInstance: Any): AnimationState<*, *>? {
         return ComposeReflection.CheckColorField?.getSafe(onDrawInstance) as? AnimationState<*, *>
     }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
@@ -129,21 +129,27 @@ internal class SemanticsUtils(private val reflectionUtils: ReflectionUtils = Ref
         }
 
     internal fun resolveCheckboxFillColor(semanticsNode: SemanticsNode): Long? =
-        resolveReflectedProperty(
+        resolveOnDrawProperty(
             semanticsNode,
-            CheckmarkFieldType.FILL_COLOR
+            OnDrawFieldType.FILL_COLOR
         )
 
     internal fun resolveCheckmarkColor(semanticsNode: SemanticsNode): Long? =
-        resolveReflectedProperty(
+        resolveOnDrawProperty(
             semanticsNode,
-            CheckmarkFieldType.CHECKMARK_COLOR
+            OnDrawFieldType.CHECKMARK_COLOR
+        )
+
+    internal fun resolveRadioButtonColor(semanticsNode: SemanticsNode): Long? =
+        resolveOnDrawProperty(
+            semanticsNode,
+            OnDrawFieldType.RADIO_BUTTON_COLOR
         )
 
     internal fun resolveBorderColor(semanticsNode: SemanticsNode): Long? =
-        resolveReflectedProperty(
+        resolveOnDrawProperty(
             semanticsNode,
-            CheckmarkFieldType.BORDER_COLOR
+            OnDrawFieldType.BORDER_COLOR
         )
 
     private fun shrinkInnerBounds(
@@ -338,19 +344,22 @@ internal class SemanticsUtils(private val reflectionUtils: ReflectionUtils = Ref
         }
     }
 
-    private fun resolveReflectedProperty(semanticsNode: SemanticsNode, fieldType: CheckmarkFieldType): Long? {
+    private fun resolveOnDrawProperty(semanticsNode: SemanticsNode, fieldType: OnDrawFieldType): Long? {
         val onDrawInstance = resolveOnDrawInstance(semanticsNode)
 
         val color = onDrawInstance?.let {
             when (fieldType) {
-                CheckmarkFieldType.FILL_COLOR -> {
+                OnDrawFieldType.FILL_COLOR -> {
                     reflectionUtils.getBoxColor(onDrawInstance)
                 }
-                CheckmarkFieldType.CHECKMARK_COLOR -> {
+                OnDrawFieldType.CHECKMARK_COLOR -> {
                     reflectionUtils.getCheckColor(onDrawInstance)
                 }
-                CheckmarkFieldType.BORDER_COLOR -> {
+                OnDrawFieldType.BORDER_COLOR -> {
                     reflectionUtils.getBorderColor(onDrawInstance)
+                }
+                OnDrawFieldType.RADIO_BUTTON_COLOR -> {
+                    reflectionUtils.getRadioColor(onDrawInstance)
                 }
             }
         }
@@ -361,11 +370,14 @@ internal class SemanticsUtils(private val reflectionUtils: ReflectionUtils = Ref
     }
 
     internal companion object {
-        internal enum class CheckmarkFieldType {
+        internal enum class OnDrawFieldType {
             FILL_COLOR,
             CHECKMARK_COLOR,
-            BORDER_COLOR
+            BORDER_COLOR,
+            RADIO_BUTTON_COLOR
         }
+        internal const val DEFAULT_COLOR_BLACK = "#000000FF"
+        internal const val DEFAULT_COLOR_WHITE = "#FFFFFFFF"
     }
 
     internal fun getProgressBarRangeInfo(semanticsNode: SemanticsNode): ProgressBarRangeInfo? {

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/CheckboxSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/CheckboxSemanticsNodeMapperTest.kt
@@ -18,11 +18,11 @@ import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.CheckboxSemanticsNodeMapper.Companion.BOX_BORDER_WIDTH_DP
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.CheckboxSemanticsNodeMapper.Companion.CHECKBOX_CORNER_RADIUS
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.CheckboxSemanticsNodeMapper.Companion.CHECKBOX_SIZE_DP
-import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.CheckboxSemanticsNodeMapper.Companion.DEFAULT_COLOR_BLACK
-import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.CheckboxSemanticsNodeMapper.Companion.DEFAULT_COLOR_WHITE
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.CheckboxSemanticsNodeMapper.Companion.STROKE_WIDTH_DP
 import com.datadog.android.sessionreplay.compose.internal.utils.ColorUtils
 import com.datadog.android.sessionreplay.compose.internal.utils.PathUtils
+import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils.Companion.DEFAULT_COLOR_BLACK
+import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils.Companion.DEFAULT_COLOR_WHITE
 import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -269,7 +269,7 @@ internal class CheckboxSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest
         // Then
         val foregroundWireframe = semanticsWireframe.wireframes[1] as MobileSegment.Wireframe.ShapeWireframe
         val expectedShapeStyle = MobileSegment.ShapeStyle(
-            backgroundColor = DEFAULT_COLOR_WHITE,
+            backgroundColor = DEFAULT_COLOR_BLACK,
             opacity = 1f,
             cornerRadius = CHECKBOX_CORNER_RADIUS
         )

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SwitchSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SwitchSemanticsNodeMapperTest.kt
@@ -15,11 +15,11 @@ import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.SwitchSemanticsNodeMapper.Companion.BORDER_WIDTH_DP
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.SwitchSemanticsNodeMapper.Companion.CORNER_RADIUS_DP
-import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.SwitchSemanticsNodeMapper.Companion.DEFAULT_COLOR_BLACK
-import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.SwitchSemanticsNodeMapper.Companion.DEFAULT_COLOR_WHITE
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.SwitchSemanticsNodeMapper.Companion.THUMB_DIAMETER_DP
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.SwitchSemanticsNodeMapper.Companion.TRACK_WIDTH_DP
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
+import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils.Companion.DEFAULT_COLOR_BLACK
+import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils.Companion.DEFAULT_COLOR_WHITE
 import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtilsTest.kt
@@ -189,6 +189,23 @@ class SemanticsUtilsTest {
     }
 
     @Test
+    fun `M return radio button fill color W resolveRadioButtonColor`(
+        @IntForgery fakeColorValue: Int
+    ) {
+        // Given
+        val fakeColor = Color(fakeColorValue)
+        val mockAnimationState = mock<AnimationState<*, *>>()
+        whenever(mockReflectionUtils.getRadioColor(mockOnDraw)) doReturn mockAnimationState
+        whenever(mockAnimationState.value).thenReturn(fakeColor)
+
+        // When
+        val result = testedSemanticsUtils.resolveRadioButtonColor(mockSemanticsNode)
+
+        // Then
+        assertThat(result).isEqualTo(fakeColor.value.toLong())
+    }
+
+    @Test
     fun `M return checkmark color W resolveCheckmarkColor`(
         @IntForgery fakeColorValue: Int
     ) {


### PR DESCRIPTION
### What does this PR do?
Adds the correct Jetpack Compose RadioButton color to the mapper. Also adds masking support for RadioButton since it was not part of the original pr that added RadioButton support. 

### Motivation
Part of the support for Jetpack Compose.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

