### PR TITLE
RUM-8366 Forward RUM Session ID in trace headers

### DIFF
--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -4481,10 +4481,12 @@ public abstract class com/datadog/trace/core/propagation/PropagationTags {
 	public static fun factory (Lcom/datadog/trace/api/Config;)Lcom/datadog/trace/core/propagation/PropagationTags$Factory;
 	public abstract fun fillTagMap (Ljava/util/Map;)V
 	public abstract fun getOrigin ()Ljava/lang/CharSequence;
+	public abstract fun getRumSessionId ()Ljava/lang/String;
 	public abstract fun getSamplingPriority ()I
 	public abstract fun getTraceIdHighOrderBits ()J
 	public abstract fun getW3CTracestate ()Ljava/lang/String;
 	public abstract fun headerValue (Lcom/datadog/trace/core/propagation/PropagationTags$HeaderType;)Ljava/lang/String;
+	public abstract fun updateRumSessionId (Ljava/lang/String;)V
 	public abstract fun updateTraceIdHighOrderBits (J)V
 	public abstract fun updateTraceOrigin (Ljava/lang/CharSequence;)V
 	public abstract fun updateTraceSamplingPriority (II)V
@@ -4520,6 +4522,7 @@ public class com/datadog/trace/core/propagation/ptags/W3CPTagsCodec {
 	protected static final field DECISION_MAKER_TAG Lcom/datadog/trace/core/propagation/ptags/TagKey;
 	protected static final field PROPAGATION_ERROR_INCONSISTENT_TID Ljava/lang/String;
 	protected static final field PROPAGATION_ERROR_MALFORMED_TID Ljava/lang/String;
+	protected static final field RUM_SESSION_ID_TAG Lcom/datadog/trace/core/propagation/ptags/TagKey;
 	protected static final field TRACE_ID_TAG Lcom/datadog/trace/core/propagation/ptags/TagKey;
 	protected static final field UPSTREAM_SERVICES_DEPRECATED_TAG Lcom/datadog/trace/core/propagation/ptags/TagKey;
 	public fun <init> ()V

--- a/features/dd-sdk-android-trace/src/main/java/com/datadog/trace/core/propagation/HttpCodec.java
+++ b/features/dd-sdk-android-trace/src/main/java/com/datadog/trace/core/propagation/HttpCodec.java
@@ -48,6 +48,8 @@ public class HttpCodec {
   static final String CF_CONNECTING_IP_KEY = "cf-connecting-ip";
   static final String CF_CONNECTING_IP_V6_KEY = "cf-connecting-ipv6";
 
+  static final String RUM_SESSION_ID_KEY = "session_id";
+
   public interface Injector {
     <C> void inject(
         final DDSpanContext context, final C carrier, final AgentPropagation.Setter<C> setter);
@@ -184,6 +186,12 @@ public class HttpCodec {
     public <C> void inject(
         final DDSpanContext context, final C carrier, final AgentPropagation.Setter<C> setter) {
       log.debug("Inject context {}", context);
+      // Update session ide before injecting propagation tags
+      final String sessionId = (String) context.getTags().get(RUM_SESSION_ID_KEY);
+      if (sessionId != null) {
+        context.getPropagationTags().updateRumSessionId(sessionId);
+      }
+
       for (final Injector injector : injectors) {
         injector.inject(context, carrier, setter);
       }

--- a/features/dd-sdk-android-trace/src/main/java/com/datadog/trace/core/propagation/PropagationTags.java
+++ b/features/dd-sdk-android-trace/src/main/java/com/datadog/trace/core/propagation/PropagationTags.java
@@ -67,6 +67,10 @@ public abstract class PropagationTags {
 
   public abstract void updateTraceIdHighOrderBits(long highOrderBits);
 
+  public abstract String getRumSessionId();
+
+  public abstract void updateRumSessionId(String sessionId);
+
   /**
    * Gets the original <a href="https://www.w3.org/TR/trace-context/#tracestate-header">W3C
    * tracestate header</a> value.

--- a/features/dd-sdk-android-trace/src/main/java/com/datadog/trace/core/propagation/ptags/PTagsCodec.java
+++ b/features/dd-sdk-android-trace/src/main/java/com/datadog/trace/core/propagation/ptags/PTagsCodec.java
@@ -16,6 +16,7 @@ abstract class PTagsCodec {
 
   protected static final TagKey DECISION_MAKER_TAG = TagKey.from("dm");
   protected static final TagKey TRACE_ID_TAG = TagKey.from("tid");
+  protected static final TagKey RUM_SESSION_ID_TAG = TagKey.from("rsid");
   protected static final String PROPAGATION_ERROR_MALFORMED_TID = "malformed_tid ";
   protected static final String PROPAGATION_ERROR_INCONSISTENT_TID = "inconsistent_tid ";
   protected static final TagKey UPSTREAM_SERVICES_DEPRECATED_TAG = TagKey.from("upstream_services");
@@ -35,6 +36,9 @@ abstract class PTagsCodec {
       }
       if (ptags.getTraceIdHighOrderBitsHexTagValue() != null) {
         size = codec.appendTag(sb, TRACE_ID_TAG, ptags.getTraceIdHighOrderBitsHexTagValue(), size);
+      }
+      if (ptags.getRumSessionId() != null) {
+        size = codec.appendTag(sb, RUM_SESSION_ID_TAG, ptags.getRumSessionIdTagValue(), size);
       }
       Iterator<TagElement> it = ptags.getTagPairs().iterator();
       while (it.hasNext() && !codec.isTooLarge(sb, size)) {

--- a/features/dd-sdk-android-trace/src/main/java/com/datadog/trace/core/propagation/ptags/PTagsFactory.java
+++ b/features/dd-sdk-android-trace/src/main/java/com/datadog/trace/core/propagation/ptags/PTagsFactory.java
@@ -84,6 +84,10 @@ public class PTagsFactory implements PropagationTags.Factory {
     private volatile String[] headerCache = null;
     /** The high-order 64 bits of the trace id. */
     private volatile long traceIdHighOrderBits;
+
+    private volatile String rumSessionId;
+    private volatile TagValue rumSessionIdTagValue ;
+
     /**
      * The zero-padded lower-case 16 character hexadecimal representation of the high-order 64 bits
      * of the trace id, wrapped into a {@link TagValue}, <code>null</code> if not set.
@@ -203,6 +207,7 @@ public class PTagsFactory implements PropagationTags.Factory {
       return traceIdHighOrderBits;
     }
 
+    @Override
     public void updateTraceIdHighOrderBits(long highOrderBits) {
       if (traceIdHighOrderBits != highOrderBits) {
         traceIdHighOrderBits = highOrderBits;
@@ -211,6 +216,21 @@ public class PTagsFactory implements PropagationTags.Factory {
                 ? null
                 : TagValue.from(LongStringUtils.toHexStringPadded(highOrderBits, 16));
         clearCachedHeader(DATADOG);
+      }
+    }
+
+    @Override
+    public String getRumSessionId() {
+      return rumSessionId;
+    }
+
+    @Override
+    public void updateRumSessionId(String sessionId) {
+      if (!Objects.equals(rumSessionId, sessionId)) {
+        rumSessionId = sessionId;
+        rumSessionIdTagValue = TagValue.from(rumSessionId);
+        clearCachedHeader(DATADOG);
+        clearCachedHeader(W3C);
       }
     }
 
@@ -294,6 +314,10 @@ public class PTagsFactory implements PropagationTags.Factory {
 
     TagValue getTraceIdHighOrderBitsHexTagValue() {
       return traceIdHighOrderBitsHexTagValue;
+    }
+
+    TagValue getRumSessionIdTagValue() {
+      return rumSessionIdTagValue;
     }
 
     TagValue getDecisionMakerTagValue() {


### PR DESCRIPTION
### What does this PR do?

As part of our Joint Sampling project, we forward the RUM session ID as tag in the tracing headers (DD and W3C style).

