### PR TITLE
RUM-8041: Add telemetry for pending batch files

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/MetricsDispatcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/MetricsDispatcher.kt
@@ -11,7 +11,7 @@ import java.io.File
 
 @NoOpImplementation
 internal interface MetricsDispatcher {
-    fun sendBatchDeletedMetric(batchFile: File, removalReason: RemovalReason)
+    fun sendBatchDeletedMetric(batchFile: File, removalReason: RemovalReason, numPendingBatches: Int)
 
     fun sendBatchClosedMetric(batchFile: File, batchMetadata: BatchClosedMetadata)
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
@@ -182,7 +182,8 @@ internal class ConsentAwareStorage(
     private fun deleteBatchFile(batchFile: File, reason: RemovalReason) {
         val result = fileMover.delete(batchFile)
         if (result) {
-            metricsDispatcher.sendBatchDeletedMetric(batchFile, reason)
+            val numPendingFiles = grantedOrchestrator.decrementAndGetPendingFilesCount()
+            metricsDispatcher.sendBatchDeletedMetric(batchFile, reason, numPendingFiles)
         } else {
             internalLogger.log(
                 InternalLogger.Level.WARN,

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileOrchestrator.kt
@@ -66,4 +66,9 @@ internal interface FileOrchestrator {
      * @return the name of the root directory of this orchestrator or null if the root directory does not exist.
      */
     fun getRootDirName(): String?
+
+    /**
+     * @return the number of pending files in the orchestrator, after decrementing by 1.
+     */
+    fun decrementAndGetPendingFilesCount(): Int
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
@@ -72,6 +72,10 @@ internal open class ConsentAwareFileOrchestrator(
         return delegateOrchestrator.getMetadataFile(file)
     }
 
+    override fun decrementAndGetPendingFilesCount(): Int {
+        return delegateOrchestrator.decrementAndGetPendingFilesCount()
+    }
+
     // endregion
 
     // region TrackingConsentProviderCallback

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
@@ -22,15 +22,18 @@ import com.datadog.android.core.internal.persistence.file.mkdirsSafe
 import java.io.File
 import java.io.FileFilter
 import java.util.Locale
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.roundToLong
 
 // TODO RUM-438 Improve this class: need to make it thread-safe and optimize work with file
 //  system in order to reduce the number of syscalls (which are expensive) for files already seen
+@Suppress("TooManyFunctions")
 internal class BatchFileOrchestrator(
     private val rootDir: File,
     internal val config: FilePersistenceConfig,
     private val internalLogger: InternalLogger,
-    private val metricsDispatcher: MetricsDispatcher
+    private val metricsDispatcher: MetricsDispatcher,
+    private var pendingFiles: AtomicInteger = AtomicInteger(0)
 ) : FileOrchestrator {
 
     private val fileFilter = BatchFileFilter()
@@ -81,6 +84,7 @@ internal class BatchFileOrchestrator(
             deleteObsoleteFiles(it)
         }
         lastCleanupTimestamp = System.currentTimeMillis()
+        pendingFiles.set(files.count())
 
         return files.firstOrNull {
             (it !in excludeFiles) && !isFileRecent(it, recentReadDelayMs)
@@ -143,6 +147,10 @@ internal class BatchFileOrchestrator(
     // endregion
 
     // region Internal
+
+    override fun decrementAndGetPendingFilesCount(): Int {
+        return pendingFiles.decrementAndGet()
+    }
 
     @Suppress("LiftReturnOrAssignment", "ReturnCount")
     private fun isRootDirValid(): Boolean {
@@ -215,6 +223,7 @@ internal class BatchFileOrchestrator(
         previousFile = newFile
         previousFileItemCount = 1
         lastFileAccessTimestamp = System.currentTimeMillis()
+        pendingFiles.incrementAndGet()
         return newFile
     }
 
@@ -260,7 +269,11 @@ internal class BatchFileOrchestrator(
                 val isOldFile = (it.name.toLongOrNull() ?: 0) < threshold
                 if (isOldFile) {
                     if (it.deleteSafe(internalLogger)) {
-                        metricsDispatcher.sendBatchDeletedMetric(it, RemovalReason.Obsolete)
+                        metricsDispatcher.sendBatchDeletedMetric(
+                            batchFile = it,
+                            removalReason = RemovalReason.Obsolete,
+                            numPendingBatches = pendingFiles.decrementAndGet()
+                        )
                     }
                     if (it.metadata.existsSafe(internalLogger)) {
                         it.metadata.deleteSafe(internalLogger)
@@ -301,7 +314,7 @@ internal class BatchFileOrchestrator(
         val wasDeleted = file.deleteSafe(internalLogger)
         return if (wasDeleted) {
             if (sendMetric) {
-                metricsDispatcher.sendBatchDeletedMetric(file, RemovalReason.Purged)
+                metricsDispatcher.sendBatchDeletedMetric(file, RemovalReason.Purged, pendingFiles.decrementAndGet())
             }
             size
         } else {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleFileOrchestrator.kt
@@ -64,5 +64,10 @@ internal class SingleFileOrchestrator(
         return file.parentFile?.nameWithoutExtension
     }
 
+    // single file orchestrator has a single file, so this is essentially a noop implementation
+    override fun decrementAndGetPendingFilesCount(): Int {
+        return 0
+    }
+
     // endregion
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
@@ -14,6 +14,7 @@ import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -46,7 +47,7 @@ import kotlin.math.max
 @ForgeConfiguration(Configurator::class)
 internal class BatchMetricsDispatcherTest {
 
-    lateinit var testedBatchMetricsDispatcher: BatchMetricsDispatcher
+    private lateinit var testedBatchMetricsDispatcher: BatchMetricsDispatcher
 
     lateinit var fakeFeatureName: String
 
@@ -60,6 +61,9 @@ internal class BatchMetricsDispatcherTest {
 
     @Mock
     lateinit var mockInternalLogger: InternalLogger
+
+    @IntForgery(min = 0, max = 100)
+    var fakePendingBatches: Int = 0
 
     @Forgery
     lateinit var fakeFilePersistenceConfig: FilePersistenceConfig
@@ -95,7 +99,7 @@ internal class BatchMetricsDispatcherTest {
         }
 
         // When
-        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
+        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason, fakePendingBatches)
 
         // Then
         argumentCaptor<Map<String, Any?>> {
@@ -118,7 +122,7 @@ internal class BatchMetricsDispatcherTest {
         whenever(fakeFile.name).thenReturn(newFileName)
 
         // When
-        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
+        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason, fakePendingBatches)
 
         // Then
         verifyNoInteractions(mockInternalLogger)
@@ -136,7 +140,7 @@ internal class BatchMetricsDispatcherTest {
         testedBatchMetricsDispatcher.onPaused()
 
         // When
-        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
+        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason, fakePendingBatches)
 
         // Then
         argumentCaptor<Map<String, Any?>> {
@@ -162,7 +166,7 @@ internal class BatchMetricsDispatcherTest {
         }
         // When
         testedBatchMetricsDispatcher.onResumed()
-        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
+        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason, fakePendingBatches)
 
         // Then
         argumentCaptor<Map<String, Any?>> {
@@ -190,7 +194,7 @@ internal class BatchMetricsDispatcherTest {
             put(BatchMetricsDispatcher.TRACKING_CONSENT_KEY, "pending")
         }
         // When
-        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
+        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason, fakePendingBatches)
 
         // Then
         argumentCaptor<Map<String, Any?>> {
@@ -217,7 +221,7 @@ internal class BatchMetricsDispatcherTest {
             put(BatchMetricsDispatcher.TRACKING_CONSENT_KEY, null)
         }
         // When
-        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
+        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason, fakePendingBatches)
 
         // Then
         argumentCaptor<Map<String, Any?>> {
@@ -244,7 +248,7 @@ internal class BatchMetricsDispatcherTest {
             put(BatchMetricsDispatcher.TRACKING_CONSENT_KEY, null)
         }
         // When
-        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
+        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason, fakePendingBatches)
 
         // Then
         argumentCaptor<Map<String, Any?>> {
@@ -267,7 +271,7 @@ internal class BatchMetricsDispatcherTest {
         }
 
         // When
-        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
+        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason, fakePendingBatches)
 
         // Then
         verify(mockInternalLogger).log(
@@ -300,7 +304,7 @@ internal class BatchMetricsDispatcherTest {
         val fakeFile: File = forge.forgeValidFile()
 
         // When
-        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
+        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason, fakePendingBatches)
 
         // Then
         verifyNoInteractions(mockInternalLogger)
@@ -561,6 +565,7 @@ internal class BatchMetricsDispatcherTest {
             BatchMetricsDispatcher.FILE_NAME to file.name,
             BatchMetricsDispatcher.THREAD_NAME to Thread.currentThread().name,
             BatchMetricsDispatcher.TRACKING_CONSENT_KEY to "granted",
+            BatchMetricsDispatcher.PENDING_BATCHES to fakePendingBatches,
             BatchMetricsDispatcher.IN_BACKGROUND_KEY to true
         )
     }

--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -716,6 +716,7 @@ datadog:
       - "java.util.concurrent.atomic.AtomicInteger.get()"
       - "java.util.concurrent.atomic.AtomicInteger.getAndIncrement()"
       - "java.util.concurrent.atomic.AtomicInteger.incrementAndGet()"
+      - "java.util.concurrent.atomic.AtomicInteger.set(kotlin.Int)"
       - "java.util.concurrent.atomic.AtomicLong.constructor(kotlin.Long)"
       - "java.util.concurrent.atomic.AtomicLong.get()"
       - "java.util.concurrent.atomic.AtomicLong.set(kotlin.Long)"


### PR DESCRIPTION
### What does this PR do?
Adds to `batch deleted` events the number of pending batch files in the directory at the time the metric was sent.

### Motivation
Additional telemetry to increase transparency.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

