### PR TITLE
Fix flaky test in Head-based sampling test suite

### DIFF
--- a/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/HeadBasedSamplingTest.kt
+++ b/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/HeadBasedSamplingTest.kt
@@ -470,7 +470,8 @@ class HeadBasedSamplingTest {
                 )
                 hasMostSignificant64BitsTraceId(mostSignificantTraceId)
                 hasSpanId(spanId.toLong().toHexString())
-                hasParentId(localSpanId)
+                // OpenTelemetry Span IDs are always padded with 0
+                hasParentId(localSpanId.dropWhile { it == '0' })
                 hasVersion(stubSdkCore.getDatadogContext().version)
                 hasSource(stubSdkCore.getDatadogContext().source)
                 hasTracerVersion(stubSdkCore.getDatadogContext().sdkVersion)


### PR DESCRIPTION
### What does this PR do?

This PR fixes a flaky test related to the fact that OpenTelemetry Span context is using fixed-length identifier for Span ID, unlike `SpanEvent`, where leading zeros are dropped.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

