### PR TITLE
RUM-8051: Implement Head-based sampling for network instrumentation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -318,6 +318,27 @@ test-pyramid:single-fit-trace:
     reports:
       junit: "**/build/test-results/testReleaseUnitTest/*.xml"
 
+test-pyramid:single-fit-okhttp:
+  tags: [ "arch:amd64" ]
+  image: $CI_IMAGE_DOCKER
+  stage: test-pyramid
+  timeout: 1h
+  cache:
+    key: $CI_COMMIT_REF_SLUG
+    paths:
+      - cache/caches/
+      - cache/notifications/
+    policy: pull
+  script:
+    - rm -rf ~/.gradle/daemon/
+    - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
+    - GRADLE_OPTS="-Xmx3072m" DD_TAGS="test.configuration.variant:release" ./gradlew :reliability:single-fit:okhttp:testReleaseUnitTest --stacktrace --no-daemon --build-cache --gradle-user-home cache/ -Dorg.gradle.jvmargs=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar=$DD_COMMON_AGENT_CONFIG
+  artifacts:
+    when: always
+    expire_in: 1 week
+    reports:
+      junit: "**/build/test-results/testReleaseUnitTest/*.xml"
+
 # RUN INSTRUMENTED TESTS ON MIN API (21), LATEST API (34) and MEDIAN API (28)
 
 test-pyramid:legacy-integration-instrumented-min-api:

