### PR TITLE
chore: Set the local-ci script to check for specific version of KTLint

### DIFF
--- a/local_ci.sh
+++ b/local_ci.sh
@@ -8,6 +8,7 @@ ANALYSIS=0
 COMPILE=0
 TEST=0
 UPDATE_SESSION_REPLAY_PAYLOAD=0
+KTLINT_VERSION=0.50.0
 
 export CI=true
 
@@ -56,17 +57,34 @@ if [[ $SETUP == 1 ]]; then
   echo "-- SETUP"
 
   echo "---- Install KtLint"
+  INSTALL_KTLINT=false
   if [[ -x "$(command -v ktlint)" ]]; then
-      echo "  KtLint already installed; version $(ktlint --version)"
-  else
-    curl -SLO https://github.com/pinterest/ktlint/releases/download/0.50.0/ktlint && chmod a+x ktlint
+      INSTALLED_KTLINT=`ktlint --version`
+      echo "  KtLint already installed; version $INSTALLED_KTLINT"
+      if [[ $INSTALLED_KTLINT != $KTLINT_VERSION ]]; then
+        echo "  Upgrading to version $KTLINT_VERSION"
+        INSTALL_KTLINT=true
+      fi
+  fi
+
+  if [[ $INSTALL_KTLINT = true ]]; then
+    curl -SLO https://github.com/pinterest/ktlint/releases/download/$KTLINT_VERSION/ktlint && chmod a+x ktlint
     sudo mv ktlint /usr/local/bin/
     echo "  KtLint installed; version $(ktlint --version)"
   fi
 
+
+
   echo "---- Install Detekt"
   if [[ -x "$(command -v detekt)" ]]; then
       echo "  Detekt already installed; version $(detekt --version)"
+      read -p "  Would you like to update Detekt? " -n 1 -r
+      echo
+      if [[ $REPLY =~ ^[Yy]$ ]]
+      then
+        brew upgrade detekt
+        echo "  Detekt upgraded; version $(detekt --version)"
+      fi
   else
     brew install detekt
     echo "  Detekt installed; version $(detekt --version)"


### PR DESCRIPTION
### What does this PR do?

Makes `./local-ci.sh --setup` check for a specific version of KTLint instead of just outputting your current version. Also ask if you want to upgrade detekt after printing the current version.

### Motivation

Older / incorrect versions of KTLint will clash with what's on CI, giving fewer or more errors than what CI.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

