### PR TITLE
Fix ViewTarget is garbage collected during actions tracking

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -299,8 +299,10 @@ interface com.datadog.android.rum.tracking.TrackingStrategy
   fun unregister(android.content.Context?)
 interface com.datadog.android.rum.tracking.ViewAttributesProvider
   fun extractAttributes(android.view.View, MutableMap<String, Any?>)
-data class com.datadog.android.rum.tracking.ViewTarget
-  constructor(android.view.View? = null, String? = null)
+class com.datadog.android.rum.tracking.ViewTarget
+  constructor(java.lang.ref.WeakReference<android.view.View?> = WeakReference(null), String? = null)
+  override fun equals(Any?): Boolean
+  override fun hashCode(): Int
 interface com.datadog.android.rum.tracking.ViewTrackingStrategy : TrackingStrategy
 class com.datadog.android.sqlite.DatadogDatabaseErrorHandler : android.database.DatabaseErrorHandler
   constructor(String? = null, android.database.DatabaseErrorHandler = DefaultDatabaseErrorHandler())

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -6868,17 +6868,12 @@ public abstract interface class com/datadog/android/rum/tracking/ViewAttributesP
 
 public final class com/datadog/android/rum/tracking/ViewTarget {
 	public fun <init> ()V
-	public fun <init> (Landroid/view/View;Ljava/lang/String;)V
-	public synthetic fun <init> (Landroid/view/View;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Landroid/view/View;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Landroid/view/View;Ljava/lang/String;)Lcom/datadog/android/rum/tracking/ViewTarget;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/tracking/ViewTarget;Landroid/view/View;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/tracking/ViewTarget;
+	public fun <init> (Ljava/lang/ref/WeakReference;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/ref/WeakReference;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getTag ()Ljava/lang/String;
-	public final fun getView ()Landroid/view/View;
+	public final fun getViewRef ()Ljava/lang/ref/WeakReference;
 	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class com/datadog/android/rum/tracking/ViewTrackingStrategy : com/datadog/android/rum/tracking/TrackingStrategy {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AndroidActionTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AndroidActionTrackingStrategy.kt
@@ -14,6 +14,7 @@ import androidx.core.view.ScrollingView
 import com.datadog.android.api.SdkCore
 import com.datadog.android.rum.tracking.ActionTrackingStrategy
 import com.datadog.android.rum.tracking.ViewTarget
+import java.lang.ref.WeakReference
 
 /**
  * Implementation of [ActionTrackingStrategy] for Android View, used to locate the target view
@@ -34,7 +35,7 @@ internal class AndroidActionTrackingStrategy : ActionTrackingStrategy {
 
     override fun findTargetForTap(view: View, x: Float, y: Float): ViewTarget? {
         return if (hitTest(view, x, y, coordinatesContainer) && isValidTapTarget(view)) {
-            ViewTarget(view)
+            ViewTarget(viewRef = WeakReference(view))
         } else {
             null
         }
@@ -42,7 +43,7 @@ internal class AndroidActionTrackingStrategy : ActionTrackingStrategy {
 
     override fun findTargetForScroll(view: View, x: Float, y: Float): ViewTarget? {
         return if (hitTest(view, x, y, coordinatesContainer) && isValidScrollableTarget(view)) {
-            ViewTarget(view)
+            ViewTarget(viewRef = WeakReference(view))
         } else {
             null
         }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesUtils.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesUtils.kt
@@ -17,7 +17,7 @@ internal fun resolveViewTargetName(
     interactionPredicate: InteractionPredicate,
     target: ViewTarget
 ): String {
-    return target.view?.let { view ->
+    return target.viewRef.get()?.let { view ->
         resolveTargetName(interactionPredicate, view)
     } ?: target.tag ?: ""
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ViewTarget.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ViewTarget.kt
@@ -7,18 +7,39 @@
 package com.datadog.android.rum.tracking
 
 import android.view.View
+import java.lang.ref.WeakReference
 
 /**
  * Represents the result of locating a target view in response to a user interaction,
  * such as a tap or scroll event in [GesturesListener].
  *
- * @property view The Android [View] that was found. If non-null, indicates a classic View was located.
+ * @property viewRef The Weak Reference of Android [View] that was found.
+ *                     If non-null, indicates a classic View was located.
  * @property tag The semantics tag associated with a Jetpack Compose component. If non-null, indicates
  *               that a Compose node with the given semantics tag was found.
  *
- * Only one of [view] or [tag] is expected to be non-null, depending on the UI framework used.
+ * Only one of [viewRef] or [tag] is expected to be non-null, depending on the UI framework used.
  */
-data class ViewTarget(
-    val view: View? = null,
+class ViewTarget(
+    val viewRef: WeakReference<View?> = WeakReference(null),
     val tag: String? = null
-)
+) {
+
+    override fun equals(other: Any?): Boolean {
+        // Overriding hashcode & equals because we should compare the referent
+        // instead of the reference.
+        if (this === other) return true
+        if (other !is ViewTarget) return false
+
+        if (viewRef.get() != other.viewRef.get()) return false
+        if (tag != other.tag) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = viewRef.get().hashCode()
+        result = 31 * result + tag.hashCode()
+        return result
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
@@ -364,7 +364,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         val y = mockEvent.y
         val mockComposeActionTrackingStrategy: ActionTrackingStrategy = mock {
             whenever(it.findTargetForTap(composeView, x, y))
-                .thenReturn(ViewTarget(null, targetName))
+                .thenReturn(ViewTarget(WeakReference(null), targetName))
         }
         testedListener = GesturesListener(
             rumMonitor.mockSdkCore,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/ViewTargetTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/ViewTargetTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.tracking
+
+import android.view.View
+import com.datadog.tools.unit.ObjectTest
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+import java.lang.ref.WeakReference
+
+@Extensions(ExtendWith(ForgeExtension::class))
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ViewTargetTest : ObjectTest<ViewTarget>() {
+
+    @Mock
+    private lateinit var mockView: View
+
+    @Mock
+    private lateinit var mockAnotherView: View
+
+    override fun createInstance(forge: Forge): ViewTarget {
+        return ViewTarget(
+            viewRef = WeakReference(mockView),
+            tag = forge.anAlphabeticalString()
+        )
+    }
+
+    override fun createUnequalInstance(source: ViewTarget, forge: Forge): ViewTarget? {
+        return ViewTarget(
+            viewRef = WeakReference(mockAnotherView),
+            tag = forge.anAlphabeticalString()
+        )
+    }
+
+    override fun createEqualInstance(source: ViewTarget, forge: Forge): ViewTarget {
+        return ViewTarget(
+            viewRef = WeakReference(source.viewRef.get()),
+            tag = source.tag
+        )
+    }
+}

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/ComposeActionTrackingStrategyTest.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/ComposeActionTrackingStrategyTest.kt
@@ -112,7 +112,7 @@ class ComposeActionTrackingStrategyTest {
             testedComposeActionTrackingStrategy.findTargetForTap(mockAndroidComposeView, x, y)
 
         // Then
-        assertThat(result).isEqualTo(ViewTarget(view = null, tag = "node3"))
+        assertThat(result).isEqualTo(ViewTarget(tag = "node3"))
     }
 
     /**
@@ -140,7 +140,7 @@ class ComposeActionTrackingStrategyTest {
             testedComposeActionTrackingStrategy.findTargetForScroll(mockAndroidComposeView, x, y)
 
         // Then
-        assertThat(result).isEqualTo(ViewTarget(view = null, tag = "node3"))
+        assertThat(result).isEqualTo(ViewTarget(tag = "node3"))
     }
 
     /**
@@ -169,7 +169,7 @@ class ComposeActionTrackingStrategyTest {
             testedComposeActionTrackingStrategy.findTargetForTap(mockAndroidComposeView, x, y)
 
         // Then
-        assertThat(result).isEqualTo(ViewTarget(view = null, tag = "node3"))
+        assertThat(result).isEqualTo(ViewTarget(tag = "node3"))
     }
 
     /**
@@ -201,7 +201,7 @@ class ComposeActionTrackingStrategyTest {
             testedComposeActionTrackingStrategy.findTargetForScroll(mockAndroidComposeView, x, y)
 
         // Then
-        assertThat(result).isEqualTo(ViewTarget(view = null, tag = "node3"))
+        assertThat(result).isEqualTo(ViewTarget(tag = "node3"))
     }
 
     /**
@@ -229,7 +229,7 @@ class ComposeActionTrackingStrategyTest {
             testedComposeActionTrackingStrategy.findTargetForTap(mockAndroidComposeView, x, y)
 
         // Then
-        assertThat(result).isEqualTo(ViewTarget(view = null, tag = "node4"))
+        assertThat(result).isEqualTo(ViewTarget(tag = "node4"))
     }
 
     /**
@@ -257,7 +257,7 @@ class ComposeActionTrackingStrategyTest {
             testedComposeActionTrackingStrategy.findTargetForScroll(mockAndroidComposeView, x, y)
 
         // Then
-        assertThat(result).isEqualTo(ViewTarget(view = null, tag = "node4"))
+        assertThat(result).isEqualTo(ViewTarget(tag = "node4"))
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?

Prior to this PR, we were using `WeakReference` on `ViewTarget`, since `ViewTarget` is a local variable only in the scope of `findTarget` function, after execution, there will be zero reference of it, and if GC occurs, the object in  `WeakReference` will be cleaned. 

The correct way is that we should use strong reference of `ViewTarget`, but inside `ViewTarget` we hold weakReference of `View`. 

Also a dedicated GC unit test is added to cover this case.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

