### PR TITLE
RUM-9655: Fix semantics of `ExecutorService.submit` vs `Executor.execute` usage

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -71,7 +71,7 @@ import com.datadog.android.core.internal.user.DatadogUserInfoProvider
 import com.datadog.android.core.internal.user.MutableUserInfoProvider
 import com.datadog.android.core.internal.user.NoOpMutableUserInfoProvider
 import com.datadog.android.core.internal.user.UserInfoDeserializer
-import com.datadog.android.core.internal.utils.submitSafe
+import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.core.internal.utils.unboundInternalLogger
 import com.datadog.android.core.persistence.PersistenceStrategy
 import com.datadog.android.core.thread.FlushableExecutorService
@@ -201,7 +201,7 @@ internal class CoreFeature(
         readApplicationInformation(appContext, configuration)
         resolveProcessInfo(appContext)
         setupExecutors()
-        persistenceExecutorService.submitSafe("NTP Sync initialization", unboundInternalLogger) {
+        persistenceExecutorService.executeSafe("NTP Sync initialization", unboundInternalLogger) {
             // Kronos performs I/O operation on startup, it needs to run in background
             initializeClockSync(appContext)
         }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -34,8 +34,8 @@ import com.datadog.android.core.internal.logger.SdkInternalLogger
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.core.internal.time.DefaultAppStartTimeProvider
+import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.core.internal.utils.scheduleSafe
-import com.datadog.android.core.internal.utils.submitSafe
 import com.datadog.android.core.thread.FlushableExecutorService
 import com.datadog.android.error.internal.CrashReportsFeature
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
@@ -182,7 +182,7 @@ internal class DatadogCore(
         features.values.forEach {
             it.clearAllData()
         }
-        getPersistenceExecutorService().submitSafe("Clear all data", internalLogger) {
+        getPersistenceExecutorService().executeSafe("Clear all data", internalLogger) {
             coreFeature.deleteLastViewEvent()
             coreFeature.deleteLastFatalAnrSent()
         }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AbstractStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AbstractStorage.kt
@@ -16,7 +16,7 @@ import com.datadog.android.api.storage.FeatureStorageConfiguration
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.internal.metrics.RemovalReason
 import com.datadog.android.core.internal.privacy.ConsentProvider
-import com.datadog.android.core.internal.utils.submitSafe
+import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.core.persistence.NoOpPersistenceStrategy
 import com.datadog.android.core.persistence.PersistenceStrategy
 import com.datadog.android.privacy.TrackingConsent
@@ -64,7 +64,7 @@ internal class AbstractStorage(
         forceNewBatch: Boolean,
         callback: (EventBatchWriter) -> Unit
     ) {
-        executorService.submitSafe("Data write", internalLogger) {
+        executorService.executeSafe("Data write", internalLogger) {
             val strategy = resolvePersistenceStrategy()
             val writer = object : EventBatchWriter {
                 @WorkerThread
@@ -115,7 +115,7 @@ internal class AbstractStorage(
 
     @AnyThread
     override fun dropAll() {
-        executorService.submitSafe("Data drop", internalLogger) {
+        executorService.executeSafe("Data drop", internalLogger) {
             grantedPersistenceStrategy.dropAll()
             pendingPersistenceStrategy.dropAll()
         }
@@ -129,7 +129,7 @@ internal class AbstractStorage(
         previousConsent: TrackingConsent,
         newConsent: TrackingConsent
     ) {
-        executorService.submitSafe("Data migration", internalLogger) {
+        executorService.executeSafe("Data migration", internalLogger) {
             if (previousConsent == TrackingConsent.PENDING) {
                 when (newConsent) {
                     TrackingConsent.GRANTED -> pendingPersistenceStrategy.migrateData(grantedPersistenceStrategy)

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
@@ -23,7 +23,7 @@ import com.datadog.android.core.internal.persistence.file.batch.BatchFileReaderW
 import com.datadog.android.core.internal.persistence.file.existsSafe
 import com.datadog.android.core.internal.persistence.file.lengthSafe
 import com.datadog.android.core.internal.privacy.ConsentProvider
-import com.datadog.android.core.internal.utils.submitSafe
+import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.core.metrics.TelemetryMetricType
 import com.datadog.android.privacy.TrackingConsent
@@ -66,12 +66,12 @@ internal class ConsentAwareStorage(
             samplingRate = MethodCallSamplingRate.RARE.rate,
             operationName = "writeCurrentBatch[$featureName]"
         )
-        executorService.submitSafe("Data write", internalLogger) {
+        executorService.executeSafe("Data write", internalLogger) {
             val orchestrator = resolveOrchestrator()
             if (orchestrator == null) {
                 callback.invoke(NoOpEventBatchWriter())
                 metric?.stopAndSend(false)
-                return@submitSafe
+                return@executeSafe
             }
             synchronized(writeLock) {
                 val batchFile = orchestrator.getWritableFile(forceNewBatch)
@@ -144,7 +144,7 @@ internal class ConsentAwareStorage(
     /** @inheritdoc */
     @AnyThread
     override fun dropAll() {
-        executorService.submitSafe("ConsentAwareStorage.dropAll", internalLogger) {
+        executorService.executeSafe("ConsentAwareStorage.dropAll", internalLogger) {
             synchronized(lockedBatches) {
                 lockedBatches.forEach {
                     deleteBatch(it, RemovalReason.Flushed)

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
@@ -12,7 +12,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.NoOpFileOrchestrator
 import com.datadog.android.core.internal.privacy.ConsentProvider
-import com.datadog.android.core.internal.utils.submitSafe
+import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.privacy.TrackingConsentProviderCallback
 import java.io.File
@@ -98,7 +98,7 @@ internal open class ConsentAwareFileOrchestrator(
     ) {
         val previousOrchestrator = resolveDelegateOrchestrator(previousConsent)
         val newOrchestrator = resolveDelegateOrchestrator(newConsent)
-        executorService.submitSafe("Data migration", internalLogger) {
+        executorService.executeSafe("Data migration", internalLogger) {
             dataMigrator.migrateData(
                 previousConsent,
                 previousOrchestrator,

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ScheduledWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ScheduledWriter.kt
@@ -9,7 +9,7 @@ package com.datadog.android.core.internal.persistence.file.advanced
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.persistence.DataWriter
-import com.datadog.android.core.internal.utils.submitSafe
+import com.datadog.android.core.internal.utils.executeSafe
 import java.util.concurrent.ExecutorService
 
 internal class ScheduledWriter<T : Any>(
@@ -22,14 +22,14 @@ internal class ScheduledWriter<T : Any>(
 
     @WorkerThread
     override fun write(element: T) {
-        executorService.submitSafe("Data writing", internalLogger) {
+        executorService.executeSafe("Data writing", internalLogger) {
             delegateWriter.write(element)
         }
     }
 
     @WorkerThread
     override fun write(data: List<T>) {
-        executorService.submitSafe("Data writing", internalLogger) {
+        executorService.executeSafe("Data writing", internalLogger) {
             delegateWriter.write(data)
         }
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/ndk/internal/DatadogNdkCrashHandler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/ndk/internal/DatadogNdkCrashHandler.kt
@@ -17,7 +17,7 @@ import com.datadog.android.core.internal.persistence.file.FileReader
 import com.datadog.android.core.internal.persistence.file.existsSafe
 import com.datadog.android.core.internal.persistence.file.listFilesSafe
 import com.datadog.android.core.internal.persistence.file.readTextSafe
-import com.datadog.android.core.internal.utils.submitSafe
+import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.log.LogAttributes
 import com.google.gson.JsonObject
 import java.io.File
@@ -50,7 +50,7 @@ internal class DatadogNdkCrashHandler(
     // region NdkCrashHandler
 
     override fun prepareData() {
-        dataPersistenceExecutorService.submitSafe("NDK crash check", internalLogger) {
+        dataPersistenceExecutorService.executeSafe("NDK crash check", internalLogger) {
             readCrashData()
         }
     }
@@ -59,7 +59,7 @@ internal class DatadogNdkCrashHandler(
         sdkCore: FeatureSdkCore,
         reportTarget: NdkCrashHandler.ReportTarget
     ) {
-        dataPersistenceExecutorService.submitSafe("NDK crash report ", internalLogger) {
+        dataPersistenceExecutorService.executeSafe("NDK crash report ", internalLogger) {
             checkAndHandleNdkCrashReport(sdkCore, reportTarget)
         }
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
@@ -92,10 +92,6 @@ internal class DatadogCoreInitializationTest {
         whenever(mockPersistenceExecutorService.execute(any())) doAnswer {
             it.getArgument<Runnable>(0).run()
         }
-        whenever(mockPersistenceExecutorService.submit(any())) doAnswer {
-            it.getArgument<Runnable>(0).run()
-            mock()
-        }
     }
 
     @AfterEach

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
@@ -79,7 +79,6 @@ import java.util.Collections
 import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
@@ -121,10 +120,6 @@ internal class DatadogCoreTest {
         CoreFeature.disableKronosBackgroundSync = true
         whenever(mockPersistenceExecutorService.execute(any())) doAnswer {
             it.getArgument<Runnable>(0).run()
-        }
-        whenever(mockPersistenceExecutorService.submit(any())) doAnswer {
-            it.getArgument<Runnable>(0).run()
-            mock()
         }
 
         testedCore = DatadogCore(
@@ -753,10 +748,9 @@ internal class DatadogCoreTest {
         testedCore.coreFeature = mockCoreFeature
         val mockExecutorService: FlushableExecutorService = mock()
         whenever(mockCoreFeature.persistenceExecutorService) doReturn mockExecutorService
-        whenever(mockExecutorService.submit(any())) doAnswer {
+        whenever(mockExecutorService.execute(any())) doAnswer {
             val runnable = it.arguments.first() as Runnable
             runnable.run()
-            mock<Future<*>>()
         }
 
         // When

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -155,10 +155,6 @@ internal class CoreFeatureTest {
         whenever(mockPersistenceExecutorService.execute(any())) doAnswer {
             it.getArgument<Runnable>(0).run()
         }
-        whenever(mockPersistenceExecutorService.submit(any())) doAnswer {
-            it.getArgument<Runnable>(0).run()
-            mock()
-        }
     }
 
     @AfterEach

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
@@ -332,7 +332,7 @@ internal class ConsentAwareStorageTest {
     ) {
         // Given
         val mockExecutor = mock<ExecutorService>()
-        whenever(mockExecutor.submit(any())) doThrow RejectedExecutionException()
+        whenever(mockExecutor.execute(any())) doThrow RejectedExecutionException()
         testedStorage = ConsentAwareStorage(
             // same thread executor
             executorService = mockExecutor,

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestratorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestratorTest.kt
@@ -96,7 +96,7 @@ internal class ConsentAwareFileOrchestratorTest {
 
         // Then
         argumentCaptor<Runnable> {
-            verify(mockExecutorService).submit(capture())
+            verify(mockExecutorService).execute(capture())
             firstValue.run()
             verify(mockDataMigrator).migrateData(
                 null,
@@ -114,7 +114,7 @@ internal class ConsentAwareFileOrchestratorTest {
 
         // Then
         argumentCaptor<Runnable> {
-            verify(mockExecutorService).submit(capture())
+            verify(mockExecutorService).execute(capture())
             firstValue.run()
             verify(mockDataMigrator).migrateData(
                 null,
@@ -132,7 +132,7 @@ internal class ConsentAwareFileOrchestratorTest {
 
         // Then
         argumentCaptor<Runnable> {
-            verify(mockExecutorService).submit(capture())
+            verify(mockExecutorService).execute(capture())
             firstValue.run()
             verify(mockDataMigrator).migrateData(
                 null,
@@ -678,7 +678,7 @@ internal class ConsentAwareFileOrchestratorTest {
 
         // Then
         argumentCaptor<Runnable> {
-            verify(mockExecutorService).submit(capture())
+            verify(mockExecutorService).execute(capture())
             firstValue.run()
             verify(mockDataMigrator).migrateData(
                 TrackingConsent.GRANTED,
@@ -696,7 +696,7 @@ internal class ConsentAwareFileOrchestratorTest {
 
         // Then
         argumentCaptor<Runnable> {
-            verify(mockExecutorService).submit(capture())
+            verify(mockExecutorService).execute(capture())
             firstValue.run()
             verify(mockDataMigrator).migrateData(
                 TrackingConsent.GRANTED,
@@ -714,7 +714,7 @@ internal class ConsentAwareFileOrchestratorTest {
 
         // Then
         argumentCaptor<Runnable> {
-            verify(mockExecutorService).submit(capture())
+            verify(mockExecutorService).execute(capture())
             firstValue.run()
             verify(mockDataMigrator).migrateData(
                 TrackingConsent.GRANTED,
@@ -732,7 +732,7 @@ internal class ConsentAwareFileOrchestratorTest {
 
         // Then
         argumentCaptor<Runnable> {
-            verify(mockExecutorService).submit(capture())
+            verify(mockExecutorService).execute(capture())
             firstValue.run()
             verify(mockDataMigrator).migrateData(
                 TrackingConsent.PENDING,
@@ -750,7 +750,7 @@ internal class ConsentAwareFileOrchestratorTest {
 
         // Then
         argumentCaptor<Runnable> {
-            verify(mockExecutorService).submit(capture())
+            verify(mockExecutorService).execute(capture())
             firstValue.run()
             verify(mockDataMigrator).migrateData(
                 TrackingConsent.PENDING,
@@ -768,7 +768,7 @@ internal class ConsentAwareFileOrchestratorTest {
 
         // Then
         argumentCaptor<Runnable> {
-            verify(mockExecutorService).submit(capture())
+            verify(mockExecutorService).execute(capture())
             firstValue.run()
             verify(mockDataMigrator).migrateData(
                 TrackingConsent.PENDING,
@@ -786,7 +786,7 @@ internal class ConsentAwareFileOrchestratorTest {
 
         // Then
         argumentCaptor<Runnable> {
-            verify(mockExecutorService).submit(capture())
+            verify(mockExecutorService).execute(capture())
             firstValue.run()
             verify(mockDataMigrator).migrateData(
                 TrackingConsent.NOT_GRANTED,
@@ -804,7 +804,7 @@ internal class ConsentAwareFileOrchestratorTest {
 
         // Then
         argumentCaptor<Runnable> {
-            verify(mockExecutorService).submit(capture())
+            verify(mockExecutorService).execute(capture())
             firstValue.run()
             verify(mockDataMigrator).migrateData(
                 TrackingConsent.NOT_GRANTED,
@@ -825,7 +825,7 @@ internal class ConsentAwareFileOrchestratorTest {
 
         // Then
         argumentCaptor<Runnable> {
-            verify(mockExecutorService).submit(capture())
+            verify(mockExecutorService).execute(capture())
             firstValue.run()
             verify(mockDataMigrator).migrateData(
                 TrackingConsent.NOT_GRANTED,
@@ -844,7 +844,7 @@ internal class ConsentAwareFileOrchestratorTest {
     ) {
         // Given
         val exception = RejectedExecutionException(errorMessage)
-        whenever(mockExecutorService.submit(any())) doThrow exception
+        whenever(mockExecutorService.execute(any())) doThrow exception
 
         // When
         testedOrchestrator.onConsentUpdated(previousConsent, newConsent)
@@ -874,7 +874,7 @@ internal class ConsentAwareFileOrchestratorTest {
 
     private fun runPendingRunnable() {
         argumentCaptor<Runnable> {
-            verify(mockExecutorService, atLeast(0)).submit(capture())
+            verify(mockExecutorService, atLeast(0)).execute(capture())
             allValues.forEach { it.run() }
         }
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ScheduledWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ScheduledWriterTest.kt
@@ -71,7 +71,7 @@ internal class ScheduledWriterTest {
         // Then
         verifyNoInteractions(mockDelegateWriter)
         argumentCaptor<Runnable> {
-            verify(mockExecutorService).submit(capture())
+            verify(mockExecutorService).execute(capture())
             firstValue.run()
             verify(mockDelegateWriter).write(data)
         }
@@ -86,7 +86,7 @@ internal class ScheduledWriterTest {
     ) {
         // Given
         val exception = RejectedExecutionException(errorMessage)
-        whenever(mockExecutorService.submit(any())) doThrow exception
+        whenever(mockExecutorService.execute(any())) doThrow exception
 
         // When
         testedWriter.write(data)
@@ -113,7 +113,7 @@ internal class ScheduledWriterTest {
         // Then
         verifyNoInteractions(mockDelegateWriter)
         argumentCaptor<Runnable> {
-            verify(mockExecutorService).submit(capture())
+            verify(mockExecutorService).execute(capture())
             firstValue.run()
             verify(mockDelegateWriter).write(data)
         }
@@ -128,7 +128,7 @@ internal class ScheduledWriterTest {
     ) {
         // Given
         val exception = RejectedExecutionException(errorMessage)
-        whenever(mockExecutorService.submit(any())) doThrow exception
+        whenever(mockExecutorService.execute(any())) doThrow exception
 
         // When
         testedWriter.write(data)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/ndk/internal/DatadogNdkCrashHandlerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/ndk/internal/DatadogNdkCrashHandlerTest.kt
@@ -149,7 +149,7 @@ internal class DatadogNdkCrashHandlerTest {
 
         // Then
         assertThat(testedHandler.lastNdkCrashLog).isNull()
-        verify(mockExecutorService).submit(captureRunnable.capture())
+        verify(mockExecutorService).execute(captureRunnable.capture())
         captureRunnable.firstValue.run()
         assertThat(testedHandler.lastNdkCrashLog)
             .isEqualTo(fakeCrashData)
@@ -169,7 +169,7 @@ internal class DatadogNdkCrashHandlerTest {
 
         // Then
         assertThat(testedHandler.lastRumViewEvent).isNull()
-        verify(mockExecutorService).submit(captureRunnable.capture())
+        verify(mockExecutorService).execute(captureRunnable.capture())
         captureRunnable.firstValue.run()
         assertThat(testedHandler.lastRumViewEvent)
             .isEqualTo(fakeViewEvent.toJson())
@@ -191,7 +191,7 @@ internal class DatadogNdkCrashHandlerTest {
 
         // Then
         assertThat(testedHandler.lastNetworkInfo).isNull()
-        verify(mockExecutorService).submit(captureRunnable.capture())
+        verify(mockExecutorService).execute(captureRunnable.capture())
         captureRunnable.firstValue.run()
         assertThat(testedHandler.lastNetworkInfo)
             .isEqualTo(fakeNetworkInfo)
@@ -212,7 +212,7 @@ internal class DatadogNdkCrashHandlerTest {
 
         // Then
         assertThat(testedHandler.lastUserInfo).isNull()
-        verify(mockExecutorService).submit(captureRunnable.capture())
+        verify(mockExecutorService).execute(captureRunnable.capture())
         captureRunnable.firstValue.run()
         assertThat(testedHandler.lastUserInfo)
             .isEqualTo(fakeUserInfo)
@@ -227,7 +227,7 @@ internal class DatadogNdkCrashHandlerTest {
         whenever(mockNetworkInfoDeserializer.deserialize(any())) doReturn mock()
 
         // Then
-        verify(mockExecutorService).submit(captureRunnable.capture())
+        verify(mockExecutorService).execute(captureRunnable.capture())
         captureRunnable.firstValue.run()
         assertThat(testedHandler.lastRumViewEvent).isNull()
         assertThat(testedHandler.lastNdkCrashLog).isNull()
@@ -253,7 +253,7 @@ internal class DatadogNdkCrashHandlerTest {
         testedHandler.prepareData()
 
         // Then
-        verify(mockExecutorService).submit(captureRunnable.capture())
+        verify(mockExecutorService).execute(captureRunnable.capture())
         captureRunnable.firstValue.run()
         assertThat(fakeNdkCacheDir).isEmptyDirectory
     }
@@ -271,7 +271,7 @@ internal class DatadogNdkCrashHandlerTest {
         testedHandler.handleNdkCrash(mockSdkCore, reportTarget)
 
         // Then
-        verify(mockExecutorService).submit(captureRunnable.capture())
+        verify(mockExecutorService).execute(captureRunnable.capture())
         captureRunnable.firstValue.run()
         verifyNoInteractions(mockSdkCore)
     }
@@ -288,7 +288,7 @@ internal class DatadogNdkCrashHandlerTest {
         testedHandler.handleNdkCrash(mockSdkCore, NdkCrashHandler.ReportTarget.LOGS)
 
         // Then
-        verify(mockExecutorService).submit(captureRunnable.capture())
+        verify(mockExecutorService).execute(captureRunnable.capture())
         verifyNoInteractions(mockSdkCore)
         captureRunnable.firstValue.run()
 
@@ -314,7 +314,7 @@ internal class DatadogNdkCrashHandlerTest {
         testedHandler.handleNdkCrash(mockSdkCore, NdkCrashHandler.ReportTarget.LOGS)
 
         // Then
-        verify(mockExecutorService).submit(captureRunnable.capture())
+        verify(mockExecutorService).execute(captureRunnable.capture())
         verifyNoInteractions(mockSdkCore)
         captureRunnable.firstValue.run()
         verify(mockLogsFeatureScope).sendEvent(expectedLogEvent)
@@ -337,7 +337,7 @@ internal class DatadogNdkCrashHandlerTest {
         testedHandler.handleNdkCrash(mockSdkCore, NdkCrashHandler.ReportTarget.LOGS)
 
         // Then
-        verify(mockExecutorService).submit(captureRunnable.capture())
+        verify(mockExecutorService).execute(captureRunnable.capture())
         verifyNoInteractions(mockSdkCore)
         captureRunnable.firstValue.run()
         verify(mockLogsFeatureScope).sendEvent(expectedLogEvent)
@@ -359,7 +359,7 @@ internal class DatadogNdkCrashHandlerTest {
         testedHandler.handleNdkCrash(mockSdkCore, NdkCrashHandler.ReportTarget.LOGS)
 
         // Then
-        verify(mockExecutorService).submit(captureRunnable.capture())
+        verify(mockExecutorService).execute(captureRunnable.capture())
         verifyNoInteractions(mockSdkCore)
         captureRunnable.firstValue.run()
         verify(mockLogsFeatureScope).sendEvent(expectedLogEvent)
@@ -392,7 +392,7 @@ internal class DatadogNdkCrashHandlerTest {
         handler.handleNdkCrash(mockSdkCore, NdkCrashHandler.ReportTarget.LOGS)
 
         // Then
-        verify(mockExecutorService).submit(captureRunnable.capture())
+        verify(mockExecutorService).execute(captureRunnable.capture())
         verifyNoInteractions(mockSdkCore)
         captureRunnable.firstValue.run()
         verify(mockLogsFeatureScope).sendEvent(expectedLogEvent)
@@ -451,7 +451,7 @@ internal class DatadogNdkCrashHandlerTest {
         testedHandler.handleNdkCrash(mockSdkCore, NdkCrashHandler.ReportTarget.LOGS)
 
         // Then
-        verify(mockExecutorService).submit(captureRunnable.capture())
+        verify(mockExecutorService).execute(captureRunnable.capture())
         verifyNoInteractions(mockSdkCore)
         captureRunnable.firstValue.run()
         verify(mockLogsFeatureScope).sendEvent(expectedLogEvent)
@@ -478,7 +478,7 @@ internal class DatadogNdkCrashHandlerTest {
         testedHandler.handleNdkCrash(mockSdkCore, NdkCrashHandler.ReportTarget.RUM)
 
         // Then
-        verify(mockExecutorService).submit(captureRunnable.capture())
+        verify(mockExecutorService).execute(captureRunnable.capture())
         verifyNoInteractions(mockSdkCore)
         captureRunnable.firstValue.run()
         mockInternalLogger.verifyLog(
@@ -499,7 +499,7 @@ internal class DatadogNdkCrashHandlerTest {
         testedHandler.handleNdkCrash(mockSdkCore, NdkCrashHandler.ReportTarget.RUM)
 
         // Then
-        verify(mockExecutorService).submit(captureRunnable.capture())
+        verify(mockExecutorService).execute(captureRunnable.capture())
         verifyNoInteractions(mockSdkCore)
         captureRunnable.firstValue.run()
         verifyNoInteractions(mockInternalLogger, mockRumFeatureScope)
@@ -519,7 +519,7 @@ internal class DatadogNdkCrashHandlerTest {
         testedHandler.handleNdkCrash(mockSdkCore, NdkCrashHandler.ReportTarget.RUM)
 
         // Then
-        verify(mockExecutorService).submit(captureRunnable.capture())
+        verify(mockExecutorService).execute(captureRunnable.capture())
         verifyNoInteractions(mockSdkCore)
         captureRunnable.firstValue.run()
         verify(mockRumFeatureScope).sendEvent(
@@ -563,7 +563,7 @@ internal class DatadogNdkCrashHandlerTest {
         handler.handleNdkCrash(mockSdkCore, NdkCrashHandler.ReportTarget.RUM)
 
         // Then
-        verify(mockExecutorService).submit(captureRunnable.capture())
+        verify(mockExecutorService).execute(captureRunnable.capture())
         verifyNoInteractions(mockSdkCore)
         captureRunnable.firstValue.run()
         verify(mockRumFeatureScope).sendEvent(
@@ -606,7 +606,7 @@ internal class DatadogNdkCrashHandlerTest {
             }
 
         // Then
-        verify(mockExecutorService, times(2)).submit(captureRunnable.capture())
+        verify(mockExecutorService, times(2)).execute(captureRunnable.capture())
         verifyNoInteractions(mockSdkCore)
         captureRunnable.allValues.forEach { it.run() }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -30,7 +30,6 @@ import com.datadog.android.core.feature.event.JvmCrash
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.core.internal.utils.scheduleSafe
-import com.datadog.android.core.internal.utils.submitSafe
 import com.datadog.android.event.EventMapper
 import com.datadog.android.event.MapperSerializer
 import com.datadog.android.event.NoOpEventMapper
@@ -421,7 +420,7 @@ internal class RumFeature(
             null
         } ?: return
 
-        rumEventsExecutorService.submitSafe("Send fatal ANR", sdkCore.internalLogger) {
+        rumEventsExecutorService.executeSafe("Send fatal ANR", sdkCore.internalLogger) {
             val lastRumViewEvent = (sdkCore as InternalSdkCore).lastViewEvent
             if (lastRumViewEvent != null) {
                 lateCrashEventHandler.handleAnrCrash(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -15,7 +15,7 @@ import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.feature.event.ThreadDump
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
-import com.datadog.android.core.internal.utils.submitSafe
+import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.rum.DdRumContentProvider
 import com.datadog.android.rum.ExperimentalRumApi
@@ -116,7 +116,7 @@ internal class DatadogRumMonitor(
     // region RumMonitor
 
     override fun getCurrentSessionId(callback: (String?) -> Unit) {
-        executorService.submitSafe(
+        executorService.executeSafe(
             "Get current session ID",
             sdkCore.internalLogger
         ) {
@@ -684,7 +684,7 @@ internal class DatadogRumMonitor(
             handler.removeCallbacks(keepAliveRunnable)
             // avoid trowing a RejectedExecutionException
             if (!executorService.isShutdown) {
-                executorService.submitSafe("Rum event handling", sdkCore.internalLogger) {
+                executorService.executeSafe("Rum event handling", sdkCore.internalLogger) {
                     synchronized(rootScope) {
                         rootScope.handleEvent(event, writer)
                         notifyDebugListenerWithState()
@@ -704,7 +704,7 @@ internal class DatadogRumMonitor(
         if (!executorService.isShutdown) {
             @Suppress("UnsafeThirdPartyFunctionCall") // 1 cannot be negative
             val latch = CountDownLatch(1)
-            executorService.submitSafe("pending event waiting", sdkCore.internalLogger) {
+            executorService.executeSafe("pending event waiting", sdkCore.internalLogger) {
                 latch.countDown()
             }
             try {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -1428,9 +1428,8 @@ internal class RumFeatureTest {
 
     private fun mockSameThreadExecutorService(): ExecutorService {
         return mock<ExecutorService>().apply {
-            whenever(submit(any())) doAnswer {
+            whenever(execute(any())) doAnswer {
                 it.getArgument<Runnable>(0).run()
-                mock()
             }
         }
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -183,9 +183,8 @@ internal class DatadogRumMonitorTest {
 
     @BeforeEach
     fun `set up`(forge: Forge) {
-        whenever(mockExecutorService.submit(any())) doAnswer {
+        whenever(mockExecutorService.execute(any())) doAnswer {
             it.getArgument<Runnable>(0).run()
-            StubFuture()
         }
 
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
@@ -376,9 +375,8 @@ internal class DatadogRumMonitorTest {
         @Forgery type: RumActionType,
         @StringForgery name: String
     ) {
-        whenever(mockExecutorService.submit(any())) doAnswer {
+        whenever(mockExecutorService.execute(any())) doAnswer {
             it.getArgument<Runnable>(0).run()
-            StubFuture()
         }
 
         testedMonitor.addAction(type, name, fakeAttributes)
@@ -1777,7 +1775,7 @@ internal class DatadogRumMonitorTest {
         testedMonitor.handleEvent(mock())
 
         // Then
-        verify(mockExecutorService, never()).submit(any())
+        verify(mockExecutorService, never()).execute(any())
     }
 
     @Test
@@ -2243,17 +2241,6 @@ internal class DatadogRumMonitorTest {
             InternalLogger.Target.USER,
             DatadogRumMonitor.RUM_DEBUG_RUM_NOT_ENABLED_WARNING
         )
-    }
-
-    class StubFuture : Future<Any> {
-        override fun cancel(mayInterruptIfRunning: Boolean) =
-            error("Not supposed to be called")
-
-        override fun isCancelled(): Boolean = error("Not supposed to be called")
-        override fun isDone(): Boolean = error("Not supposed to be called")
-        override fun get(): Any = error("Not supposed to be called")
-        override fun get(timeout: Long, unit: TimeUnit?): Any =
-            error("Not supposed to be called")
     }
 
     companion object {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtils.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtils.kt
@@ -16,7 +16,7 @@ import android.util.DisplayMetrics
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.core.internal.utils.submitSafe
+import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.sessionreplay.internal.recorder.resources.BitmapCachesManager
 import com.datadog.android.sessionreplay.internal.recorder.resources.ResourceResolver
 import com.datadog.android.sessionreplay.recorder.wrappers.BitmapWrapper
@@ -56,7 +56,7 @@ internal class DrawableUtils(
             resizeBitmapCallback = object : ResizeBitmapCallback {
                 @WorkerThread
                 override fun onSuccess(bitmap: Bitmap) {
-                    executorService.submitSafe("drawOnCanvas", internalLogger) {
+                    executorService.executeSafe("drawOnCanvas", internalLogger) {
                         drawOnCanvas(
                             bitmap,
                             drawable,

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtilsTest.kt
@@ -43,7 +43,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.Future
 import java.util.stream.Stream
 
 @Extensions(
@@ -101,9 +100,6 @@ internal class DrawableUtilsTest {
     @Mock
     private lateinit var mockLogger: InternalLogger
 
-    @Mock
-    private lateinit var mockFuture: Future<Unit>
-
     @BeforeEach
     fun setup() {
         whenever(mockConstantState.newDrawable(mockResources)).thenReturn(mockSecondDrawable)
@@ -117,10 +113,9 @@ internal class DrawableUtilsTest {
         whenever(mockBitmap.config).thenReturn(mockConfig)
         whenever(mockBitmapCachesManager.getBitmapByProperties(any(), any(), any())).thenReturn(null)
 
-        whenever(mockExecutorService.submit(any())) doAnswer {
+        whenever(mockExecutorService.execute(any())) doAnswer {
             val runnable = it.getArgument<Runnable>(0)
             runnable.run()
-            mockFuture
         }
 
         testedDrawableUtils = DrawableUtils(


### PR DESCRIPTION
### What does this PR do?

We are using `ExecutorService.submit(): Future<?>` in some places where `Executor.execute(): Unit` is enough, because we don’t use return value. This PR switches to `Executor.execute(): Unit` usage where possible to explicitly indicate that we don't need return value.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