--- a/features/dd-sdk-android-trace/src/main/java/com/datadog/legacy/trace/common/sampling/RateByServiceSampler.java
+++ b/features/dd-sdk-android-trace/src/main/java/com/datadog/legacy/trace/common/sampling/RateByServiceSampler.java
@@ -59,7 +59,7 @@ public class RateByServiceSampler implements Sampler, PrioritySampler {
     final boolean priorityWasSet;
 
     if (sampler.sample(span)) {
-      priorityWasSet = span.context().setSamplingPriority(com.datadog.legacy.trace.api.sampling.PrioritySampling.SAMPLER_KEEP);
+      priorityWasSet = span.context().setSamplingPriority(PrioritySampling.SAMPLER_KEEP);
     } else {
       priorityWasSet = span.context().setSamplingPriority(PrioritySampling.SAMPLER_DROP);
     }

--- a/features/dd-sdk-android-trace/src/main/java/com/datadog/opentracing/propagation/DatadogHttpCodec.java
+++ b/features/dd-sdk-android-trace/src/main/java/com/datadog/opentracing/propagation/DatadogHttpCodec.java
@@ -71,9 +71,9 @@ class DatadogHttpCodec {
             // adding the tags
             carrier.put(DATADOG_TAGS_KEY, MOST_SIGNIFICANT_TRACE_ID_KEY + "=" + mostSignificantTraceId);
 
-
-            // always use max sampling priority for Android traces
-            carrier.put(SAMPLING_PRIORITY_KEY, "1");
+            if (context.lockSamplingPriority()) {
+                carrier.put(SAMPLING_PRIORITY_KEY, String.valueOf(context.getSamplingPriority()));
+            }
         }
     }
 

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/OtelTraceWriterTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/OtelTraceWriterTest.kt
@@ -106,7 +106,9 @@ internal class OtelTraceWriterTest {
     @Test
     fun `M write spans W write()`(forge: Forge) {
         // GIVEN
-        val ddSpans = forge.aList { getForgery<DDSpan>() }.toMutableList()
+        val ddSpans = forge.aList { getForgery<DDSpan>() }
+            .filter { it.samplingPriority() !in OtelTraceWriter.DROP_SAMPLING_PRIORITIES }
+            .toMutableList()
         val spanEvents = ddSpans.map { forge.getForgery<SpanEvent>() }
         val serializedSpans = ddSpans.map { forge.aString() }
 
@@ -132,9 +134,29 @@ internal class OtelTraceWriterTest {
     }
 
     @Test
+    fun `M not write spans with drop sampling priority W write()`(forge: Forge) {
+        // GIVEN
+        val ddSpans = forge.aList { getForgery<DDSpan>() }
+            .filter { it.samplingPriority() in OtelTraceWriter.DROP_SAMPLING_PRIORITIES }
+            .toMutableList()
+
+        // WHEN
+        testedWriter.write(ddSpans)
+
+        // THEN
+        verifyNoInteractions(mockEventBatchWriter)
+
+        ddSpans.forEach {
+            it.finish()
+        }
+    }
+
+    @Test
     fun `M not write non-mapped spans W write()`(forge: Forge) {
         // GIVEN
-        val ddSpans = forge.aList { getForgery<DDSpan>() }.toMutableList()
+        val ddSpans = forge.aList { getForgery<DDSpan>() }
+            .filter { it.samplingPriority() !in OtelTraceWriter.DROP_SAMPLING_PRIORITIES }
+            .toMutableList()
         val spanEvents = ddSpans.map { forge.getForgery<SpanEvent>() }
         val mappedEvents = spanEvents.map { forge.aNullable { it } }
 
@@ -168,7 +190,9 @@ internal class OtelTraceWriterTest {
     @Test
     fun `M not write non-serialized spans W write()`(forge: Forge) {
         // GIVEN
-        val ddSpans = forge.aList { getForgery<DDSpan>() }.toMutableList()
+        val ddSpans = forge.aList { getForgery<DDSpan>() }
+            .filter { it.samplingPriority() !in OtelTraceWriter.DROP_SAMPLING_PRIORITIES }
+            .toMutableList()
         val spanEvents = ddSpans.map { forge.getForgery<SpanEvent>() }
 
         val serializedSpans = spanEvents.map { forge.aNullable { aString() } }
@@ -213,7 +237,9 @@ internal class OtelTraceWriterTest {
     @Test
     fun `M log error and proceed W write() { serialization failed }`(forge: Forge) {
         // GIVEN
-        val ddSpans = forge.aList { getForgery<DDSpan>() }.toMutableList()
+        val ddSpans = forge.aList { getForgery<DDSpan>() }
+            .filter { it.samplingPriority() !in OtelTraceWriter.DROP_SAMPLING_PRIORITIES }
+            .toMutableList()
         val spanEvents = ddSpans.map { forge.getForgery<SpanEvent>() }
         val serializedSpans = ddSpans.map { forge.aString() }
 
@@ -261,7 +287,9 @@ internal class OtelTraceWriterTest {
     @Test
     fun `M request event write context once W write()`(forge: Forge) {
         // GIVEN
-        val ddSpans = forge.aList { getForgery<DDSpan>() }.toMutableList()
+        val ddSpans = forge.aList { getForgery<DDSpan>() }
+            .filter { it.samplingPriority() !in OtelTraceWriter.DROP_SAMPLING_PRIORITIES }
+            .toMutableList()
 
         // WHEN
         testedWriter.write(ddSpans)

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/CoreDDSpanForgeryFactory.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/CoreDDSpanForgeryFactory.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.utils.forge
 
 import com.datadog.trace.api.DD128bTraceId
+import com.datadog.trace.api.sampling.PrioritySampling
 import com.datadog.trace.bootstrap.instrumentation.api.AgentSpanLink
 import com.datadog.trace.core.DDSpan
 import com.datadog.trace.core.DDSpanContext
@@ -31,7 +32,13 @@ internal class CoreDDSpanForgeryFactory : ForgeryFactory<DDSpan> {
         val lowOrderTraceId = forge.aLong(min = 0)
         val spanId = forge.aLong(min = 1)
         val parentId = forge.aLong(min = 1)
-        val samplingPriority = forge.anInt()
+        val samplingPriority = forge.anElementFrom(
+            PrioritySampling.UNSET,
+            PrioritySampling.SAMPLER_DROP,
+            PrioritySampling.USER_DROP,
+            PrioritySampling.SAMPLER_KEEP,
+            PrioritySampling.USER_KEEP
+        ).toInt()
         val tagsAndMetrics = tags + metrics
         val mockSpanContext: DDSpanContext = mock {
             whenever(it.baggageItems).thenReturn(baggageItems)

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/DDSpanContextForgeryFactory.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/DDSpanContextForgeryFactory.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.utils.forge
 
+import com.datadog.legacy.trace.api.sampling.PrioritySampling
 import com.datadog.opentracing.DDSpanContext
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
@@ -26,7 +27,13 @@ internal class DDSpanContextForgeryFactory : ForgeryFactory<DDSpanContext> {
         val serviceName = forge.anAlphabeticalString()
         val spanType = forge.anAlphabeticalString()
         val origin = forge.anAlphabeticalString()
-        val samplingPriority = forge.anInt()
+        val samplingPriority = forge.anElementFrom(
+            PrioritySampling.UNSET,
+            PrioritySampling.SAMPLER_DROP,
+            PrioritySampling.USER_DROP,
+            PrioritySampling.SAMPLER_KEEP,
+            PrioritySampling.USER_KEEP
+        )
         val baggageItems = forge.aMap(size = forge.anInt(min = 0, max = 10)) {
             anAlphabeticalString() to anAlphabeticalString()
         }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/SpanForgeryFactory.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/SpanForgeryFactory.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.utils.forge
 
 import com.datadog.legacy.trace.api.Config
+import com.datadog.legacy.trace.api.sampling.PrioritySampling
 import com.datadog.opentracing.DDSpan
 import com.datadog.opentracing.DDTracer
 import com.datadog.opentracing.DDTracer.DDSpanBuilder
@@ -34,6 +35,15 @@ internal class SpanForgeryFactory : ForgeryFactory<DDSpan> {
             isWithErrorFlag,
             tags
         ).start() as DDSpan
+        if (forge.aBool()) {
+            span.samplingPriority = forge.anElementFrom(
+                PrioritySampling.UNSET,
+                PrioritySampling.SAMPLER_DROP,
+                PrioritySampling.USER_DROP,
+                PrioritySampling.SAMPLER_KEEP,
+                PrioritySampling.USER_KEEP
+            )
+        }
         metrics.forEach {
             span.context().setMetric(it.key, it.value)
         }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/opentracing/propagation/DatadogHttpCodecTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/opentracing/propagation/DatadogHttpCodecTest.kt
@@ -8,6 +8,7 @@ package com.datadog.opentracing.propagation
 
 import com.datadog.android.trace.internal.domain.event.BigIntegerUtils
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.legacy.trace.api.sampling.PrioritySampling
 import com.datadog.opentracing.DDSpanContext
 import com.datadog.tools.unit.setFieldValue
 import fr.xgouchet.elmyr.Forge
@@ -89,7 +90,14 @@ internal class DatadogHttpCodecTest {
             headers[DatadogHttpCodec.LEAST_SIGNIFICANT_TRACE_ID_KEY]
         ).isEqualTo(fakeLeastSignificant64BitsTraceId)
         assertThat(headers[DatadogHttpCodec.DATADOG_TAGS_KEY]).isEqualTo(expectedInjectedTags())
-        assertThat(headers[DatadogHttpCodec.SAMPLING_PRIORITY_KEY]).isEqualTo("1")
+        assertThat(headers[DatadogHttpCodec.SAMPLING_PRIORITY_KEY])
+            .let {
+                if (fakeDDSpanContext.samplingPriority != PrioritySampling.UNSET) {
+                    it.isEqualTo(fakeDDSpanContext.samplingPriority.toString())
+                } else {
+                    it.isNull()
+                }
+            }
         assertThat(headers[DatadogHttpCodec.SPAN_ID_KEY])
             .isEqualTo(fakeDDSpanContext.spanId.toString())
         fakeDDSpanContext.baggageItems.forEach { (key, value) ->

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
@@ -146,6 +146,7 @@ internal class DatadogInterceptorWithoutTracesTest {
         whenever(mockSpanBuilder.withOrigin(DatadogInterceptor.ORIGIN_RUM)) doReturn mockSpanBuilder
         whenever(mockSpanBuilder.asChildOf(null as SpanContext?)) doReturn mockSpanBuilder
         whenever(mockSpanBuilder.start()) doReturn mockSpan
+        whenever(mockSpan.samplingPriority) doReturn null
         whenever(mockSpan.context()) doReturn mockSpanContext
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorContextInjectionSampledTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorContextInjectionSampledTest.kt
@@ -10,13 +10,11 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
-import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.okhttp.TraceContext
 import com.datadog.android.okhttp.TraceContextInjection
 import com.datadog.android.okhttp.internal.utils.forge.OkHttpConfigurator
-import com.datadog.android.okhttp.utils.assertj.HeadersAssert.Companion.assertThat
 import com.datadog.android.okhttp.utils.config.DatadogSingletonTestConfiguration
 import com.datadog.android.okhttp.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.okhttp.utils.verifyLog
@@ -306,13 +304,13 @@ internal class TracingInterceptorContextInjectionSampledTest {
         forge: Forge
     ) {
         // Given
-        val datadogContextKey = forge.anElementFrom(
-            TracingInterceptor.DATADOG_TAGS,
+        val datadogContextKeys = listOf(
+            TracingInterceptor.DATADOG_TAGS_HEADER,
             TracingInterceptor.DATADOG_SPAN_ID_HEADER,
             TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER,
+            TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER,
             TracingInterceptor.DATADOG_ORIGIN_HEADER
         )
-        val datadogContextKeyValue = forge.anAlphabeticalString()
         val nonDatadogContextKey = forge.anAlphabeticalString()
         val nonDatadogContextKeyValue = forge.anAlphabeticalString()
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
@@ -324,7 +322,9 @@ internal class TracingInterceptorContextInjectionSampledTest {
         )
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
-            carrier.put(datadogContextKey, datadogContextKeyValue)
+            datadogContextKeys.forEach {
+                carrier.put(it, forge.anAlphaNumericalString())
+            }
             carrier.put(nonDatadogContextKey, nonDatadogContextKeyValue)
         }.whenever(mockTracer).inject<TextMapInject>(any(), any(), any())
         stubChain(mockChain, statusCode)
@@ -339,7 +339,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER))
                 .isNull()
             assertThat(lastValue.header(TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER)).isNull()
-            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SPAN_ID_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.DATADOG_ORIGIN_HEADER)).isNull()
         }
@@ -434,13 +434,13 @@ internal class TracingInterceptorContextInjectionSampledTest {
         forge: Forge
     ) {
         // Given
-        val datadogContextKey = forge.anElementFrom(
-            TracingInterceptor.DATADOG_TAGS,
+        val datadogContext = listOf(
+            TracingInterceptor.DATADOG_TAGS_HEADER,
             TracingInterceptor.DATADOG_SPAN_ID_HEADER,
             TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER,
+            TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER,
             TracingInterceptor.DATADOG_ORIGIN_HEADER
-        )
-        val datadogContextKeyValue = forge.anAlphabeticalString()
+        ).associate { it to forge.anAlphabeticalString() }
         val nonDatadogContextKey = forge.anAlphabeticalString()
         val nonDatadogContextKeyValue = forge.anAlphabeticalString()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -452,7 +452,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
         stubChain(mockChain, statusCode)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
-            carrier.put(datadogContextKey, datadogContextKeyValue)
+            datadogContext.forEach { carrier.put(it.key, it.value) }
             carrier.put(nonDatadogContextKey, nonDatadogContextKeyValue)
         }.whenever(mockTracer).inject<TextMapInject>(any(), any(), any())
 
@@ -463,7 +463,9 @@ internal class TracingInterceptorContextInjectionSampledTest {
         assertThat(response).isSameAs(fakeResponse)
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(lastValue.header(datadogContextKey)).isEqualTo(datadogContextKeyValue)
+            datadogContext.forEach {
+                assertThat(lastValue.header(it.key)).isEqualTo(it.value)
+            }
             assertThat(lastValue.header(nonDatadogContextKey)).isEqualTo(nonDatadogContextKeyValue)
         }
     }
@@ -525,7 +527,11 @@ internal class TracingInterceptorContextInjectionSampledTest {
         assertThat(response).isSameAs(fakeResponse)
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(firstValue.headers(key)).containsOnly(value)
+            if (fakeTraceContext.samplingPriority > 0) {
+                assertThat(firstValue.headers(key)).containsOnly(value)
+            } else {
+                assertThat(firstValue.headers(key)).isEmpty()
+            }
         }
         argumentCaptor<SpanContext>() {
             verify(mockSpanBuilder).asChildOf(capture())
@@ -614,7 +620,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
-        val parentSpanContext: SpanContext = mock()
+        val parentSpanContext: ExtractedContext = mock()
         whenever(mockTracer.extract<TextMapExtract>(any(), any())) doReturn parentSpanContext
         whenever(mockSpanBuilder.asChildOf(any<SpanContext>())) doReturn mockSpanBuilder
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -786,18 +792,17 @@ internal class TracingInterceptorContextInjectionSampledTest {
         forge: Forge
     ) {
         // Given
-        val datadogContextKey = forge.anElementFrom(
-            TracingInterceptor.DATADOG_TAGS,
+        val datadogContext = listOf(
+            TracingInterceptor.DATADOG_TAGS_HEADER,
             TracingInterceptor.DATADOG_SPAN_ID_HEADER,
             TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER,
             TracingInterceptor.DATADOG_ORIGIN_HEADER
-        )
-        val datadogContextKeyValue = forge.anAlphabeticalString()
+        ).associate { it to forge.anAlphabeticalString() }
         val nonDatadogContextKey = forge.anAlphabeticalString()
         val nonDatadogContextKeyValue = forge.anAlphabeticalString()
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
-            carrier.put(datadogContextKey, datadogContextKeyValue)
+            datadogContext.forEach { carrier.put(it.key, it.value) }
             carrier.put(nonDatadogContextKey, nonDatadogContextKeyValue)
         }.whenever(mockTracer).inject<TextMapInject>(any(), any(), any())
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -826,7 +831,9 @@ internal class TracingInterceptorContextInjectionSampledTest {
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER)).isNull()
-            assertThat(lastValue.header(datadogContextKey)).isNull()
+            datadogContext.forEach {
+                assertThat(lastValue.header(it.key)).isNull()
+            }
             assertThat(lastValue.header(nonDatadogContextKey)).isNull()
         }
     }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
@@ -22,6 +22,7 @@ import com.datadog.legacy.trace.api.interceptor.MutableSpan
 import com.datadog.legacy.trace.api.sampling.PrioritySampling
 import com.datadog.opentracing.DDSpanContext
 import com.datadog.opentracing.DDTracer
+import com.datadog.opentracing.propagation.ExtractedContext
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
@@ -270,6 +271,8 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
                 .isEqualTo("0")
             assertThat(lastValue.header(TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SPAN_ID_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_ORIGIN_HEADER)).isNull()
         }
     }
 
@@ -410,6 +413,8 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
                 .isEqualTo("0")
             assertThat(lastValue.header(TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SPAN_ID_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_ORIGIN_HEADER)).isNull()
         }
     }
 
@@ -551,7 +556,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         @IntForgery(min = 200, max = 300) statusCode: Int,
         forge: Forge
     ) {
-        val parentSpanContext: SpanContext = mock()
+        val parentSpanContext: ExtractedContext = mock()
         whenever(mockTracer.extract<TextMapExtract>(any(), any())) doReturn parentSpanContext
         whenever(mockSpanBuilder.asChildOf(any<SpanContext>())) doReturn mockSpanBuilder
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -744,6 +749,8 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
                 .isEqualTo("0")
             assertThat(lastValue.header(TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SPAN_ID_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_ORIGIN_HEADER)).isNull()
         }
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
@@ -10,7 +10,6 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
-import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.okhttp.TraceContextInjection
@@ -22,6 +21,7 @@ import com.datadog.legacy.trace.api.interceptor.MutableSpan
 import com.datadog.legacy.trace.api.sampling.PrioritySampling
 import com.datadog.opentracing.DDSpanContext
 import com.datadog.opentracing.DDTracer
+import com.datadog.opentracing.propagation.ExtractedContext
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
@@ -296,7 +296,8 @@ internal open class TracingInterceptorNonDdTracerTest {
                 .isEqualTo("0")
             assertThat(lastValue.header(TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SPAN_ID_HEADER)).isNull()
-            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_ORIGIN_HEADER)).isNull()
         }
     }
 
@@ -437,7 +438,8 @@ internal open class TracingInterceptorNonDdTracerTest {
                 .isEqualTo("0")
             assertThat(lastValue.header(TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SPAN_ID_HEADER)).isNull()
-            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_ORIGIN_HEADER)).isNull()
         }
     }
 
