### PR TITLE
Fix `_dd.rule_psr` attribute calculation for RUM

### DIFF
--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -324,7 +324,7 @@ open class DatadogInterceptor internal constructor(
             mapOf(
                 RumAttributes.TRACE_ID to span.context().traceIdAsHexString(),
                 RumAttributes.SPAN_ID to span.context().toSpanId(),
-                RumAttributes.RULE_PSR to traceSampler.getSampleRate()
+                RumAttributes.RULE_PSR to (traceSampler.getSampleRate() ?: ZERO_SAMPLE_RATE) / ALL_IN_SAMPLE_RATE
             )
         }
         (GlobalRumMonitor.get(sdkCore) as? AdvancedNetworkRumMonitor)?.stopResource(
@@ -516,5 +516,8 @@ open class DatadogInterceptor internal constructor(
 
         // We need to limit this value as the body will be loaded in memory
         private const val MAX_BODY_PEEK: Long = 32 * 1024L * 1024L
+
+        private const val ALL_IN_SAMPLE_RATE: Float = 100f
+        private const val ZERO_SAMPLE_RATE: Float = 0f
     }
 }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -77,7 +77,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
     @Mock
     lateinit var mockRumAttributesProvider: RumResourceAttributesProvider
 
-    @FloatForgery(0f, 1f)
+    @FloatForgery(0f, 100f)
     var fakeTracingSampleRate: Float = 0f
 
     private lateinit var fakeAttributes: Map<String, Any?>
@@ -188,7 +188,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         val expectedStopAttrs = mapOf(
             RumAttributes.TRACE_ID to fakeTraceIdAsString,
             RumAttributes.SPAN_ID to fakeSpanId,
-            RumAttributes.RULE_PSR to fakeTracingSampleRate
+            RumAttributes.RULE_PSR to fakeTracingSampleRate / 100
         ) + fakeAttributes
         val mimeType = fakeMediaType?.type
         val kind = when {
@@ -233,7 +233,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         val expectedStopAttrs = mapOf(
             RumAttributes.TRACE_ID to fakeTraceIdAsString,
             RumAttributes.SPAN_ID to fakeSpanId,
-            RumAttributes.RULE_PSR to fakeTracingSampleRate
+            RumAttributes.RULE_PSR to fakeTracingSampleRate / 100
         ) + fakeAttributes
         val kind = RumResourceKind.NATIVE
 
@@ -274,7 +274,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         val expectedStopAttrs = mapOf(
             RumAttributes.TRACE_ID to fakeTraceIdAsString,
             RumAttributes.SPAN_ID to fakeSpanId,
-            RumAttributes.RULE_PSR to fakeTracingSampleRate
+            RumAttributes.RULE_PSR to fakeTracingSampleRate / 100
         ) + fakeAttributes
         val mimeType = fakeMediaType?.type
         val kind = when {
@@ -321,7 +321,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         val expectedStopAttrs = mapOf(
             RumAttributes.TRACE_ID to fakeTraceIdAsString,
             RumAttributes.SPAN_ID to fakeSpanId,
-            RumAttributes.RULE_PSR to fakeTracingSampleRate
+            RumAttributes.RULE_PSR to fakeTracingSampleRate / 100
         ) + fakeAttributes
         val mimeType = fakeMediaType?.type
         val kind = when {
@@ -417,7 +417,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         val expectedStopAttrs = mapOf(
             RumAttributes.TRACE_ID to fakeTraceIdAsString,
             RumAttributes.SPAN_ID to fakeSpanId,
-            RumAttributes.RULE_PSR to fakeTracingSampleRate
+            RumAttributes.RULE_PSR to fakeTracingSampleRate / 100
         ) + fakeAttributes
         val mimeType = fakeMediaType?.type
         val kind = when {
@@ -466,7 +466,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         val expectedStopAttrs = mapOf(
             RumAttributes.TRACE_ID to fakeTraceIdAsString,
             RumAttributes.SPAN_ID to fakeSpanId,
-            RumAttributes.RULE_PSR to fakeTracingSampleRate
+            RumAttributes.RULE_PSR to fakeTracingSampleRate / 100
         ) + fakeAttributes
         val mimeType = fakeMediaType?.type
         val kind = when {
@@ -624,7 +624,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         val expectedStopAttrs = mapOf(
             RumAttributes.TRACE_ID to fakeTraceIdAsString,
             RumAttributes.SPAN_ID to fakeSpanId,
-            RumAttributes.RULE_PSR to fakeTracingSampleRate
+            RumAttributes.RULE_PSR to fakeTracingSampleRate / 100
         ) + fakeAttributes
         val mimeType = fakeMediaType?.type
         val kind = when {
@@ -727,7 +727,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         val expectedStopAttrs = mapOf(
             RumAttributes.TRACE_ID to fakeTraceIdAsString,
             RumAttributes.SPAN_ID to fakeSpanId,
-            RumAttributes.RULE_PSR to fakeTracingSampleRate
+            RumAttributes.RULE_PSR to fakeTracingSampleRate / 100
         ) + fakeAttributes
         val mimeType = fakeMediaType?.type
         val kind = when {


### PR DESCRIPTION
### What does this PR do?

This attribute should be in the range `[0;1]`, but [Sampler#getSampleRate](https://github.com/DataDog/dd-sdk-android/blob/54a38b64e366225767d1dad95b5e0271b329e9a9/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/sampling/Sampler.kt#L23-L28) returns a value in the range `[0;100]`, so we need to normalize.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

