### PR TITLE
Remove double computation of the RUM payload

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/net/RumRequestFactory.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/net/RumRequestFactory.kt
@@ -51,12 +51,7 @@ internal class RumRequestFactory(
                 idempotencyKey,
                 context
             ),
-            body = viewEventFilter.filterOutRedundantViewEvents(batchData)
-                .map { it.data }
-                .join(
-                    separator = PAYLOAD_SEPARATOR,
-                    internalLogger = internalLogger
-                ),
+            body = body,
             contentType = RequestFactory.CONTENT_TYPE_TEXT_UTF8
         )
     }


### PR DESCRIPTION
### What does this PR do?

With https://github.com/DataDog/dd-sdk-android/pull/2298/files#diff-f064e155f59f2de7bfba9d1771f4f6721c48ba34cc1247e8cca065129dedf51b the double computation of the RUM upload body was added, but in fact `MessageDigest.digest` (-> `MessageDigest.update` under the hood) doesn't mutate input data, so it is safe to use it even after calling this method.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

