### PR TITLE
fix: Allow first build complete to be any number format

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -903,10 +903,10 @@ internal open class RumViewScope(
             )
         }
 
-        val performance = (internalAttributes[RumAttributes.FLUTTER_FIRST_BUILD_COMPLETE] as? Long)?.let {
+        val performance = (internalAttributes[RumAttributes.FLUTTER_FIRST_BUILD_COMPLETE] as? Number)?.let {
             ViewEvent.Performance(
                 fbc = ViewEvent.Fbc(
-                    timestamp = it
+                    timestamp = it.toLong()
                 )
             )
         }


### PR DESCRIPTION
### What does this PR do?

Allow the Flutter First Build Complete vital to be any numeric type, then convert it to long when creating the Performance structure.

### Motivation

Flutter will truncate Longs down to Ints if they are below a certain value, which was causing the `as? Long` cast to fail

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

