### PR TITLE
RUM-7745 update defaults in Tracing configuration

### DIFF
--- a/integrations/dd-sdk-android-okhttp/api/apiSurface
+++ b/integrations/dd-sdk-android-okhttp/api/apiSurface
@@ -31,8 +31,8 @@ open class com.datadog.android.okhttp.DatadogInterceptor : com.datadog.android.o
 data class com.datadog.android.okhttp.TraceContext
   constructor(String, String, Int)
 enum com.datadog.android.okhttp.TraceContextInjection
-  - All
-  - Sampled
+  - ALL
+  - SAMPLED
 open class com.datadog.android.okhttp.trace.DeterministicTraceSampler : com.datadog.android.core.sampling.DeterministicSampler<io.opentracing.Span>
   constructor(() -> Float)
   constructor(Float)

--- a/integrations/dd-sdk-android-okhttp/api/dd-sdk-android-okhttp.api
+++ b/integrations/dd-sdk-android-okhttp/api/dd-sdk-android-okhttp.api
@@ -69,8 +69,8 @@ public final class com/datadog/android/okhttp/TraceContext {
 }
 
 public final class com/datadog/android/okhttp/TraceContextInjection : java/lang/Enum {
-	public static final field All Lcom/datadog/android/okhttp/TraceContextInjection;
-	public static final field Sampled Lcom/datadog/android/okhttp/TraceContextInjection;
+	public static final field ALL Lcom/datadog/android/okhttp/TraceContextInjection;
+	public static final field SAMPLED Lcom/datadog/android/okhttp/TraceContextInjection;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/okhttp/TraceContextInjection;
 	public static fun values ()[Lcom/datadog/android/okhttp/TraceContextInjection;
 }

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -115,7 +115,7 @@ open class DatadogInterceptor internal constructor(
      * auto-instrumented requests. By default it is [DeterministicTraceSampler], which either can accept
      * fixed sample rate or can get it dynamically from the provider. Value between `0.0` and
      * `100.0`. A value of `0.0` means no trace will be kept, `100.0` means all traces will
-     * be kept (default value is `20.0`).
+     * be kept (default value is `100.0`).
      */
     @JvmOverloads
     @Deprecated(
@@ -136,7 +136,7 @@ open class DatadogInterceptor internal constructor(
         tracedRequestListener = tracedRequestListener,
         rumResourceAttributesProvider = rumResourceAttributesProvider,
         traceSampler = traceSampler,
-        traceContextInjection = TraceContextInjection.All,
+        traceContextInjection = TraceContextInjection.SAMPLED,
         redacted404ResourceName = true,
         localTracerFactory = { sdkCore, tracingHeaderTypes ->
             AndroidTracer.Builder(sdkCore).setTracingHeaderTypes(tracingHeaderTypes).build()
@@ -165,7 +165,7 @@ open class DatadogInterceptor internal constructor(
      * auto-instrumented requests. By default it is [DeterministicTraceSampler], which either can accept
      * fixed sample rate or can get it dynamically from the provider. Value between `0.0` and
      * `100.0`. A value of `0.0` means no trace will be kept, `100.0` means all traces will
-     * be kept (default value is `20.0`).
+     * be kept (default value is `100.0`).
      */
     @JvmOverloads
     @Deprecated(
@@ -191,7 +191,7 @@ open class DatadogInterceptor internal constructor(
         tracedRequestListener = tracedRequestListener,
         rumResourceAttributesProvider = rumResourceAttributesProvider,
         traceSampler = traceSampler,
-        traceContextInjection = TraceContextInjection.All,
+        traceContextInjection = TraceContextInjection.SAMPLED,
         redacted404ResourceName = true,
         localTracerFactory = { sdkCore, tracingHeaderTypes ->
             AndroidTracer.Builder(sdkCore).setTracingHeaderTypes(tracingHeaderTypes).build()
@@ -212,7 +212,7 @@ open class DatadogInterceptor internal constructor(
      * auto-instrumented requests. By default it is [DeterministicTraceSampler], which either can accept
      * fixed sample rate or can get it dynamically from the provider. Value between `0.0` and
      * `100.0`. A value of `0.0` means no trace will be kept, `100.0` means all traces will
-     * be kept (default value is `20.0`).
+     * be kept (default value is `100.0`).
      */
     @JvmOverloads
     @Deprecated(
@@ -232,7 +232,7 @@ open class DatadogInterceptor internal constructor(
         tracedRequestListener = tracedRequestListener,
         rumResourceAttributesProvider = rumResourceAttributesProvider,
         traceSampler = traceSampler,
-        traceContextInjection = TraceContextInjection.All,
+        traceContextInjection = TraceContextInjection.SAMPLED,
         redacted404ResourceName = true,
         localTracerFactory = { sdkCore, tracingHeaderTypes ->
             AndroidTracer.Builder(sdkCore).setTracingHeaderTypes(tracingHeaderTypes).build()

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/TraceContextInjection.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/TraceContextInjection.kt
@@ -16,7 +16,7 @@ enum class TraceContextInjection {
      * headers but the sampling priority will be `0`. This will mean that the client will dictate the sampling priority
      * on the server side and no trace will be created no matter the sampling rate at the server side.
      */
-    All,
+    ALL,
 
     /**
      * Injects trace context only into sampled requests.
@@ -25,5 +25,5 @@ enum class TraceContextInjection {
      * This will mean that if the server side sampling rate is higher than the client side sampling rate there will
      * be a chance that a trace will be created down the stream.
      */
-    Sampled
+    SAMPLED
 }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorBuilderTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorBuilderTest.kt
@@ -77,13 +77,14 @@ internal class DatadogInterceptorBuilderTest {
 
         // Then
         assertThat(interceptor.tracedHosts).isEqualTo(fakeTracedHostsWithHeaderType)
-        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.All)
+        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.SAMPLED)
         assertThat(interceptor.sdkInstanceName).isNull()
         assertThat(
             interceptor.rumResourceAttributesProvider
         ).isInstanceOf(NoOpRumResourceAttributesProvider::class.java)
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
         assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
         assertThat(interceptor.localTracerFactory).isNotNull()
     }
@@ -102,13 +103,14 @@ internal class DatadogInterceptorBuilderTest {
                 setOf(TracingHeaderType.DATADOG, TracingHeaderType.TRACECONTEXT)
             }
         )
-        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.All)
+        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.SAMPLED)
         assertThat(interceptor.sdkInstanceName).isNull()
         assertThat(
             interceptor.rumResourceAttributesProvider
         ).isInstanceOf(NoOpRumResourceAttributesProvider::class.java)
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
         assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
         assertThat(interceptor.localTracerFactory).isNotNull()
     }
@@ -122,13 +124,14 @@ internal class DatadogInterceptorBuilderTest {
 
         // Then
         assertThat(interceptor.tracedHosts).isEqualTo(fakeTracedHostsWithHeaderType)
-        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.All)
+        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.SAMPLED)
         assertThat(interceptor.sdkInstanceName).isEqualTo(fakeSdkInstaceName)
         assertThat(
             interceptor.rumResourceAttributesProvider
         ).isInstanceOf(NoOpRumResourceAttributesProvider::class.java)
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
         assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
         assertThat(interceptor.localTracerFactory).isNotNull()
     }
@@ -149,6 +152,7 @@ internal class DatadogInterceptorBuilderTest {
         ).isInstanceOf(NoOpRumResourceAttributesProvider::class.java)
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
         assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
         assertThat(interceptor.localTracerFactory).isNotNull()
     }
@@ -162,13 +166,14 @@ internal class DatadogInterceptorBuilderTest {
 
         // Then
         assertThat(interceptor.tracedHosts).isEqualTo(fakeTracedHostsWithHeaderType)
-        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.All)
+        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.SAMPLED)
         assertThat(interceptor.sdkInstanceName).isNull()
         assertThat(
             interceptor.rumResourceAttributesProvider
         ).isInstanceOf(NoOpRumResourceAttributesProvider::class.java)
         assertThat(interceptor.tracedRequestListener).isSameAs(mockTracedRequestListener)
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
         assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
         assertThat(interceptor.localTracerFactory).isNotNull()
     }
@@ -182,11 +187,12 @@ internal class DatadogInterceptorBuilderTest {
 
         // Then
         assertThat(interceptor.tracedHosts).isEqualTo(fakeTracedHostsWithHeaderType)
-        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.All)
+        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.SAMPLED)
         assertThat(interceptor.sdkInstanceName).isNull()
         assertThat(interceptor.rumResourceAttributesProvider).isSameAs(mockRumResourceAttributesProvider)
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
         assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
         assertThat(interceptor.localTracerFactory).isNotNull()
     }
