### PR TITLE
RUM-7797 Anonymous RUM Identifier

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -89,7 +89,7 @@ data class com.datadog.android.api.context.ProcessInfo
 data class com.datadog.android.api.context.TimeInfo
   constructor(Long, Long, Long, Long)
 data class com.datadog.android.api.context.UserInfo
-  constructor(kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, Map<kotlin.String, kotlin.Any?> = emptyMap())
+  constructor(kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, Map<kotlin.String, kotlin.Any?> = emptyMap())
 interface com.datadog.android.api.feature.Feature
   val name: String
   fun onInitialize(android.content.Context)
@@ -123,6 +123,7 @@ interface com.datadog.android.api.feature.FeatureSdkCore : com.datadog.android.a
   fun removeEventReceiver(String)
   fun createSingleThreadExecutorService(String): java.util.concurrent.ExecutorService
   fun createScheduledExecutorService(String): java.util.concurrent.ScheduledExecutorService
+  fun setAnonymousId(java.util.UUID?)
 interface com.datadog.android.api.feature.StorageBackedFeature : Feature
   val requestFactory: com.datadog.android.api.net.RequestFactory
   val storageConfiguration: com.datadog.android.api.storage.FeatureStorageConfiguration

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -281,18 +281,20 @@ public final class com/datadog/android/api/context/TimeInfo {
 
 public final class com/datadog/android/api/context/UserInfo {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/util/Map;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/datadog/android/api/context/UserInfo;
-	public static synthetic fun copy$default (Lcom/datadog/android/api/context/UserInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/datadog/android/api/context/UserInfo;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/datadog/android/api/context/UserInfo;
+	public static synthetic fun copy$default (Lcom/datadog/android/api/context/UserInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/datadog/android/api/context/UserInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/api/context/UserInfo;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/api/context/UserInfo;
 	public final fun getAdditionalProperties ()Ljava/util/Map;
+	public final fun getAnonymousId ()Ljava/lang/String;
 	public final fun getEmail ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
@@ -355,6 +357,7 @@ public abstract interface class com/datadog/android/api/feature/FeatureSdkCore :
 	public abstract fun registerFeature (Lcom/datadog/android/api/feature/Feature;)V
 	public abstract fun removeContextUpdateReceiver (Ljava/lang/String;Lcom/datadog/android/api/feature/FeatureContextUpdateReceiver;)V
 	public abstract fun removeEventReceiver (Ljava/lang/String;)V
+	public abstract fun setAnonymousId (Ljava/util/UUID;)V
 	public abstract fun setContextUpdateReceiver (Ljava/lang/String;Lcom/datadog/android/api/feature/FeatureContextUpdateReceiver;)V
 	public abstract fun setEventReceiver (Ljava/lang/String;Lcom/datadog/android/api/feature/FeatureEventReceiver;)V
 	public abstract fun updateFeatureContext (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/context/UserInfo.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/context/UserInfo.kt
@@ -22,12 +22,14 @@ import kotlin.jvm.Throws
 
 /**
  * Holds information about the current User.
+ * @property anonymousId a unique anonymous identifier for the device, or null
  * @property id a unique identifier for the user, or null
  * @property name the name of the user, or null
  * @property email the email address of the user, or null
  * @property additionalProperties a dictionary of custom properties attached to the current user
  */
 data class UserInfo(
+    val anonymousId: String? = null,
     val id: String? = null,
     val name: String? = null,
     val email: String? = null,
@@ -37,6 +39,9 @@ data class UserInfo(
     @Suppress("StringLiteralDuplication")
     internal fun toJson(): JsonElement {
         val json = JsonObject()
+        anonymousId?.let { idNonNull ->
+            json.addProperty("anonymous_id", idNonNull)
+        }
         id?.let { idNonNull ->
             json.addProperty("id", idNonNull)
         }
@@ -79,6 +84,7 @@ data class UserInfo(
         @Suppress("StringLiteralDuplication", "ThrowsCount")
         fun fromJsonObject(jsonObject: JsonObject): UserInfo {
             try {
+                val anonymousId = jsonObject.get("anonymous_id")?.asString
                 val id = jsonObject.get("id")?.asString
                 val name = jsonObject.get("name")?.asString
                 val email = jsonObject.get("email")?.asString
@@ -88,7 +94,7 @@ data class UserInfo(
                         additionalProperties[entry.key] = entry.value
                     }
                 }
-                return UserInfo(id, name, email, additionalProperties)
+                return UserInfo(anonymousId, id, name, email, additionalProperties)
             } catch (e: IllegalStateException) {
                 throw JsonParseException(
                     "Unable to parse json into type UserInfo",

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureSdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureSdkCore.kt
@@ -8,6 +8,7 @@ package com.datadog.android.api.feature
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
+import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.ScheduledExecutorService
 
@@ -104,4 +105,11 @@ interface FeatureSdkCore : SdkCore {
      * @param executorContext Context to be used for logging and naming threads running on this executor.
      */
     fun createScheduledExecutorService(executorContext: String): ScheduledExecutorService
+
+    /**
+     * Allows the given feature to set the anonymous ID for the SDK.
+     *
+     * @param anonymousId Anonymous ID to set.
+     */
+    fun setAnonymousId(anonymousId: UUID?)
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureSdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureSdkCore.kt
@@ -17,6 +17,7 @@ import java.util.concurrent.ScheduledExecutorService
  *
  * SDK core is always guaranteed to implement this interface.
  */
+@Suppress("TooManyFunctions")
 interface FeatureSdkCore : SdkCore {
 
     /**

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureSdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureSdkCore.kt
@@ -110,7 +110,7 @@ interface FeatureSdkCore : SdkCore {
     /**
      * Allows the given feature to set the anonymous ID for the SDK.
      *
-     * @param anonymousId Anonymous ID to set.
+     * @param anonymousId Anonymous ID to set. Can be null if feature is disabled.
      */
     fun setAnonymousId(anonymousId: UUID?)
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -270,7 +270,7 @@ internal class DatadogCore(
     }
 
     override fun setAnonymousId(anonymousId: UUID?) {
-        coreFeature.userInfoProvider.setAnonymousId(anonymousId.toString())
+        coreFeature.userInfoProvider.setAnonymousId(anonymousId?.toString())
     }
 
     override fun isCoreActive(): Boolean = isActive

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -44,6 +44,7 @@ import com.datadog.android.privacy.TrackingConsent
 import com.google.gson.JsonObject
 import java.io.File
 import java.util.Locale
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.ScheduledExecutorService
@@ -266,6 +267,10 @@ internal class DatadogCore(
     /** @inheritDoc */
     override fun createScheduledExecutorService(executorContext: String): ScheduledExecutorService {
         return coreFeature.createScheduledExecutorService(executorContext)
+    }
+
+    override fun setAnonymousId(anonymousId: UUID?) {
+        coreFeature.userInfoProvider.setAnonymousId(anonymousId.toString())
     }
 
     override fun isCoreActive(): Boolean = isActive

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/NoOpContextProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/NoOpContextProvider.kt
@@ -45,7 +45,7 @@ internal class NoOpContextProvider : ContextProvider {
                 cellularTechnology = null
             ),
             deviceInfo = DeviceInfo("", "", "", DeviceType.OTHER, "", "", "", "", ""),
-            userInfo = UserInfo(null, null, null, emptyMap()),
+            userInfo = UserInfo(null, null, null, null, emptyMap()),
             trackingConsent = TrackingConsent.NOT_GRANTED,
             appBuildId = null,
             featuresContext = emptyMap()

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/NoOpInternalSdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/NoOpInternalSdkCore.kt
@@ -22,6 +22,7 @@ import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.privacy.TrackingConsent
 import com.google.gson.JsonObject
 import java.io.File
+import java.util.UUID
 import java.util.concurrent.Callable
 import java.util.concurrent.Delayed
 import java.util.concurrent.ExecutionException
@@ -127,6 +128,8 @@ internal object NoOpInternalSdkCore : InternalSdkCore {
     override fun createScheduledExecutorService(executorContext: String): ScheduledExecutorService {
         return NoOpScheduledExecutorService()
     }
+
+    override fun setAnonymousId(anonymousId: UUID?) = Unit
 
     // endregion
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/user/DatadogUserInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/user/DatadogUserInfoProvider.kt
@@ -29,6 +29,12 @@ internal class DatadogUserInfoProvider(
         )
     }
 
+    override fun setAnonymousId(id: String?) {
+        internalUserInfo = internalUserInfo.copy(
+            anonymousId = id
+        )
+    }
+
     override fun addUserProperties(properties: Map<String, Any?>) {
         internalUserInfo = internalUserInfo.copy(
             additionalProperties = internalUserInfo.additionalProperties + properties

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/user/MutableUserInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/user/MutableUserInfoProvider.kt
@@ -18,5 +18,7 @@ internal interface MutableUserInfoProvider : UserInfoProvider {
         extraInfo: Map<String, Any?>
     )
 
+    fun setAnonymousId(id: String?)
+
     fun addUserProperties(properties: Map<String, Any?>)
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
@@ -77,6 +77,7 @@ import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.util.Collections
 import java.util.Locale
+import java.util.UUID
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
@@ -226,6 +227,22 @@ internal class DatadogCoreTest {
 
         // Then
         verify(mockUserInfoProvider).setUserInfo(id, name, email, fakeUserProperties)
+    }
+
+    @Test
+    fun `M update anonymousId W setAnonymousId()`(
+        forge: Forge
+    ) {
+        // Given
+        val uuid = forge.getForgery<UUID>()
+        val mockUserInfoProvider = mock<MutableUserInfoProvider>()
+        testedCore.coreFeature.userInfoProvider = mockUserInfoProvider
+
+        // When
+        testedCore.setAnonymousId(uuid)
+
+        // Then
+        verify(mockUserInfoProvider).setAnonymousId(uuid.toString())
     }
 
     @Test

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
@@ -246,6 +246,19 @@ internal class DatadogCoreTest {
     }
 
     @Test
+    fun `M clears anonymousId W setAnonymousId(null)`() {
+        // Given
+        val mockUserInfoProvider = mock<MutableUserInfoProvider>()
+        testedCore.coreFeature.userInfoProvider = mockUserInfoProvider
+
+        // When
+        testedCore.setAnonymousId(null)
+
+        // Then
+        verify(mockUserInfoProvider).setAnonymousId(null)
+    }
+
+    @Test
     fun `M set additional user info W addUserProperties() is called`(
         @StringForgery(type = StringForgeryType.HEXADECIMAL) id: String,
         @StringForgery name: String,

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/user/DatadogUserInfoProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/user/DatadogUserInfoProviderTest.kt
@@ -224,6 +224,92 @@ internal class DatadogUserInfoProviderTest {
     }
 
     @Test
+    fun `M enriches empty user info with anonymousId W setAnonymousId`(
+        @StringForgery(type = StringForgeryType.HEXADECIMAL) anonymousId: String
+    ) {
+        // When
+        testedProvider.setAnonymousId(anonymousId)
+
+        // Then
+        testedProvider.getUserInfo().let {
+            assertThat(it.anonymousId).isEqualTo(anonymousId)
+            assertThat(it.id).isNull()
+            assertThat(it.name).isNull()
+            assertThat(it.email).isNull()
+            assertThat(it.additionalProperties).isEmpty()
+        }
+    }
+
+    @Test
+    fun `M enriches existing user info with anonymousId W setAnonymousId`(
+        @StringForgery(type = StringForgeryType.HEXADECIMAL) anonymousId: String,
+        @StringForgery(type = StringForgeryType.HEXADECIMAL) id: String,
+        @StringForgery name: String,
+        @StringForgery(regex = "\\w+@\\w+") email: String,
+        @MapForgery(
+            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)]),
+            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)])
+        ) fakeUserProperties: Map<String, String>
+    ) {
+        // Given
+        testedProvider.setUserInfo(id, name, email, fakeUserProperties)
+
+        // When
+        testedProvider.setAnonymousId(anonymousId)
+
+        // Then
+        testedProvider.getUserInfo().let {
+            assertThat(it.anonymousId).isEqualTo(anonymousId)
+            assertThat(it.id).isEqualTo(id)
+            assertThat(it.name).isEqualTo(name)
+            assertThat(it.email).isEqualTo(email)
+            assertThat(it.additionalProperties).isEqualTo(fakeUserProperties)
+        }
+    }
+
+    @Test
+    fun `M clears the anonymousId W setAnonymousId { null }`(
+        @StringForgery(type = StringForgeryType.HEXADECIMAL) anonymousId: String
+    ) {
+        // Given
+        testedProvider.setAnonymousId(anonymousId)
+
+        // When
+        testedProvider.setAnonymousId(null)
+
+        // Then
+        assertThat(testedProvider.getUserInfo().anonymousId).isNull()
+    }
+
+    @Test
+    fun `M clears the anonymousId and keeps existing user info W setAnonymousId { null }`(
+        @StringForgery(type = StringForgeryType.HEXADECIMAL) anonymousId: String,
+        @StringForgery(type = StringForgeryType.HEXADECIMAL) id: String,
+        @StringForgery name: String,
+        @StringForgery(regex = "\\w+@\\w+") email: String,
+        @MapForgery(
+            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)]),
+            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)])
+        ) fakeUserProperties: Map<String, String>
+    ) {
+        // Given
+        testedProvider.setUserInfo(id, name, email, fakeUserProperties)
+        testedProvider.setAnonymousId(anonymousId)
+
+        // When
+        testedProvider.setAnonymousId(null)
+
+        // Then
+        testedProvider.getUserInfo().let {
+            assertThat(it.anonymousId).isNull()
+            assertThat(it.id).isEqualTo(id)
+            assertThat(it.name).isEqualTo(name)
+            assertThat(it.email).isEqualTo(email)
+            assertThat(it.additionalProperties).isEqualTo(fakeUserProperties)
+        }
+    }
+
+    @Test
     fun `M use immutable values W setUserInfo { removing properties }()`(
         forge: Forge,
         @StringForgery(type = StringForgeryType.HEXADECIMAL) id: String,

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -44,11 +44,6 @@ public final class com/datadog/android/rum/RumActionType : java/lang/Enum {
 	public static fun values ()[Lcom/datadog/android/rum/RumActionType;
 }
 
-public final class com/datadog/android/rum/RumAnonymousIdentifierManager {
-	public static final field INSTANCE Lcom/datadog/android/rum/RumAnonymousIdentifierManager;
-	public static final fun manageAnonymousId (ZLcom/datadog/android/api/storage/datastore/DataStoreHandler;Lcom/datadog/android/api/feature/FeatureSdkCore;)V
-}
-
 public final class com/datadog/android/rum/RumAttributes {
 	public static final field ACTION_GESTURE_DIRECTION Ljava/lang/String;
 	public static final field ACTION_GESTURE_FROM_STATE Ljava/lang/String;

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -44,6 +44,11 @@ public final class com/datadog/android/rum/RumActionType : java/lang/Enum {
 	public static fun values ()[Lcom/datadog/android/rum/RumActionType;
 }
 
+public final class com/datadog/android/rum/RumAnonymousIdentifierManager {
+	public static final field INSTANCE Lcom/datadog/android/rum/RumAnonymousIdentifierManager;
+	public static final fun manageAnonymousId (ZLcom/datadog/android/api/storage/datastore/DataStoreHandler;Lcom/datadog/android/api/feature/FeatureSdkCore;)V
+}
+
 public final class com/datadog/android/rum/RumAttributes {
 	public static final field ACTION_GESTURE_DIRECTION Ljava/lang/String;
 	public static final field ACTION_GESTURE_FROM_STATE Ljava/lang/String;

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
@@ -16,6 +16,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.sampling.RateBasedSampler
+import com.datadog.android.rum.internal.RumAnonymousIdentifierManager
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.metric.SessionEndedMetricDispatcher
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
@@ -73,6 +73,14 @@ object Rum {
 
         sdkCore.registerFeature(rumFeature)
 
+        sdkCore.getFeature(rumFeature.name)?.dataStore?.let {
+            AnonymousIdentifierManager.manageAnonymousId(
+                rumConfiguration.featureConfiguration.trackAnonymousUser,
+                it,
+                sdkCore
+            )
+        }
+
         val rumMonitor = createMonitor(sdkCore, rumFeature)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
@@ -74,10 +74,8 @@ object Rum {
         sdkCore.registerFeature(rumFeature)
 
         sdkCore.getFeature(rumFeature.name)?.dataStore?.let {
-            RumAnonymousIdentifierManager.manageAnonymousId(
-                rumConfiguration.featureConfiguration.trackAnonymousUser,
-                it,
-                sdkCore
+            RumAnonymousIdentifierManager(it, sdkCore).manageAnonymousId(
+                rumConfiguration.featureConfiguration.trackAnonymousUser
             )
         }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
@@ -74,7 +74,7 @@ object Rum {
         sdkCore.registerFeature(rumFeature)
 
         sdkCore.getFeature(rumFeature.name)?.dataStore?.let {
-            AnonymousIdentifierManager.manageAnonymousId(
+            RumAnonymousIdentifierManager.manageAnonymousId(
                 rumConfiguration.featureConfiguration.trackAnonymousUser,
                 it,
                 sdkCore

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumAnonymousIdentifierManager.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumAnonymousIdentifierManager.kt
@@ -1,0 +1,68 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum
+
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.api.storage.datastore.DataStoreHandler
+import com.datadog.android.api.storage.datastore.DataStoreReadCallback
+import com.datadog.android.core.internal.persistence.Deserializer
+import com.datadog.android.core.persistence.Serializer
+import com.datadog.android.core.persistence.datastore.DataStoreContent
+import java.util.UUID
+
+internal class AnonymousIdentifierManager {
+    companion object {
+        fun manageAnonymousId(shouldTrack: Boolean, dataStore: DataStoreHandler, core: FeatureSdkCore) {
+            val anonymousIdKey = "anonymous"
+            if (shouldTrack) {
+                dataStore.value(
+                    anonymousIdKey,
+                    null,
+                    AnonymousIdentifierReadCallback { anonymousId ->
+                        if (anonymousId == null) {
+                            val newAnonymousId = UUID.randomUUID()
+                            dataStore.setValue(
+                                anonymousIdKey,
+                                newAnonymousId,
+                                0,
+                                null,
+                                AnonymousIdentifierSerializer()
+                            )
+                            core.setAnonymousId(newAnonymousId)
+                        } else {
+                            core.setAnonymousId(anonymousId)
+                        }
+                    },
+                    AnonymousIdentifierDeserializer()
+                )
+            } else {
+                dataStore.removeValue(anonymousIdKey)
+                core.setAnonymousId(null)
+            }
+        }
+    }
+}
+
+internal class AnonymousIdentifierDeserializer : Deserializer<String, UUID> {
+    override fun deserialize(model: String): UUID? = UUID.fromString(model)
+}
+
+internal class AnonymousIdentifierSerializer : Serializer<UUID> {
+    override fun serialize(model: UUID): String? = model.toString()
+}
+
+internal class AnonymousIdentifierReadCallback(
+    private val onFinished: (UUID?) -> Unit
+) : DataStoreReadCallback<UUID> {
+    override fun onSuccess(dataStoreContent: DataStoreContent<UUID>?) {
+        onFinished(dataStoreContent?.data)
+    }
+
+    override fun onFailure() {
+        onFinished(null)
+    }
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumAnonymousIdentifierManager.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumAnonymousIdentifierManager.kt
@@ -14,35 +14,34 @@ import com.datadog.android.core.persistence.Serializer
 import com.datadog.android.core.persistence.datastore.DataStoreContent
 import java.util.UUID
 
-internal class AnonymousIdentifierManager {
-    companion object {
-        fun manageAnonymousId(shouldTrack: Boolean, dataStore: DataStoreHandler, core: FeatureSdkCore) {
-            val anonymousIdKey = "anonymous"
-            if (shouldTrack) {
-                dataStore.value(
-                    anonymousIdKey,
-                    null,
-                    AnonymousIdentifierReadCallback { anonymousId ->
-                        if (anonymousId == null) {
-                            val newAnonymousId = UUID.randomUUID()
-                            dataStore.setValue(
-                                anonymousIdKey,
-                                newAnonymousId,
-                                0,
-                                null,
-                                AnonymousIdentifierSerializer()
-                            )
-                            core.setAnonymousId(newAnonymousId)
-                        } else {
-                            core.setAnonymousId(anonymousId)
-                        }
-                    },
-                    AnonymousIdentifierDeserializer()
-                )
-            } else {
-                dataStore.removeValue(anonymousIdKey)
-                core.setAnonymousId(null)
-            }
+object RumAnonymousIdentifierManager {
+    @JvmStatic
+    fun manageAnonymousId(shouldTrack: Boolean, dataStore: DataStoreHandler, core: FeatureSdkCore) {
+        val anonymousIdKey = "anonymous_id_key"
+        if (shouldTrack) {
+            dataStore.value(
+                anonymousIdKey,
+                null,
+                AnonymousIdentifierReadCallback { anonymousId ->
+                    if (anonymousId == null) {
+                        val newAnonymousId = UUID.randomUUID()
+                        dataStore.setValue(
+                            anonymousIdKey,
+                            newAnonymousId,
+                            0,
+                            null,
+                            AnonymousIdentifierSerializer()
+                        )
+                        core.setAnonymousId(newAnonymousId)
+                    } else {
+                        core.setAnonymousId(anonymousId)
+                    }
+                },
+                AnonymousIdentifierDeserializer()
+            )
+        } else {
+            dataStore.removeValue(anonymousIdKey)
+            core.setAnonymousId(null)
         }
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
@@ -218,7 +218,7 @@ internal class DatadogLateCrashReporter(
                     user?.id,
                     user?.name,
                     user?.email,
-                    null,
+                    user?.anonymousId,
                     additionalUserProperties
                 )
             },

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumAnonymousIdentifierManager.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumAnonymousIdentifierManager.kt
@@ -63,8 +63,7 @@ internal class RumAnonymousIdentifierManager(
     }
 }
 
-
-@Suppress("SwallowedException")
+@Suppress("SwallowedException", "UnsafeThirdPartyFunctionCall")
 internal class AnonymousIdentifierDeserializer : Deserializer<String, UUID> {
     override fun deserialize(model: String): UUID? {
         return try {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumAnonymousIdentifierManager.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumAnonymousIdentifierManager.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.rum
+package com.datadog.android.rum.internal
 
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.datastore.DataStoreHandler
@@ -59,7 +59,7 @@ internal class RumAnonymousIdentifierManager(
     }
 
     companion object {
-        private val ANONYMOUS_ID_KEY = "anonymous_id_key"
+        private const val ANONYMOUS_ID_KEY = "anonymous_id_key"
     }
 }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumAnonymousIdentifierManager.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumAnonymousIdentifierManager.kt
@@ -63,9 +63,9 @@ internal class RumAnonymousIdentifierManager(
     }
 }
 
-@Suppress("SwallowedException", "UnsafeThirdPartyFunctionCall")
 internal class AnonymousIdentifierDeserializer : Deserializer<String, UUID> {
     override fun deserialize(model: String): UUID? {
+        @Suppress("SwallowedException")
         return try {
             UUID.fromString(model)
         } catch (e: IllegalArgumentException) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumAnonymousIdentifierManager.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumAnonymousIdentifierManager.kt
@@ -67,6 +67,7 @@ internal class AnonymousIdentifierDeserializer : Deserializer<String, UUID> {
     override fun deserialize(model: String): UUID? {
         @Suppress("SwallowedException")
         return try {
+            @Suppress("UnsafeThirdPartyFunctionCall")
             UUID.fromString(model)
         } catch (e: IllegalArgumentException) {
             null

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -542,7 +542,8 @@ internal class RumFeature(
         val sessionListener: RumSessionListener,
         val initialResourceIdentifier: InitialResourceIdentifier,
         val lastInteractionIdentifier: LastInteractionIdentifier,
-        val additionalConfig: Map<String, Any>
+        val additionalConfig: Map<String, Any>,
+        val trackAnonymousUser: Boolean
     )
 
     internal companion object {
@@ -587,7 +588,8 @@ internal class RumFeature(
             sessionListener = NoOpRumSessionListener(),
             initialResourceIdentifier = TimeBasedInitialResourceIdentifier(),
             lastInteractionIdentifier = TimeBasedInteractionIdentifier(),
-            additionalConfig = emptyMap()
+            additionalConfig = emptyMap(),
+            trackAnonymousUser = true
         )
 
         internal const val EVENT_MESSAGE_PROPERTY = "message"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
@@ -285,6 +285,7 @@ internal class RumActionScope(
                         id = user.id,
                         name = user.name,
                         email = user.email,
+                        anonymousId = user.anonymousId,
                         additionalProperties = user.additionalProperties.toMutableMap()
                     )
                 } else {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -252,6 +252,7 @@ internal class RumResourceScope(
                         id = user.id,
                         name = user.name,
                         email = user.email,
+                        anonymousId = user.anonymousId,
                         additionalProperties = user.additionalProperties.toMutableMap()
                     )
                 } else {
@@ -400,6 +401,7 @@ internal class RumResourceScope(
                         id = user.id,
                         name = user.name,
                         email = user.email,
+                        anonymousId = user.anonymousId,
                         additionalProperties = user.additionalProperties.toMutableMap()
                     )
                 } else {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -521,6 +521,7 @@ internal open class RumViewScope(
                         id = user.id,
                         name = user.name,
                         email = user.email,
+                        anonymousId = user.anonymousId,
                         additionalProperties = user.additionalProperties.toMutableMap()
                     )
                 } else {
@@ -955,6 +956,7 @@ internal open class RumViewScope(
                         id = user.id,
                         name = user.name,
                         email = user.email,
+                        anonymousId = user.anonymousId,
                         additionalProperties = user.additionalProperties.toMutableMap()
                     )
                 } else {
@@ -1121,6 +1123,7 @@ internal open class RumViewScope(
                         id = user.id,
                         name = user.name,
                         email = user.email,
+                        anonymousId = user.anonymousId,
                         additionalProperties = user.additionalProperties.toMutableMap()
                     )
                 } else {
@@ -1227,6 +1230,7 @@ internal open class RumViewScope(
                         id = user.id,
                         name = user.name,
                         email = user.email,
+                        anonymousId = user.anonymousId,
                         additionalProperties = user.additionalProperties.toMutableMap()
                     )
                 } else {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumAnonymousIdentifierManagerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumAnonymousIdentifierManagerTest.kt
@@ -13,23 +13,31 @@ import com.datadog.android.rum.internal.AnonymousIdentifierReadCallback
 import com.datadog.android.rum.internal.RumAnonymousIdentifierManager
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.mock
+import org.junit.runner.RunWith
+import org.mockito.Mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.whenever
 import java.util.UUID
 
+@RunWith(MockitoJUnitRunner::class)
 class RumAnonymousIdentifierManagerTest {
 
+    @Mock
     private lateinit var dataStore: DataStoreHandler
+
+    @Mock
     private lateinit var core: FeatureSdkCore
+
+    private lateinit var rumAnonymousIdentifierManager: RumAnonymousIdentifierManager
 
     @Before
     fun setUp() {
-        dataStore = mock()
-        core = mock()
+        rumAnonymousIdentifierManager = RumAnonymousIdentifierManager(dataStore, core)
     }
 
     @Test
@@ -38,7 +46,7 @@ class RumAnonymousIdentifierManagerTest {
         whenever(
             dataStore.value(
                 eq("anonymous_id_key"),
-                eq(null),
+                isNull(),
                 any<AnonymousIdentifierReadCallback>(),
                 any()
             )
@@ -48,10 +56,10 @@ class RumAnonymousIdentifierManagerTest {
         }
 
         // When
-        RumAnonymousIdentifierManager.manageAnonymousId(true, dataStore, core)
+        rumAnonymousIdentifierManager.manageAnonymousId(true)
 
         // Then
-        verify(dataStore).setValue(eq("anonymous_id_key"), any(), eq(0), eq(null), any())
+        verify(dataStore).setValue(eq("anonymous_id_key"), any(), eq(0), isNull(), any())
         verify(core).setAnonymousId(any())
     }
 
@@ -61,7 +69,7 @@ class RumAnonymousIdentifierManagerTest {
         whenever(
             dataStore.value(
                 eq("anonymous_id_key"),
-                eq(null),
+                isNull(),
                 any<AnonymousIdentifierReadCallback>(),
                 any()
             )
@@ -71,11 +79,11 @@ class RumAnonymousIdentifierManagerTest {
         }
 
         // When
-        RumAnonymousIdentifierManager.manageAnonymousId(true, dataStore, core)
+        rumAnonymousIdentifierManager.manageAnonymousId(true)
 
         // Then
-        verify(dataStore, never()).setValue(eq("anonymous_id_key"), any(), eq(0), eq(null), any())
-        verify(dataStore, never()).removeValue(eq("anonymous_id_key"), eq(null))
+        verify(dataStore, never()).setValue(eq("anonymous_id_key"), any(), eq(0), isNull(), any())
+        verify(dataStore, never()).removeValue(eq("anonymous_id_key"), isNull())
         verify(core).setAnonymousId(any())
     }
 
@@ -85,10 +93,10 @@ class RumAnonymousIdentifierManagerTest {
         val shouldTrack = false
 
         // When
-        RumAnonymousIdentifierManager.manageAnonymousId(shouldTrack, dataStore, core)
+        rumAnonymousIdentifierManager.manageAnonymousId(shouldTrack)
 
         // Then
-        verify(dataStore).removeValue(eq("anonymous_id_key"), eq(null))
-        verify(core).setAnonymousId(eq(null))
+        verify(dataStore).removeValue(eq("anonymous_id_key"), isNull())
+        verify(core).setAnonymousId(isNull())
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumAnonymousIdentifierManagerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumAnonymousIdentifierManagerTest.kt
@@ -9,6 +9,8 @@ package com.datadog.android.rum
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.datastore.DataStoreHandler
 import com.datadog.android.core.persistence.datastore.DataStoreContent
+import com.datadog.android.rum.internal.AnonymousIdentifierReadCallback
+import com.datadog.android.rum.internal.RumAnonymousIdentifierManager
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumAnonymousIdentifierManagerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumAnonymousIdentifierManagerTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum
+
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.api.storage.datastore.DataStoreHandler
+import com.datadog.android.core.persistence.datastore.DataStoreContent
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import java.util.UUID
+
+class RumAnonymousIdentifierManagerTest {
+
+    private lateinit var dataStore: DataStoreHandler
+    private lateinit var core: FeatureSdkCore
+
+    @Before
+    fun setUp() {
+        dataStore = mock()
+        core = mock()
+    }
+
+    @Test
+    fun `M generate new anonymous id W id not present and tracking enabled`() {
+        // Given
+        whenever(
+            dataStore.value(
+                eq("anonymous_id_key"),
+                eq(null),
+                any<AnonymousIdentifierReadCallback>(),
+                any()
+            )
+        ).thenAnswer {
+            val callback = it.arguments[2] as AnonymousIdentifierReadCallback
+            callback.onSuccess(null)
+        }
+
+        // When
+        RumAnonymousIdentifierManager.manageAnonymousId(true, dataStore, core)
+
+        // Then
+        verify(dataStore).setValue(eq("anonymous_id_key"), any(), eq(0), eq(null), any())
+        verify(core).setAnonymousId(any())
+    }
+
+    @Test
+    fun `M do not generate new anonymous id W id present and tracking enabled`() {
+        // Given
+        whenever(
+            dataStore.value(
+                eq("anonymous_id_key"),
+                eq(null),
+                any<AnonymousIdentifierReadCallback>(),
+                any()
+            )
+        ).thenAnswer {
+            val callback = it.arguments[2] as AnonymousIdentifierReadCallback
+            callback.onSuccess(DataStoreContent(0, UUID.randomUUID()))
+        }
+
+        // When
+        RumAnonymousIdentifierManager.manageAnonymousId(true, dataStore, core)
+
+        // Then
+        verify(dataStore, never()).setValue(eq("anonymous_id_key"), any(), eq(0), eq(null), any())
+        verify(dataStore, never()).removeValue(eq("anonymous_id_key"), eq(null))
+        verify(core).setAnonymousId(any())
+    }
+
+    @Test
+    fun `M do not generate new anonymous id W tracking disabled`() {
+        // Given
+        val shouldTrack = false
+
+        // When
+        RumAnonymousIdentifierManager.manageAnonymousId(shouldTrack, dataStore, core)
+
+        // Then
+        verify(dataStore).removeValue(eq("anonymous_id_key"), eq(null))
+        verify(core).setAnonymousId(eq(null))
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
@@ -105,7 +105,8 @@ internal class RumConfigurationBuilderTest {
                 sessionListener = NoOpRumSessionListener(),
                 additionalConfig = emptyMap(),
                 initialResourceIdentifier = TimeBasedInitialResourceIdentifier(),
-                lastInteractionIdentifier = TimeBasedInteractionIdentifier()
+                lastInteractionIdentifier = TimeBasedInteractionIdentifier(),
+                trackAnonymousUser = true
             )
         )
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
@@ -9,7 +9,6 @@ package com.datadog.android.rum
 import android.os.Looper
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
-import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.sampling.RateBasedSampler
@@ -35,9 +34,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
-import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mock
-import org.mockito.Mockito.mockStatic
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
@@ -234,32 +231,6 @@ internal class RumTest {
             Rum.RUM_FEATURE_ALREADY_ENABLED
         )
         verify(mockSdkCore, never()).registerFeature(any())
-    }
-
-    @Test
-    fun `M manages anonymousId W build()`(
-        @Forgery fakeRumConfiguration: RumConfiguration
-    ) {
-        // Given
-        val feature: FeatureScope = mock()
-        val anonymousIdentifierManagerStatic = mockStatic(RumAnonymousIdentifierManager::class.java)
-        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME))
-            .thenReturn(null)
-            .thenReturn(feature)
-        whenever(feature.dataStore).thenReturn(mock())
-
-        // When
-        Rum.enable(fakeRumConfiguration, mockSdkCore)
-
-        // Then
-        anonymousIdentifierManagerStatic.verify {
-            RumAnonymousIdentifierManager.manageAnonymousId(
-                eq(fakeRumConfiguration.featureConfiguration.trackAnonymousUser),
-                any(),
-                any()
-            )
-        }
-        anonymousIdentifierManagerStatic.close()
     }
 
     companion object {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum
 import android.os.Looper
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.sampling.RateBasedSampler
@@ -34,7 +35,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mock
+import org.mockito.Mockito.mockStatic
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
@@ -231,6 +234,32 @@ internal class RumTest {
             Rum.RUM_FEATURE_ALREADY_ENABLED
         )
         verify(mockSdkCore, never()).registerFeature(any())
+    }
+
+    @Test
+    fun `M manages anonymousId W build()`(
+        @Forgery fakeRumConfiguration: RumConfiguration
+    ) {
+        // Given
+        val feature: FeatureScope = mock()
+        val anonymousIdentifierManagerStatic = mockStatic(RumAnonymousIdentifierManager::class.java)
+        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME))
+            .thenReturn(null)
+            .thenReturn(feature)
+        whenever(feature.dataStore).thenReturn(mock())
+
+        // When
+        Rum.enable(fakeRumConfiguration, mockSdkCore)
+
+        // Then
+        anonymousIdentifierManagerStatic.verify {
+            RumAnonymousIdentifierManager.manageAnonymousId(
+                eq(fakeRumConfiguration.featureConfiguration.trackAnonymousUser),
+                any(),
+                any()
+            )
+        }
+        anonymousIdentifierManagerStatic.close()
     }
 
     companion object {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
@@ -182,6 +182,7 @@ internal class DatadogLateCrashReporterTest {
                 .hasTimestamp(fakeTimestamp + fakeServerOffset)
                 .hasUserInfo(
                     UserInfo(
+                        fakeViewEvent.usr?.anonymousId,
                         fakeViewEvent.usr?.id,
                         fakeViewEvent.usr?.name,
                         fakeViewEvent.usr?.email,
@@ -283,6 +284,7 @@ internal class DatadogLateCrashReporterTest {
                 .hasTimestamp(fakeTimestamp + fakeServerOffset)
                 .hasUserInfo(
                     UserInfo(
+                        fakeViewEvent.usr?.anonymousId,
                         fakeViewEvent.usr?.id,
                         fakeViewEvent.usr?.name,
                         fakeViewEvent.usr?.email,
@@ -531,6 +533,7 @@ internal class DatadogLateCrashReporterTest {
                 .hasTimestamp(fakeTimestamp + fakeServerOffset)
                 .hasUserInfo(
                     UserInfo(
+                        fakeViewEvent.usr?.anonymousId,
                         fakeViewEvent.usr?.id,
                         fakeViewEvent.usr?.name,
                         fakeViewEvent.usr?.email,
@@ -728,6 +731,7 @@ internal class DatadogLateCrashReporterTest {
                 .hasTimestamp(fakeTimestamp + fakeServerOffset)
                 .hasUserInfo(
                     UserInfo(
+                        fakeViewEvent.usr?.anonymousId,
                         fakeViewEvent.usr?.id,
                         fakeViewEvent.usr?.name,
                         fakeViewEvent.usr?.email,
@@ -905,6 +909,7 @@ internal class DatadogLateCrashReporterTest {
                 .hasTimestamp(fakeTimestamp + fakeServerOffset)
                 .hasUserInfo(
                     UserInfo(
+                        fakeViewEvent.usr?.anonymousId,
                         fakeViewEvent.usr?.id,
                         fakeViewEvent.usr?.name,
                         fakeViewEvent.usr?.email,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
@@ -140,6 +140,7 @@ internal class DatadogLateCrashReporterTest {
                 id = fakeUserInfo.id,
                 name = fakeUserInfo.name,
                 email = fakeUserInfo.email,
+                anonymousId = fakeUserInfo.anonymousId,
                 additionalProperties = fakeUserInfo.additionalProperties.toMutableMap()
             )
         )
@@ -239,6 +240,7 @@ internal class DatadogLateCrashReporterTest {
                 id = fakeUserInfo.id,
                 name = fakeUserInfo.name,
                 email = fakeUserInfo.email,
+                anonymousId = fakeUserInfo.anonymousId,
                 additionalProperties = fakeUserInfo.additionalProperties.toMutableMap()
             )
         )
@@ -339,6 +341,7 @@ internal class DatadogLateCrashReporterTest {
                 id = fakeUserInfo.id,
                 name = fakeUserInfo.name,
                 email = fakeUserInfo.email,
+                anonymousId = fakeUserInfo.anonymousId,
                 additionalProperties = fakeUserInfo.additionalProperties.toMutableMap()
             )
         )
@@ -481,6 +484,7 @@ internal class DatadogLateCrashReporterTest {
                 id = fakeUserInfo.id,
                 name = fakeUserInfo.name,
                 email = fakeUserInfo.email,
+                anonymousId = fakeUserInfo.anonymousId,
                 additionalProperties = fakeUserInfo.additionalProperties.toMutableMap()
             )
         )
@@ -685,6 +689,7 @@ internal class DatadogLateCrashReporterTest {
                 id = fakeUserInfo.id,
                 name = fakeUserInfo.name,
                 email = fakeUserInfo.email,
+                anonymousId = fakeUserInfo.anonymousId,
                 additionalProperties = fakeUserInfo.additionalProperties.toMutableMap()
             )
         )
@@ -861,6 +866,7 @@ internal class DatadogLateCrashReporterTest {
                 id = fakeUserInfo.id,
                 name = fakeUserInfo.name,
                 email = fakeUserInfo.email,
+                anonymousId = fakeUserInfo.anonymousId,
                 additionalProperties = fakeUserInfo.additionalProperties.toMutableMap()
             )
         )

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ActionEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ActionEventForgeryFactory.kt
@@ -68,6 +68,7 @@ internal class ActionEventForgeryFactory :
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
+                    anonymousId = aNullable { anHexadecimalString() },
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
@@ -49,7 +49,8 @@ internal class ConfigurationRumForgeryFactory :
             sessionListener = mock(),
             additionalConfig = forge.aMap { aString() to aString() },
             initialResourceIdentifier = mock(),
-            lastInteractionIdentifier = mock()
+            lastInteractionIdentifier = mock(),
+            trackAnonymousUser = forge.aBool()
         )
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ErrorEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ErrorEventForgeryFactory.kt
@@ -90,6 +90,7 @@ internal class ErrorEventForgeryFactory : ForgeryFactory<ErrorEvent> {
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
+                    anonymousId = aNullable { anHexadecimalString() },
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/LongTaskEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/LongTaskEventForgeryFactory.kt
@@ -53,6 +53,7 @@ internal class LongTaskEventForgeryFactory :
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
+                    anonymousId = aNullable { anHexadecimalString() },
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ResourceEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ResourceEventForgeryFactory.kt
@@ -90,6 +90,7 @@ internal class ResourceEventForgeryFactory :
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
+                    anonymousId = aNullable { anHexadecimalString() },
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ViewEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ViewEventForgeryFactory.kt
@@ -88,6 +88,7 @@ internal class ViewEventForgeryFactory : ForgeryFactory<ViewEvent> {
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
+                    anonymousId = aNullable { anHexadecimalString() },
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ActionEventForgeryFactory.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ActionEventForgeryFactory.kt
@@ -69,6 +69,7 @@ internal class ActionEventForgeryFactory :
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
+                    anonymousId = aNullable { anHexadecimalString() },
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ErrorEventForgeryFactory.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ErrorEventForgeryFactory.kt
@@ -79,6 +79,7 @@ internal class ErrorEventForgeryFactory : ForgeryFactory<ErrorEvent> {
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
+                    anonymousId = aNullable { anHexadecimalString() },
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/LongTaskEventForgeryFactory.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/LongTaskEventForgeryFactory.kt
@@ -54,6 +54,7 @@ internal class LongTaskEventForgeryFactory :
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
+                    anonymousId = aNullable { anHexadecimalString() },
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ResourceEventForgeryFactory.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ResourceEventForgeryFactory.kt
@@ -101,6 +101,7 @@ internal class ResourceEventForgeryFactory :
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
+                    anonymousId = aNullable { anHexadecimalString() },
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ViewEventForgeryFactory.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ViewEventForgeryFactory.kt
@@ -89,6 +89,7 @@ internal class ViewEventForgeryFactory : ForgeryFactory<ViewEvent> {
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
+                    anonymousId = aNullable { anHexadecimalString() },
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/elmyr/ActionEventForgeryFactory.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/elmyr/ActionEventForgeryFactory.kt
@@ -68,6 +68,7 @@ internal class ActionEventForgeryFactory :
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
+                    anonymousId = aNullable { anHexadecimalString() },
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/elmyr/ErrorEventForgeryFactory.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/elmyr/ErrorEventForgeryFactory.kt
@@ -90,6 +90,7 @@ internal class ErrorEventForgeryFactory : ForgeryFactory<ErrorEvent> {
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
+                    anonymousId = aNullable { anHexadecimalString() },
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/elmyr/LongTaskEventForgeryFactory.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/elmyr/LongTaskEventForgeryFactory.kt
@@ -53,6 +53,7 @@ internal class LongTaskEventForgeryFactory :
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
+                    anonymousId = aNullable { anHexadecimalString() },
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/elmyr/ResourceEventForgeryFactory.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/elmyr/ResourceEventForgeryFactory.kt
@@ -85,6 +85,7 @@ internal class ResourceEventForgeryFactory :
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
+                    anonymousId = aNullable { anHexadecimalString() },
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/elmyr/ViewEventForgeryFactory.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/elmyr/ViewEventForgeryFactory.kt
@@ -88,6 +88,7 @@ internal class ViewEventForgeryFactory : ForgeryFactory<ViewEvent> {
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
+                    anonymousId = aNullable { anHexadecimalString() },
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
@@ -182,7 +182,7 @@ class StubSDKCore(
         email: String?,
         extraInfo: Map<String, Any?>
     ) {
-        stubUserInfo(UserInfo(id, name, email, extraInfo))
+        stubUserInfo(UserInfo(null, id, name, email, extraInfo))
     }
 
     // endregion


### PR DESCRIPTION
### What and why?

Adds capability of tracking anonymous id (enabled by default). This data allows linking sessions coming from the same device.

### How?

Following proposal from this [RFC (internal)](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/4447830354/RFC+-+Session+Continuity+in+SDKs) it reuses data store mechanism, and based on configuration it generates and reuses stored identifier.

This identifier is attached to `UserInfo` object ([schema already updated](https://github.com/DataDog/rum-events-format/blob/a48cdd6c5dac83b144519fa9d29615ea87d36905/schemas/rum/_common-schema.json#L127)), which is enriching other SDK events.

### Motivation

This extra property adds ability to link sessions coming from the same device.

### Additional Notes

The identifier is read asynchronously from a file, which means RUM events created immediately after calling `RUM.enable()` will not include it. However, this is not an issue since the `anonymous_id` belongs to the Session entity. As long as the `anonymous_id` is present in at least in one event, it is sufficient for linking.

Here's corresponding PR for iOS:
https://github.com/DataDog/dd-sdk-ios/pull/2172

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

