### PR TITLE
[RUM-8098] Support for configuration schema updates for time based strategy of TNS and INV metrics

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -261,14 +261,13 @@ interface com.datadog.android.core.internal.attributes.LocalAttribute
     - CREATION_SAMPLING_RATE
     - REPORTING_SAMPLING_RATE
     - VIEW_SCOPE_INSTRUMENTATION_TYPE
+    override fun toString(): String
   interface Constant
     val key: Key
-    val value: Any
 fun MutableMap<String, Any?>.enrichWithConstantAttribute(LocalAttribute.Constant)
 fun MutableMap<String, Any?>.enrichWithNonNullAttribute(LocalAttribute.Key, Any?)
 fun MutableMap<String, Any?>.enrichWithLocalAttribute(LocalAttribute.Key, Any?)
 enum com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType : LocalAttribute.Constant
-  constructor(String)
   - MANUAL
   - COMPOSE
   - ACTIVITY

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -728,7 +728,7 @@ public final class com/datadog/android/core/internal/attributes/LocalAttribute$K
 	public static final field CREATION_SAMPLING_RATE Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
 	public static final field REPORTING_SAMPLING_RATE Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
 	public static final field VIEW_SCOPE_INSTRUMENTATION_TYPE Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
-	public final fun getString ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
 	public static fun values ()[Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
 }

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -721,7 +721,6 @@ public abstract interface class com/datadog/android/core/internal/attributes/Loc
 
 public abstract interface class com/datadog/android/core/internal/attributes/LocalAttribute$Constant {
 	public abstract fun getKey ()Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
-	public abstract fun getValue ()Ljava/lang/Object;
 }
 
 public final class com/datadog/android/core/internal/attributes/LocalAttribute$Key : java/lang/Enum {
@@ -745,8 +744,6 @@ public final class com/datadog/android/core/internal/attributes/ViewScopeInstrum
 	public static final field FRAGMENT Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
 	public static final field MANUAL Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
 	public fun getKey ()Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
-	public synthetic fun getValue ()Ljava/lang/Object;
-	public fun getValue ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
 	public static fun values ()[Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/attributes/LocalAttribute.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/attributes/LocalAttribute.kt
@@ -18,22 +18,23 @@ interface LocalAttribute {
      * Enumeration of all local attributes keys used in the application.
      * Made via **enum** to make sure that all such attributes will be removed before sending the event to the backend.
      *
-     * @property string - Unique string value for a local attribute key.
+     * @param string - Unique string value for a local attribute key.
      */
     @InternalApi
     enum class Key(
-        val string: String
+        private val string: String
     ) {
-        /* Some of the metrics like [PerformanceMetric] being sampled on the
-         * metric creation place and then reported with 100% probability.
-         * In such cases we need to use *creationSampleRate* to compute effectiveSampleRate correctlyThe sampling
-         * rate is used when creating metrics.
-         * Creation(head) sampling rate exist only for long-lived metrics like method performance.
-         * Created metric still could not be sent it depends on [REPORTING_SAMPLING_RATE] sampling rate
+        /*
+         * Some of the metrics such as [PerformanceMetric] are sampled at the point of
+         * metric creation and then reported with 100% probability.
+         * In such cases we need to use *creationSampleRate* to correctly calculate effectiveSampleRate.
+         * The creation(head) sample rate only exists for long-lived metrics such as method performance.
+         * Created metric still could not be sent, it depends on the [REPORTING_SAMPLING_RATE] sample rate.
          */
         CREATION_SAMPLING_RATE("_dd.local.head_sampling_rate_key"),
 
-        /* Sampling rate that is used to decide to send or not to send the metric.
+        /*
+         * Sampling rate that is used to decide to send or not to send the metric.
          * Each metric should have reporting(tail) sampling rate.
          * It's possible that metric has only reporting(tail) sampling rate.
          */
@@ -43,7 +44,11 @@ interface LocalAttribute {
          * Indicates which instrumentation was used to track the view scope.
          * See [ViewScopeInstrumentationType] for possible values.
          */
-        VIEW_SCOPE_INSTRUMENTATION_TYPE("_dd.local.view_instrumentation_type_key")
+        VIEW_SCOPE_INSTRUMENTATION_TYPE("_dd.local.view_instrumentation_type_key");
+
+        override fun toString(): String {
+            return string
+        }
     }
 
     /**
@@ -56,9 +61,6 @@ interface LocalAttribute {
     interface Constant {
         /** Constant attribute key. For enum constants will be same for all values. */
         val key: Key
-
-        /** Constant attribute value. One item from set of possible finite values for a given constant attribute.*/
-        val value: Any
     }
 }
 
@@ -99,5 +101,5 @@ fun MutableMap<String, Any?>.enrichWithLocalAttribute(
     key: LocalAttribute.Key,
     value: Any?
 ) = apply {
-    this[key.string] = value
+    this[key.toString()] = value
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/attributes/ViewScopeInstrumentationType.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/attributes/ViewScopeInstrumentationType.kt
@@ -11,20 +11,18 @@ import com.datadog.android.lint.InternalApi
  * A set of constants describing the instrumentation that were used to define the view scope.
  */
 @InternalApi
-enum class ViewScopeInstrumentationType(
-    override val value: String
-) : LocalAttribute.Constant {
+enum class ViewScopeInstrumentationType : LocalAttribute.Constant {
     /** Tracked manually through the RUMMonitor API. */
-    MANUAL("manual"),
+    MANUAL,
 
     /** Tracked through ComposeNavigationObserver instrumentation. */
-    COMPOSE("compose"),
+    COMPOSE,
 
     /** Tracked through ActivityViewTrackingStrategy instrumentation. */
-    ACTIVITY("activity"),
+    ACTIVITY,
 
     /** Tracked through FragmentViewTrackingStrategy instrumentation. */
-    FRAGMENT("fragment");
+    FRAGMENT;
 
     /** @inheritdoc */
     override val key: LocalAttribute.Key = LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/logger/SdkInternalLoggerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/logger/SdkInternalLoggerTest.kt
@@ -453,7 +453,7 @@ internal class SdkInternalLoggerTest {
         // Given
         val samplingRate = 100.0f
         val fakeAdditionalProperties = forge.exhaustiveAttributes().also {
-            it[LocalAttribute.Key.REPORTING_SAMPLING_RATE.string] = samplingRate
+            it[LocalAttribute.Key.REPORTING_SAMPLING_RATE.toString()] = samplingRate
         }
         val mockLambda: () -> String = mock()
         whenever(mockLambda.invoke()) doReturn fakeMessage
@@ -505,13 +505,13 @@ internal class SdkInternalLoggerTest {
             val metricEvent = firstValue as InternalTelemetryEvent.Metric
 
             assertThat(
-                metricEvent.additionalProperties?.get(LocalAttribute.Key.CREATION_SAMPLING_RATE.string)
+                metricEvent.additionalProperties?.get(LocalAttribute.Key.CREATION_SAMPLING_RATE.toString())
             ).isEqualTo(
                 expectedCreationSampleRate
             )
 
             assertThat(
-                metricEvent.additionalProperties?.get(LocalAttribute.Key.REPORTING_SAMPLING_RATE.string)
+                metricEvent.additionalProperties?.get(LocalAttribute.Key.REPORTING_SAMPLING_RATE.toString())
             ).isEqualTo(
                 samplingRate
             )
@@ -544,11 +544,11 @@ internal class SdkInternalLoggerTest {
             assertThat(
                 apiUsageEvent.additionalProperties
             ).doesNotContainKeys(
-                LocalAttribute.Key.CREATION_SAMPLING_RATE.string
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.toString()
             )
 
             assertThat(
-                apiUsageEvent.additionalProperties[LocalAttribute.Key.REPORTING_SAMPLING_RATE.string]
+                apiUsageEvent.additionalProperties[LocalAttribute.Key.REPORTING_SAMPLING_RATE.toString()]
             ).isEqualTo(
                 samplingRate
             )
@@ -569,7 +569,7 @@ internal class SdkInternalLoggerTest {
             ),
             target = InternalLogger.Target.TELEMETRY,
             messageBuilder = { forge.aString() },
-            additionalProperties = mapOf(LocalAttribute.Key.REPORTING_SAMPLING_RATE.string to samplingRate)
+            additionalProperties = mapOf(LocalAttribute.Key.REPORTING_SAMPLING_RATE.toString() to samplingRate)
         )
 
         // Then
@@ -581,11 +581,11 @@ internal class SdkInternalLoggerTest {
             assertThat(
                 debugEvent.additionalProperties
             ).doesNotContainKeys(
-                LocalAttribute.Key.CREATION_SAMPLING_RATE.string
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.toString()
             )
 
             assertThat(
-                debugEvent.additionalProperties?.get(LocalAttribute.Key.REPORTING_SAMPLING_RATE.string)
+                debugEvent.additionalProperties?.get(LocalAttribute.Key.REPORTING_SAMPLING_RATE.toString())
             ).isEqualTo(
                 samplingRate
             )
@@ -604,7 +604,7 @@ internal class SdkInternalLoggerTest {
             target = InternalLogger.Target.TELEMETRY,
             throwable = forge.aThrowable(),
             messageBuilder = { forge.aString() },
-            additionalProperties = mapOf(LocalAttribute.Key.REPORTING_SAMPLING_RATE.string to samplingRate)
+            additionalProperties = mapOf(LocalAttribute.Key.REPORTING_SAMPLING_RATE.toString() to samplingRate)
         )
 
         // Then
@@ -616,11 +616,11 @@ internal class SdkInternalLoggerTest {
             assertThat(
                 debugEvent.additionalProperties
             ).doesNotContainKeys(
-                LocalAttribute.Key.CREATION_SAMPLING_RATE.string
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.toString()
             )
 
             assertThat(
-                debugEvent.additionalProperties?.get(LocalAttribute.Key.REPORTING_SAMPLING_RATE.string)
+                debugEvent.additionalProperties?.get(LocalAttribute.Key.REPORTING_SAMPLING_RATE.toString())
             ).isEqualTo(
                 samplingRate
             )

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -2174,7 +2174,7 @@ data class com.datadog.android.telemetry.model.TelemetryConfigurationEvent
       fun fromJson(kotlin.String): Os
       fun fromJsonObject(com.google.gson.JsonObject): Os
   data class Configuration
-    constructor(kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, TraceContextInjection? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, TrackingConsent? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, SessionPersistence? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.collections.List<SelectedTracingPropagator>? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.collections.List<kotlin.String>? = null, kotlin.collections.List<kotlin.String>? = null, kotlin.Boolean? = null, ViewTrackingStrategy? = null, kotlin.Boolean? = null, kotlin.Long? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Long? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.collections.List<Plugin>? = null, kotlin.Boolean? = null, kotlin.collections.List<TrackFeatureFlagsForEvent>? = null, kotlin.Boolean? = true)
+    constructor(kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, TraceContextInjection? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, TrackingConsent? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, SessionPersistence? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.collections.List<SelectedTracingPropagator>? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.collections.List<kotlin.String>? = null, kotlin.collections.List<kotlin.String>? = null, kotlin.Boolean? = null, ViewTrackingStrategy? = null, kotlin.Boolean? = null, kotlin.Long? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Long? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.collections.List<Plugin>? = null, kotlin.Boolean? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.collections.List<TrackFeatureFlagsForEvent>? = null, kotlin.Boolean? = true)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Configuration
@@ -2467,6 +2467,30 @@ data class com.datadog.android.telemetry.model.TelemetryUsageEvent
       companion object 
         fun fromJson(kotlin.String): StartView
         fun fromJsonObject(com.google.gson.JsonObject): StartView
+    class SetViewContext : Usage
+      val feature: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): SetViewContext
+        fun fromJsonObject(com.google.gson.JsonObject): SetViewContext
+    class SetViewContextProperty : Usage
+      val feature: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): SetViewContextProperty
+        fun fromJsonObject(com.google.gson.JsonObject): SetViewContextProperty
+    class SetViewName : Usage
+      val feature: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): SetViewName
+        fun fromJsonObject(com.google.gson.JsonObject): SetViewName
+    class GetViewContext : Usage
+      val feature: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): GetViewContext
+        fun fromJsonObject(com.google.gson.JsonObject): GetViewContext
     class AddAction : Usage
       val feature: kotlin.String
       override fun toJson(): com.google.gson.JsonElement

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -6655,8 +6655,8 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 public final class com/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration {
 	public static final field Companion Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SessionPersistence;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SessionPersistence;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SessionPersistence;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/List;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SessionPersistence;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/List;Ljava/lang/Boolean;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Long;
 	public final fun component10 ()Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;
 	public final fun component11 ()Ljava/lang/Boolean;
@@ -6728,12 +6728,14 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public final fun component71 ()Ljava/lang/Boolean;
 	public final fun component72 ()Ljava/util/List;
 	public final fun component73 ()Ljava/lang/Boolean;
-	public final fun component74 ()Ljava/util/List;
-	public final fun component75 ()Ljava/lang/Boolean;
+	public final fun component74 ()Ljava/lang/Long;
+	public final fun component75 ()Ljava/lang/Long;
+	public final fun component76 ()Ljava/util/List;
+	public final fun component77 ()Ljava/lang/Boolean;
 	public final fun component8 ()Ljava/lang/Long;
 	public final fun component9 ()Ljava/lang/Long;
-	public final fun copy (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SessionPersistence;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
-	public static synthetic fun copy$default (Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SessionPersistence;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;IIILjava/lang/Object;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
+	public final fun copy (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SessionPersistence;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/List;Ljava/lang/Boolean;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
+	public static synthetic fun copy$default (Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SessionPersistence;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/util/List;Ljava/lang/Boolean;IIILjava/lang/Object;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
@@ -6754,6 +6756,7 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public final fun getForwardReports ()Ljava/util/List;
 	public final fun getImagePrivacyLevel ()Ljava/lang/String;
 	public final fun getInitializationType ()Ljava/lang/String;
+	public final fun getInvTimeThresholdMs ()Ljava/lang/Long;
 	public final fun getMobileVitalsUpdatePeriod ()Ljava/lang/Long;
 	public final fun getPlugins ()Ljava/util/List;
 	public final fun getPremiumSampleRate ()Ljava/lang/Long;
@@ -6773,6 +6776,7 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public final fun getTelemetrySampleRate ()Ljava/lang/Long;
 	public final fun getTelemetryUsageSampleRate ()Ljava/lang/Long;
 	public final fun getTextAndInputPrivacyLevel ()Ljava/lang/String;
+	public final fun getTnsTimeThresholdMs ()Ljava/lang/Long;
 	public final fun getTouchPrivacyLevel ()Ljava/lang/String;
 	public final fun getTraceContextInjection ()Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;
 	public final fun getTraceSampleRate ()Ljava/lang/Long;
@@ -7952,6 +7956,20 @@ public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage;
 }
 
+public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$GetViewContext : com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage {
+	public static final field Companion Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$GetViewContext$Companion;
+	public fun <init> ()V
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$GetViewContext;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$GetViewContext;
+	public final fun getFeature ()Ljava/lang/String;
+	public fun toJson ()Lcom/google/gson/JsonElement;
+}
+
+public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$GetViewContext$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$GetViewContext;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$GetViewContext;
+}
+
 public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetAccount : com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage {
 	public static final field Companion Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetAccount$Companion;
 	public fun <init> ()V
@@ -8013,6 +8031,48 @@ public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage
 public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetUser$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetUser;
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetUser;
+}
+
+public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewContext : com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage {
+	public static final field Companion Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewContext$Companion;
+	public fun <init> ()V
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewContext;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewContext;
+	public final fun getFeature ()Ljava/lang/String;
+	public fun toJson ()Lcom/google/gson/JsonElement;
+}
+
+public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewContext$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewContext;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewContext;
+}
+
+public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewContextProperty : com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage {
+	public static final field Companion Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewContextProperty$Companion;
+	public fun <init> ()V
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewContextProperty;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewContextProperty;
+	public final fun getFeature ()Ljava/lang/String;
+	public fun toJson ()Lcom/google/gson/JsonElement;
+}
+
+public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewContextProperty$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewContextProperty;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewContextProperty;
+}
+
+public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewName : com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage {
+	public static final field Companion Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewName$Companion;
+	public fun <init> ()V
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewName;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewName;
+	public final fun getFeature ()Ljava/lang/String;
+	public fun toJson ()Lcom/google/gson/JsonElement;
+}
+
+public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewName$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewName;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$SetViewName;
 }
 
 public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$StartDurationVital : com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage {

--- a/features/dd-sdk-android-rum/src/main/json/telemetry/configuration-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/telemetry/configuration-schema.json
@@ -414,6 +414,14 @@
                   "type": "boolean",
                   "description": "Whether the SDK is initialised on the application's main or a secondary process"
                 },
+                "inv_time_threshold_ms": {
+                  "type": "integer",
+                  "description": "Interval in milliseconds when the last action is considered as the action that created the next view. Only sent if a time based strategy has been used"
+                },
+                "tns_time_threshold_ms": {
+                  "type": "integer",
+                  "description": "The interval in milliseconds during which all network requests will be considered as initial, i.e. caused by the creation of this view. Only sent if a time based strategy has been used"
+                },
                 "track_feature_flags_for_events": {
                   "type": "array",
                   "items": {

--- a/features/dd-sdk-android-rum/src/main/json/telemetry/usage/common-features-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/telemetry/usage/common-features-schema.json
@@ -45,6 +45,50 @@
     },
     {
       "required": ["feature"],
+      "title": "SetViewContext",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "setViewContext API",
+          "const": "set-view-context"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "title": "SetViewContextProperty",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "setViewContextProperty API",
+          "const": "set-view-context-property"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "title": "SetViewName",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "setViewName API",
+          "const": "set-view-name"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
+      "title": "GetViewContext",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "getViewContext API",
+          "const": "get-view-context"
+        }
+      }
+    },
+    {
+      "required": ["feature"],
       "title": "AddAction",
       "properties": {
         "feature": {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -1434,7 +1434,7 @@ internal open class RumViewScope(
         }
 
         private fun RumRawEvent.StartView.tryResolveInstrumentationType() =
-            attributes[LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.string] as? ViewScopeInstrumentationType
+            attributes[LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.toString()] as? ViewScopeInstrumentationType
 
         @Suppress("CommentOverPrivateFunction")
         /**

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/metric/interactiontonextview/TimeBasedInteractionIdentifier.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/metric/interactiontonextview/TimeBasedInteractionIdentifier.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
  * @param timeThresholdInMilliseconds The time threshold in milliseconds. Default is 3000ms.
  */
 class TimeBasedInteractionIdentifier(
-    timeThresholdInMilliseconds: Long = DEFAULT_TIME_THRESHOLD_MS
+    internal val timeThresholdInMilliseconds: Long = DEFAULT_TIME_THRESHOLD_MS
 ) : LastInteractionIdentifier {
 
     private val timeThresholdInNanoSeconds: Long = TimeUnit.MILLISECONDS.toNanos(timeThresholdInMilliseconds)
@@ -27,7 +27,7 @@ class TimeBasedInteractionIdentifier(
     }
 
     internal fun defaultThresholdUsed(): Boolean {
-        return DEFAULT_TIME_THRESHOLD_MS == TimeUnit.NANOSECONDS.toMillis(timeThresholdInNanoSeconds)
+        return DEFAULT_TIME_THRESHOLD_MS == timeThresholdInMilliseconds
     }
 
     // region Object

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/metric/networksettled/TimeBasedInitialResourceIdentifier.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/metric/networksettled/TimeBasedInitialResourceIdentifier.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
  * @param timeThresholdInMilliseconds The threshold in milliseconds.
  */
 class TimeBasedInitialResourceIdentifier(
-    timeThresholdInMilliseconds: Long = DEFAULT_TIME_THRESHOLD_MS
+    internal val timeThresholdInMilliseconds: Long = DEFAULT_TIME_THRESHOLD_MS
 ) : InitialResourceIdentifier {
     private val timeThresholdInNanoSeconds: Long = TimeUnit.MILLISECONDS.toNanos(timeThresholdInMilliseconds)
 
@@ -28,9 +28,8 @@ class TimeBasedInitialResourceIdentifier(
     }
 
     internal fun defaultThresholdUsed(): Boolean {
-        return DEFAULT_TIME_THRESHOLD_MS == TimeUnit.NANOSECONDS.toMillis(timeThresholdInNanoSeconds)
+        return DEFAULT_TIME_THRESHOLD_MS == timeThresholdInMilliseconds
     }
-
     // region Object
 
     override fun equals(other: Any?): Boolean {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -289,7 +289,7 @@ internal class TelemetryEventHandler(
         val sessionReplayFeatureContext =
             sdkCore.getFeatureContext(Feature.SESSION_REPLAY_FEATURE_NAME)
         val sessionReplaySampleRate = sessionReplayFeatureContext[SESSION_REPLAY_SAMPLE_RATE_KEY]
-                as? Long
+            as? Long
         val startRecordingImmediately =
             sessionReplayFeatureContext[SESSION_REPLAY_START_IMMEDIATE_RECORDING_KEY] as? Boolean
         val sessionReplayImagePrivacy =
@@ -439,7 +439,7 @@ internal class TelemetryEventHandler(
                     InternalLogger.Target.TELEMETRY,
                     {
                         "GlobalTracer class exists in the runtime classpath, " +
-                                "but there is an error invoking isRegistered method"
+                            "but there is an error invoking isRegistered method"
                     },
                     t
                 )

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -367,7 +367,9 @@ internal class TelemetryEventHandler(
                     textAndInputPrivacyLevel = sessionReplayTextAndInputPrivacy,
                     startRecordingImmediately = startRecordingImmediately,
                     batchProcessingLevel = event.batchProcessingLevel.toLong(),
-                    isMainProcess = datadogContext.processInfo.isMainProcess
+                    isMainProcess = datadogContext.processInfo.isMainProcess,
+                    invTimeThresholdMs = invTimeBasedThreshold,
+                    tnsTimeThresholdMs = tnsTimeBasedThreshold
                 )
             )
         )

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -25,6 +25,8 @@ import com.datadog.android.rum.internal.domain.scope.RumRawEvent
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.utils.HUNDRED
 import com.datadog.android.rum.internal.utils.percent
+import com.datadog.android.rum.metric.interactiontonextview.TimeBasedInteractionIdentifier
+import com.datadog.android.rum.metric.networksettled.TimeBasedInitialResourceIdentifier
 import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
 import com.datadog.android.rum.tracking.FragmentViewTrackingStrategy
 import com.datadog.android.rum.tracking.MixedViewTrackingStrategy
@@ -287,7 +289,7 @@ internal class TelemetryEventHandler(
         val sessionReplayFeatureContext =
             sdkCore.getFeatureContext(Feature.SESSION_REPLAY_FEATURE_NAME)
         val sessionReplaySampleRate = sessionReplayFeatureContext[SESSION_REPLAY_SAMPLE_RATE_KEY]
-            as? Long
+                as? Long
         val startRecordingImmediately =
             sessionReplayFeatureContext[SESSION_REPLAY_START_IMMEDIATE_RECORDING_KEY] as? Boolean
         val sessionReplayImagePrivacy =
@@ -309,6 +311,12 @@ internal class TelemetryEventHandler(
         val tracerApi = resolveTracerApi(traceContext)
         val openTelemetryApiVersion = resolveOpenTelemetryApiVersion(tracerApi, traceContext)
         val useTracing = (traceFeature != null && tracerApi != null)
+
+        val invTimeBasedThreshold = (rumConfig?.lastInteractionIdentifier as? TimeBasedInteractionIdentifier)
+            ?.timeThresholdInMilliseconds
+        val tnsTimeBasedThreshold = (rumConfig?.initialResourceIdentifier as? TimeBasedInitialResourceIdentifier)
+            ?.timeThresholdInMilliseconds
+
         return TelemetryConfigurationEvent(
             dd = TelemetryConfigurationEvent.Dd(),
             date = timestamp,
@@ -429,7 +437,7 @@ internal class TelemetryEventHandler(
                     InternalLogger.Target.TELEMETRY,
                     {
                         "GlobalTracer class exists in the runtime classpath, " +
-                            "but there is an error invoking isRegistered method"
+                                "but there is an error invoking isRegistered method"
                     },
                     t
                 )

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -498,10 +498,10 @@ internal class TelemetryEventHandler(
         return (effectiveSampleRate * HUNDRED).toFloat()
     }
 
-    private fun Map<String, Any?>.getFloat(key: LocalAttribute.Key) = get(key.string) as? Float
+    private fun Map<String, Any?>.getFloat(key: LocalAttribute.Key) = get(key.toString()) as? Float
 
     private fun Map<String, Any?>.cleanUpInternalAttributes() = toMutableMap().apply {
-        LocalAttribute.Key.values().forEach { key -> remove(key.string) }
+        LocalAttribute.Key.values().forEach { key -> remove(key.toString()) }
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityViewTrackingStrategyTest.kt
@@ -107,7 +107,7 @@ internal class ActivityViewTrackingStrategyTest :
         verify(rumMonitor.mockInstance).startView(
             mockActivity,
             mockActivity.resolveViewName(),
-            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.string to ViewScopeInstrumentationType.ACTIVITY)
+            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.toString() to ViewScopeInstrumentationType.ACTIVITY)
         )
     }
 
@@ -163,7 +163,7 @@ internal class ActivityViewTrackingStrategyTest :
         val expectedAttributes = mapOf<String, Any?>(
             "view.intent.action" to action,
             "view.intent.uri" to uri,
-            ViewScopeInstrumentationType.ACTIVITY.key.string to ViewScopeInstrumentationType.ACTIVITY
+            ViewScopeInstrumentationType.ACTIVITY.key.toString() to ViewScopeInstrumentationType.ACTIVITY
         )
 
         testedStrategy.register(rumMonitor.mockSdkCore, mockActivity)
@@ -223,7 +223,7 @@ internal class ActivityViewTrackingStrategyTest :
         verify(rumMonitor.mockInstance).startView(
             mockActivity,
             fakeName,
-            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.string to ViewScopeInstrumentationType.ACTIVITY)
+            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.toString() to ViewScopeInstrumentationType.ACTIVITY)
         )
     }
 
@@ -244,7 +244,7 @@ internal class ActivityViewTrackingStrategyTest :
         verify(rumMonitor.mockInstance).startView(
             mockActivity,
             mockActivity.resolveViewName(),
-            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.string to ViewScopeInstrumentationType.ACTIVITY)
+            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.toString() to ViewScopeInstrumentationType.ACTIVITY)
         )
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/metric/ViewEndedMetricDispatcherTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/metric/ViewEndedMetricDispatcherTest.kt
@@ -88,7 +88,7 @@ internal class ViewEndedMetricDispatcherTest {
             )
         }
 
-        fakeInstrumentationType = instrumentationType?.value
+        fakeInstrumentationType = instrumentationType?.name?.lowercase()
 
         dispatcherUnderTest = ViewEndedMetricDispatcher(
             viewType = fakeViewType,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategyTest.kt
@@ -261,7 +261,7 @@ internal class FragmentViewTrackingStrategyTest : ObjectTest<FragmentViewTrackin
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
         val mockFragment: Fragment = mockFragmentWithArguments(forge)
         val expectedAttrs = mapOf(
-            ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT
+            ViewScopeInstrumentationType.FRAGMENT.key.toString() to ViewScopeInstrumentationType.FRAGMENT
         )
         val argumentCaptor = argumentCaptor<FragmentManager.FragmentLifecycleCallbacks>()
 
@@ -478,7 +478,7 @@ internal class FragmentViewTrackingStrategyTest : ObjectTest<FragmentViewTrackin
         )
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
         val expectedAttrs = mapOf(
-            ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT
+            ViewScopeInstrumentationType.FRAGMENT.key.toString() to ViewScopeInstrumentationType.FRAGMENT
         )
         val mockFragment: android.app.Fragment = mockDeprecatedFragmentWithArguments(forge)
         val argumentCaptor =

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
@@ -314,7 +314,7 @@ internal class NavigationViewTrackingStrategyTest {
         verify(rumMonitor.mockInstance).startView(
             mockNavDestination,
             fakeDestinationName,
-            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT)
+            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.toString() to ViewScopeInstrumentationType.FRAGMENT)
         )
     }
 
@@ -341,7 +341,7 @@ internal class NavigationViewTrackingStrategyTest {
         verify(rumMonitor.mockInstance).startView(
             mockNavDestination,
             customName,
-            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT)
+            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.toString() to ViewScopeInstrumentationType.FRAGMENT)
         )
     }
 