@@ -202,7 +208,7 @@ internal class DatadogInterceptorBuilderTest {
 
         // Then
         assertThat(interceptor.tracedHosts).isEqualTo(fakeTracedHostsWithHeaderType)
-        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.All)
+        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.SAMPLED)
         assertThat(interceptor.sdkInstanceName).isNull()
         assertThat(
             interceptor.rumResourceAttributesProvider
@@ -223,7 +229,7 @@ internal class DatadogInterceptorBuilderTest {
 
         // Then
         assertThat(interceptor.tracedHosts).isEqualTo(fakeTracedHostsWithHeaderType)
-        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.All)
+        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.SAMPLED)
         assertThat(interceptor.sdkInstanceName).isNull()
         assertThat(
             interceptor.rumResourceAttributesProvider

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -94,7 +94,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             tracedRequestListener = mockRequestListener,
             rumResourceAttributesProvider = mockRumAttributesProvider,
             traceSampler = mockTraceSampler,
-            traceContextInjection = TraceContextInjection.All,
+            traceContextInjection = TraceContextInjection.ALL,
             redacted404ResourceName = fakeRedacted404Resources,
             localTracerFactory = factory
         )

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutRumTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutRumTest.kt
@@ -59,7 +59,7 @@ internal class DatadogInterceptorWithoutRumTest : TracingInterceptorTest() {
             tracedRequestListener = mockRequestListener,
             rumResourceAttributesProvider = mockRumAttributesProvider,
             traceSampler = mockTraceSampler,
-            traceContextInjection = TraceContextInjection.All,
+            traceContextInjection = TraceContextInjection.ALL,
             redacted404ResourceName = fakeRedacted404Resources,
             localTracerFactory = factory
         )

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
@@ -166,7 +166,7 @@ internal class DatadogInterceptorWithoutTracesTest {
             rumResourceAttributesProvider = mockRumAttributesProvider,
             traceSampler = mockTraceSampler,
             redacted404ResourceName = fakeRedacted404Resources,
-            traceContextInjection = TraceContextInjection.All
+            traceContextInjection = TraceContextInjection.ALL
         ) { _, _ -> mockLocalTracer }
         whenever(rumMonitor.mockSdkCore.getFeature(Feature.TRACING_FEATURE_NAME)) doReturn mock()
         whenever(rumMonitor.mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mock()

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/TracingInterceptorBuilderTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/TracingInterceptorBuilderTest.kt
@@ -16,6 +16,7 @@ import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.forge.BaseConfigurator
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.FloatForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -76,10 +77,11 @@ internal class TracingInterceptorBuilderTest {
 
         // Then
         assertThat(interceptor.tracedHosts).isEqualTo(fakeTracedHostsWithHeaderType)
-        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.All)
+        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.SAMPLED)
         assertThat(interceptor.sdkInstanceName).isNull()
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
         assertThat(interceptor.traceOrigin).isNull()
         assertThat(interceptor.localTracerFactory).isNotNull()
         assertThat(interceptor.redacted404ResourceName).isTrue()
