### PR TITLE
Remove test fixtures content root duplication in `dd-sdk-android-session-replay-compose` module

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-compose/build.gradle.kts
@@ -49,11 +49,6 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion = libs.versions.androidXComposeCompilerExtension.get()
     }
-
-    sourceSets.named("test") {
-        // Required because AGP doesn't support kotlin test fixtures :/
-        java.srcDirs("${project.rootDir.path}/dd-sdk-android-core/src/testFixtures/kotlin")
-    }
 }
 
 dependencies {


### PR DESCRIPTION
### What does this PR do?

Minor follow-up for https://github.com/DataDog/dd-sdk-android/pull/2234: there was one entry that added duplicate context root causing a warning in Android Studio.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