@@ -352,7 +352,7 @@ internal class NavigationViewTrackingStrategyTest {
         whenever(mockPredicate.accept(mockNavDestination)) doReturn true
         val arguments = Bundle()
         val expectedAttrs = mutableMapOf<String, Any?>(
-            ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT
+            ViewScopeInstrumentationType.FRAGMENT.key.toString() to ViewScopeInstrumentationType.FRAGMENT
         )
         repeat(10) {
             val key = forge.anAlphabeticalString()
@@ -391,7 +391,7 @@ internal class NavigationViewTrackingStrategyTest {
         verify(rumMonitor.mockInstance).startView(
             mockNavDestination,
             fakeDestinationName,
-            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT)
+            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.toString() to ViewScopeInstrumentationType.FRAGMENT)
         )
     }
 
@@ -413,12 +413,12 @@ internal class NavigationViewTrackingStrategyTest {
             verify(rumMonitor.mockInstance).startView(
                 mockNavDestination,
                 fakeDestinationName,
-                mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT)
+                mapOf(ViewScopeInstrumentationType.FRAGMENT.key.toString() to ViewScopeInstrumentationType.FRAGMENT)
             )
             verify(rumMonitor.mockInstance).startView(
                 newDestination,
                 newDestinationName,
-                mapOf(ViewScopeInstrumentationType.FRAGMENT.key.string to ViewScopeInstrumentationType.FRAGMENT)
+                mapOf(ViewScopeInstrumentationType.FRAGMENT.key.toString() to ViewScopeInstrumentationType.FRAGMENT)
             )
         }
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
@@ -8,6 +8,10 @@ package com.datadog.android.rum.utils.forge
 
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
 import com.datadog.android.rum.internal.RumFeature
