### PR TITLE
[RUM-9151]: fix issue with missing freeze rate and slow frames rate

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -898,7 +898,7 @@ internal open class RumViewScope(
         // make a copy - by the time we iterate over it on another thread, it may already be changed
         val eventFeatureFlags = featureFlags.toMutableMap()
         val eventAdditionalAttributes = (eventAttributes + globalAttributes).toMutableMap()
-        val uiSlownessReport = slowFramesListener?.resolveReport(viewId)
+        val uiSlownessReport = slowFramesListener?.resolveReport(viewId, viewComplete)
         val slowFrames = uiSlownessReport?.slowFramesRecords?.map {
             ViewEvent.SlowFrame(
                 start = it.startTimestampNs - startedNanos,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/slowframes/SlowFramesListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/slowframes/SlowFramesListener.kt
@@ -18,7 +18,7 @@ import kotlin.math.min
 
 internal interface SlowFramesListener : FrameStateListener {
     fun onViewCreated(viewId: String, startedTimestampNs: Long)
-    fun resolveReport(viewId: String): ViewUIPerformanceReport?
+    fun resolveReport(viewId: String, viewCompleted: Boolean): ViewUIPerformanceReport?
     fun onAddLongTask(durationNs: Long)
 }
 
@@ -41,9 +41,11 @@ internal class DefaultSlowFramesListener(
     }
 
     @MainThread
-    override fun resolveReport(viewId: String): ViewUIPerformanceReport? {
+    override fun resolveReport(viewId: String, viewCompleted: Boolean): ViewUIPerformanceReport? {
         @Suppress("UnsafeThirdPartyFunctionCall") // can't have NPE here
-        val report = slowFramesRecords.remove(viewId) ?: return null
+        val report = if (viewCompleted) slowFramesRecords.remove(viewId) else slowFramesRecords[viewId]
+
+        if (report == null) return null
 
         // making sure that report is not partially updated
         return synchronized(report) { report.copy() }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/slowframes/SlowFramesListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/slowframes/SlowFramesListener.kt
@@ -18,7 +18,7 @@ import kotlin.math.min
 
 internal interface SlowFramesListener : FrameStateListener {
     fun onViewCreated(viewId: String, startedTimestampNs: Long)
-    fun resolveReport(viewId: String, viewCompleted: Boolean): ViewUIPerformanceReport?
+    fun resolveReport(viewId: String, isViewCompleted: Boolean): ViewUIPerformanceReport?
     fun onAddLongTask(durationNs: Long)
 }
 
@@ -41,9 +41,9 @@ internal class DefaultSlowFramesListener(
     }
 
     @MainThread
-    override fun resolveReport(viewId: String, viewCompleted: Boolean): ViewUIPerformanceReport? {
+    override fun resolveReport(viewId: String, isViewCompleted: Boolean): ViewUIPerformanceReport? {
         @Suppress("UnsafeThirdPartyFunctionCall") // can't have NPE here
-        val report = if (viewCompleted) slowFramesRecords.remove(viewId) else slowFramesRecords[viewId]
+        val report = if (isViewCompleted) slowFramesRecords.remove(viewId) else slowFramesRecords[viewId]
 
         if (report == null) return null
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -131,7 +131,7 @@ internal class RumApplicationScopeTest {
         whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
         whenever(mockSdkCore.time) doReturn fakeTimeInfoAtScopeStart
         whenever(mockSdkCore.internalLogger) doReturn mock()
-        whenever(mockSlowFramesListener.resolveReport(any())) doReturn viewUIPerformanceReport
+        whenever(mockSlowFramesListener.resolveReport(any(), any())) doReturn viewUIPerformanceReport
 
         testedScope = RumApplicationScope(
             fakeApplicationId,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -144,7 +144,7 @@ internal class RumViewManagerScopeTest {
         whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
         whenever(mockChildScope.isActive()) doReturn true
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
-        whenever(mockSlowFramesListener.resolveReport(any())) doReturn fakeViewUIPerformanceReport
+        whenever(mockSlowFramesListener.resolveReport(any(), any())) doReturn fakeViewUIPerformanceReport
 
         testedScope = RumViewManagerScope(
             mockParentScope,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/slowframes/DefaultSlowFramesListenerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/slowframes/DefaultSlowFramesListenerTest.kt
@@ -61,7 +61,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(jankFrameData)
 
         // When
-        val report = checkNotNull(testedListener.resolveReport(viewId))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false))
 
         // Then
         assertThat(report.slowFramesRecords).hasSize(1)
@@ -74,19 +74,36 @@ internal class DefaultSlowFramesListenerTest {
     }
 
     @Test
-    fun `M return report only once W resolveReport`(forge: Forge) {
+    fun `M return report only once W resolveReport(viewId, true)`(forge: Forge) {
         // Given
         testedListener.onViewCreated(viewId, viewCreatedTimestampNs)
         val jankFrameData = forge.aFrameData()
         testedListener.onFrame(jankFrameData)
 
         // When
-        val report1 = checkNotNull(testedListener.resolveReport(viewId))
-        val report2 = testedListener.resolveReport(viewId)
+        val report1 = checkNotNull(testedListener.resolveReport(viewId, true))
+        val report2 = testedListener.resolveReport(viewId, false)
 
         // Then
         assertThat(report1.isEmpty()).isFalse()
         assertThat(report2).isNull()
+    }
+
+    @Test
+    fun `M return report same report W resolveReport(viewId, false)`(forge: Forge) {
+        // Given
+        testedListener.onViewCreated(viewId, viewCreatedTimestampNs)
+        val jankFrameData = forge.aFrameData()
+        testedListener.onFrame(jankFrameData)
+
+        // When
+        val report1 = checkNotNull(testedListener.resolveReport(viewId, false))
+        val report2 = checkNotNull(testedListener.resolveReport(viewId, false))
+
+        // Then
+        assertThat(report1).isEqualTo(report2)
+        assertThat(report1.isEmpty()).isFalse()
+        assertThat(report1.isEmpty()).isFalse()
     }
 
     @Test
@@ -97,7 +114,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(jankFrameData)
 
         // When
-        val report = checkNotNull(testedListener.resolveReport(viewId))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false))
 
         // Then
         assertThat(report.isEmpty()).isTrue()
@@ -111,7 +128,7 @@ internal class DefaultSlowFramesListenerTest {
 
         // When
         testedListener.onViewCreated(viewId + forge.aString(), viewCreatedTimestampNs)
-        val report = checkNotNull(testedListener.resolveReport(viewId))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false))
 
         // Then
         assertThat(report.slowFramesRecords).isNotEmpty()
@@ -124,7 +141,7 @@ internal class DefaultSlowFramesListenerTest {
 
         // When
         testedListener.onViewCreated(viewId, viewCreatedTimestampNs)
-        val report = testedListener.resolveReport(viewId)
+        val report = testedListener.resolveReport(viewId, false)
 
         // Then
         assertThat(report).isNull()
@@ -157,7 +174,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(jank2)
 
         // When
-        val report = checkNotNull(testedListener.resolveReport(viewId))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false))
 
         // Then
         assertThat(report.size).isEqualTo(1)
@@ -198,7 +215,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(jank2)
 
         // When
-        val report = checkNotNull(testedListener.resolveReport(viewId))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false))
 
         // Then
         assertThat(report.size).isEqualTo(2)
@@ -234,7 +251,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(jank)
 
         // When
-        val report = checkNotNull(testedListener.resolveReport(viewId))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false))
 
         // Then
         assertThat(report.size).isEqualTo(0)
@@ -267,7 +284,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(jank2)
 
         // When
-        val report = checkNotNull(testedListener.resolveReport(viewId))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false))
 
         // Then
         assertThat(report.size).isEqualTo(1)
