### PR TITLE
[RUM-8875] Add ability to manually add an activity to JankStats

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -160,6 +160,7 @@ class com.datadog.android.rum._RumInternalProxy
   fun updatePerformanceMetric(RumPerformanceMetric, Double)
   fun setInternalViewAttribute(String, Any?)
   fun setSyntheticsAttribute(String?, String?)
+  fun enableJankStatsTracking(android.app.Activity)
   companion object 
     fun setTelemetryConfigurationEventMapper(RumConfiguration.Builder, com.datadog.android.event.EventMapper<com.datadog.android.telemetry.model.TelemetryConfigurationEvent>): RumConfiguration.Builder
     fun setAdditionalConfiguration(RumConfiguration.Builder, Map<String, Any>): RumConfiguration.Builder

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -235,6 +235,7 @@ public final class com/datadog/android/rum/_RumInternalProxy {
 	public static final field Companion Lcom/datadog/android/rum/_RumInternalProxy$Companion;
 	public final fun addLongTask (JLjava/lang/String;)V
 	public final fun setInternalViewAttribute (Ljava/lang/String;Ljava/lang/Object;)V
+	public final fun enableJankStatsTracking (Landroid/app/Activity;)V
 	public final fun setSyntheticsAttribute (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun updatePerformanceMetric (Lcom/datadog/android/rum/RumPerformanceMetric;D)V
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum
 
+import android.app.Activity
 import android.content.Intent
 import com.datadog.android.event.EventMapper
 import com.datadog.android.lint.InternalApi
@@ -58,6 +59,15 @@ class _RumInternalProxy internal constructor(private val rumMonitor: AdvancedRum
         }
 
         rumMonitor.setSyntheticsAttribute(testId, resultId)
+    }
+
+    /**
+     * Enables the tracking of JankStats for the given activity. This should only be necessary for the
+     * initial activity of an application if Datadog is initialized after that activity is created.
+     * @param activity the activity to track
+     */
+    fun enableJankStatsTracking(activity: Activity) {
+        rumMonitor.enableJankStatsTracking(activity)
     }
 
     internal fun setSyntheticsAttributeFromIntent(intent: Intent) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal
 
+import android.app.Activity
 import android.app.ActivityManager
 import android.app.Application
 import android.app.ApplicationExitInfo
@@ -379,6 +380,24 @@ internal class RumFeature(
         }
     }
 
