### PR TITLE
Adjust telemetry metrics sampling rates

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
@@ -15,7 +15,6 @@ import com.datadog.android.core.internal.persistence.file.advanced.FeatureFileOr
 import com.datadog.android.core.internal.persistence.file.existsSafe
 import com.datadog.android.core.internal.persistence.file.lengthSafe
 import com.datadog.android.core.internal.time.TimeProvider
-import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.privacy.TrackingConsent
 import java.io.File
 import java.util.Locale
@@ -43,7 +42,7 @@ internal class BatchMetricsDispatcher(
             internalLogger.logMetric(
                 messageBuilder = { BATCH_DELETED_MESSAGE },
                 additionalProperties = it,
-                samplingRate = MethodCallSamplingRate.LOW.rate
+                samplingRate = 1.5f
             )
         }
     }
@@ -56,7 +55,7 @@ internal class BatchMetricsDispatcher(
             internalLogger.logMetric(
                 messageBuilder = { BATCH_CLOSED_MESSAGE },
                 additionalProperties = it,
-                samplingRate = MethodCallSamplingRate.LOW.rate
+                samplingRate = 1.5f
             )
         }
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
@@ -102,7 +102,7 @@ internal class BatchMetricsDispatcherTest {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_DELETED_MESSAGE },
                 capture(),
-                eq(0.1f),
+                eq(1.5f),
                 eq(null)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
@@ -143,7 +143,7 @@ internal class BatchMetricsDispatcherTest {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_DELETED_MESSAGE },
                 capture(),
-                eq(0.1f),
+                eq(1.5f),
                 eq(null)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
@@ -169,7 +169,7 @@ internal class BatchMetricsDispatcherTest {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_DELETED_MESSAGE },
                 capture(),
-                eq(0.1f),
+                eq(1.5f),
                 eq(null)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
@@ -197,7 +197,7 @@ internal class BatchMetricsDispatcherTest {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_DELETED_MESSAGE },
                 capture(),
-                eq(0.1f),
+                eq(1.5f),
                 eq(null)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
@@ -224,7 +224,7 @@ internal class BatchMetricsDispatcherTest {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_DELETED_MESSAGE },
                 capture(),
-                eq(0.1f),
+                eq(1.5f),
                 eq(null)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
@@ -251,7 +251,7 @@ internal class BatchMetricsDispatcherTest {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_DELETED_MESSAGE },
                 capture(),
-                eq(0.1f),
+                eq(1.5f),
                 eq(null)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
@@ -326,7 +326,7 @@ internal class BatchMetricsDispatcherTest {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_CLOSED_MESSAGE },
                 capture(),
-                eq(0.1f),
+                eq(1.5f),
                 eq(null)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
@@ -373,7 +373,7 @@ internal class BatchMetricsDispatcherTest {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_CLOSED_MESSAGE },
                 capture(),
-                eq(0.1f),
+                eq(1.5f),
                 eq(null)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
@@ -405,7 +405,7 @@ internal class BatchMetricsDispatcherTest {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_CLOSED_MESSAGE },
                 capture(),
-                eq(0.1f),
+                eq(1.5f),
                 eq(null)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
@@ -437,7 +437,7 @@ internal class BatchMetricsDispatcherTest {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_CLOSED_MESSAGE },
                 capture(),
-                eq(0.1f),
+                eq(1.5f),
                 eq(null)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
@@ -469,7 +469,7 @@ internal class BatchMetricsDispatcherTest {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_CLOSED_MESSAGE },
                 capture(),
-                eq(0.1f),
+                eq(1.5f),
                 eq(null)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcher.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcher.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.rum.internal.metric
 
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.rum.internal.domain.scope.RumSessionScope
 import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
 import com.datadog.android.rum.model.ViewEvent
@@ -39,7 +38,7 @@ internal class SessionEndedMetricDispatcher(private val internalLogger: Internal
             internalLogger.logMetric(
                 messageBuilder = { SessionEndedMetric.RUM_SESSION_ENDED_METRIC_NAME },
                 additionalProperties = metric.toMetricAttributes(ntpOffsetAtEndMs),
-                samplingRate = MethodCallSamplingRate.ALL.rate
+                samplingRate = 15.0f
             )
         }
     }


### PR DESCRIPTION
### What does this PR do?

Adjust the metrics sampling rate, to ensure we have consistent data across platforms, and don't overwhelm our intake.