### PR TITLE
RUM-8314 allow disabling 404 span redaction

### DIFF
--- a/integrations/dd-sdk-android-okhttp/api/apiSurface
+++ b/integrations/dd-sdk-android-okhttp/api/apiSurface
@@ -58,4 +58,5 @@ open class com.datadog.android.okhttp.trace.TracingInterceptor : okhttp3.Interce
     fun setTraceSampleRate(Float): R
     fun setTraceSampler(com.datadog.android.core.sampling.Sampler<io.opentracing.Span>): R
     fun setTraceContextInjection(com.datadog.android.okhttp.TraceContextInjection): R
+    fun set404ResourcesRedacted(Boolean): R
     abstract fun build(): T

--- a/integrations/dd-sdk-android-okhttp/api/dd-sdk-android-okhttp.api
+++ b/integrations/dd-sdk-android-okhttp/api/dd-sdk-android-okhttp.api
@@ -112,6 +112,7 @@ public class com/datadog/android/okhttp/trace/TracingInterceptor : okhttp3/Inter
 public abstract class com/datadog/android/okhttp/trace/TracingInterceptor$BaseBuilder {
 	public fun <init> (Ljava/util/Map;)V
 	public abstract fun build ()Lcom/datadog/android/okhttp/trace/TracingInterceptor;
+	public final fun set404ResourcesRedacted (Z)Lcom/datadog/android/okhttp/trace/TracingInterceptor$BaseBuilder;
 	public final fun setSdkInstanceName (Ljava/lang/String;)Lcom/datadog/android/okhttp/trace/TracingInterceptor$BaseBuilder;
 	public final fun setTraceContextInjection (Lcom/datadog/android/okhttp/TraceContextInjection;)Lcom/datadog/android/okhttp/trace/TracingInterceptor$BaseBuilder;
 	public final fun setTraceSampleRate (F)Lcom/datadog/android/okhttp/trace/TracingInterceptor$BaseBuilder;

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -79,6 +79,7 @@ open class DatadogInterceptor internal constructor(
     internal val rumResourceAttributesProvider: RumResourceAttributesProvider,
     traceSampler: Sampler<Span>,
     traceContextInjection: TraceContextInjection,
+    redacted404ResourceName: Boolean,
     localTracerFactory: (SdkCore, Set<TracingHeaderType>) -> Tracer
 ) : TracingInterceptor(
     sdkInstanceName,
@@ -87,6 +88,7 @@ open class DatadogInterceptor internal constructor(
     ORIGIN_RUM,
     traceSampler,
     traceContextInjection,
+    redacted404ResourceName,
     localTracerFactory
 ) {
 
@@ -135,6 +137,7 @@ open class DatadogInterceptor internal constructor(
         rumResourceAttributesProvider = rumResourceAttributesProvider,
         traceSampler = traceSampler,
         traceContextInjection = TraceContextInjection.All,
+        redacted404ResourceName = true,
         localTracerFactory = { sdkCore, tracingHeaderTypes ->
             AndroidTracer.Builder(sdkCore).setTracingHeaderTypes(tracingHeaderTypes).build()
         }
@@ -189,6 +192,7 @@ open class DatadogInterceptor internal constructor(
         rumResourceAttributesProvider = rumResourceAttributesProvider,
         traceSampler = traceSampler,
         traceContextInjection = TraceContextInjection.All,
+        redacted404ResourceName = true,
         localTracerFactory = { sdkCore, tracingHeaderTypes ->
             AndroidTracer.Builder(sdkCore).setTracingHeaderTypes(tracingHeaderTypes).build()
         }
@@ -229,6 +233,7 @@ open class DatadogInterceptor internal constructor(
         rumResourceAttributesProvider = rumResourceAttributesProvider,
         traceSampler = traceSampler,
         traceContextInjection = TraceContextInjection.All,
+        redacted404ResourceName = true,
         localTracerFactory = { sdkCore, tracingHeaderTypes ->
             AndroidTracer.Builder(sdkCore).setTracingHeaderTypes(tracingHeaderTypes).build()
         }
@@ -469,6 +474,7 @@ open class DatadogInterceptor internal constructor(
                 rumResourceAttributesProvider,
                 traceSampler,
                 traceContextInjection,
+                redacted404ResourceName,
                 localTracerFactory
             )
         }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -95,6 +95,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             rumResourceAttributesProvider = mockRumAttributesProvider,
             traceSampler = mockTraceSampler,
             traceContextInjection = TraceContextInjection.All,
+            redacted404ResourceName = fakeRedacted404Resources,
             localTracerFactory = factory
         )
     }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutRumTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutRumTest.kt
@@ -60,6 +60,7 @@ internal class DatadogInterceptorWithoutRumTest : TracingInterceptorTest() {
             rumResourceAttributesProvider = mockRumAttributesProvider,
             traceSampler = mockTraceSampler,
             traceContextInjection = TraceContextInjection.All,
+            redacted404ResourceName = fakeRedacted404Resources,
             localTracerFactory = factory
         )
     }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
@@ -31,6 +31,7 @@ import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.forge.BaseConfigurator
 import com.datadog.tools.unit.forge.exhaustiveAttributes
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -138,6 +139,8 @@ internal class DatadogInterceptorWithoutTracesTest {
     @StringForgery(type = StringForgeryType.HEXADECIMAL)
     lateinit var fakeTraceId: String
 
+    @BoolForgery
+    var fakeRedacted404Resources: Boolean = true
     // endregion
 
     @BeforeEach
@@ -162,6 +165,7 @@ internal class DatadogInterceptorWithoutTracesTest {
             tracedRequestListener = mockRequestListener,
             rumResourceAttributesProvider = mockRumAttributesProvider,
             traceSampler = mockTraceSampler,
+            redacted404ResourceName = fakeRedacted404Resources,
             traceContextInjection = TraceContextInjection.All
         ) { _, _ -> mockLocalTracer }
         whenever(rumMonitor.mockSdkCore.getFeature(Feature.TRACING_FEATURE_NAME)) doReturn mock()

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/TracingInterceptorBuilderTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/TracingInterceptorBuilderTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.trace.TracingHeaderType
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.forge.BaseConfigurator
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -81,6 +82,7 @@ internal class TracingInterceptorBuilderTest {
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
         assertThat(interceptor.traceOrigin).isNull()
         assertThat(interceptor.localTracerFactory).isNotNull()
+        assertThat(interceptor.redacted404ResourceName).isTrue()
     }
 
     @Test
@@ -103,6 +105,7 @@ internal class TracingInterceptorBuilderTest {
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
         assertThat(interceptor.traceOrigin).isNull()
         assertThat(interceptor.localTracerFactory).isNotNull()
+        assertThat(interceptor.redacted404ResourceName).isTrue()
     }
 
     @Test
@@ -120,6 +123,7 @@ internal class TracingInterceptorBuilderTest {
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
         assertThat(interceptor.traceOrigin).isNull()
         assertThat(interceptor.localTracerFactory).isNotNull()
+        assertThat(interceptor.redacted404ResourceName).isTrue()
     }
 
     @Test
@@ -137,6 +141,7 @@ internal class TracingInterceptorBuilderTest {
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
         assertThat(interceptor.traceOrigin).isNull()
         assertThat(interceptor.localTracerFactory).isNotNull()
+        assertThat(interceptor.redacted404ResourceName).isTrue()
     }
 
     @Test
@@ -154,6 +159,7 @@ internal class TracingInterceptorBuilderTest {
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
         assertThat(interceptor.traceOrigin).isEqualTo(fakeOrigin)
         assertThat(interceptor.localTracerFactory).isNotNull()
+        assertThat(interceptor.redacted404ResourceName).isTrue()
     }
 
     @Test
@@ -171,6 +177,7 @@ internal class TracingInterceptorBuilderTest {
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
         assertThat(interceptor.traceOrigin).isNull()
         assertThat(interceptor.localTracerFactory).isNotNull()
+        assertThat(interceptor.redacted404ResourceName).isTrue()
     }
 
     @Test
@@ -188,5 +195,26 @@ internal class TracingInterceptorBuilderTest {
         assertThat(interceptor.traceSampler).isSameAs(mockSampler)
         assertThat(interceptor.traceOrigin).isNull()
         assertThat(interceptor.localTracerFactory).isNotNull()
+        assertThat(interceptor.redacted404ResourceName).isTrue()
+    }
+
+    @Test
+    fun `M set redacted404Resources W build { setTraceSampler }`(
+        @BoolForgery redacted: Boolean
+    ) {
+        // When
+        val interceptor = TracingInterceptor.Builder(fakeTracedHostsWithHeaderType)
+            .set404ResourcesRedacted(redacted)
+            .build()
+
+        // Then
+        assertThat(interceptor.tracedHosts).isEqualTo(fakeTracedHostsWithHeaderType)
+        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.All)
+        assertThat(interceptor.sdkInstanceName).isNull()
+        assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
+        assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceOrigin).isNull()
+        assertThat(interceptor.localTracerFactory).isNotNull()
+        assertThat(interceptor.redacted404ResourceName).isEqualTo(redacted)
     }
 }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
