### PR TITLE
RUM-9340: Fix RumAction Tap is added twice for every ACTION_UP

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesDetectorWrapper.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesDetectorWrapper.kt
@@ -24,7 +24,9 @@ internal class GesturesDetectorWrapper(
     )
 
     fun onTouchEvent(event: MotionEvent) {
-        defaultGesturesDetector.onTouchEvent(event)
+        if (defaultGesturesDetector.onTouchEvent(event)) {
+            return
+        }
         val action = event.actionMasked
         if (action == MotionEvent.ACTION_UP) {
             gestureListener.onUp(event)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
@@ -53,7 +53,7 @@ internal class GesturesListener(
     override fun onSingleTapUp(e: MotionEvent): Boolean {
         val decorView = windowReference.get()?.decorView
         handleTapUp(decorView, e)
-        return false
+        return true
     }
 
     override fun onDown(e: MotionEvent): Boolean {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesDetectorWrapperTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesDetectorWrapperTest.kt
@@ -19,8 +19,10 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -87,5 +89,21 @@ internal class GesturesDetectorWrapperTest {
         testedWrapper.onTouchEvent(event)
 
         verifyNoInteractions(mockGesturesDetectorListener)
+    }
+
+    @Test
+    fun `M not call 'onUp' W action up is consumed`() {
+        // Given
+        val event: MotionEvent = mock {
+            whenever(it.actionMasked).thenReturn(MotionEvent.ACTION_UP)
+        }
+        whenever(mockGesturesDetectorCompat.onTouchEvent(event)).thenReturn(true)
+
+        // When
+        testedWrapper.onTouchEvent(event)
+
+        // Given
+        verify(mockGesturesDetectorCompat).onTouchEvent(event)
+        verify(mockGesturesDetectorListener, never()).onUp(any())
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
@@ -24,6 +24,7 @@ import com.datadog.android.rum.utils.verifyLog
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
@@ -46,6 +47,24 @@ import java.lang.ref.WeakReference
 @ForgeConfiguration(Configurator::class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
+
+    @Test
+    fun `M return true W call onSingleTap()`(forge: Forge) {
+        // Given
+        val mockEvent: MotionEvent = forge.getForgery()
+        testedListener = GesturesListener(
+            rumMonitor.mockSdkCore,
+            WeakReference(mockWindow),
+            contextRef = WeakReference(mockAppContext),
+            internalLogger = mockInternalLogger
+        )
+
+        // When
+        val result = testedListener.onSingleTapUp(mockEvent)
+
+        // Then
+        assertThat(result).isTrue()
+    }
 
     @Test
     fun `onTap sends the right target when the ViewGroup and its child are both clickable`(


### PR DESCRIPTION
### What does this PR do?

Prior to this PR, `RumMonitor.addActions(RumActionType.Tap)` will always be called twice for a single tap action, this is because that in `GestureListener` both `onSingleTapUp` and `onUp` are called by `GesturesDetectorWrapper` when a ACTION_UP is received. both functions will call `addActions` for this tap.

The fix is to make `onSingleTapUp` return true, indicating that the tap is already consumed and should not be handled it again.

### Motivation

RUM-9340


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