@@ -99,10 +101,11 @@ internal class TracingInterceptorBuilderTest {
                 setOf(TracingHeaderType.DATADOG, TracingHeaderType.TRACECONTEXT)
             }
         )
-        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.All)
+        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.SAMPLED)
         assertThat(interceptor.sdkInstanceName).isNull()
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
         assertThat(interceptor.traceOrigin).isNull()
         assertThat(interceptor.localTracerFactory).isNotNull()
         assertThat(interceptor.redacted404ResourceName).isTrue()
@@ -117,10 +120,11 @@ internal class TracingInterceptorBuilderTest {
 
         // Then
         assertThat(interceptor.tracedHosts).isEqualTo(fakeTracedHostsWithHeaderType)
-        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.All)
+        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.SAMPLED)
         assertThat(interceptor.sdkInstanceName).isEqualTo(fakeSdkInstaceName)
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
         assertThat(interceptor.traceOrigin).isNull()
         assertThat(interceptor.localTracerFactory).isNotNull()
         assertThat(interceptor.redacted404ResourceName).isTrue()
@@ -139,6 +143,7 @@ internal class TracingInterceptorBuilderTest {
         assertThat(interceptor.sdkInstanceName).isNull()
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
         assertThat(interceptor.traceOrigin).isNull()
         assertThat(interceptor.localTracerFactory).isNotNull()
         assertThat(interceptor.redacted404ResourceName).isTrue()
@@ -153,7 +158,7 @@ internal class TracingInterceptorBuilderTest {
 
         // Then
         assertThat(interceptor.tracedHosts).isEqualTo(fakeTracedHostsWithHeaderType)
-        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.All)
+        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.SAMPLED)
         assertThat(interceptor.sdkInstanceName).isNull()
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
@@ -171,10 +176,32 @@ internal class TracingInterceptorBuilderTest {
 
         // Then
         assertThat(interceptor.tracedHosts).isEqualTo(fakeTracedHostsWithHeaderType)
-        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.All)
+        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.SAMPLED)
         assertThat(interceptor.sdkInstanceName).isNull()
         assertThat(interceptor.tracedRequestListener).isSameAs(mockTracedRequestListener)
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
+        assertThat(interceptor.traceOrigin).isNull()
+        assertThat(interceptor.localTracerFactory).isNotNull()
+        assertThat(interceptor.redacted404ResourceName).isTrue()
+    }
+
+    @Test
+    fun `M set traceSampler W build { setTraceSampleRate }`(
+        @FloatForgery(0f, 100f) fakeSampleRate: Float
+    ) {
+        // When
+        val interceptor = TracingInterceptor.Builder(fakeTracedHostsWithHeaderType)
+            .setTraceSampleRate(fakeSampleRate)
+            .build()
+
+        // Then
+        assertThat(interceptor.tracedHosts).isEqualTo(fakeTracedHostsWithHeaderType)
+        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.SAMPLED)
+        assertThat(interceptor.sdkInstanceName).isNull()
+        assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
+        assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(fakeSampleRate)
         assertThat(interceptor.traceOrigin).isNull()
         assertThat(interceptor.localTracerFactory).isNotNull()
         assertThat(interceptor.redacted404ResourceName).isTrue()
