### PR TITLE
RUM-9309: Add `ActionTrackingStrategy` Interface to decouple find view logic

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -425,6 +425,7 @@ datadog:
       - "android.view.View.getTag(kotlin.Int)"
       - "android.view.View.hashCode()"
       - "android.view.View.post(java.lang.Runnable?)"
+      - "android.view.View.takeIf(kotlin.Function1)"
       - "android.view.View.setTag(kotlin.Int, kotlin.Any?)"
       - "android.view.ViewGroup.findViewById(kotlin.Int)"
       - "android.view.ViewGroup.getChildAt(kotlin.Int)"

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -246,6 +246,9 @@ open class com.datadog.android.rum.tracking.AcceptAllSupportFragments : Componen
   override fun getViewName(androidx.fragment.app.Fragment): String?
   override fun equals(Any?): Boolean
   override fun hashCode(): Int
+interface com.datadog.android.rum.tracking.ActionTrackingStrategy
+  fun findTargetForTap(android.view.View, Float, Float): ViewTarget?
+  fun findTargetForScroll(android.view.View, Float, Float): ViewTarget?
 abstract class com.datadog.android.rum.tracking.ActivityLifecycleTrackingStrategy : android.app.Application.ActivityLifecycleCallbacks, TrackingStrategy
   protected var sdkCore: com.datadog.android.api.feature.FeatureSdkCore
   override fun register(com.datadog.android.api.SdkCore, android.content.Context)
@@ -295,6 +298,8 @@ interface com.datadog.android.rum.tracking.TrackingStrategy
   fun unregister(android.content.Context?)
 interface com.datadog.android.rum.tracking.ViewAttributesProvider
   fun extractAttributes(android.view.View, MutableMap<String, Any?>)
+data class com.datadog.android.rum.tracking.ViewTarget
+  constructor(android.view.View? = null, String? = null)
 interface com.datadog.android.rum.tracking.ViewTrackingStrategy : TrackingStrategy
 class com.datadog.android.sqlite.DatadogDatabaseErrorHandler : android.database.DatabaseErrorHandler
   constructor(String? = null, android.database.DatabaseErrorHandler = DefaultDatabaseErrorHandler())

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -6777,6 +6777,11 @@ public class com/datadog/android/rum/tracking/AcceptAllSupportFragments : com/da
 	public fun hashCode ()I
 }
 
