### PR TITLE
RUM-2558: Let AndroidTracer.logErrorMessage() send an ERROR log

### DIFF
--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -260,6 +260,8 @@ internal class LogsFeature(
             ?.filterKeys { it is String }
             ?.mapKeys { it.key as String }
 
+        val logStatus = data[LOG_STATUS_EVENT_KEY] as? Int ?: Log.VERBOSE
+
         @Suppress("ComplexCondition")
         if (loggerName == null || message == null || attributes == null || timestamp == null) {
             sdkCore.internalLogger.log(
@@ -273,7 +275,7 @@ internal class LogsFeature(
         sdkCore.getFeature(name)
             ?.withWriteContext { datadogContext, eventBatchWriter ->
                 val log = logGenerator.generateLog(
-                    Log.VERBOSE,
+                    logStatus,
                     datadogContext = datadogContext,
                     attachNetworkInfo = true,
                     loggerName = loggerName,
@@ -303,6 +305,7 @@ internal class LogsFeature(
         private const val MESSAGE_EVENT_KEY = "message"
         private const val USER_INFO_EVENT_KEY = "userInfo"
         private const val NETWORK_INFO_EVENT_KEY = "networkInfo"
+        private const val LOG_STATUS_EVENT_KEY = "logStatus"
 
         internal const val UNSUPPORTED_EVENT_TYPE =
             "Logs feature receive an event of unsupported type=%s."

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/AndroidTracer.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/AndroidTracer.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.trace
 
+import android.util.Log
 import androidx.annotation.FloatRange
 import com.datadog.android.Datadog
 import com.datadog.android.api.InternalLogger
@@ -297,6 +298,8 @@ class AndroidTracer internal constructor(
 
         internal const val SPAN_ID_BIT_SIZE = 63
 
+        internal const val LOG_STATUS = "status"
+
         /**
          * Helper method to attach a Throwable to a specific Span.
          * The Throwable information (class name, message and stacktrace) will be added to the
@@ -312,13 +315,13 @@ class AndroidTracer internal constructor(
 
         /**
          * Helper method to attach an error message to a specific Span.
-         * The error message will be added to the provided Span as a standard Error Tag.
+         * The error message will be logged with ERROR status and can be seen in logs attached to the span.
          * @param span the active Span
          * @param message the error message you want to attach
          */
         @JvmStatic
         fun logErrorMessage(span: Span, message: String) {
-            val fieldsMap = mapOf(Fields.MESSAGE to message)
+            val fieldsMap = mapOf(Fields.MESSAGE to message, LOG_STATUS to Log.ERROR)
             span.log(fieldsMap)
         }
     }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/SpanExt.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/SpanExt.kt
@@ -21,7 +21,7 @@ fun Span.setError(throwable: Throwable) {
 
 /**
  * Helper method to attach an error message to this [Span].
- * The error message will be added to this [Span] as a standard Error Tag.
+ * The error message will be logged with ERROR status and can be seen in logs attached to the span.
  * @param message the error message you want to attach.
  */
 fun Span.setError(message: String) {

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/handlers/AndroidSpanLogsHandler.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/handlers/AndroidSpanLogsHandler.kt
@@ -6,12 +6,13 @@
 
 package com.datadog.android.trace.internal.handlers
 
+import android.util.Log
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
-import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.log.LogAttributes
+import com.datadog.android.trace.AndroidTracer
 import com.datadog.android.trace.internal.utils.traceIdAsHexString
 import com.datadog.legacy.trace.api.DDTags
 import com.datadog.opentracing.DDSpan
@@ -67,6 +68,8 @@ internal class AndroidSpanLogsHandler(
         timestampMicroseconds: Long? = null
     ) {
         val logsFeature = sdkCore.getFeature(Feature.LOGS_FEATURE_NAME)
+        val spanLogStatus = fields.remove(AndroidTracer.LOG_STATUS) as? Int
+
         if (logsFeature != null && fields.isNotEmpty()) {
             val message = fields.remove(Fields.MESSAGE)?.toString() ?: DEFAULT_EVENT_MESSAGE
             fields[LogAttributes.DD_TRACE_ID] = span.context().traceIdAsHexString()
@@ -78,7 +81,8 @@ internal class AndroidSpanLogsHandler(
                     "loggerName" to TRACE_LOGGER_NAME,
                     "message" to message,
                     "attributes" to fields,
-                    "timestamp" to timestamp
+                    "timestamp" to timestamp,
+                    "logStatus" to (spanLogStatus ?: Log.VERBOSE)
                 )
             )
         } else if (logsFeature == null) {

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/AndroidTracerTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/AndroidTracerTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.trace
 
+import android.util.Log
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
@@ -653,7 +654,8 @@ internal class AndroidTracerTest {
             verify(mockSpan).log(capture())
             assertThat(firstValue)
                 .containsEntry(Fields.MESSAGE, anErrorMessage)
-                .containsOnlyKeys(Fields.MESSAGE)
+                .containsEntry(AndroidTracer.LOG_STATUS, Log.ERROR)
+                .containsOnlyKeys(Fields.MESSAGE, AndroidTracer.LOG_STATUS)
         }
     }
 

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/SpanExtTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/SpanExtTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.trace
 
+import android.util.Log
 import com.datadog.tools.unit.forge.BaseConfigurator
 import com.datadog.tools.unit.setStaticValue
 import fr.xgouchet.elmyr.annotation.Forgery
@@ -105,7 +106,8 @@ class SpanExtTest {
             verify(mockSpan).log(capture())
             assertThat(firstValue)
                 .containsEntry(Fields.MESSAGE, message)
-                .containsOnlyKeys(Fields.MESSAGE)
+                .containsEntry(AndroidTracer.LOG_STATUS, Log.ERROR)
+                .containsOnlyKeys(Fields.MESSAGE, AndroidTracer.LOG_STATUS)
         }
     }
 

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/handlers/AndroidSpanLogsHandlerTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/handlers/AndroidSpanLogsHandlerTest.kt
@@ -6,11 +6,11 @@
 
 package com.datadog.android.trace.internal.handlers
 
+import android.util.Log
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
-import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.internal.utils.toHexString
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.log.LogAttributes
@@ -113,7 +113,8 @@ internal class AndroidSpanLogsHandlerTest {
                         Fields.EVENT to event,
                         LogAttributes.DD_TRACE_ID to fakeTraceId.toHexString().padStart(32, '0'),
                         LogAttributes.DD_SPAN_ID to fakeSpanId.toString()
-                    )
+                    ),
+                    "logStatus" to Log.VERBOSE
                 )
             )
 
@@ -142,7 +143,8 @@ internal class AndroidSpanLogsHandlerTest {
                         LogAttributes.DD_TRACE_ID to fakeTraceId.toHexString().padStart(32, '0'),
                         LogAttributes.DD_SPAN_ID to fakeSpanId.toString()
                     ),
-                    "timestamp" to TimeUnit.MICROSECONDS.toMillis(timestampMicros)
+                    "timestamp" to TimeUnit.MICROSECONDS.toMillis(timestampMicros),
+                    "logStatus" to Log.VERBOSE
                 )
             )
     }
@@ -174,7 +176,8 @@ internal class AndroidSpanLogsHandlerTest {
                     "type" to "span_log",
                     "loggerName" to AndroidSpanLogsHandler.TRACE_LOGGER_NAME,
                     "message" to AndroidSpanLogsHandler.DEFAULT_EVENT_MESSAGE,
-                    "attributes" to logAttributes
+                    "attributes" to logAttributes,
+                    "logStatus" to Log.VERBOSE
                 )
             )
 
@@ -207,7 +210,8 @@ internal class AndroidSpanLogsHandlerTest {
                     "loggerName" to AndroidSpanLogsHandler.TRACE_LOGGER_NAME,
                     "message" to AndroidSpanLogsHandler.DEFAULT_EVENT_MESSAGE,
                     "attributes" to logAttributes,
-                    "timestamp" to TimeUnit.MICROSECONDS.toMillis(timestampMicros)
+                    "timestamp" to TimeUnit.MICROSECONDS.toMillis(timestampMicros),
+                    "logStatus" to Log.VERBOSE
                 )
             )
     }