+import com.datadog.android.rum.metric.interactiontonextview.NoOpLastInteractionIdentifier
+import com.datadog.android.rum.metric.interactiontonextview.TimeBasedInteractionIdentifier
+import com.datadog.android.rum.metric.networksettled.NoOpInitialResourceIdentifier
+import com.datadog.android.rum.metric.networksettled.TimeBasedInitialResourceIdentifier
 import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
 import com.datadog.android.rum.tracking.FragmentViewTrackingStrategy
 import com.datadog.android.rum.tracking.MixedViewTrackingStrategy
@@ -48,8 +52,18 @@ internal class ConfigurationRumForgeryFactory :
             vitalsMonitorUpdateFrequency = forge.aValueFrom(VitalsUpdateFrequency::class.java),
             sessionListener = mock(),
             additionalConfig = forge.aMap { aString() to aString() },
-            initialResourceIdentifier = mock(),
-            lastInteractionIdentifier = mock(),
+            initialResourceIdentifier = forge.anElementFrom(
+                NoOpInitialResourceIdentifier(),
+                TimeBasedInitialResourceIdentifier(
+                    timeThresholdInMilliseconds = forge.aLong(min = 1)
+                )
+            ),
+            lastInteractionIdentifier = forge.anElementFrom(
+                NoOpLastInteractionIdentifier(),
+                TimeBasedInteractionIdentifier(
+                    timeThresholdInMilliseconds = forge.aLong(min = 1)
+                )
+            ),
             trackAnonymousUser = forge.aBool()
         )
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryConfigurationEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryConfigurationEventAssert.kt
@@ -104,7 +104,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.sessionSampleRate)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.sessionSampleRate $expected " +
-                    "but was ${actual.telemetry.configuration.sessionSampleRate}"
+                        "but was ${actual.telemetry.configuration.sessionSampleRate}"
             )
             .isEqualTo(expected)
         return this
