### PR TITLE
Update 2.11.0 changelog with a note about `com.datadog.trace` package move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,6 +294,7 @@
 * [FEATURE] Trace: Add OpenTelemetry use case into the `vendor-lib` sample. See [#2069](https://github.com/DataDog/dd-sdk-android/pull/2069)
 * [FEATURE] Trace: Add the OkHttp Otel extensions module. See [#2073](https://github.com/DataDog/dd-sdk-android/pull/2073)
 * [FEATURE] Trace: `OtelTraceProvider.Builder`: introduce the trace rate limit property. See [#2086](https://github.com/DataDog/dd-sdk-android/pull/2086)
+* **WARNING**: Existing `com.datadog.trace` package renamed to `com.datadog.legacy.trace`. `com.datadog.trace` package will contain new members, so update your imports accordingly.
 * [BUGFIX] Session Replay: Fix time drift in `RecordedDataQueueHandler`. See [#2075](https://github.com/DataDog/dd-sdk-android/pull/2075)
 * [IMPROVEMENT] Trace: Remove some unused IAST/CI Visibility classes. See [#2000](https://github.com/DataDog/dd-sdk-android/pull/2000)
 * [IMPROVEMENT] Trace: Remove `moshi` dependency from trace module. See [#2003](https://github.com/DataDog/dd-sdk-android/pull/2003)


### PR DESCRIPTION
### What does this PR do?

The following commit https://github.com/DataDog/dd-sdk-android/commit/eddf6d89cc06d7b5e5c6912278d3815a99c10de3 shipped with release `2.11.0` moved existing `com.datadog.trace` package to the `com.datadog.legacy.trace` and as a result `com.datadog.trace` had new members.

This can leads to the following, as an example:

`com.datadog.trace.api.interceptor.MutableSpan` got renamed to `com.datadog.legacy.trace.api.interceptor.MutableSpan`, but also a new `com.datadog.trace.api.interceptor.MutableSpan` was added, so the following code written by the customer:

```
import com.datadog.trace.api.interceptor.MutableSpan
// some resourceName configurations here
(span as? MutableSpan)?.resourceName = resourceName
```

will do nothing, because `span` instance now implements `com.datadog.legacy.trace.api.interceptor.MutableSpan`.

This change adds an important note to the changelog regarding such move.

There was a discussion in the original PR about that https://github.com/DataDog/dd-sdk-android/pull/2077#discussion_r1635975086.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

