### PR TITLE
[RUM-9154]: reverting back os version constraints to S for registerMetricsListener and unregisterMetricsListener

### DIFF
--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -234,8 +234,8 @@ public abstract interface class com/datadog/android/rum/RumSessionListener {
 public final class com/datadog/android/rum/_RumInternalProxy {
 	public static final field Companion Lcom/datadog/android/rum/_RumInternalProxy$Companion;
 	public final fun addLongTask (JLjava/lang/String;)V
-	public final fun setInternalViewAttribute (Ljava/lang/String;Ljava/lang/Object;)V
 	public final fun enableJankStatsTracking (Landroid/app/Activity;)V
+	public final fun setInternalViewAttribute (Ljava/lang/String;Ljava/lang/Object;)V
 	public final fun setSyntheticsAttribute (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun updatePerformanceMetric (Lcom/datadog/android/rum/RumPerformanceMetric;D)V
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/JankStatsActivityLifecycleListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/JankStatsActivityLifecycleListener.kt
@@ -143,7 +143,7 @@ internal class JankStatsActivityLifecycleListener(
         if (activeActivities[activity.window].isNullOrEmpty()) {
             activeWindowsListener.remove(activity.window)
             activeActivities.remove(activity.window)
-            if (buildSdkVersionProvider.version >= Build.VERSION_CODES.N) {
+            if (buildSdkVersionProvider.version >= Build.VERSION_CODES.S) {
                 unregisterMetricListener(activity.window)
             }
         }
@@ -204,7 +204,7 @@ internal class JankStatsActivityLifecycleListener(
     @SuppressLint("NewApi")
     @MainThread
     private fun trackWindowMetrics(isKnownWindow: Boolean, window: Window, activity: Activity) {
-        if (buildSdkVersionProvider.version >= Build.VERSION_CODES.N && !isKnownWindow) {
+        if (buildSdkVersionProvider.version >= Build.VERSION_CODES.S && !isKnownWindow) {
             registerMetricListener(window)
         } else if (display == null && buildSdkVersionProvider.version == Build.VERSION_CODES.R) {
             // Fallback - Android 30 allows apps to not run at a fixed 60hz, but didn't yet have
@@ -214,7 +214,9 @@ internal class JankStatsActivityLifecycleListener(
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.N)
+    // There is a bug in AndroidFramework that could throw NPE, so we subscribing to the FrameMetrics only since S
+    // https://github.com/DataDog/dd-sdk-android/issues/2556
+    @RequiresApi(Build.VERSION_CODES.S)
     private fun registerMetricListener(window: Window) {
         if (frameMetricsListener == null) {
             frameMetricsListener = DDFrameMetricsListener()
@@ -261,7 +263,9 @@ internal class JankStatsActivityLifecycleListener(
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.N)
+    // There is a bug in AndroidFramework that could throw NPE, so we subscribing to the FrameMetrics only since S
+    // https://github.com/DataDog/dd-sdk-android/issues/2556
+    @RequiresApi(Build.VERSION_CODES.S)
     private fun unregisterMetricListener(window: Window) {
         try {
             window.removeOnFrameMetricsAvailableListener(frameMetricsListener)


### PR DESCRIPTION
### What does this PR do?

* Reverting SDK constraints for  `registerMetricsListener` and `unregisterMetricsListener` to S
* Add tests  and comments to prevent this issue from happening in the future 

### Motivation

[Issue](https://github.com/DataDog/dd-sdk-android/issues/2556)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