@@ -649,7 +651,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
-        val parentSpanContext: SpanContext = mock()
+        val parentSpanContext: ExtractedContext = mock()
         whenever(mockTracer.extract<TextMapExtract>(any(), any())) doReturn parentSpanContext
         whenever(mockSpanBuilder.asChildOf(any<SpanContext>())) doReturn mockSpanBuilder
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -860,7 +862,8 @@ internal open class TracingInterceptorNonDdTracerTest {
                 .isEqualTo("0")
             assertThat(lastValue.header(TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SPAN_ID_HEADER)).isNull()
-            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_ORIGIN_HEADER)).isNull()
         }
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
@@ -10,7 +10,6 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
-import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.okhttp.TraceContextInjection
@@ -24,6 +23,7 @@ import com.datadog.legacy.trace.api.interceptor.MutableSpan
 import com.datadog.legacy.trace.api.sampling.PrioritySampling
 import com.datadog.opentracing.DDSpanContext
 import com.datadog.opentracing.DDTracer
+import com.datadog.opentracing.propagation.ExtractedContext
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
@@ -284,8 +284,9 @@ internal open class TracingInterceptorNotSendingSpanTest {
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER))
                 .isEqualTo("0")
             assertThat(lastValue.header(TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER)).isNull()
-            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SPAN_ID_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_ORIGIN_HEADER)).isNull()
         }
     }
 
@@ -407,7 +408,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
             assertThat(lastValue.header(TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SPAN_ID_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.DATADOG_ORIGIN_HEADER)).isNull()
-            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.B3M_SAMPLING_PRIORITY_KEY))
                 .isEqualTo("0")
             assertThat(lastValue.header(TracingInterceptor.B3M_SPAN_ID_KEY)).isNull()
@@ -476,7 +477,8 @@ internal open class TracingInterceptorNotSendingSpanTest {
                 .isEqualTo("0")
             assertThat(lastValue.header(TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SPAN_ID_HEADER)).isNull()
-            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_ORIGIN_HEADER)).isNull()
         }
     }
 
@@ -619,7 +621,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         @IntForgery(min = 200, max = 300) statusCode: Int,
         forge: Forge
     ) {
-        val parentSpanContext: SpanContext = mock()
+        val parentSpanContext: ExtractedContext = mock()
         whenever(mockTracer.extract<TextMapExtract>(any(), any())) doReturn parentSpanContext
         whenever(mockSpanBuilder.asChildOf(any<SpanContext>())) doReturn mockSpanBuilder
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -812,7 +814,8 @@ internal open class TracingInterceptorNotSendingSpanTest {
                 .isEqualTo("0")
             assertThat(lastValue.header(TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SPAN_ID_HEADER)).isNull()
-            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_ORIGIN_HEADER)).isNull()
         }
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
@@ -10,7 +10,6 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
-import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.okhttp.TraceContext
@@ -392,18 +391,17 @@ internal open class TracingInterceptorTest {
         forge: Forge
     ) {
         // Given
-        val datadogContextKey = forge.anElementFrom(
-            TracingInterceptor.DATADOG_TAGS,
+        val datadogContext = listOf(
             TracingInterceptor.DATADOG_SPAN_ID_HEADER,
             TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER,
-            TracingInterceptor.DATADOG_ORIGIN_HEADER
-        )
-        val datadogContextKeyValue = forge.anAlphabeticalString()
+            TracingInterceptor.DATADOG_ORIGIN_HEADER,
+            TracingInterceptor.DATADOG_TAGS_HEADER
+        ).associateWith { forge.anAlphabeticalString() }
         val nonDatadogContextKey = forge.anAlphabeticalString()
         val nonDatadogContextKeyValue = forge.anAlphabeticalString()
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
-            carrier.put(datadogContextKey, datadogContextKeyValue)
+            datadogContext.forEach { carrier.put(it.key, it.value) }
             carrier.put(nonDatadogContextKey, nonDatadogContextKeyValue)
         }.whenever(mockTracer).inject<TextMapInject>(any(), any(), any())
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
@@ -427,7 +425,9 @@ internal open class TracingInterceptorTest {
             verify(mockChain).proceed(capture())
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER))
                 .isEqualTo("0")
-            assertThat(lastValue.header(datadogContextKey)).isEqualTo(datadogContextKeyValue)
+            datadogContext.forEach {
+                assertThat(lastValue.header(it.key)).isEqualTo(it.value)
+            }
             assertThat(lastValue.header(nonDatadogContextKey)).isNull()
             assertThat(lastValue.header(TracingInterceptor.B3M_SAMPLING_PRIORITY_KEY))
                 .isEqualTo("0")
@@ -480,18 +480,17 @@ internal open class TracingInterceptorTest {
         forge: Forge
     ) {
         // Given
-        val datadogContextKey = forge.anElementFrom(
-            TracingInterceptor.DATADOG_TAGS,
+        val datadogContext = listOf(
+            TracingInterceptor.DATADOG_TAGS_HEADER,
             TracingInterceptor.DATADOG_SPAN_ID_HEADER,
             TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER,
             TracingInterceptor.DATADOG_ORIGIN_HEADER
-        )
-        val datadogContextKeyValue = forge.anAlphabeticalString()
+        ).associateWith { forge.anAlphabeticalString() }
         val nonDatadogContextKey = forge.anAlphabeticalString()
         val nonDatadogContextKeyValue = forge.anAlphabeticalString()
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
-            carrier.put(datadogContextKey, datadogContextKeyValue)
+            datadogContext.forEach { carrier.put(it.key, it.value) }
             carrier.put(nonDatadogContextKey, nonDatadogContextKeyValue)
         }.whenever(mockTracer).inject<TextMapInject>(any(), any(), any())
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
@@ -509,7 +508,9 @@ internal open class TracingInterceptorTest {
             verify(mockChain).proceed(capture())
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER))
                 .isEqualTo("0")
-            assertThat(lastValue.header(datadogContextKey)).isEqualTo(datadogContextKeyValue)
+            datadogContext.forEach {
+                assertThat(lastValue.header(it.key)).isEqualTo(it.value)
+            }
             assertThat(lastValue.header(nonDatadogContextKey)).isNull()
         }
     }
@@ -643,7 +644,7 @@ internal open class TracingInterceptorTest {
                 .isEqualTo("0")
             assertThat(lastValue.header(TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.DATADOG_ORIGIN_HEADER)).isNull()
-            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SPAN_ID_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.B3M_SAMPLING_PRIORITY_KEY))
                 .isEqualTo("0")
@@ -672,8 +673,8 @@ internal open class TracingInterceptorTest {
         @IntForgery(min = 200, max = 300) statusCode: Int,
         forge: Forge
     ) {
-        val parentSpan: Span = mock()
-        val parentSpanContext: SpanContext = mock()
+        val parentSpan = mock<Span>()
+        val parentSpanContext = mock<ExtractedContext>()
         whenever(parentSpan.context()) doReturn parentSpanContext
         whenever(mockSpanBuilder.asChildOf(parentSpanContext)) doReturn mockSpanBuilder
         fakeRequest = forgeRequest(forge) { it.tag(Span::class.java, parentSpan) }
@@ -722,7 +723,11 @@ internal open class TracingInterceptorTest {
         assertThat(response).isSameAs(fakeResponse)
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(firstValue.headers(key)).containsOnly(value)
+            if (fakeTraceContext.samplingPriority > 0) {
+                assertThat(firstValue.headers(key)).containsOnly(value)
+            } else {
+                assertThat(firstValue.headers(key)).isEmpty()
+            }
         }
         argumentCaptor<SpanContext>() {
             verify(mockSpanBuilder).asChildOf(capture())
@@ -811,7 +816,7 @@ internal open class TracingInterceptorTest {
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
-        val parentSpanContext: SpanContext = mock()
+        val parentSpanContext: ExtractedContext = mock()
         whenever(mockTracer.extract<TextMapExtract>(any(), any())) doReturn parentSpanContext
         whenever(mockSpanBuilder.asChildOf(any<SpanContext>())) doReturn mockSpanBuilder
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -1004,7 +1009,8 @@ internal open class TracingInterceptorTest {
                 .isEqualTo("0")
             assertThat(lastValue.header(TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER)).isNull()
             assertThat(lastValue.header(TracingInterceptor.DATADOG_SPAN_ID_HEADER)).isNull()
-            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_TAGS_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.DATADOG_ORIGIN_HEADER)).isNull()
         }
     }
 

--- a/reliability/single-fit/okhttp/build.gradle.kts
+++ b/reliability/single-fit/okhttp/build.gradle.kts
@@ -1,0 +1,70 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+import com.datadog.gradle.config.androidLibraryConfig
+import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.javadocConfig
+import com.datadog.gradle.config.junitConfig
+import com.datadog.gradle.config.kotlinConfig
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    // Build
+    id("com.android.library")
+    kotlin("android")
+    id("com.google.devtools.ksp")
+
+    // Analysis tools
+    id("com.github.ben-manes.versions")
+
+    // Tests
+    id("de.mobilej.unmock")
+}
+
+android {
+    namespace = "com.datadog.android.okhttp.integration"
+}
+
+dependencies {
+    implementation(project(":features:dd-sdk-android-trace"))
+    implementation(project(":features:dd-sdk-android-trace-otel"))
+    implementation(project(":integrations:dd-sdk-android-okhttp"))
+    implementation(project(":integrations:dd-sdk-android-okhttp-otel"))
+    implementation(libs.kotlin)
+
+    // Testing
+    testImplementation(project(":tools:unit")) {
+        attributes {
+            attribute(
+                com.android.build.api.attributes.ProductFlavorAttr.of("platform"),
+                objects.named("jvm")
+            )
+        }
+    }
+    testImplementation(testFixtures(project(":dd-sdk-android-core")))
+    testImplementation(project(":reliability:stub-core"))
+    testImplementation(libs.bundles.jUnit5)
+    testImplementation(libs.bundles.testTools)
+    testImplementation(libs.okHttp)
+    testImplementation(libs.okHttpMock)
+    testImplementation(libs.gson)
+    unmock(libs.robolectric)
+}
+
+unMock {
+    keep("android.util.Singleton")
+    keep("com.android.internal.util.FastPrintWriter")
+    keep("dalvik.system.BlockGuard")
+    keep("dalvik.system.CloseGuard")
+    keepStartingWith("android.os")
+    keepStartingWith("org.json")
+}
+
+androidLibraryConfig()
+kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+junitConfig()
+javadocConfig()
+dependencyUpdateConfig()