@@ -189,7 +216,7 @@ internal class TracingInterceptorBuilderTest {
 
         // Then
         assertThat(interceptor.tracedHosts).isEqualTo(fakeTracedHostsWithHeaderType)
-        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.All)
+        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.SAMPLED)
         assertThat(interceptor.sdkInstanceName).isNull()
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
         assertThat(interceptor.traceSampler).isSameAs(mockSampler)
@@ -209,10 +236,11 @@ internal class TracingInterceptorBuilderTest {
 
         // Then
         assertThat(interceptor.tracedHosts).isEqualTo(fakeTracedHostsWithHeaderType)
-        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.All)
+        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.SAMPLED)
         assertThat(interceptor.sdkInstanceName).isNull()
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
         assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
         assertThat(interceptor.traceOrigin).isNull()
         assertThat(interceptor.localTracerFactory).isNotNull()
         assertThat(interceptor.redacted404ResourceName).isEqualTo(redacted)

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorContextInjectionSampledTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorContextInjectionSampledTest.kt
@@ -202,7 +202,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
             .setTracedRequestListener(mockRequestListener)
             .setTraceOrigin(fakeOrigin)
             .setTraceSampler(mockTraceSampler)
-            .setTraceContextInjection(TraceContextInjection.Sampled)
+            .setTraceContextInjection(TraceContextInjection.SAMPLED)
             .setLocalTracerFactory(factory)
             .set404ResourcesRedacted(fakeRedacted404Resources)
             .build()

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
@@ -10,7 +10,6 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
-import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.okhttp.TraceContextInjection
@@ -219,7 +218,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
                 tracedRequestListener = mockRequestListener,
                 traceOrigin = fakeOrigin,
                 traceSampler = mockTraceSampler,
