### PR TITLE
Revert "Remove shared ThreadLocal scopes"

### DIFF
--- a/features/dd-sdk-android-trace/src/main/java/com/datadog/opentracing/scopemanager/ContextualScopeManager.java
+++ b/features/dd-sdk-android-trace/src/main/java/com/datadog/opentracing/scopemanager/ContextualScopeManager.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class ContextualScopeManager implements ScopeManager {
-  final ThreadLocal<DDScope> tlsScope = new ThreadLocal<>();
+  static final ThreadLocal<DDScope> tlsScope = new ThreadLocal<>();
   final Deque<ScopeContext> scopeContexts = new LinkedList<>();
   final List<ScopeListener> scopeListeners = new CopyOnWriteArrayList<>();
 

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/AndroidTracerTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/AndroidTracerTest.kt
@@ -19,6 +19,7 @@ import com.datadog.legacy.trace.api.Config
 import com.datadog.legacy.trace.common.writer.Writer
 import com.datadog.opentracing.DDSpan
 import com.datadog.opentracing.LogHandler
+import com.datadog.opentracing.scopemanager.ScopeTestHelper
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.DoubleForgery
 import fr.xgouchet.elmyr.annotation.Forgery
@@ -133,6 +134,8 @@ internal class AndroidTracerTest {
         val activeScope = tracer?.scopeManager()?.active()
         activeSpan?.finish()
         activeScope?.close()
+
+        ScopeTestHelper.removeThreadLocalScope()
     }
 
     // region Tracer

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/utils/TracerExtensionsTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/utils/TracerExtensionsTest.kt
@@ -10,6 +10,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.trace.AndroidTracer
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.opentracing.DDSpan
+import com.datadog.opentracing.scopemanager.ScopeTestHelper
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -57,6 +58,8 @@ internal class TracerExtensionsTest {
         val activeScope = tracer.scopeManager().active()
         activeSpan?.finish()
         activeScope?.close()
+
+        ScopeTestHelper.removeThreadLocalScope()
     }
 
     @Test

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/opentracing/scopemanager/ScopeTestHelper.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/opentracing/scopemanager/ScopeTestHelper.kt
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.opentracing.scopemanager
+
+object ScopeTestHelper {
+
+    fun removeThreadLocalScope() {
+        ContextualScopeManager.tlsScope.remove()
+    }
+}


### PR DESCRIPTION
This reverts commit 32afc41a21d49d505fc7dc1fadabbfd6676d8096.

### What does this PR do?

The original commit attempted to allow using the tracer in a kotlin coroutine context, but ended up leading to possible memory leaks. Before we write a better integration with couroutines, we revert this to prevent the memory leak