### PR TITLE
Catch Coroutines errors while getting all threads stacktraces

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
@@ -146,12 +146,13 @@ internal class DatadogExceptionHandler(
     private fun safeGetAllStacktraces(): Map<Thread, Array<StackTraceElement>> {
         return try {
             Thread.getAllStackTraces()
-        } catch (e: SecurityException) {
+        } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+            // coroutines machinery can throw errors here
             sdkCore.internalLogger.log(
                 InternalLogger.Level.ERROR,
                 InternalLogger.Target.MAINTAINER,
                 { "Failed to get all threads dump" },
-                e
+                t
             )
             emptyMap()
         }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnable.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnable.kt
@@ -99,12 +99,13 @@ internal class ANRDetectorRunnable(
     private fun safeGetAllStacktraces(): Map<Thread, Array<StackTraceElement>> {
         return try {
             Thread.getAllStackTraces()
-        } catch (e: SecurityException) {
+        } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+            // coroutines machinery can throw errors here
             sdkCore.internalLogger.log(
                 InternalLogger.Level.ERROR,
                 InternalLogger.Target.MAINTAINER,
                 { "Failed to get all stack traces." },
-                e
+                t
             )
             emptyMap()
         }


### PR DESCRIPTION
### What does this PR do?

It seems the Kotlin Coroutines machinery can throw `Error` sometimes while getting all threads stacktraces. In this PR we will catch them, so that we don't interrupt the flow.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

