### PR TITLE
Fix KDoc for `RumMonitor#stopSession`

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -317,9 +317,9 @@ interface RumMonitor {
 
     /**
      * Stops the current session.
-     * A new session will start in response to a call to `startView`, `addAction`, or
-     * `startAction`. If the session is started because of a call to `addAction`,
-     * or `startAction`, the last know view is restarted in the new session.
+     * A new session will start in response to a call to [startView], [addAction], or
+     * [startAction]. If the session is started because of a call to [addAction],
+     * or [startAction], the last know view is restarted in the new session.
      */
     fun stopSession()
 


### PR DESCRIPTION
### What does this PR do?

Tiny change to use KDoc-specific syntax to properly reference existing code symbols.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