@@ -298,7 +315,7 @@ internal class DefaultSlowFramesListenerTest {
         val expectedSlowFrameRate = expectedSlowFramesDuration.toDouble() / expectedTotalFrameDuration * 1000
 
         // When
-        val report = checkNotNull(testedListener.resolveReport(viewId))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false))
 
         // Then
         assertThat(report.slowFramesDurationNs)
@@ -312,7 +329,7 @@ internal class DefaultSlowFramesListenerTest {
     }
 
     @Test
-    fun `M return 0 W slowFramesRate W resolveReport { totalFramesDurationNs = 0 }`(
+    fun `M return W slowFramesRate { totalFramesDurationNs = 0 }`(
         @LongForgery(min = 1, max = MAX_DURATION_NS) viewDurationNs: Long,
         forge: Forge
     ) {
@@ -321,14 +338,14 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(forge.aFrameData(frameDurationUiNanos = 0))
 
         // When
-        val report = testedListener.resolveReport(viewId)
+        val report = testedListener.resolveReport(viewId, false)
 
         // Then
-        assertThat(checkNotNull(report).freezeFramesRate(viewDurationNs)).isZero()
+        assertThat(checkNotNull(report).slowFramesRate(viewDurationNs)).isZero()
     }
 
     @Test
-    fun `M return 0 W freezeFramesRate W resolveReport { totalFramesDurationNs = 0 }`(
+    fun `M return 0 W freezeFramesRate { totalFramesDurationNs = 0 }`(
         @LongForgery(min = 1, max = MAX_DURATION_NS) viewDurationNs: Long,
         forge: Forge
     ) {
@@ -337,7 +354,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(forge.aFrameData(frameDurationUiNanos = 0))
 
         // When
-        val report = testedListener.resolveReport(viewId)
+        val report = testedListener.resolveReport(viewId, false)
 
         // Then
         assertThat(checkNotNull(report).freezeFramesRate(viewDurationNs)).isZero()
@@ -380,7 +397,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onAddLongTask(longTaskDuration)
 
         // Then
-        val report = checkNotNull(testedListener.resolveReport(viewId))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false))
         assertThat(
             report.freezeFramesRate(viewEndedTimestampNs)
         ).isEqualTo(
@@ -389,7 +406,7 @@ internal class DefaultSlowFramesListenerTest {
     }
 
     @Test
-    fun `M return 0 freezeFramesRate W onAddLongTask { view lived less than minViewLifetimeThresholdNs }`(
+    fun `M return 0 W freezeFramesRate { view lived less than minViewLifetimeThresholdNs }`(
         @StringForgery viewId: String,
         @LongForgery(min = 1L, max = MAX_DURATION_NS) longTaskDuration: Long,
         @LongForgery(min = 100L, max = MAX_DURATION_NS) minViewLifetimeThresholdNs: Long
@@ -410,7 +427,7 @@ internal class DefaultSlowFramesListenerTest {
 
         // Then
         assertDoesNotThrow { // No ArithmeticException
-            val report = checkNotNull(testedListener.resolveReport(viewId))
+            val report = checkNotNull(testedListener.resolveReport(viewId, false))
             assertThat(report.freezeFramesRate(minViewLifetimeThresholdNs - 1)).isZero()
         }
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/slowframes/DefaultSlowFramesListenerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/slowframes/DefaultSlowFramesListenerTest.kt
@@ -329,7 +329,7 @@ internal class DefaultSlowFramesListenerTest {
     }
 
     @Test
-    fun `M return W slowFramesRate { totalFramesDurationNs = 0 }`(
+    fun `M return 0 slowFramesRate W resolveReport { totalFramesDurationNs = 0 }`(
         @LongForgery(min = 1, max = MAX_DURATION_NS) viewDurationNs: Long,
         forge: Forge
     ) {
@@ -345,7 +345,7 @@ internal class DefaultSlowFramesListenerTest {
     }
 
     @Test
-    fun `M return 0 W freezeFramesRate { totalFramesDurationNs = 0 }`(
+    fun `M return 0 freezeFramesRate W resolveReport { totalFramesDurationNs = 0 }`(
         @LongForgery(min = 1, max = MAX_DURATION_NS) viewDurationNs: Long,
         forge: Forge
     ) {
@@ -406,7 +406,7 @@ internal class DefaultSlowFramesListenerTest {
     }
 
     @Test
-    fun `M return 0 W freezeFramesRate { view lived less than minViewLifetimeThresholdNs }`(
+    fun `M return 0 freezeFramesRate W resolveReport { view lived less than minViewLifetimeThresholdNs }`(
         @StringForgery viewId: String,
         @LongForgery(min = 1L, max = MAX_DURATION_NS) longTaskDuration: Long,
         @LongForgery(min = 100L, max = MAX_DURATION_NS) minViewLifetimeThresholdNs: Long

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -190,7 +190,7 @@ internal class DatadogRumMonitorTest {
 
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockSdkCore.time) doReturn fakeTimeInfo
-        whenever(mockSlowFramesListener.resolveReport(any())) doReturn fakeViewUIPerformanceReport
+        whenever(mockSlowFramesListener.resolveReport(any(), any())) doReturn fakeViewUIPerformanceReport
 
         fakeAttributes = forge.exhaustiveAttributes()
         testedMonitor = DatadogRumMonitor(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/AddCustomTimingEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/AddCustomTimingEventForgeryFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.android.rum.utils.forge
+
+import com.datadog.android.rum.internal.domain.scope.RumRawEvent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class AddCustomTimingEventForgeryFactory : ForgeryFactory<RumRawEvent.AddCustomTiming> {
+    override fun getForgery(forge: Forge): RumRawEvent.AddCustomTiming {
+        return RumRawEvent.AddCustomTiming(
+            name = forge.aString()
+        )
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/AddErrorEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/AddErrorEventForgeryFactory.kt
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.android.rum.utils.forge
+
+import com.datadog.android.rum.RumErrorSource
+import com.datadog.android.rum.internal.RumErrorSourceType
+import com.datadog.android.rum.internal.domain.scope.RumRawEvent
+import com.datadog.tools.unit.forge.aThrowable
+import com.datadog.tools.unit.forge.exhaustiveAttributes
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class AddErrorEventForgeryFactory : ForgeryFactory<RumRawEvent.AddError> {
+    override fun getForgery(forge: Forge) = RumRawEvent.AddError(
+        message = forge.aString(),
+        sourceType = forge.aValueFrom(RumErrorSourceType::class.java),
+        source = forge.aValueFrom(RumErrorSource::class.java),
+        throwable = forge.aNullable { aThrowable() },
+        stacktrace = forge.aNullable { aString() },
+        isFatal = forge.aBool(),
+        attributes = forge.exhaustiveAttributes(),
+        type = forge.aNullable { aString() },
+        threads = forge.aList { getForgery() },
+        timeSinceAppStartNs = forge.aNullable { aPositiveLong() }
+    )
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/AddFeatureFlagEvaluationForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/AddFeatureFlagEvaluationForgeryFactory.kt
@@ -1,0 +1,17 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.android.rum.utils.forge
+
+import com.datadog.android.rum.internal.domain.scope.RumRawEvent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class AddFeatureFlagEvaluationForgeryFactory : ForgeryFactory<RumRawEvent.AddFeatureFlagEvaluation> {
+    override fun getForgery(forge: Forge) = RumRawEvent.AddFeatureFlagEvaluation(
+        name = forge.aString(),
+        value = forge.aString()
+    )
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/AddFeatureFlagEvaluationsForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/AddFeatureFlagEvaluationsForgeryFactory.kt
@@ -1,0 +1,16 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.android.rum.utils.forge
+
+import com.datadog.android.rum.internal.domain.scope.RumRawEvent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class AddFeatureFlagEvaluationsForgeryFactory : ForgeryFactory<RumRawEvent.AddFeatureFlagEvaluations> {
+    override fun getForgery(forge: Forge) = RumRawEvent.AddFeatureFlagEvaluations(
+        featureFlags = forge.aMap { aString() to aString() }
+    )
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
@@ -53,7 +53,7 @@ internal class Configurator : BaseConfigurator() {
         forge.addFactory(FrameDataForgeryFactory())
         forge.addFactory(FrameMetricDataForgeryFactory())
         forge.addFactory(ViewUIPerformanceReportForgeryFactory())
-        forge.addFactory(SlowFramesListenerConfigurationForgeryFactory())
+        forge.addFactory(SlowFramesConfigurationForgeryFactory())
 
         // Telemetry schema models
         forge.addFactory(TelemetryDebugEventForgeryFactory())
@@ -73,5 +73,12 @@ internal class Configurator : BaseConfigurator() {
         forge.addFactory(ActionSentForgeryFactory())
         forge.addFactory(ResourceSentForgeryFactory())
         forge.addFactory(ResourceDroppedForgeryFactory())
+        forge.addFactory(AddCustomTimingEventForgeryFactory())
+        forge.addFactory(AddErrorEventForgeryFactory())
+        forge.addFactory(AddFeatureFlagEvaluationForgeryFactory())
+        forge.addFactory(AddFeatureFlagEvaluationsForgeryFactory())
+        forge.addFactory(ErrorSentForgeryFactory())
+        forge.addFactory(KeepAliveForgeryFactory())
+        forge.addFactory(LongTaskSentForgeryFactory())
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ErrorSentForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ErrorSentForgeryFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.android.rum.utils.forge
+
+import com.datadog.android.rum.internal.domain.scope.RumRawEvent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class ErrorSentForgeryFactory : ForgeryFactory<RumRawEvent.ErrorSent> {
+    override fun getForgery(forge: Forge) = RumRawEvent.ErrorSent(
+        viewId = forge.aString(),
+        resourceId = forge.aNullable { aString() },
+        resourceEndTimestampInNanos = forge.aNullable { aPositiveLong() }
+    )
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/KeepAliveForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/KeepAliveForgeryFactory.kt
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.android.rum.utils.forge
+
+import com.datadog.android.rum.internal.domain.scope.RumRawEvent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class KeepAliveForgeryFactory : ForgeryFactory<RumRawEvent.KeepAlive> {
+    override fun getForgery(forge: Forge) = RumRawEvent.KeepAlive()
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/LongTaskSentForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/LongTaskSentForgeryFactory.kt
@@ -1,0 +1,17 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.android.rum.utils.forge
+
+import com.datadog.android.rum.internal.domain.scope.RumRawEvent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class LongTaskSentForgeryFactory : ForgeryFactory<RumRawEvent.LongTaskSent> {
+    override fun getForgery(forge: Forge) = RumRawEvent.LongTaskSent(
+        viewId = forge.aString(),
+        isFrozenFrame = forge.aBool()
+    )
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/SlowFramesConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/SlowFramesConfigurationForgeryFactory.kt
@@ -10,7 +10,7 @@ import com.datadog.android.rum.configuration.SlowFramesConfiguration
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
-internal class SlowFramesListenerConfigurationForgeryFactory : ForgeryFactory<SlowFramesConfiguration> {
+internal class SlowFramesConfigurationForgeryFactory : ForgeryFactory<SlowFramesConfiguration> {
     override fun getForgery(forge: Forge) = SlowFramesConfiguration(
         maxSlowFramesAmount = forge.anInt(min = 0),
         maxSlowFrameThresholdNs = forge.aLong(min = 0),


### PR DESCRIPTION
### What does this PR do?

Changes logic for ui slowness report a bit: now report is removed only when view is complete

### Motivation

We have an issue with `resolveReport` method implementation: report was removed from the map when `resolveReport`  is called, so in case if there are several events within the view scope -  report will be sent only for the first update

### Additional Notes

These changes should be part of the [main feature branch PR](https://github.com/DataDog/dd-sdk-android/pull/2518) but it was too big so I've decided to merge them separately

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

