### PR TITLE
RUMS-4305 Fix the memory leak in the `PendingTrace#cleaner`

### DIFF
--- a/features/dd-sdk-android-trace/src/main/java/com/datadog/opentracing/PendingTrace.java
+++ b/features/dd-sdk-android-trace/src/main/java/com/datadog/opentracing/PendingTrace.java
@@ -6,6 +6,8 @@
 
 package com.datadog.opentracing;
 
+import androidx.annotation.VisibleForTesting;
+
 import com.datadog.android.api.InternalLogger;
 import com.datadog.exec.CommonTaskExecutor;
 import com.datadog.exec.CommonTaskExecutor.Task;
@@ -25,410 +27,470 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class PendingTrace extends LinkedList<DDSpan> {
-  private static final AtomicReference<SpanCleaner> SPAN_CLEANER = new AtomicReference<>();
+    private static final AtomicReference<SpanCleaner> SPAN_CLEANER = new AtomicReference<>();
 
-  private final DDTracer tracer;
-  private final BigInteger traceId;
+    private final DDTracer tracer;
+    private final BigInteger traceId;
 
-  // TODO: consider moving these time fields into DDTracer to ensure that traces have precise
-  // relative time
-  /**
-   * Trace start time in nano seconds measured up to a millisecond accuracy
-   */
-  private final long startTimeNano;
-  /**
-   * Nano second ticks value at trace start
-   */
-  private final long startNanoTicks;
+    // TODO: consider moving these time fields into DDTracer to ensure that traces have precise
+    // relative time
+    /**
+     * Trace start time in nano seconds measured up to a millisecond accuracy
+     */
+    private final long startTimeNano;
+    /**
+     * Nano second ticks value at trace start
+     */
+    private final long startNanoTicks;
 
-  private final ReferenceQueue referenceQueue = new ReferenceQueue();
-  private final Set<WeakReference<?>> weakReferences =
-      Collections.newSetFromMap(new ConcurrentHashMap<WeakReference<?>, Boolean>());
+    private final ReferenceQueue referenceQueue = new ReferenceQueue();
+    private final Set<WeakReference<?>> weakReferences =
+            Collections.newSetFromMap(new ConcurrentHashMap<WeakReference<?>, Boolean>());
 
-  private final AtomicInteger pendingReferenceCount = new AtomicInteger(0);
+    private final AtomicInteger pendingReferenceCount = new AtomicInteger(0);
 
-  // We must maintain a separate count because ConcurrentLinkedDeque.size() is a linear operation.
-  private final AtomicInteger completedSpanCount = new AtomicInteger(0);
-  /**
-   * During a trace there are cases where the root span must be accessed (e.g. priority sampling and
-   * trace-search tags).
-   *
-   * <p>Use a weak ref because we still need to handle buggy cases where the root span is not
-   * correctly closed (see SpanCleaner).
-   *
-   * <p>The root span will be available in non-buggy cases because it has either finished and
-   * strongly ref'd in this queue or is unfinished and ref'd in a ContinuableScope.
-   */
-  private final AtomicReference<WeakReference<DDSpan>> rootSpan = new AtomicReference<>();
+    // We must maintain a separate count because ConcurrentLinkedDeque.size() is a linear operation.
+    private final AtomicInteger completedSpanCount = new AtomicInteger(0);
+    /**
+     * During a trace there are cases where the root span must be accessed (e.g. priority sampling and
+     * trace-search tags).
+     *
+     * <p>Use a weak ref because we still need to handle buggy cases where the root span is not
+     * correctly closed (see SpanCleaner).
+     *
+     * <p>The root span will be available in non-buggy cases because it has either finished and
+     * strongly ref'd in this queue or is unfinished and ref'd in a ContinuableScope.
+     */
+    private final AtomicReference<WeakReference<DDSpan>> rootSpan = new AtomicReference<>();
 
-  /**
-   * Ensure a trace is never written multiple times
-   */
-  private final AtomicBoolean isWritten = new AtomicBoolean(false);
+    /**
+     * Ensure a trace is never written multiple times
+     */
+    private final AtomicBoolean isWritten = new AtomicBoolean(false);
 
-  private final InternalLogger internalLogger;
+    private final InternalLogger internalLogger;
 
-  PendingTrace(final DDTracer tracer, final BigInteger traceId, final InternalLogger internalLogger) {
-    this.tracer = tracer;
-    this.traceId = traceId;
-    this.internalLogger = internalLogger;
+    PendingTrace(final DDTracer tracer, final BigInteger traceId, final InternalLogger internalLogger) {
+        this.tracer = tracer;
+        this.traceId = traceId;
+        this.internalLogger = internalLogger;
 
-    startTimeNano = Clock.currentNanoTime();
-    startNanoTicks = Clock.currentNanoTicks();
+        startTimeNano = Clock.currentNanoTime();
+        startNanoTicks = Clock.currentNanoTicks();
 
-    addPendingTrace();
-  }
-
-  /**
-   * Current timestamp in nanoseconds.
-   *
-   * <p>Note: it is not possible to get 'real' nanosecond time. This method uses trace start time
-   * (which has millisecond precision) as a reference and it gets time with nanosecond precision
-   * after that. This means time measured within same Trace in different Spans is relatively correct
-   * with nanosecond precision.
-   *
-   * @return timestamp in nanoseconds
-   */
-  public long getCurrentTimeNano() {
-    return startTimeNano + Math.max(0, Clock.currentNanoTicks() - startNanoTicks);
-  }
-
-  public void registerSpan(final DDSpan span) {
-    if (traceId == null || span.context() == null) {
-      internalLogger.log(
-          InternalLogger.Level.ERROR,
-          InternalLogger.Target.USER,
-          () -> "Span " + span.getOperationName() + " not registered because of null traceId or context; " +
-              "spanId:" + span.getSpanId() + " traceid:" + traceId,
-          null,
-          false,
-          new HashMap<>()
-      );
-      return;
+        addPendingTrace();
     }
-    BigInteger spanTraceId = span.context().getTraceId();
-    if (!traceId.equals(spanTraceId)) {
-      internalLogger.log(
-          InternalLogger.Level.ERROR,
-          InternalLogger.Target.USER,
-          () -> "Span " + span.getOperationName() + " not registered because of traceId mismatch; " +
-              "spanId:" + span.getSpanId() + " span.traceid:" + spanTraceId + " traceid:" + traceId,
-          null,
-          false,
-          new HashMap<>()
-      );
-      return;
-    }
-    rootSpan.compareAndSet(null, new WeakReference<>(span));
-    synchronized (span) {
-      if (null == span.ref) {
-        span.ref = new WeakReference<DDSpan>(span, referenceQueue);
-        weakReferences.add(span.ref);
-        final int count = pendingReferenceCount.incrementAndGet();
-      } else {
-        internalLogger.log(
-            InternalLogger.Level.ERROR,
-            InternalLogger.Target.USER,
-            () -> "Span " + span.getOperationName() + " not registered because it is already registered; " +
-                "spanId:" + span.getSpanId() + " traceid:" + traceId,
-            null,
-            false,
-            new HashMap<>()
-        );
-      }
-    }
-  }
 
-  private void expireSpan(final DDSpan span, final boolean write) {
-    if (traceId == null || span.context() == null) {
-      internalLogger.log(
-          InternalLogger.Level.ERROR,
-          InternalLogger.Target.USER,
-          () -> "Span " + span.getOperationName() + " not expired because of null traceId or context; " +
-              "spanId:" + span.getSpanId() + " traceid:" + traceId,
-          null,
-          false,
-          new HashMap<>()
-      );
-      return;
+    /**
+     * Current timestamp in nanoseconds.
+     *
+     * <p>Note: it is not possible to get 'real' nanosecond time. This method uses trace start time
+     * (which has millisecond precision) as a reference and it gets time with nanosecond precision
+     * after that. This means time measured within same Trace in different Spans is relatively correct
+     * with nanosecond precision.
+     *
+     * @return timestamp in nanoseconds
+     */
+    public long getCurrentTimeNano() {
+        return startTimeNano + Math.max(0, Clock.currentNanoTicks() - startNanoTicks);
     }
-    BigInteger spanTraceId = span.context().getTraceId();
-    if (!traceId.equals(spanTraceId)) {
-      internalLogger.log(
-          InternalLogger.Level.ERROR,
-          InternalLogger.Target.USER,
-          () -> "Span " + span.getOperationName() + " not expired because of traceId mismatch; " +
-              "spanId:" + span.getSpanId() + " span.traceid:" + spanTraceId + " traceid:" + traceId,
-          null,
-          false,
-          new HashMap<>()
-      );
-      return;
-    }
-    synchronized (span) {
-      if (span.ref == null) {
-        internalLogger.log(
-            InternalLogger.Level.ERROR,
-            InternalLogger.Target.USER,
-            () -> "Span " + span.getOperationName() + " not expired because it's not registered; " +
-                "spanId:" + span.getSpanId() + " traceid:" + traceId,
-            null,
-            false,
-            new HashMap<>()
-        );
-        return;
-      }
-      weakReferences.remove(span.ref);
-      span.ref.clear();
-      span.ref = null;
-      if (write) {
-        expireReference();
-      } else {
-        pendingReferenceCount.decrementAndGet();
-      }
-    }
-  }
 
-  public void dropSpan(final DDSpan span) {
-    expireSpan(span, false);
-  }
-
-  public void addSpan(final DDSpan span) {
-    synchronized (this) {
-      if (span.getDurationNano() == 0) {
-        internalLogger.log(
-            InternalLogger.Level.ERROR,
-            InternalLogger.Target.USER,
-            () -> "Span " + span.getOperationName() + " not added because duration is zero; " +
-                "spanId:" + span.getSpanId() + " traceid:" + traceId,
-            null,
-            false,
-            new HashMap<>()
-        );
-        return;
-      }
-      if (traceId == null || span.context() == null) {
-        internalLogger.log(
-            InternalLogger.Level.ERROR,
-            InternalLogger.Target.USER,
-            () -> "Span " + span.getOperationName() + " not added because of null traceId or context; " +
-                "spanId:" + span.getSpanId() + " traceid:" + traceId,
-            null,
-            false,
-            new HashMap<>()
-        );
-        return;
-      }
-      if (!traceId.equals(span.getTraceId())) {
-        internalLogger.log(
-            InternalLogger.Level.ERROR,
-            InternalLogger.Target.USER,
-            () -> "Span " + span.getOperationName() + " not added because of traceId mismatch; " +
-                "spanId:" + span.getSpanId() + " traceid:" + traceId,
-            null,
-            false,
-            new HashMap<>()
-        );
-        return;
-      }
-
-      if (!isWritten.get()) {
-        addFirst(span);
-      } else {
-        internalLogger.log(
-            InternalLogger.Level.ERROR,
-            InternalLogger.Target.USER,
-            () -> "Span " + span.getOperationName() + " not added because trace already written; " +
-                "spanId:" + span.getSpanId() + " traceid:" + traceId,
-            null,
-            false,
-            new HashMap<>()
-        );
-      }
-      expireSpan(span, true);
-    }
-  }
-
-  public DDSpan getRootSpan() {
-    final WeakReference<DDSpan> rootRef = rootSpan.get();
-    return rootRef == null ? null : rootRef.get();
-  }
-
-  /**
-   * When using continuations, it's possible one may be used after all existing spans are otherwise
-   * completed, so we need to wait till continuations are de-referenced before reporting.
-   */
-  public void registerContinuation(final ContinuableScope.Continuation continuation) {
-    synchronized (continuation) {
-      if (continuation.ref == null) {
-        continuation.ref =
-            new WeakReference<ContinuableScope.Continuation>(continuation, referenceQueue);
-        weakReferences.add(continuation.ref);
-        final int count = pendingReferenceCount.incrementAndGet();
-      } else {
-      }
-    }
-  }
-
-  public void cancelContinuation(final ContinuableScope.Continuation continuation) {
-    synchronized (continuation) {
-      if (continuation.ref == null) {
-      } else {
-        weakReferences.remove(continuation.ref);
-        continuation.ref.clear();
-        continuation.ref = null;
-        expireReference();
-      }
-    }
-  }
-
-  private void expireReference() {
-    final int count = pendingReferenceCount.decrementAndGet();
-    if (count == 0) {
-      write();
-    } else {
-      if (tracer.getPartialFlushMinSpans() > 0 && size() > tracer.getPartialFlushMinSpans()) {
-        synchronized (this) {
-          if (size() > tracer.getPartialFlushMinSpans()) {
-            final DDSpan rootSpan = getRootSpan();
-            final List<DDSpan> partialTrace = new ArrayList(size());
-            final Iterator<DDSpan> it = iterator();
-            while (it.hasNext()) {
-              final DDSpan span = it.next();
-              if (span != rootSpan) {
-                partialTrace.add(span);
-                completedSpanCount.decrementAndGet();
-                it.remove();
-              }
-            }
-            tracer.write(partialTrace);
-          }
+    public void registerSpan(final DDSpan span) {
+        if (traceId == null || span.context() == null) {
+            internalLogger.log(
+                    InternalLogger.Level.ERROR,
+                    InternalLogger.Target.USER,
+                    () -> "Span " + span.getOperationName() + " not registered because of null traceId or context; " +
+                            "spanId:" + span.getSpanId() + " traceid:" + traceId,
+                    null,
+                    false,
+                    new HashMap<>()
+            );
+            return;
         }
-      }
+        BigInteger spanTraceId = span.context().getTraceId();
+        if (!traceId.equals(spanTraceId)) {
+            internalLogger.log(
+                    InternalLogger.Level.ERROR,
+                    InternalLogger.Target.USER,
+                    () -> "Span " + span.getOperationName() + " not registered because of traceId mismatch; " +
+                            "spanId:" + span.getSpanId() + " span.traceid:" + spanTraceId + " traceid:" + traceId,
+                    null,
+                    false,
+                    new HashMap<>()
+            );
+            return;
+        }
+        rootSpan.compareAndSet(null, new WeakReference<>(span));
+        synchronized (span) {
+            if (null == span.ref) {
+                span.ref = new WeakReference<DDSpan>(span, referenceQueue);
+                weakReferences.add(span.ref);
+                final int count = pendingReferenceCount.incrementAndGet();
+            } else {
+                internalLogger.log(
+                        InternalLogger.Level.ERROR,
+                        InternalLogger.Target.USER,
+                        () -> "Span " + span.getOperationName() + " not registered because it is already registered; " +
+                                "spanId:" + span.getSpanId() + " traceid:" + traceId,
+                        null,
+                        false,
+                        new HashMap<>()
+                );
+            }
+        }
     }
-  }
 
-  private synchronized void write() {
-    if (isWritten.compareAndSet(false, true)) {
-      removePendingTrace();
-      if (!isEmpty()) {
-        tracer.write(this);
-      }
-    } else {
-      internalLogger.log(
-          InternalLogger.Level.ERROR,
-          InternalLogger.Target.USER,
-          () -> "Trace " + traceId + " write ignored: isWritten already true",
-          null,
-          false,
-          new HashMap<>()
-      );
+    private void expireSpan(final DDSpan span, final boolean write) {
+        if (traceId == null || span.context() == null) {
+            internalLogger.log(
+                    InternalLogger.Level.ERROR,
+                    InternalLogger.Target.USER,
+                    () -> "Span " + span.getOperationName() + " not expired because of null traceId or context; " +
+                            "spanId:" + span.getSpanId() + " traceid:" + traceId,
+                    null,
+                    false,
+                    new HashMap<>()
+            );
+            return;
+        }
+        BigInteger spanTraceId = span.context().getTraceId();
+        if (!traceId.equals(spanTraceId)) {
+            internalLogger.log(
+                    InternalLogger.Level.ERROR,
+                    InternalLogger.Target.USER,
+                    () -> "Span " + span.getOperationName() + " not expired because of traceId mismatch; " +
+                            "spanId:" + span.getSpanId() + " span.traceid:" + spanTraceId + " traceid:" + traceId,
+                    null,
+                    false,
+                    new HashMap<>()
+            );
+            return;
+        }
+        synchronized (span) {
+            if (span.ref == null) {
+                internalLogger.log(
+                        InternalLogger.Level.ERROR,
+                        InternalLogger.Target.USER,
+                        () -> "Span " + span.getOperationName() + " not expired because it's not registered; " +
+                                "spanId:" + span.getSpanId() + " traceid:" + traceId,
+                        null,
+                        false,
+                        new HashMap<>()
+                );
+                return;
+            }
+            weakReferences.remove(span.ref);
+            span.ref.clear();
+            span.ref = null;
+            if (write) {
+                expireReference();
+            } else {
+                pendingReferenceCount.decrementAndGet();
+            }
+        }
     }
-  }
 
-  public synchronized boolean clean() {
-    Reference ref;
-    int count = 0;
-    while ((ref = referenceQueue.poll()) != null) {
-      weakReferences.remove(ref);
-      if (isWritten.compareAndSet(false, true)) {
-        removePendingTrace();
-        // preserve throughput count.
-        // Don't report the trace because the data comes from buggy uses of the api and is suspect.
-        tracer.incrementTraceCount();
-      }
-      count++;
-      expireReference();
+    public void dropSpan(final DDSpan span) {
+        expireSpan(span, false);
+        if (pendingReferenceCount.get() == 0 && weakReferences.isEmpty()) {
+            // this trace is empty and doesn't have any continuations
+            removePendingTrace();
+        }
     }
-    if (count > 0) {
-      // TODO attempt to flatten and report if top level spans are finished. (for accurate metrics)
+
+    public void addSpan(final DDSpan span) {
+        synchronized (this) {
+            if (span.getDurationNano() == 0) {
+                internalLogger.log(
+                        InternalLogger.Level.ERROR,
+                        InternalLogger.Target.USER,
+                        () -> "Span " + span.getOperationName() + " not added because duration is zero; " +
+                                "spanId:" + span.getSpanId() + " traceid:" + traceId,
+                        null,
+                        false,
+                        new HashMap<>()
+                );
+                return;
+            }
+            if (traceId == null || span.context() == null) {
+                internalLogger.log(
+                        InternalLogger.Level.ERROR,
+                        InternalLogger.Target.USER,
+                        () -> "Span " + span.getOperationName() + " not added because of null traceId or context; " +
+                                "spanId:" + span.getSpanId() + " traceid:" + traceId,
+                        null,
+                        false,
+                        new HashMap<>()
+                );
+                return;
+            }
+            if (!traceId.equals(span.getTraceId())) {
+                internalLogger.log(
+                        InternalLogger.Level.ERROR,
+                        InternalLogger.Target.USER,
+                        () -> "Span " + span.getOperationName() + " not added because of traceId mismatch; " +
+                                "spanId:" + span.getSpanId() + " traceid:" + traceId,
+                        null,
+                        false,
+                        new HashMap<>()
+                );
+                return;
+            }
+
+            if (!isWritten.get()) {
+                addFirst(span);
+            } else {
+                internalLogger.log(
+                        InternalLogger.Level.ERROR,
+                        InternalLogger.Target.USER,
+                        () -> "Span " + span.getOperationName() + " not added because trace already written; " +
+                                "spanId:" + span.getSpanId() + " traceid:" + traceId,
+                        null,
+                        false,
+                        new HashMap<>()
+                );
+            }
+            expireSpan(span, true);
+        }
     }
-    return count > 0;
-  }
 
-  @Override
-  public void addFirst(final DDSpan span) {
-    synchronized (this) {
-      super.addFirst(span);
+    public DDSpan getRootSpan() {
+        final WeakReference<DDSpan> rootRef = rootSpan.get();
+        return rootRef == null ? null : rootRef.get();
     }
-    completedSpanCount.incrementAndGet();
-  }
 
-  @Override
-  public int size() {
-    return completedSpanCount.get();
-  }
-
-  private void addPendingTrace() {
-    final SpanCleaner cleaner = SPAN_CLEANER.get();
-    if (cleaner != null) {
-      cleaner.pendingTraces.add(this);
+    /**
+     * When using continuations, it's possible one may be used after all existing spans are otherwise
+     * completed, so we need to wait till continuations are de-referenced before reporting.
+     */
+    public void registerContinuation(final ContinuableScope.Continuation continuation) {
+        synchronized (continuation) {
+            if (continuation.ref == null) {
+                continuation.ref =
+                        new WeakReference<ContinuableScope.Continuation>(continuation, referenceQueue);
+                weakReferences.add(continuation.ref);
+                final int count = pendingReferenceCount.incrementAndGet();
+            } else {
+            }
+        }
     }
-  }
 
-  private void removePendingTrace() {
-    final SpanCleaner cleaner = SPAN_CLEANER.get();
-    if (cleaner != null) {
-      cleaner.pendingTraces.remove(this);
+    public void cancelContinuation(final ContinuableScope.Continuation continuation) {
+        synchronized (continuation) {
+            if (continuation.ref == null) {
+            } else {
+                weakReferences.remove(continuation.ref);
+                continuation.ref.clear();
+                continuation.ref = null;
+                expireReference();
+            }
+        }
     }
-  }
 
-  static void initialize() {
-    final SpanCleaner oldCleaner = SPAN_CLEANER.getAndSet(new SpanCleaner());
-    if (oldCleaner != null) {
-      oldCleaner.close();
+    private void expireReference() {
+        final int count = pendingReferenceCount.decrementAndGet();
+        if (count == 0) {
+            write();
+        } else {
+            if (tracer.getPartialFlushMinSpans() > 0 && size() > tracer.getPartialFlushMinSpans()) {
+                synchronized (this) {
+                    if (size() > tracer.getPartialFlushMinSpans()) {
+                        final DDSpan rootSpan = getRootSpan();
+                        final List<DDSpan> partialTrace = new ArrayList(size());
+                        final Iterator<DDSpan> it = iterator();
+                        while (it.hasNext()) {
+                            final DDSpan span = it.next();
+                            if (span != rootSpan) {
+                                partialTrace.add(span);
+                                completedSpanCount.decrementAndGet();
+                                it.remove();
+                            }
+                        }
+                        tracer.write(partialTrace);
+                    }
+                }
+            }
+        }
     }
-  }
 
-  static void close() {
-    final SpanCleaner cleaner = SPAN_CLEANER.getAndSet(null);
-    if (cleaner != null) {
-      cleaner.close();
+    private synchronized void write() {
+        if (isWritten.compareAndSet(false, true)) {
+            removePendingTrace();
+            if (!isEmpty()) {
+                tracer.write(this);
+            }
+        } else {
+            internalLogger.log(
+                    InternalLogger.Level.ERROR,
+                    InternalLogger.Target.USER,
+                    () -> "Trace " + traceId + " write ignored: isWritten already true",
+                    null,
+                    false,
+                    new HashMap<>()
+            );
+        }
     }
-  }
 
-  // FIXME: it should be possible to simplify this logic and avoid having SpanCleaner and
-  // SpanCleanerTask
-  private static class SpanCleaner implements Runnable, Closeable {
-    private static final long CLEAN_FREQUENCY = 1;
-
-    private final Set<PendingTrace> pendingTraces =
-        Collections.newSetFromMap(new ConcurrentHashMap<PendingTrace, Boolean>());
-
-    public SpanCleaner() {
-      CommonTaskExecutor.INSTANCE.scheduleAtFixedRate(
-          SpanCleanerTask.INSTANCE,
-          this,
-          0,
-          CLEAN_FREQUENCY,
-          TimeUnit.SECONDS,
-          "Pending trace cleaner");
+    public synchronized boolean clean() {
+        Reference ref;
+        int count = 0;
+        while ((ref = referenceQueue.poll()) != null) {
+            weakReferences.remove(ref);
+            if (isWritten.compareAndSet(false, true)) {
+                removePendingTrace();
+                // preserve throughput count.
+                // Don't report the trace because the data comes from buggy uses of the api and is suspect.
+                tracer.incrementTraceCount();
+            }
+            count++;
+            expireReference();
+        }
+        if (count > 0) {
+            // TODO attempt to flatten and report if top level spans are finished. (for accurate metrics)
+        }
+        return count > 0;
     }
 
     @Override
-    public void run() {
-      for (final PendingTrace trace : pendingTraces) {
-        trace.clean();
-      }
+    public void addFirst(final DDSpan span) {
+        synchronized (this) {
+            super.addFirst(span);
+        }
+        completedSpanCount.incrementAndGet();
     }
 
     @Override
-    public void close() {
-      // Make sure that whatever was left over gets cleaned up
-      run();
+    public int size() {
+        return completedSpanCount.get();
     }
-  }
 
-  /*
-   * Important to use explicit class to avoid implicit hard references to cleaners from within executor.
-   */
-  private static class SpanCleanerTask implements Task<SpanCleaner> {
-
-    static final SpanCleanerTask INSTANCE = new SpanCleanerTask();
-
-    @Override
-    public void run(final SpanCleaner target) {
-      target.run();
+    private void addPendingTrace() {
+        final SpanCleaner cleaner = SPAN_CLEANER.get();
+        if (cleaner != null) {
+            cleaner.addPendingTrace(this);
+        }
     }
-  }
+
+    private void removePendingTrace() {
+        final SpanCleaner cleaner = SPAN_CLEANER.get();
+        if (cleaner != null) {
+            cleaner.removePendingTrace(this);
+        }
+    }
+
+    static void initialize() {
+        final SpanCleaner oldCleaner = SPAN_CLEANER.getAndSet(new SpanCleaner());
+        if (oldCleaner != null) {
+            oldCleaner.close();
+        }
+    }
+
+    static void close() {
+        final SpanCleaner cleaner = SPAN_CLEANER.getAndSet(null);
+        if (cleaner != null) {
+            cleaner.close();
+        }
+    }
+
+    @VisibleForTesting
+    static int getPendingTracesSize() {
+        final SpanCleaner cleaner = SPAN_CLEANER.get();
+        if (cleaner != null) {
+            return cleaner.pendingTraces.size();
+        }
+        return 0;
+    }
+
+    @VisibleForTesting
+    static SpanCleaner getSpanCleaner() {
+        return SPAN_CLEANER.get();
+    }
+
+    @VisibleForTesting
+    static class SpanCleaner implements Runnable, Closeable {
+        private static final long CLEAN_FREQUENCY = 1;
+
+        private final Map<IdentityKey, PendingTrace> pendingTraces = new ConcurrentHashMap<>();
+
+        public SpanCleaner() {
+            CommonTaskExecutor.INSTANCE.scheduleAtFixedRate(
+                    SpanCleanerTask.INSTANCE,
+                    this,
+                    0,
+                    CLEAN_FREQUENCY,
+                    TimeUnit.SECONDS,
+                    "Pending trace cleaner");
+        }
+
+        @Override
+        public void run() {
+            for (final PendingTrace trace : pendingTraces.values()) {
+                trace.clean();
+            }
+        }
+
+        @Override
+        public void close() {
+            // Make sure that whatever was left over gets cleaned up
+            run();
+        }
+
+        public void addPendingTrace(PendingTrace pendingTrace) {
+            pendingTraces.put(new IdentityKey(pendingTrace), pendingTrace);
+        }
+
+        public void removePendingTrace(PendingTrace pendingTrace) {
+            pendingTraces.remove(new IdentityKey((pendingTrace)));
+        }
+
+        @VisibleForTesting
+        Map<IdentityKey, PendingTrace> getPendingTraces() {
+            return pendingTraces;
+        }
+    }
+
+    /**
+     * This class is used to create a unique key for the pending trace map.
+     * It uses the identity hash code of the object to create hash code.
+     * In case of hash code collision, it compares the object references to ensure uniqueness.
+     * The JVM system guarantees that `System.identityHashCode` will return same value for the lifetime of the
+     * object. This will ensure that add/remove operations are legit for the same object.
+     */
+    @VisibleForTesting
+    static class IdentityKey {
+        private final PendingTrace key;
+
+        @VisibleForTesting
+        PendingTrace getKey() {
+            return key;
+        }
+
+        IdentityKey(PendingTrace key) {
+            this.key = key;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof IdentityKey && ((IdentityKey) obj).key == key;
+        }
+
+        @Override
+        public int hashCode() {
+            return System.identityHashCode(key);
+        }
+    }
+
+    /*
+     * Important to use explicit class to avoid implicit hard references to cleaners from within executor.
+     */
+    private static class SpanCleanerTask implements Task<SpanCleaner> {
+
+        static final SpanCleanerTask INSTANCE = new SpanCleanerTask();
+
+        @Override
+        public void run(final SpanCleaner target) {
+            target.run();
+        }
+    }
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/opentracing/IdentityKeyTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/opentracing/IdentityKeyTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.opentracing
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.opentracing.PendingTrace.IdentityKey
+import com.datadog.tools.unit.ObjectTest
+import fr.xgouchet.elmyr.Forge
+import org.mockito.kotlin.mock
+import java.math.BigInteger
+
+internal class IdentityKeyTest : ObjectTest<IdentityKey>() {
+
+    override fun createInstance(forge: Forge): IdentityKey {
+        val mockTracer: DDTracer = mock()
+        val mockInternalLogger: InternalLogger = mock()
+        val fakeTraceId = BigInteger.valueOf(forge.aLong())
+        return IdentityKey(PendingTrace(mockTracer, fakeTraceId, mockInternalLogger))
+    }
+
+    override fun createEqualInstance(source: IdentityKey, forge: Forge): IdentityKey {
+        return IdentityKey(source.key)
+    }
+
+    override fun createUnequalInstance(source: IdentityKey, forge: Forge): IdentityKey {
+        val mockTracer: DDTracer = mock()
+        val mockInternalLogger: InternalLogger = mock()
+        val fakeTraceId = BigInteger.valueOf(forge.aLong())
+        return IdentityKey(PendingTrace(mockTracer, fakeTraceId, mockInternalLogger))
+    }
+}

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/opentracing/PendingTraceTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/opentracing/PendingTraceTest.kt
@@ -9,18 +9,23 @@ package com.datadog.opentracing
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.legacy.trace.api.sampling.PrioritySampling
+import com.datadog.opentracing.scopemanager.ContinuableScope.Continuation
 import com.datadog.tools.unit.createInstance
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.math.BigInteger
@@ -35,6 +40,16 @@ import java.util.concurrent.TimeUnit
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(value = Configurator::class)
 class PendingTraceTest {
+
+    @BeforeEach
+    fun `set up`() {
+        PendingTrace.initialize()
+    }
+
+    @AfterEach
+    fun `tear down`() {
+        PendingTrace.close()
+    }
 
     @Test
     fun `PendingTrace is thread safe`(forge: Forge) {
@@ -67,6 +82,287 @@ class PendingTraceTest {
         }
     }
 
+    @Test
+    fun `M not leak the PendingTraces W finish`(
+        forge: Forge
+    ) {
+        // Given
+        val mockTracer: DDTracer = mock()
+        val mockInternalLogger: InternalLogger = mock()
+        whenever(mockTracer.partialFlushMinSpans) doReturn 1
+
+        repeat(forge.anInt(min = 10, max = 30)) {
+            val fakeTraceId = BigInteger.valueOf(forge.aLong())
+
+            val pendingTrace = createInstance(
+                PendingTrace::class.java,
+                mockTracer,
+                fakeTraceId,
+                mockInternalLogger
+            )
+
+            val rootSpan =
+                forge.fakeSpan(
+                    pendingTrace,
+                    mockTracer,
+                    fakeTraceId,
+                    BigInteger.ZERO,
+                    forge.anAlphabeticalString(),
+                    mockInternalLogger
+                )
+            Thread.sleep(1)
+            rootSpan.finish()
+        }
+
+        // When
+        PendingTrace.getSpanCleaner().run()
+
+        // Then
+        assertThat(PendingTrace.getPendingTracesSize()).isZero()
+    }
+
+    @Test
+    fun `M not leak the PendingTraces W finishSpan from different threads`(
+        forge: Forge
+    ) {
+        // Given
+        val mockTracer: DDTracer = mock()
+        val mockInternalLogger: InternalLogger = mock()
+        whenever(mockTracer.partialFlushMinSpans) doReturn 1
+        val repeatCount = forge.anInt(min = 10, max = 30)
+        val countDownLatch = CountDownLatch(repeatCount)
+        repeat(repeatCount) {
+            Thread {
+                val fakeTraceId = BigInteger.valueOf(forge.aLong())
+
+                val pendingTrace = createInstance(
+                    PendingTrace::class.java,
+                    mockTracer,
+                    fakeTraceId,
+                    mockInternalLogger
+                )
+
+                val rootSpan =
+                    forge.fakeSpan(
+                        pendingTrace,
+                        mockTracer,
+                        fakeTraceId,
+                        BigInteger.ZERO,
+                        forge.anAlphabeticalString(),
+                        mockInternalLogger
+                    )
+                Thread.sleep(1)
+                rootSpan.finish()
+                countDownLatch.countDown()
+            }.start()
+        }
+        countDownLatch.await(2, TimeUnit.SECONDS)
+
+        // When
+        Thread {
+            PendingTrace.getSpanCleaner().run()
+        }.apply {
+            start()
+            join(3)
+        }
+
+        // Then
+        assertThat(PendingTrace.getPendingTracesSize()).isEqualTo(0)
+    }
+
+    @Test
+    fun `M not leak the PendingTraces W drop`(
+        forge: Forge
+    ) {
+        // Given
+        val mockTracer: DDTracer = mock()
+        val mockInternalLogger: InternalLogger = mock()
+        whenever(mockTracer.partialFlushMinSpans) doReturn 1
+        val repeatTimes = forge.anInt(min = 10, max = 30)
+        repeat(repeatTimes) {
+            val fakeTraceId = BigInteger.valueOf(forge.aLong())
+
+            val pendingTrace = createInstance(
+                PendingTrace::class.java,
+                mockTracer,
+                fakeTraceId,
+                mockInternalLogger
+            )
+
+            val rootSpan =
+                forge.fakeSpan(
+                    pendingTrace,
+                    mockTracer,
+                    fakeTraceId,
+                    BigInteger.ZERO,
+                    forge.anAlphabeticalString(),
+                    mockInternalLogger
+                )
+            Thread.sleep(1)
+            rootSpan.drop()
+        }
+
+        // When
+        PendingTrace.getSpanCleaner().run()
+
+        // Then
+        assertThat(PendingTrace.getPendingTracesSize()).isZero()
+    }
+
+    @Test
+    fun `M write the PendingTrace W addParentSpan and drop some spans`(
+        forge: Forge
+    ) {
+        // Given
+        val mockTracer: DDTracer = mock()
+        val mockInternalLogger: InternalLogger = mock()
+        whenever(mockTracer.partialFlushMinSpans) doReturn 1
+        val fakeParentTraceId = BigInteger.valueOf(forge.aLong())
+        val pendingTrace = createInstance(
+            PendingTrace::class.java,
+            mockTracer,
+            fakeParentTraceId,
+            mockInternalLogger
+        )
+        val rootSpan =
+            forge.fakeSpan(
+                pendingTrace,
+                mockTracer,
+                fakeParentTraceId,
+                BigInteger.ZERO,
+                forge.anAlphabeticalString(),
+                mockInternalLogger
+            )
+        val childSpan1 = DDSpan(forge.aPositiveLong(), rootSpan.context())
+        val childSpan2 = DDSpan(forge.aPositiveLong(), rootSpan.context())
+
+        // When
+        childSpan1.drop()
+        childSpan2.finish()
+        rootSpan.finish()
+        PendingTrace.getSpanCleaner().run()
+
+        // Then
+        assertThat(PendingTrace.getPendingTracesSize()).isZero()
+        argumentCaptor<Collection<DDSpan>>().apply {
+            verify(mockTracer).write(capture())
+            assertThat(firstValue).hasSize(2)
+            assertThat(firstValue).containsExactlyInAnyOrder(rootSpan, childSpan2)
+        }
+    }
+
+    @Test
+    fun `M write the PendingTrace W addParentSpan and drop the only child`(
+        forge: Forge
+    ) {
+        // Given
+        val mockTracer: DDTracer = mock()
+        val mockInternalLogger: InternalLogger = mock()
+        whenever(mockTracer.partialFlushMinSpans) doReturn 1
+        val fakeParentTraceId = BigInteger.valueOf(forge.aLong())
+        val pendingTrace = createInstance(
+            PendingTrace::class.java,
+            mockTracer,
+            fakeParentTraceId,
+            mockInternalLogger
+        )
+        val rootSpan =
+            forge.fakeSpan(
+                pendingTrace,
+                mockTracer,
+                fakeParentTraceId,
+                BigInteger.ZERO,
+                forge.anAlphabeticalString(),
+                mockInternalLogger
+            )
+        val childSpan1 = DDSpan(forge.aPositiveLong(), rootSpan.context())
+
+        // When
+        childSpan1.drop()
+        // add intermediary cleaner just to make sure we're testing this case
+        PendingTrace.getSpanCleaner().run()
+        rootSpan.finish()
+        PendingTrace.getSpanCleaner().run()
+
+        // Then
+        assertThat(PendingTrace.getPendingTracesSize()).isZero()
+        argumentCaptor<Collection<DDSpan>>().apply {
+            verify(mockTracer).write(capture())
+            assertThat(firstValue).hasSize(1)
+            assertThat(firstValue).containsExactlyInAnyOrder(rootSpan)
+        }
+    }
+
+    @Test
+    fun `M not drop the PendingTrace W active continuable scope and dropSpan`(
+        forge: Forge
+    ) {
+        // Given
+        val mockTracer: DDTracer = mock()
+        val mockInternalLogger: InternalLogger = mock()
+        whenever(mockTracer.partialFlushMinSpans) doReturn 1
+        val fakeParentTraceId = BigInteger.valueOf(forge.aLong())
+        val pendingTrace = createInstance(
+            PendingTrace::class.java,
+            mockTracer,
+            fakeParentTraceId,
+            mockInternalLogger
+        )
+        val rootSpan =
+            forge.fakeSpan(
+                pendingTrace,
+                mockTracer,
+                fakeParentTraceId,
+                BigInteger.ZERO,
+                forge.anAlphabeticalString(),
+                mockInternalLogger
+            )
+        val continuation: Continuation = mock()
+        pendingTrace.registerContinuation(continuation)
+
+        // When
+        rootSpan.drop()
+        PendingTrace.getSpanCleaner().run()
+
+        // Then
+        assertThat(PendingTrace.getPendingTracesSize()).isEqualTo(1)
+    }
+
+    @Test
+    fun `M not drop the PendingTrace W continuable scope stopped and dropSpan`(
+        forge: Forge
+    ) {
+        // Given
+        val mockTracer: DDTracer = mock()
+        val mockInternalLogger: InternalLogger = mock()
+        whenever(mockTracer.partialFlushMinSpans) doReturn 1
+        val fakeParentTraceId = BigInteger.valueOf(forge.aLong())
+        val pendingTrace = createInstance(
+            PendingTrace::class.java,
+            mockTracer,
+            fakeParentTraceId,
+            mockInternalLogger
+        )
+        val rootSpan =
+            forge.fakeSpan(
+                pendingTrace,
+                mockTracer,
+                fakeParentTraceId,
+                BigInteger.ZERO,
+                forge.anAlphabeticalString(),
+                mockInternalLogger
+            )
+        val continuation: Continuation = mock()
+        pendingTrace.registerContinuation(continuation)
+
+        // When
+        pendingTrace.cancelContinuation(continuation)
+        rootSpan.drop()
+
+        // Then
+        assertThat(PendingTrace.getPendingTracesSize()).isZero
+    }
+
     private class StressTestRunnable(
         val pendingTrace: PendingTrace,
         val tracer: DDTracer,
@@ -89,7 +385,6 @@ class PendingTraceTest {
                         "childSpan_$i",
                         internalLogger
                     )
-                    pendingTrace.registerSpan(span)
                     span.finish()
                 }
             } catch (e: ConcurrentModificationException) {
@@ -131,5 +426,5 @@ private fun Forge.fakeSpan(
         internalLogger
     )
 
-    return DDSpan(aLong(), ddSpanContext)
+    return DDSpan(aPositiveLong(), ddSpanContext)
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/opentracing/SpanCleanerTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/opentracing/SpanCleanerTest.kt
@@ -1,0 +1,204 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.opentracing
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.opentracing.PendingTrace.SpanCleaner
+import com.datadog.tools.unit.createInstance
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.quality.Strictness
+import java.math.BigInteger
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(value = Configurator::class)
+internal class SpanCleanerTest {
+
+    private var testedCleaner: SpanCleaner = SpanCleaner()
+
+    // region cleanup
+
+    @Test
+    fun `M remove random traces W add and remove`(forge: Forge) {
+        // Given
+        val pendingTraces = forge.aList(size = forge.anInt(min = 10, max = 50)) { mock<PendingTrace>() }
+        pendingTraces.forEach {
+            testedCleaner.addPendingTrace(it)
+        }
+        Assumptions.assumeTrue(testedCleaner.pendingTraces.values.size == pendingTraces.size)
+        Assumptions.assumeTrue(testedCleaner.pendingTraces.values.containsAll(pendingTraces))
+
+        // When
+        pendingTraces.shuffled().forEach {
+            testedCleaner.removePendingTrace(it)
+        }
+
+        // Then
+        assertThat(testedCleaner.pendingTraces).isEmpty()
+    }
+
+    @Test
+    fun `M cleanup random traces W add and close`(forge: Forge) {
+        // Given
+        val pendingTraces = forge.aList(size = forge.anInt(min = 10, max = 50)) { mock<PendingTrace>() }
+        pendingTraces.forEach {
+            testedCleaner.addPendingTrace(it)
+        }
+        assertThat(testedCleaner.pendingTraces.values).containsExactlyInAnyOrderElementsOf(pendingTraces)
+
+        // When
+        testedCleaner.close()
+
+        // Then
+        pendingTraces.forEach {
+            verify(it).clean()
+        }
+    }
+
+    // endregion
+
+    // region `equals` contract
+
+    @Test
+    fun `M contain only one entry W add same PendingTrace twice`(forge: Forge) {
+        // Given
+        val pendingTrace = mockPendingTrace(forge)
+        testedCleaner.addPendingTrace(pendingTrace)
+        testedCleaner.addPendingTrace(pendingTrace)
+
+        // Then
+        assertThat(testedCleaner.pendingTraces).hasSize(1)
+        assertThat(testedCleaner.pendingTraces.values).containsExactly(pendingTrace)
+    }
+
+    @Test
+    fun `M contain only one entry W add {same PendingTrace mutated, twice}`(forge: Forge) {
+        // Given
+        val pendingTrace = mockPendingTrace(forge)
+        testedCleaner.addPendingTrace(pendingTrace)
+        pendingTrace.addSpan(mock())
+        pendingTrace.addSpan(mock())
+        testedCleaner.addPendingTrace(pendingTrace)
+
+        // Then
+        assertThat(testedCleaner.pendingTraces).hasSize(1)
+        assertThat(testedCleaner.pendingTraces.values).containsExactly(pendingTrace)
+
+        // When
+        testedCleaner.removePendingTrace(pendingTrace)
+
+        // Then
+        assertThat(testedCleaner.pendingTraces).isEmpty()
+    }
+
+    @Test
+    fun `M contain 2 entries W add {2 PendingTrace instances with same root span}`(forge: Forge) {
+        // Given
+        val pendingTrace1 = mockPendingTrace(forge)
+        val pendingTrace2 = mockPendingTrace(forge)
+        val mock = mock<DDSpan>()
+        pendingTrace1.addSpan(mock)
+        pendingTrace2.addSpan(mock)
+        testedCleaner.addPendingTrace(pendingTrace1)
+        testedCleaner.addPendingTrace(pendingTrace2)
+
+        // Then
+        assertThat(testedCleaner.pendingTraces).hasSize(2)
+        assertThat(testedCleaner.pendingTraces.values).containsExactlyInAnyOrder(pendingTrace1, pendingTrace2)
+
+        // When
+        testedCleaner.removePendingTrace(pendingTrace1)
+        testedCleaner.removePendingTrace(pendingTrace2)
+
+        // Then
+        assertThat(testedCleaner.pendingTraces).isEmpty()
+    }
+
+    // endregion
+
+    // region concurrency
+
+    @Test
+    fun `M not leak any PendingTrace W add, mutate and remove { different threads }`(forge: Forge) {
+        // Given
+        val pendingTraces = forge.aList(size = forge.anInt(min = 10, max = 50)) { mockPendingTrace(forge) }
+        val addCountDownLatch = CountDownLatch(pendingTraces.size)
+        val removeCountDownLatch = CountDownLatch(pendingTraces.size)
+        val half = pendingTraces.size / 2
+        pendingTraces.take(half).forEach { pendingTrace ->
+            Thread {
+                testedCleaner.addPendingTrace(pendingTrace)
+                repeat(forge.anInt(min = 1, max = 10)) {
+                    pendingTrace.addSpan(mock())
+                }
+                addCountDownLatch.countDown()
+            }.start()
+        }
+        pendingTraces.subList(half, pendingTraces.size).forEach { pendingTrace ->
+            Thread {
+                if (forge.aBool()) {
+                    repeat(forge.anInt(min = 1, max = 10)) {
+                        pendingTrace.addSpan(mock())
+                    }
+                }
+                testedCleaner.addPendingTrace(pendingTrace)
+                repeat(forge.anInt(min = 1, max = 10)) {
+                    pendingTrace.addSpan(mock())
+                }
+                addCountDownLatch.countDown()
+            }.start()
+        }
+        addCountDownLatch.await(3, TimeUnit.SECONDS)
+
+        // When
+        pendingTraces.forEach {
+            Thread {
+                testedCleaner.removePendingTrace(it)
+                removeCountDownLatch.countDown()
+            }.start()
+        }
+        removeCountDownLatch.await(3, TimeUnit.SECONDS)
+
+        // Then
+        assertThat(testedCleaner.pendingTraces).isEmpty()
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun mockPendingTrace(forge: Forge): PendingTrace {
+        val mockTracer: DDTracer = mock()
+        val mockInternalLogger: InternalLogger = mock()
+        val fakeTraceId = BigInteger.valueOf(forge.aLong())
+        return createInstance(
+            PendingTrace::class.java,
+            mockTracer,
+            fakeTraceId,
+            mockInternalLogger
+        )
+    }
+
+    // endregion
+}


### PR DESCRIPTION
### What does this PR do?

After analysing the borrowed code from the deprecated APM java tracer following some internal investigations `PendingTrace` was actually leaking in 2 places:

1. In one place when using `dropSpan` the cleaner could not actually clean the `PendingTrace` reference and this was persisted forever in the `pendingTraces` set. Basically when the cleaner was trying to `clean` that method was doing nothing as there was no pending Span to write and the reference was not removed. 
2. Because of using a mutable `LinkedList` as an entry key to a `Set<PendingTrace>`. Basically because the key is resolved from the `LinkedList#hashCode()` method which is dependent on the values contained in the list first time a `PendingTrace` is created the `hashCode()` is always `1` and when later we're trying to remove it through `clean` the `hashCodes` no longer match. 
The problem was not that visible when instrumenting the `httpRequest` as the `hashCode` when adding the list was always `1` so only 1 `PendingTrace` was persisted but it became more visible when using a very trivial example as:
```
val tracer = GlobalTracer.get()
            repeat(100){
                val span = tracer.buildSpan("AsyncOperation")
                    .start()
                Thread.sleep(1)
                span.finish()
            }
```
In this moment we're going to leak 200 `PendingTraces` because:

- when adding each first `PendingTrace` the set will contain `[1]->[(pendingTrace1, key1)]`
- when adding second `PendingTrace` the set will check if key `1` exist and then will equal the keys by values but because at the lists are equaling the elements in the `equal` method in this moment the first trace has 1 element and the one to be added has 0 so they do not match so the set will contain `[1]->[(pendingTrace1, key1), (pendingTrace2, key2)]
- when later trying to remove each of these it will first try to match the `hashCode` but because they all have elements in them the `hashCode` will not longer match `1` key so the will all be leaked.
This problem is not reproducible when using the `DatadogInterceptor` because there we are using `drop` instead of `finish` in the Span and this will not add the span into the `PendingTrace` a.k.a `LinkedList`. In that situation the `pendingTraces` set will only contain one empty `PendingTrace`: `[1]->[(PendingTrace, key)]`. Every time a new `PendingTrace` will be created it will match through `hashCode` and `equal` to the one in the `Set` and it will not be added. In this situation only the first added `PendingTrace` will be leaked and this is because of the reason number 1 described above.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

