### PR TITLE
RUM-8729 ensure span logs use 128 bits trace id as hex string

### DIFF
--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/handlers/AndroidSpanLogsHandler.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/handlers/AndroidSpanLogsHandler.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.log.LogAttributes
+import com.datadog.android.trace.internal.utils.traceIdAsHexString
 import com.datadog.legacy.trace.api.DDTags
 import com.datadog.opentracing.DDSpan
 import com.datadog.opentracing.LogHandler
@@ -68,8 +69,8 @@ internal class AndroidSpanLogsHandler(
         val logsFeature = sdkCore.getFeature(Feature.LOGS_FEATURE_NAME)
         if (logsFeature != null && fields.isNotEmpty()) {
             val message = fields.remove(Fields.MESSAGE)?.toString() ?: DEFAULT_EVENT_MESSAGE
-            fields[LogAttributes.DD_TRACE_ID] = span.traceId.toString()
-            fields[LogAttributes.DD_SPAN_ID] = span.spanId.toString()
+            fields[LogAttributes.DD_TRACE_ID] = span.context().traceIdAsHexString()
+            fields[LogAttributes.DD_SPAN_ID] = span.context().toSpanId()
             val timestamp = toMilliseconds(timestampMicroseconds) ?: System.currentTimeMillis()
             logsFeature.sendEvent(
                 mapOf(

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/handlers/AndroidSpanLogsHandlerTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/handlers/AndroidSpanLogsHandlerTest.kt
@@ -11,12 +11,14 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.core.internal.utils.toHexString
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.log.LogAttributes
 import com.datadog.android.trace.utils.verifyLog
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.legacy.trace.api.DDTags
 import com.datadog.opentracing.DDSpan
+import com.datadog.opentracing.DDSpanContext
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.LongForgery
@@ -62,7 +64,10 @@ internal class AndroidSpanLogsHandlerTest {
     @Mock
     lateinit var mockSpan: DDSpan
 
-    @LongForgery
+    @Mock
+    lateinit var mockSpanContext: DDSpanContext
+
+    @LongForgery(min = 1)
     var fakeTraceId: Long = 0L
 
     @LongForgery
@@ -70,8 +75,11 @@ internal class AndroidSpanLogsHandlerTest {
 
     @BeforeEach
     fun `set up`() {
+        whenever(mockSpan.context()) doReturn mockSpanContext
         whenever(mockSpan.traceId) doReturn BigInteger.valueOf(fakeTraceId)
         whenever(mockSpan.spanId) doReturn BigInteger.valueOf(fakeSpanId)
+        whenever(mockSpanContext.traceId) doReturn BigInteger.valueOf(fakeTraceId)
+        whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId.toString()
 
         whenever(
             mockSdkCore.getFeature(Feature.LOGS_FEATURE_NAME)
@@ -103,7 +111,7 @@ internal class AndroidSpanLogsHandlerTest {
                     "message" to AndroidSpanLogsHandler.DEFAULT_EVENT_MESSAGE,
                     "attributes" to mapOf(
                         Fields.EVENT to event,
-                        LogAttributes.DD_TRACE_ID to fakeTraceId.toString(),
+                        LogAttributes.DD_TRACE_ID to fakeTraceId.toHexString().padStart(32, '0'),
                         LogAttributes.DD_SPAN_ID to fakeSpanId.toString()
                     )
                 )
@@ -131,7 +139,7 @@ internal class AndroidSpanLogsHandlerTest {
                     "message" to AndroidSpanLogsHandler.DEFAULT_EVENT_MESSAGE,
                     "attributes" to mapOf(
                         Fields.EVENT to event,
-                        LogAttributes.DD_TRACE_ID to fakeTraceId.toString(),
+                        LogAttributes.DD_TRACE_ID to fakeTraceId.toHexString().padStart(32, '0'),
                         LogAttributes.DD_SPAN_ID to fakeSpanId.toString()
                     ),
                     "timestamp" to TimeUnit.MICROSECONDS.toMillis(timestampMicros)
@@ -147,7 +155,7 @@ internal class AndroidSpanLogsHandlerTest {
         val fields = forge.aMap { anAlphabeticalString() to anAsciiString() }
         val logAttributes = fields.toMutableMap()
             .apply {
-                put(LogAttributes.DD_TRACE_ID, fakeTraceId.toString())
+                put(LogAttributes.DD_TRACE_ID, fakeTraceId.toHexString().padStart(32, '0'))
                 put(LogAttributes.DD_SPAN_ID, fakeSpanId.toString())
             }
 
@@ -184,7 +192,7 @@ internal class AndroidSpanLogsHandlerTest {
         val fields = forge.aMap { anAlphabeticalString() to anAsciiString() }
         val logAttributes = fields.toMutableMap()
             .apply {
-                put(LogAttributes.DD_TRACE_ID, fakeTraceId.toString())
+                put(LogAttributes.DD_TRACE_ID, fakeTraceId.toHexString().padStart(32, '0'))
                 put(LogAttributes.DD_SPAN_ID, fakeSpanId.toString())
             }
 
@@ -216,7 +224,7 @@ internal class AndroidSpanLogsHandlerTest {
 
         val logAttributes = fields.toMutableMap()
             .apply {
-                put(LogAttributes.DD_TRACE_ID, fakeTraceId.toString())
+                put(LogAttributes.DD_TRACE_ID, fakeTraceId.toHexString().padStart(32, '0'))
                 put(LogAttributes.DD_SPAN_ID, fakeSpanId.toString())
             }
 
@@ -262,7 +270,7 @@ internal class AndroidSpanLogsHandlerTest {
 
         val logAttributes = fields.toMutableMap()
             .apply {
-                put(LogAttributes.DD_TRACE_ID, fakeTraceId.toString())
+                put(LogAttributes.DD_TRACE_ID, fakeTraceId.toHexString().padStart(32, '0'))
                 put(LogAttributes.DD_SPAN_ID, fakeSpanId.toString())
             }
 
@@ -304,7 +312,7 @@ internal class AndroidSpanLogsHandlerTest {
 
         val logAttributes = fields.toMutableMap()
             .apply {
-                put(LogAttributes.DD_TRACE_ID, fakeTraceId.toString())
+                put(LogAttributes.DD_TRACE_ID, fakeTraceId.toHexString().padStart(32, '0'))
                 put(LogAttributes.DD_SPAN_ID, fakeSpanId.toString())
             }
 
@@ -353,7 +361,7 @@ internal class AndroidSpanLogsHandlerTest {
 
         val logAttributes = fields.toMutableMap()
             .apply {
-                put(LogAttributes.DD_TRACE_ID, fakeTraceId.toString())
+                put(LogAttributes.DD_TRACE_ID, fakeTraceId.toHexString().padStart(32, '0'))
                 put(LogAttributes.DD_SPAN_ID, fakeSpanId.toString())
             }
 
@@ -404,7 +412,7 @@ internal class AndroidSpanLogsHandlerTest {
 
         val logAttributes = fields.toMutableMap()
             .apply {
-                put(LogAttributes.DD_TRACE_ID, fakeTraceId.toString())
+                put(LogAttributes.DD_TRACE_ID, fakeTraceId.toHexString().padStart(32, '0'))
                 put(LogAttributes.DD_SPAN_ID, fakeSpanId.toString())
             }
 

--- a/reliability/single-fit/trace/src/test/kotlin/com/datadog/android/trace/integration/opentracing/UtilitiesTest.kt
+++ b/reliability/single-fit/trace/src/test/kotlin/com/datadog/android/trace/integration/opentracing/UtilitiesTest.kt
@@ -131,7 +131,7 @@ class UtilitiesTest {
             val span = testedTracer.buildSpan(fakeOperation).start()
             leastSignificantTraceId = span.leastSignificant64BitsTraceId()
             mostSignificantTraceId = span.mostSignificant64BitsTraceId()
-            traceId = (span as? DDSpan)?.traceId?.toString() ?: ""
+            traceId = (span as? DDSpan)?.traceId?.toString(16) ?: ""
             spanId = span.spanIdAsLong()
             Thread.sleep(OP_DURATION_MS)
             span.setError(fakeErrorMessage)
@@ -232,7 +232,7 @@ class UtilitiesTest {
             val span = testedTracer.buildSpan(fakeOperation).start()
             leastSignificantTraceId = span.leastSignificant64BitsTraceId()
             mostSignificantTraceId = span.mostSignificant64BitsTraceId()
-            traceId = (span as? DDSpan)?.traceId?.toString() ?: ""
+            traceId = (span as? DDSpan)?.traceId?.toString(16) ?: ""
             spanId = span.spanIdAsLong()
             Thread.sleep(OP_DURATION_MS)
             AndroidTracer.Companion.logErrorMessage(span, fakeErrorMessage)

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/TracesViewModel.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/TracesViewModel.kt
@@ -368,14 +368,20 @@ internal class TracesViewModel(
             withinSpan("AsyncOperation", activeSpanInMainThread) {
                 logger.v("Starting Async Operation...")
 
-                for (i in 0..100) {
+                val count = (Random().nextInt() % 50) + 50
+                log("Async op loops $count times")
+                var actualCount = 0
+
+                for (i in 0 until count) {
                     if (isCancelled) {
+                        log("Async operation cancelled")
                         break
                     }
                     onProgress(i)
                     Thread.sleep(((i * i).toDouble() / 100.0).toLong())
+                    actualCount++
                 }
-
+                log(mapOf("wanted_count" to count, "actual_count" to actualCount))
                 logger.v("Finishing Async Operation...")
             }
         }


### PR DESCRIPTION
### What does this PR do?

Ensures that the logs created from a `DDSpan.log()` behave the same way as the ones created from our `Logger` with `bundleWithTrace=true`.