### PR TITLE
RUM-482: [Android] - Add traceSampleRate to Telemetry Configuration Event

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -512,13 +512,18 @@ internal class DatadogCore(
     private fun sendCoreConfigurationTelemetryEvent(configuration: Configuration) {
         val runnable = Runnable {
             val rumFeature = getFeature(Feature.RUM_FEATURE_NAME) ?: return@Runnable
+
+            val tracingFeatureContext = getFeatureContext(Feature.TRACING_FEATURE_NAME)
+            val okhttpInterceptorSamplingRate = tracingFeatureContext[OKHTTP_INTERCEPTOR_SAMPLE_RATE] as? Float?
+
             val event = InternalTelemetryEvent.Configuration(
                 trackErrors = configuration.crashReportsEnabled,
                 batchSize = configuration.coreConfig.batchSize.windowDurationMs,
                 useProxy = configuration.coreConfig.proxy != null,
                 useLocalEncryption = configuration.coreConfig.encryption != null,
                 batchUploadFrequency = configuration.coreConfig.uploadFrequency.baseStepMs,
-                batchProcessingLevel = configuration.coreConfig.batchProcessingLevel.maxBatchesPerUploadJob
+                batchProcessingLevel = configuration.coreConfig.batchProcessingLevel.maxBatchesPerUploadJob,
+                okhttpInterceptorSamplingRate = okhttpInterceptorSamplingRate
             )
             rumFeature.sendEvent(event)
         }
@@ -591,5 +596,7 @@ internal class DatadogCore(
 
         // fallback for APIs below Android N, see [DefaultAppStartTimeProvider].
         internal val startupTimeNs: Long = System.nanoTime()
+
+        internal const val OKHTTP_INTERCEPTOR_SAMPLE_RATE = "okhttp_interceptor_sampling_rate"
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
@@ -17,6 +17,7 @@ import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.DatadogCore
+import com.datadog.android.core.internal.DatadogCore.Companion.OKHTTP_INTERCEPTOR_SAMPLE_RATE
 import com.datadog.android.core.internal.SdkFeature
 import com.datadog.android.core.thread.FlushableExecutorService
 import com.datadog.android.error.internal.CrashReportsFeature
@@ -366,6 +367,14 @@ internal class DatadogCoreInitializationTest {
         val mockRumFeature = mock<SdkFeature>()
         testedCore.features += Feature.RUM_FEATURE_NAME to mockRumFeature
 
+        val mockTracingFeature = mock<SdkFeature>()
+        testedCore.features += Feature.TRACING_FEATURE_NAME to mockTracingFeature
+
+        val traceSampleRate = 42f
+        testedCore.updateFeatureContext(Feature.TRACING_FEATURE_NAME) {
+            it[OKHTTP_INTERCEPTOR_SAMPLE_RATE] = traceSampleRate
+        }
+
         testedCore.coreFeature.uploadExecutorService.queue
             .toTypedArray()
             .forEach {
@@ -388,6 +397,8 @@ internal class DatadogCoreInitializationTest {
                 .isEqualTo(configuration.coreConfig.batchProcessingLevel.maxBatchesPerUploadJob)
             assertThat(telemetryConfigurationEvent.useProxy)
                 .isEqualTo(configuration.coreConfig.proxy != null)
+            assertThat(telemetryConfigurationEvent.okhttpInterceptorSamplingRate)
+                .isEqualTo(traceSampleRate)
         }
     }
 

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -71,19 +71,21 @@ public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent
 }
 
 public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent$Configuration : com/datadog/android/internal/telemetry/InternalTelemetryEvent {
-	public fun <init> (ZJJZZI)V
+	public fun <init> (ZJJZZILjava/lang/Float;)V
 	public final fun component1 ()Z
 	public final fun component2 ()J
 	public final fun component3 ()J
 	public final fun component4 ()Z
 	public final fun component5 ()Z
 	public final fun component6 ()I
-	public final fun copy (ZJJZZI)Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$Configuration;
-	public static synthetic fun copy$default (Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$Configuration;ZJJZZIILjava/lang/Object;)Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$Configuration;
+	public final fun component7 ()Ljava/lang/Float;
+	public final fun copy (ZJJZZILjava/lang/Float;)Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$Configuration;
+	public static synthetic fun copy$default (Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$Configuration;ZJJZZILjava/lang/Float;ILjava/lang/Object;)Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$Configuration;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBatchProcessingLevel ()I
 	public final fun getBatchSize ()J
 	public final fun getBatchUploadFrequency ()J
+	public final fun getInterceptorsSamplingRate ()Ljava/lang/Float;
 	public final fun getTrackErrors ()Z
 	public final fun getUseLocalEncryption ()Z
 	public final fun getUseProxy ()Z

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/telemetry/InternalTelemetryEvent.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/telemetry/InternalTelemetryEvent.kt
@@ -40,7 +40,8 @@ sealed class InternalTelemetryEvent {
         val batchUploadFrequency: Long,
         val useProxy: Boolean,
         val useLocalEncryption: Boolean,
-        val batchProcessingLevel: Int
+        val batchProcessingLevel: Int,
+        val okhttpInterceptorSamplingRate: Float?
     ) : InternalTelemetryEvent()
 
     data class Metric(

--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/InternalTelemetryConfigurationForgeryFactory.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/InternalTelemetryConfigurationForgeryFactory.kt
@@ -19,7 +19,8 @@ class InternalTelemetryConfigurationForgeryFactory : ForgeryFactory<InternalTele
             batchProcessingLevel = forge.anInt(),
             batchUploadFrequency = forge.aLong(),
             useProxy = forge.aBool(),
-            useLocalEncryption = forge.aBool()
+            useLocalEncryption = forge.aBool(),
+            okhttpInterceptorSamplingRate = forge.aFloat(min = 0f, max = 100f)
         )
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -369,7 +369,8 @@ internal class TelemetryEventHandler(
                     batchProcessingLevel = event.batchProcessingLevel.toLong(),
                     isMainProcess = datadogContext.processInfo.isMainProcess,
                     invTimeThresholdMs = invTimeBasedThreshold,
-                    tnsTimeThresholdMs = tnsTimeBasedThreshold
+                    tnsTimeThresholdMs = tnsTimeBasedThreshold,
+                    traceSampleRate = event.okhttpInterceptorSamplingRate?.toLong()
                 )
             )
         )

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryConfigurationEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryConfigurationEventAssert.kt
@@ -290,6 +290,16 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         return this
     }
 
+    fun hasOkhttpInterceptorSamplingRate(expected: Float?): TelemetryConfigurationEventAssert {
+        assertThat(actual.telemetry.configuration.traceSampleRate)
+            .overridingErrorMessage(
+                "Expected event data to have telemetry.configuration.traceSampleRate" +
+                    " $expected but was ${actual.telemetry.configuration.traceSampleRate}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
     fun hasTnsTimeBasedThreshold(expected: Long?): TelemetryConfigurationEventAssert {
         assertThat(actual.telemetry.configuration.tnsTimeThresholdMs)
             .overridingErrorMessage(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -1548,6 +1548,7 @@ internal class TelemetryEventHandlerTest {
             .hasUseProxy(internalConfigurationEvent.useProxy)
             .hasUseLocalEncryption(internalConfigurationEvent.useLocalEncryption)
             .hasIsMainProcess(fakeDatadogContext.processInfo.isMainProcess)
+            .hasOkhttpInterceptorSamplingRate(internalConfigurationEvent.okhttpInterceptorSamplingRate)
     }
 
     private fun assertConfigEventMatchesInternalEvent(
@@ -1567,6 +1568,7 @@ internal class TelemetryEventHandlerTest {
             .hasUseProxy(internalConfigurationEvent.useProxy)
             .hasUseLocalEncryption(internalConfigurationEvent.useLocalEncryption)
             .hasIsMainProcess(fakeDatadogContext.processInfo.isMainProcess)
+            .hasOkhttpInterceptorSamplingRate(internalConfigurationEvent.okhttpInterceptorSamplingRate)
     }
 
     private fun Forge.forgeWritableInternalTelemetryEvent(): InternalTelemetryEvent {

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -221,6 +221,15 @@ internal constructor(
         localTracerFactory = DEFAULT_LOCAL_TRACER_FACTORY
     )
 
+    init {
+        val sdkCore: FeatureSdkCore? = sdkCoreReference.get() as? FeatureSdkCore
+
+        sdkCore?.updateFeatureContext(Feature.TRACING_FEATURE_NAME) {
+            val samplingRate = traceSampler.getSampleRate()
+            it[OKHTTP_INTERCEPTOR_SAMPLE_RATE] = samplingRate
+        }
+    }
+
     // region Interceptor
 
     /** @inheritdoc */
@@ -983,5 +992,7 @@ internal constructor(
                     .setTracingHeaderTypes(tracingHeaderTypes)
                     .build()
             }
+
+        private const val OKHTTP_INTERCEPTOR_SAMPLE_RATE = "okhttp_interceptor_sampling_rate"
     }
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -82,28 +82,34 @@ class SampleApplication : Application() {
         "127.0.0.1"
     )
 
-    private val okHttpClient = OkHttpClient.Builder()
-        .addInterceptor(
-            DatadogInterceptor.Builder(tracedHosts)
-                .setTraceSampler(RateBasedSampler(100f))
-                .build()
-        )
-        .addNetworkInterceptor(
-            TracingInterceptor.Builder(tracedHosts)
-                .setTraceSampler(RateBasedSampler(100f))
-                .build()
-        )
-        .eventListenerFactory(DatadogEventListener.Factory())
-        .build()
+    private val okHttpClient by lazy {
+        OkHttpClient.Builder()
+            .addInterceptor(
+                DatadogInterceptor.Builder(tracedHosts)
+                    .setTraceSampler(RateBasedSampler(100f))
+                    .build()
+            )
+            .addNetworkInterceptor(
+                TracingInterceptor.Builder(tracedHosts)
+                    .setTraceSampler(RateBasedSampler(100f))
+                    .build()
+            )
+            .eventListenerFactory(DatadogEventListener.Factory())
+            .build()
+    }
 
-    private val retrofitClient = Retrofit.Builder()
-        .baseUrl("https://api.datadoghq.com/api/v2/")
-        .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
-        .addCallAdapterFactory(RxJava3CallAdapterFactory.createSynchronous())
-        .client(okHttpClient)
-        .build()
+    private val retrofitClient by lazy {
+        Retrofit.Builder()
+            .baseUrl("https://api.datadoghq.com/api/v2/")
+            .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
+            .addCallAdapterFactory(RxJava3CallAdapterFactory.createSynchronous())
+            .client(okHttpClient)
+            .build()
+    }
 
-    private val retrofitBaseDataSource = retrofitClient.create(RemoteDataSource::class.java)
+    private val retrofitBaseDataSource by lazy {
+        retrofitClient.create(RemoteDataSource::class.java)
+    }
 
     private val localServer = LocalServer()
 


### PR DESCRIPTION
### What does this PR do?

It adds a sampling rate from OkHttp interceptor to the telemetry configuration event. In the `init` block of `TracingInterceptor` we put the sampling rate into the feature context of the tracing feature. And then extract it in `DatadogCore.sendCoreConfigurationTelemetryEvent` when we send the event to the Rum feature.

Problems that remain unsolved:
1. If `TracingInterceptor` is created before `DatadogCore` then we will not send the sampling rate, because there is no way to submit the feature context without having an instance of `DatadogCore`. It happened in the sample app. I fixed it by making necessary things lazy.
2. There can be multiple instances of `TracingInterceptor` in the app and we don't know which one's sampling rate will be sent.

But for our purposes it looks like that these problems aren't blocking.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

