### PR TITLE
[RUM-8375]  View ended instrumentation type attribute support

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -255,6 +255,25 @@ sealed class com.datadog.android.core.feature.event.JvmCrash
     constructor(Throwable, String, List<ThreadDump>)
 data class com.datadog.android.core.feature.event.ThreadDump
   constructor(String, String, String, Boolean)
+interface com.datadog.android.core.internal.attributes.LocalAttribute
+  enum Key
+    constructor(String)
+    - CREATION_SAMPLING_RATE
+    - REPORTING_SAMPLING_RATE
+    - VIEW_SCOPE_INSTRUMENTATION_TYPE
+  interface Constant
+    val key: Key
+    val value: Any
+fun MutableMap<String, Any?>.enrichWithConstantAttribute(LocalAttribute.Constant)
+fun MutableMap<String, Any?>.enrichWithNonNullAttribute(LocalAttribute.Key, Any?)
+fun MutableMap<String, Any?>.enrichWithLocalAttribute(LocalAttribute.Key, Any?)
+enum com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType : LocalAttribute.Constant
+  constructor(String)
+  - MANUAL
+  - COMPOSE
+  - ACTIVITY
+  - FRAGMENT
+  override val key: LocalAttribute.Key
 class com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver : FirstPartyHostHeaderTypeResolver
   constructor(Map<String, Set<com.datadog.android.trace.TracingHeaderType>>)
   override fun isFirstPartyUrl(okhttp3.HttpUrl): Boolean

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -716,6 +716,40 @@ public final class com/datadog/android/core/feature/event/ThreadDump {
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class com/datadog/android/core/internal/attributes/LocalAttribute {
+}
+
+public abstract interface class com/datadog/android/core/internal/attributes/LocalAttribute$Constant {
+	public abstract fun getKey ()Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/core/internal/attributes/LocalAttribute$Key : java/lang/Enum {
+	public static final field CREATION_SAMPLING_RATE Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
+	public static final field REPORTING_SAMPLING_RATE Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
+	public static final field VIEW_SCOPE_INSTRUMENTATION_TYPE Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
+	public final fun getString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
+	public static fun values ()[Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
+}
+
+public final class com/datadog/android/core/internal/attributes/LocalAttributeKt {
+	public static final fun enrichWithConstantAttribute (Ljava/util/Map;Lcom/datadog/android/core/internal/attributes/LocalAttribute$Constant;)Ljava/util/Map;
+	public static final fun enrichWithLocalAttribute (Ljava/util/Map;Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;Ljava/lang/Object;)Ljava/util/Map;
+	public static final fun enrichWithNonNullAttribute (Ljava/util/Map;Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;Ljava/lang/Object;)Ljava/util/Map;
+}
+
+public final class com/datadog/android/core/internal/attributes/ViewScopeInstrumentationType : java/lang/Enum, com/datadog/android/core/internal/attributes/LocalAttribute$Constant {
+	public static final field ACTIVITY Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
+	public static final field COMPOSE Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
+	public static final field FRAGMENT Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
+	public static final field MANUAL Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
+	public fun getKey ()Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
+	public static fun values ()[Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
+}
+
 public final class com/datadog/android/core/internal/net/DefaultFirstPartyHostHeaderTypeResolver : com/datadog/android/core/internal/net/FirstPartyHostHeaderTypeResolver {
 	public fun <init> (Ljava/util/Map;)V
 	public fun getAllHeaderTypes ()Ljava/util/Set;

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -721,7 +721,7 @@ public abstract interface class com/datadog/android/core/internal/attributes/Loc
 
 public abstract interface class com/datadog/android/core/internal/attributes/LocalAttribute$Constant {
 	public abstract fun getKey ()Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
-	public abstract fun getValue ()Ljava/lang/String;
+	public abstract fun getValue ()Ljava/lang/Object;
 }
 
 public final class com/datadog/android/core/internal/attributes/LocalAttribute$Key : java/lang/Enum {
@@ -745,6 +745,7 @@ public final class com/datadog/android/core/internal/attributes/ViewScopeInstrum
 	public static final field FRAGMENT Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
 	public static final field MANUAL Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
 	public fun getKey ()Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
+	public synthetic fun getValue ()Ljava/lang/Object;
 	public fun getValue ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
 	public static fun values ()[Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/attributes/LocalAttribute.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/attributes/LocalAttribute.kt
@@ -73,7 +73,7 @@ fun MutableMap<String, Any?>.enrichWithConstantAttribute(
     attribute: LocalAttribute.Constant
 ) = enrichWithLocalAttribute(
     attribute.key,
-    attribute.value
+    attribute
 )
 
 /**

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/attributes/LocalAttribute.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/attributes/LocalAttribute.kt
@@ -13,7 +13,16 @@ import com.datadog.android.lint.InternalApi
  */
 interface LocalAttribute {
 
-    enum class Key(val string: String) {
+    /**
+     * Enumeration of all local attributes keys used in the application.
+     * Made via **enum** to make sure that all such attributes will be removed before sending the event to the backend.
+     *
+     * @property string - Unique string value for a local attribute key.
+     */
+    @InternalApi
+    enum class Key(
+        val string: String
+    ) {
         /* Some of the metrics like [PerformanceMetric] being sampled on the
          * metric creation place and then reported with 100% probability.
          * In such cases we need to use *creationSampleRate* to compute effectiveSampleRate correctlyThe sampling
@@ -21,19 +30,17 @@ interface LocalAttribute {
          * Creation(head) sampling rate exist only for long-lived metrics like method performance.
          * Created metric still could not be sent it depends on [REPORTING_SAMPLING_RATE_KEY] sampling rate
          */
-        @InternalApi
         CREATION_SAMPLING_RATE("_dd.local.head_sampling_rate_key"),
 
         /* Sampling rate that is used to decide to send or not to send the metric.
          * Each metric should have reporting(tail) sampling rate.
          * It's possible that metric has only reporting(tail) sampling rate.
          */
-        @InternalApi
         REPORTING_SAMPLING_RATE("_dd.local.tail_sampling_rate_key"),
 
         /*
          * Indicates which instrumentation was used to track the view scope.
-         * See [ViewScopeInstrumentationType] for possible values
+         * See [ViewScopeInstrumentationType] for possible values.
          */
         VIEW_SCOPE_INSTRUMENTATION_TYPE("_dd.local.view_instrumentation_type_key")
     }
@@ -44,12 +51,27 @@ interface LocalAttribute {
      * an attribute and reduces the possibility of inconsistent use of api (when an unsupported value is passed
      * for a particular attribute key).
      */
+    @InternalApi
     interface Constant {
+        /**
+         * Constant attribute key. For enum constants will be same for all values.
+         */
         val key: Key
-        val value: String
+
+        /**
+         * Constant attribute value. One item from set of possible finite values for a given constant attribute.
+         */
+        val value: Any
     }
 }
 
+/**
+ * Adds local attribute to the mutable map.
+ *
+ * @param attribute - Constant attribute value that should be added.
+ * Key for the attribute will be resolved automatically.
+ */
+@InternalApi
 fun MutableMap<String, Any?>.enrichWithConstantAttribute(
     attribute: LocalAttribute.Constant
 ) = enrichWithLocalAttribute(
@@ -57,11 +79,25 @@ fun MutableMap<String, Any?>.enrichWithConstantAttribute(
     attribute.value
 )
 
+/**
+ * Adds value to the map for specified key if value is not null.
+ *
+ * @param key - local attribute key.
+ * @param value - attribute value.
+ */
+@InternalApi
 fun MutableMap<String, Any?>.enrichWithNonNullAttribute(
     key: LocalAttribute.Key,
     value: Any?
 ) = value?.let { enrichWithLocalAttribute(key, it) } ?: this
 
+/**
+ * Adds value to the map for specified key.
+ *
+ * @param key - local attribute key.
+ * @param value - attribute value.
+ */
+@InternalApi
 fun MutableMap<String, Any?>.enrichWithLocalAttribute(
     key: LocalAttribute.Key,
     value: Any?
@@ -69,12 +105,36 @@ fun MutableMap<String, Any?>.enrichWithLocalAttribute(
     this[key.string] = value
 }
 
+/**
+ * A set of constants describing the instrumentation that were used to define the view scope.
+ *
+ * @property value - String value of the constant
+ * @property key - Key that is being used for this attribute.
+ * Equals to [LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE] for every value.
+ */
+@Suppress("KDocUnresolvedReference")
+@InternalApi
 enum class ViewScopeInstrumentationType(
     override val value: String
 ) : LocalAttribute.Constant {
+    /**
+     * Tracked manually through the RUMMonitor API.
+     */
     MANUAL("manual"),
+
+    /**
+     * Tracked through [ComposeNavigationObserver] instrumentation
+     */
     COMPOSE("compose"),
+
+    /**
+     * Tracked through [ActivityViewTrackingStrategy] instrumentation
+     */
     ACTIVITY("activity"),
+
+    /**
+     * Tracked through [FragmentViewTrackingStrategy] instrumentation
+     */
     FRAGMENT("fragment");
 
     override val key: LocalAttribute.Key = LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/attributes/LocalAttribute.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/attributes/LocalAttribute.kt
@@ -11,6 +11,7 @@ import com.datadog.android.lint.InternalApi
  * Local attributes are used to pass additional metadata along with the event
  * and are never sent to the backend directly.
  */
+@InternalApi
 interface LocalAttribute {
 
     /**
@@ -53,14 +54,10 @@ interface LocalAttribute {
      */
     @InternalApi
     interface Constant {
-        /**
-         * Constant attribute key. For enum constants will be same for all values.
-         */
+        /** Constant attribute key. For enum constants will be same for all values. */
         val key: Key
 
-        /**
-         * Constant attribute value. One item from set of possible finite values for a given constant attribute.
-         */
+        /** Constant attribute value. One item from set of possible finite values for a given constant attribute.*/
         val value: Any
     }
 }
@@ -103,39 +100,4 @@ fun MutableMap<String, Any?>.enrichWithLocalAttribute(
     value: Any?
 ) = apply {
     this[key.string] = value
-}
-
-/**
- * A set of constants describing the instrumentation that were used to define the view scope.
- *
- * @property value - String value of the constant
- * @property key - Key that is being used for this attribute.
- * Equals to [LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE] for every value.
- */
-@Suppress("KDocUnresolvedReference")
-@InternalApi
-enum class ViewScopeInstrumentationType(
-    override val value: String
-) : LocalAttribute.Constant {
-    /**
-     * Tracked manually through the RUMMonitor API.
-     */
-    MANUAL("manual"),
-
-    /**
-     * Tracked through [ComposeNavigationObserver] instrumentation
-     */
-    COMPOSE("compose"),
-
-    /**
-     * Tracked through [ActivityViewTrackingStrategy] instrumentation
-     */
-    ACTIVITY("activity"),
-
-    /**
-     * Tracked through [FragmentViewTrackingStrategy] instrumentation
-     */
-    FRAGMENT("fragment");
-
-    override val key: LocalAttribute.Key = LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/attributes/LocalAttribute.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/attributes/LocalAttribute.kt
@@ -29,7 +29,7 @@ interface LocalAttribute {
          * In such cases we need to use *creationSampleRate* to compute effectiveSampleRate correctlyThe sampling
          * rate is used when creating metrics.
          * Creation(head) sampling rate exist only for long-lived metrics like method performance.
-         * Created metric still could not be sent it depends on [REPORTING_SAMPLING_RATE_KEY] sampling rate
+         * Created metric still could not be sent it depends on [REPORTING_SAMPLING_RATE] sampling rate
          */
         CREATION_SAMPLING_RATE("_dd.local.head_sampling_rate_key"),
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/attributes/LocalAttribute.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/attributes/LocalAttribute.kt
@@ -1,0 +1,81 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.android.core.internal.attributes
+
+import com.datadog.android.lint.InternalApi
+
+/**
+ * Local attributes are used to pass additional metadata along with the event
+ * and are never sent to the backend directly.
+ */
+interface LocalAttribute {
+
+    enum class Key(val string: String) {
+        /* Some of the metrics like [PerformanceMetric] being sampled on the
+         * metric creation place and then reported with 100% probability.
+         * In such cases we need to use *creationSampleRate* to compute effectiveSampleRate correctlyThe sampling
+         * rate is used when creating metrics.
+         * Creation(head) sampling rate exist only for long-lived metrics like method performance.
+         * Created metric still could not be sent it depends on [REPORTING_SAMPLING_RATE_KEY] sampling rate
+         */
+        @InternalApi
+        CREATION_SAMPLING_RATE("_dd.local.head_sampling_rate_key"),
+
+        /* Sampling rate that is used to decide to send or not to send the metric.
+         * Each metric should have reporting(tail) sampling rate.
+         * It's possible that metric has only reporting(tail) sampling rate.
+         */
+        @InternalApi
+        REPORTING_SAMPLING_RATE("_dd.local.tail_sampling_rate_key"),
+
+        /*
+         * Indicates which instrumentation was used to track the view scope.
+         * See [ViewScopeInstrumentationType] for possible values
+         */
+        VIEW_SCOPE_INSTRUMENTATION_TYPE("_dd.local.view_instrumentation_type_key")
+    }
+
+    /**
+     * Used for attributes that have a finite set of possible values (such as enumerations, see [ViewScopeInstrumentationType]).
+     * This interface makes it possible to use only the value (see [enrichWithConstantAttribute]) when setting
+     * an attribute and reduces the possibility of inconsistent use of api (when an unsupported value is passed
+     * for a particular attribute key).
+     */
+    interface Constant {
+        val key: Key
+        val value: String
+    }
+}
+
+fun MutableMap<String, Any?>.enrichWithConstantAttribute(
+    attribute: LocalAttribute.Constant
+) = enrichWithLocalAttribute(
+    attribute.key,
+    attribute.value
+)
+
+fun MutableMap<String, Any?>.enrichWithNonNullAttribute(
+    key: LocalAttribute.Key,
+    value: Any?
+) = value?.let { enrichWithLocalAttribute(key, it) } ?: this
+
+fun MutableMap<String, Any?>.enrichWithLocalAttribute(
+    key: LocalAttribute.Key,
+    value: Any?
+) = apply {
+    this[key.string] = value
+}
+
+enum class ViewScopeInstrumentationType(
+    override val value: String
+) : LocalAttribute.Constant {
+    MANUAL("manual"),
+    COMPOSE("compose"),
+    ACTIVITY("activity"),
+    FRAGMENT("fragment");
+
+    override val key: LocalAttribute.Key = LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/attributes/ViewScopeInstrumentationType.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/attributes/ViewScopeInstrumentationType.kt
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.android.core.internal.attributes
+
+import com.datadog.android.lint.InternalApi
+
+/**
+ * A set of constants describing the instrumentation that were used to define the view scope.
+ */
+@InternalApi
+enum class ViewScopeInstrumentationType(
+    override val value: String
+) : LocalAttribute.Constant {
+    /** Tracked manually through the RUMMonitor API. */
+    MANUAL("manual"),
+
+    /** Tracked through ComposeNavigationObserver instrumentation. */
+    COMPOSE("compose"),
+
+    /** Tracked through ActivityViewTrackingStrategy instrumentation. */
+    ACTIVITY("activity"),
+
+    /** Tracked through FragmentViewTrackingStrategy instrumentation. */
+    FRAGMENT("fragment");
+
+    /** @inheritdoc */
+    override val key: LocalAttribute.Key = LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/logger/SdkInternalLogger.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/logger/SdkInternalLogger.kt
@@ -274,18 +274,6 @@ internal class SdkInternalLogger(
         }
     }
 
-    private fun enrichWithNonNullValue(
-        map: MutableMap<String, Any?>,
-        key: String,
-        value: Float?
-    ) {
-        if (value == null) return
-
-        if (!map.containsKey(key)) {
-            map[key] = value
-        }
-    }
-
     companion object {
         internal const val SDK_LOG_TAG = "DD_LOG"
         internal const val DEV_LOG_TAG = "Datadog"

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/logger/SdkInternalLogger.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/logger/SdkInternalLogger.kt
@@ -12,6 +12,8 @@ import com.datadog.android.Datadog
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.core.internal.attributes.LocalAttribute
+import com.datadog.android.core.internal.attributes.enrichWithNonNullAttribute
 import com.datadog.android.core.internal.metrics.MethodCalledTelemetry
 import com.datadog.android.core.metrics.PerformanceMetric
 import com.datadog.android.core.metrics.TelemetryMetricType
@@ -102,18 +104,14 @@ internal class SdkInternalLogger(
         if (!sample(samplingRate)) return
         val rumFeature = sdkCore?.getFeature(Feature.RUM_FEATURE_NAME) ?: return
         val additionalPropertiesMutable = additionalProperties.toMutableMap()
-
-        enrichWithNonNullValue(
-            additionalPropertiesMutable,
-            InternalTelemetryEvent.CREATION_SAMPLING_RATE_KEY,
-            creationSampleRate
-        )
-
-        enrichWithNonNullValue(
-            additionalPropertiesMutable,
-            InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY,
-            samplingRate
-        )
+            .enrichWithNonNullAttribute(
+                LocalAttribute.Key.CREATION_SAMPLING_RATE,
+                creationSampleRate
+            )
+            .enrichWithNonNullAttribute(
+                LocalAttribute.Key.REPORTING_SAMPLING_RATE,
+                samplingRate
+            )
 
         val metricEvent = InternalTelemetryEvent.Metric(
             message = messageBuilder(),
@@ -150,10 +148,8 @@ internal class SdkInternalLogger(
         val rumFeature = sdkCore?.getFeature(Feature.RUM_FEATURE_NAME) ?: return
 
         val event = apiUsageEventBuilder()
-
-        enrichWithNonNullValue(
-            event.additionalProperties,
-            InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY,
+        event.additionalProperties.enrichWithNonNullAttribute(
+            LocalAttribute.Key.REPORTING_SAMPLING_RATE,
             samplingRate
         )
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/logger/SdkInternalLoggerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/logger/SdkInternalLoggerTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.core.internal.attributes.LocalAttribute
 import com.datadog.android.core.internal.metrics.MethodCalledTelemetry
 import com.datadog.android.core.metrics.TelemetryMetricType
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
@@ -452,7 +453,7 @@ internal class SdkInternalLoggerTest {
         // Given
         val samplingRate = 100.0f
         val fakeAdditionalProperties = forge.exhaustiveAttributes().also {
-            it[InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY] = samplingRate
+            it[LocalAttribute.Key.REPORTING_SAMPLING_RATE.string] = samplingRate
         }
         val mockLambda: () -> String = mock()
         whenever(mockLambda.invoke()) doReturn fakeMessage
@@ -504,13 +505,13 @@ internal class SdkInternalLoggerTest {
             val metricEvent = firstValue as InternalTelemetryEvent.Metric
 
             assertThat(
-                metricEvent.additionalProperties?.get(InternalTelemetryEvent.CREATION_SAMPLING_RATE_KEY)
+                metricEvent.additionalProperties?.get(LocalAttribute.Key.CREATION_SAMPLING_RATE.string)
             ).isEqualTo(
                 expectedCreationSampleRate
             )
 
             assertThat(
-                metricEvent.additionalProperties?.get(InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY)
+                metricEvent.additionalProperties?.get(LocalAttribute.Key.REPORTING_SAMPLING_RATE.string)
             ).isEqualTo(
                 samplingRate
             )
@@ -543,11 +544,11 @@ internal class SdkInternalLoggerTest {
             assertThat(
                 apiUsageEvent.additionalProperties
             ).doesNotContainKeys(
-                InternalTelemetryEvent.CREATION_SAMPLING_RATE_KEY
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.string
             )
 
             assertThat(
-                apiUsageEvent.additionalProperties[InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY]
+                apiUsageEvent.additionalProperties[LocalAttribute.Key.REPORTING_SAMPLING_RATE.string]
             ).isEqualTo(
                 samplingRate
             )
@@ -568,7 +569,7 @@ internal class SdkInternalLoggerTest {
             ),
             target = InternalLogger.Target.TELEMETRY,
             messageBuilder = { forge.aString() },
-            additionalProperties = mapOf(InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY to samplingRate)
+            additionalProperties = mapOf(LocalAttribute.Key.REPORTING_SAMPLING_RATE.string to samplingRate)
         )
 
         // Then
@@ -580,11 +581,11 @@ internal class SdkInternalLoggerTest {
             assertThat(
                 debugEvent.additionalProperties
             ).doesNotContainKeys(
-                InternalTelemetryEvent.CREATION_SAMPLING_RATE_KEY
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.string
             )
 
             assertThat(
-                debugEvent.additionalProperties?.get(InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY)
+                debugEvent.additionalProperties?.get(LocalAttribute.Key.REPORTING_SAMPLING_RATE.string)
             ).isEqualTo(
                 samplingRate
             )
@@ -603,7 +604,7 @@ internal class SdkInternalLoggerTest {
             target = InternalLogger.Target.TELEMETRY,
             throwable = forge.aThrowable(),
             messageBuilder = { forge.aString() },
-            additionalProperties = mapOf(InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY to samplingRate)
+            additionalProperties = mapOf(LocalAttribute.Key.REPORTING_SAMPLING_RATE.string to samplingRate)
         )
 
         // Then
@@ -615,11 +616,11 @@ internal class SdkInternalLoggerTest {
             assertThat(
                 debugEvent.additionalProperties
             ).doesNotContainKeys(
-                InternalTelemetryEvent.CREATION_SAMPLING_RATE_KEY
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.string
             )
 
             assertThat(
-                debugEvent.additionalProperties?.get(InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY)
+                debugEvent.additionalProperties?.get(LocalAttribute.Key.REPORTING_SAMPLING_RATE.string)
             ).isEqualTo(
                 samplingRate
             )

--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -28,9 +28,6 @@ sealed class com.datadog.android.internal.telemetry.InternalTelemetryEvent
     class AddViewLoadingTime : ApiUsage
       constructor(Boolean, Boolean, Boolean, MutableMap<String, Any?> = mutableMapOf())
   object InterceptorInstantiated : InternalTelemetryEvent
-  companion object 
-    const val CREATION_SAMPLING_RATE_KEY: String
-    const val REPORTING_SAMPLING_RATE_KEY: String
 fun ByteArray.toHexString(): String
 object com.datadog.android.internal.utils.ImageViewUtils
   fun resolveParentRectAbsPosition(android.view.View, Boolean = true): android.graphics.Rect

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -30,9 +30,6 @@ public final class com/datadog/android/internal/profiler/GlobalBenchmark {
 }
 
 public abstract class com/datadog/android/internal/telemetry/InternalTelemetryEvent {
-	public static final field CREATION_SAMPLING_RATE_KEY Ljava/lang/String;
-	public static final field Companion Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$Companion;
-	public static final field REPORTING_SAMPLING_RATE_KEY Ljava/lang/String;
 }
 
 public abstract class com/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage : com/datadog/android/internal/telemetry/InternalTelemetryEvent {
@@ -47,9 +44,6 @@ public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent
 	public final fun getNoActiveView ()Z
 	public final fun getNoView ()Z
 	public final fun getOverwrite ()Z
-}
-
-public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent$Companion {
 }
 
 public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent$Configuration : com/datadog/android/internal/telemetry/InternalTelemetryEvent {

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/telemetry/InternalTelemetryEvent.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/telemetry/InternalTelemetryEvent.kt
@@ -59,22 +59,4 @@ sealed class InternalTelemetryEvent {
     }
 
     object InterceptorInstantiated : InternalTelemetryEvent()
-
-    companion object {
-
-        /* Some of the metrics like [PerformanceMetric] being sampled on the
-         * metric creation place and then reported with 100% probability.
-         * In such cases we need to use *creationSampleRate* to compute effectiveSampleRate correctlyThe sampling
-         * rate is used when creating metrics.
-         * Creation(head) sampling rate exist only for long-lived metrics like method performance.
-         * Created metric still could not be sent it depends on [REPORTING_SAMPLING_RATE_KEY] sampling rate
-         */
-        const val CREATION_SAMPLING_RATE_KEY: String = "HEAD_SAMPLING_RATE_KEY"
-
-        /* Sampling rate that is used to decide to send or not to send the metric.
-         * Each metric should have reporting(tail) sampling rate.
-         * It's possible that metric has only reporting(tail) sampling rate.
-         */
-        const val REPORTING_SAMPLING_RATE_KEY: String = "TAIL_SAMPLING_RATE_KEY"
-    }
 }

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -254,7 +254,7 @@ class com.datadog.android.rum.tracking.ActivityViewTrackingStrategy : ActivityLi
   override fun onActivityStopped(android.app.Activity)
   override fun equals(Any?): Boolean
   override fun hashCode(): Int
-fun android.os.Bundle?.convertToRumViewAttributes(): MutableMap<String, Any?>
+fun android.os.Bundle?.convertToRumViewAttributes(): Map<String, Any?>
 interface com.datadog.android.rum.tracking.ComponentPredicate<T>
   fun accept(T): Boolean
   fun getViewName(T): String?
@@ -1520,6 +1520,12 @@ data class com.datadog.android.rum.model.ResourceEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): OperationType
+data class com.datadog.android.rum.model.RumRect
+  constructor(kotlin.Number, kotlin.Number, kotlin.Number, kotlin.Number)
+  fun toJson(): com.google.gson.JsonElement
+  companion object 
+    fun fromJson(kotlin.String): RumRect
+    fun fromJsonObject(com.google.gson.JsonObject): RumRect
 data class com.datadog.android.rum.model.RumVitalEvent
   constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, RumVitalEventSession, RumVitalEventSource? = null, RumVitalEventView, Usr? = null, Account? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Container? = null, RumVitalEventVital)
   val type: kotlin.String
@@ -2069,6 +2075,48 @@ data class com.datadog.android.rum.model.ViewEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): State
+data class com.datadog.android.rum.model.ViewPerformanceData
+  constructor(Cls? = null, Fcp? = null, Fid? = null, Inp? = null, Lcp? = null)
+  fun toJson(): com.google.gson.JsonElement
+  companion object 
+    fun fromJson(kotlin.String): ViewPerformanceData
+    fun fromJsonObject(com.google.gson.JsonObject): ViewPerformanceData
+  data class Cls
+    constructor(kotlin.Number, kotlin.Long? = null, kotlin.String? = null, PreviousRect? = null, PreviousRect? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Cls
+      fun fromJsonObject(com.google.gson.JsonObject): Cls
+  data class Fcp
+    constructor(kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Fcp
+      fun fromJsonObject(com.google.gson.JsonObject): Fcp
+  data class Fid
+    constructor(kotlin.Long, kotlin.Long, kotlin.String? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Fid
+      fun fromJsonObject(com.google.gson.JsonObject): Fid
+  data class Inp
+    constructor(kotlin.Long, kotlin.Long? = null, kotlin.String? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Inp
+      fun fromJsonObject(com.google.gson.JsonObject): Inp
+  data class Lcp
+    constructor(kotlin.Long, kotlin.String? = null, kotlin.String? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Lcp
+      fun fromJsonObject(com.google.gson.JsonObject): Lcp
+  data class PreviousRect
+    constructor(kotlin.Number, kotlin.Number, kotlin.Number, kotlin.Number)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): PreviousRect
+      fun fromJsonObject(com.google.gson.JsonObject): PreviousRect
 data class com.datadog.android.telemetry.model.TelemetryConfigurationEvent
   constructor(Dd, kotlin.Long, kotlin.String, Source, kotlin.String, Application? = null, Session? = null, View? = null, Action? = null, kotlin.Number? = null, kotlin.collections.List<kotlin.String>? = null, Telemetry)
   val type: kotlin.String

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -254,7 +254,7 @@ class com.datadog.android.rum.tracking.ActivityViewTrackingStrategy : ActivityLi
   override fun onActivityStopped(android.app.Activity)
   override fun equals(Any?): Boolean
   override fun hashCode(): Int
-fun android.os.Bundle?.convertToRumViewAttributes(): Map<String, Any?>
+fun android.os.Bundle?.convertToRumViewAttributes(): MutableMap<String, Any?>
 interface com.datadog.android.rum.tracking.ComponentPredicate<T>
   fun accept(T): Boolean
   fun getViewName(T): String?

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -4315,6 +4315,32 @@ public final class com/datadog/android/rum/model/ResourceEvent$Worker$Companion 
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ResourceEvent$Worker;
 }
 
+public final class com/datadog/android/rum/model/RumRect {
+	public static final field Companion Lcom/datadog/android/rum/model/RumRect$Companion;
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)V
+	public final fun component1 ()Ljava/lang/Number;
+	public final fun component2 ()Ljava/lang/Number;
+	public final fun component3 ()Ljava/lang/Number;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/RumRect;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumRect;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumRect;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumRect;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumRect;
+	public final fun getHeight ()Ljava/lang/Number;
+	public final fun getWidth ()Ljava/lang/Number;
+	public final fun getX ()Ljava/lang/Number;
+	public final fun getY ()Ljava/lang/Number;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumRect$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumRect;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumRect;
+}
+
 public final class com/datadog/android/rum/model/RumVitalEvent {
 	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$Companion;
 	public fun <init> (JLcom/datadog/android/rum/model/RumVitalEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSession;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventSource;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventView;Lcom/datadog/android/rum/model/RumVitalEvent$Usr;Lcom/datadog/android/rum/model/RumVitalEvent$Account;Lcom/datadog/android/rum/model/RumVitalEvent$Connectivity;Lcom/datadog/android/rum/model/RumVitalEvent$Display;Lcom/datadog/android/rum/model/RumVitalEvent$Synthetics;Lcom/datadog/android/rum/model/RumVitalEvent$CiTest;Lcom/datadog/android/rum/model/RumVitalEvent$Os;Lcom/datadog/android/rum/model/RumVitalEvent$Device;Lcom/datadog/android/rum/model/RumVitalEvent$Dd;Lcom/datadog/android/rum/model/RumVitalEvent$Context;Lcom/datadog/android/rum/model/RumVitalEvent$Container;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;)V
@@ -6189,6 +6215,186 @@ public final class com/datadog/android/rum/model/ViewEvent$Viewport {
 public final class com/datadog/android/rum/model/ViewEvent$Viewport$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$Viewport;
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewEvent$Viewport;
+}
+
+public final class com/datadog/android/rum/model/ViewPerformanceData {
+	public static final field Companion Lcom/datadog/android/rum/model/ViewPerformanceData$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/datadog/android/rum/model/ViewPerformanceData$Cls;Lcom/datadog/android/rum/model/ViewPerformanceData$Fcp;Lcom/datadog/android/rum/model/ViewPerformanceData$Fid;Lcom/datadog/android/rum/model/ViewPerformanceData$Inp;Lcom/datadog/android/rum/model/ViewPerformanceData$Lcp;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/ViewPerformanceData$Cls;Lcom/datadog/android/rum/model/ViewPerformanceData$Fcp;Lcom/datadog/android/rum/model/ViewPerformanceData$Fid;Lcom/datadog/android/rum/model/ViewPerformanceData$Inp;Lcom/datadog/android/rum/model/ViewPerformanceData$Lcp;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/rum/model/ViewPerformanceData$Cls;
+	public final fun component2 ()Lcom/datadog/android/rum/model/ViewPerformanceData$Fcp;
+	public final fun component3 ()Lcom/datadog/android/rum/model/ViewPerformanceData$Fid;
+	public final fun component4 ()Lcom/datadog/android/rum/model/ViewPerformanceData$Inp;
+	public final fun component5 ()Lcom/datadog/android/rum/model/ViewPerformanceData$Lcp;
+	public final fun copy (Lcom/datadog/android/rum/model/ViewPerformanceData$Cls;Lcom/datadog/android/rum/model/ViewPerformanceData$Fcp;Lcom/datadog/android/rum/model/ViewPerformanceData$Fid;Lcom/datadog/android/rum/model/ViewPerformanceData$Inp;Lcom/datadog/android/rum/model/ViewPerformanceData$Lcp;)Lcom/datadog/android/rum/model/ViewPerformanceData;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewPerformanceData;Lcom/datadog/android/rum/model/ViewPerformanceData$Cls;Lcom/datadog/android/rum/model/ViewPerformanceData$Fcp;Lcom/datadog/android/rum/model/ViewPerformanceData$Fid;Lcom/datadog/android/rum/model/ViewPerformanceData$Inp;Lcom/datadog/android/rum/model/ViewPerformanceData$Lcp;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewPerformanceData;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewPerformanceData;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewPerformanceData;
+	public final fun getCls ()Lcom/datadog/android/rum/model/ViewPerformanceData$Cls;
+	public final fun getFcp ()Lcom/datadog/android/rum/model/ViewPerformanceData$Fcp;
+	public final fun getFid ()Lcom/datadog/android/rum/model/ViewPerformanceData$Fid;
+	public final fun getInp ()Lcom/datadog/android/rum/model/ViewPerformanceData$Inp;
+	public final fun getLcp ()Lcom/datadog/android/rum/model/ViewPerformanceData$Lcp;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/ViewPerformanceData$Cls {
+	public static final field Companion Lcom/datadog/android/rum/model/ViewPerformanceData$Cls$Companion;
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Long;Ljava/lang/String;Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;)V
+	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Long;Ljava/lang/String;Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Number;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;
+	public final fun component5 ()Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Long;Ljava/lang/String;Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;)Lcom/datadog/android/rum/model/ViewPerformanceData$Cls;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewPerformanceData$Cls;Ljava/lang/Number;Ljava/lang/Long;Ljava/lang/String;Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewPerformanceData$Cls;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewPerformanceData$Cls;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewPerformanceData$Cls;
+	public final fun getCurrentRect ()Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;
+	public final fun getPreviousRect ()Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;
+	public final fun getScore ()Ljava/lang/Number;
+	public final fun getTargetSelector ()Ljava/lang/String;
+	public final fun getTimestamp ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/ViewPerformanceData$Cls$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewPerformanceData$Cls;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewPerformanceData$Cls;
+}
+
+public final class com/datadog/android/rum/model/ViewPerformanceData$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewPerformanceData;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewPerformanceData;
+}
+
+public final class com/datadog/android/rum/model/ViewPerformanceData$Fcp {
+	public static final field Companion Lcom/datadog/android/rum/model/ViewPerformanceData$Fcp$Companion;
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lcom/datadog/android/rum/model/ViewPerformanceData$Fcp;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewPerformanceData$Fcp;JILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewPerformanceData$Fcp;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewPerformanceData$Fcp;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewPerformanceData$Fcp;
+	public final fun getTimestamp ()J
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/ViewPerformanceData$Fcp$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewPerformanceData$Fcp;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewPerformanceData$Fcp;
+}
+
+public final class com/datadog/android/rum/model/ViewPerformanceData$Fid {
+	public static final field Companion Lcom/datadog/android/rum/model/ViewPerformanceData$Fid$Companion;
+	public fun <init> (JJLjava/lang/String;)V
+	public synthetic fun <init> (JJLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (JJLjava/lang/String;)Lcom/datadog/android/rum/model/ViewPerformanceData$Fid;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewPerformanceData$Fid;JJLjava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewPerformanceData$Fid;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewPerformanceData$Fid;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewPerformanceData$Fid;
+	public final fun getDuration ()J
+	public final fun getTargetSelector ()Ljava/lang/String;
+	public final fun getTimestamp ()J
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/ViewPerformanceData$Fid$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewPerformanceData$Fid;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewPerformanceData$Fid;
+}
+
+public final class com/datadog/android/rum/model/ViewPerformanceData$Inp {
+	public static final field Companion Lcom/datadog/android/rum/model/ViewPerformanceData$Inp$Companion;
+	public fun <init> (JLjava/lang/Long;Ljava/lang/String;)V
+	public synthetic fun <init> (JLjava/lang/Long;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/Long;Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewPerformanceData$Inp;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewPerformanceData$Inp;JLjava/lang/Long;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewPerformanceData$Inp;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewPerformanceData$Inp;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewPerformanceData$Inp;
+	public final fun getDuration ()J
+	public final fun getTargetSelector ()Ljava/lang/String;
+	public final fun getTimestamp ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/ViewPerformanceData$Inp$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewPerformanceData$Inp;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewPerformanceData$Inp;
+}
+
+public final class com/datadog/android/rum/model/ViewPerformanceData$Lcp {
+	public static final field Companion Lcom/datadog/android/rum/model/ViewPerformanceData$Lcp$Companion;
+	public fun <init> (JLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewPerformanceData$Lcp;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewPerformanceData$Lcp;JLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewPerformanceData$Lcp;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewPerformanceData$Lcp;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewPerformanceData$Lcp;
+	public final fun getResourceUrl ()Ljava/lang/String;
+	public final fun getTargetSelector ()Ljava/lang/String;
+	public final fun getTimestamp ()J
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/ViewPerformanceData$Lcp$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewPerformanceData$Lcp;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewPerformanceData$Lcp;
+}
+
+public final class com/datadog/android/rum/model/ViewPerformanceData$PreviousRect {
+	public static final field Companion Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect$Companion;
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)V
+	public final fun component1 ()Ljava/lang/Number;
+	public final fun component2 ()Ljava/lang/Number;
+	public final fun component3 ()Ljava/lang/Number;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;
+	public final fun getHeight ()Ljava/lang/Number;
+	public final fun getWidth ()Ljava/lang/Number;
+	public final fun getX ()Ljava/lang/Number;
+	public final fun getY ()Ljava/lang/Number;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/ViewPerformanceData$PreviousRect$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewPerformanceData$PreviousRect;
 }
 
 public final class com/datadog/android/rum/resource/ContextExtKt {

--- a/features/dd-sdk-android-rum/src/main/json/rum/_rect-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/_rect-schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/_rect-schema.json",
+  "title": "RumRect",
+  "type": "object",
+  "description": "Schema for DOMRect-like rectangles describing an element's bounding client rect",
+  "required": ["x", "y", "width", "height"],
+  "properties": {
+    "x": {
+      "type": "number",
+      "description": "The x coordinate of the element's origin",
+      "readOnly": true
+    },
+    "y": {
+      "type": "number",
+      "description": "The y coordinate of the element's origin",
+      "readOnly": true
+    },
+    "width": {
+      "type": "number",
+      "description": "The element's width",
+      "readOnly": true
+    },
+    "height": {
+      "type": "number",
+      "description": "The element's height",
+      "readOnly": true
+    }
+  }
+}

--- a/features/dd-sdk-android-rum/src/main/json/rum/_view-performance-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/_view-performance-schema.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/_view-performance-schema.json",
+  "title": "ViewPerformanceData",
+  "type": "object",
+  "description": "Schema for view-level RUM performance data (Web Vitals, etc.)",
+  "properties": {
+    "cls": {
+      "type": "object",
+      "description": "Cumulative Layout Shift",
+      "required": ["score"],
+      "properties": {
+        "score": {
+          "type": "number",
+          "description": "Total layout shift score that occurred on the view",
+          "$comment": "Replaces the deprecated `view.cumulative_layout_shift`",
+          "minimum": 0,
+          "readOnly": true
+        },
+        "timestamp": {
+          "type": "integer",
+          "description": "Timestamp in ns of the largest layout shift contributing to CLS",
+          "$comment": "Replaces the deprecated `view.cumulative_layout_shift_time`",
+          "minimum": 0,
+          "readOnly": true
+        },
+        "target_selector": {
+          "type": "string",
+          "description": "CSS selector path of the first element (in document order) of the largest layout shift contributing to CLS",
+          "$comment": "Replaces the deprecated `view.cumulative_layout_shift_target_selector`",
+          "readOnly": true
+        },
+        "previous_rect": {
+          "description": "Bounding client rect of the element before the layout shift",
+          "allOf": [{ "$ref": "_rect-schema.json" }]
+        },
+        "current_rect": {
+          "description": "Bounding client rect of the element after the layout shift",
+          "allOf": [{ "$ref": "_rect-schema.json" }]
+        }
+      },
+      "readOnly": true
+    },
+    "fcp": {
+      "type": "object",
+      "description": "First Contentful Paint",
+      "required": ["timestamp"],
+      "properties": {
+        "timestamp": {
+          "type": "integer",
+          "description": "Timestamp in ns of the first rendering",
+          "$comment": "Replaces the deprecated `view.first_contentful_paint`",
+          "minimum": 0,
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "fid": {
+      "type": "object",
+      "description": "First Input Delay",
+      "required": ["duration", "timestamp"],
+      "properties": {
+        "duration": {
+          "type": "integer",
+          "description": "Duration in ns of the first input event delay",
+          "$comment": "Replaces the deprecated `view.first_input_delay`",
+          "minimum": 0,
+          "readOnly": true
+        },
+        "timestamp": {
+          "type": "integer",
+          "description": "Timestamp in ns of the first input event",
+          "$comment": "Replaces the deprecated `view.first_input_time`",
+          "minimum": 0,
+          "readOnly": true
+        },
+        "target_selector": {
+          "type": "string",
+          "description": "CSS selector path of the first input target element",
+          "$comment": "Replaces the deprecated `view.first_input_target_selector`",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "inp": {
+      "type": "object",
+      "description": "Interaction to Next Paint",
+      "required": ["duration"],
+      "properties": {
+        "duration": {
+          "type": "integer",
+          "description": "Longest duration in ns between an interaction and the next paint",
+          "$comment": "Replaces the deprecated `view.interaction_to_next_paint`",
+          "minimum": 0,
+          "readOnly": true
+        },
+        "timestamp": {
+          "type": "integer",
+          "description": "Timestamp in ns of the start of the INP interaction",
+          "$comment": "Replaces the deprecated `view.interaction_to_next_paint_time`",
+          "minimum": 0,
+          "readOnly": true
+        },
+        "target_selector": {
+          "type": "string",
+          "description": "CSS selector path of the interacted element for the INP interaction",
+          "$comment": "Replaces the deprecated `view.interaction_to_next_paint_target_selector`",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "lcp": {
+      "type": "object",
+      "description": "Largest Contentful Paint",
+      "required": ["timestamp"],
+      "properties": {
+        "timestamp": {
+          "type": "integer",
+          "description": "Timestamp in ns of the largest contentful paint",
+          "$comment": "Replaces the deprecated `view.largest_contentful_paint`",
+          "minimum": 0,
+          "readOnly": true
+        },
+        "target_selector": {
+          "type": "string",
+          "description": "CSS selector path of the largest contentful paint element",
+          "$comment": "Replaces the deprecated `view.largest_contentful_paint_target_selector`",
+          "readOnly": true
+        },
+        "resource_url": {
+          "type": "string",
+          "description": "URL of the largest contentful paint element",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    }
+  }
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -1330,9 +1330,9 @@ internal open class RumViewScope(
 
     private fun isViewComplete(): Boolean {
         val pending = pendingActionCount +
-                pendingResourceCount +
-                pendingErrorCount +
-                pendingLongTaskCount
+            pendingResourceCount +
+            pendingErrorCount +
+            pendingLongTaskCount
         // we use <= 0 for pending counter as a safety measure to make sure this ViewScope will
         // be closed.
         return stopped && activeResourceScopes.isEmpty() && (pending <= 0L)
@@ -1356,26 +1356,26 @@ internal open class RumViewScope(
         internal val ONE_SECOND_NS = TimeUnit.SECONDS.toNanos(1)
 
         internal const val ACTION_DROPPED_WARNING = "RUM Action (%s on %s) was dropped, because" +
-                " another action is still active for the same view"
+            " another action is still active for the same view"
 
         internal const val RUM_CONTEXT_UPDATE_IGNORED_AT_STOP_VIEW_MESSAGE =
             "Trying to update global RUM context when StopView event arrived, but the context" +
-                    " doesn't reference this view."
+                " doesn't reference this view."
         internal const val RUM_CONTEXT_UPDATE_IGNORED_AT_ACTION_UPDATE_MESSAGE =
             "Trying to update active action in the global RUM context, but the context" +
-                    " doesn't reference this view."
+                " doesn't reference this view."
 
         internal val FROZEN_FRAME_THRESHOLD_NS = TimeUnit.MILLISECONDS.toNanos(700)
         internal const val SLOW_RENDERED_THRESHOLD_FPS = 55
         internal const val ZERO_DURATION_WARNING_MESSAGE = "The computed duration for the " +
-                "view: %s was 0. In order to keep the view we forced it to 1ns."
+            "view: %s was 0. In order to keep the view we forced it to 1ns."
         internal const val NEGATIVE_DURATION_WARNING_MESSAGE = "The computed duration for the " +
-                "view: %s was negative. In order to keep the view we forced it to 1ns."
+            "view: %s was negative. In order to keep the view we forced it to 1ns."
         internal const val ADDING_VIEW_LOADING_TIME_DEBUG_MESSAGE_FORMAT =
             "View loading time %dns added to the view %s"
         internal const val OVERWRITING_VIEW_LOADING_TIME_WARNING_MESSAGE_FORMAT =
             "View loading time already exists for the view %s. Replacing the existing %d ns " +
-                    "view loading time with the new %d ns loading time."
+                "view loading time with the new %d ns loading time."
 
         internal fun fromEvent(
             parentScope: RumScope,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -13,6 +13,8 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.core.internal.attributes.LocalAttribute
+import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.utils.loggableStackTrace
@@ -1328,9 +1330,9 @@ internal open class RumViewScope(
 
     private fun isViewComplete(): Boolean {
         val pending = pendingActionCount +
-            pendingResourceCount +
-            pendingErrorCount +
-            pendingLongTaskCount
+                pendingResourceCount +
+                pendingErrorCount +
+                pendingLongTaskCount
         // we use <= 0 for pending counter as a safety measure to make sure this ViewScope will
         // be closed.
         return stopped && activeResourceScopes.isEmpty() && (pending <= 0L)
@@ -1354,26 +1356,26 @@ internal open class RumViewScope(
         internal val ONE_SECOND_NS = TimeUnit.SECONDS.toNanos(1)
 
         internal const val ACTION_DROPPED_WARNING = "RUM Action (%s on %s) was dropped, because" +
-            " another action is still active for the same view"
+                " another action is still active for the same view"
 
         internal const val RUM_CONTEXT_UPDATE_IGNORED_AT_STOP_VIEW_MESSAGE =
             "Trying to update global RUM context when StopView event arrived, but the context" +
-                " doesn't reference this view."
+                    " doesn't reference this view."
         internal const val RUM_CONTEXT_UPDATE_IGNORED_AT_ACTION_UPDATE_MESSAGE =
             "Trying to update active action in the global RUM context, but the context" +
-                " doesn't reference this view."
+                    " doesn't reference this view."
 
         internal val FROZEN_FRAME_THRESHOLD_NS = TimeUnit.MILLISECONDS.toNanos(700)
         internal const val SLOW_RENDERED_THRESHOLD_FPS = 55
         internal const val ZERO_DURATION_WARNING_MESSAGE = "The computed duration for the " +
-            "view: %s was 0. In order to keep the view we forced it to 1ns."
+                "view: %s was 0. In order to keep the view we forced it to 1ns."
         internal const val NEGATIVE_DURATION_WARNING_MESSAGE = "The computed duration for the " +
-            "view: %s was negative. In order to keep the view we forced it to 1ns."
+                "view: %s was negative. In order to keep the view we forced it to 1ns."
         internal const val ADDING_VIEW_LOADING_TIME_DEBUG_MESSAGE_FORMAT =
             "View loading time %dns added to the view %s"
         internal const val OVERWRITING_VIEW_LOADING_TIME_WARNING_MESSAGE_FORMAT =
             "View loading time already exists for the view %s. Replacing the existing %d ns " +
-                "view loading time with the new %d ns loading time."
+                    "view loading time with the new %d ns loading time."
 
         internal fun fromEvent(
             parentScope: RumScope,
@@ -1398,7 +1400,8 @@ internal open class RumViewScope(
             val viewType = RumViewType.FOREGROUND
             val viewEndedMetricDispatcher = ViewEndedMetricDispatcher(
                 viewType = viewType,
-                internalLogger = sdkCore.internalLogger
+                internalLogger = sdkCore.internalLogger,
+                instrumentationType = event.tryResolveInstrumentationType()
             )
 
             return RumViewScope(
@@ -1429,6 +1432,9 @@ internal open class RumViewScope(
                 average = meanValue
             )
         }
+
+        private fun RumRawEvent.StartView.tryResolveInstrumentationType() =
+            attributes[LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.string] as? ViewScopeInstrumentationType
 
         @Suppress("CommentOverPrivateFunction")
         /**

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/ViewEndedMetricDispatcher.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/ViewEndedMetricDispatcher.kt
@@ -153,12 +153,12 @@ internal class ViewEndedMetricDispatcher(
         @VisibleForTesting
         private fun toAttributeValue(
             instrumentationType: ViewScopeInstrumentationType?
-        ) = when (instrumentationType) {
+        ): String = when (instrumentationType) {
             ViewScopeInstrumentationType.COMPOSE -> VALUE_INSTRUMENTATION_TYPE_COMPOSE
             ViewScopeInstrumentationType.MANUAL -> VALUE_INSTRUMENTATION_TYPE_MANUAL
             ViewScopeInstrumentationType.ACTIVITY -> VALUE_INSTRUMENTATION_TYPE_ACTIVITY
             ViewScopeInstrumentationType.FRAGMENT -> VALUE_INSTRUMENTATION_TYPE_FRAGMENT
-            null -> ViewScopeInstrumentationType.MANUAL
+            null -> VALUE_INSTRUMENTATION_TYPE_MANUAL
         }
 
         @VisibleForTesting

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/ViewEndedMetricDispatcher.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/ViewEndedMetricDispatcher.kt
@@ -154,11 +154,11 @@ internal class ViewEndedMetricDispatcher(
         private fun toAttributeValue(
             instrumentationType: ViewScopeInstrumentationType?
         ) = when (instrumentationType) {
-            null -> null
             ViewScopeInstrumentationType.COMPOSE -> VALUE_INSTRUMENTATION_TYPE_COMPOSE
             ViewScopeInstrumentationType.MANUAL -> VALUE_INSTRUMENTATION_TYPE_MANUAL
             ViewScopeInstrumentationType.ACTIVITY -> VALUE_INSTRUMENTATION_TYPE_ACTIVITY
             ViewScopeInstrumentationType.FRAGMENT -> VALUE_INSTRUMENTATION_TYPE_FRAGMENT
+            null -> ViewScopeInstrumentationType.MANUAL
         }
 
         @VisibleForTesting

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityViewTrackingStrategy.kt
@@ -110,7 +110,7 @@ constructor(
      * Maps the Bundle key - value properties into compatible attributes for the Rum Events.
      * @param intent the [Intent] we need to transform. Returns an empty Map if this is null.
      */
-    private fun convertToRumAttributes(intent: Intent?): MutableMap<String, Any?> {
+    private fun convertToRumAttributes(intent: Intent?): Map<String, Any?> {
         if (intent == null) return mutableMapOf()
 
         val attributes = mutableMapOf<String, Any?>()

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityViewTrackingStrategy.kt
@@ -11,6 +11,8 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.MainThread
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.core.internal.attributes.enrichWithConstantAttribute
 import com.datadog.android.core.internal.utils.scheduleSafe
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumMonitor
@@ -108,8 +110,8 @@ constructor(
      * Maps the Bundle key - value properties into compatible attributes for the Rum Events.
      * @param intent the [Intent] we need to transform. Returns an empty Map if this is null.
      */
-    private fun convertToRumAttributes(intent: Intent?): Map<String, Any?> {
-        if (intent == null) return emptyMap()
+    private fun convertToRumAttributes(intent: Intent?): MutableMap<String, Any?> {
+        if (intent == null) return mutableMapOf()
 
         val attributes = mutableMapOf<String, Any?>()
 
@@ -121,6 +123,7 @@ constructor(
         }
 
         attributes.putAll(intent.safeExtras.convertToRumViewAttributes())
+        attributes.enrichWithConstantAttribute(ViewScopeInstrumentationType.ACTIVITY)
 
         return attributes
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/BundleExt.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/BundleExt.kt
@@ -13,8 +13,8 @@ internal const val ARGUMENT_TAG = "view.arguments"
 /**
  * Converts this bundle into a Map of attributes to be included in a RUM View event.
  */
-fun Bundle?.convertToRumViewAttributes(): MutableMap<String, Any?> {
-    if (this == null) return mutableMapOf()
+fun Bundle?.convertToRumViewAttributes(): Map<String, Any?> {
+    if (this == null) return emptyMap()
 
     val attributes = mutableMapOf<String, Any?>()
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/BundleExt.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/BundleExt.kt
@@ -13,8 +13,8 @@ internal const val ARGUMENT_TAG = "view.arguments"
 /**
  * Converts this bundle into a Map of attributes to be included in a RUM View event.
  */
-fun Bundle?.convertToRumViewAttributes(): Map<String, Any?> {
-    if (this == null) return emptyMap()
+fun Bundle?.convertToRumViewAttributes(): MutableMap<String, Any?> {
+    if (this == null) return mutableMapOf()
 
     val attributes = mutableMapOf<String, Any?>()
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategy.kt
@@ -76,7 +76,7 @@ internal constructor(
                 AndroidXFragmentLifecycleCallbacks(
                     argumentsProvider = {
                         if (trackArguments) {
-                            it.arguments.convertToRumViewAttributes()
+                            it.arguments.convertToRumViewAttributes().toMutableMap()
                         } else {
                             mutableMapOf()
                         }.enrichWithConstantAttribute(ViewScopeInstrumentationType.FRAGMENT)
@@ -103,7 +103,7 @@ internal constructor(
                 OreoFragmentLifecycleCallbacks(
                     argumentsProvider = {
                         if (trackArguments) {
-                            it.arguments.convertToRumViewAttributes()
+                            it.arguments.convertToRumViewAttributes().toMutableMap()
                         } else {
                             mutableMapOf()
                         }.enrichWithConstantAttribute(ViewScopeInstrumentationType.FRAGMENT)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategy.kt
@@ -67,56 +67,56 @@ internal constructor(
     )
 
     private val androidXLifecycleCallbacks: FragmentLifecycleCallbacks<FragmentActivity>
-            by lazy {
-                val rumFeature = withSdkCore {
-                    it.getFeature(Feature.RUM_FEATURE_NAME)?.unwrap<RumFeature>()
-                }
-                val rumMonitor = withSdkCore { GlobalRumMonitor.get(it) }
-                if (rumFeature != null && rumMonitor != null) {
-                    AndroidXFragmentLifecycleCallbacks(
-                        argumentsProvider = {
-                            if (trackArguments) {
-                                it.arguments.convertToRumViewAttributes()
-                            } else {
-                                mutableMapOf()
-                            }.enrichWithConstantAttribute(ViewScopeInstrumentationType.FRAGMENT)
-                        },
-                        componentPredicate = supportFragmentComponentPredicate,
-                        rumMonitor = rumMonitor,
-                        rumFeature = rumFeature
-                    )
-                } else {
-                    NoOpFragmentLifecycleCallbacks()
-                }
+        by lazy {
+            val rumFeature = withSdkCore {
+                it.getFeature(Feature.RUM_FEATURE_NAME)?.unwrap<RumFeature>()
             }
+            val rumMonitor = withSdkCore { GlobalRumMonitor.get(it) }
+            if (rumFeature != null && rumMonitor != null) {
+                AndroidXFragmentLifecycleCallbacks(
+                    argumentsProvider = {
+                        if (trackArguments) {
+                            it.arguments.convertToRumViewAttributes()
+                        } else {
+                            mutableMapOf()
+                        }.enrichWithConstantAttribute(ViewScopeInstrumentationType.FRAGMENT)
+                    },
+                    componentPredicate = supportFragmentComponentPredicate,
+                    rumMonitor = rumMonitor,
+                    rumFeature = rumFeature
+                )
+            } else {
+                NoOpFragmentLifecycleCallbacks()
+            }
+        }
 
     private val oreoLifecycleCallbacks: FragmentLifecycleCallbacks<Activity>
-            by lazy {
-                val rumFeature = withSdkCore {
-                    it.getFeature(Feature.RUM_FEATURE_NAME)?.unwrap<RumFeature>()
-                }
-                val rumMonitor = withSdkCore { GlobalRumMonitor.get(it) }
-                if (
-                    buildSdkVersionProvider.version >= Build.VERSION_CODES.O &&
-                    rumFeature != null && rumMonitor != null
-                ) {
-                    OreoFragmentLifecycleCallbacks(
-                        argumentsProvider = {
-                            if (trackArguments) {
-                                it.arguments.convertToRumViewAttributes()
-                            } else {
-                                mutableMapOf()
-                            }.enrichWithConstantAttribute(ViewScopeInstrumentationType.FRAGMENT)
-                        },
-                        componentPredicate = defaultFragmentComponentPredicate,
-                        rumMonitor = rumMonitor,
-                        rumFeature = rumFeature,
-                        buildSdkVersionProvider = buildSdkVersionProvider
-                    )
-                } else {
-                    NoOpFragmentLifecycleCallbacks()
-                }
+        by lazy {
+            val rumFeature = withSdkCore {
+                it.getFeature(Feature.RUM_FEATURE_NAME)?.unwrap<RumFeature>()
             }
+            val rumMonitor = withSdkCore { GlobalRumMonitor.get(it) }
+            if (
+                buildSdkVersionProvider.version >= Build.VERSION_CODES.O &&
+                rumFeature != null && rumMonitor != null
+            ) {
+                OreoFragmentLifecycleCallbacks(
+                    argumentsProvider = {
+                        if (trackArguments) {
+                            it.arguments.convertToRumViewAttributes()
+                        } else {
+                            mutableMapOf()
+                        }.enrichWithConstantAttribute(ViewScopeInstrumentationType.FRAGMENT)
+                    },
+                    componentPredicate = defaultFragmentComponentPredicate,
+                    rumMonitor = rumMonitor,
+                    rumFeature = rumFeature,
+                    buildSdkVersionProvider = buildSdkVersionProvider
+                )
+            } else {
+                NoOpFragmentLifecycleCallbacks()
+            }
+        }
 
     // region ActivityLifecycleTrackingStrategy
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategy.kt
@@ -13,6 +13,8 @@ import androidx.annotation.MainThread
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.datadog.android.api.feature.Feature
+import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.core.internal.attributes.enrichWithConstantAttribute
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.internal.RumFeature
@@ -65,48 +67,56 @@ internal constructor(
     )
 
     private val androidXLifecycleCallbacks: FragmentLifecycleCallbacks<FragmentActivity>
-        by lazy {
-            val rumFeature = withSdkCore {
-                it.getFeature(Feature.RUM_FEATURE_NAME)?.unwrap<RumFeature>()
+            by lazy {
+                val rumFeature = withSdkCore {
+                    it.getFeature(Feature.RUM_FEATURE_NAME)?.unwrap<RumFeature>()
+                }
+                val rumMonitor = withSdkCore { GlobalRumMonitor.get(it) }
+                if (rumFeature != null && rumMonitor != null) {
+                    AndroidXFragmentLifecycleCallbacks(
+                        argumentsProvider = {
+                            if (trackArguments) {
+                                it.arguments.convertToRumViewAttributes()
+                            } else {
+                                mutableMapOf()
+                            }.enrichWithConstantAttribute(ViewScopeInstrumentationType.FRAGMENT)
+                        },
+                        componentPredicate = supportFragmentComponentPredicate,
+                        rumMonitor = rumMonitor,
+                        rumFeature = rumFeature
+                    )
+                } else {
+                    NoOpFragmentLifecycleCallbacks()
+                }
             }
-            val rumMonitor = withSdkCore { GlobalRumMonitor.get(it) }
-            if (rumFeature != null && rumMonitor != null) {
-                AndroidXFragmentLifecycleCallbacks(
-                    argumentsProvider = {
-                        if (trackArguments) it.arguments.convertToRumViewAttributes() else emptyMap()
-                    },
-                    componentPredicate = supportFragmentComponentPredicate,
-                    rumMonitor = rumMonitor,
-                    rumFeature = rumFeature
-                )
-            } else {
-                NoOpFragmentLifecycleCallbacks()
-            }
-        }
 
     private val oreoLifecycleCallbacks: FragmentLifecycleCallbacks<Activity>
-        by lazy {
-            val rumFeature = withSdkCore {
-                it.getFeature(Feature.RUM_FEATURE_NAME)?.unwrap<RumFeature>()
+            by lazy {
+                val rumFeature = withSdkCore {
+                    it.getFeature(Feature.RUM_FEATURE_NAME)?.unwrap<RumFeature>()
+                }
+                val rumMonitor = withSdkCore { GlobalRumMonitor.get(it) }
+                if (
+                    buildSdkVersionProvider.version >= Build.VERSION_CODES.O &&
+                    rumFeature != null && rumMonitor != null
+                ) {
+                    OreoFragmentLifecycleCallbacks(
+                        argumentsProvider = {
+                            if (trackArguments) {
+                                it.arguments.convertToRumViewAttributes()
+                            } else {
+                                mutableMapOf()
+                            }.enrichWithConstantAttribute(ViewScopeInstrumentationType.FRAGMENT)
+                        },
+                        componentPredicate = defaultFragmentComponentPredicate,
+                        rumMonitor = rumMonitor,
+                        rumFeature = rumFeature,
+                        buildSdkVersionProvider = buildSdkVersionProvider
+                    )
+                } else {
+                    NoOpFragmentLifecycleCallbacks()
+                }
             }
-            val rumMonitor = withSdkCore { GlobalRumMonitor.get(it) }
-            if (
-                buildSdkVersionProvider.version >= Build.VERSION_CODES.O &&
-                rumFeature != null && rumMonitor != null
-            ) {
-                OreoFragmentLifecycleCallbacks(
-                    argumentsProvider = {
-                        if (trackArguments) it.arguments.convertToRumViewAttributes() else emptyMap()
-                    },
-                    componentPredicate = defaultFragmentComponentPredicate,
-                    rumMonitor = rumMonitor,
-                    rumFeature = rumFeature,
-                    buildSdkVersionProvider = buildSdkVersionProvider
-                )
-            } else {
-                NoOpFragmentLifecycleCallbacks()
-            }
-        }
 
     // region ActivityLifecycleTrackingStrategy
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
@@ -97,7 +97,7 @@ class NavigationViewTrackingStrategy(
         val rumMonitor = withSdkCore { GlobalRumMonitor.get(it) }
         componentPredicate.runIfValid(destination, internalLogger) {
             val attributes = if (trackArguments) {
-                arguments.convertToRumViewAttributes()
+                arguments.convertToRumViewAttributes().toMutableMap()
             } else {
                 mutableMapOf()
             }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
@@ -17,6 +17,8 @@ import androidx.navigation.NavDestination
 import androidx.navigation.Navigation
 import androidx.navigation.fragment.NavHostFragment
 import com.datadog.android.api.feature.Feature
+import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.core.internal.attributes.enrichWithConstantAttribute
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.NoOpRumMonitor
 import com.datadog.android.rum.internal.RumFeature
@@ -94,7 +96,14 @@ class NavigationViewTrackingStrategy(
     ) {
         val rumMonitor = withSdkCore { GlobalRumMonitor.get(it) }
         componentPredicate.runIfValid(destination, internalLogger) {
-            val attributes = if (trackArguments) arguments.convertToRumViewAttributes() else emptyMap()
+            val attributes = if (trackArguments) {
+                arguments.convertToRumViewAttributes()
+            } else {
+                mutableMapOf()
+            }
+
+            attributes.enrichWithConstantAttribute(ViewScopeInstrumentationType.FRAGMENT)
+
             val viewName = componentPredicate.resolveViewName(destination)
             rumMonitor?.startView(destination, viewName, attributes)
         }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -13,11 +13,11 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.core.internal.attributes.LocalAttribute
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.rum.RumSessionListener
-import com.datadog.android.core.internal.attributes.LocalAttribute
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.RumFeature.Configuration
 import com.datadog.android.rum.internal.domain.RumContext

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -17,6 +17,7 @@ import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.rum.RumSessionListener
+import com.datadog.android.core.internal.attributes.LocalAttribute
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.RumFeature.Configuration
 import com.datadog.android.rum.internal.domain.RumContext
@@ -286,7 +287,7 @@ internal class TelemetryEventHandler(
         val sessionReplayFeatureContext =
             sdkCore.getFeatureContext(Feature.SESSION_REPLAY_FEATURE_NAME)
         val sessionReplaySampleRate = sessionReplayFeatureContext[SESSION_REPLAY_SAMPLE_RATE_KEY]
-            as? Long
+                as? Long
         val startRecordingImmediately =
             sessionReplayFeatureContext[SESSION_REPLAY_START_IMMEDIATE_RECORDING_KEY] as? Boolean
         val sessionReplayImagePrivacy =
@@ -428,7 +429,7 @@ internal class TelemetryEventHandler(
                     InternalLogger.Target.TELEMETRY,
                     {
                         "GlobalTracer class exists in the runtime classpath, " +
-                            "but there is an error invoking isRegistered method"
+                                "but there is an error invoking isRegistered method"
                     },
                     t
                 )
@@ -473,11 +474,11 @@ internal class TelemetryEventHandler(
         val telemetrySampleRate = rumConfig?.telemetrySampleRate?.percent() ?: return 0f
 
         val creatingSamplingRate = properties
-            ?.getFloat(InternalTelemetryEvent.CREATION_SAMPLING_RATE_KEY)
+            ?.getFloat(LocalAttribute.Key.CREATION_SAMPLING_RATE)
             ?.percent() ?: 1.0
 
         val reportingSamplingRate = properties
-            ?.getFloat(InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY)
+            ?.getFloat(LocalAttribute.Key.REPORTING_SAMPLING_RATE)
             ?.percent() ?: 1.0
 
         val eventSamplingRate = eventSpecificSamplingRate?.percent() ?: 1.0
@@ -487,11 +488,10 @@ internal class TelemetryEventHandler(
         return (effectiveSampleRate * HUNDRED).toFloat()
     }
 
-    private fun Map<String, Any?>.getFloat(key: String) = get(key) as? Float
+    private fun Map<String, Any?>.getFloat(key: LocalAttribute.Key) = get(key.string) as? Float
 
     private fun Map<String, Any?>.cleanUpInternalAttributes() = toMutableMap().apply {
-        remove(InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY)
-        remove(InternalTelemetryEvent.CREATION_SAMPLING_RATE_KEY)
+        LocalAttribute.Key.values().forEach { key -> remove(key.string) }
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -287,7 +287,7 @@ internal class TelemetryEventHandler(
         val sessionReplayFeatureContext =
             sdkCore.getFeatureContext(Feature.SESSION_REPLAY_FEATURE_NAME)
         val sessionReplaySampleRate = sessionReplayFeatureContext[SESSION_REPLAY_SAMPLE_RATE_KEY]
-                as? Long
+            as? Long
         val startRecordingImmediately =
             sessionReplayFeatureContext[SESSION_REPLAY_START_IMMEDIATE_RECORDING_KEY] as? Boolean
         val sessionReplayImagePrivacy =
@@ -429,7 +429,7 @@ internal class TelemetryEventHandler(
                     InternalLogger.Target.TELEMETRY,
                     {
                         "GlobalTracer class exists in the runtime classpath, " +
-                                "but there is an error invoking isRegistered method"
+                            "but there is an error invoking isRegistered method"
                     },
                     t
                 )

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityViewTrackingStrategyTest.kt
@@ -8,6 +8,8 @@ package com.datadog.android.rum
 
 import android.app.Activity
 import android.os.Bundle
+import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.core.internal.attributes.enrichWithConstantAttribute
 import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
 import com.datadog.android.rum.tracking.ComponentPredicate
 import com.datadog.android.rum.tracking.StubComponentPredicate
@@ -105,7 +107,7 @@ internal class ActivityViewTrackingStrategyTest :
         verify(rumMonitor.mockInstance).startView(
             mockActivity,
             mockActivity.resolveViewName(),
-            emptyMap()
+            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.string to ViewScopeInstrumentationType.ACTIVITY.value)
         )
     }
 
@@ -128,7 +130,8 @@ internal class ActivityViewTrackingStrategyTest :
         whenever(mockActivity.intent).thenReturn(mockIntent)
         whenever(mockPredicate.accept(mockActivity)) doReturn true
         val expectedAttributes = extras.map { (k, v) -> "view.arguments.$k" to v }
-            .toMutableMap()
+            .toMutableMap<String, Any?>()
+            .enrichWithConstantAttribute(ViewScopeInstrumentationType.ACTIVITY)
         expectedAttributes["view.intent.action"] = action
         expectedAttributes["view.intent.uri"] = uri
         testedStrategy.register(rumMonitor.mockSdkCore, mockActivity)
@@ -157,7 +160,12 @@ internal class ActivityViewTrackingStrategyTest :
         whenever(mockIntent.dataString).thenReturn(uri)
         whenever(mockActivity.intent).thenReturn(mockIntent)
         whenever(mockPredicate.accept(mockActivity)) doReturn true
-        val expectedAttributes = mapOf("view.intent.action" to action, "view.intent.uri" to uri)
+        val expectedAttributes = mapOf<String, Any?>(
+            "view.intent.action" to action,
+            "view.intent.uri" to uri,
+            ViewScopeInstrumentationType.ACTIVITY.key.string to ViewScopeInstrumentationType.ACTIVITY.value
+        )
+
         testedStrategy.register(rumMonitor.mockSdkCore, mockActivity)
 
         // When
@@ -215,7 +223,7 @@ internal class ActivityViewTrackingStrategyTest :
         verify(rumMonitor.mockInstance).startView(
             mockActivity,
             fakeName,
-            emptyMap()
+            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.string to ViewScopeInstrumentationType.ACTIVITY.value)
         )
     }
 
@@ -236,7 +244,7 @@ internal class ActivityViewTrackingStrategyTest :
         verify(rumMonitor.mockInstance).startView(
             mockActivity,
             mockActivity.resolveViewName(),
-            emptyMap()
+            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.string to ViewScopeInstrumentationType.ACTIVITY.value)
         )
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityViewTrackingStrategyTest.kt
@@ -107,7 +107,7 @@ internal class ActivityViewTrackingStrategyTest :
         verify(rumMonitor.mockInstance).startView(
             mockActivity,
             mockActivity.resolveViewName(),
-            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.string to ViewScopeInstrumentationType.ACTIVITY.value)
+            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.string to ViewScopeInstrumentationType.ACTIVITY)
         )
     }
 
@@ -163,7 +163,7 @@ internal class ActivityViewTrackingStrategyTest :
         val expectedAttributes = mapOf<String, Any?>(
             "view.intent.action" to action,
             "view.intent.uri" to uri,
-            ViewScopeInstrumentationType.ACTIVITY.key.string to ViewScopeInstrumentationType.ACTIVITY.value
+            ViewScopeInstrumentationType.ACTIVITY.key.string to ViewScopeInstrumentationType.ACTIVITY
         )
 
         testedStrategy.register(rumMonitor.mockSdkCore, mockActivity)
@@ -223,7 +223,7 @@ internal class ActivityViewTrackingStrategyTest :
         verify(rumMonitor.mockInstance).startView(
             mockActivity,
             fakeName,
-            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.string to ViewScopeInstrumentationType.ACTIVITY.value)
+            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.string to ViewScopeInstrumentationType.ACTIVITY)
         )
     }
 
@@ -244,7 +244,7 @@ internal class ActivityViewTrackingStrategyTest :
         verify(rumMonitor.mockInstance).startView(
             mockActivity,
             mockActivity.resolveViewName(),
-            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.string to ViewScopeInstrumentationType.ACTIVITY.value)
+            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.string to ViewScopeInstrumentationType.ACTIVITY)
         )
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/metric/ViewEndedMetricDispatcherTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/metric/ViewEndedMetricDispatcherTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.rum.internal.metric.NoValueReason
 import com.datadog.android.rum.internal.metric.ViewEndedMetricDispatcher
 import com.datadog.android.rum.internal.metric.ViewEndedMetricDispatcher.Companion.KEY_CONFIG
 import com.datadog.android.rum.internal.metric.ViewEndedMetricDispatcher.Companion.KEY_DURATION
+import com.datadog.android.rum.internal.metric.ViewEndedMetricDispatcher.Companion.KEY_INSTRUMENTATION_TYPE
 import com.datadog.android.rum.internal.metric.ViewEndedMetricDispatcher.Companion.KEY_INTERACTION_TO_NEXT_VIEW
 import com.datadog.android.rum.internal.metric.ViewEndedMetricDispatcher.Companion.KEY_LOADING_TIME
 import com.datadog.android.rum.internal.metric.ViewEndedMetricDispatcher.Companion.KEY_METRIC_TYPE
@@ -68,12 +69,14 @@ internal class ViewEndedMetricDispatcherTest {
     private lateinit var fakeViewType: RumViewType
     private lateinit var fakeInvState: ViewInitializationMetricsState
     private lateinit var fakeTnsState: ViewInitializationMetricsState
+    private var fakeInstrumentationType: String? = null
 
     private lateinit var dispatcherUnderTest: ViewEndedMetricDispatcher
 
     @BeforeEach
     fun `set up`(forge: Forge) {
         fakeViewType = forge.aValueFrom(RumViewType::class.java)
+        fakeInstrumentationType = forge.aNullable { anElementFrom("compose", "manual", "activity", "fragment") }
         fakeTnsState = forge.aViewInitializationMetricsState(NoValueReason.TimeToNetworkSettle::class.java)
         fakeInvState = forge.aViewInitializationMetricsState(NoValueReason.InteractionToNextView::class.java)
 
@@ -220,7 +223,8 @@ internal class ViewEndedMetricDispatcherTest {
         loadingTime: Long? = fakeLoadingTime,
         viewType: RumViewType = fakeViewType,
         invState: ViewInitializationMetricsState = fakeInvState,
-        tnsState: ViewInitializationMetricsState = fakeTnsState
+        tnsState: ViewInitializationMetricsState = fakeTnsState,
+        instrumentationType: String? = fakeInstrumentationType
     ) = buildAttributesMap(
         duration = duration,
         loadingTime = loadingTime,
@@ -232,7 +236,8 @@ internal class ViewEndedMetricDispatcherTest {
 
         tnsValue = tnsState.initializationTime,
         tnsConfig = toAttributeValue(tnsState.config),
-        tnsNoValueReason = toAttributeValue(tnsState.noValueReason)
+        tnsNoValueReason = toAttributeValue(tnsState.noValueReason),
+        instrumentationType = instrumentationType
     )
 
     companion object {
@@ -245,7 +250,8 @@ internal class ViewEndedMetricDispatcherTest {
             invNoValueReason: String?,
             tnsValue: Long?,
             tnsConfig: String,
-            tnsNoValueReason: String?
+            tnsNoValueReason: String?,
+            instrumentationType: String?
         ): Map<String, Any?> = mapOf(
             KEY_METRIC_TYPE to "rum view ended",
             KEY_RUM_VIEW_ENDED to mapOf(
@@ -261,7 +267,8 @@ internal class ViewEndedMetricDispatcherTest {
                     invValue,
                     invConfig,
                     invNoValueReason
-                )
+                ),
+                KEY_INSTRUMENTATION_TYPE to (instrumentationType ?: "manual")
             )
         )
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/metric/ViewEndedMetricDispatcherTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/metric/ViewEndedMetricDispatcherTest.kt
@@ -7,6 +7,7 @@ package com.datadog.android.rum.metric
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.InternalLogger.Target
+import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
 import com.datadog.android.rum.internal.domain.scope.RumViewType
 import com.datadog.android.rum.internal.metric.NoValueReason
 import com.datadog.android.rum.internal.metric.ViewEndedMetricDispatcher
@@ -76,14 +77,24 @@ internal class ViewEndedMetricDispatcherTest {
     @BeforeEach
     fun `set up`(forge: Forge) {
         fakeViewType = forge.aValueFrom(RumViewType::class.java)
-        fakeInstrumentationType = forge.aNullable { anElementFrom("compose", "manual", "activity", "fragment") }
         fakeTnsState = forge.aViewInitializationMetricsState(NoValueReason.TimeToNetworkSettle::class.java)
         fakeInvState = forge.aViewInitializationMetricsState(NoValueReason.InteractionToNextView::class.java)
+        val instrumentationType = forge.aNullable {
+            anElementFrom(
+                ViewScopeInstrumentationType.COMPOSE,
+                ViewScopeInstrumentationType.MANUAL,
+                ViewScopeInstrumentationType.ACTIVITY,
+                ViewScopeInstrumentationType.FRAGMENT
+            )
+        }
+
+        fakeInstrumentationType = instrumentationType?.value
 
         dispatcherUnderTest = ViewEndedMetricDispatcher(
             viewType = fakeViewType,
             internalLogger = mockInternalLogger,
-            samplingRate = fakeSampleRate
+            samplingRate = fakeSampleRate,
+            instrumentationType = instrumentationType
         )
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategyTest.kt
@@ -261,7 +261,7 @@ internal class FragmentViewTrackingStrategyTest : ObjectTest<FragmentViewTrackin
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
         val mockFragment: Fragment = mockFragmentWithArguments(forge)
         val expectedAttrs = mapOf(
-            ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT.value
+            ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT
         )
         val argumentCaptor = argumentCaptor<FragmentManager.FragmentLifecycleCallbacks>()
 
@@ -478,7 +478,7 @@ internal class FragmentViewTrackingStrategyTest : ObjectTest<FragmentViewTrackin
         )
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
         val expectedAttrs = mapOf(
-            ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT.value
+            ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT
         )
         val mockFragment: android.app.Fragment = mockDeprecatedFragmentWithArguments(forge)
         val argumentCaptor =

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategyTest.kt
@@ -17,6 +17,8 @@ import androidx.fragment.app.FragmentManager
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
+import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.core.internal.attributes.enrichWithConstantAttribute
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.tracking.AndroidXFragmentLifecycleCallbacks
@@ -175,7 +177,9 @@ internal class FragmentViewTrackingStrategyTest : ObjectTest<FragmentViewTrackin
         // Given
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
         val mockFragment: Fragment = mockFragmentWithArguments(forge)
-        val expectedAttrs = mockFragment.arguments!!.toRumAttributes()
+        val expectedAttrs = mockFragment.arguments!!
+            .toRumAttributes()
+            .enrichWithConstantAttribute(ViewScopeInstrumentationType.FRAGMENT)
         val argumentCaptor = argumentCaptor<FragmentManager.FragmentLifecycleCallbacks>()
 
         // When
@@ -256,7 +260,9 @@ internal class FragmentViewTrackingStrategyTest : ObjectTest<FragmentViewTrackin
         testedStrategy = FragmentViewTrackingStrategy(false)
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
         val mockFragment: Fragment = mockFragmentWithArguments(forge)
-        val expectedAttrs = emptyMap<String, Any?>()
+        val expectedAttrs = mapOf(
+            ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT.value
+        )
         val argumentCaptor = argumentCaptor<FragmentManager.FragmentLifecycleCallbacks>()
 
         // When
@@ -376,7 +382,9 @@ internal class FragmentViewTrackingStrategyTest : ObjectTest<FragmentViewTrackin
         whenever(mockBuildSdkVersionProvider.version) doReturn fakeApiVersion
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
         val mockFragment: android.app.Fragment = mockDeprecatedFragmentWithArguments(forge)
-        val expectedAttrs = mockFragment.arguments.toRumAttributes()
+        val expectedAttrs = mockFragment.arguments
+            .toRumAttributes()
+            .enrichWithConstantAttribute(ViewScopeInstrumentationType.FRAGMENT)
         val argumentCaptor =
             argumentCaptor<android.app.FragmentManager.FragmentLifecycleCallbacks>()
 
@@ -469,7 +477,9 @@ internal class FragmentViewTrackingStrategyTest : ObjectTest<FragmentViewTrackin
             buildSdkVersionProvider = mockBuildSdkVersionProvider
         )
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
-        val expectedAttrs = emptyMap<String, Any?>()
+        val expectedAttrs = mapOf(
+            ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT.value
+        )
         val mockFragment: android.app.Fragment = mockDeprecatedFragmentWithArguments(forge)
         val argumentCaptor =
             argumentCaptor<android.app.FragmentManager.FragmentLifecycleCallbacks>()
@@ -663,7 +673,7 @@ internal class FragmentViewTrackingStrategyTest : ObjectTest<FragmentViewTrackin
         return arguments
     }
 
-    private fun Bundle.toRumAttributes(): Map<String, Any?> {
+    private fun Bundle.toRumAttributes(): MutableMap<String, Any?> {
         val attributes = mutableMapOf<String, Any?>()
         keySet().forEach {
             attributes["view.arguments.$it"] = get(it)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
@@ -24,6 +24,7 @@ import androidx.navigation.fragment.NavHostFragment
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
+import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.rum.utils.forge.Configurator
@@ -313,7 +314,7 @@ internal class NavigationViewTrackingStrategyTest {
         verify(rumMonitor.mockInstance).startView(
             mockNavDestination,
             fakeDestinationName,
-            emptyMap()
+            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT.value)
         )
     }
 
@@ -337,7 +338,11 @@ internal class NavigationViewTrackingStrategyTest {
 
         testedStrategy.onDestinationChanged(mockNavController, mockNavDestination, null)
 
-        verify(rumMonitor.mockInstance).startView(mockNavDestination, customName, emptyMap())
+        verify(rumMonitor.mockInstance).startView(
+            mockNavDestination,
+            customName,
+            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT.value)
+        )
     }
 
     @Test
@@ -346,7 +351,9 @@ internal class NavigationViewTrackingStrategyTest {
     ) {
         whenever(mockPredicate.accept(mockNavDestination)) doReturn true
         val arguments = Bundle()
-        val expectedAttrs = mutableMapOf<String, Any?>()
+        val expectedAttrs = mutableMapOf<String, Any?>(
+            ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT.value
+        )
         repeat(10) {
             val key = forge.anAlphabeticalString()
             val value = forge.anAsciiString()
@@ -384,7 +391,7 @@ internal class NavigationViewTrackingStrategyTest {
         verify(rumMonitor.mockInstance).startView(
             mockNavDestination,
             fakeDestinationName,
-            emptyMap()
+            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT.value)
         )
     }
 
@@ -406,12 +413,12 @@ internal class NavigationViewTrackingStrategyTest {
             verify(rumMonitor.mockInstance).startView(
                 mockNavDestination,
                 fakeDestinationName,
-                emptyMap()
+                mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT.value)
             )
             verify(rumMonitor.mockInstance).startView(
                 newDestination,
                 newDestinationName,
-                emptyMap()
+                mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT.value)
             )
         }
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
@@ -314,7 +314,7 @@ internal class NavigationViewTrackingStrategyTest {
         verify(rumMonitor.mockInstance).startView(
             mockNavDestination,
             fakeDestinationName,
-            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT.value)
+            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT)
         )
     }
 
@@ -341,7 +341,7 @@ internal class NavigationViewTrackingStrategyTest {
         verify(rumMonitor.mockInstance).startView(
             mockNavDestination,
             customName,
-            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT.value)
+            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT)
         )
     }
 
@@ -352,7 +352,7 @@ internal class NavigationViewTrackingStrategyTest {
         whenever(mockPredicate.accept(mockNavDestination)) doReturn true
         val arguments = Bundle()
         val expectedAttrs = mutableMapOf<String, Any?>(
-            ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT.value
+            ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT
         )
         repeat(10) {
             val key = forge.anAlphabeticalString()
@@ -391,7 +391,7 @@ internal class NavigationViewTrackingStrategyTest {
         verify(rumMonitor.mockInstance).startView(
             mockNavDestination,
             fakeDestinationName,
-            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT.value)
+            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT)
         )
     }
 
@@ -413,12 +413,12 @@ internal class NavigationViewTrackingStrategyTest {
             verify(rumMonitor.mockInstance).startView(
                 mockNavDestination,
                 fakeDestinationName,
-                mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT.value)
+                mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT)
             )
             verify(rumMonitor.mockInstance).startView(
                 newDestination,
                 newDestinationName,
-                mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT.value)
+                mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT)
             )
         }
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.core.internal.attributes.LocalAttribute
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.utils.loggableStackTrace
@@ -1095,8 +1096,8 @@ internal class TelemetryEventHandlerTest {
         @Forgery fakeApiUsageEvent: InternalTelemetryEvent.ApiUsage
     ) {
         fakeApiUsageEvent.additionalProperties.also { properties ->
-            properties[InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY] = "value that should not exist"
-            properties[InternalTelemetryEvent.CREATION_SAMPLING_RATE_KEY] = "value that should not exist"
+            properties[LocalAttribute.Key.REPORTING_SAMPLING_RATE.string] = "value that should not exist"
+            properties[LocalAttribute.Key.CREATION_SAMPLING_RATE.string] = "value that should not exist"
             properties[fakeAdditionalPropertyKey] = fakeAdditionalPropertyValue
         }
 
@@ -1121,8 +1122,8 @@ internal class TelemetryEventHandlerTest {
         val fakeMetricEvent = InternalTelemetryEvent.Metric(
             message = forge.aString(),
             additionalProperties = mapOf(
-                InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY to "value that should not exist",
-                InternalTelemetryEvent.CREATION_SAMPLING_RATE_KEY to "value that should not exist",
+                LocalAttribute.Key.REPORTING_SAMPLING_RATE.string to "value that should not exist",
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.string to "value that should not exist",
                 fakeAdditionalPropertyKey to fakeAdditionalPropertyValue
             )
         )
@@ -1148,8 +1149,8 @@ internal class TelemetryEventHandlerTest {
         val fakeLogDebugEvent = InternalTelemetryEvent.Log.Debug(
             message = forge.aString(),
             additionalProperties = mapOf(
-                InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY to "value that should not exist",
-                InternalTelemetryEvent.CREATION_SAMPLING_RATE_KEY to "value that should not exist",
+                LocalAttribute.Key.REPORTING_SAMPLING_RATE.string to "value that should not exist",
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.string to "value that should not exist",
                 fakeAdditionalPropertyKey to fakeAdditionalPropertyValue
             )
         )
@@ -1175,8 +1176,8 @@ internal class TelemetryEventHandlerTest {
         val fakeLogDebugEvent = InternalTelemetryEvent.Log.Error(
             message = forge.aString(),
             additionalProperties = mapOf(
-                InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY to "value that should not exist",
-                InternalTelemetryEvent.CREATION_SAMPLING_RATE_KEY to "value that should not exist",
+                LocalAttribute.Key.REPORTING_SAMPLING_RATE.string to "value that should not exist",
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.string to "value that should not exist",
                 fakeAdditionalPropertyKey to fakeAdditionalPropertyValue
             )
         )
@@ -1206,8 +1207,8 @@ internal class TelemetryEventHandlerTest {
         whenever(mockRumFeature.configuration) doReturn fakeRumConfiguration
         whenever(mockRumFeatureScope.unwrap<RumFeature>()) doReturn mockRumFeature
         fakeApiUsageEvent.additionalProperties.also { properties ->
-            properties[InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY] = reportingSamplingRate
-            properties[InternalTelemetryEvent.CREATION_SAMPLING_RATE_KEY] = creationSamplingRate
+            properties[LocalAttribute.Key.REPORTING_SAMPLING_RATE.string] = reportingSamplingRate
+            properties[LocalAttribute.Key.CREATION_SAMPLING_RATE.string] = creationSamplingRate
         }
 
         // When
@@ -1241,8 +1242,8 @@ internal class TelemetryEventHandlerTest {
         val fakeMetricEvent = InternalTelemetryEvent.Metric(
             message = forge.aString(),
             additionalProperties = mapOf(
-                InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY to creatingSamplingRate,
-                InternalTelemetryEvent.CREATION_SAMPLING_RATE_KEY to reportingSamplingRate,
+                LocalAttribute.Key.REPORTING_SAMPLING_RATE.string to creatingSamplingRate,
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.string to reportingSamplingRate,
                 fakeAdditionalPropertyKey to fakeAdditionalPropertyValue
             )
         )
@@ -1277,8 +1278,8 @@ internal class TelemetryEventHandlerTest {
         val fakeDebugEvent = InternalTelemetryEvent.Log.Debug(
             message = forge.aString(),
             additionalProperties = mapOf(
-                InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY to creatingSamplingRate,
-                InternalTelemetryEvent.CREATION_SAMPLING_RATE_KEY to reportingSamplingRate,
+                LocalAttribute.Key.REPORTING_SAMPLING_RATE.string to creatingSamplingRate,
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.string to reportingSamplingRate,
                 fakeAdditionalPropertyKey to fakeAdditionalPropertyValue
             )
         )
@@ -1313,8 +1314,8 @@ internal class TelemetryEventHandlerTest {
         val fakeErrorEvent = InternalTelemetryEvent.Log.Error(
             message = forge.aString(),
             additionalProperties = mapOf(
-                InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY to creatingSamplingRate,
-                InternalTelemetryEvent.CREATION_SAMPLING_RATE_KEY to reportingSamplingRate,
+                LocalAttribute.Key.REPORTING_SAMPLING_RATE.string to creatingSamplingRate,
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.string to reportingSamplingRate,
                 fakeAdditionalPropertyKey to fakeAdditionalPropertyValue
             )
         )
@@ -1387,8 +1388,8 @@ internal class TelemetryEventHandlerTest {
     ) {
         assertThat(additionalProperties)
             .doesNotContainKeys(
-                InternalTelemetryEvent.CREATION_SAMPLING_RATE_KEY,
-                InternalTelemetryEvent.REPORTING_SAMPLING_RATE_KEY
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.string,
+                LocalAttribute.Key.REPORTING_SAMPLING_RATE.string
             )
 
         expectedEntries.forEach { (expectedKey, expectedValue) ->

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/ComposeNavigationObserver.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/ComposeNavigationObserver.kt
@@ -64,7 +64,7 @@ internal class ComposeNavigationObserver(
     ) {
         val viewName = destinationPredicate.getViewName(navDestination) ?: route
         val attributes = if (trackArguments) {
-            arguments.convertToRumViewAttributes()
+            arguments.convertToRumViewAttributes().toMutableMap()
         } else {
             mutableMapOf()
         }.enrichWithConstantAttribute(ViewScopeInstrumentationType.COMPOSE)

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/ComposeNavigationObserver.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/ComposeNavigationObserver.kt
@@ -12,6 +12,8 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
+import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.core.internal.attributes.enrichWithConstantAttribute
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.tracking.AcceptAllNavDestinations
 import com.datadog.android.rum.tracking.ComponentPredicate
@@ -61,14 +63,12 @@ internal class ComposeNavigationObserver(
         arguments: Bundle?
     ) {
         val viewName = destinationPredicate.getViewName(navDestination) ?: route
-        rumMonitor.startView(
-            key = route,
-            name = viewName,
-            attributes = if (trackArguments) {
-                arguments.convertToRumViewAttributes()
-            } else {
-                emptyMap()
-            }
-        )
+        val attributes = if (trackArguments) {
+            arguments.convertToRumViewAttributes()
+        } else {
+            mutableMapOf()
+        }.enrichWithConstantAttribute(ViewScopeInstrumentationType.COMPOSE)
+
+        rumMonitor.startView(key = route, name = viewName, attributes = attributes)
     }
 }

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/internal/ComposeNavigationObserverTest.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/internal/ComposeNavigationObserverTest.kt
@@ -10,6 +10,8 @@ import android.os.Bundle
 import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
+import com.datadog.android.core.internal.attributes.LocalAttribute
+import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.tracking.ComponentPredicate
 import com.datadog.tools.unit.forge.BaseConfigurator
@@ -76,7 +78,9 @@ internal class ComposeNavigationObserverTest {
     ) {
         // Given
         val arguments = Bundle()
-        val expectedAttrs = mutableMapOf<String, Any?>()
+        val expectedAttrs = mutableMapOf<String, Any?>(
+            LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.string to ViewScopeInstrumentationType.COMPOSE
+        )
         repeat(10) {
             val key = forge.anAlphabeticalString()
             val value = forge.anAsciiString()
@@ -108,7 +112,9 @@ internal class ComposeNavigationObserverTest {
         whenever(mockPredicate.getViewName(any())) doReturn fakeViewName
 
         val arguments = Bundle()
-        val expectedAttrs = mutableMapOf<String, Any?>()
+        val expectedAttrs = mutableMapOf<String, Any?>(
+            LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.string to ViewScopeInstrumentationType.COMPOSE
+        )
         repeat(10) {
             val key = forge.anAlphabeticalString()
             val value = forge.anAsciiString()
@@ -158,7 +164,7 @@ internal class ComposeNavigationObserverTest {
         verify(mockRumMonitor).startView(
             mockNavDestination.route!!,
             mockNavDestination.route!!,
-            emptyMap()
+            mapOf(LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.string to ViewScopeInstrumentationType.COMPOSE)
         )
         verifyNoMoreInteractions(mockRumMonitor)
     }


### PR DESCRIPTION
### What does this PR do?

Adds support for optional instrumentation_type attributes into view ended telemetry metric.


### Motivation
[Spec](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/4534173727/RUM+View+Ended+Telemetry+-+Spec)

[Previous](https://github.com/DataDog/dd-sdk-android/pull/2495) PR was too big to add this logic, I'd decided to split them into two separate ones 

### Additional Notes

I noticed that we were using the additionalAttributes map as a container for some local values that shouldn't be passed 
directly to the backend, but used to determine some values just before the actual events are sent, so as a side effect of this PR the local attributes logic has been refactored: Added a single place for such attributes and their cleanup.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