--- a/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/HeadBasedSamplingTest.kt
+++ b/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/HeadBasedSamplingTest.kt
@@ -1,0 +1,670 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.okhttp
+
+import com.datadog.android.Datadog
+import com.datadog.android.api.SdkCore
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.core.internal.utils.toHexString
+import com.datadog.android.core.stub.StubSDKCore
+import com.datadog.android.okhttp.otel.addParentSpan
+import com.datadog.android.okhttp.tests.assertj.SpansPayloadAssert
+import com.datadog.android.okhttp.tests.elmyr.OkHttpConfigurator
+import com.datadog.android.okhttp.trace.TracingInterceptor
+import com.datadog.android.okhttp.trace.parentSpan
+import com.datadog.android.tests.ktx.getString
+import com.datadog.android.trace.AndroidTracer
+import com.datadog.android.trace.Trace
+import com.datadog.android.trace.TraceConfiguration
+import com.datadog.android.trace.TracingHeaderType
+import com.datadog.android.trace.opentelemetry.OtelTracerProvider
+import com.datadog.legacy.trace.api.sampling.PrioritySampling
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.getFieldValue
+import com.datadog.tools.unit.getStaticValue
+import com.datadog.tools.unit.setStaticValue
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.opentracing.propagation.Format
+import io.opentracing.propagation.TextMapInject
+import io.opentracing.util.GlobalTracer
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@ForgeConfiguration(OkHttpConfigurator::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class HeadBasedSamplingTest {
+
+    private lateinit var stubSdkCore: StubSDKCore
+    private lateinit var mockServer: MockWebServer
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        stubSdkCore = StubSDKCore(forge)
+        val registry: Any = Datadog::class.java.getStaticValue("registry")
+        val instances: MutableMap<String, SdkCore> = registry.getFieldValue("instances")
+        instances += stubSdkCore.name to stubSdkCore
+        mockServer = MockWebServer()
+
+        val fakeTraceConfiguration = TraceConfiguration.Builder().build()
+        Trace.enable(fakeTraceConfiguration, stubSdkCore)
+    }
+
+    @AfterEach
+    fun `tear down`() {
+        unregisterGlobalTracer()
+        Datadog.stopInstance(stubSdkCore.name)
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `M use network sampling rate W call is made { no parent context }`(forge: Forge) {
+        // Given
+        if (forge.aBool()) {
+            // outcome should be the same for cases where there is GlobalTracer and when local tracer is used
+            registerGlobalTracer(0.0)
+        }
+
+        mockServer.enqueue(MockResponse())
+        mockServer.start()
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor(
+                TracingInterceptor.Builder(
+                    tracedHostsWithHeaderType = mapOf(mockServer.hostName to setOf(TracingHeaderType.DATADOG))
+                )
+                    .setTraceContextInjection(TraceContextInjection.All)
+                    .setSdkInstanceName(stubSdkCore.name)
+                    .setTraceSampleRate(100f)
+                    .build()
+            )
+            .build()
+
+        // When
+        okHttpClient.newCall(
+            Request.Builder()
+                .url(mockServer.url("/"))
+                .build()
+        ).execute()
+
+        // Then
+        val requestSent = mockServer.takeRequest()
+        assertThat(requestSent.getHeader(DATADOG_SAMPLING_PRIORITY_HEADER)).isEqualTo("1")
+        val leastSignificantTraceId = requestSent.getHeader(DATADOG_TRACE_ID_HEADER)
+        checkNotNull(leastSignificantTraceId)
+        val spanId = requestSent.getHeader(DATADOG_SPAN_ID_HEADER)
+        checkNotNull(spanId)
+        val datadogTags = requestSent.getHeader(DATADOG_TAGS_HEADER)
+            ?.toTags()
+        checkNotNull(datadogTags)
+        assertThat(datadogTags).isNotEmpty
+        assertThat(datadogTags).containsKey(MOST_SIGNIFICANT_TRACE_ID_KEY)
+        val mostSignificantTraceId = datadogTags.getValue(MOST_SIGNIFICANT_TRACE_ID_KEY)
+
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.TRACING_FEATURE_NAME)
+        assertThat(eventsWritten).hasSize(1)
+
+        val spanPayload = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
+        SpansPayloadAssert.assertThat(spanPayload)
+            .hasEnv(stubSdkCore.getDatadogContext().env)
+            .hasSpanAtIndexWith(0) {
+                hasLeastSignificant64BitsTraceId(
+                    leastSignificantTraceId.toLong().toHexString().padStart(16, '0')
+                )
+                hasMostSignificant64BitsTraceId(mostSignificantTraceId)
+                hasSpanId(spanId.toLong().toHexString())
+                hasVersion(stubSdkCore.getDatadogContext().version)
+                hasSource(stubSdkCore.getDatadogContext().source)
+                hasTracerVersion(stubSdkCore.getDatadogContext().sdkVersion)
+                hasError(0)
+                hasName("okhttp.request")
+                hasResource("http://${mockServer.hostName}:${mockServer.port}/")
+                hasAgentPsr(1.0)
+                hasSamplingPriority(1)
+                hasGenericMetricValue("_top_level", 1)
+                hasSpanKind("client")
+                hasHttpMethod("GET")
+                hasHttpUrl("http://${mockServer.hostName}:${mockServer.port}/")
+                hasHttpStatusCode(200)
+            }
+    }
+
+    @Test
+    fun `M calculate PSR rate W call is made { no parent context }`(forge: Forge) {
+        // Given
+        if (forge.aBool()) {
+            // outcome should be the same for cases where there is GlobalTracer and when local tracer is used
+            registerGlobalTracer(0.0)
+        }
+
+        mockServer.start()
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor(
+                TracingInterceptor.Builder(
+                    tracedHostsWithHeaderType = mapOf(mockServer.hostName to setOf(TracingHeaderType.DATADOG))
+                )
+                    .setTraceContextInjection(TraceContextInjection.All)
+                    .setSdkInstanceName(stubSdkCore.name)
+                    .setTraceSampleRate(50f)
+                    .build()
+            )
+            .build()
+
+        // When
+
+        repeat(10) {
+            mockServer.enqueue(MockResponse())
+            okHttpClient.newCall(
+                Request.Builder()
+                    .url(mockServer.url("/"))
+                    .build()
+            ).execute()
+        }
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.TRACING_FEATURE_NAME)
+        eventsWritten.forEach {
+            val spanPayload = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
+            SpansPayloadAssert.assertThat(spanPayload)
+                .hasEnv(stubSdkCore.getDatadogContext().env)
+                .hasSpanAtIndexWith(0) {
+                    hasAgentPsr(0.5)
+                }
+        }
+    }
+
+    @Test
+    fun `M respect parent sampling decision W call is made { parent context = OpenTracing Span, parent not sampled }`(
+        @StringForgery fakeSpanName: String
+    ) {
+        // Given
+        registerGlobalTracer(0.0)
+
+        mockServer.enqueue(MockResponse())
+        mockServer.start()
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor(
+                TracingInterceptor.Builder(
+                    tracedHostsWithHeaderType = mapOf(mockServer.hostName to setOf(TracingHeaderType.DATADOG))
+                )
+                    .setTraceContextInjection(TraceContextInjection.All)
+                    .setSdkInstanceName(stubSdkCore.name)
+                    .setTraceSampleRate(100f)
+                    .build()
+            )
+            .build()
+
+        val parentSpan = GlobalTracer.get()
+            .buildSpan(fakeSpanName)
+            .start()
+
+        // When
+        okHttpClient.newCall(
+            Request.Builder()
+                .url(mockServer.url("/"))
+                .parentSpan(parentSpan)
+                .build()
+        ).execute()
+        parentSpan.finish()
+
+        // Then
+        val requestSent = mockServer.takeRequest()
+        assertThat(requestSent.getHeader(DATADOG_SAMPLING_PRIORITY_HEADER)).isEqualTo("0")
+        assertThat(requestSent.getHeader(DATADOG_TRACE_ID_HEADER)).isNotEmpty()
+        assertThat(requestSent.getHeader(DATADOG_SPAN_ID_HEADER)).isNotEmpty()
+        assertThat(requestSent.getHeader(DATADOG_TAGS_HEADER)).isNotEmpty()
+
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.TRACING_FEATURE_NAME)
+        assertThat(eventsWritten).isEmpty()
+    }
+
+    @Test
+    fun `M respect parent sampling decision W call is made { parent context = OpenTelemetry Span, parent not sampled }`(
+        @StringForgery fakeInstrumentationName: String,
+        @StringForgery fakeSpanName: String
+    ) {
+        // Given
+        val otelTracer = OtelTracerProvider.Builder(stubSdkCore)
+            .setTracingHeaderTypes(setOf(TracingHeaderType.DATADOG))
+            .setSampleRate(0.0)
+            .build()
+
+        mockServer.enqueue(MockResponse())
+        mockServer.start()
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor(
+                TracingInterceptor.Builder(
+                    tracedHostsWithHeaderType = mapOf(mockServer.hostName to setOf(TracingHeaderType.DATADOG))
+                )
+                    .setTraceContextInjection(TraceContextInjection.All)
+                    .setSdkInstanceName(stubSdkCore.name)
+                    .setTraceSampleRate(100f)
+                    .build()
+            )
+            .build()
+
+        val parentSpan = otelTracer.get(fakeInstrumentationName)
+            .spanBuilder(fakeSpanName)
+            .startSpan()
+
+        // When
+        okHttpClient.newCall(
+            Request.Builder()
+                .url(mockServer.url("/"))
+                .addParentSpan(parentSpan)
+                .build()
+        ).execute()
+        parentSpan.end()
+
+        // Then
+        val requestSent = mockServer.takeRequest()
+        assertThat(requestSent.getHeader(DATADOG_SAMPLING_PRIORITY_HEADER)).isEqualTo("0")
+        assertThat(requestSent.getHeader(DATADOG_TRACE_ID_HEADER)).isNotEmpty()
+        assertThat(requestSent.getHeader(DATADOG_SPAN_ID_HEADER)).isNotEmpty()
+        assertThat(requestSent.getHeader(DATADOG_TAGS_HEADER)).isNotEmpty()
+
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.TRACING_FEATURE_NAME)
+        assertThat(eventsWritten).isEmpty()
+    }
+
+    @Test
+    fun `M respect parent sampling decision W call is made { parent context = OpenTracing Span, parent sampled }`(
+        @StringForgery fakeSpanName: String
+    ) {
+        // Given
+        registerGlobalTracer(100.0)
+
+        mockServer.enqueue(MockResponse())
+        mockServer.start()
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor(
+                TracingInterceptor.Builder(
+                    tracedHostsWithHeaderType = mapOf(mockServer.hostName to setOf(TracingHeaderType.DATADOG))
+                )
+                    .setTraceContextInjection(TraceContextInjection.All)
+                    .setSdkInstanceName(stubSdkCore.name)
+                    .setTraceSampleRate(0f)
+                    .build()
+            )
+            .build()
+
+        val parentSpan = GlobalTracer.get()
+            .buildSpan(fakeSpanName)
+            .start()
+
+        // When
+        okHttpClient.newCall(
+            Request.Builder()
+                .url(mockServer.url("/"))
+                .parentSpan(parentSpan)
+                .build()
+        ).execute()
+        parentSpan.finish()
+
+        // Then
+        val requestSent = mockServer.takeRequest()
+        assertThat(requestSent.getHeader(DATADOG_SAMPLING_PRIORITY_HEADER)).isEqualTo("1")
+        val leastSignificantTraceId = requestSent.getHeader(DATADOG_TRACE_ID_HEADER)
+        checkNotNull(leastSignificantTraceId)
+        val spanId = requestSent.getHeader(DATADOG_SPAN_ID_HEADER)
+        checkNotNull(spanId)
+        val datadogTags = requestSent.getHeader(DATADOG_TAGS_HEADER)
+            ?.toTags()
+        checkNotNull(datadogTags)
+        assertThat(datadogTags).isNotEmpty
+        assertThat(datadogTags).containsKey(MOST_SIGNIFICANT_TRACE_ID_KEY)
+        val mostSignificantTraceId = datadogTags.getValue(MOST_SIGNIFICANT_TRACE_ID_KEY)
+
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.TRACING_FEATURE_NAME)
+        assertThat(eventsWritten).hasSize(2)
+
+        val localSpanPayload = JsonParser.parseString(eventsWritten[0].eventData).asJsonObject
+        SpansPayloadAssert.assertThat(localSpanPayload)
+            .hasSpanAtIndexWith(0) {
+                hasLeastSignificant64BitsTraceId(
+                    leastSignificantTraceId.toLong().toHexString().padStart(16, '0')
+                )
+                hasMostSignificant64BitsTraceId(mostSignificantTraceId)
+                hasParentId("0")
+                hasAgentPsr(1.0)
+                hasSamplingPriority(PrioritySampling.SAMPLER_KEEP)
+                hasGenericMetricValue("_top_level", 1)
+            }
+
+        val localSpanId = localSpanPayload.getAsJsonArray("spans")
+            .first()
+            .asJsonObject
+            .getString("span_id")
+            .orEmpty()
+
+        val okHttpSpanPayload = JsonParser.parseString(eventsWritten[1].eventData) as JsonObject
+        SpansPayloadAssert.assertThat(okHttpSpanPayload)
+            .hasEnv(stubSdkCore.getDatadogContext().env)
+            .hasSpanAtIndexWith(0) {
+                hasLeastSignificant64BitsTraceId(
+                    leastSignificantTraceId.toLong().toHexString().padStart(16, '0')
+                )
+                hasMostSignificant64BitsTraceId(mostSignificantTraceId)
+                hasSpanId(spanId.toLong().toHexString())
+                hasParentId(localSpanId)
+                hasVersion(stubSdkCore.getDatadogContext().version)
+                hasSource(stubSdkCore.getDatadogContext().source)
+                hasTracerVersion(stubSdkCore.getDatadogContext().sdkVersion)
+                hasError(0)
+                hasName("okhttp.request")
+                hasResource("http://${mockServer.hostName}:${mockServer.port}/")
+                hasNoAgentPsr()
+                hasNoSamplingPriority()
+                hasNoGenericMetric("_top_level")
+                hasSpanKind("client")
+                hasHttpMethod("GET")
+                hasHttpUrl("http://${mockServer.hostName}:${mockServer.port}/")
+                hasHttpStatusCode(200)
+            }
+    }
+
+    @Test
+    fun `M respect parent sampling decision W call is made { parent context = OpenTelemetry Span, parent sampled }`(
+        @StringForgery fakeInstrumentationName: String,
+        @StringForgery fakeSpanName: String
+    ) {
+        // Given
+        val otelTracerProvider = OtelTracerProvider.Builder(stubSdkCore)
+            .setTracingHeaderTypes(setOf(TracingHeaderType.DATADOG))
+            .setSampleRate(100.0)
+            .build()
+
+        mockServer.enqueue(MockResponse())
+        mockServer.start()
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor(
+                TracingInterceptor.Builder(
+                    tracedHostsWithHeaderType = mapOf(mockServer.hostName to setOf(TracingHeaderType.DATADOG))
+                )
+                    .setTraceContextInjection(TraceContextInjection.All)
+                    .setSdkInstanceName(stubSdkCore.name)
+                    .setTraceSampleRate(0f)
+                    .build()
+            )
+            .build()
+
+        val parentSpan = otelTracerProvider.get(fakeInstrumentationName)
+            .spanBuilder(fakeSpanName)
+            .startSpan()
+
+        // When
+        okHttpClient.newCall(
+            Request.Builder()
+                .url(mockServer.url("/"))
+                .addParentSpan(parentSpan)
+                .build()
+        ).execute()
+        parentSpan.end()
+
+        // Then
+        val requestSent = mockServer.takeRequest()
+        assertThat(requestSent.getHeader(DATADOG_SAMPLING_PRIORITY_HEADER)).isEqualTo("2")
+        val leastSignificantTraceId = requestSent.getHeader(DATADOG_TRACE_ID_HEADER)
+        checkNotNull(leastSignificantTraceId)
+        val spanId = requestSent.getHeader(DATADOG_SPAN_ID_HEADER)
+        checkNotNull(spanId)
+        val datadogTags = requestSent.getHeader(DATADOG_TAGS_HEADER)
+            ?.toTags()
+        checkNotNull(datadogTags)
+        assertThat(datadogTags).isNotEmpty
+        assertThat(datadogTags).containsKey(MOST_SIGNIFICANT_TRACE_ID_KEY)
+        val mostSignificantTraceId = datadogTags.getValue(MOST_SIGNIFICANT_TRACE_ID_KEY)
+
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.TRACING_FEATURE_NAME)
+        assertThat(eventsWritten).hasSize(2)
+
+        val localSpanPayload = JsonParser.parseString(eventsWritten[1].eventData).asJsonObject
+        SpansPayloadAssert.assertThat(localSpanPayload)
+            .hasSpanAtIndexWith(0) {
+                hasLeastSignificant64BitsTraceId(
+                    leastSignificantTraceId.toLong().toHexString().padStart(16, '0')
+                )
+                hasMostSignificant64BitsTraceId(mostSignificantTraceId)
+                hasParentId("0000000000000000")
+                // OpenTelemetry span will have _dd.rule_psr instead of _dd.agent_psr
+                hasRulePsr(1.0)
+                hasSamplingPriority(PrioritySampling.USER_KEEP)
+                hasGenericMetricValue("_top_level", 1)
+            }
+
+        val localSpanId = localSpanPayload.getAsJsonArray("spans")
+            .first()
+            .asJsonObject
+            .getString("span_id")
+            .orEmpty()
+
+        val okHttpSpanPayload = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
+        SpansPayloadAssert.assertThat(okHttpSpanPayload)
+            .hasEnv(stubSdkCore.getDatadogContext().env)
+            .hasSpanAtIndexWith(0) {
+                hasLeastSignificant64BitsTraceId(
+                    leastSignificantTraceId.toLong().toHexString().padStart(16, '0')
+                )
+                hasMostSignificant64BitsTraceId(mostSignificantTraceId)
+                hasSpanId(spanId.toLong().toHexString())
+                hasParentId(localSpanId)
+                hasVersion(stubSdkCore.getDatadogContext().version)
+                hasSource(stubSdkCore.getDatadogContext().source)
+                hasTracerVersion(stubSdkCore.getDatadogContext().sdkVersion)
+                hasError(0)
+                hasName("okhttp.request")
+                hasResource("http://${mockServer.hostName}:${mockServer.port}/")
+                hasNoAgentPsr()
+                hasSamplingPriority(PrioritySampling.USER_KEEP)
+                hasNoGenericMetric("_top_level")
+                hasSpanKind("client")
+                hasHttpMethod("GET")
+                hasHttpUrl("http://${mockServer.hostName}:${mockServer.port}/")
+                hasHttpStatusCode(200)
+            }
+    }
+
+    @Test
+    fun `M respect parent sampling decision W call is made {parent context = headers, parent not sampled}`(
+        @StringForgery fakeSpanName: String
+    ) {
+        // Given
+        registerGlobalTracer(0.0)
+
+        mockServer.enqueue(MockResponse())
+        mockServer.start()
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor(
+                TracingInterceptor.Builder(
+                    tracedHostsWithHeaderType = mapOf(mockServer.hostName to setOf(TracingHeaderType.DATADOG))
+                )
+                    .setTraceContextInjection(TraceContextInjection.All)
+                    .setSdkInstanceName(stubSdkCore.name)
+                    .setTraceSampleRate(100f)
+                    .build()
+            )
+            .build()
+
+        val parentSpan = GlobalTracer.get()
+            .buildSpan(fakeSpanName)
+            .start()
+
+        // When
+        okHttpClient.newCall(
+            Request.Builder()
+                .url(mockServer.url("/"))
+                .apply {
+                    GlobalTracer.get().inject(
+                        parentSpan.context(),
+                        Format.Builtin.TEXT_MAP_INJECT,
+                        TextMapInject { key, value -> addHeader(key, value) }
+                    )
+                }
+                .build()
+        ).execute()
+        parentSpan.finish()
+
+        // Then
+        val requestSent = mockServer.takeRequest()
+        assertThat(requestSent.getHeader(DATADOG_SAMPLING_PRIORITY_HEADER)).isEqualTo("0")
+        assertThat(requestSent.getHeader(DATADOG_TRACE_ID_HEADER)).isNotEmpty()
+        assertThat(requestSent.getHeader(DATADOG_SPAN_ID_HEADER)).isNotEmpty()
+        assertThat(requestSent.getHeader(DATADOG_TAGS_HEADER)).isNotEmpty()
+
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.TRACING_FEATURE_NAME)
+        assertThat(eventsWritten).isEmpty()
+    }
+
+    @Test
+    fun `M respect parent sampling decision W call is made { parent context=headers, parent sampled }`(
+        @StringForgery fakeSpanName: String
+    ) {
+        // Given
+        registerGlobalTracer(100.0)
+
+        mockServer.enqueue(MockResponse())
+        mockServer.start()
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor(
+                TracingInterceptor.Builder(
+                    tracedHostsWithHeaderType = mapOf(mockServer.hostName to setOf(TracingHeaderType.DATADOG))
+                )
+                    .setTraceContextInjection(TraceContextInjection.All)
+                    .setSdkInstanceName(stubSdkCore.name)
+                    .setTraceSampleRate(100f)
+                    .build()
+            )
+            .build()
+
+        val parentSpan = GlobalTracer.get()
+            .buildSpan(fakeSpanName)
+            .start()
+
+        // When
+        okHttpClient.newCall(
+            Request.Builder()
+                .url(mockServer.url("/"))
+                .apply {
+                    GlobalTracer.get().inject(
+                        parentSpan.context(),
+                        Format.Builtin.TEXT_MAP_INJECT,
+                        TextMapInject { key, value -> addHeader(key, value) }
+                    )
+                }
+                .build()
+        ).execute()
+        parentSpan.finish()
+
+        // Then
+        val requestSent = mockServer.takeRequest()
+        assertThat(requestSent.getHeader(DATADOG_SAMPLING_PRIORITY_HEADER)).isEqualTo("1")
+        val leastSignificantTraceId = requestSent.getHeader(DATADOG_TRACE_ID_HEADER)
+        checkNotNull(leastSignificantTraceId)
+        val spanId = requestSent.getHeader(DATADOG_SPAN_ID_HEADER)
+        checkNotNull(spanId)
+        val datadogTags = requestSent.getHeader(DATADOG_TAGS_HEADER)
+            ?.toTags()
+        checkNotNull(datadogTags)
+        assertThat(datadogTags).isNotEmpty
+        assertThat(datadogTags).containsKey(MOST_SIGNIFICANT_TRACE_ID_KEY)
+        val mostSignificantTraceId = datadogTags.getValue(MOST_SIGNIFICANT_TRACE_ID_KEY)
+
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.TRACING_FEATURE_NAME)
+        assertThat(eventsWritten).hasSize(2)
+
+        val localSpanPayload = JsonParser.parseString(eventsWritten[1].eventData).asJsonObject
+        SpansPayloadAssert.assertThat(localSpanPayload)
+            .hasSpanAtIndexWith(0) {
+                hasLeastSignificant64BitsTraceId(
+                    leastSignificantTraceId.toLong().toHexString().padStart(16, '0')
+                )
+                hasMostSignificant64BitsTraceId(mostSignificantTraceId)
+                hasParentId("0")
+                hasAgentPsr(1.0)
+                hasSamplingPriority(PrioritySampling.SAMPLER_KEEP)
+                hasGenericMetricValue("_top_level", 1)
+            }
+
+        val localSpanId = localSpanPayload.getAsJsonArray("spans")
+            .first()
+            .asJsonObject
+            .getString("span_id")
+            .orEmpty()
+
+        val okHttpSpanPayload = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
+        SpansPayloadAssert.assertThat(okHttpSpanPayload)
+            .hasEnv(stubSdkCore.getDatadogContext().env)
+            .hasSpanAtIndexWith(0) {
+                hasLeastSignificant64BitsTraceId(
+                    leastSignificantTraceId.toLong().toHexString().padStart(16, '0')
+                )
+                hasMostSignificant64BitsTraceId(mostSignificantTraceId)
+                hasSpanId(spanId.toLong().toHexString())
+                hasParentId(localSpanId)
+                hasVersion(stubSdkCore.getDatadogContext().version)
+                hasSource(stubSdkCore.getDatadogContext().source)
+                hasTracerVersion(stubSdkCore.getDatadogContext().sdkVersion)
+                hasError(0)
+                hasName("okhttp.request")
+                hasResource("http://${mockServer.hostName}:${mockServer.port}/")
+                hasNoAgentPsr()
+                // this one will have sampling priority unlike in case of propagation with tagged Span directly,
+                // because there sampling priority is not yet set at the parent during child creation
+                hasSamplingPriority(1)
+                hasNoGenericMetric("_top_level")
+                hasSpanKind("client")
+                hasHttpMethod("GET")
+                hasHttpUrl("http://${mockServer.hostName}:${mockServer.port}/")
+                hasHttpStatusCode(200)
+            }
+    }
+
+    private fun registerGlobalTracer(sampleRate: Double) {
+        GlobalTracer.registerIfAbsent(
+            AndroidTracer.Builder(stubSdkCore)
+                .setTracingHeaderTypes(setOf(TracingHeaderType.DATADOG))
+                // this is on purpose, we want to make sure that it is not taken into account
+                .setSampleRate(sampleRate)
+                .build()
+        )
+    }
+
+    private fun unregisterGlobalTracer() {
+        GlobalTracer::class.java.setStaticValue("isRegistered", false)
+    }
+
+    private fun String.toTags(): Map<String, String> = split(",")
+        .associate { it.split("=").let { it[0] to it[1] } }
+
+    companion object {
+        private const val DATADOG_TRACE_ID_HEADER = "x-datadog-trace-id"
+        private const val DATADOG_TAGS_HEADER = "x-datadog-tags"
+        private const val DATADOG_SPAN_ID_HEADER = "x-datadog-parent-id"
+        private const val DATADOG_SAMPLING_PRIORITY_HEADER = "x-datadog-sampling-priority"
+
+        private const val MOST_SIGNIFICANT_TRACE_ID_KEY = "_dd.p.tid"
+    }
+}

