### PR TITLE
RUM-9410 Remove the noisy warning log as for some views is normal to not have itv

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/interactiontonextview/InteractionToNextViewMetricResolver.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/interactiontonextview/InteractionToNextViewMetricResolver.kt
@@ -68,15 +68,6 @@ internal class InteractionToNextViewMetricResolver(
                 return null
             }
         }
-        // in case there are no previous interactions for this view and there's only one view created
-        // we are probably in the first view of the app (AppLaunch) and we can't calculate the metric
-        if (lastViewCreatedTimestamps.size > 1) {
-            internalLogger.log(
-                InternalLogger.Level.WARN,
-                InternalLogger.Target.MAINTAINER,
-                { "[ViewNetworkSettledMetric] No previous interaction found for this viewId:$viewId" }
-            )
-        }
         return null
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/interactiontonextview/InteractionToNextViewMetricResolverTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/interactiontonextview/InteractionToNextViewMetricResolverTest.kt
@@ -283,11 +283,6 @@ internal class InteractionToNextViewMetricResolverTest {
 
         // Then
         assertThat(result).isNull()
-        mockInternalLogger.verifyLog(
-            InternalLogger.Level.WARN,
-            InternalLogger.Target.MAINTAINER,
-            "[ViewNetworkSettledMetric] No previous interaction found for this viewId:$fakeViewId"
-        )
     }
 
     @Test
@@ -317,11 +312,6 @@ internal class InteractionToNextViewMetricResolverTest {
 
         // Then
         assertThat(result).isNull()
-        mockInternalLogger.verifyLog(
-            InternalLogger.Level.WARN,
-            InternalLogger.Target.MAINTAINER,
-            "[ViewNetworkSettledMetric] No previous interaction found for this viewId:$fakeViewId"
-        )
     }
 
     @Test
@@ -339,11 +329,6 @@ internal class InteractionToNextViewMetricResolverTest {
 
         // Then
         assertThat(result).isNull()
-        mockInternalLogger.verifyLog(
-            InternalLogger.Level.WARN,
-            InternalLogger.Target.MAINTAINER,
-            "[ViewNetworkSettledMetric] No previous interaction found for this viewId:$fakeViewId"
-        )
     }
 
     @Test


### PR DESCRIPTION
…not have itv metric

### What does this PR do?

I performed a thorough functionality check on the way we resolve the ITV metric and everything seems to work fine. I chose to remove the noisy log when the metric could not be resolved as for some views (especially the first ones that are loaded automatically without any user interaction) this behaviour is normal.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