@@ -114,7 +114,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.telemetrySampleRate)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.telemetrySampleRate $expected " +
-                    "but was ${actual.telemetry.configuration.telemetrySampleRate}"
+                        "but was ${actual.telemetry.configuration.telemetrySampleRate}"
             )
             .isEqualTo(expected)
         return this
@@ -124,7 +124,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.useProxy)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.useProxy $expected " +
-                    "but was ${actual.telemetry.configuration.useProxy}"
+                        "but was ${actual.telemetry.configuration.useProxy}"
             )
             .isEqualTo(expected)
         return this
@@ -134,7 +134,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackFrustrations)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackFrustrations $expected " +
-                    "but was ${actual.telemetry.configuration.trackFrustrations}"
+                        "but was ${actual.telemetry.configuration.trackFrustrations}"
             )
             .isEqualTo(expected)
         return this
@@ -144,7 +144,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.useLocalEncryption)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.useLocalEncryption $expected " +
-                    "but was ${actual.telemetry.configuration.useLocalEncryption}"
+                        "but was ${actual.telemetry.configuration.useLocalEncryption}"
             )
             .isEqualTo(expected)
         return this
@@ -154,7 +154,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.viewTrackingStrategy)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.viewTrackingStrategy $expected " +
-                    "but was ${actual.telemetry.configuration.viewTrackingStrategy}"
+                        "but was ${actual.telemetry.configuration.viewTrackingStrategy}"
             )
             .isEqualTo(expected)
         return this
