### PR TITLE
RUM-9427: Add telemetry for compose instrumentation functions

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -522,6 +522,7 @@ datadog:
       - "androidx.compose.runtime.Composition.takeIf(kotlin.Function1)"
       - "androidx.compose.runtime.DisposableEffect(kotlin.Any?, kotlin.Any?, kotlin.Function1)"
       - "androidx.compose.runtime.DisposableEffectScope.onDispose(kotlin.Function0)"
+      - "androidx.compose.runtime.LaunchedEffect(kotlin.Any?, kotlin.coroutines.SuspendFunction1)"
       - "androidx.compose.runtime.LaunchedEffect(kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.coroutines.SuspendFunction1)"
       - "androidx.compose.runtime.remember(kotlin.Any?, kotlin.Any?, kotlin.Function0)"
       - "androidx.compose.runtime.remember(kotlin.Function0)"

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/DatadogModifier.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/DatadogModifier.kt
@@ -3,6 +3,7 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2016-Present Datadog, Inc.
  */
+@file:Suppress("PackageNameVisibility")
 
 package com.datadog.android.compose
 
@@ -12,6 +13,8 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.semantics
+import com.datadog.android.compose.internal.InstrumentationType
+import com.datadog.android.compose.internal.sendTelemetry
 
 /**
  * Adds Datadog-specific semantic information to the layout node for the Session Replay feature.
@@ -24,6 +27,20 @@ import androidx.compose.ui.semantics.semantics
  *                attempt to resolve and capture the image content appropriately.
  */
 fun Modifier.datadog(name: String, isImage: Boolean = false): Modifier {
+    sendTelemetry(autoInstrumented = false, InstrumentationType.Semantics)
+    return this.datadogSemantics(name, isImage)
+}
+
+/**
+ * This is the internal function reserved to Datadog Kotlin Compiler Plugin for auto instrumentation,
+ * with telemetry to indicate that the auto-instrumentation is used instead of manual instrumentation.
+ */
+internal fun Modifier.instrumentedDatadog(name: String, isImage: Boolean): Modifier {
+    sendTelemetry(autoInstrumented = true, InstrumentationType.Semantics)
+    return this.datadogSemantics(name, isImage)
+}
+
+private fun Modifier.datadogSemantics(name: String, isImage: Boolean): Modifier {
     return this.semantics {
         this.datadog = name
         if (isImage) {

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/Telemetry.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/Telemetry.kt
@@ -1,0 +1,47 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.compose.internal
+
+import com.datadog.android.Datadog
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.SdkCore
+import com.datadog.android.api.feature.FeatureSdkCore
+
+internal fun sendTelemetry(
+    autoInstrumented: Boolean = false,
+    instrumentationType: InstrumentationType,
+    sdkCore: SdkCore = Datadog.getInstance()
+) {
+    val message = "$DATADOG_SEMANTICS_TELEMETRY_LOG: ${instrumentationType.value}"
+    val attributes = mapOf(
+        KEY_COMPOSE_INSTRUMENTATION to mapOf(
+            KEY_ENABLED to autoInstrumented,
+            KEY_INSTRUMENTATION_TYPE to instrumentationType
+        )
+    )
+    (sdkCore as? FeatureSdkCore)?.internalLogger?.log(
+        level = InternalLogger.Level.INFO,
+        target = InternalLogger.Target.TELEMETRY,
+        messageBuilder = { message },
+        onlyOnce = true,
+        additionalProperties = attributes
+    )
+}
+
+internal enum class InstrumentationType(val value: String) {
+    Semantics("Semantics"),
+    ViewTracking("ViewTracking")
+}
+
+private const val KEY_COMPOSE_INSTRUMENTATION = "compose_instrumentation"
+
+private const val KEY_ENABLED = "enabled"
+
+private const val KEY_INSTRUMENTATION_TYPE = "instrumentation_type"
+
+private const val DATADOG_SEMANTICS_TELEMETRY_LOG =
+    "Datadog Compose Integration Telemetry"


### PR DESCRIPTION
### What does this PR do?

Before releasing the compose auto instrumentation, we need to add telemetry about the usage of auto instrumentation.
Since it is almost impossible to add telemetry directly, the idea of this PR is to send telemetry when the instrumented function is call.

Main changes in this PR:
* Before we have two public APIs `datadog` and `NavigationViewTrackingEffect` which can be called by user manually and also instrumented by KCP automatically. Now `instrumentedDatadog` and `instrumentedNavigationViewTrackingEffect` internal functions are added, and they are reserved to KCP for auto instrumentation. The public APIs stay the same.
* The public APIs and internal functions will execute the same core functions under the hood, they only difference is that they will send telemetry with different attributes to indicate the way of instrumentation (manual or auto).
* Two functions send telemetry will different messages, both of them are sent only once.
<img width="801" alt="image" src="https://github.com/user-attachments/assets/aba13ea8-f950-4a4f-b5c0-050f520520c5" />

* There are two additional attributes:
<img width="453" alt="image" src="https://github.com/user-attachments/assets/461a4254-4640-4e22-99e7-92e11bb4ff96" />


### Motivation

RUM-9427


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

