### PR TITLE
RUM-8038: Improvements to the upload mechanism

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/BatchProcessingLevel.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/BatchProcessingLevel.kt
@@ -23,9 +23,9 @@ enum class BatchProcessingLevel(val maxBatchesPerUploadJob: Int) {
     LOW(maxBatchesPerUploadJob = 1),
 
     /**
-     * 10 batches will be sent in a single upload cycle.
+     * 20 batches will be sent in a single upload cycle.
      */
-    MEDIUM(maxBatchesPerUploadJob = 10),
+    MEDIUM(maxBatchesPerUploadJob = 20),
 
     /**
      * 100 batches will be sent in a single upload cycle.

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DefaultUploadSchedulerStrategy.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DefaultUploadSchedulerStrategy.kt
@@ -12,7 +12,6 @@ import com.datadog.android.core.internal.data.upload.DataOkHttpUploader.Companio
 import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
-import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToLong
 
@@ -32,7 +31,7 @@ internal class DefaultUploadSchedulerStrategy(
     ): Long {
         val previousDelay = currentDelays.getOrPut(featureName) { uploadConfiguration.defaultDelayMs }
         val updatedDelay = if (uploadAttempts > 0 && throwable == null && lastStatusCode == HTTP_ACCEPTED) {
-            decreaseInterval(previousDelay)
+            uploadConfiguration.minDelayMs
         } else {
             increaseInterval(previousDelay, throwable)
         }
@@ -43,12 +42,6 @@ internal class DefaultUploadSchedulerStrategy(
     // endregion
 
     // region Internal
-
-    private fun decreaseInterval(previousDelay: Long): Long {
-        @Suppress("UnsafeThirdPartyFunctionCall") // not a NaN
-        val newDelayMs = (previousDelay * DECREASE_PERCENT).roundToLong()
-        return max(uploadConfiguration.minDelayMs, newDelayMs)
-    }
 
     private fun increaseInterval(previousDelay: Long, throwable: Throwable?): Long {
         @Suppress("UnsafeThirdPartyFunctionCall") // not a NaN
@@ -67,7 +60,6 @@ internal class DefaultUploadSchedulerStrategy(
     // endregion
 
     companion object {
-        internal const val DECREASE_PERCENT = 0.90
         internal const val INCREASE_PERCENT = 1.10
         internal val NETWORK_ERROR_DELAY_MS = TimeUnit.MINUTES.toMillis(1) // 1 minute delay
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DefaultUploadSchedulerStrategyTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DefaultUploadSchedulerStrategyTest.kt
@@ -26,7 +26,7 @@ import java.io.IOException
 @ForgeConfiguration(Configurator::class)
 internal class DefaultUploadSchedulerStrategyTest {
 
-    lateinit var testedStrategy: UploadSchedulerStrategy
+    private lateinit var testedStrategy: UploadSchedulerStrategy
 
     @Forgery
     lateinit var fakeConfiguration: DataUploadConfiguration
@@ -34,7 +34,7 @@ internal class DefaultUploadSchedulerStrategyTest {
     @StringForgery
     lateinit var fakeFeatureName: String
 
-    var initialDelay = 0L
+    private var initialDelay = 0L
 
     @BeforeEach
     fun `set up`() {
@@ -43,7 +43,7 @@ internal class DefaultUploadSchedulerStrategyTest {
     }
 
     @Test
-    fun `M decrease delay W getMsDelayUntilNextUpload() {successful attempt}`(
+    fun `M decrease delay to minimum W getMsDelayUntilNextUpload() {successful attempt}`(
         @IntForgery(1, 128) repeats: Int,
         @IntForgery(1, 64) attempts: Int
     ) {
@@ -54,8 +54,7 @@ internal class DefaultUploadSchedulerStrategyTest {
         repeat(repeats) { delay = testedStrategy.getMsDelayUntilNextUpload(fakeFeatureName, attempts, 202, null) }
 
         // Then
-        assertThat(delay).isLessThan(initialDelay)
-        assertThat(delay).isGreaterThanOrEqualTo(fakeConfiguration.minDelayMs)
+        assertThat(delay).isEqualTo(fakeConfiguration.minDelayMs)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
Part of the effort to reduce batch loss.

The improvements implemented here:
• Doubling the average batch upload frequency, so that instead of an average 10 uploads (10 batches) per upload trigger, it will now be 20.
• Reducing the backoff to the minimum when an upload has succeeded, instead of the previous behavior where we gradually reduced by 10% until we reached the minimum.

### Motivation
Faster recovery from offline periods.

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