@@ -164,7 +164,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackBackgroundEvents)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackBackgroundEvents $expected " +
-                    "but was ${actual.telemetry.configuration.trackBackgroundEvents}"
+                        "but was ${actual.telemetry.configuration.trackBackgroundEvents}"
             )
             .isEqualTo(expected)
         return this
@@ -174,7 +174,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.mobileVitalsUpdatePeriod)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.mobileVitalsUpdatePeriod $expected " +
-                    "but was ${actual.telemetry.configuration.mobileVitalsUpdatePeriod}"
+                        "but was ${actual.telemetry.configuration.mobileVitalsUpdatePeriod}"
             )
             .isEqualTo(expected)
         return this
@@ -184,7 +184,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackInteractions)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackActions $expected " +
-                    "but was ${actual.telemetry.configuration.trackInteractions}"
+                        "but was ${actual.telemetry.configuration.trackInteractions}"
             )
             .isEqualTo(expected)
         return this
@@ -194,7 +194,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackErrors)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackErrors $expected " +
-                    "but was ${actual.telemetry.configuration.trackErrors}"
+                        "but was ${actual.telemetry.configuration.trackErrors}"
             )
             .isEqualTo(expected)
         return this
@@ -204,7 +204,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackNetworkRequests)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackNetworkRequests $expected " +
-                    "but was ${actual.telemetry.configuration.trackNetworkRequests}"
+                        "but was ${actual.telemetry.configuration.trackNetworkRequests}"
             )
             .isEqualTo(expected)
         return this
@@ -214,7 +214,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackNativeLongTasks)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackNativeLongTasks $expected " +
-                    "but was ${actual.telemetry.configuration.trackNativeLongTasks}"
+                        "but was ${actual.telemetry.configuration.trackNativeLongTasks}"
             )
             .isEqualTo(expected)
         return this
@@ -224,7 +224,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.useTracing)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.useTracing $expected " +
-                    "but was ${actual.telemetry.configuration.useTracing}"
+                        "but was ${actual.telemetry.configuration.useTracing}"
             )
             .isEqualTo(expected)
         return this
@@ -234,7 +234,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.tracerApi)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.tracerApi $tracerApi " +
-                    "but was ${actual.telemetry.configuration.tracerApi}"
+                        "but was ${actual.telemetry.configuration.tracerApi}"
             )
             .isEqualTo(tracerApi)
         return this
@@ -244,7 +244,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.tracerApiVersion)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.tracerApiVersion $tracerApiVersion " +
-                    "but was ${actual.telemetry.configuration.tracerApiVersion}"
+                        "but was ${actual.telemetry.configuration.tracerApiVersion}"
             )
             .isEqualTo(tracerApiVersion)
         return this
@@ -254,7 +254,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.batchSize)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.batchSize $expected " +
-                    "but was ${actual.telemetry.configuration.batchSize}"
+                        "but was ${actual.telemetry.configuration.batchSize}"
             )
             .isEqualTo(expected)
         return this
@@ -264,7 +264,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.batchUploadFrequency)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.batchUploadFrequency $expected " +
-                    "but was ${actual.telemetry.configuration.batchUploadFrequency}"
+                        "but was ${actual.telemetry.configuration.batchUploadFrequency}"
             )
             .isEqualTo(expected)
         return this
@@ -274,7 +274,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.batchProcessingLevel)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.batchProcessingLevel $expected " +
-                    "but was ${actual.telemetry.configuration.batchProcessingLevel}"
+                        "but was ${actual.telemetry.configuration.batchProcessingLevel}"
             )
             .isEqualTo(expected?.toLong())
         return this
@@ -284,7 +284,27 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.isMainProcess)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.isMainProcess $expected " +
-                    "but was ${actual.telemetry.configuration.isMainProcess}"
+                        "but was ${actual.telemetry.configuration.isMainProcess}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasTnsTimeBasedThreshold(expected: Long?): TelemetryConfigurationEventAssert {
+        assertThat(actual.telemetry.configuration.tnsTimeThresholdMs)
+            .overridingErrorMessage(
+                "Expected event data to have telemetry.configuration.tnsTimeThresholdMs $expected " +
+                        "but was ${actual.telemetry.configuration.tnsTimeThresholdMs}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasInvTimeBasedThreshold(expected: Long?): TelemetryConfigurationEventAssert {
+        assertThat(actual.telemetry.configuration.invTimeThresholdMs)
+            .overridingErrorMessage(
+                "Expected event data to have telemetry.configuration.invTimeThresholdMs $expected " +
+                        "but was ${actual.telemetry.configuration.invTimeThresholdMs}"
             )
             .isEqualTo(expected)
         return this
@@ -298,7 +318,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackNativeViews)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackNativeViews $expected " +
-                    "but was ${actual.telemetry.configuration.trackNativeViews}"
+                        "but was ${actual.telemetry.configuration.trackNativeViews}"
             )
             .isEqualTo(expected)
         return this
