### PR TITLE
[RUM-9065] Bugfixes and platform alignment

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -975,6 +975,7 @@ datadog:
       - "kotlin.collections.MutableList.add(com.datadog.android.core.internal.persistence.tlvformat.TLVBlock)"
       - "kotlin.collections.MutableList.add(com.datadog.android.plugin.DatadogPlugin)"
       - "kotlin.collections.MutableList.add(com.datadog.android.rum.internal.domain.scope.RumScope)"
+      - "kotlin.collections.MutableList.add(com.datadog.android.rum.internal.vitals.FrameStateListener)"
       - "kotlin.collections.MutableList.add(com.datadog.android.rum.model.ActionEvent.Type)"
       - "kotlin.collections.MutableList.add(com.datadog.android.sessionreplay.compose.internal.data.Parameter)"
       - "kotlin.collections.MutableList.add(com.datadog.android.sessionreplay.compose.internal.utils.BackgroundInfo)"

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -86,7 +86,7 @@ data class com.datadog.android.rum.RumConfiguration
     fun setSessionListener(RumSessionListener): Builder
     fun setInitialResourceIdentifier(com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier): Builder
     fun setLastInteractionIdentifier(com.datadog.android.rum.metric.interactiontonextview.LastInteractionIdentifier?): Builder
-    fun setSlowFrameListenerConfiguration(com.datadog.android.rum.configuration.SlowFramesConfiguration?): Builder
+    fun setSlowFramesConfiguration(com.datadog.android.rum.configuration.SlowFramesConfiguration?): Builder
     fun trackAnonymousUser(Boolean): Builder
     fun build(): RumConfiguration
 enum com.datadog.android.rum.RumErrorSource

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -86,7 +86,7 @@ data class com.datadog.android.rum.RumConfiguration
     fun setSessionListener(RumSessionListener): Builder
     fun setInitialResourceIdentifier(com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier): Builder
     fun setLastInteractionIdentifier(com.datadog.android.rum.metric.interactiontonextview.LastInteractionIdentifier?): Builder
-    fun setSlowFrameListenerConfiguration(com.datadog.android.rum.configuration.SlowFrameListenerConfiguration?): Builder
+    fun setSlowFrameListenerConfiguration(com.datadog.android.rum.configuration.SlowFramesConfiguration?): Builder
     fun trackAnonymousUser(Boolean): Builder
     fun build(): RumConfiguration
 enum com.datadog.android.rum.RumErrorSource
@@ -166,10 +166,10 @@ class com.datadog.android.rum._RumInternalProxy
   companion object 
     fun setTelemetryConfigurationEventMapper(RumConfiguration.Builder, com.datadog.android.event.EventMapper<com.datadog.android.telemetry.model.TelemetryConfigurationEvent>): RumConfiguration.Builder
     fun setAdditionalConfiguration(RumConfiguration.Builder, Map<String, Any>): RumConfiguration.Builder
-data class com.datadog.android.rum.configuration.SlowFrameListenerConfiguration
+data class com.datadog.android.rum.configuration.SlowFramesConfiguration
   constructor(Int = DEFAULT_SLOW_FRAME_RECORDS_MAX_AMOUNT, Long = DEFAULT_FROZEN_FRAME_THRESHOLD_NS, Long = DEFAULT_CONTINUOUS_SLOW_FRAME_THRESHOLD_NS, Long = DEFAULT_FREEZE_DURATION_NS, Long = DEFAULT_VIEW_LIFETIME_THRESHOLD_NS)
   companion object 
