### PR TITLE
Remove the possibility to read Tracer config from env and from config file

### DIFF
--- a/features/dd-sdk-android-trace/src/main/java/com/datadog/legacy/trace/api/Config.java
+++ b/features/dd-sdk-android-trace/src/main/java/com/datadog/legacy/trace/api/Config.java
@@ -883,17 +883,7 @@ public class Config {
             return value;
         }
 
-        // If value not provided from system properties, looking at env variables
-        value = System.getenv(propertyNameToEnvironmentVariableName(name));
-        if (null != value) {
-            return value;
-        }
-
-        // If value is not defined yet, we look at properties optionally defined in a properties file
-        value = propertiesFromConfigFile.getProperty(systemPropertyName);
-        if (null != value) {
-            return value;
-        }
+        // getting setting from env or from config file is not supported on Android
 
         return defaultValue;
     }


### PR DESCRIPTION
### What does this PR do?

This PR removes the functionality of reading Tracer config from env variables and config file: both are options are not possible on Android.

It gives saves quite a good time during the Tracer initialization:

* before the change

![before the change](https://github.com/user-attachments/assets/af427ef0-de0f-4ef7-95c0-a3055f277ebd)

* after the change

![after the change](https://github.com/user-attachments/assets/cf273ce9-bf83-448d-9e2c-7edf10ab04af)

In theory, we can also remove config read from system properties (`System.getProperties`), but these ones can be set from the process (unlike env variables). Unlikely that it is used by any customer, but anyway removal of this block won't give a significant gain.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

