### PR TITLE
Fix NPE when Drawable.getCurrent returns null

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapper.kt
@@ -200,7 +200,9 @@ open class LegacyDrawableToColorMapper(
      * @return the color to map to or null if not applicable
      */
     private fun resolveStateListDrawable(drawable: StateListDrawable, internalLogger: InternalLogger): Int? {
-        return mapDrawableToColor(drawable = drawable.current, internalLogger = internalLogger)
+        // Drawable.getCurrent() can return null in case <selector> doesn't have an item for the default case.
+        @Suppress("UNNECESSARY_SAFE_CALL")
+        return drawable.current?.let { mapDrawableToColor(drawable = it, internalLogger = internalLogger) }
     }
 
     companion object {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapperTest.kt
@@ -214,7 +214,7 @@ open class LegacyDrawableToColorMapperTest {
     }
 
     @Test
-    fun `M map StateListDrawable to null W mapDrawableToColor() { in case Drawable getCurrent returns null }`() {
+    fun `M map StateListDrawable to null W mapDrawableToColor() { Drawable getCurrent returns null }`() {
         val stateListDrawable = mock<StateListDrawable>().apply {
             whenever<Drawable?>(this.current) doReturn null
         }
@@ -223,6 +223,6 @@ open class LegacyDrawableToColorMapperTest {
         val result = testedMapper.mapDrawableToColor(stateListDrawable, mockInternalLogger)
 
         // Then
-        assertThat(result).isEqualTo(null)
+        assertThat(result).isNull()
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapperTest.kt
@@ -212,4 +212,17 @@ open class LegacyDrawableToColorMapperTest {
         // Then
         assertThat(result).isEqualTo(drawableColor)
     }
+
+    @Test
+    fun `M map StateListDrawable to null W mapDrawableToColor() { in case Drawable getCurrent returns null }`() {
+        val stateListDrawable = mock<StateListDrawable>().apply {
+            whenever<Drawable?>(this.current) doReturn null
+        }
+
+        // When
+        val result = testedMapper.mapDrawableToColor(stateListDrawable, mockInternalLogger)
+
+        // Then
+        assertThat(result).isEqualTo(null)
+    }
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/sessionreplay/ImageComponentsFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/sessionreplay/ImageComponentsFragment.kt
@@ -64,6 +64,12 @@ internal class ImageComponentsFragment : Fragment() {
             backgroundId = R.drawable.selector_statelist_images
         )
 
+        setupStateListButton(
+            rootView = rootView,
+            buttonId = R.id.button_statelist_images_no_default,
+            backgroundId = R.drawable.selector_statelist_images_no_default
+        )
+
         return rootView
     }
 

--- a/sample/kotlin/src/main/res/drawable/selector_statelist_images_no_default.xml
+++ b/sample/kotlin/src/main/res/drawable/selector_statelist_images_no_default.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/ic_dd_icon_red" android:state_pressed="true"/>
+    <item android:drawable="@drawable/ic_dd_icon_green" android:state_selected="true" />
+</selector>

--- a/sample/kotlin/src/main/res/layout/fragment_image_components.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_image_components.xml
@@ -382,6 +382,17 @@
                     android:contentDescription="@null"
                     />
 
+                <Button
+                    android:id="@+id/button_statelist_images_no_default"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:layout_marginStart="48dp"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:contentDescription="@null"
+                    />
+
             </LinearLayout>
 
         </LinearLayout>


### PR DESCRIPTION
### What does this PR do?

`LegacyDrawableToColorMapper.mapDrawableToColor` can crash with NPE when invoked on a `StateListDrawable`, whose `getCurrent()` method returns `null`. This can happen when `<selector>` doesn't contain the default item.

demo [internal]

https://mobile-integration.datadoghq.com/rum/replay/sessions/de3b1c36-f346-4733-abdf-d295f21b99e4?seed=31a96bad-0d88-4292-8e2f-9dd615cadab4&ts=1741884288920

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

