### PR TITLE
RUM-9537: Catch NPE when drawing cloned drawable in Session Replay

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtils.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtils.kt
@@ -11,7 +11,6 @@ import android.graphics.Bitmap.Config
 import android.graphics.Color
 import android.graphics.PorterDuff
 import android.graphics.drawable.Drawable
-import android.util.AndroidRuntimeException
 import android.util.DisplayMetrics
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
@@ -119,11 +118,7 @@ internal class DrawableUtils(
 
             try {
                 drawable.draw(canvas)
-            } catch (e: IndexOutOfBoundsException) {
-                logDrawableDrawException(drawable, e)
-                bitmapCreationCallback.onFailure()
-                return
-            } catch (e: AndroidRuntimeException) {
+            } catch (e: RuntimeException) {
                 logDrawableDrawException(drawable, e)
                 bitmapCreationCallback.onFailure()
                 return


### PR DESCRIPTION
### What does this PR do?

We have a SDK crash reported:
```
2025-04-15 15:52:34.448 27880-28415 Datadog com.carvana.carvanaTest E java.lang.NullPointerException: Attempt to invoke virtual method 'void com.google.android.material.shape.ShapePath$PathOperation.applyToPath(android.graphics.Matrix, android.graphics.Path)' on a null object reference
at com.google.android.material.shape.ShapePath.applyToPath(ShapePath.java:244)
at com.google.android.material.shape.ShapeAppearancePathProvider.appendEdgePath(ShapeAppearancePathProvider.java:202)
at com.google.android.material.shape.ShapeAppearancePathProvider.calculatePath(ShapeAppearancePathProvider.java:135)
at com.google.android.material.shape.MaterialShapeDrawable.calculatePathForSize(MaterialShapeDrawable.java:1165)
at com.google.android.material.shape.MaterialShapeDrawable.calculatePath(MaterialShapeDrawable.java:1226)
at com.google.android.material.shape.MaterialShapeDrawable.draw(MaterialShapeDrawable.java:970)
at com.datadog.android.sessionreplay.internal.utils.DrawableUtils.drawOnCanvas(DrawableUtils.kt:117)
at com.datadog.android.sessionreplay.internal.utils.DrawableUtils.access$drawOnCanvas(DrawableUtils.kt:26)
at com.datadog.android.sessionreplay.internal.utils.DrawableUtils$createBitmapOfApproxSizeFromDrawable$1.onSuccess$lambda$0(DrawableUtils.kt:59)
at com.datadog.android.sessionreplay.internal.utils.DrawableUtils$createBitmapOfApproxSizeFromDrawable$1.$r8$lambda$KM5fqvVrfqCeggp4FNtAik4G8SQ(Unknown Source:0)
```
It turns out a internal crash from `Material` library when we draw the cloned drawable, we are not able to make any fix inside `Material` library, so we need to catch it and skip it.

### Motivation

RUM-9537


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