@@ -29,6 +29,7 @@ import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.forge.BaseConfigurator
 import com.datadog.tools.unit.setStaticValue
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -161,6 +162,9 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
     lateinit var fakeLocalHosts: Map<String, Set<TracingHeaderType>>
 
+    @BoolForgery
+    var fakeRedacted404Resources: Boolean = true
+
     // endregion
 
     @BeforeEach
@@ -216,6 +220,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
                 traceOrigin = fakeOrigin,
                 traceSampler = mockTraceSampler,
                 traceContextInjection = TraceContextInjection.All,
+                redacted404ResourceName = fakeRedacted404Resources,
                 localTracerFactory = factory
             ) {
             override fun canSendSpan(): Boolean {

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
@@ -28,6 +28,7 @@ import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.forge.BaseConfigurator
 import com.datadog.tools.unit.setStaticValue
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -154,6 +155,9 @@ internal open class TracingInterceptorNonDdTracerTest {
 
     lateinit var fakeLocalHosts: Map<String, Set<TracingHeaderType>>
 
+    @BoolForgery
+    var fakeRedacted404Resources: Boolean = true
+
     // endregion
 
     @BeforeEach
@@ -200,6 +204,7 @@ internal open class TracingInterceptorNonDdTracerTest {
             traceOrigin = fakeOrigin,
             traceSampler = mockTraceSampler,
             traceContextInjection = TraceContextInjection.All,
+            redacted404ResourceName = fakeRedacted404Resources,
             localTracerFactory = factory
         )
     }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
@@ -30,6 +30,7 @@ import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.setStaticValue
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -154,6 +155,9 @@ internal open class TracingInterceptorTest {
 
     lateinit var fakeLocalHosts: Map<String, Set<TracingHeaderType>>
 
+    @BoolForgery
+    var fakeRedacted404Resources: Boolean = true
+
     // endregion
 
     @BeforeEach
@@ -199,6 +203,7 @@ internal open class TracingInterceptorTest {
             traceOrigin = fakeOrigin,
             traceSampler = mockTraceSampler,
             localTracerFactory = factory,
+            redacted404ResourceName = fakeRedacted404Resources,
             traceContextInjection = TraceContextInjection.All
         )
     }
@@ -1223,7 +1228,11 @@ internal open class TracingInterceptorTest {
         verify(mockSpan).setTag("http.status_code", 404)
         verify(mockSpan).setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_CLIENT)
         verify(mockSpan as MutableSpan).setError(true)
-        verify(mockSpan as MutableSpan).setResourceName(TracingInterceptor.RESOURCE_NAME_404)
+        if (fakeRedacted404Resources) {
+            verify(mockSpan as MutableSpan).setResourceName(TracingInterceptor.RESOURCE_NAME_404)
+        } else {
+            verify(mockSpan as MutableSpan, never()).setResourceName(TracingInterceptor.RESOURCE_NAME_404)
+        }
         verify(mockSpan).finish()
         assertThat(response).isSameAs(fakeResponse)
     }


### PR DESCRIPTION
### What does this PR do?

Adds an option to keep the resource name for network requests ending in `404` as original, instead of having them redacted to `"404"`.