+public abstract interface class com/datadog/android/rum/tracking/ActionTrackingStrategy {
+	public abstract fun findTargetForScroll (Landroid/view/View;FF)Lcom/datadog/android/rum/tracking/ViewTarget;
+	public abstract fun findTargetForTap (Landroid/view/View;FF)Lcom/datadog/android/rum/tracking/ViewTarget;
+}
+
 public abstract class com/datadog/android/rum/tracking/ActivityLifecycleTrackingStrategy : android/app/Application$ActivityLifecycleCallbacks, com/datadog/android/rum/tracking/TrackingStrategy {
 	protected field sdkCore Lcom/datadog/android/api/feature/FeatureSdkCore;
 	public fun <init> ()V
@@ -6858,6 +6863,21 @@ public abstract interface class com/datadog/android/rum/tracking/TrackingStrateg
 
 public abstract interface class com/datadog/android/rum/tracking/ViewAttributesProvider {
 	public abstract fun extractAttributes (Landroid/view/View;Ljava/util/Map;)V
+}
+
+public final class com/datadog/android/rum/tracking/ViewTarget {
+	public fun <init> ()V
+	public fun <init> (Landroid/view/View;Ljava/lang/String;)V
+	public synthetic fun <init> (Landroid/view/View;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Landroid/view/View;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Landroid/view/View;Ljava/lang/String;)Lcom/datadog/android/rum/tracking/ViewTarget;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/tracking/ViewTarget;Landroid/view/View;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/tracking/ViewTarget;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTag ()Ljava/lang/String;
+	public final fun getView ()Landroid/view/View;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/datadog/android/rum/tracking/ViewTrackingStrategy : com/datadog/android/rum/tracking/TrackingStrategy {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AndroidActionTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AndroidActionTrackingStrategy.kt
@@ -1,0 +1,157 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.instrumentation.gestures
+
+import android.view.View
+import android.view.ViewGroup
+import android.widget.AbsListView
+import android.widget.ScrollView
+import androidx.core.view.ScrollingView
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.rum.internal.instrumentation.gestures.GesturesListener.Companion.MSG_NO_TARGET_SCROLL_SWIPE
+import com.datadog.android.rum.internal.instrumentation.gestures.GesturesListener.Companion.MSG_NO_TARGET_TAP
+import com.datadog.android.rum.tracking.ActionTrackingStrategy
+import com.datadog.android.rum.tracking.ViewTarget
+import java.util.LinkedList
+
+/**
+ * Implementation of [ActionTrackingStrategy] for Android View, used to locate the target view
+ * with given coordinates when tapping or scrolling on Android View.
+ *
+ * @param internalLogger used to log information when finding the view.
+ */
+internal class AndroidActionTrackingStrategy(
+    private val internalLogger: InternalLogger
+) : ActionTrackingStrategy {
+
+    private val coordinatesContainer = IntArray(2)
+
+    override fun findTargetForTap(decorView: View, x: Float, y: Float): ViewTarget {
+        val queue = LinkedList<View>()
+        queue.addFirst(decorView)
+        var target: View? = null
+        var notifyMissingTarget = true
+
+        while (queue.isNotEmpty()) {
+            // removeFirst can't fail because we checked isNotEmpty
+            @Suppress("UnsafeThirdPartyFunctionCall")
+            val view = queue.removeFirst()
+            // TODO RUM-9289: Move Jetpack Compose Logic to the Compose implementation.
+            if (queue.isEmpty() && isJetpackComposeView(view)) {
+                notifyMissingTarget = false
+            }
+
+            if (isValidTapTarget(view)) {
+                target = view
+            }
+
+            if (view is ViewGroup) {
+                handleViewGroup(view, x, y, queue, coordinatesContainer)
+            }
+        }
+
+        if (target == null && notifyMissingTarget) {
+            internalLogger.log(
+                InternalLogger.Level.INFO,
+                InternalLogger.Target.USER,
+                { MSG_NO_TARGET_TAP }
+            )
+        }
+        return ViewTarget(target)
+    }
+
+    override fun findTargetForScroll(decorView: View, x: Float, y: Float): ViewTarget? {
+        val queue = LinkedList<View>()
+        queue.add(decorView)
+
+        var notifyMissingTarget = true
+        while (queue.isNotEmpty()) {
+            // removeFirst can't fail because we checked isNotEmpty
+            @Suppress("UnsafeThirdPartyFunctionCall")
+            val view = queue.removeFirst()
+            if (queue.isEmpty() && isJetpackComposeView(view)) {
+                notifyMissingTarget = false
+            }
+
+            if (isValidScrollableTarget(view)) {
+                return ViewTarget(view)
+            }
+
+            if (view is ViewGroup) {
+                handleViewGroup(view, x, y, queue, coordinatesContainer)
+            }
+        }
+
+        if (notifyMissingTarget) {
+            internalLogger.log(
+                InternalLogger.Level.INFO,
+                InternalLogger.Target.USER,
+                { MSG_NO_TARGET_SCROLL_SWIPE }
+            )
+        }
+
+        return null
+    }
+
+    private fun isJetpackComposeView(view: View): Boolean {
+        // startsWith here is to make testing easier: mocks don't have name exactly
+        // like this, and writing manual stub is not possible, because some necessary
+        // methods are final.
+        return view::class.java.name.startsWith("androidx.compose.ui.platform.ComposeView")
+    }
+
+    private fun isValidTapTarget(view: View): Boolean {
+        return view.isClickable && view.isVisible
+    }
+
+    private val View.isVisible: Boolean
+        get() = visibility == View.VISIBLE
+
+    private fun handleViewGroup(
+        view: ViewGroup,
+        x: Float,
+        y: Float,
+        stack: LinkedList<View>,
+        coordinatesContainer: IntArray
+    ) {
+        if (!view.isVisible) return
+
+        for (i in 0 until view.childCount) {
+            val child = view.getChildAt(i)
+            if (hitTest(child, x, y, coordinatesContainer)) {
+                stack.add(child)
+            }
+        }
+    }
+
+    private fun hitTest(
+        view: View,
+        x: Float,
+        y: Float,
+        container: IntArray
+    ): Boolean {
+        @Suppress("UnsafeThirdPartyFunctionCall") // container always have the correct size
+        view.getLocationInWindow(container)
+        val vx = container[0]
+        val vy = container[1]
+        val w = view.width
+        val h = view.height
+
+        return !(x < vx || x > vx + w || y < vy || y > vy + h)
+    }
+
+    private fun isValidScrollableTarget(view: View): Boolean {
+        return view.isVisible && isScrollableView(view)
+    }
+
+    @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
+    private fun isScrollableView(view: View): Boolean {
+        return ScrollingView::class.java.isAssignableFrom(view.javaClass) ||
+            AbsListView::class.java.isAssignableFrom(view.javaClass) ||
+            ScrollView::class.java.isAssignableFrom(view.javaClass)
+    }
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActionTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActionTrackingStrategy.kt
@@ -1,0 +1,40 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.tracking
+
+import android.view.View
+import com.datadog.tools.annotation.NoOpImplementation
+
+/**
+ * Strategy interface for tracking user interaction targets within a UI,
+ * such as taps and scrolls.
+ */
+@NoOpImplementation
+interface ActionTrackingStrategy {
+
+    /**
+     * Finds the target element at the given screen coordinates in response to a tap action.
+     *
+     * @param decorView The root [View] of the current window hierarchy.
+     * @param x The X coordinate of the tap, in screen coordinates.
+     * @param y The Y coordinate of the tap, in screen coordinates.
+     * @return A [ViewTarget] representing the UI element found at the given location,
+     *         or `null` if no target was found.
+     */
+    fun findTargetForTap(decorView: View, x: Float, y: Float): ViewTarget?
+
+    /**
+     * Finds the target element at the given screen coordinates in response to a scroll action.
+     *
+     * @param decorView The root [View] of the current window hierarchy.
+     * @param x The X coordinate of the scroll event, in screen coordinates.
+     * @param y The Y coordinate of the scroll event, in screen coordinates.
+     * @return A [ViewTarget] representing the UI element found at the given location,
+     *         or `null` if no target was found.
+     */
+    fun findTargetForScroll(decorView: View, x: Float, y: Float): ViewTarget?
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ViewTarget.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ViewTarget.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.tracking
+
+import android.view.View
+
+/**
+ * Represents the result of locating a target view in response to a user interaction,
+ * such as a tap or scroll event in [GesturesListener].
+ *
+ * @property view The Android [View] that was found. If non-null, indicates a classic View was located.
+ * @property tag The semantics tag associated with a Jetpack Compose component. If non-null, indicates
+ *               that a Compose node with the given semantics tag was found.
+ *
+ * Only one of [view] or [tag] is expected to be non-null, depending on the UI framework used.
+ */
+data class ViewTarget(
+    val view: View? = null,
+    val tag: String? = null
+)


### PR DESCRIPTION
### What does this PR do?

Prior to this PR, `GesturesListener` is coupled with Android View framework to find a target view of user interaction, making it difficult to extend to Jetpack Compose.

To make the Jetpack compose view finding possible within `GesturesListener`, this PR adds an interface called `ActionTrackingStrategy`, and move all the Android View framework logic from `GestureListener` into the `AndroidActionTrackingStrategy` implementation.  This change makes `GesturesListener` agnostic about the view framework, prepares for the Compose actions tracking integration

### Motivation

RUM-9309

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