+    /**
+     * Enables the tracking of JankStats for the given activity. This should only be necessary for the
+     * initial activity of an application if Datadog is initialized after that activity is created.
+     * @param activity the activity to track
+     */
+    internal fun enableJankStatsTracking(activity: Activity) {
+        try {
+            jankStatsActivityLifecycleListener?.onActivityStarted(activity)
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            sdkCore.internalLogger.log(
+                InternalLogger.Level.ERROR,
+                InternalLogger.Target.TELEMETRY,
+                { FAILED_TO_ENABLE_JANK_STATS_TRACKING_MANUALLY },
+                e
+            )
+        }
+    }
+
     private fun registerTrackingStrategies(appContext: Context) {
         actionTrackingStrategy.register(sdkCore, appContext)
         viewTrackingStrategy.register(sdkCore, appContext)
@@ -619,6 +638,8 @@ internal class RumFeature(
         internal const val RUM_FEATURE_NOT_YET_INITIALIZED =
             "RUM feature is not initialized yet, you need to register it with a" +
                 " SDK instance by calling SdkCore#registerFeature method."
+        internal const val FAILED_TO_ENABLE_JANK_STATS_TRACKING_MANUALLY =
+            "Manually enabling JankStats tracking threw an exception."
 
         private fun provideUserTrackingStrategy(
             touchTargetExtraAttributesProviders: Array<ViewAttributesProvider>,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -387,6 +387,7 @@ internal class RumFeature(
      */
     internal fun enableJankStatsTracking(activity: Activity) {
         try {
+            @Suppress("UnsafeThirdPartyFunctionCall")
             jankStatsActivityLifecycleListener?.onActivityStarted(activity)
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             sdkCore.internalLogger.log(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.monitor
 
+import android.app.Activity
 import com.datadog.android.core.feature.event.ThreadDump
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.rum.RumErrorSource
@@ -51,4 +52,6 @@ internal interface AdvancedRumMonitor : RumMonitor, AdvancedNetworkRumMonitor {
     fun setInternalViewAttribute(key: String, value: Any?)
 
     fun setSyntheticsAttribute(testId: String, resultId: String)
+
+    fun enableJankStatsTracking(activity: Activity)
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -646,13 +646,9 @@ internal class DatadogRumMonitor(
     }
 
     override fun enableJankStatsTracking(activity: Activity) {
-        val rumFeatureScope = sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
+        sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
             ?.unwrap<RumFeature>()
-        if (rumFeatureScope == null) {
-            return
-        }
-
-        rumFeatureScope.enableJankStatsTracking(activity)
+            ?.enableJankStatsTracking(activity)
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.monitor
 
+import android.app.Activity
 import android.app.ActivityManager
 import android.os.Handler
 import com.datadog.android.api.InternalLogger
@@ -642,6 +643,16 @@ internal class DatadogRumMonitor(
 
     override fun sendTelemetryEvent(telemetryEvent: InternalTelemetryEvent) {
         handleEvent(RumRawEvent.TelemetryEventWrapper(telemetryEvent))
+    }
+
+    override fun enableJankStatsTracking(activity: Activity) {
+        val rumFeatureScope = sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
+            ?.unwrap<RumFeature>()
+        if (rumFeatureScope == null) {
+            return
+        }
+
+        rumFeatureScope.enableJankStatsTracking(activity)
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/JankStatsActivityLifecycleListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/JankStatsActivityLifecycleListener.kt
@@ -165,6 +165,9 @@ internal class JankStatsActivityLifecycleListener(
 
     private fun trackActivity(window: Window, activity: Activity) {
         val list = activeActivities[window] ?: mutableListOf()
+        if (list.find { it.get() == activity } != null) {
+            return
+        }
         list.add(WeakReference(activity))
         activeActivities[window] = list
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumInternalProxyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumInternalProxyTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum
 
+import android.app.Activity
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
@@ -61,5 +62,19 @@ internal class RumInternalProxyTest {
 
         // Then
         verify(mockRumMonitor).updatePerformanceMetric(metric, value)
+    }
+
+    @Test
+    fun `M proxy enableJankStatsTracking to RumMonitor W enableJankStatsTracking()`() {
+        // Given
+        val mockRumMonitor = mock(AdvancedRumMonitor::class.java)
+        val proxy = _RumInternalProxy(mockRumMonitor)
+        val activity: Activity = mock()
+
+        // When
+        proxy.enableJankStatsTracking(activity)
+
+        // Then
+        verify(mockRumMonitor).enableJankStatsTracking(activity)
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -545,13 +545,14 @@ internal class RumFeatureTest {
             fakeConfiguration,
             lateCrashReporterFactory = { mockLateCrashReporter }
         )
-        testedFeature.jankStatsActivityLifecycleListener = mock()
+        val mockJankStatsActivityLifecycleListener = mock<JankStatsActivityLifecycleListener>()
+        testedFeature.jankStatsActivityLifecycleListener = mockJankStatsActivityLifecycleListener
 
         // When
         testedFeature.enableJankStatsTracking(activity)
 
         // Then
-        verify(testedFeature.jankStatsActivityLifecycleListener)!!.onActivityStarted(activity)
+        verify(mockJankStatsActivityLifecycleListener).onActivityStarted(activity)
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal
 
+import android.app.Activity
 import android.app.ActivityManager
 import android.app.Application
 import android.app.ApplicationExitInfo
@@ -532,6 +533,25 @@ internal class RumFeatureTest {
             .isInstanceOf(NoOpScheduledExecutorService::class.java)
         assertThat(testedFeature.jankStatsActivityLifecycleListener)
             .isNull()
+    }
+
+    @Test
+    fun `M call onActivityStarted W enableJankStatsTracking()`() {
+        // Given
+        val activity: Activity = mock()
+        testedFeature = RumFeature(
+            mockSdkCore,
+            fakeApplicationId.toString(),
+            fakeConfiguration,
+            lateCrashReporterFactory = { mockLateCrashReporter }
+        )
+        testedFeature.jankStatsActivityLifecycleListener = mock()
+
+        // When
+        testedFeature.enableJankStatsTracking(activity)
+
+        // Then
+        verify(testedFeature.jankStatsActivityLifecycleListener)!!.onActivityStarted(activity)
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.monitor
 
+import android.app.Activity
 import android.app.ActivityManager
 import android.os.Handler
 import com.datadog.android.api.InternalLogger
@@ -1909,6 +1910,22 @@ internal class DatadogRumMonitorTest {
             )
             assertThat(lastValue.event).isEqualTo(fakeInternalTelemetryEvent)
         }
+    }
+
+    @Test
+    fun `M call enableJankStatsTracking on RUM feature W enableJankStatsTracking`() {
+        // Given
+        val mockActivity = mock<Activity>()
+        val mockRumScope = mock<FeatureScope>()
+        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumScope
+        val mockRumFeature = mock<RumFeature>()
+        whenever(mockRumScope.unwrap<RumFeature>()) doReturn mockRumFeature
+
+        // When
+        testedMonitor.enableJankStatsTracking(mockActivity)
+
+        // Then
+        verify(mockRumFeature).enableJankStatsTracking(mockActivity)
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/vitals/JankStatsActivityLifecycleListenerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/vitals/JankStatsActivityLifecycleListenerTest.kt
@@ -128,6 +128,16 @@ internal class JankStatsActivityLifecycleListenerTest {
     }
 
     @Test
+    fun `M not track same activity twice W onActivityStarted {}`() {
+        // When
+        testedJankListener.onActivityStarted(mockActivity)
+        testedJankListener.onActivityStarted(mockActivity)
+
+        // Then
+        assertThat(testedJankListener.activeActivities[mockWindow]?.size).isEqualTo(1)
+    }
+
+    @Test
     fun `M register jankStats once W onActivityStarted() { multiple activities, same window}`() {
         // Given
         val mockActivity2 = mock<Activity>()

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/vitals/JankStatsActivityLifecycleListenerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/vitals/JankStatsActivityLifecycleListenerTest.kt
@@ -134,7 +134,7 @@ internal class JankStatsActivityLifecycleListenerTest {
         testedJankListener.onActivityStarted(mockActivity)
 
         // Then
-        assertThat(testedJankListener.activeActivities[mockWindow]?.size).isEqualTo(1)
+        assertThat(testedJankListener.activeActivities[mockWindow]).hasSize(1)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

Add a method to `AdvancedRumMonitor` to manually add an activity to JankStats tracking so that we can get framerate information.

### Motivation

Unity's main activity is started prior to initializing Datadog, so it misses adding the Activity to JankStats tracking. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