@@ -248,7 +252,8 @@ internal class AndroidSpanLogsHandlerTest {
                     "type" to "span_log",
                     "loggerName" to AndroidSpanLogsHandler.TRACE_LOGGER_NAME,
                     "message" to AndroidSpanLogsHandler.DEFAULT_EVENT_MESSAGE,
-                    "attributes" to logAttributes
+                    "attributes" to logAttributes,
+                    "logStatus" to Log.VERBOSE
                 )
             )
 
@@ -289,7 +294,8 @@ internal class AndroidSpanLogsHandlerTest {
                     "loggerName" to AndroidSpanLogsHandler.TRACE_LOGGER_NAME,
                     "message" to AndroidSpanLogsHandler.DEFAULT_EVENT_MESSAGE,
                     "attributes" to logAttributes,
-                    "timestamp" to TimeUnit.MICROSECONDS.toMillis(timestampMicros)
+                    "timestamp" to TimeUnit.MICROSECONDS.toMillis(timestampMicros),
+                    "logStatus" to Log.VERBOSE
                 )
             )
     }
@@ -336,7 +342,8 @@ internal class AndroidSpanLogsHandlerTest {
                     "type" to "span_log",
                     "loggerName" to AndroidSpanLogsHandler.TRACE_LOGGER_NAME,
                     "message" to message,
-                    "attributes" to logAttributes
+                    "attributes" to logAttributes,
+                    "logStatus" to Log.VERBOSE
                 )
             )
 
