### PR TITLE
Avoid logging initial null viewLoadingTime on first call to addViewLoadingTime

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -275,7 +275,7 @@ internal open class RumViewScope(
             internalLogger.log(
                 InternalLogger.Level.DEBUG,
                 InternalLogger.Target.USER,
-                { ADDING_VIEW_LOADING_TIME_DEBUG_MESSAGE_FORMAT.format(Locale.US, viewLoadingTime, viewName) }
+                { ADDING_VIEW_LOADING_TIME_DEBUG_MESSAGE_FORMAT.format(Locale.US, newLoadingTime, viewName) }
             )
             internalLogger.logApiUsage {
                 InternalTelemetryEvent.ApiUsage.AddViewLoadingTime(


### PR DESCRIPTION
### What does this PR do?

This PR aims to fix and match the behaviour of the first call made to `addViewLoadingTime`, so it properly logs the newLoadingTime that it has just calculated and that it will use to set viewLoadingTime to just a few lines after this log is registered.

The change is as simple as changing the log call to use `newLoadingTime` instead of `viewLoadingTime`.

### Motivation

This change is done so both Android and iOS SDKs behave in the same way, and also so the SDK avoids logging the initial null value of `viewLoadingTime`, which may confuse users into thinking that there's something wrong by logging a message like:

`[_dd.sdk_core.default]: View loading time nullns added to the view Main`

instead of:

`[_dd.sdk_core.default]: View loading time 525.0829529762268ns added to the view Main`

### Additional Notes

Found this while testing the implementation of https://datadoghq.atlassian.net/browse/RUM-6479

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