-                traceContextInjection = TraceContextInjection.All,
+                traceContextInjection = TraceContextInjection.ALL,
                 redacted404ResourceName = fakeRedacted404Resources,
                 localTracerFactory = factory
             ) {

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
@@ -203,7 +203,7 @@ internal open class TracingInterceptorNonDdTracerTest {
             tracedRequestListener = mockRequestListener,
             traceOrigin = fakeOrigin,
             traceSampler = mockTraceSampler,
-            traceContextInjection = TraceContextInjection.All,
+            traceContextInjection = TraceContextInjection.ALL,
             redacted404ResourceName = fakeRedacted404Resources,
             localTracerFactory = factory
         )

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
@@ -218,7 +218,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
                 traceSampler = mockTraceSampler,
                 localTracerFactory = factory,
                 redacted404ResourceName = fakeRedacted404Resources,
-                traceContextInjection = TraceContextInjection.All
+                traceContextInjection = TraceContextInjection.ALL
             ) {
             override fun canSendSpan(): Boolean {
                 return false

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
@@ -204,7 +204,7 @@ internal open class TracingInterceptorTest {
             traceSampler = mockTraceSampler,
             localTracerFactory = factory,
             redacted404ResourceName = fakeRedacted404Resources,
-            traceContextInjection = TraceContextInjection.All
+            traceContextInjection = TraceContextInjection.ALL
         )
     }
 

--- a/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/HeadBasedSamplingTest.kt
+++ b/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/HeadBasedSamplingTest.kt
@@ -96,7 +96,7 @@ class HeadBasedSamplingTest {
                 TracingInterceptor.Builder(
                     tracedHostsWithHeaderType = mapOf(mockServer.hostName to setOf(TracingHeaderType.DATADOG))
                 )
-                    .setTraceContextInjection(TraceContextInjection.All)
+                    .setTraceContextInjection(TraceContextInjection.ALL)
                     .setSdkInstanceName(stubSdkCore.name)
                     .setTraceSampleRate(100f)
                     .build()
@@ -166,7 +166,7 @@ class HeadBasedSamplingTest {
                 TracingInterceptor.Builder(
                     tracedHostsWithHeaderType = mapOf(mockServer.hostName to setOf(TracingHeaderType.DATADOG))
                 )
-                    .setTraceContextInjection(TraceContextInjection.All)
+                    .setTraceContextInjection(TraceContextInjection.ALL)
                     .setSdkInstanceName(stubSdkCore.name)
                     .setTraceSampleRate(50f)
                     .build()
@@ -210,7 +210,7 @@ class HeadBasedSamplingTest {
                 TracingInterceptor.Builder(
                     tracedHostsWithHeaderType = mapOf(mockServer.hostName to setOf(TracingHeaderType.DATADOG))
                 )
-                    .setTraceContextInjection(TraceContextInjection.All)
+                    .setTraceContextInjection(TraceContextInjection.ALL)
                     .setSdkInstanceName(stubSdkCore.name)
                     .setTraceSampleRate(100f)
                     .build()
@@ -259,7 +259,7 @@ class HeadBasedSamplingTest {
                 TracingInterceptor.Builder(
                     tracedHostsWithHeaderType = mapOf(mockServer.hostName to setOf(TracingHeaderType.DATADOG))
                 )
-                    .setTraceContextInjection(TraceContextInjection.All)
+                    .setTraceContextInjection(TraceContextInjection.ALL)
                     .setSdkInstanceName(stubSdkCore.name)
                     .setTraceSampleRate(100f)
                     .build()
@@ -304,7 +304,7 @@ class HeadBasedSamplingTest {
                 TracingInterceptor.Builder(
                     tracedHostsWithHeaderType = mapOf(mockServer.hostName to setOf(TracingHeaderType.DATADOG))
                 )
-                    .setTraceContextInjection(TraceContextInjection.All)
+                    .setTraceContextInjection(TraceContextInjection.ALL)
                     .setSdkInstanceName(stubSdkCore.name)
                     .setTraceSampleRate(0f)
                     .build()
@@ -404,7 +404,7 @@ class HeadBasedSamplingTest {
                 TracingInterceptor.Builder(
                     tracedHostsWithHeaderType = mapOf(mockServer.hostName to setOf(TracingHeaderType.DATADOG))
                 )
-                    .setTraceContextInjection(TraceContextInjection.All)
+                    .setTraceContextInjection(TraceContextInjection.ALL)
                     .setSdkInstanceName(stubSdkCore.name)
                     .setTraceSampleRate(0f)
                     .build()
@@ -502,7 +502,7 @@ class HeadBasedSamplingTest {
                 TracingInterceptor.Builder(
                     tracedHostsWithHeaderType = mapOf(mockServer.hostName to setOf(TracingHeaderType.DATADOG))
                 )
-                    .setTraceContextInjection(TraceContextInjection.All)
+                    .setTraceContextInjection(TraceContextInjection.ALL)
                     .setSdkInstanceName(stubSdkCore.name)
                     .setTraceSampleRate(100f)
                     .build()
@@ -553,7 +553,7 @@ class HeadBasedSamplingTest {
                 TracingInterceptor.Builder(
                     tracedHostsWithHeaderType = mapOf(mockServer.hostName to setOf(TracingHeaderType.DATADOG))
                 )
-                    .setTraceContextInjection(TraceContextInjection.All)
+                    .setTraceContextInjection(TraceContextInjection.ALL)
                     .setSdkInstanceName(stubSdkCore.name)
                     .setTraceSampleRate(100f)
                     .build()


### PR DESCRIPTION
### What does this PR do?

Update the default configuration for tracing, namely: 
- use `SAMPLED` instead of `ALL` as the default `TraceContextInjection` strategy
- use 100% instead of 20% for the default network tracing sampling rate

### Additional Notes

Renamed the enum constants in `TraceContextInjection` to be all uppercase