### PR TITLE
Merge feature/compose-instrumentation api into feature/actions-tracking

### DIFF
--- a/integrations/dd-sdk-android-compose/api/apiSurface
+++ b/integrations/dd-sdk-android-compose/api/apiSurface
@@ -1,3 +1,4 @@
+fun androidx.compose.ui.Modifier.datadog(String, Boolean = false): androidx.compose.ui.Modifier
 annotation com.datadog.android.compose.ExperimentalTrackingApi
 fun trackClick(String, Map<String, Any?> = remember { emptyMap() }, com.datadog.android.api.SdkCore = Datadog.getInstance(), () -> Unit): () -> Unit
 fun TrackInteractionEffect(String, androidx.compose.foundation.interaction.InteractionSource, InteractionType, Map<String, Any?> = emptyMap(), com.datadog.android.api.SdkCore = Datadog.getInstance())
@@ -7,3 +8,5 @@ sealed class com.datadog.android.compose.InteractionType
   class Scroll : InteractionType
     constructor(androidx.compose.foundation.gestures.ScrollableState, androidx.compose.foundation.gestures.Orientation, Boolean = false)
 fun NavigationViewTrackingEffect(androidx.navigation.NavController, Boolean = true, com.datadog.android.rum.tracking.ComponentPredicate<androidx.navigation.NavDestination> = AcceptAllNavDestinations(), com.datadog.android.api.SdkCore = Datadog.getInstance())
+annotation com.datadog.android.compose.RecordImages
+annotation com.datadog.android.compose.TrackViews

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/DatadogModifier.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/DatadogModifier.kt
@@ -1,0 +1,42 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.compose
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import androidx.compose.ui.semantics.semantics
+
+/**
+ * Adds Datadog-specific semantic information to the layout node for the Session Replay feature.
+ *
+ * This modifier ensures that the component is included in the semantics tree, allowing
+ * Session Replay to identify and interpret it correctly during recording.
+ *
+ * @param name The name of the component to be displayed in the semantics tree.
+ * @param isImage Set to `true` if the component represents an image. This helps Session Replay
+ *                attempt to resolve and capture the image content appropriately.
+ */
+fun Modifier.datadog(name: String, isImage: Boolean = false): Modifier {
+    return this.semantics {
+        this.datadog = name
+        if (isImage) {
+            this[SemanticsProperties.Role] = Role.Image
+        }
+    }
+}
+
+internal val DatadogSemanticsPropertyKey: SemanticsPropertyKey<String> = SemanticsPropertyKey(
+    name = "_dd_semantics",
+    mergePolicy = { parentValue, _ ->
+        parentValue
+    }
+)
+
+private var SemanticsPropertyReceiver.datadog by DatadogSemanticsPropertyKey

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/RecordImages.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/RecordImages.kt
@@ -1,0 +1,12 @@
+package com.datadog.android.compose
+
+/**
+ * Indicates that the annotated composable function should be instrumented for
+ * the Session Replay image recording.
+ *
+ * When this annotation is applied, the Datadog compiler plugin will automatically
+ * apply the [datadog] modifier to all components within the function, ensuring they
+ * are included in the semantics tree and can be recorded appropriately.
+ */
+@Retention(AnnotationRetention.SOURCE)
+annotation class RecordImages

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/TrackViews.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/TrackViews.kt
@@ -1,0 +1,12 @@
+package com.datadog.android.compose
+
+/**
+ * Indicates that the annotated composable function should be instrumented for
+ * the RUM view tracking.
+ *
+ * When this annotation is applied, the Datadog compiler plugin will automatically
+ * apply [NavigationViewTrackingEffect] to [NavHost] within the function, ensuring they
+ * the compose navigation can be tracked by RUM.
+ */
+@Retention(AnnotationRetention.SOURCE)
+annotation class TrackViews


### PR DESCRIPTION
### What does this PR do?

`datadog` Modifier API is necessary for compose actions tracking, so merge feature branch of the instrumentation api into feature branch of actions tracking.

NOTE: this commit has already been reviewed before.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

