### PR TITLE
[RUM-9361] fixing negative values in slow frames, adjusting telemetry

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -898,7 +898,7 @@ internal open class RumViewScope(
         // make a copy - by the time we iterate over it on another thread, it may already be changed
         val eventFeatureFlags = featureFlags.toMutableMap()
         val eventAdditionalAttributes = (eventAttributes + globalAttributes).toMutableMap()
-        val uiSlownessReport = slowFramesListener?.resolveReport(viewId, viewComplete)
+        val uiSlownessReport = slowFramesListener?.resolveReport(viewId, viewComplete, durationNs)
         val slowFrames = uiSlownessReport?.slowFramesRecords?.map {
             ViewEvent.SlowFrame(
                 start = it.startTimestampNs - startedNanos,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/slowframes/SlowFramesListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/slowframes/SlowFramesListener.kt
@@ -16,7 +16,7 @@ import kotlin.math.min
 
 internal interface SlowFramesListener : FrameStateListener {
     fun onViewCreated(viewId: String, startedTimestampNs: Long)
-    fun resolveReport(viewId: String, isViewCompleted: Boolean, viewDuration: Long): ViewUIPerformanceReport?
+    fun resolveReport(viewId: String, isViewCompleted: Boolean, viewDurationNs: Long): ViewUIPerformanceReport?
     fun onAddLongTask(durationNs: Long)
 }
 
@@ -41,7 +41,11 @@ internal class DefaultSlowFramesListener(
     }
 
     // Called from the main thread
-    override fun resolveReport(viewId: String, isViewCompleted: Boolean, viewDuration: Long): ViewUIPerformanceReport? {
+    override fun resolveReport(
+        viewId: String,
+        isViewCompleted: Boolean,
+        viewDurationNs: Long
+    ): ViewUIPerformanceReport? {
         @Suppress("UnsafeThirdPartyFunctionCall") // can't have NPE here
         val report = if (isViewCompleted) slowFramesRecords.remove(viewId) else slowFramesRecords[viewId]
 
@@ -49,7 +53,7 @@ internal class DefaultSlowFramesListener(
 
         // making sure that report is not partially updated
         return synchronized(report) {
-            if (isViewCompleted) metricDispatcher.sendMetric(viewId, viewDuration)
+            if (isViewCompleted) metricDispatcher.sendMetric(viewId, viewDurationNs)
             report.copy()
         }
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/slowframes/SlowFramesListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/slowframes/SlowFramesListener.kt
@@ -58,6 +58,9 @@ internal class DefaultSlowFramesListener(
     override fun onFrame(volatileFrameData: FrameData) {
         val viewId = currentViewId
         if (viewId == null || volatileFrameData.frameStartNanos < currentViewStartedTimeStampNs) {
+            if (viewId != null) {
+                metricDispatcher.incrementMissedFrameCount(viewId)
+            }
             // Due to the asynchronous nature of collecting jank frames data, there is a possible situation where
             // androidx.performance.metrics started detecting jank frames on a previous view, but reported them after the new view
             // was started. In this case, we don't save this data, because the previous view has already

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/slowframes/SlowFramesListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/slowframes/SlowFramesListener.kt
@@ -16,7 +16,7 @@ import kotlin.math.min
 
 internal interface SlowFramesListener : FrameStateListener {
     fun onViewCreated(viewId: String, startedTimestampNs: Long)
-    fun resolveReport(viewId: String, isViewCompleted: Boolean): ViewUIPerformanceReport?
+    fun resolveReport(viewId: String, isViewCompleted: Boolean, viewDuration: Long): ViewUIPerformanceReport?
     fun onAddLongTask(durationNs: Long)
 }
 
@@ -41,7 +41,7 @@ internal class DefaultSlowFramesListener(
     }
 
     // Called from the main thread
-    override fun resolveReport(viewId: String, isViewCompleted: Boolean): ViewUIPerformanceReport? {
+    override fun resolveReport(viewId: String, isViewCompleted: Boolean, viewDuration: Long): ViewUIPerformanceReport? {
         @Suppress("UnsafeThirdPartyFunctionCall") // can't have NPE here
         val report = if (isViewCompleted) slowFramesRecords.remove(viewId) else slowFramesRecords[viewId]
 
@@ -49,7 +49,7 @@ internal class DefaultSlowFramesListener(
 
         // making sure that report is not partially updated
         return synchronized(report) {
-            if (isViewCompleted) metricDispatcher.sendMetric(viewId)
+            if (isViewCompleted) metricDispatcher.sendMetric(viewId, viewDuration)
             report.copy()
         }
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/slowframes/UISlownessMetricDispatcher.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/slowframes/UISlownessMetricDispatcher.kt
@@ -23,7 +23,7 @@ internal interface UISlownessMetricDispatcher {
 
     fun incrementMissedFrameCount(viewId: String)
 
-    fun sendMetric(viewId: String, viewDuration: Long)
+    fun sendMetric(viewId: String, viewDurationNs: Long)
 }
 
 internal class DefaultUISlownessMetricDispatcher(
@@ -61,7 +61,7 @@ internal class DefaultUISlownessMetricDispatcher(
     }
 
     // Called from the main thread
-    override fun sendMetric(viewId: String, viewDuration: Long) {
+    override fun sendMetric(viewId: String, viewDurationNs: Long) {
         val telemetry = viewTelemetry.remove(viewId)
         if (telemetry == null) {
             internalLogger.log(
@@ -79,7 +79,7 @@ internal class DefaultUISlownessMetricDispatcher(
                 slowFramesCount = telemetry.slowFramesCount.get(),
                 ignoredFramesCount = telemetry.ignoredFramesCount.get(),
                 missedFramesCount = telemetry.missedFrameCount.get(),
-                viewDuration = viewDuration
+                viewDurationNs = viewDurationNs
             )
         )
     }
@@ -88,13 +88,13 @@ internal class DefaultUISlownessMetricDispatcher(
         slowFramesCount: Int,
         ignoredFramesCount: Int,
         missedFramesCount: Int,
-        viewDuration: Long
+        viewDurationNs: Long
     ): Map<String, Any> = buildMap {
         put(KEY_METRIC_TYPE, VALUE_METRIC_TYPE)
         put(
             KEY_RUM_UI_SLOWNESS,
             buildMap {
-                put(KEY_VIEW_DURATION, viewDuration)
+                put(KEY_VIEW_DURATION, viewDurationNs)
                 put(
                     KEY_SLOW_FRAMES,
                     buildMap {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/slowframes/UISlownessMetricDispatcher.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/slowframes/UISlownessMetricDispatcher.kt
@@ -23,7 +23,7 @@ internal interface UISlownessMetricDispatcher {
 
     fun incrementMissedFrameCount(viewId: String)
 
-    fun sendMetric(viewId: String)
+    fun sendMetric(viewId: String, viewDuration: Long)
 }
 
 internal class DefaultUISlownessMetricDispatcher(
@@ -61,7 +61,7 @@ internal class DefaultUISlownessMetricDispatcher(
     }
 
     // Called from the main thread
-    override fun sendMetric(viewId: String) {
+    override fun sendMetric(viewId: String, viewDuration: Long) {
         val telemetry = viewTelemetry.remove(viewId)
         if (telemetry == null) {
             internalLogger.log(
@@ -79,6 +79,7 @@ internal class DefaultUISlownessMetricDispatcher(
                 slowFramesCount = telemetry.slowFramesCount.get(),
                 ignoredFramesCount = telemetry.ignoredFramesCount.get(),
                 missedFramesCount = telemetry.missedFrameCount.get(),
+                viewDuration = viewDuration
             )
         )
     }
@@ -86,12 +87,14 @@ internal class DefaultUISlownessMetricDispatcher(
     private fun buildMetricAttributesMap(
         slowFramesCount: Int,
         ignoredFramesCount: Int,
-        missedFramesCount: Int
+        missedFramesCount: Int,
+        viewDuration: Long
     ): Map<String, Any> = buildMap {
         put(KEY_METRIC_TYPE, VALUE_METRIC_TYPE)
         put(
             KEY_RUM_UI_SLOWNESS,
             buildMap {
+                put(KEY_VIEW_DURATION, viewDuration)
                 put(
                     KEY_SLOW_FRAMES,
                     buildMap {
@@ -125,6 +128,7 @@ internal class DefaultUISlownessMetricDispatcher(
 
         internal const val KEY_SLOW_FRAMES = "slow_frames"
         internal const val KEY_COUNT = "count"
+        internal const val KEY_VIEW_DURATION = "view_duration"
         internal const val KEY_IGNORED_COUNT = "ignored_count"
         internal const val KEY_MISSED_COUNT = "missed_count"
         internal const val KEY_CONFIG = "config"

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -131,7 +131,7 @@ internal class RumApplicationScopeTest {
         whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
         whenever(mockSdkCore.time) doReturn fakeTimeInfoAtScopeStart
         whenever(mockSdkCore.internalLogger) doReturn mock()
-        whenever(mockSlowFramesListener.resolveReport(any(), any())) doReturn viewUIPerformanceReport
+        whenever(mockSlowFramesListener.resolveReport(any(), any(), any())) doReturn viewUIPerformanceReport
 
         testedScope = RumApplicationScope(
             fakeApplicationId,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
@@ -26,10 +26,11 @@ internal fun Forge.interactiveRumRawEvent(): RumRawEvent {
     )
 }
 
-internal fun Forge.startViewEvent(): RumRawEvent.StartView {
+internal fun Forge.startViewEvent(eventTime: Time = Time()): RumRawEvent.StartView {
     return RumRawEvent.StartView(
         key = getForgery(),
-        attributes = exhaustiveAttributes()
+        attributes = exhaustiveAttributes(),
+        eventTime = eventTime
     )
 }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -144,7 +144,7 @@ internal class RumViewManagerScopeTest {
         whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
         whenever(mockChildScope.isActive()) doReturn true
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
-        whenever(mockSlowFramesListener.resolveReport(any(), any())) doReturn fakeViewUIPerformanceReport
+        whenever(mockSlowFramesListener.resolveReport(any(), any(), any())) doReturn fakeViewUIPerformanceReport
 
         testedScope = RumViewManagerScope(
             mockParentScope,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -235,7 +235,7 @@ internal class RumViewScopeTest {
     var fakeTrackFrustrations: Boolean = true
 
     @LongForgery(min = 1L)
-    var fakeViewDuration: Long = 0
+    var fakeViewDurationNs: Long = 0
 
     lateinit var fakeReplayStats: ViewEvent.ReplayStats
 
@@ -9632,14 +9632,14 @@ internal class RumViewScopeTest {
         fakeEvent = RumRawEvent.StopView(
             key = testedScope.key,
             attributes = forge.exhaustiveAttributes(),
-            eventTime = Time(nanoTime = fakeEventTime.nanoTime + fakeViewDuration)
+            eventTime = Time(nanoTime = fakeEventTime.nanoTime + fakeViewDurationNs)
         )
 
         // When
         testedScope.handleEvent(fakeEvent, mockWriter)
 
         // Then
-        verify(mockSlowFramesListener).resolveReport(testedScope.viewId, true, fakeViewDuration)
+        verify(mockSlowFramesListener).resolveReport(testedScope.viewId, true, fakeViewDurationNs)
     }
 
     @Test
@@ -9648,24 +9648,24 @@ internal class RumViewScopeTest {
     ) {
         // When
         testedScope.handleEvent(
-            forge.startViewEvent(eventTime = Time(nanoTime = fakeEventTime.nanoTime + fakeViewDuration)),
+            forge.startViewEvent(eventTime = Time(nanoTime = fakeEventTime.nanoTime + fakeViewDurationNs)),
             mockWriter
         )
 
         // Then
-        verify(mockSlowFramesListener).resolveReport(testedScope.viewId, true, fakeViewDuration)
+        verify(mockSlowFramesListener).resolveReport(testedScope.viewId, true, fakeViewDurationNs)
     }
 
     @Test
     fun `M call resolveReport(viewId, true, Long) of slowFramesListener W handleEvent(StopSession)`() {
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopSession(eventTime = Time(nanoTime = fakeEventTime.nanoTime + fakeViewDuration)),
+            RumRawEvent.StopSession(eventTime = Time(nanoTime = fakeEventTime.nanoTime + fakeViewDurationNs)),
             mockWriter
         )
 
         // Then
-        verify(mockSlowFramesListener).resolveReport(testedScope.viewId, true, fakeViewDuration)
+        verify(mockSlowFramesListener).resolveReport(testedScope.viewId, true, fakeViewDurationNs)
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/slowframes/DefaultSlowFramesListenerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/slowframes/DefaultSlowFramesListenerTest.kt
@@ -44,6 +44,9 @@ internal class DefaultSlowFramesListenerTest {
     @LongForgery(min = 1L, max = 10_000_000_000L)
     var viewCreatedTimestampNs: Long = 0L
 
+    @LongForgery(min = 1L, max = 10_000_000_000L)
+    var fakeViewDurationNs: Long = 0L
+
     @Mock
     lateinit var mockMetricDispatcher: UISlownessMetricDispatcher
 
@@ -67,7 +70,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(jankFrameData)
 
         // When
-        val report = checkNotNull(testedListener.resolveReport(viewId, false))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false, fakeViewDurationNs))
 
         // Then
         assertThat(report.slowFramesRecords).hasSize(1)
@@ -82,8 +85,8 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(jankFrameData)
 
         // When
-        val report1 = checkNotNull(testedListener.resolveReport(viewId, true))
-        val report2 = testedListener.resolveReport(viewId, false)
+        val report1 = checkNotNull(testedListener.resolveReport(viewId, true, fakeViewDurationNs))
+        val report2 = testedListener.resolveReport(viewId, false, fakeViewDurationNs)
 
         // Then
         assertThat(report1.isEmpty()).isFalse()
@@ -98,8 +101,8 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(jankFrameData)
 
         // When
-        val report1 = checkNotNull(testedListener.resolveReport(viewId, false))
-        val report2 = checkNotNull(testedListener.resolveReport(viewId, false))
+        val report1 = checkNotNull(testedListener.resolveReport(viewId, false, fakeViewDurationNs))
+        val report2 = checkNotNull(testedListener.resolveReport(viewId, false, fakeViewDurationNs))
 
         // Then
         assertThat(report1).isEqualTo(report2)
@@ -115,7 +118,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(jankFrameData)
 
         // When
-        val report = checkNotNull(testedListener.resolveReport(viewId, false))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false, fakeViewDurationNs))
 
         // Then
         assertThat(report.isEmpty()).isTrue()
@@ -129,7 +132,7 @@ internal class DefaultSlowFramesListenerTest {
 
         // When
         testedListener.onViewCreated(viewId + forge.aString(), viewCreatedTimestampNs)
-        val report = checkNotNull(testedListener.resolveReport(viewId, false))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false, fakeViewDurationNs))
 
         // Then
         assertThat(report.slowFramesRecords).isNotEmpty()
@@ -142,7 +145,7 @@ internal class DefaultSlowFramesListenerTest {
 
         // When
         testedListener.onViewCreated(viewId, viewCreatedTimestampNs)
-        val report = testedListener.resolveReport(viewId, false)
+        val report = testedListener.resolveReport(viewId, false, fakeViewDurationNs)
 
         // Then
         assertThat(report).isNull()
@@ -175,7 +178,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(jank2)
 
         // When
-        val report = checkNotNull(testedListener.resolveReport(viewId, false))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false, fakeViewDurationNs))
 
         // Then
         assertThat(report.size).isEqualTo(1)
@@ -215,7 +218,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(jank2)
 
         // When
-        val report = checkNotNull(testedListener.resolveReport(viewId, false))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false, fakeViewDurationNs))
 
         // Then
         assertThat(report.size).isEqualTo(2)
@@ -251,7 +254,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(jank)
 
         // When
-        val report = checkNotNull(testedListener.resolveReport(viewId, false))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false, fakeViewDurationNs))
 
         // Then
         assertThat(report.size).isEqualTo(0)
@@ -284,7 +287,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(jank2)
 
         // When
-        val report = checkNotNull(testedListener.resolveReport(viewId, false))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false, fakeViewDurationNs))
 
         // Then
         assertThat(report.size).isEqualTo(1)
@@ -312,7 +315,7 @@ internal class DefaultSlowFramesListenerTest {
         val expectedSlowFrameRate = expectedSlowFramesDuration.toDouble() / expectedTotalFrameDuration * 1000
 
         // When
-        val report = checkNotNull(testedListener.resolveReport(viewId, false))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false, fakeViewDurationNs))
 
         // Then
         assertThat(report.slowFramesDurationNs)
@@ -335,7 +338,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(forge.aFrameData(frameDurationUiNanos = 0))
 
         // When
-        val report = testedListener.resolveReport(viewId, false)
+        val report = testedListener.resolveReport(viewId, false, fakeViewDurationNs)
 
         // Then
         assertThat(checkNotNull(report).slowFramesRate(viewDurationNs)).isZero()
@@ -351,7 +354,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(forge.aFrameData(frameDurationUiNanos = 0))
 
         // When
-        val report = testedListener.resolveReport(viewId, false)
+        val report = testedListener.resolveReport(viewId, false, fakeViewDurationNs)
 
         // Then
         assertThat(checkNotNull(report).freezeFramesRate(viewDurationNs)).isZero()
@@ -394,7 +397,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onAddLongTask(longTaskDuration)
 
         // Then
-        val report = checkNotNull(testedListener.resolveReport(viewId, false))
+        val report = checkNotNull(testedListener.resolveReport(viewId, false, fakeViewDurationNs))
         assertThat(
             report.freezeFramesRate(viewEndedTimestampNs)
         ).isEqualTo(
@@ -424,7 +427,7 @@ internal class DefaultSlowFramesListenerTest {
 
         // Then
         assertDoesNotThrow { // No ArithmeticException
-            val report = checkNotNull(testedListener.resolveReport(viewId, false))
+            val report = checkNotNull(testedListener.resolveReport(viewId, false, fakeViewDurationNs))
             assertThat(report.freezeFramesRate(minViewLifetimeThresholdNs - 1)).isZero()
         }
     }
@@ -506,10 +509,10 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(forge.aFrameData())
 
         // When
-        testedListener.resolveReport(viewId, isViewCompleted = true)
+        testedListener.resolveReport(viewId, isViewCompleted = true, fakeViewDurationNs)
 
         // Then
-        verify(mockMetricDispatcher).sendMetric(viewId)
+        verify(mockMetricDispatcher).sendMetric(viewId, fakeViewDurationNs)
     }
 
     @Test
@@ -521,10 +524,10 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(forge.aFrameData())
 
         // When
-        testedListener.resolveReport(viewId, isViewCompleted = false)
+        testedListener.resolveReport(viewId, isViewCompleted = false, fakeViewDurationNs)
 
         // Then
-        verify(mockMetricDispatcher, never()).sendMetric(viewId)
+        verify(mockMetricDispatcher, never()).sendMetric(viewId, fakeViewDurationNs)
     }
 
     @Test
@@ -541,7 +544,7 @@ internal class DefaultSlowFramesListenerTest {
         testedListener.onFrame(validFrameData)
 
         // Then
-        val report = testedListener.resolveReport(viewId, true)
+        val report = testedListener.resolveReport(viewId, true, fakeViewDurationNs)
         val slowFrameRecords = report?.slowFramesRecords?.toList()
 
         assertThat(report).isNotNull

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/slowframes/DefaultSlowFramesListenerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/slowframes/DefaultSlowFramesListenerTest.kt
@@ -528,7 +528,7 @@ internal class DefaultSlowFramesListenerTest {
     }
 
     @Test
-    fun `M drop frame data if it started before view`(
+    fun `M drop frame data if it started before view W onFrame { missed frame }`(
         forge: Forge
     ) {
         // Given
@@ -548,6 +548,23 @@ internal class DefaultSlowFramesListenerTest {
         assertThat(report?.size).isOne()
         assertThat(slowFrameRecords).hasSize(1)
         assertThat(slowFrameRecords?.first()).isEqualTo(validFrameData.toSlowFrame())
+    }
+
+    @Test
+    fun `M incrementMissedFrameCount W onFrame { missed frame }`(
+        forge: Forge
+    ) {
+        // Given
+        val expiredFrameData = forge.aFrameData(frameStartNanos = viewCreatedTimestampNs - 1)
+        val validFrameData = forge.aFrameData(frameStartNanos = viewCreatedTimestampNs + 1)
+        testedListener.onViewCreated(viewId, viewCreatedTimestampNs)
+
+        // When
+        testedListener.onFrame(expiredFrameData)
+        testedListener.onFrame(validFrameData)
+
+        // Then
+        verify(mockMetricDispatcher).incrementMissedFrameCount(viewId)
     }
 
     private fun FrameData.toSlowFrame(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/slowframes/DefaultUISlownessMetricDispatcherTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/slowframes/DefaultUISlownessMetricDispatcherTest.kt
@@ -10,6 +10,7 @@ import com.datadog.android.api.InternalLogger.Target
 import com.datadog.android.rum.configuration.SlowFramesConfiguration
 import com.datadog.android.rum.internal.metric.slowframes.DefaultUISlownessMetricDispatcher.Companion.KEY_COUNT
 import com.datadog.android.rum.internal.metric.slowframes.DefaultUISlownessMetricDispatcher.Companion.KEY_IGNORED_COUNT
+import com.datadog.android.rum.internal.metric.slowframes.DefaultUISlownessMetricDispatcher.Companion.KEY_MISSED_COUNT
 import com.datadog.android.rum.internal.metric.slowframes.DefaultUISlownessMetricDispatcher.Companion.KEY_RUM_UI_SLOWNESS
 import com.datadog.android.rum.internal.metric.slowframes.DefaultUISlownessMetricDispatcher.Companion.KEY_SLOW_FRAMES
 import com.datadog.android.rum.utils.forge.Configurator
@@ -97,6 +98,24 @@ internal class DefaultUISlownessMetricDispatcherTest {
         verify(mockInternalLogger).logMetric(
             argThat { invoke() == DefaultUISlownessMetricDispatcher.UI_SLOWNESS_MESSAGE },
             argThat { hasExpectedValue(1, KEY_RUM_UI_SLOWNESS, KEY_SLOW_FRAMES, KEY_IGNORED_COUNT) },
+            eq(fakeSamplingRate),
+            eq(null)
+        )
+    }
+
+    @Test
+    fun `M increment missedFramesCount W incrementMissedFrameCount`() {
+        // Given
+        testedDispatcher.onViewCreated(fakeViewId)
+
+        // When
+        testedDispatcher.incrementMissedFrameCount(fakeViewId)
+        testedDispatcher.sendMetric(fakeViewId)
+
+        // Then
+        verify(mockInternalLogger).logMetric(
+            argThat { invoke() == DefaultUISlownessMetricDispatcher.UI_SLOWNESS_MESSAGE },
+            argThat { hasExpectedValue(1, KEY_RUM_UI_SLOWNESS, KEY_SLOW_FRAMES, KEY_MISSED_COUNT) },
             eq(fakeSamplingRate),
             eq(null)
         )

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/slowframes/DefaultUISlownessMetricDispatcherTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/slowframes/DefaultUISlownessMetricDispatcherTest.kt
@@ -53,7 +53,7 @@ internal class DefaultUISlownessMetricDispatcherTest {
     var fakeSamplingRate: Float = 0f
 
     @LongForgery(min = 1, max = 100)
-    var fakeViewDuration: Long = 0
+    var fakeViewDurationNs: Long = 0
 
     @Forgery
     lateinit var fakeSlowFramesConfiguration: SlowFramesConfiguration
@@ -79,7 +79,7 @@ internal class DefaultUISlownessMetricDispatcherTest {
 
         // When
         testedDispatcher.incrementSlowFrameCount(fakeViewId)
-        testedDispatcher.sendMetric(fakeViewId, fakeViewDuration)
+        testedDispatcher.sendMetric(fakeViewId, fakeViewDurationNs)
 
         // Then
         verify(mockInternalLogger).logMetric(
@@ -97,7 +97,7 @@ internal class DefaultUISlownessMetricDispatcherTest {
 
         // When
         testedDispatcher.incrementIgnoredFrameCount(fakeViewId)
-        testedDispatcher.sendMetric(fakeViewId, fakeViewDuration)
+        testedDispatcher.sendMetric(fakeViewId, fakeViewDurationNs)
 
         // Then
         verify(mockInternalLogger).logMetric(
@@ -115,7 +115,7 @@ internal class DefaultUISlownessMetricDispatcherTest {
 
         // When
         testedDispatcher.incrementMissedFrameCount(fakeViewId)
-        testedDispatcher.sendMetric(fakeViewId, fakeViewDuration)
+        testedDispatcher.sendMetric(fakeViewId, fakeViewDurationNs)
 
         // Then
         verify(mockInternalLogger).logMetric(
@@ -133,12 +133,12 @@ internal class DefaultUISlownessMetricDispatcherTest {
 
         // When
         testedDispatcher.incrementMissedFrameCount(fakeViewId)
-        testedDispatcher.sendMetric(fakeViewId, fakeViewDuration)
+        testedDispatcher.sendMetric(fakeViewId, fakeViewDurationNs)
 
         // Then
         verify(mockInternalLogger).logMetric(
             argThat { invoke() == DefaultUISlownessMetricDispatcher.UI_SLOWNESS_MESSAGE },
-            argThat { hasExpectedValue(fakeViewDuration, KEY_RUM_UI_SLOWNESS, KEY_VIEW_DURATION) },
+            argThat { hasExpectedValue(fakeViewDurationNs, KEY_RUM_UI_SLOWNESS, KEY_VIEW_DURATION) },
             eq(fakeSamplingRate),
             eq(null)
         )
@@ -150,8 +150,8 @@ internal class DefaultUISlownessMetricDispatcherTest {
         testedDispatcher.onViewCreated(fakeViewId)
 
         // When
-        testedDispatcher.sendMetric(fakeViewId, fakeViewDuration)
-        testedDispatcher.sendMetric(fakeViewId, fakeViewDuration)
+        testedDispatcher.sendMetric(fakeViewId, fakeViewDurationNs)
+        testedDispatcher.sendMetric(fakeViewId, fakeViewDurationNs)
 
         // Then
         verify(mockInternalLogger).logMetric(
@@ -168,8 +168,8 @@ internal class DefaultUISlownessMetricDispatcherTest {
         testedDispatcher.onViewCreated(fakeViewId)
 
         // When
-        testedDispatcher.sendMetric(fakeViewId, fakeViewDuration)
-        testedDispatcher.sendMetric(fakeViewId, fakeViewDuration)
+        testedDispatcher.sendMetric(fakeViewId, fakeViewDurationNs)
+        testedDispatcher.sendMetric(fakeViewId, fakeViewDurationNs)
 
         // Then
         verify(mockInternalLogger).log(
@@ -192,7 +192,7 @@ internal class DefaultUISlownessMetricDispatcherTest {
         testedDispatcher.onViewCreated(fakeViewId)
 
         // When
-        testedDispatcher.sendMetric(fakeViewId, fakeViewDuration)
+        testedDispatcher.sendMetric(fakeViewId, fakeViewDurationNs)
 
         // Then
         verify(mockInternalLogger).logMetric(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -190,7 +190,7 @@ internal class DatadogRumMonitorTest {
 
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockSdkCore.time) doReturn fakeTimeInfo
-        whenever(mockSlowFramesListener.resolveReport(any(), any())) doReturn fakeViewUIPerformanceReport
+        whenever(mockSlowFramesListener.resolveReport(any(), any(), any())) doReturn fakeViewUIPerformanceReport
 
         fakeAttributes = forge.exhaustiveAttributes()
         testedMonitor = DatadogRumMonitor(


### PR DESCRIPTION
### What does this PR do?

* Fixes negative value for `start` variable for slow frames record
* Adds `missed_count` for ui slowness telemetry to see how often such events occurs 
* Adds `view_duration` value to align with iOS implementation


### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