@@ -308,7 +328,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackNativeErrors)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackNativeErrors $expected " +
-                    "but was ${actual.telemetry.configuration.trackNativeErrors}"
+                        "but was ${actual.telemetry.configuration.trackNativeErrors}"
             )
             .isEqualTo(expected)
         return this
@@ -318,7 +338,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.useFirstPartyHosts)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.useFirstPartyHosts $expected " +
-                    "but was ${actual.telemetry.configuration.useFirstPartyHosts}"
+                        "but was ${actual.telemetry.configuration.useFirstPartyHosts}"
             )
             .isEqualTo(expected)
         return this
@@ -328,7 +348,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackFlutterPerformance)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackFlutterPerformance $expected " +
-                    "but was ${actual.telemetry.configuration.trackFlutterPerformance}"
+                        "but was ${actual.telemetry.configuration.trackFlutterPerformance}"
             )
             .isEqualTo(expected)
         return this
@@ -338,7 +358,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.initializationType)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.initializationType $expected " +
-                    "but was ${actual.telemetry.configuration.initializationType}"
+                        "but was ${actual.telemetry.configuration.initializationType}"
             )
             .isEqualTo(expected)
         return this
@@ -352,8 +372,8 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.sessionReplaySampleRate)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.sessionReplaySampleRate" +
-                    " $expected " +
-                    "but was ${actual.telemetry.configuration.sessionReplaySampleRate}"
+                        " $expected " +
+                        "but was ${actual.telemetry.configuration.sessionReplaySampleRate}"
             )
             .isEqualTo(expected)
         return this
@@ -363,8 +383,8 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.imagePrivacyLevel)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.imagePrivacyLevel" +
-                    " $expected " +
-                    "but was ${actual.telemetry.configuration.imagePrivacyLevel}"
+                        " $expected " +
+                        "but was ${actual.telemetry.configuration.imagePrivacyLevel}"
             )
             .isEqualTo(expected)
         return this
@@ -374,8 +394,8 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.touchPrivacyLevel)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.touchPrivacyLevel" +
-                    " $expected " +
-                    "but was ${actual.telemetry.configuration.touchPrivacyLevel}"
+                        " $expected " +
+                        "but was ${actual.telemetry.configuration.touchPrivacyLevel}"
             )
             .isEqualTo(expected)
         return this
@@ -385,8 +405,8 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.textAndInputPrivacyLevel)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.textAndInputPrivacyLevel" +
-                    " $expected " +
-                    "but was ${actual.telemetry.configuration.textAndInputPrivacyLevel}"
+                        " $expected " +
+                        "but was ${actual.telemetry.configuration.textAndInputPrivacyLevel}"
             )
             .isEqualTo(expected)
         return this
@@ -394,9 +414,9 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
 
     fun hasStartRecordingImmediately(expected: Boolean?): TelemetryConfigurationEventAssert {
         val assertErrorMessage = "Expected event data to have" +
-            " telemetry.configuration.startRecordingImmediately" +
-            " $expected " +
-            "but was ${actual.telemetry.configuration.startRecordingImmediately}"
+                " telemetry.configuration.startRecordingImmediately" +
+                " $expected " +
+                "but was ${actual.telemetry.configuration.startRecordingImmediately}"
         assertThat(actual.telemetry.configuration.startRecordingImmediately)
             .overridingErrorMessage(assertErrorMessage)
             .isEqualTo(expected)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryConfigurationEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryConfigurationEventAssert.kt
@@ -104,7 +104,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.sessionSampleRate)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.sessionSampleRate $expected " +
-                        "but was ${actual.telemetry.configuration.sessionSampleRate}"
+                    "but was ${actual.telemetry.configuration.sessionSampleRate}"
             )
             .isEqualTo(expected)
         return this
@@ -114,7 +114,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.telemetrySampleRate)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.telemetrySampleRate $expected " +
-                        "but was ${actual.telemetry.configuration.telemetrySampleRate}"
+                    "but was ${actual.telemetry.configuration.telemetrySampleRate}"
             )
             .isEqualTo(expected)
         return this
@@ -124,7 +124,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.useProxy)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.useProxy $expected " +
-                        "but was ${actual.telemetry.configuration.useProxy}"
+                    "but was ${actual.telemetry.configuration.useProxy}"
             )
             .isEqualTo(expected)
         return this
@@ -134,7 +134,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackFrustrations)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackFrustrations $expected " +
-                        "but was ${actual.telemetry.configuration.trackFrustrations}"
+                    "but was ${actual.telemetry.configuration.trackFrustrations}"
             )
             .isEqualTo(expected)
         return this
@@ -144,7 +144,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.useLocalEncryption)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.useLocalEncryption $expected " +
-                        "but was ${actual.telemetry.configuration.useLocalEncryption}"
+                    "but was ${actual.telemetry.configuration.useLocalEncryption}"
             )
             .isEqualTo(expected)
         return this
@@ -154,7 +154,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.viewTrackingStrategy)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.viewTrackingStrategy $expected " +
-                        "but was ${actual.telemetry.configuration.viewTrackingStrategy}"
+                    "but was ${actual.telemetry.configuration.viewTrackingStrategy}"
             )
             .isEqualTo(expected)
         return this
@@ -164,7 +164,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackBackgroundEvents)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackBackgroundEvents $expected " +
-                        "but was ${actual.telemetry.configuration.trackBackgroundEvents}"
+                    "but was ${actual.telemetry.configuration.trackBackgroundEvents}"
             )
             .isEqualTo(expected)
         return this
@@ -174,7 +174,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.mobileVitalsUpdatePeriod)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.mobileVitalsUpdatePeriod $expected " +
-                        "but was ${actual.telemetry.configuration.mobileVitalsUpdatePeriod}"
+                    "but was ${actual.telemetry.configuration.mobileVitalsUpdatePeriod}"
             )
             .isEqualTo(expected)
         return this
@@ -184,7 +184,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackInteractions)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackActions $expected " +
-                        "but was ${actual.telemetry.configuration.trackInteractions}"
+                    "but was ${actual.telemetry.configuration.trackInteractions}"
             )
             .isEqualTo(expected)
         return this
@@ -194,7 +194,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackErrors)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackErrors $expected " +
-                        "but was ${actual.telemetry.configuration.trackErrors}"
+                    "but was ${actual.telemetry.configuration.trackErrors}"
             )
             .isEqualTo(expected)
         return this
@@ -204,7 +204,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackNetworkRequests)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackNetworkRequests $expected " +
-                        "but was ${actual.telemetry.configuration.trackNetworkRequests}"
+                    "but was ${actual.telemetry.configuration.trackNetworkRequests}"
             )
             .isEqualTo(expected)
         return this
@@ -214,7 +214,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackNativeLongTasks)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackNativeLongTasks $expected " +
-                        "but was ${actual.telemetry.configuration.trackNativeLongTasks}"
+                    "but was ${actual.telemetry.configuration.trackNativeLongTasks}"
             )
             .isEqualTo(expected)
         return this
@@ -224,7 +224,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.useTracing)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.useTracing $expected " +
-                        "but was ${actual.telemetry.configuration.useTracing}"
+                    "but was ${actual.telemetry.configuration.useTracing}"
             )
             .isEqualTo(expected)
         return this
@@ -234,7 +234,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.tracerApi)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.tracerApi $tracerApi " +
-                        "but was ${actual.telemetry.configuration.tracerApi}"
+                    "but was ${actual.telemetry.configuration.tracerApi}"
             )
             .isEqualTo(tracerApi)
         return this