@@ -385,7 +392,8 @@ internal class AndroidSpanLogsHandlerTest {
                     "type" to "span_log",
                     "loggerName" to AndroidSpanLogsHandler.TRACE_LOGGER_NAME,
                     "message" to AndroidSpanLogsHandler.DEFAULT_EVENT_MESSAGE,
-                    "attributes" to logAttributes
+                    "attributes" to logAttributes,
+                    "logStatus" to Log.VERBOSE
                 )
             )
 
@@ -436,7 +444,8 @@ internal class AndroidSpanLogsHandlerTest {
                     "type" to "span_log",
                     "loggerName" to AndroidSpanLogsHandler.TRACE_LOGGER_NAME,
                     "message" to message,
-                    "attributes" to logAttributes
+                    "attributes" to logAttributes,
+                    "logStatus" to Log.VERBOSE
                 )
             )
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/TracesViewModel.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/TracesViewModel.kt
@@ -13,6 +13,7 @@ import com.datadog.android.log.Logger
 import com.datadog.android.rum.coroutines.sendErrorToDatadog
 import com.datadog.android.sample.BuildConfig
 import com.datadog.android.sample.data.Result
+import com.datadog.android.trace.AndroidTracer
 import com.datadog.android.trace.coroutines.CoroutineScopeSpan
 import com.datadog.android.trace.coroutines.asyncTraced
 import com.datadog.android.trace.coroutines.awaitTraced
@@ -366,6 +367,8 @@ internal class TracesViewModel(
         @Deprecated("Deprecated in Java")
         override fun doInBackground(vararg params: Unit?) {
             withinSpan("AsyncOperation", activeSpanInMainThread) {
+                AndroidTracer.logErrorMessage(this, "Test error log in async operation")
+
                 logger.v("Starting Async Operation...")
 
                 val count = (Random().nextInt() % 50) + 50


### PR DESCRIPTION
### What does this PR do?

Makes `AndroidTracer.logErrorMessage` create a log with `ERROR` severity that is attached to the span.

[demo](https://mobile-integration.datadoghq.com/apm/traces?query=service%3Acom.datadog.android.sample%20%40usr.name%3Agringauz&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=span_list&historicalData=false&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=desc&spanID=4452119431085811750&spanType=all&spanViewType=logs&storage=hot&timeHint=1744814536832&trace=88227298555719713454452119431085811750&traceID=8822729855571971345&view=spans&start=1744813901627&end=1744814801627&paused=false)

I discussed with Xavier that we shouldn't make the span itself have an error state, just change the log severity.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

