### PR TITLE
RUM-9720: Remove `forceNewBatch` API

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -108,7 +108,7 @@ interface com.datadog.android.api.feature.FeatureEventReceiver
   fun onReceive(Any)
 interface com.datadog.android.api.feature.FeatureScope
   val dataStore: com.datadog.android.api.storage.datastore.DataStoreHandler
-  fun withWriteContext(Boolean = false, (com.datadog.android.api.context.DatadogContext, com.datadog.android.api.storage.EventBatchWriter) -> Unit)
+  fun withWriteContext((com.datadog.android.api.context.DatadogContext, com.datadog.android.api.storage.EventBatchWriter) -> Unit)
   fun sendEvent(Any)
   fun <T: Feature> unwrap(): T
 fun <R: Any?> com.datadog.android.api.InternalLogger.measureMethodCallPerf(Class<*>, String, Float = 100f, () -> R): R

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -344,11 +344,7 @@ public abstract interface class com/datadog/android/api/feature/FeatureScope {
 	public abstract fun getDataStore ()Lcom/datadog/android/api/storage/datastore/DataStoreHandler;
 	public abstract fun sendEvent (Ljava/lang/Object;)V
 	public abstract fun unwrap ()Lcom/datadog/android/api/feature/Feature;
-	public abstract fun withWriteContext (ZLkotlin/jvm/functions/Function2;)V
-}
-
-public final class com/datadog/android/api/feature/FeatureScope$DefaultImpls {
-	public static synthetic fun withWriteContext$default (Lcom/datadog/android/api/feature/FeatureScope;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public abstract fun withWriteContext (Lkotlin/jvm/functions/Function2;)V
 }
 
 public final class com/datadog/android/api/feature/FeatureScopeExtKt {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureScope.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureScope.kt
@@ -23,8 +23,6 @@ interface FeatureScope {
 
     /**
      * Utility to write an event, asynchronously.
-     * @param forceNewBatch if `true` forces the [EventBatchWriter] to write in a new file and
-     * not reuse the already existing pending data persistence file. By default it is `false`.
      * @param callback an operation called with an up-to-date [DatadogContext]
      * and an [EventBatchWriter]. Callback will be executed on a worker thread from I/O pool.
      * [DatadogContext] will have a state created at the moment this method is called, before the
@@ -32,7 +30,6 @@ interface FeatureScope {
      */
     @AnyThread
     fun withWriteContext(
-        forceNewBatch: Boolean = false,
         callback: (DatadogContext, EventBatchWriter) -> Unit
     )
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -169,7 +169,6 @@ internal class SdkFeature(
     // region FeatureScope
 
     override fun withWriteContext(
-        forceNewBatch: Boolean,
         callback: (DatadogContext, EventBatchWriter) -> Unit
     ) {
         // TODO RUM-1462 thread safety. Thread switch happens in Storage right now. Open questions:
@@ -179,7 +178,7 @@ internal class SdkFeature(
         val contextProvider = coreFeature.contextProvider
         if (contextProvider is NoOpContextProvider) return
         val context = contextProvider.context
-        storage.writeCurrentBatch(context, forceNewBatch) { callback(context, it) }
+        storage.writeCurrentBatch(context) { callback(context, it) }
     }
 
     override fun sendEvent(event: Any) {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchClosedMetadata.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchClosedMetadata.kt
@@ -8,6 +8,5 @@ package com.datadog.android.core.internal.metrics
 
 internal data class BatchClosedMetadata(
     internal val lastTimeWasUsedInMs: Long,
-    internal val forcedNew: Boolean,
     internal val eventsCount: Long
 )

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
@@ -136,7 +136,6 @@ internal class BatchMetricsDispatcher(
             // be sent as a batch_delete telemetry later
             BATCH_SIZE_KEY to file.lengthSafe(internalLogger),
             BATCH_EVENTS_COUNT_KEY to batchMetadata.eventsCount,
-            FORCE_NEW_KEY to batchMetadata.forcedNew,
             TRACKING_CONSENT_KEY to file.resolveFileOriginAsConsent(),
             FILE_NAME to file.name,
             THREAD_NAME to Thread.currentThread().name
@@ -245,9 +244,6 @@ internal class BatchMetricsDispatcher(
 
         /* The duration from batch creation to batch closing (in ms).*/
         internal const val BATCH_DURATION_KEY = "batch_duration"
-
-        /* If the batch was closed by core or after new batch was forced by the feature.*/
-        internal const val FORCE_NEW_KEY = "forced_new"
 
         internal const val BATCH_CLOSED_MESSAGE = "[Mobile Metric] Batch Closed"
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AbstractStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AbstractStorage.kt
@@ -61,7 +61,6 @@ internal class AbstractStorage(
     @AnyThread
     override fun writeCurrentBatch(
         datadogContext: DatadogContext,
-        forceNewBatch: Boolean,
         callback: (EventBatchWriter) -> Unit
     ) {
         executorService.executeSafe("Data write", internalLogger) {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
@@ -55,7 +55,6 @@ internal class ConsentAwareStorage(
     @WorkerThread
     override fun writeCurrentBatch(
         datadogContext: DatadogContext,
-        forceNewBatch: Boolean,
         callback: (EventBatchWriter) -> Unit
     ) {
         executorService.executeSafe("Data write", internalLogger) {
@@ -68,7 +67,6 @@ internal class ConsentAwareStorage(
             synchronized(writeLock) {
                 val writer = FileEventBatchWriter(
                     fileOrchestrator = orchestrator,
-                    forceNewBatch = forceNewBatch,
                     eventsWriter = batchEventsReaderWriter,
                     metadataReaderWriter = batchMetadataReaderWriter,
                     filePersistenceConfig = filePersistenceConfig,

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriter.kt
@@ -21,7 +21,6 @@ import java.util.Locale
 
 internal class FileEventBatchWriter(
     private val fileOrchestrator: FileOrchestrator,
-    private val forceNewBatch: Boolean,
     private val eventsWriter: FileWriter<RawBatchEvent>,
     private val metadataReaderWriter: FileReaderWriter,
     private val filePersistenceConfig: FilePersistenceConfig,
@@ -32,7 +31,7 @@ internal class FileEventBatchWriter(
     @get:WorkerThread
     private val batchFile: File? by lazy {
         @Suppress("ThreadSafety") // called in the worker context
-        fileOrchestrator.getWritableFile(forceNewFile = forceNewBatch)
+        fileOrchestrator.getWritableFile()
     }
 
     @get:WorkerThread

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/Storage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/Storage.kt
@@ -22,15 +22,12 @@ internal interface Storage {
     /**
      * Utility to write data, asynchronously.
      * @param datadogContext the context for the write operation
-     * @param forceNewBatch if `true` will force the writer to start a new batch before storing the
-     * data. By default this flag is `false`.
      * @param callback an operation to perform with a [EventBatchWriter] that will target the current
      * writeable Batch
      */
     @AnyThread
     fun writeCurrentBatch(
         datadogContext: DatadogContext,
-        forceNewBatch: Boolean,
         callback: (EventBatchWriter) -> Unit
     )
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileOrchestrator.kt
@@ -21,13 +21,11 @@ import java.io.File
 internal interface FileOrchestrator {
 
     /**
-     * @param forceNewFile if `true` will force the orchestrator to start a new file.
-     * By default this flag is `false`.
      * @return a File with enough space to write data, or null if no space is available
      * or the disk can't be written to.
      */
     @WorkerThread
-    fun getWritableFile(forceNewFile: Boolean = false): File?
+    fun getWritableFile(): File?
 
     /**
      * @param excludeFiles a set of files to exclude from the readable files

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
@@ -39,8 +39,8 @@ internal open class ConsentAwareFileOrchestrator(
     // region FileOrchestrator
 
     @WorkerThread
-    override fun getWritableFile(forceNewFile: Boolean): File? {
-        return delegateOrchestrator.getWritableFile(forceNewFile)
+    override fun getWritableFile(): File? {
+        return delegateOrchestrator.getWritableFile()
     }
 
     @WorkerThread

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
@@ -55,7 +55,7 @@ internal class BatchFileOrchestrator(
     // region FileOrchestrator
 
     @WorkerThread
-    override fun getWritableFile(forceNewFile: Boolean): File? {
+    override fun getWritableFile(): File? {
         if (!isRootDirValid()) {
             return null
         }
@@ -67,11 +67,7 @@ internal class BatchFileOrchestrator(
             lastCleanupTimestamp = System.currentTimeMillis()
         }
 
-        return if (!forceNewFile) {
-            getReusableWritableFile() ?: createNewFile()
-        } else {
-            createNewFile(true)
-        }
+        return getReusableWritableFile() ?: createNewFile()
     }
 
     @WorkerThread
@@ -205,7 +201,7 @@ internal class BatchFileOrchestrator(
         }
     }
 
-    private fun createNewFile(wasForced: Boolean = false): File {
+    private fun createNewFile(): File {
         val newFileName = System.currentTimeMillis().toString()
         val newFile = File(rootDir, newFileName)
         val closedFile = previousFile
@@ -215,8 +211,7 @@ internal class BatchFileOrchestrator(
                 closedFile,
                 BatchClosedMetadata(
                     lastTimeWasUsedInMs = closedFileLastAccessTimestamp,
-                    eventsCount = previousFileItemCount,
-                    forcedNew = wasForced
+                    eventsCount = previousFileItemCount
                 )
             )
         }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleFileOrchestrator.kt
@@ -19,12 +19,8 @@ internal class SingleFileOrchestrator(
 
     // region FileOrchestrator
 
-    /**
-     * @param forceNewFile Does not have any effect on this method and it is only used to comply
-     * with the [FileOrchestrator] interface.
-     */
     @WorkerThread
-    override fun getWritableFile(forceNewFile: Boolean): File? {
+    override fun getWritableFile(): File? {
         file.parentFile?.mkdirsSafe(internalLogger)
         return file
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -55,7 +55,6 @@ import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import fr.xgouchet.elmyr.Forge
-import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -474,7 +473,6 @@ internal class SdkFeatureTest {
 
     @Test
     fun `M provide write context W withWriteContext(callback)`(
-        @BoolForgery forceNewBatch: Boolean,
         @Forgery fakeContext: DatadogContext,
         @Mock mockBatchWriter: EventBatchWriter
     ) {
@@ -486,16 +484,15 @@ internal class SdkFeatureTest {
         whenever(
             mockStorage.writeCurrentBatch(
                 eq(fakeContext),
-                eq(forceNewBatch),
                 any()
             )
         ) doAnswer {
-            val storageCallback = it.getArgument<(EventBatchWriter) -> Unit>(2)
+            val storageCallback = it.getArgument<(EventBatchWriter) -> Unit>(1)
             storageCallback.invoke(mockBatchWriter)
         }
 
         // When
-        testedFeature.withWriteContext(forceNewBatch, callback = callback)
+        testedFeature.withWriteContext(callback = callback)
 
         // Then
         verify(callback).invoke(
@@ -505,9 +502,7 @@ internal class SdkFeatureTest {
     }
 
     @Test
-    fun `M do nothing W withWriteContext(callback) { no Datadog context }`(
-        @BoolForgery forceNewBatch: Boolean
-    ) {
+    fun `M do nothing W withWriteContext(callback) { no Datadog context }`() {
         // Given
         testedFeature.storage = mockStorage
         val callback = mock<(DatadogContext, EventBatchWriter) -> Unit>()
@@ -515,7 +510,7 @@ internal class SdkFeatureTest {
         whenever(coreFeature.mockInstance.contextProvider) doReturn NoOpContextProvider()
 
         // When
-        testedFeature.withWriteContext(forceNewBatch, callback = callback)
+        testedFeature.withWriteContext(callback = callback)
 
         // Then
         verifyNoInteractions(mockStorage)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
@@ -581,7 +581,6 @@ internal class BatchMetricsDispatcherTest {
                 max(0, (batchClosedMetadata.lastTimeWasUsedInMs - file.name.toLong())),
             BatchMetricsDispatcher.UPLOADER_WINDOW_KEY to
                 fakeFilePersistenceConfig.recentDelayMs,
-            BatchMetricsDispatcher.FORCE_NEW_KEY to batchClosedMetadata.forcedNew,
             BatchMetricsDispatcher.BATCH_EVENTS_COUNT_KEY to batchClosedMetadata.eventsCount,
             BatchMetricsDispatcher.FILE_NAME to file.name,
             BatchMetricsDispatcher.THREAD_NAME to Thread.currentThread().name,

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AbstractStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AbstractStorageTest.kt
@@ -104,7 +104,6 @@ internal class AbstractStorageTest {
 
     @Test
     fun `M provide writer W writeCurrentBatch()+write() {consent=granted, batchMetadata=null}`(
-        @BoolForgery forceNewBatch: Boolean,
         @BoolForgery fakeResult: Boolean,
         @Forgery fakeBatchEvent: RawBatchEvent
     ) {
@@ -118,7 +117,7 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
 
         // Then
         assertThat(result).isEqualTo(fakeResult)
@@ -132,7 +131,6 @@ internal class AbstractStorageTest {
 
     @Test
     fun `M provide writer W writeCurrentBatch()+write() {consent=granted, batchMetadata!=null}`(
-        @BoolForgery forceNewBatch: Boolean,
         @BoolForgery fakeResult: Boolean,
         @Forgery fakeBatchEvent: RawBatchEvent,
         @StringForgery fakeBatchMetadata: String
@@ -148,7 +146,7 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
 
         // Then
         assertThat(result).isEqualTo(fakeResult)
@@ -161,9 +159,7 @@ internal class AbstractStorageTest {
     }
 
     @Test
-    fun `M provide writer W writeCurrentBatch()+currentMetadata() {consent=granted, batchMetadata=null}`(
-        @BoolForgery forceNewBatch: Boolean
-    ) {
+    fun `M provide writer W writeCurrentBatch()+currentMetadata() {consent=granted, batchMetadata=null}`() {
         // Given
         whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.GRANTED
         whenever(mockGrantedPersistenceStrategy.currentMetadata()) doReturn null
@@ -175,7 +171,7 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
 
         // Then
         assertThat(resultMetadata).isNull()
@@ -189,7 +185,6 @@ internal class AbstractStorageTest {
 
     @Test
     fun `M provide writer W writeCurrentBatch()+currentMetadata() {consent=granted, batchMetadata!=null}`(
-        @BoolForgery forceNewBatch: Boolean,
         @StringForgery fakeBatchMetadata: String
     ) {
         // Given
@@ -203,7 +198,7 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
 
         // Then
         assertThat(resultMetadata).isEqualTo(batchMetadata)
@@ -217,7 +212,6 @@ internal class AbstractStorageTest {
 
     @Test
     fun `M provide writer W writeCurrentBatch()+write() {consent=pending, batchMetadata=null}`(
-        @BoolForgery forceNewBatch: Boolean,
         @BoolForgery fakeResult: Boolean,
         @Forgery fakeBatchEvent: RawBatchEvent
     ) {
@@ -231,7 +225,7 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
 
         // Then
         assertThat(result).isEqualTo(fakeResult)
@@ -245,7 +239,6 @@ internal class AbstractStorageTest {
 
     @Test
     fun `M provide writer W writeCurrentBatch()+write() {consent=pending, batchMetadata!=null}`(
-        @BoolForgery forceNewBatch: Boolean,
         @BoolForgery fakeResult: Boolean,
         @Forgery fakeBatchEvent: RawBatchEvent,
         @StringForgery fakeBatchMetadata: String
@@ -261,7 +254,7 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
 
         // Then
         assertThat(result).isEqualTo(fakeResult)
@@ -274,9 +267,7 @@ internal class AbstractStorageTest {
     }
 
     @Test
-    fun `M provide writer W writeCurrentBatch()+currentMetadata() {consent=pending, batchMetadata=null}`(
-        @BoolForgery forceNewBatch: Boolean
-    ) {
+    fun `M provide writer W writeCurrentBatch()+currentMetadata() {consent=pending, batchMetadata=null}`() {
         // Given
         whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.PENDING
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
@@ -287,7 +278,7 @@ internal class AbstractStorageTest {
         whenever(mockPendingPersistenceStrategy.currentMetadata()) doReturn null
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
 
         // Then
         assertThat(resultMetadata).isNull()
@@ -301,7 +292,6 @@ internal class AbstractStorageTest {
 
     @Test
     fun `M provide writer W writeCurrentBatch()+currentMetadata() {consent=pending, batchMetadata!=null}`(
-        @BoolForgery forceNewBatch: Boolean,
         @StringForgery fakeBatchMetadata: String
     ) {
         // Given
@@ -315,7 +305,7 @@ internal class AbstractStorageTest {
         whenever(mockPendingPersistenceStrategy.currentMetadata()) doReturn batchMetadata
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
 
         // Then
         assertThat(resultMetadata).isEqualTo(batchMetadata)
@@ -329,7 +319,6 @@ internal class AbstractStorageTest {
 
     @Test
     fun `M provide no op writer W writeCurrentBatch()+write() {consent=not_granted}`(
-        @BoolForgery forceNewBatch: Boolean,
         @Forgery fakeBatchEvent: RawBatchEvent,
         @StringForgery fakeBatchMetadata: String
     ) {
@@ -343,7 +332,7 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
 
         // Then
         assertThat(result).isFalse()
@@ -355,9 +344,7 @@ internal class AbstractStorageTest {
     }
 
     @Test
-    fun `M provide no op writer W writeCurrentBatch()+currentMetadata() {consent=not_granted}`(
-        @BoolForgery forceNewBatch: Boolean
-    ) {
+    fun `M provide no op writer W writeCurrentBatch()+currentMetadata() {consent=not_granted}`() {
         // Given
         whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.NOT_GRANTED
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
@@ -367,7 +354,7 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
 
         // Then
         assertThat(resultMetadata).isNull()

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriterTest.kt
@@ -20,7 +20,6 @@ import com.datadog.android.core.internal.persistence.file.FileWriter
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.Forge
-import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -31,7 +30,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.junit.jupiter.api.io.TempDir
-import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -82,14 +80,10 @@ internal class FileEventBatchWriterTest {
     @Forgery
     lateinit var fakeEventType: EventType
 
-    @BoolForgery
-    var fakeForceNewBatch: Boolean = false
-
     @BeforeEach
     fun `set up`() {
         testedWriter = FileEventBatchWriter(
             fileOrchestrator = mockFileOrchestrator,
-            forceNewBatch = fakeForceNewBatch,
             eventsWriter = mockBatchWriter,
             metadataReaderWriter = mockMetaReaderWriter,
             filePersistenceConfig = mockFilePersistenceConfig,
@@ -97,7 +91,7 @@ internal class FileEventBatchWriterTest {
             batchWriteEventListener = mockBatchWriteEventListener
         )
         whenever(mockFilePersistenceConfig.maxItemSize) doReturn Long.MAX_VALUE
-        whenever(mockFileOrchestrator.getWritableFile(anyBoolean())) doReturn fakeBatchFile
+        whenever(mockFileOrchestrator.getWritableFile()) doReturn fakeBatchFile
         whenever(mockFileOrchestrator.getMetadataFile(fakeBatchFile)) doReturn fakeBatchMetadataFile
     }
 
@@ -165,7 +159,7 @@ internal class FileEventBatchWriterTest {
     ) {
         // Given
         val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
-        whenever(mockFileOrchestrator.getWritableFile(anyBoolean())) doReturn null
+        whenever(mockFileOrchestrator.getWritableFile()) doReturn null
 
         // When
         val result = testedWriter.write(batchEvent, serializedBatchMetadata, fakeEventType)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestratorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestratorTest.kt
@@ -13,7 +13,6 @@ import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.Forge
-import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -149,14 +148,13 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `M return pending writable file W getWritableFile() {consent=PENDING}`(
-        @BoolForgery forceNewFile: Boolean,
         @Forgery file: File
     ) {
         // Given
-        whenever(mockPendingOrchestrator.getWritableFile(forceNewFile)) doReturn file
+        whenever(mockPendingOrchestrator.getWritableFile()) doReturn file
 
         // When
-        val result = testedOrchestrator.getWritableFile(forceNewFile)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isSameAs(file)
@@ -165,18 +163,17 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `M return pending writable file W getWritableFile() {consent=GRANTED then PENDING}`(
-        @BoolForgery forceNewFile: Boolean,
         @Forgery file: File
     ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.GRANTED)
         runPendingRunnable()
-        whenever(mockPendingOrchestrator.getWritableFile(forceNewFile)) doReturn file
+        whenever(mockPendingOrchestrator.getWritableFile()) doReturn file
 
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.GRANTED, TrackingConsent.PENDING)
         runPendingRunnable()
-        val result = testedOrchestrator.getWritableFile(forceNewFile)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isSameAs(file)
@@ -185,18 +182,17 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `M return pending writable file W getWritableFile() {consent=NOT_GRANTED then PENDING}`(
-        @BoolForgery forceNewFile: Boolean,
         @Forgery file: File
     ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.NOT_GRANTED)
         runPendingRunnable()
-        whenever(mockPendingOrchestrator.getWritableFile(forceNewFile)) doReturn file
+        whenever(mockPendingOrchestrator.getWritableFile()) doReturn file
 
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.NOT_GRANTED, TrackingConsent.PENDING)
         runPendingRunnable()
-        val result = testedOrchestrator.getWritableFile(forceNewFile)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isSameAs(file)
@@ -205,16 +201,15 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `M return granted writable file W getWritableFile() {consent=GRANTED}`(
-        @BoolForgery forceNewFile: Boolean,
         @Forgery file: File
     ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.GRANTED)
         runPendingRunnable()
-        whenever(mockGrantedOrchestrator.getWritableFile(forceNewFile)) doReturn file
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
 
         // When
-        val result = testedOrchestrator.getWritableFile(forceNewFile)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isSameAs(file)
@@ -223,18 +218,17 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `M return granted writable file W getWritableFile() {consent=NOT_GRANTED then GRANTED}`(
-        @BoolForgery forceNewFile: Boolean,
         @Forgery file: File
     ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.NOT_GRANTED)
         runPendingRunnable()
-        whenever(mockGrantedOrchestrator.getWritableFile(forceNewFile)) doReturn file
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
 
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.NOT_GRANTED, TrackingConsent.GRANTED)
         runPendingRunnable()
-        val result = testedOrchestrator.getWritableFile(forceNewFile)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isSameAs(file)
@@ -243,18 +237,17 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `M return granted writable file W getWritableFile() {consent=PENDING then GRANTED}`(
-        @BoolForgery forceNewFile: Boolean,
         @Forgery file: File
     ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.PENDING)
         runPendingRunnable()
-        whenever(mockGrantedOrchestrator.getWritableFile(forceNewFile)) doReturn file
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
 
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.PENDING, TrackingConsent.GRANTED)
         runPendingRunnable()
-        val result = testedOrchestrator.getWritableFile(forceNewFile)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isSameAs(file)
@@ -262,15 +255,13 @@ internal class ConsentAwareFileOrchestratorTest {
     }
 
     @Test
-    fun `M return null file W getWritableFile() {consent=NOT_GRANTED}`(
-        @BoolForgery forceNewFile: Boolean
-    ) {
+    fun `M return null file W getWritableFile() {consent=NOT_GRANTED}`() {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.NOT_GRANTED)
         runPendingRunnable()
 
         // When
-        val result = testedOrchestrator.getWritableFile(forceNewFile)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isNull()
@@ -278,9 +269,7 @@ internal class ConsentAwareFileOrchestratorTest {
     }
 
     @Test
-    fun `M return null file W getWritableFile() {consent=GRANTED then NOT_GRANTED}`(
-        @BoolForgery forceNewFile: Boolean
-    ) {
+    fun `M return null file W getWritableFile() {consent=GRANTED then NOT_GRANTED}`() {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.GRANTED)
         runPendingRunnable()
@@ -288,7 +277,7 @@ internal class ConsentAwareFileOrchestratorTest {
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.GRANTED, TrackingConsent.NOT_GRANTED)
         runPendingRunnable()
-        val result = testedOrchestrator.getWritableFile(forceNewFile)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isNull()
@@ -296,9 +285,7 @@ internal class ConsentAwareFileOrchestratorTest {
     }
 
     @Test
-    fun `M return null file W getWritableFile() {consent=PENDING then NOT_GRANTED}`(
-        @BoolForgery forceNewFile: Boolean
-    ) {
+    fun `M return null file W getWritableFile() {consent=PENDING then NOT_GRANTED}`() {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.PENDING)
         runPendingRunnable()
@@ -306,7 +293,7 @@ internal class ConsentAwareFileOrchestratorTest {
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.PENDING, TrackingConsent.NOT_GRANTED)
         runPendingRunnable()
-        val result = testedOrchestrator.getWritableFile(forceNewFile)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isNull()

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/SingleFileOrchestratorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/SingleFileOrchestratorTest.kt
@@ -9,7 +9,6 @@ package com.datadog.android.core.internal.persistence.file.advanced
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.persistence.file.single.SingleFileOrchestrator
 import com.datadog.android.utils.forge.Configurator
-import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -59,18 +58,18 @@ internal class SingleFileOrchestratorTest {
     // region getWritableFile
 
     @Test
-    fun `M create parent dir W getWritableFile()`(@BoolForgery forceNewBatch: Boolean) {
+    fun `M create parent dir W getWritableFile()`() {
         // When
-        testedOrchestrator.getWritableFile(forceNewBatch)
+        testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(fakeFile.parentFile).exists()
     }
 
     @Test
-    fun `M return file W getWritableFile()`(@BoolForgery forceNewBatch: Boolean) {
+    fun `M return file W getWritableFile()`() {
         // When
-        val result = testedOrchestrator.getWritableFile(forceNewBatch)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isSameAs(fakeFile)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/BatchClosedMetadataForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/BatchClosedMetadataForgeryFactory.kt
@@ -15,7 +15,6 @@ internal class BatchClosedMetadataForgeryFactory : ForgeryFactory<BatchClosedMet
     override fun getForgery(forge: Forge): BatchClosedMetadata {
         return BatchClosedMetadata(
             lastTimeWasUsedInMs = forge.aPositiveLong(),
-            forcedNew = forge.aBool(),
             eventsCount = forge.aPositiveLong()
         )
     }

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
@@ -142,8 +142,8 @@ internal class LogsFeatureTest {
             mockSdkCore.getFeature(Feature.LOGS_FEATURE_NAME)
         ) doReturn mockLogsFeatureScope
 
-        whenever(mockLogsFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockLogsFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
 
@@ -479,8 +479,8 @@ internal class LogsFeatureTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockLogsFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockLogsFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             val executor = Executors.newSingleThreadExecutor()
             executor.execute {
                 Thread.sleep(300)
@@ -561,8 +561,8 @@ internal class LogsFeatureTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockLogsFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockLogsFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             val executor = Executors.newSingleThreadExecutor()
             executor.execute {
                 Thread.sleep(LogsFeature.MAX_WRITE_WAIT_TIMEOUT_MS + 200)
@@ -584,7 +584,7 @@ internal class LogsFeatureTest {
         testedFeature.onReceive(event)
 
         // Then
-        verify(mockLogsFeatureScope).withWriteContext(any(), any())
+        verify(mockLogsFeatureScope).withWriteContext(any())
         verifyNoInteractions(mockDataWriter)
     }
 

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -137,8 +137,8 @@ internal class DatadogLogHandlerTest {
             mockSdkCore.getFeature(Feature.LOGS_FEATURE_NAME)
         ) doReturn mockLogsFeatureScope
         whenever(mockLogsFeatureScope.unwrap<LogsFeature>()) doReturn mockLogsFeature
-        whenever(mockLogsFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockLogsFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
@@ -97,8 +97,8 @@ internal class DatadogLateCrashReporterTest {
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
 
-        whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
@@ -158,8 +158,8 @@ internal class RumActionScopeTest {
         whenever(rumMonitor.mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
         whenever(rumMonitor.mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
-        whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
         whenever(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -145,8 +145,8 @@ internal class RumContinuousActionScopeTest {
         whenever(rumMonitor.mockSdkCore.internalLogger) doReturn mockInternalLogger
 
         whenever(rumMonitor.mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
-        whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
         whenever(mockWriter.write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))) doReturn true

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -195,8 +195,8 @@ internal class RumResourceScopeTest {
             )
         ).thenReturn(fakeHasReplay)
         whenever(rumMonitor.mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
-        whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
         whenever(mockWriter.write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))) doReturn true

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -724,8 +724,8 @@ internal class RumViewManagerScopeTest {
         val mockRumFeatureScope: FeatureScope = mock()
         val mockEventBatchWriter: EventBatchWriter = mock()
         whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
-        whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
         val fakeAppStartEvent = forge.applicationStartedEvent()

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -338,8 +338,8 @@ internal class RumViewScopeTest {
         whenever(rumMonitor.mockSdkCore.time) doReturn fakeTimeInfoAtScopeStart
         whenever(rumMonitor.mockSdkCore.networkInfo) doReturn fakeNetworkInfoAtScopeStart
         whenever(rumMonitor.mockSdkCore.internalLogger) doReturn mockInternalLogger
-        whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
         whenever(mockWriter.write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))) doReturn true
@@ -9700,8 +9700,8 @@ internal class RumViewScopeTest {
         // Given
         val writeWorker = Executors.newCachedThreadPool()
         val tasks = mutableListOf<Future<*>>()
-        whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             tasks += writeWorker.submit {
                 callback.invoke(fakeDatadogContext, mockEventBatchWriter)
             }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/utils/SdkCoreExtTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/utils/SdkCoreExtTest.kt
@@ -76,8 +76,8 @@ internal class SdkCoreExtTest {
 
     @BeforeEach
     fun `set up`() {
-        whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
         whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -192,8 +192,8 @@ internal class TelemetryEventHandlerTest {
         whenever(
             mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)
         ) doReturn mockRumFeatureScope
-        whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriter.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriter.kt
@@ -20,7 +20,7 @@ internal class SessionReplayResourcesWriter(
 ) : ResourcesWriter {
     override fun write(enrichedResource: EnrichedResource) {
         sdkCore.getFeature(SESSION_REPLAY_RESOURCES_FEATURE_NAME)
-            ?.withWriteContext() { datadogContext, eventBatchWriter ->
+            ?.withWriteContext { datadogContext, eventBatchWriter ->
                 synchronized(this) {
                     val serializedMetadata = enrichedResource.asBinaryMetadata(datadogContext.rumApplicationId)
                     eventBatchWriter.write(

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayRecordWriterTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayRecordWriterTest.kt
@@ -30,7 +30,6 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
@@ -76,8 +75,8 @@ internal class SessionReplayRecordWriterTest {
     fun `M write the record in a batch W write`(forge: Forge) {
         // Given
         val fakeRecord = forge.forgeEnrichedRecord()
-        whenever(mockSessionReplayFeature.withWriteContext(eq(false), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockSessionReplayFeature.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
 
@@ -118,8 +117,8 @@ internal class SessionReplayRecordWriterTest {
             .thenReturn(false)
 
         val fakeRecord = forge.forgeEnrichedRecord()
-        whenever(mockSessionReplayFeature.withWriteContext(eq(false), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockSessionReplayFeature.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriterTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriterTest.kt
@@ -78,8 +78,8 @@ internal class SessionReplayResourcesWriterTest {
     @Test
     fun `M write the resource W write()`() {
         // Given
-        whenever(mockResourcesFeature.withWriteContext(anyOrNull(), anyOrNull())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockResourcesFeature.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
         fakeDatadogContext = fakeDatadogContext.copy(

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/OtelTraceWriterTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/OtelTraceWriterTest.kt
@@ -87,8 +87,8 @@ internal class OtelTraceWriterTest {
             mockSdkCore.getFeature(Feature.TRACING_FEATURE_NAME)
         ) doReturn mockTracingFeatureScope
 
-        whenever(mockTracingFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockTracingFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
 
@@ -301,8 +301,8 @@ internal class OtelTraceWriterTest {
         testedWriter.write(ddSpans)
 
         // THEN
-        verify(mockSdkCore, times(1)).getFeature(Feature.TRACING_FEATURE_NAME)
-        verify(mockTracingFeatureScope, times(1)).withWriteContext(any(), any())
+        verify(mockSdkCore).getFeature(Feature.TRACING_FEATURE_NAME)
+        verify(mockTracingFeatureScope).withWriteContext(any())
 
         verifyNoMoreInteractions(mockSdkCore, mockTracingFeatureScope)
     }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/TraceWriterTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/TraceWriterTest.kt
@@ -88,8 +88,8 @@ internal class TraceWriterTest {
             mockSdkCore.getFeature(Feature.TRACING_FEATURE_NAME)
         ) doReturn mockTracingFeatureScope
 
-        whenever(mockTracingFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockTracingFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
 
@@ -317,8 +317,8 @@ internal class TraceWriterTest {
         testedWriter.write(ddSpans)
 
         // THEN
-        verify(mockSdkCore, times(1)).getFeature(Feature.TRACING_FEATURE_NAME)
-        verify(mockTracingFeatureScope, times(1)).withWriteContext(any(), any())
+        verify(mockSdkCore).getFeature(Feature.TRACING_FEATURE_NAME)
+        verify(mockTracingFeatureScope).withWriteContext(any())
 
         verifyNoMoreInteractions(mockSdkCore, mockTracingFeatureScope)
 

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/WebViewTrackingTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/WebViewTrackingTest.kt
@@ -634,7 +634,7 @@ internal class WebViewTrackingTest {
         // When
         proxy.consumeWebviewEvent(fakeWebEvent.toString())
         argumentCaptor<(DatadogContext, EventBatchWriter) -> Unit> {
-            verify(mockWebViewRumFeature).withWriteContext(any(), capture())
+            verify(mockWebViewRumFeature).withWriteContext(capture())
             firstValue(mockDatadogContext, mockEventBatchWriter)
         }
 

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumerTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumerTest.kt
@@ -100,8 +100,8 @@ internal class WebViewLogEventConsumerTest {
         ) doReturn mockWebViewLogsFeatureScope
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
 
-        whenever(mockWebViewLogsFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockWebViewLogsFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
 
@@ -170,7 +170,7 @@ internal class WebViewLogEventConsumerTest {
         )
 
         // Then
-        verify(mockWebViewLogsFeatureScope, never()).withWriteContext(any(), any())
+        verify(mockWebViewLogsFeatureScope, never()).withWriteContext(any())
     }
 
     @Test

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventConsumerTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventConsumerTest.kt
@@ -113,8 +113,8 @@ internal class WebViewReplayEventConsumerTest {
         whenever(
             mockSdkCore.getFeature(WebViewReplayFeature.WEB_REPLAY_FEATURE_NAME)
         ) doReturn mockSessionReplayFeatureScope
-        whenever(mockSessionReplayFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockSessionReplayFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumerTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumerTest.kt
@@ -143,8 +143,8 @@ internal class WebViewRumEventConsumerTest {
             mockSdkCore.getFeature(WebViewRumFeature.WEB_RUM_FEATURE_NAME)
         ) doReturn mockWebViewRumFeatureScope
 
-        whenever(mockWebViewRumFeatureScope.withWriteContext(any(), any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+        whenever(mockWebViewRumFeatureScope.withWriteContext(any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubFeatureScope.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubFeatureScope.kt
@@ -57,7 +57,6 @@ internal class StubFeatureScope(
     // region FeatureScope
 
     override fun withWriteContext(
-        forceNewBatch: Boolean,
         callback: (DatadogContext, EventBatchWriter) -> Unit
     ) {
         callback(datadogContextProvider(), eventBatchWriter)


### PR DESCRIPTION
### What does this PR do?

This API was originally added as a workaround for the Session Replay intake requirement, but it is not used anymore, so it can be removed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