-    val DEFAULT: SlowFrameListenerConfiguration
+    val DEFAULT: SlowFramesConfiguration
 enum com.datadog.android.rum.configuration.VitalsUpdateFrequency
   constructor(Long)
   - FREQUENT

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -111,7 +111,7 @@ public final class com/datadog/android/rum/RumConfiguration$Builder {
 	public final fun setResourceEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setSessionListener (Lcom/datadog/android/rum/RumSessionListener;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setSessionSampleRate (F)Lcom/datadog/android/rum/RumConfiguration$Builder;
-	public final fun setSlowFrameListenerConfiguration (Lcom/datadog/android/rum/configuration/SlowFrameListenerConfiguration;)Lcom/datadog/android/rum/RumConfiguration$Builder;
+	public final fun setSlowFrameListenerConfiguration (Lcom/datadog/android/rum/configuration/SlowFramesConfiguration;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setTelemetrySampleRate (F)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setViewEventMapper (Lcom/datadog/android/rum/event/ViewEventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setVitalsUpdateFrequency (Lcom/datadog/android/rum/configuration/VitalsUpdateFrequency;)Lcom/datadog/android/rum/RumConfiguration$Builder;
@@ -247,20 +247,20 @@ public final class com/datadog/android/rum/_RumInternalProxy$Companion {
 	public final fun setTelemetryConfigurationEventMapper (Lcom/datadog/android/rum/RumConfiguration$Builder;Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 }
 
-public final class com/datadog/android/rum/configuration/SlowFrameListenerConfiguration {
-	public static final field Companion Lcom/datadog/android/rum/configuration/SlowFrameListenerConfiguration$Companion;
+public final class com/datadog/android/rum/configuration/SlowFramesConfiguration {
+	public static final field Companion Lcom/datadog/android/rum/configuration/SlowFramesConfiguration$Companion;
 	public fun <init> ()V
 	public fun <init> (IJJJJ)V
 	public synthetic fun <init> (IJJJJILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (IJJJJ)Lcom/datadog/android/rum/configuration/SlowFrameListenerConfiguration;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/configuration/SlowFrameListenerConfiguration;IJJJJILjava/lang/Object;)Lcom/datadog/android/rum/configuration/SlowFrameListenerConfiguration;
+	public final fun copy (IJJJJ)Lcom/datadog/android/rum/configuration/SlowFramesConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/configuration/SlowFramesConfiguration;IJJJJILjava/lang/Object;)Lcom/datadog/android/rum/configuration/SlowFramesConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/rum/configuration/SlowFrameListenerConfiguration$Companion {
-	public final fun getDEFAULT ()Lcom/datadog/android/rum/configuration/SlowFrameListenerConfiguration;
+public final class com/datadog/android/rum/configuration/SlowFramesConfiguration$Companion {
+	public final fun getDEFAULT ()Lcom/datadog/android/rum/configuration/SlowFramesConfiguration;
 }
 
 public final class com/datadog/android/rum/configuration/VitalsUpdateFrequency : java/lang/Enum {

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -111,7 +111,7 @@ public final class com/datadog/android/rum/RumConfiguration$Builder {
 	public final fun setResourceEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setSessionListener (Lcom/datadog/android/rum/RumSessionListener;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setSessionSampleRate (F)Lcom/datadog/android/rum/RumConfiguration$Builder;
-	public final fun setSlowFrameListenerConfiguration (Lcom/datadog/android/rum/configuration/SlowFramesConfiguration;)Lcom/datadog/android/rum/RumConfiguration$Builder;
+	public final fun setSlowFramesConfiguration (Lcom/datadog/android/rum/configuration/SlowFramesConfiguration;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setTelemetrySampleRate (F)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setViewEventMapper (Lcom/datadog/android/rum/event/ViewEventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setVitalsUpdateFrequency (Lcom/datadog/android/rum/configuration/VitalsUpdateFrequency;)Lcom/datadog/android/rum/RumConfiguration$Builder;

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
@@ -304,7 +304,7 @@ data class RumConfiguration internal constructor(
          * @param slowFramesConfiguration The configuration to be applied to the [SlowFramesListener].
          */
         @ExperimentalRumApi
-        fun setSlowFrameListenerConfiguration(
+        fun setSlowFramesConfiguration(
             slowFramesConfiguration: SlowFramesConfiguration?
         ): Builder {
             rumConfig = rumConfig.copy(slowFramesConfiguration = slowFramesConfiguration)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
@@ -9,7 +9,7 @@ package com.datadog.android.rum
 import android.os.Looper
 import androidx.annotation.FloatRange
 import com.datadog.android.event.EventMapper
-import com.datadog.android.rum.configuration.SlowFrameListenerConfiguration
+import com.datadog.android.rum.configuration.SlowFramesConfiguration
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
 import com.datadog.android.rum.event.ViewEventMapper
 import com.datadog.android.rum.internal.RumFeature
@@ -296,18 +296,18 @@ data class RumConfiguration internal constructor(
          *
          *
          * This configuration sets the parameters for the [SlowFramesListener], which are used to calculate the slow frames array,
-         * slow frame ratio, and freeze ratio. For additional details, refer to [SlowFrameListenerConfiguration].
+         * slow frame ratio, and freeze ratio. For additional details, refer to [SlowFramesConfiguration].
          *
          * Assigning a null value to this property will disable the [SlowFramesListener] and stop the computation of the
          * associated rates.
          *
-         * @param slowFrameListenerConfiguration The configuration to be applied to the [SlowFramesListener].
+         * @param slowFramesConfiguration The configuration to be applied to the [SlowFramesListener].
          */
         @ExperimentalRumApi
         fun setSlowFrameListenerConfiguration(
-            slowFrameListenerConfiguration: SlowFrameListenerConfiguration?
+            slowFramesConfiguration: SlowFramesConfiguration?
         ): Builder {
-            rumConfig = rumConfig.copy(slowFrameListenerConfiguration = slowFrameListenerConfiguration)
+            rumConfig = rumConfig.copy(slowFramesConfiguration = slowFramesConfiguration)
             return this
         }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/configuration/SlowFramesConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/configuration/SlowFramesConfiguration.kt
@@ -36,7 +36,7 @@ package com.datadog.android.rum.configuration
  * The default value is 5,000,000,000 ns (5 seconds).
  *
  * @param minViewLifetimeThresholdNs The minimum lifetime (in nanoseconds) a view must have before it is considered
- * for monitoring. The default value is 100,000,000 ns (1 s).
+ * for monitoring. The default value is 1,000,000,000 ns (1 s).
  */
 
 data class SlowFramesConfiguration(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/configuration/SlowFramesConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/configuration/SlowFramesConfiguration.kt
@@ -36,10 +36,10 @@ package com.datadog.android.rum.configuration
  * The default value is 5,000,000,000 ns (5 seconds).
  *
  * @param minViewLifetimeThresholdNs The minimum lifetime (in nanoseconds) a view must have before it is considered
- * for monitoring. The default value is 100,000,000 ns (100 ms).
+ * for monitoring. The default value is 100,000,000 ns (1 s).
  */
 
-data class SlowFrameListenerConfiguration(
+data class SlowFramesConfiguration(
     internal val maxSlowFramesAmount: Int = DEFAULT_SLOW_FRAME_RECORDS_MAX_AMOUNT,
     internal val maxSlowFrameThresholdNs: Long = DEFAULT_FROZEN_FRAME_THRESHOLD_NS,
     internal val continuousSlowFrameThresholdNs: Long = DEFAULT_CONTINUOUS_SLOW_FRAME_THRESHOLD_NS,
@@ -49,15 +49,15 @@ data class SlowFrameListenerConfiguration(
 
     companion object {
         /**
-         * A default configuration of the [SlowFrameListenerConfiguration] class with all parameters set to their default values.
+         * A default configuration of the [SlowFramesConfiguration] class with all parameters set to their default values.
          */
-        val DEFAULT: SlowFrameListenerConfiguration = SlowFrameListenerConfiguration()
+        val DEFAULT: SlowFramesConfiguration = SlowFramesConfiguration()
 
         // Taking into account each Hitch takes 64B in the payload, we can have 64KB max per view event
         private const val DEFAULT_SLOW_FRAME_RECORDS_MAX_AMOUNT: Int = 1000
         private const val DEFAULT_CONTINUOUS_SLOW_FRAME_THRESHOLD_NS: Long = 16_666_666L // 1/60 fps in nanoseconds
         private const val DEFAULT_FROZEN_FRAME_THRESHOLD_NS: Long = 700_000_000 // 700ms
         private const val DEFAULT_FREEZE_DURATION_NS: Long = 5_000_000_000L // 5s
-        private const val DEFAULT_VIEW_LIFETIME_THRESHOLD_NS: Long = 100_000_000L // 100ms
+        private const val DEFAULT_VIEW_LIFETIME_THRESHOLD_NS: Long = 1_000_000_000L // 1s
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
@@ -39,7 +39,7 @@ internal class RumApplicationScope(
     private val sessionListener: RumSessionListener?,
     internal val initialResourceIdentifier: InitialResourceIdentifier,
     internal val lastInteractionIdentifier: LastInteractionIdentifier?,
-    private val slowFramesListener: SlowFramesListener
+    private val slowFramesListener: SlowFramesListener?
 ) : RumScope, RumViewChangedListener {
 
     private var rumContext = RumContext(applicationId = applicationId)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -42,7 +42,7 @@ internal class RumSessionScope(
     applicationDisplayed: Boolean,
     networkSettledResourceIdentifier: InitialResourceIdentifier,
     lastInteractionIdentifier: LastInteractionIdentifier?,
-    slowFramesListener: SlowFramesListener,
+    slowFramesListener: SlowFramesListener?,
     private val sessionInactivityNanos: Long = DEFAULT_SESSION_INACTIVITY_NS,
     private val sessionMaxDurationNanos: Long = DEFAULT_SESSION_MAX_DURATION_NS
 ) : RumScope {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -46,7 +46,7 @@ internal class RumViewManagerScope(
     internal var applicationDisplayed: Boolean,
     internal val sampleRate: Float,
     internal val initialResourceIdentifier: InitialResourceIdentifier,
-    private val slowFramesListener: SlowFramesListener,
+    private val slowFramesListener: SlowFramesListener?,
     lastInteractionIdentifier: LastInteractionIdentifier?
 ) : RumScope {
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -71,7 +71,7 @@ internal open class RumViewScope(
     internal val sampleRate: Float,
     private val interactionToNextViewMetricResolver: InteractionToNextViewMetricResolver,
     private val networkSettledMetricResolver: NetworkSettledMetricResolver,
-    private val slowFramesListener: SlowFramesListener,
+    private val slowFramesListener: SlowFramesListener?,
     private val viewEndedMetricDispatcher: ViewMetricDispatcher
 ) : RumScope {
 
@@ -177,7 +177,7 @@ internal open class RumViewScope(
         }
         networkSettledMetricResolver.viewWasCreated(eventTime.nanoTime)
         interactionToNextViewMetricResolver.onViewCreated(viewId, eventTime.nanoTime)
-        slowFramesListener.onViewCreated(viewId, startedNanos)
+        slowFramesListener?.onViewCreated(viewId, startedNanos)
     }
 
     // region RumScope
@@ -898,8 +898,20 @@ internal open class RumViewScope(
         // make a copy - by the time we iterate over it on another thread, it may already be changed
         val eventFeatureFlags = featureFlags.toMutableMap()
         val eventAdditionalAttributes = (eventAttributes + globalAttributes).toMutableMap()
+        val uiSlownessReport = slowFramesListener?.resolveReport(viewId)
+        val slowFrames = uiSlownessReport?.slowFramesRecords?.map {
+            ViewEvent.SlowFrame(
+                start = it.startTimestampNs - startedNanos,
+                duration = it.durationNs
+            )
+        }
 
-        if (isViewComplete() && getRumContext().sessionState != RumSessionScope.State.NOT_TRACKED) {
+        // freezeRate and slowFramesRate should be sent only with StopView event
+        val viewCompletedWithStopEvent = viewComplete && event is RumRawEvent.StopView
+        val freezeRate = if (viewCompletedWithStopEvent) uiSlownessReport?.freezeFramesRate(stoppedNanos) else null
+        val slowFramesRate = if (viewCompletedWithStopEvent) uiSlownessReport?.slowFramesRate(stoppedNanos) else null
+
+        if (viewComplete && getRumContext().sessionState != RumSessionScope.State.NOT_TRACKED) {
             viewEndedMetricDispatcher.sendViewEnded(
                 interactionToNextViewMetricResolver.getState(viewId),
                 networkSettledMetricResolver.getState()
@@ -911,16 +923,6 @@ internal open class RumViewScope(
                 fbc = ViewEvent.Fbc(
                     timestamp = it.toLong()
                 )
-            )
-        }
-
-        val uiSlownessReport = slowFramesListener.resolveReport(viewId)
-        val freezeRate = uiSlownessReport.freezeFramesRate(stoppedNanos)
-        val slowFramesRate = uiSlownessReport.slowFramesRate(stoppedNanos)
-        val slowFrames = uiSlownessReport.slowFramesRecords.map {
-            ViewEvent.SlowFrame(
-                start = it.startTimestampNs - startedNanos,
-                duration = it.durationNs
             )
         }
 
@@ -1234,7 +1236,7 @@ internal open class RumViewScope(
         )
         val timestamp = event.eventTime.timestamp + serverTimeOffsetInMs
         val isFrozenFrame = event.durationNs > FROZEN_FRAME_THRESHOLD_NS
-        slowFramesListener.onAddLongTask(event.durationNs)
+        slowFramesListener?.onAddLongTask(event.durationNs)
         sdkCore.newRumEventWriteOperation(writer) { datadogContext ->
 
             val user = datadogContext.userInfo
@@ -1434,7 +1436,7 @@ internal open class RumViewScope(
             sampleRate: Float,
             interactionToNextViewMetricResolver: InteractionToNextViewMetricResolver,
             networkSettledResourceIdentifier: InitialResourceIdentifier,
-            slowFramesListener: SlowFramesListener
+            slowFramesListener: SlowFramesListener?
         ): RumViewScope {
             val networkSettledMetricResolver = NetworkSettledMetricResolver(
                 networkSettledResourceIdentifier,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -906,10 +906,10 @@ internal open class RumViewScope(
             )
         }
 
-        // freezeRate and slowFramesRate should be sent only with StopView event
-        val viewCompletedWithStopEvent = viewComplete && event is RumRawEvent.StopView
-        val freezeRate = if (viewCompletedWithStopEvent) uiSlownessReport?.freezeFramesRate(stoppedNanos) else null
-        val slowFramesRate = if (viewCompletedWithStopEvent) uiSlownessReport?.slowFramesRate(stoppedNanos) else null
+        // freezeRate and slowFramesRate should be sent with last view update for this view scope,
+        // that will happen when isViewComplete == true
+        val freezeRate = if (viewComplete) uiSlownessReport?.freezeFramesRate(stoppedNanos) else null
+        val slowFramesRate = if (viewComplete) uiSlownessReport?.slowFramesRate(stoppedNanos) else null
 
         if (viewComplete && getRumContext().sessionState != RumSessionScope.State.NOT_TRACKED) {
             viewEndedMetricDispatcher.sendViewEnded(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/state/ViewUIPerformanceReport.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/state/ViewUIPerformanceReport.kt
@@ -14,7 +14,7 @@ internal data class ViewUIPerformanceReport(
     var slowFramesRecords: Queue<SlowFrameRecord> = EvictingQueue(),
     var totalFramesDurationNs: Long = 0L,
     var slowFramesDurationNs: Long = 0L,
-    var anrDurationNs: Long = 0,
+    var freezeFramesDuration: Long = 0,
     val minViewLifetimeThresholdNs: Long = 0
 ) {
     constructor(
@@ -37,7 +37,7 @@ internal data class ViewUIPerformanceReport(
 
     fun slowFramesRate(viewEndedTimeStamp: Long): Double = when {
         viewEndedTimeStamp - viewStartedTimeStamp <= minViewLifetimeThresholdNs -> 0.0
-        totalFramesDurationNs > 0.0 -> slowFramesDurationNs.toDouble() / totalFramesDurationNs
+        totalFramesDurationNs > 0.0 -> slowFramesDurationNs.toDouble() / totalFramesDurationNs * MILLISECONDS_IN_SECOND
         else -> 0.0
     }
 
@@ -45,7 +45,12 @@ internal data class ViewUIPerformanceReport(
         viewEndedTimeStamp - viewStartedTimeStamp <= minViewLifetimeThresholdNs -> 0.0
         else -> max(
             0.0,
-            anrDurationNs.toDouble() / (viewEndedTimeStamp - viewStartedTimeStamp)
+            freezeFramesDuration.toDouble() / (viewEndedTimeStamp - viewStartedTimeStamp) * SECONDS_IN_HOUR
         )
+    }
+
+    companion object {
+        private const val MILLISECONDS_IN_SECOND = 1000
+        private const val SECONDS_IN_HOUR = 3600
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -77,7 +77,7 @@ internal class DatadogRumMonitor(
     internal val executorService: ExecutorService,
     initialResourceIdentifier: InitialResourceIdentifier,
     lastInteractionIdentifier: LastInteractionIdentifier?,
-    slowFramesListener: SlowFramesListener
+    slowFramesListener: SlowFramesListener?
 ) : RumMonitor, AdvancedRumMonitor {
 
     internal var rootScope: RumScope = RumApplicationScope(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
@@ -10,7 +10,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.event.EventMapper
 import com.datadog.android.event.NoOpEventMapper
 import com.datadog.android.rum.assertj.ConfigurationRumAssert
-import com.datadog.android.rum.configuration.SlowFrameListenerConfiguration
+import com.datadog.android.rum.configuration.SlowFramesConfiguration
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
 import com.datadog.android.rum.event.ViewEventMapper
 import com.datadog.android.rum.internal.NoOpRumSessionListener
@@ -108,7 +108,7 @@ internal class RumConfigurationBuilderTest {
                 initialResourceIdentifier = TimeBasedInitialResourceIdentifier(),
                 lastInteractionIdentifier = TimeBasedInteractionIdentifier(),
                 trackAnonymousUser = true,
-                slowFrameListenerConfiguration = null
+                slowFramesConfiguration = null
             )
         )
     }
@@ -583,15 +583,15 @@ internal class RumConfigurationBuilderTest {
     @Test
     fun `M use a custom slowFramesListenerConfiguration W setSlowFrameListenerConfiguration()`() {
         // Given
-        val slowFrameListenerConfiguration = mock<SlowFrameListenerConfiguration>()
+        val slowFramesConfiguration = mock<SlowFramesConfiguration>()
 
         // When
         val rumConfiguration = testedBuilder
-            .setSlowFrameListenerConfiguration(slowFrameListenerConfiguration)
+            .setSlowFrameListenerConfiguration(slowFramesConfiguration)
             .build()
 
         // Then
-        assertThat(rumConfiguration.featureConfiguration.slowFrameListenerConfiguration)
-            .isSameAs(slowFrameListenerConfiguration)
+        assertThat(rumConfiguration.featureConfiguration.slowFramesConfiguration)
+            .isSameAs(slowFramesConfiguration)
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
@@ -581,13 +581,13 @@ internal class RumConfigurationBuilderTest {
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M use a custom slowFramesListenerConfiguration W setSlowFrameListenerConfiguration()`() {
+    fun `M use a custom slowFramesConfiguration W setSlowFramesConfiguration()`() {
         // Given
         val slowFramesConfiguration = mock<SlowFramesConfiguration>()
 
         // When
         val rumConfiguration = testedBuilder
-            .setSlowFrameListenerConfiguration(slowFramesConfiguration)
+            .setSlowFramesConfiguration(slowFramesConfiguration)
             .build()
 
         // Then

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
@@ -589,8 +589,8 @@ internal class ViewEventAssert(actual: ViewEvent) :
 
     fun hasSlownessInfo(
         slowFrames: List<ViewEvent.SlowFrame>,
-        slowFramesRate: Double,
-        freezeRate: Double
+        slowFramesRate: Double? = null,
+        freezeRate: Double? = null
     ): ViewEventAssert = apply {
         assertThat(actual.view.slowFrames)
             .overridingErrorMessage(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -916,7 +916,11 @@ internal class RumViewScopeTest {
                     fakeDatadogContext.deviceInfo.osVersion,
                     fakeDatadogContext.deviceInfo.osMajorVersion
                 )
-                hasSlownessInfo(fakeSlowRecords)
+                hasSlownessInfo(
+                    fakeSlowRecords,
+                    fakeSlownessRate,
+                    fakeFreezeRate
+                )
                 hasConnectivityInfo(fakeDatadogContext.networkInfo)
                 hasServiceName(fakeDatadogContext.service)
                 hasVersion(fakeDatadogContext.version)
@@ -989,7 +993,11 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(fakeSlowRecords)
+                    hasSlownessInfo(
+                        fakeSlowRecords,
+                        fakeSlownessRate,
+                        fakeFreezeRate
+                    )
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -2948,7 +2956,11 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(fakeSlowRecords)
+                    hasSlownessInfo(
+                        fakeSlowRecords,
+                        fakeSlownessRate,
+                        fakeFreezeRate
+                    )
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -3042,7 +3054,11 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(fakeSlowRecords)
+                    hasSlownessInfo(
+                        fakeSlowRecords,
+                        fakeSlownessRate,
+                        fakeFreezeRate
+                    )
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -3146,7 +3162,11 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(fakeSlowRecords)
+                    hasSlownessInfo(
+                        fakeSlowRecords,
+                        fakeSlownessRate,
+                        fakeFreezeRate
+                    )
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -3242,7 +3262,11 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(fakeSlowRecords)
+                    hasSlownessInfo(
+                        fakeSlowRecords,
+                        fakeSlownessRate,
+                        fakeFreezeRate
+                    )
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -916,11 +916,7 @@ internal class RumViewScopeTest {
                     fakeDatadogContext.deviceInfo.osVersion,
                     fakeDatadogContext.deviceInfo.osMajorVersion
                 )
-                hasSlownessInfo(
-                    fakeSlowRecords,
-                    fakeSlownessRate,
-                    fakeFreezeRate
-                )
+                hasSlownessInfo(fakeSlowRecords)
                 hasConnectivityInfo(fakeDatadogContext.networkInfo)
                 hasServiceName(fakeDatadogContext.service)
                 hasVersion(fakeDatadogContext.version)
@@ -993,11 +989,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -1239,11 +1231,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -1321,11 +1309,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -1894,11 +1878,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -2011,11 +1991,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -2087,11 +2063,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -2183,11 +2155,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -2266,11 +2234,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -2371,11 +2335,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -2450,11 +2410,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -2549,11 +2505,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -2628,11 +2580,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -2705,11 +2653,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -2784,11 +2728,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -3008,11 +2948,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -3106,11 +3042,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -3214,11 +3146,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -3314,11 +3242,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -3543,11 +3467,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -6949,11 +6869,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -7033,11 +6949,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -7094,11 +7006,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -7193,11 +7101,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -7288,11 +7192,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -7385,11 +7285,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -7464,11 +7360,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -7733,11 +7625,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -7814,11 +7702,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -7894,11 +7778,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -7984,11 +7864,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
@@ -8074,11 +7950,7 @@ internal class RumViewScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasSlownessInfo(
-                        fakeSlowRecords,
-                        fakeSlownessRate,
-                        fakeFreezeRate
-                    )
+                    hasSlownessInfo(fakeSlowRecords)
                     hasConnectivityInfo(fakeDatadogContext.networkInfo)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/vitals/FPSVitalListenerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/vitals/FPSVitalListenerTest.kt
@@ -10,10 +10,10 @@ import androidx.metrics.performance.FrameData
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.rum.internal.domain.FrameMetricsData
-import com.datadog.android.rum.internal.vitals.JankStatsActivityLifecycleListenerTest.Companion.MAX_FPS
-import com.datadog.android.rum.internal.vitals.JankStatsActivityLifecycleListenerTest.Companion.MIN_FPS
-import com.datadog.android.rum.internal.vitals.JankStatsActivityLifecycleListenerTest.Companion.ONE_MILLISECOND_NS
-import com.datadog.android.rum.internal.vitals.JankStatsActivityLifecycleListenerTest.Companion.ONE_SECOND_NS
+import com.datadog.android.rum.internal.vitals.FrameStatesAggregatorTest.Companion.MAX_FPS
+import com.datadog.android.rum.internal.vitals.FrameStatesAggregatorTest.Companion.MIN_FPS
+import com.datadog.android.rum.internal.vitals.FrameStatesAggregatorTest.Companion.ONE_MILLISECOND_NS
+import com.datadog.android.rum.internal.vitals.FrameStatesAggregatorTest.Companion.ONE_SECOND_NS
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import fr.xgouchet.elmyr.annotation.BoolForgery

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/vitals/FrameStatesAggregatorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/vitals/FrameStatesAggregatorTest.kt
@@ -430,15 +430,12 @@ internal class FrameStatesAggregatorTest {
         internalLogger: InternalLogger = mockInternalLogger,
         jankStatsProvider: JankStatsProvider = mockJankStatsProvider,
         buildSdkVersionProvider: BuildSdkVersionProvider = mockBuildSdkVersionProvider
-    ): FrameStatesAggregator {
-        return FrameStatesAggregator(
-            internalLogger,
-            jankStatsProvider,
-            buildSdkVersionProvider
-        ).also {
-            delegates.forEach { delegate -> it.addListener(delegate) }
-        }
-    }
+    ) = FrameStatesAggregator(
+        delegates,
+        internalLogger,
+        jankStatsProvider,
+        buildSdkVersionProvider
+    )
 
     companion object {
         const val ONE_MILLISECOND_NS: Long = 1000L * 1000L

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.rum.utils.forge
 
-import com.datadog.android.rum.configuration.SlowFrameListenerConfiguration
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.metric.interactiontonextview.NoOpLastInteractionIdentifier
@@ -66,13 +65,7 @@ internal class ConfigurationRumForgeryFactory :
                 )
             ),
             trackAnonymousUser = forge.aBool(),
-            slowFrameListenerConfiguration = SlowFrameListenerConfiguration(
-                maxSlowFramesAmount = forge.anInt(min = 1),
-                maxSlowFrameThresholdNs = forge.aLong(min = 1),
-                continuousSlowFrameThresholdNs = forge.aLong(min = 1),
-                freezeDurationThreshold = forge.aLong(min = 1),
-                minViewLifetimeThresholdNs = forge.aLong(min = 1)
-            )
+            slowFramesConfiguration = forge.getForgery()
         )
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
@@ -53,7 +53,7 @@ internal class Configurator : BaseConfigurator() {
         forge.addFactory(FrameDataForgeryFactory())
         forge.addFactory(FrameMetricDataForgeryFactory())
         forge.addFactory(ViewUIPerformanceReportForgeryFactory())
-        forge.addFactory(SlowFrameListenerConfigurationForgeryFactory())
+        forge.addFactory(SlowFramesListenerConfigurationForgeryFactory())
 
         // Telemetry schema models
         forge.addFactory(TelemetryDebugEventForgeryFactory())

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
@@ -53,6 +53,7 @@ internal class Configurator : BaseConfigurator() {
         forge.addFactory(FrameDataForgeryFactory())
         forge.addFactory(FrameMetricDataForgeryFactory())
         forge.addFactory(ViewUIPerformanceReportForgeryFactory())
+        forge.addFactory(SlowFrameListenerConfigurationForgeryFactory())
 
         // Telemetry schema models
         forge.addFactory(TelemetryDebugEventForgeryFactory())

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/SlowFrameListenerConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/SlowFrameListenerConfigurationForgeryFactory.kt
@@ -16,6 +16,6 @@ internal class SlowFrameListenerConfigurationForgeryFactory : ForgeryFactory<Slo
         maxSlowFrameThresholdNs = forge.aLong(min = 0),
         continuousSlowFrameThresholdNs = forge.aLong(min = 0),
         freezeDurationThreshold = forge.aLong(min = 0),
-        minViewLifetimeThresholdNs = forge.aLong(min = 0),
+        minViewLifetimeThresholdNs = forge.aLong(min = 0)
     )
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/SlowFrameListenerConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/SlowFrameListenerConfigurationForgeryFactory.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.utils.forge
+
+import com.datadog.android.rum.configuration.SlowFramesConfiguration
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class SlowFrameListenerConfigurationForgeryFactory : ForgeryFactory<SlowFramesConfiguration> {
+    override fun getForgery(forge: Forge) = SlowFramesConfiguration(
+        maxSlowFramesAmount = forge.anInt(min = 0),
+        maxSlowFrameThresholdNs = forge.aLong(min = 0),
+        continuousSlowFrameThresholdNs = forge.aLong(min = 0),
+        freezeDurationThreshold = forge.aLong(min = 0),
+        minViewLifetimeThresholdNs = forge.aLong(min = 0),
+    )
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/SlowFramesListenerConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/SlowFramesListenerConfigurationForgeryFactory.kt
@@ -10,7 +10,7 @@ import com.datadog.android.rum.configuration.SlowFramesConfiguration
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
-internal class SlowFrameListenerConfigurationForgeryFactory : ForgeryFactory<SlowFramesConfiguration> {
+internal class SlowFramesListenerConfigurationForgeryFactory : ForgeryFactory<SlowFramesConfiguration> {
     override fun getForgery(forge: Forge) = SlowFramesConfiguration(
         maxSlowFramesAmount = forge.anInt(min = 0),
         maxSlowFrameThresholdNs = forge.aLong(min = 0),

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ViewUIPerformanceReportForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ViewUIPerformanceReportForgeryFactory.kt
@@ -25,7 +25,7 @@ internal class ViewUIPerformanceReportForgeryFactory : ForgeryFactory<ViewUIPerf
             }.toEvictingQueue(),
             totalFramesDurationNs = forge.aLong(min = 1),
             slowFramesDurationNs = forge.aLong(min = 0),
-            anrDurationNs = forge.aLong(min = 0),
+            freezeFramesDuration = forge.aLong(min = 0),
             minViewLifetimeThresholdNs = 0
         )
     }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -299,7 +299,7 @@ class SampleApplication : Application() {
             .trackUserInteractions()
             .trackLongTasks(250L)
             .trackNonFatalAnrs(true)
-            .setSlowFrameListenerConfiguration(SlowFramesConfiguration.DEFAULT)
+            .setSlowFramesConfiguration(SlowFramesConfiguration.DEFAULT)
             .setViewEventMapper { event ->
                 event.context?.additionalProperties?.put(ATTR_IS_MAPPED, true)
                 event

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -31,7 +31,7 @@ import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.Rum
 import com.datadog.android.rum.RumConfiguration
 import com.datadog.android.rum.RumErrorSource
-import com.datadog.android.rum.configuration.SlowFrameListenerConfiguration
+import com.datadog.android.rum.configuration.SlowFramesConfiguration
 import com.datadog.android.rum.tracking.NavigationViewTrackingStrategy
 import com.datadog.android.sample.data.db.LocalDataSource
 import com.datadog.android.sample.data.remote.RemoteDataSource
@@ -299,7 +299,7 @@ class SampleApplication : Application() {
             .trackUserInteractions()
             .trackLongTasks(250L)
             .trackNonFatalAnrs(true)
-            .setSlowFrameListenerConfiguration(SlowFrameListenerConfiguration.DEFAULT)
+            .setSlowFrameListenerConfiguration(SlowFramesConfiguration.DEFAULT)
             .setViewEventMapper { event ->
                 event.context?.additionalProperties?.put(ATTR_IS_MAPPED, true)
                 event


### PR DESCRIPTION
### What does this PR do?

In this PR I made several changes, mostly targeted to make implementation bit cleaner:

1.  Aligned threshold constants for `SlowFrameListener` with iOS.
2. `JankStatsActivityLifecycleListener`  renamed into FrameStatesAggregator as this name better represents responsibility of this class 
3. Initialization logic of `FrameStatesAggregator` refactored in `RumFeature` in order to avoid unpredictable behavior: `JankStatsActivityLifecycleListener` was initialized only within vital monitor logic when `VitalsUpdateFrequency` != `NEVER`
4. Fixed discrepancies with freezeRate and slowRate computation

### Additional Notes

PR targets into RUM-8654 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