--- a/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/tests/assertj/SpansPayloadAssert.kt
+++ b/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/tests/assertj/SpansPayloadAssert.kt
@@ -1,0 +1,471 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.okhttp.tests.assertj
+
+import com.datadog.android.tests.ktx.getAtPath
+import com.datadog.android.tests.ktx.getDouble
+import com.datadog.android.tests.ktx.getInt
+import com.datadog.android.tests.ktx.getLong
+import com.datadog.android.tests.ktx.getString
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import org.assertj.core.api.AbstractObjectAssert
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import java.util.Locale
+
+internal class SpansPayloadAssert(actual: JsonObject) :
+    AbstractObjectAssert<SpansPayloadAssert, JsonObject>(actual, SpansPayloadAssert::class.java) {
+
+    private val spans = actual.getAsJsonArray(SPANS_KEY)
+
+    fun hasEnv(env: String): SpansPayloadAssert {
+        assertThat(actual.getString(ENV_KEY)).overridingErrorMessage(
+            "Expected env to be $env but was ${actual.getString(ENV_KEY)}"
+        ).isEqualTo(env)
+        return this
+    }
+
+    fun hasSpanAtIndexWith(index: Int, block: SpanAssert.() -> Unit): SpansPayloadAssert {
+        SpanAssert(spans.get(index).asJsonObject, index).block()
+        return this
+    }
+
+    class SpanAssert(private val actualSpan: JsonObject, private val index: Int) :
+        AbstractObjectAssert<SpanAssert, JsonObject>(actualSpan, SpanAssert::class.java) {
+
+        fun hasLeastSignificant64BitsTraceId(traceId: String): SpanAssert {
+            val actualTraceId = actualSpan.getString(TRACE_ID_KEY)
+            assertThat(actualTraceId).overridingErrorMessage(
+                "Expected least significant traceId to be $traceId " +
+                    "but was $actualTraceId for index $index"
+            ).isEqualTo(traceId)
+            return this
+        }
+
+        fun hasValidLeastSignificant64BitsTraceId(): SpanAssert {
+            val actualTraceId = actualSpan.getString(TRACE_ID_KEY)
+            assertThat(actualTraceId).matches("[0-9a-f]{16}")
+            return this
+        }
+
+        fun hasValidMostSignificant64BitsTraceId(): SpanAssert {
+            val actualTraceId = actualSpan.getString(TRACE_ID_META_KEY)
+            assertThat(actualTraceId).matches("[0-9a-f]{16}")
+            return this
+        }
+
+        fun hasMostSignificant64BitsTraceId(traceId: String): SpanAssert {
+            val actualTraceId = actualSpan.getString(TRACE_ID_META_KEY)
+            assertThat(actualTraceId).overridingErrorMessage(
+                "Expected the most significant trace id to be $traceId but " +
+                    "was $actualTraceId for index $index"
+            ).isEqualTo(traceId)
+            return this
+        }
+
+        fun hasSpanId(spanId: String): SpanAssert {
+            val actualSpanId = actualSpan.getString(SPAN_ID_KEY)
+            assertThat(actualSpanId).overridingErrorMessage(
+                "Expected spanId to be $spanId but was $actualSpanId for index $index"
+            ).isEqualTo(spanId)
+            return this
+        }
+
+        fun hasParentId(parentId: String): SpanAssert {
+            val actualParentId = actualSpan.getString(PARENT_ID_KEY)
+            assertThat(actualParentId).overridingErrorMessage(
+                "Expected parentId to be $parentId but was $actualParentId for index $index"
+            ).isEqualTo(parentId)
+            return this
+        }
+
+        fun hasService(service: String): SpanAssert {
+            val actualServiceName = actualSpan.getString(SERVICE_KEY)
+            assertThat(actualServiceName).overridingErrorMessage(
+                "Expected service to be $service but was $actualServiceName for index $index"
+            ).isEqualTo(service)
+            return this
+        }
+
+        fun hasError(error: Int): SpanAssert {
+            val actualHasError = actualSpan.getInt(ERROR_KEY)
+            assertThat(actualHasError).overridingErrorMessage(
+                "Expected error to be $error but was $actualHasError for index $index"
+            ).isEqualTo(error)
+            return this
+        }
+
+        fun hasName(name: String): SpanAssert {
+            val actualName = actualSpan.getString(NAME_KEY)
+            assertThat(actualName).overridingErrorMessage(
+                "Expected name to be $name but was $actualName for index $index"
+            ).isEqualTo(name)
+            return this
+        }
+
+        fun hasResource(resource: String): SpanAssert {
+            val actualResource = actualSpan.getString(RESOURCE_KEY)
+            assertThat(actualResource).overridingErrorMessage(
+                "Expected resource to be $resource but was $actualResource for index $index"
+            ).isEqualTo(resource)
+            return this
+        }
+
+        fun hasUserObject(usr: String): SpanAssert {
+            val actualUserObject = actualSpan.getString(USR_KEY)
+            assertThat(actualUserObject).overridingErrorMessage(
+                "Expected usr to be $usr but was $actualUserObject for index $index"
+            ).isEqualTo(usr)
+            return this
+        }
+
+        fun hasUserId(usrId: String): SpanAssert {
+            val actualUserId = actualSpan.getString(USR_ID_KEY)
+            assertThat(actualUserId).overridingErrorMessage(
+                "Expected usrId to be $usrId but was $actualUserId for index $index"
+            ).isEqualTo(usrId)
+            return this
+        }
+
+        fun hasUserName(usrName: String): SpanAssert {
+            val actualUserName = actualSpan.getString(USR_NAME_KEY)
+            assertThat(actualUserName).overridingErrorMessage(
+                "Expected usrName to be $usrName but was $actualUserName for index $index"
+            ).isEqualTo(usrName)
+            return this
+        }
+
+        fun hasUserEmail(usrEmail: String): SpanAssert {
+            val actualUserEmail = actualSpan.getString(USR_EMAIL_KEY)
+            assertThat(actualUserEmail).overridingErrorMessage(
+                "Expected usrEmail to be $usrEmail but was $actualUserEmail for index $index"
+            ).isEqualTo(usrEmail)
+            return this
+        }
+
+        fun hasDuration(duration: Long): SpanAssert {
+            val actualDuration = actualSpan.getLong(DURATION_KEY)
+            assertThat(actualDuration).overridingErrorMessage(
+                "Expected duration to be $duration but was $actualDuration for index $index"
+
+            ).isEqualTo(duration)
+            return this
+        }
+
+        fun hasDurationBetween(durationStartInteval: Long, durationEndInterval: Long): SpanAssert {
+            val actualDuration = actualSpan.getLong(DURATION_KEY)
+            assertThat(actualDuration).overridingErrorMessage(
+                "Expected duration to be between $durationStartInteval " +
+                    "and $durationEndInterval but was $actualDuration for index $index"
+            ).isBetween(durationStartInteval, durationEndInterval)
+            return this
+        }
+
+        fun hasSource(source: String): SpanAssert {
+            val actualSource = actualSpan.getString(SOURCE_KEY)
+            assertThat(actualSource).overridingErrorMessage(
+                "Expected source to be $source but was $actualSource for index $index"
+            ).isEqualTo(source)
+            return this
+        }
+
+        fun hasVersion(version: String): SpanAssert {
+            val actualVersion = actualSpan.getString(VERSION_KEY)
+            assertThat(actualVersion).overridingErrorMessage(
+                "Expected version to be $version but was $actualVersion for index $index"
+            ).isEqualTo(version)
+            return this
+        }
+
+        fun hasTracerVersion(tracerVersion: String): SpanAssert {
+            val actualTracerVersion = actualSpan.getString(TRACER_VERSION_KEY)
+            assertThat(actualTracerVersion).overridingErrorMessage(
+                "Expected tracerVersion to be $tracerVersion but" +
+                    " was $actualTracerVersion for index $index"
+            ).isEqualTo(tracerVersion)
+            return this
+        }
+
+        fun hasSamplingPriority(samplingPriority: Int): SpanAssert {
+            val actualSamplingPriority = actualSpan.getInt(SAMPLING_PRIORITY_KEY)
+            assertThat(actualSamplingPriority).overridingErrorMessage(
+                "Expected samplingPriority to be $samplingPriority but " +
+                    "was $actualSamplingPriority for index $index"
+            ).isEqualTo(samplingPriority)
+            return this
+        }
+
+        fun hasNoSamplingPriority(): SpanAssert {
+            val actualSamplingPriority = actualSpan.getInt(SAMPLING_PRIORITY_KEY)
+            assertThat(actualSamplingPriority).overridingErrorMessage(
+                "Expected samplingPriority to be null but " +
+                    "was $actualSamplingPriority for index $index"
+            ).isNull()
+            return this
+        }
+
+        fun hasAgentPsr(agentPsr: Double): SpanAssert {
+            val actualPsrValue = actualSpan.getDouble(AGENT_PSR_KEY)
+            assertThat(actualPsrValue).overridingErrorMessage(
+                "Expected agentPsr to be $agentPsr but was $actualPsrValue for index $index"
+            ).isEqualTo(agentPsr)
+            return this
+        }
+
+        fun hasNoAgentPsr(): SpanAssert {
+            val actualPsrValue = actualSpan.getDouble(AGENT_PSR_KEY)
+            assertThat(actualPsrValue).overridingErrorMessage(
+                "Expected agentPsr to be null but was $actualPsrValue for index $index"
+            ).isNull()
+            return this
+        }
+
+        fun hasRulePsr(rulePsr: Double): SpanAssert {
+            val actualPsrValue = actualSpan.getDouble(RULE_PSR_KEY)
+            assertThat(actualPsrValue).overridingErrorMessage(
+                "Expected rulePsr to be $rulePsr but was $actualPsrValue for index $index"
+            ).isEqualTo(rulePsr)
+            return this
+        }
+
+        fun hasAgentPsrCloseTo(agentPsr: Double, offset: Offset<Double>): SpanAssert {
+            val actualPsrValue = actualSpan.getDouble(AGENT_PSR_KEY)
+            assertThat(actualPsrValue).overridingErrorMessage(
+                "Expected agentPsr to be close to $agentPsr but was $actualPsrValue for index $index"
+            ).isCloseTo(agentPsr, offset)
+            return this
+        }
+
+        fun hasApplicationId(applicationId: String?): SpanAssert {
+            val actualApplicationId = actualSpan.getString(APPLICATION_ID_KEY)
+            assertThat(actualApplicationId).overridingErrorMessage(
+                "Expected applicationId to be $applicationId but was $actualApplicationId for index $index"
+            ).isEqualTo(applicationId)
+            return this
+        }
+
+        fun hasSessionId(sessionId: String?): SpanAssert {
+            val actualSessionId = actualSpan.getString(SESSION_ID_KEY)
+            assertThat(actualSessionId).overridingErrorMessage(
+                "Expected sessionId to be $sessionId but was $actualSessionId for index $index"
+            ).isEqualTo(sessionId)
+            return this
+        }
+
+        fun hasViewId(viewId: String?): SpanAssert {
+            val actualViewId = actualSpan.getString(VIEW_ID_KEY)
+            assertThat(actualViewId).overridingErrorMessage(
+                "Expected viewId to be $viewId but was $actualViewId for index $index"
+            ).isEqualTo(viewId)
+            return this
+        }
+
+        fun hasGenericMetaValue(key: String, value: String): SpanAssert {
+            val formattedKey = GENERIC_META_KEY_FORMAT.format(Locale.US, key)
+            val actualKeyValue = actualSpan.getString(formattedKey)
+            assertThat(actualKeyValue).overridingErrorMessage(
+                "Expected meta $formattedKey to be $value but was $actualKeyValue for index $index"
+            ).isEqualTo(value)
+            return this
+        }
+
+        fun hasGenericMetricValue(key: String, value: Long): SpanAssert {
+            val formattedKey = GENERIC_METRICS_KEY_FORMAT.format(Locale.US, key)
+            val actualKeyValue = actualSpan.getLong(formattedKey)
+            assertThat(actualKeyValue).overridingErrorMessage(
+                "Expected metrics $formattedKey to be $value but was $actualKeyValue for index $index"
+            ).isEqualTo(value)
+            return this
+        }
+
+        fun hasGenericMetricValue(key: String, value: Double): SpanAssert {
+            val formattedKey = GENERIC_METRICS_KEY_FORMAT.format(Locale.US, key)
+            val actualKeyValue = actualSpan.getDouble(formattedKey)
+            assertThat(actualKeyValue).overridingErrorMessage(
+                "Expected metrics $formattedKey to be $value but was $actualKeyValue for index $index"
+            ).isEqualTo(value)
+            return this
+        }
+
+        fun hasNoGenericMetric(key: String): SpanAssert {
+            val formattedKey = GENERIC_METRICS_KEY_FORMAT.format(Locale.US, key)
+            val actualKeyValue = actualSpan.getAtPath(formattedKey)
+            assertThat(actualKeyValue).overridingErrorMessage(
+                "Expected metrics $formattedKey to be null but was $actualKeyValue for index $index"
+            ).isNull()
+            return this
+        }
+
+        fun hasLinkedSpanId(linkedSpanId: String): SpanAssert {
+            val linkedSpanObject = JsonParser.parseString(actualSpan.getString(LINKED_SPAN_KEY)).asJsonArray
+            val actualLinkedSpanId = linkedSpanObject.get(0).asJsonObject.getString(SPAN_ID_KEY)
+            assertThat(actualLinkedSpanId).overridingErrorMessage(
+                "Expected linked span id to be $linkedSpanId but was $actualLinkedSpanId for index $index"
+            ).isEqualTo(linkedSpanId)
+            return this
+        }
+
+        fun hasLinkedTraceId(linkedTraceId: String): SpanAssert {
+            val linkedSpanObject = JsonParser.parseString(actualSpan.getString(LINKED_SPAN_KEY)).asJsonArray
+            val actualLinkedTraceId = linkedSpanObject.get(0).asJsonObject.getString(TRACE_ID_KEY)
+            assertThat(actualLinkedTraceId).overridingErrorMessage(
+                "Expected linked trace id to be $linkedTraceId but was $actualLinkedTraceId for index $index"
+            ).isEqualTo(linkedTraceId)
+            return this
+        }
+
+        fun hasGenericLinkedAttribute(key: String, value: String): SpanAssert {
+            val linkedSpanObject = JsonParser.parseString(actualSpan.getString(LINKED_SPAN_KEY)).asJsonArray
+            val formattedKey = LINKED_ATTRIBUTE_KEY_FORMAT.format(Locale.US, key)
+            val actualKeyValue = linkedSpanObject.get(0).asJsonObject.getString(formattedKey)
+            assertThat(actualKeyValue).overridingErrorMessage(
+                "Expected linked attribute $key to be $value but was $actualKeyValue for index $index"
+            ).isEqualTo(value)
+            return this
+        }
+
+        fun hasGenericLinkedAttribute(key: String, value: Long): SpanAssert {
+            val linkedSpanObject = JsonParser.parseString(actualSpan.getString(LINKED_SPAN_KEY)).asJsonArray
+            val formattedKey = LINKED_ATTRIBUTE_KEY_FORMAT.format(Locale.US, key)
+            val actualKeyValue = linkedSpanObject.get(0).asJsonObject.getLong(formattedKey)
+            assertThat(actualKeyValue).overridingErrorMessage(
+                "Expected linked attribute $key to be $value but was $actualKeyValue for index $index"
+            ).isEqualTo(value)
+            return this
+        }
+
+        fun hasGenericLinkedAttribute(key: String, value: List<String>): SpanAssert {
+            value.forEachIndexed { index, valueAtIndex ->
+                hasGenericLinkedAttribute("$key.$index", valueAtIndex)
+            }
+            return this
+        }
+
+        fun hasConnectivity(connectivity: String): SpanAssert {
+            val actualConnectivity = actualSpan.getString(CONNECTIVITY_KEY)
+            assertThat(actualConnectivity).overridingErrorMessage(
+                "Expected connectivity to be $connectivity but was $actualConnectivity for index $index"
+            ).isEqualTo(connectivity)
+            return this
+        }
+
+        fun doesNotHaveConnectivity(): SpanAssert {
+            val actualConnectivity = actualSpan.getString(CONNECTIVITY_KEY)
+            assertThat(actualConnectivity).overridingErrorMessage(
+                "Expected connectivity to be null but was $actualConnectivity for index $index"
+            ).isNull()
+            return this
+        }
+
+        fun hasSimCarrierName(simCarrierName: String?): SpanAssert {
+            val actualSimCarrierName = actualSpan.getString(SIM_CARRIER_NAME_KEY)
+            assertThat(actualSimCarrierName).overridingErrorMessage(
+                "Expected simCarrierName to be $simCarrierName but was $actualSimCarrierName for index $index"
+            ).isEqualTo(simCarrierName)
+            return this
+        }
+
+        fun doesNotHaveSimCarrierName(): SpanAssert {
+            val actualSimCarrierName = actualSpan.getString(SIM_CARRIER_NAME_KEY)
+            assertThat(actualSimCarrierName).overridingErrorMessage(
+                "Expected simCarrierName to be null but was $actualSimCarrierName for index $index"
+            ).isNull()
+            return this
+        }
+
+        fun hasSimCarrierId(simCarrierId: Long?): SpanAssert {
+            val actualSimCarrierId = actualSpan.getLong(SIM_CARRIER_ID_KEY)
+            assertThat(actualSimCarrierId).overridingErrorMessage(
+                "Expected simCarrierId to be $simCarrierId but was $actualSimCarrierId for index $index"
+            ).isEqualTo(simCarrierId)
+            return this
+        }
+
+        fun doesNotHaveSimCarrierId(): SpanAssert {
+            val actualSimCarrierId = actualSpan.getString(SIM_CARRIER_ID_KEY)
+            assertThat(actualSimCarrierId).overridingErrorMessage(
+                "Expected simCarrierId to be null but was $actualSimCarrierId for index $index"
+            ).isNull()
+            return this
+        }
+
+        fun hasSpanKind(kind: String): SpanAssert {
+            val actualSpanKind = actualSpan.getString(SPAN_KIND_KEY)
+            assertThat(actualSpanKind).overridingErrorMessage(
+                "Expected span kind to be $kind but was $actualSpanKind for index $index"
+            ).isEqualTo(kind)
+            return this
+        }
+
+        fun hasHttpMethod(method: String): SpanAssert {
+            val actualHttpMethod = actualSpan.getString(HTTP_METHOD_KEY)
+            assertThat(actualHttpMethod).overridingErrorMessage(
+                "Expected HTTP method to be $method but was $actualHttpMethod for index $index"
+            ).isEqualTo(method)
+            return this
+        }
+
+        fun hasHttpStatusCode(statusCode: Int): SpanAssert {
+            val actualStatusCode = actualSpan.getInt(HTTP_STATUS_CODE_KEY)
+            assertThat(actualStatusCode).overridingErrorMessage(
+                "Expected HTTP status code to be $statusCode but was $actualStatusCode for index $index"
+            ).isEqualTo(statusCode)
+            return this
+        }
+
+        fun hasHttpUrl(url: String): SpanAssert {
+            val actualUrl = actualSpan.getString(HTTP_URL_KEY)
+            assertThat(actualUrl).overridingErrorMessage(
+                "Expected HTTP url to be $url but was $actualUrl for index $index"
+            ).isEqualTo(url)
+            return this
+        }
+    }
+
+    companion object {
+        private const val TRACE_ID_META_KEY = "meta._dd.p.id"
+        private const val SPANS_KEY = "spans"
+        private const val ENV_KEY = "env"
+        private const val TRACE_ID_KEY = "trace_id"
+        private const val SPAN_ID_KEY = "span_id"
+        private const val PARENT_ID_KEY = "parent_id"
+        private const val SERVICE_KEY = "service"
+        private const val ERROR_KEY = "error"
+        private const val NAME_KEY = "name"
+        private const val RESOURCE_KEY = "resource"
+        private const val USR_KEY = "meta.usr"
+        private const val USR_ID_KEY = "meta.usr.id"
+        private const val USR_NAME_KEY = "meta.usr.name"
+        private const val USR_EMAIL_KEY = "meta.usr.email"
+        private const val DURATION_KEY = "duration"
+        private const val SOURCE_KEY = "meta._dd.source"
+        private const val VERSION_KEY = "meta.version"
+        private const val TRACER_VERSION_KEY = "meta.tracer.version"
+        private const val SAMPLING_PRIORITY_KEY = "metrics._sampling_priority_v1"
+        private const val AGENT_PSR_KEY = "metrics._dd.agent_psr"
+        private const val RULE_PSR_KEY = "metrics._dd.rule_psr"
+        private const val APPLICATION_ID_KEY = "meta._dd.application.id"
+        private const val SESSION_ID_KEY = "meta._dd.session.id"
+        private const val VIEW_ID_KEY = "meta._dd.view.id"
+        private const val GENERIC_META_KEY_FORMAT = "meta.%s"
+        private const val GENERIC_METRICS_KEY_FORMAT = "metrics.%s"
+        private const val LINKED_SPAN_KEY = "meta._dd.span_links"
+        private const val LINKED_ATTRIBUTE_KEY_FORMAT = "attributes.%s"
+        private const val CONNECTIVITY_KEY = "meta.network.client.connectivity"
+        private const val SIM_CARRIER_NAME_KEY = "meta.network.client.sim_carrier.name"
+        private const val SIM_CARRIER_ID_KEY = "meta.network.client.sim_carrier.id"
+        private const val SPAN_KIND_KEY = "meta.span.kind"
+        private const val HTTP_METHOD_KEY = "meta.http.method"
+        private const val HTTP_STATUS_CODE_KEY = "meta.http.status_code"
+        private const val HTTP_URL_KEY = "meta.http.url"
+
+        fun assertThat(actual: JsonObject): SpansPayloadAssert {
+            return SpansPayloadAssert(actual)
+        }
+    }
+}