@@ -244,7 +244,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.tracerApiVersion)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.tracerApiVersion $tracerApiVersion " +
-                        "but was ${actual.telemetry.configuration.tracerApiVersion}"
+                    "but was ${actual.telemetry.configuration.tracerApiVersion}"
             )
             .isEqualTo(tracerApiVersion)
         return this
@@ -254,7 +254,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.batchSize)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.batchSize $expected " +
-                        "but was ${actual.telemetry.configuration.batchSize}"
+                    "but was ${actual.telemetry.configuration.batchSize}"
             )
             .isEqualTo(expected)
         return this
@@ -264,7 +264,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.batchUploadFrequency)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.batchUploadFrequency $expected " +
-                        "but was ${actual.telemetry.configuration.batchUploadFrequency}"
+                    "but was ${actual.telemetry.configuration.batchUploadFrequency}"
             )
             .isEqualTo(expected)
         return this
@@ -274,7 +274,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.batchProcessingLevel)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.batchProcessingLevel $expected " +
-                        "but was ${actual.telemetry.configuration.batchProcessingLevel}"
+                    "but was ${actual.telemetry.configuration.batchProcessingLevel}"
             )
             .isEqualTo(expected?.toLong())
         return this
@@ -284,7 +284,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.isMainProcess)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.isMainProcess $expected " +
-                        "but was ${actual.telemetry.configuration.isMainProcess}"
+                    "but was ${actual.telemetry.configuration.isMainProcess}"
             )
             .isEqualTo(expected)
         return this
@@ -294,7 +294,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.tnsTimeThresholdMs)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.tnsTimeThresholdMs $expected " +
-                        "but was ${actual.telemetry.configuration.tnsTimeThresholdMs}"
+                    "but was ${actual.telemetry.configuration.tnsTimeThresholdMs}"
             )
             .isEqualTo(expected)
         return this
@@ -304,7 +304,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.invTimeThresholdMs)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.invTimeThresholdMs $expected " +
-                        "but was ${actual.telemetry.configuration.invTimeThresholdMs}"
+                    "but was ${actual.telemetry.configuration.invTimeThresholdMs}"
             )
             .isEqualTo(expected)
         return this
@@ -318,7 +318,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackNativeViews)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackNativeViews $expected " +
-                        "but was ${actual.telemetry.configuration.trackNativeViews}"
+                    "but was ${actual.telemetry.configuration.trackNativeViews}"
             )
             .isEqualTo(expected)
         return this
@@ -328,7 +328,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackNativeErrors)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackNativeErrors $expected " +
-                        "but was ${actual.telemetry.configuration.trackNativeErrors}"
+                    "but was ${actual.telemetry.configuration.trackNativeErrors}"
             )
             .isEqualTo(expected)
         return this
@@ -338,7 +338,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.useFirstPartyHosts)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.useFirstPartyHosts $expected " +
-                        "but was ${actual.telemetry.configuration.useFirstPartyHosts}"
+                    "but was ${actual.telemetry.configuration.useFirstPartyHosts}"
             )
             .isEqualTo(expected)
         return this
@@ -348,7 +348,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.trackFlutterPerformance)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.trackFlutterPerformance $expected " +
-                        "but was ${actual.telemetry.configuration.trackFlutterPerformance}"
+                    "but was ${actual.telemetry.configuration.trackFlutterPerformance}"
             )
             .isEqualTo(expected)
         return this
@@ -358,7 +358,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.initializationType)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.initializationType $expected " +
-                        "but was ${actual.telemetry.configuration.initializationType}"
+                    "but was ${actual.telemetry.configuration.initializationType}"
             )
             .isEqualTo(expected)
         return this
@@ -372,8 +372,8 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.sessionReplaySampleRate)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.sessionReplaySampleRate" +
-                        " $expected " +
-                        "but was ${actual.telemetry.configuration.sessionReplaySampleRate}"
+                    " $expected " +
+                    "but was ${actual.telemetry.configuration.sessionReplaySampleRate}"
             )
             .isEqualTo(expected)
         return this
@@ -383,8 +383,8 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.imagePrivacyLevel)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.imagePrivacyLevel" +
-                        " $expected " +
-                        "but was ${actual.telemetry.configuration.imagePrivacyLevel}"
+                    " $expected " +
+                    "but was ${actual.telemetry.configuration.imagePrivacyLevel}"
             )
             .isEqualTo(expected)
         return this
@@ -394,8 +394,8 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.touchPrivacyLevel)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.touchPrivacyLevel" +
-                        " $expected " +
-                        "but was ${actual.telemetry.configuration.touchPrivacyLevel}"
+                    " $expected " +
+                    "but was ${actual.telemetry.configuration.touchPrivacyLevel}"
             )
             .isEqualTo(expected)
         return this
@@ -405,8 +405,8 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         assertThat(actual.telemetry.configuration.textAndInputPrivacyLevel)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.textAndInputPrivacyLevel" +
-                        " $expected " +
-                        "but was ${actual.telemetry.configuration.textAndInputPrivacyLevel}"
+                    " $expected " +
+                    "but was ${actual.telemetry.configuration.textAndInputPrivacyLevel}"
             )
             .isEqualTo(expected)
         return this
