### PR TITLE
RUM-7472: Fix center crop image is not cropped in wireframe

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -33,7 +33,7 @@ sealed class com.datadog.android.internal.telemetry.InternalTelemetryEvent
     const val REPORTING_SAMPLING_RATE_KEY: String
 fun ByteArray.toHexString(): String
 object com.datadog.android.internal.utils.ImageViewUtils
-  fun resolveParentRectAbsPosition(android.view.View): android.graphics.Rect
+  fun resolveParentRectAbsPosition(android.view.View, Boolean = true): android.graphics.Rect
   fun calculateClipping(android.graphics.Rect, android.graphics.Rect, Float): android.graphics.Rect
   fun resolveContentRectWithScaling(android.widget.ImageView, android.graphics.drawable.Drawable, android.widget.ImageView.ScaleType? = null): android.graphics.Rect
 fun Int.densityNormalized(Float): Int

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -119,7 +119,8 @@ public final class com/datadog/android/internal/utils/ImageViewUtils {
 	public final fun calculateClipping (Landroid/graphics/Rect;Landroid/graphics/Rect;F)Landroid/graphics/Rect;
 	public final fun resolveContentRectWithScaling (Landroid/widget/ImageView;Landroid/graphics/drawable/Drawable;Landroid/widget/ImageView$ScaleType;)Landroid/graphics/Rect;
 	public static synthetic fun resolveContentRectWithScaling$default (Lcom/datadog/android/internal/utils/ImageViewUtils;Landroid/widget/ImageView;Landroid/graphics/drawable/Drawable;Landroid/widget/ImageView$ScaleType;ILjava/lang/Object;)Landroid/graphics/Rect;
-	public final fun resolveParentRectAbsPosition (Landroid/view/View;)Landroid/graphics/Rect;
+	public final fun resolveParentRectAbsPosition (Landroid/view/View;Z)Landroid/graphics/Rect;
+	public static synthetic fun resolveParentRectAbsPosition$default (Lcom/datadog/android/internal/utils/ImageViewUtils;Landroid/view/View;ZILjava/lang/Object;)Landroid/graphics/Rect;
 }
 
 public final class com/datadog/android/internal/utils/IntExtKt {

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/utils/ImageViewUtils.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/utils/ImageViewUtils.kt
@@ -20,17 +20,18 @@ object ImageViewUtils {
     /**
      * Resolves the absolute position on the screen of the given [View].
      * @param view the [View].
+     * @param cropToPadding if the view has cropToPadding as true.
      * @return the [Rect] representing the absolute position of the view.
      */
-    fun resolveParentRectAbsPosition(view: View): Rect {
+    fun resolveParentRectAbsPosition(view: View, cropToPadding: Boolean = true): Rect {
         val coords = IntArray(2)
         // this will always have size >= 2
         @Suppress("UnsafeThirdPartyFunctionCall")
         view.getLocationOnScreen(coords)
-        val leftPadding = view.paddingLeft
-        val rightPadding = view.paddingRight
-        val topPadding = view.paddingTop
-        val bottomPadding = view.paddingBottom
+        val leftPadding = if (cropToPadding) view.paddingLeft else 0
+        val rightPadding = if (cropToPadding) view.paddingRight else 0
+        val topPadding = if (cropToPadding) view.paddingTop else 0
+        val bottomPadding = if (cropToPadding) view.paddingBottom else 0
         return Rect(
             coords[0] + leftPadding,
             coords[1] + topPadding,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ImageViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ImageViewMapper.kt
@@ -76,17 +76,14 @@ open class ImageViewMapper : BaseAsyncBackgroundWireframeMapper<ImageView> {
 
         val drawable = view.drawable?.current ?: return wireframes
 
-        val parentRect = imageViewUtils.resolveParentRectAbsPosition(view)
+        val parentRect = imageViewUtils.resolveParentRectAbsPosition(view, view.cropToPadding)
         val contentRect = imageViewUtils.resolveContentRectWithScaling(view, drawable)
 
         val resources = view.resources
         val density = resources.displayMetrics.density
 
-        val clipping = if (view.cropToPadding) {
+        val clipping =
             imageViewUtils.calculateClipping(parentRect, contentRect, density).toWireframeClip()
-        } else {
-            null
-        }
 
         val contentXPosInDp = contentRect.left.densityNormalized(density).toLong()
         val contentYPosInDp = contentRect.top.densityNormalized(density).toLong()

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ImageViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ImageViewMapperTest.kt
@@ -171,7 +171,9 @@ internal class ImageViewMapperTest {
         whenever(mockBackgroundDrawable.current).thenReturn(mockBackgroundDrawable)
         whenever(mockDrawableToColorMapper.mapDrawableToColor(any(), eq(mockInternalLogger))) doReturn null
 
-        whenever(stubImageViewUtils.resolveParentRectAbsPosition(any())).thenReturn(stubParentRect)
+        whenever(stubImageViewUtils.resolveParentRectAbsPosition(any(), any())).thenReturn(
+            stubParentRect
+        )
         whenever(stubImageViewUtils.resolveContentRectWithScaling(any(), any(), anyOrNull()))
             .thenReturn(stubContentRect)
         whenever(stubImageViewUtils.calculateClipping(any(), any(), any())).thenReturn(stubClipping)

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_allow_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_allow_payload.json
@@ -17,10 +17,22 @@
         "type": "shape"
       },
       {
+        "clip": {
+          "top": 2,
+          "bottom": 3,
+          "left": 0,
+          "right": 0
+        },
         "type": "image",
         "isEmpty": false
       },
       {
+        "clip": {
+          "top": 2,
+          "bottom": 3,
+          "left": 0,
+          "right": 0
+        },
         "type": "image",
         "isEmpty": false
       }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_mask_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_mask_payload.json
@@ -17,10 +17,22 @@
         "type": "shape"
       },
       {
+        "clip": {
+          "top": 2,
+          "bottom": 3,
+          "left": 0,
+          "right": 0
+        },
         "type": "placeholder",
         "label": "Image"
       },
       {
+        "clip": {
+          "top": 2,
+          "bottom": 3,
+          "left": 0,
+          "right": 0
+        },
         "type": "placeholder",
         "label": "Image"
       }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_mask_user_input_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_mask_user_input_payload.json
@@ -17,10 +17,22 @@
         "type": "shape"
       },
       {
+        "clip": {
+          "top": 2,
+          "bottom": 3,
+          "left": 0,
+          "right": 0
+        },
         "type": "image",
         "isEmpty": false
       },
       {
+        "clip": {
+          "top": 2,
+          "bottom": 3,
+          "left": 0,
+          "right": 0
+        },
         "type": "image",
         "isEmpty": false
       }


### PR DESCRIPTION
### What does this PR do?

The bug is introduced by this [PR](https://github.com/DataDog/dd-sdk-android/pull/2372), it fixed the padding issue when cropping the image, but it broke the clip for center crop image when it has cropToPadding as false.

This PR is to fix the problem by differentiate the parent content size by `cropToPadding` attribute, so the clip wireframe can be applied anyway.

### Motivation




### Demo

| Before | After |
| --- | --- |
|<img width="365" alt="image" src="https://github.com/user-attachments/assets/22bd80a8-0938-4073-ae79-1ea2c0475c73" />  |<img width="382" alt="image" src="https://github.com/user-attachments/assets/3835a650-1622-4d5b-8298-ded23f02ebbb" />|

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

