### PR TITLE
RUM-8705: Change UploadWorker visibility from internal to public

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -193,6 +193,10 @@ class com.datadog.android.core.SdkReference
   fun get(): com.datadog.android.api.SdkCore?
 fun <T> allowThreadDiskReads(() -> T): T
 fun <T> allowThreadDiskWrites(() -> T): T
+class com.datadog.android.core.UploadWorker : androidx.work.Worker
+  constructor(android.content.Context, androidx.work.WorkerParameters)
+  override fun doWork(): Result
+  companion object 
 enum com.datadog.android.core.configuration.BackPressureMitigation
   - DROP_OLDEST
   - IGNORE_NEWEST

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -548,6 +548,15 @@ public final class com/datadog/android/core/StrictModeExtKt {
 	public static final fun allowThreadDiskWrites (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
+public final class com/datadog/android/core/UploadWorker : androidx/work/Worker {
+	public static final field Companion Lcom/datadog/android/core/UploadWorker$Companion;
+	public fun <init> (Landroid/content/Context;Landroidx/work/WorkerParameters;)V
+	public fun doWork ()Landroidx/work/ListenableWorker$Result;
+}
+
+public final class com/datadog/android/core/UploadWorker$Companion {
+}
+
 public final class com/datadog/android/core/configuration/BackPressureMitigation : java/lang/Enum {
 	public static final field DROP_OLDEST Lcom/datadog/android/core/configuration/BackPressureMitigation;
 	public static final field IGNORE_NEWEST Lcom/datadog/android/core/configuration/BackPressureMitigation;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/UploadWorker.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/UploadWorker.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.core.internal.data.upload
+package com.datadog.android.core
 
 import android.content.Context
 import androidx.annotation.WorkerThread
@@ -14,16 +14,28 @@ import com.datadog.android.Datadog
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.storage.RawBatchEvent
-import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.NoOpInternalSdkCore
 import com.datadog.android.core.internal.SdkFeature
+import com.datadog.android.core.internal.data.upload.DataUploader
+import com.datadog.android.core.internal.data.upload.UploadStatus
 import com.datadog.android.core.internal.metrics.RemovalReason
 import com.datadog.android.core.internal.persistence.BatchId
 import com.datadog.android.core.internal.utils.unboundInternalLogger
 import java.util.LinkedList
 import java.util.Queue
 
-internal class UploadWorker(
+/**
+ * `UploadWorker` is responsible for handling background upload tasks using WorkManager. This
+ * worker is designed to process Datadog upload jobs asynchronously.
+ *
+ * ## Important:
+ * **This worker must be used only when a custom WorkFactory is implemented.**
+ *
+ * @constructor Creates an instance of `UploadWorker`.
+ * @param appContext The application context.
+ * @param workerParams Parameters required for the worker execution.
+ */
+class UploadWorker(
     appContext: Context,
     workerParams: WorkerParameters
 ) : Worker(appContext, workerParams) {
@@ -70,7 +82,7 @@ internal class UploadWorker(
 
     // region Internal
 
-    class UploadNextBatchTask(
+    internal class UploadNextBatchTask(
         private val taskQueue: Queue<UploadNextBatchTask>,
         private val sdkCore: InternalSdkCore,
         private val feature: SdkFeature
@@ -121,8 +133,8 @@ internal class UploadWorker(
 
     companion object {
 
-        const val MESSAGE_NOT_INITIALIZED = "Datadog has not been initialized."
+        internal const val MESSAGE_NOT_INITIALIZED = "Datadog has not been initialized."
 
-        const val DATADOG_INSTANCE_NAME = "_dd.sdk.instanceName"
+        internal const val DATADOG_INSTANCE_NAME = "_dd.sdk.instanceName"
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
@@ -14,7 +14,7 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.core.internal.data.upload.UploadWorker
+import com.datadog.android.core.UploadWorker
 import java.util.concurrent.TimeUnit
 
 internal const val CANCEL_ERROR_MESSAGE = "Error cancelling the UploadWorker"

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.Datadog
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.core.UploadWorker
 import com.datadog.android.core.internal.NoOpInternalSdkCore
 import com.datadog.android.core.internal.SdkFeature
 import com.datadog.android.core.internal.data.upload.UploadStatus.Companion.UNKNOWN_RESPONSE_CODE

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallbackTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallbackTest.kt
@@ -11,7 +11,7 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.impl.WorkManagerImpl
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.core.internal.data.upload.UploadWorker
+import com.datadog.android.core.UploadWorker
 import com.datadog.android.core.internal.utils.TAG_DATADOG_UPLOAD
 import com.datadog.android.core.internal.utils.UPLOAD_WORKER_NAME
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
@@ -11,8 +11,8 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.impl.WorkManagerImpl
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.UploadWorker
 import com.datadog.android.core.internal.CoreFeature
-import com.datadog.android.core.internal.data.upload.UploadWorker
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -15,13 +15,12 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.core.UploadWorker
 import com.datadog.android.core.feature.event.JvmCrash
 import com.datadog.android.core.internal.CoreFeature
-import com.datadog.android.core.internal.data.upload.UploadWorker
 import com.datadog.android.core.internal.thread.waitToIdle
 import com.datadog.android.core.internal.utils.TAG_DATADOG_UPLOAD
 import com.datadog.android.core.internal.utils.UPLOAD_WORKER_NAME
-import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.forge.Configurator


### PR DESCRIPTION
### What does this PR do?

* change UploadWorker from internal to public

* Add doc to warn client that it should only be used in custom workfactory case

### Motivation

Fixes #2508
RUM-8705

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