@@ -414,9 +414,9 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
 
     fun hasStartRecordingImmediately(expected: Boolean?): TelemetryConfigurationEventAssert {
         val assertErrorMessage = "Expected event data to have" +
-                " telemetry.configuration.startRecordingImmediately" +
-                " $expected " +
-                "but was ${actual.telemetry.configuration.startRecordingImmediately}"
+            " telemetry.configuration.startRecordingImmediately" +
+            " $expected " +
+            "but was ${actual.telemetry.configuration.startRecordingImmediately}"
         assertThat(actual.telemetry.configuration.startRecordingImmediately)
             .overridingErrorMessage(assertErrorMessage)
             .isEqualTo(expected)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -1102,8 +1102,8 @@ internal class TelemetryEventHandlerTest {
         @Forgery fakeApiUsageEvent: InternalTelemetryEvent.ApiUsage
     ) {
         fakeApiUsageEvent.additionalProperties.also { properties ->
-            properties[LocalAttribute.Key.REPORTING_SAMPLING_RATE.string] = "value that should not exist"
-            properties[LocalAttribute.Key.CREATION_SAMPLING_RATE.string] = "value that should not exist"
+            properties[LocalAttribute.Key.REPORTING_SAMPLING_RATE.toString()] = "value that should not exist"
+            properties[LocalAttribute.Key.CREATION_SAMPLING_RATE.toString()] = "value that should not exist"
             properties[fakeAdditionalPropertyKey] = fakeAdditionalPropertyValue
         }
 
@@ -1128,8 +1128,8 @@ internal class TelemetryEventHandlerTest {
         val fakeMetricEvent = InternalTelemetryEvent.Metric(
             message = forge.aString(),
             additionalProperties = mapOf(
-                LocalAttribute.Key.REPORTING_SAMPLING_RATE.string to "value that should not exist",
-                LocalAttribute.Key.CREATION_SAMPLING_RATE.string to "value that should not exist",
+                LocalAttribute.Key.REPORTING_SAMPLING_RATE.toString() to "value that should not exist",
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.toString() to "value that should not exist",
                 fakeAdditionalPropertyKey to fakeAdditionalPropertyValue
             )
         )
@@ -1155,8 +1155,8 @@ internal class TelemetryEventHandlerTest {
         val fakeLogDebugEvent = InternalTelemetryEvent.Log.Debug(
             message = forge.aString(),
             additionalProperties = mapOf(
-                LocalAttribute.Key.REPORTING_SAMPLING_RATE.string to "value that should not exist",
-                LocalAttribute.Key.CREATION_SAMPLING_RATE.string to "value that should not exist",
+                LocalAttribute.Key.REPORTING_SAMPLING_RATE.toString() to "value that should not exist",
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.toString() to "value that should not exist",
                 fakeAdditionalPropertyKey to fakeAdditionalPropertyValue
             )
         )
@@ -1182,8 +1182,8 @@ internal class TelemetryEventHandlerTest {
         val fakeLogDebugEvent = InternalTelemetryEvent.Log.Error(
             message = forge.aString(),
             additionalProperties = mapOf(
-                LocalAttribute.Key.REPORTING_SAMPLING_RATE.string to "value that should not exist",
-                LocalAttribute.Key.CREATION_SAMPLING_RATE.string to "value that should not exist",
+                LocalAttribute.Key.REPORTING_SAMPLING_RATE.toString() to "value that should not exist",
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.toString() to "value that should not exist",
                 fakeAdditionalPropertyKey to fakeAdditionalPropertyValue
             )
         )
@@ -1213,8 +1213,8 @@ internal class TelemetryEventHandlerTest {
         whenever(mockRumFeature.configuration) doReturn fakeRumConfiguration
         whenever(mockRumFeatureScope.unwrap<RumFeature>()) doReturn mockRumFeature
         fakeApiUsageEvent.additionalProperties.also { properties ->
-            properties[LocalAttribute.Key.REPORTING_SAMPLING_RATE.string] = reportingSamplingRate
-            properties[LocalAttribute.Key.CREATION_SAMPLING_RATE.string] = creationSamplingRate
+            properties[LocalAttribute.Key.REPORTING_SAMPLING_RATE.toString()] = reportingSamplingRate
+            properties[LocalAttribute.Key.CREATION_SAMPLING_RATE.toString()] = creationSamplingRate
         }
 
         // When
@@ -1248,8 +1248,8 @@ internal class TelemetryEventHandlerTest {
         val fakeMetricEvent = InternalTelemetryEvent.Metric(
             message = forge.aString(),
             additionalProperties = mapOf(
-                LocalAttribute.Key.REPORTING_SAMPLING_RATE.string to creatingSamplingRate,
-                LocalAttribute.Key.CREATION_SAMPLING_RATE.string to reportingSamplingRate,
+                LocalAttribute.Key.REPORTING_SAMPLING_RATE.toString() to creatingSamplingRate,
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.toString() to reportingSamplingRate,
                 fakeAdditionalPropertyKey to fakeAdditionalPropertyValue
             )
         )
@@ -1284,8 +1284,8 @@ internal class TelemetryEventHandlerTest {
         val fakeDebugEvent = InternalTelemetryEvent.Log.Debug(
             message = forge.aString(),
             additionalProperties = mapOf(
-                LocalAttribute.Key.REPORTING_SAMPLING_RATE.string to creatingSamplingRate,
-                LocalAttribute.Key.CREATION_SAMPLING_RATE.string to reportingSamplingRate,
+                LocalAttribute.Key.REPORTING_SAMPLING_RATE.toString() to creatingSamplingRate,
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.toString() to reportingSamplingRate,
                 fakeAdditionalPropertyKey to fakeAdditionalPropertyValue
             )
         )
@@ -1320,8 +1320,8 @@ internal class TelemetryEventHandlerTest {
         val fakeErrorEvent = InternalTelemetryEvent.Log.Error(
             message = forge.aString(),
             additionalProperties = mapOf(
-                LocalAttribute.Key.REPORTING_SAMPLING_RATE.string to creatingSamplingRate,
-                LocalAttribute.Key.CREATION_SAMPLING_RATE.string to reportingSamplingRate,
+                LocalAttribute.Key.REPORTING_SAMPLING_RATE.toString() to creatingSamplingRate,
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.toString() to reportingSamplingRate,
                 fakeAdditionalPropertyKey to fakeAdditionalPropertyValue
             )
         )
@@ -1394,8 +1394,8 @@ internal class TelemetryEventHandlerTest {
     ) {
         assertThat(additionalProperties)
             .doesNotContainKeys(
-                LocalAttribute.Key.CREATION_SAMPLING_RATE.string,
-                LocalAttribute.Key.REPORTING_SAMPLING_RATE.string
+                LocalAttribute.Key.CREATION_SAMPLING_RATE.toString(),
+                LocalAttribute.Key.REPORTING_SAMPLING_RATE.toString()
             )
 
         expectedEntries.forEach { (expectedKey, expectedValue) ->

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -23,6 +23,10 @@ import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.scope.RumRawEvent
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
+import com.datadog.android.rum.metric.interactiontonextview.LastInteractionIdentifier
+import com.datadog.android.rum.metric.interactiontonextview.TimeBasedInteractionIdentifier
+import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
+import com.datadog.android.rum.metric.networksettled.TimeBasedInitialResourceIdentifier
 import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
 import com.datadog.android.rum.tracking.FragmentViewTrackingStrategy
 import com.datadog.android.rum.tracking.MixedViewTrackingStrategy
@@ -575,6 +579,8 @@ internal class TelemetryEventHandlerTest {
                 .hasMobileVitalsUpdatePeriod(
                     fakeRumConfiguration.vitalsMonitorUpdateFrequency.periodInMs
                 )
+                .hasTnsTimeBasedThreshold(fakeRumConfiguration.initialResourceIdentifier.resolveThreshold())
+                .hasInvTimeBasedThreshold(fakeRumConfiguration.lastInteractionIdentifier.resolveThreshold())
         }
     }
 
@@ -1580,6 +1586,14 @@ internal class TelemetryEventHandlerTest {
             Configurator().configure(this)
         }
 
+        private fun InitialResourceIdentifier.resolveThreshold(): Long? {
+            return (this as? TimeBasedInitialResourceIdentifier)?.timeThresholdInMilliseconds
+        }
+
+        private fun LastInteractionIdentifier.resolveThreshold(): Long? {
+            return (this as? TimeBasedInteractionIdentifier)?.timeThresholdInMilliseconds
+        }
+
         @JvmStatic
         fun tracingConfigurationParameters() = listOf(
             // hasTracer, tracerApiName, tracerApiVersion
@@ -1595,3 +1609,5 @@ internal class TelemetryEventHandlerTest {
         private const val MAX_EVENTS_PER_SESSION_TEST = 10
     }
 }
+
+

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -1609,5 +1609,3 @@ internal class TelemetryEventHandlerTest {
         private const val MAX_EVENTS_PER_SESSION_TEST = 10
     }
 }
-
-

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/internal/ComposeNavigationObserverTest.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/internal/ComposeNavigationObserverTest.kt
@@ -79,7 +79,7 @@ internal class ComposeNavigationObserverTest {
         // Given
         val arguments = Bundle()
         val expectedAttrs = mutableMapOf<String, Any?>(
-            LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.string to ViewScopeInstrumentationType.COMPOSE
+            LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.toString() to ViewScopeInstrumentationType.COMPOSE
         )
         repeat(10) {
             val key = forge.anAlphabeticalString()
@@ -113,7 +113,7 @@ internal class ComposeNavigationObserverTest {
 
         val arguments = Bundle()
         val expectedAttrs = mutableMapOf<String, Any?>(
-            LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.string to ViewScopeInstrumentationType.COMPOSE
+            LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.toString() to ViewScopeInstrumentationType.COMPOSE
         )
         repeat(10) {
             val key = forge.anAlphabeticalString()
@@ -164,7 +164,7 @@ internal class ComposeNavigationObserverTest {
         verify(mockRumMonitor).startView(
             mockNavDestination.route!!,
             mockNavDestination.route!!,
-            mapOf(LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.string to ViewScopeInstrumentationType.COMPOSE)
+            mapOf(LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.toString() to ViewScopeInstrumentationType.COMPOSE)
         )
         verifyNoMoreInteractions(mockRumMonitor)
     }


### PR DESCRIPTION
### What does this PR do?

Adds support for INV and TNS time-based thresholds if they used for metric collection
Small side effect on LocalAttribute - making `string` field private

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