--- a/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/tests/elmyr/OkHttpConfigurator.kt
+++ b/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/tests/elmyr/OkHttpConfigurator.kt
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.okhttp.tests.elmyr
+
+import com.datadog.android.tests.elmyr.useCoreFactories
+import com.datadog.tools.unit.forge.BaseConfigurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.jvm.useJvmFactories
+
+class OkHttpConfigurator : BaseConfigurator() {
+    override fun configure(forge: Forge) {
+        super.configure(forge)
+        forge.useJvmFactories()
+        forge.useCoreFactories()
+    }
+}

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
@@ -22,6 +22,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.whenever
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.ScheduledExecutorService
+import org.mockito.kotlin.mock as kmock
 
 /**
  * A stub implementation of [InternalSdkCore].
@@ -33,7 +34,7 @@ import java.util.concurrent.ScheduledExecutorService
 class StubSDKCore(
     private val forge: Forge,
     private val mockContext: Application = mock(),
-    private val mockSdkCore: InternalSdkCore = mock()
+    private val mockSdkCore: InternalSdkCore = kmock { on { name } doReturn toString() }
 ) : InternalSdkCore by mockSdkCore {
 
     private val featureScopes = mutableMapOf<String, StubFeatureScope>()

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/tests/ktx/JsonObjectExt.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/tests/ktx/JsonObjectExt.kt
@@ -86,7 +86,22 @@ fun JsonObject.getDouble(path: String): Double? {
     return getAtPath(path)?.asJsonPrimitive?.asDouble
 }
 
-internal fun JsonObject.getAtPath(path: String): JsonElement? {
+/**
+ * A utility method to retrieve a nested attribute using the dotted notation.
+ * E.g.: assuming the `this` JsonObject represents the json below, calling
+ * `getString("foo.bar[0].spam")` will return the value `3.14` as [JsonElement].
+ *
+ * {
+ *   "foo": {
+ *     "bar" : [
+ *       {
+ *         "spam": 3.14
+ *       }
+ *     ]
+ *   }
+ * }
+ */
+fun JsonObject.getAtPath(path: String): JsonElement? {
     val matchResult = Regex("""(\w+)\[(\d+)]""").matchEntire(path)
     return if (matchResult != null) {
         val arrayName = matchResult.groupValues[1]

--- a/sample/kotlin/src/main/res/layout/fragment_traces.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_traces.xml
@@ -145,7 +145,7 @@
         android:visibility="invisible"
         android:layout_margin="8dp"
         app:layout_constraintStart_toEndOf="@id/spinner_request"
-        app:layout_constraintTop_toBottomOf="@id/start_404_request"
+        app:layout_constraintTop_toBottomOf="@id/start_sse_request"
         app:layout_constraintEnd_toEndOf="parent"
         tools:src="@drawable/ic_check_circle_green_24dp"
     />

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,6 +41,7 @@ include(":reliability:stub-feature")
 include(":reliability:single-fit:logs")
 include(":reliability:single-fit:rum")
 include(":reliability:single-fit:trace")
+include(":reliability:single-fit:okhttp")
 
 // CORE INTEGRATION TESTS
 include(":reliability:core-it")


### PR DESCRIPTION
### What does this PR do?

This PR implements [Head-based sampling](https://docs.datadoghq.com/tracing/trace_pipeline/ingestion_mechanisms/?tab=java#head-based-sampling) for the network instrumentation to align with default sampling existing in other Datadog tracers.

In short, Head-based sampling (HBS) allows to have a single sampling decision for the whole trace: it is kept or dropped, instead of the individual spans.

This also aligns with the following changes in iOS SDK done in the past:

* https://github.com/DataDog/dd-sdk-ios/pull/1783
* https://github.com/DataDog/dd-sdk-ios/pull/1793
* https://github.com/DataDog/dd-sdk-ios/pull/1794

Now, if there is a parent span (propagated through the headers or via request tag; OpenTracing or OpenTelemetry), then its sampling decision will be taken into account instead of the sampling decision made by the network instrumentation.

If there is no parent tracing context for the incoming request, then sampling decision will be made by interceptor.

The necessary integration tests are added, they uncovered some issues we had with trace propagation.

Also this PR bring the following change: spans with `DROP` sampling decision are not written, they are rejected by the intake anyway, so it makes no sense to send them.

There will also be a subsequent PR, allowing to make an _additional_ sampling decision (to drop or keep) for the network span if there is a parent tracing context. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

