### PR TITLE
[RUM-8652] Allow definition of custom implementations of specific SR methods

### DIFF
--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -36,6 +36,8 @@ data class com.datadog.android.sessionreplay.SessionReplayConfiguration
     fun setDynamicOptimizationEnabled(Boolean): Builder
     fun setSystemRequirements(SystemRequirementsConfiguration): Builder
     fun build(): SessionReplayConfiguration
+interface com.datadog.android.sessionreplay.SessionReplayInternalCallback
+  fun getCurrentActivity(): android.app.Activity?
 enum com.datadog.android.sessionreplay.SessionReplayPrivacy
   - ALLOW
   - MASK
@@ -55,6 +57,9 @@ enum com.datadog.android.sessionreplay.TextAndInputPrivacy : PrivacyLevel
 enum com.datadog.android.sessionreplay.TouchPrivacy : PrivacyLevel
   - SHOW
   - HIDE
+class com.datadog.android.sessionreplay._SessionReplayInternalProxy
+  constructor(SessionReplayConfiguration.Builder)
+  fun setInternalCallback(SessionReplayInternalCallback): SessionReplayConfiguration.Builder
 class com.datadog.android.sessionreplay.internal.TouchPrivacyManager
   constructor(com.datadog.android.sessionreplay.TouchPrivacy)
   fun addTouchOverrideArea(android.graphics.Rect, com.datadog.android.sessionreplay.TouchPrivacy)

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -46,8 +46,8 @@ public final class com/datadog/android/sessionreplay/SessionReplay {
 }
 
 public final class com/datadog/android/sessionreplay/SessionReplayConfiguration {
-	public final fun copy (Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ZLcom/datadog/android/sessionreplay/TouchPrivacy;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;ZLcom/datadog/android/sessionreplay/SystemRequirementsConfiguration;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
-	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ZLcom/datadog/android/sessionreplay/TouchPrivacy;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;ZLcom/datadog/android/sessionreplay/SystemRequirementsConfiguration;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ZLcom/datadog/android/sessionreplay/TouchPrivacy;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;ZLcom/datadog/android/sessionreplay/SystemRequirementsConfiguration;Lcom/datadog/android/sessionreplay/SessionReplayInternalCallback;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ZLcom/datadog/android/sessionreplay/TouchPrivacy;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;ZLcom/datadog/android/sessionreplay/SystemRequirementsConfiguration;Lcom/datadog/android/sessionreplay/SessionReplayInternalCallback;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -67,6 +67,10 @@ public final class com/datadog/android/sessionreplay/SessionReplayConfiguration$
 	public final fun setTouchPrivacy (Lcom/datadog/android/sessionreplay/TouchPrivacy;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 	public final fun startRecordingImmediately (Z)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 	public final fun useCustomEndpoint (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
+}
+
+public abstract interface class com/datadog/android/sessionreplay/SessionReplayInternalCallback {
+	public abstract fun getCurrentActivity ()Landroid/app/Activity;
 }
 
 public final class com/datadog/android/sessionreplay/SessionReplayPrivacy : java/lang/Enum {
@@ -106,6 +110,11 @@ public final class com/datadog/android/sessionreplay/TouchPrivacy : java/lang/En
 	public static final field SHOW Lcom/datadog/android/sessionreplay/TouchPrivacy;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/TouchPrivacy;
 	public static fun values ()[Lcom/datadog/android/sessionreplay/TouchPrivacy;
+}
+
+public final class com/datadog/android/sessionreplay/_SessionReplayInternalProxy {
+	public fun <init> (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;)V
+	public final fun setInternalCallback (Lcom/datadog/android/sessionreplay/SessionReplayInternalCallback;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 }
 
 public final class com/datadog/android/sessionreplay/internal/TouchPrivacyManager {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
@@ -59,7 +59,8 @@ object SessionReplay {
                     customDrawableMappers = sessionReplayConfiguration.customDrawableMappers,
                     sampleRate = sessionReplayConfiguration.sampleRate,
                     startRecordingImmediately = sessionReplayConfiguration.startRecordingImmediately,
-                    dynamicOptimizationEnabled = sessionReplayConfiguration.dynamicOptimizationEnabled
+                    dynamicOptimizationEnabled = sessionReplayConfiguration.dynamicOptimizationEnabled,
+                    internalCallback = sessionReplayConfiguration.internalCallback
                 )
 
                 if (isAlreadyRegistered()) {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay
 
 import androidx.annotation.FloatRange
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.internal.recorder.SessionReplayRecorder
 import com.datadog.android.sessionreplay.recorder.OptionSelectorDetector
 import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
 import java.util.Locale
@@ -27,7 +28,8 @@ data class SessionReplayConfiguration internal constructor(
     internal val touchPrivacy: TouchPrivacy,
     internal val textAndInputPrivacy: TextAndInputPrivacy,
     internal val dynamicOptimizationEnabled: Boolean,
-    internal val systemRequirementsConfiguration: SystemRequirementsConfiguration
+    internal val systemRequirementsConfiguration: SystemRequirementsConfiguration,
+    internal val internalCallback: SessionReplayInternalCallback
 ) {
 
     /**
@@ -73,6 +75,7 @@ data class SessionReplayConfiguration internal constructor(
         private var extensionSupportSet: MutableSet<ExtensionSupport> = mutableSetOf()
         private var dynamicOptimizationEnabled = true
         private var systemRequirementsConfiguration = SystemRequirementsConfiguration.NONE
+        private var internalCallback: SessionReplayInternalCallback = NoOpSessionReplayInternalCallback()
 
         /**
          * Adds an extension support implementation. This is mostly used when you want to provide
@@ -211,6 +214,19 @@ data class SessionReplayConfiguration internal constructor(
         }
 
         /**
+         * Allows definition of custom callback functions for Session Replay
+         * that may require platform-specific behavior.
+         * Currently, this enables defining:
+         * - [SessionReplayInternalCallback.getCurrentActivity]:
+         *   Used in [SessionReplayRecorder] to register fragment lifecycle callbacks
+         *   for clients initialized after the `Application.onCreate` phase.
+         */
+        internal fun setInternalCallback(internalCallback: SessionReplayInternalCallback): Builder {
+            this.internalCallback = internalCallback
+            return this
+        }
+
+        /**
          * Builds a [SessionReplayConfiguration] based on the current state of this Builder.
          */
         fun build(): SessionReplayConfiguration {
@@ -226,7 +242,8 @@ data class SessionReplayConfiguration internal constructor(
                 sampleRate = sampleRate,
                 startRecordingImmediately = startRecordingImmediately,
                 dynamicOptimizationEnabled = dynamicOptimizationEnabled,
-                systemRequirementsConfiguration = systemRequirementsConfiguration
+                systemRequirementsConfiguration = systemRequirementsConfiguration,
+                internalCallback = internalCallback
             )
         }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayInternalCallback.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayInternalCallback.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay
+
+import android.app.Activity
+import com.datadog.android.sessionreplay.internal.recorder.SessionReplayRecorder
+import com.datadog.tools.annotation.NoOpImplementation
+
+/**
+ * Defines points of change for clients to override existing functionality with platform specific code.
+ */
+@NoOpImplementation
+interface SessionReplayInternalCallback {
+    /**
+     * Retrieves the current activity, allowing clients to pass it when needed.
+     * This is used by [SessionReplayRecorder] to register fragment lifecycle callbacks
+     * that were missed because the client was initialized after the `Application.onCreate` phase.
+     */
+    fun getCurrentActivity(): Activity?
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/_SessionReplayInternalProxy.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/_SessionReplayInternalProxy.kt
@@ -1,0 +1,38 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay
+
+import com.datadog.android.lint.InternalApi
+
+/**
+ * This class exposes internal methods that are used by other Datadog modules and cross platform
+ * frameworks. It is not meant for public use.
+ *
+ * DO NOT USE this class or its methods if you are not working on the internals of the Datadog SDK
+ * or one of the cross platform frameworks.
+ *
+ * Methods, members, and functionality of this class  are subject to change without notice, as they
+ * are not considered part of the public interface of the Datadog SDK.
+ */
+@InternalApi
+@Suppress(
+    "ClassName",
+    "ClassNaming"
+)
+class _SessionReplayInternalProxy(private val builder: SessionReplayConfiguration.Builder) {
+    /**
+     * Sets an internal callback for session replay.
+     *
+     * @param internalCallback callback instance to override specific parts of the codebase.
+     * @return [SessionReplayConfiguration.Builder] instance.
+     */
+    fun setInternalCallback(
+        internalCallback: SessionReplayInternalCallback
+    ): SessionReplayConfiguration.Builder {
+        return builder.setInternalCallback(internalCallback)
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/DefaultRecorderProvider.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/DefaultRecorderProvider.kt
@@ -25,6 +25,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.internal.utils.ImageViewUtils
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.MapperTypeWrapper
+import com.datadog.android.sessionreplay.SessionReplayInternalCallback
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.internal.recorder.Recorder
 import com.datadog.android.sessionreplay.internal.recorder.SessionReplayRecorder
@@ -64,7 +65,8 @@ internal class DefaultRecorderProvider(
     private val customMappers: List<MapperTypeWrapper<*>>,
     private val customOptionSelectorDetectors: List<OptionSelectorDetector>,
     private val customDrawableMappers: List<DrawableToColorMapper>,
-    private val dynamicOptimizationEnabled: Boolean
+    private val dynamicOptimizationEnabled: Boolean,
+    private val internalCallback: SessionReplayInternalCallback
 ) : RecorderProvider {
 
     override fun provideSessionReplayRecorder(
@@ -87,7 +89,8 @@ internal class DefaultRecorderProvider(
             customOptionSelectorDetectors = customOptionSelectorDetectors,
             customDrawableMappers = customDrawableMappers,
             sdkCore = sdkCore,
-            dynamicOptimizationEnabled = dynamicOptimizationEnabled
+            dynamicOptimizationEnabled = dynamicOptimizationEnabled,
+            internalCallback = internalCallback
         )
     }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -20,6 +20,7 @@ import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.MapperTypeWrapper
+import com.datadog.android.sessionreplay.SessionReplayInternalCallback
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.TouchPrivacy
@@ -71,7 +72,8 @@ internal class SessionReplayFeature(
         customDrawableMappers: List<DrawableToColorMapper>,
         sampleRate: Float,
         startRecordingImmediately: Boolean,
-        dynamicOptimizationEnabled: Boolean
+        dynamicOptimizationEnabled: Boolean,
+        internalCallback: SessionReplayInternalCallback
     ) : this(
         sdkCore,
         customEndpointUrl,
@@ -89,7 +91,8 @@ internal class SessionReplayFeature(
             customMappers,
             customOptionSelectorDetectors,
             customDrawableMappers,
-            dynamicOptimizationEnabled
+            dynamicOptimizationEnabled,
+            internalCallback
         )
     )
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayLifecycleCallback.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayLifecycleCallback.kt
@@ -21,6 +21,24 @@ internal class SessionReplayLifecycleCallback(
 
     private val currentActiveWindows = WeakHashMap<Window, Any?>()
 
+    fun setCurrentWindow(activity: Activity) {
+        activity.window?.let {
+            currentActiveWindows[it] = null
+        }
+    }
+
+    fun registerFragmentLifecycleCallbacks(activity: Activity) {
+        if (activity is FragmentActivity) {
+            // we need to register before the activity resumes to catch all the fragments
+            // added even before the activity resumes
+            val lifecycleCallback = RecorderFragmentLifecycleCallback(this)
+            activity.supportFragmentManager.registerFragmentLifecycleCallbacks(
+                lifecycleCallback,
+                true
+            )
+        }
+    }
+
     override fun onWindowsAdded(windows: List<Window>) {
         windows.forEach {
             currentActiveWindows[it] = null
@@ -41,15 +59,7 @@ internal class SessionReplayLifecycleCallback(
 
     @MainThread
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-        if (activity is FragmentActivity) {
-            // we need to register before the activity resumes to catch all the fragments
-            // added even before the activity resumes
-            val lifecycleCallback = RecorderFragmentLifecycleCallback(this)
-            activity.supportFragmentManager.registerFragmentLifecycleCallbacks(
-                lifecycleCallback,
-                true
-            )
-        }
+        registerFragmentLifecycleCallbacks(activity)
     }
 
     @MainThread

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayInternalProxyTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayInternalProxyTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay
+
+import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import fr.xgouchet.elmyr.annotation.FloatForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@ForgeConfiguration(value = ForgeConfigurator::class)
+internal class SessionReplayInternalProxyTest {
+
+    private lateinit var testedBuilder: SessionReplayConfiguration.Builder
+
+    private lateinit var testedProxy: _SessionReplayInternalProxy
+
+    @Mock
+    lateinit var mockInternalCallback: SessionReplayInternalCallback
+
+    @FloatForgery
+    var fakeSampleRate: Float = 0f
+
+    @Test
+    fun `M return the same builder W setInternalCallback`() {
+        // Given
+        testedBuilder = SessionReplayConfiguration.Builder(fakeSampleRate)
+        testedProxy = _SessionReplayInternalProxy(testedBuilder)
+
+        // When
+        val result = testedProxy.setInternalCallback(mockInternalCallback)
+        val sessionReplayConfiguration = result.build()
+
+        // Then
+        assertThat(result).isEqualTo(testedBuilder)
+        assertThat(sessionReplayConfiguration.internalCallback).isEqualTo(mockInternalCallback)
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorderTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorderTest.kt
@@ -125,7 +125,8 @@ internal class SessionReplayRecorderTest {
             recordedDataQueueHandler = mockRecordedDataQueueHandler,
             uiHandler = mockUiHandler,
             internalLogger = mockInternalLogger,
-            resourceDataStoreManager = mockDataStoreManager
+            resourceDataStoreManager = mockDataStoreManager,
+            internalCallback = NoOpSessionReplayInternalCallback()
         )
     }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SessionReplayConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SessionReplayConfigurationForgeryFactory.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.forge
 
 import com.datadog.android.sessionreplay.ImagePrivacy
+import com.datadog.android.sessionreplay.NoOpSessionReplayInternalCallback
 import com.datadog.android.sessionreplay.SessionReplayConfiguration
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.SystemRequirementsConfiguration
@@ -30,6 +31,7 @@ class SessionReplayConfigurationForgeryFactory : ForgeryFactory<SessionReplayCon
             startRecordingImmediately = forge.aBool(),
             sampleRate = forge.aFloat(min = 0f, max = 100f),
             dynamicOptimizationEnabled = forge.aBool(),
+            internalCallback = NoOpSessionReplayInternalCallback(),
             systemRequirementsConfiguration = SystemRequirementsConfiguration.Builder()
                 .setMinRAMSizeMb(forge.aSmallInt())
                 .setMinCPUCoreNumber(forge.aSmallInt())

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -10,6 +10,7 @@ import android.app.Application
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.sessionreplay.NoOpSessionReplayInternalCallback
 import com.datadog.android.sessionreplay.SessionReplayConfiguration
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.net.SegmentRequestFactory
@@ -142,7 +143,8 @@ internal class SessionReplayFeatureTest {
             customDrawableMappers = emptyList(),
             startRecordingImmediately = true,
             sampleRate = fakeConfiguration.sampleRate,
-            dynamicOptimizationEnabled = fakeConfiguration.dynamicOptimizationEnabled
+            dynamicOptimizationEnabled = fakeConfiguration.dynamicOptimizationEnabled,
+            internalCallback = NoOpSessionReplayInternalCallback()
         )
 
         // When
@@ -169,7 +171,8 @@ internal class SessionReplayFeatureTest {
             customDrawableMappers = emptyList(),
             sampleRate = fakeConfiguration.sampleRate,
             startRecordingImmediately = true,
-            dynamicOptimizationEnabled = fakeConfiguration.dynamicOptimizationEnabled
+            dynamicOptimizationEnabled = fakeConfiguration.dynamicOptimizationEnabled,
+            internalCallback = NoOpSessionReplayInternalCallback()
         )
 
         // When


### PR DESCRIPTION
### What does this PR do?

- Exposes a new SessionReplayConfigutation option to allow clients to pass their own implementations of specific methods used in the Session Replay SDK. 

- Updates the SDK code to use the overriden function if provided and falling back to the original implementation otherwise. 
( Currently only `getCurrentActivity` is allowed to be redefined, but there's a high likelihood that more will be needed ) 

### Motivation

What inspired you to submit this pull request?

Certain parts of the session replay SDK don't  work as intended when ran in a react-native environment, leading to broken replays. In order to keep platform specific code out of the android SDK, the goal is to allow each client to add their own implementations of the parts that don't work.

### Additional Notes

We keep the `setInternalCallback` only accessible through a internal proxy in order to not expose internal config options. In practice it would look something like this:
```
        val internalCallback = ReactNativeSessionReplayInternalCallback(reactContext)
        
        val configuration = SessionReplayConfiguration.Builder(replaySampleRate.toFloat())
            /* .... */
            .setImagePrivacy(/* .... */)
            .setTouchPrivacy(/* .... */)
            .setTextAndInputPrivacy(/* .... */)
            .let { builder ->
                _SessionReplayInternalProxy(builder).setInternalCallback(internalCallback)
            }
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

