### PR TITLE
RUM-9746: Resolve file orchestrator for write operation from `DatadogContext`

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -371,7 +371,6 @@ internal class SdkFeature(
             internalLogger = internalLogger,
             filePersistenceConfig = filePersistenceConfig,
             metricsDispatcher = metricsDispatcher,
-            coreFeature.trackingConsentProvider,
             featureName
         )
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AbstractStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AbstractStorage.kt
@@ -30,7 +30,7 @@ internal class AbstractStorage(
     private val executorService: ExecutorService,
     private val internalLogger: InternalLogger,
     internal val storageConfiguration: FeatureStorageConfiguration,
-    private val consentProvider: ConsentProvider
+    consentProvider: ConsentProvider
 ) : Storage, TrackingConsentProviderCallback {
 
     private val grantedPersistenceStrategy: PersistenceStrategy by lazy {
@@ -64,7 +64,7 @@ internal class AbstractStorage(
         callback: (EventBatchWriter) -> Unit
     ) {
         executorService.executeSafe("Data write", internalLogger) {
-            val strategy = resolvePersistenceStrategy()
+            val strategy = resolvePersistenceStrategy(datadogContext)
             val writer = object : EventBatchWriter {
                 @WorkerThread
                 override fun currentMetadata(): ByteArray? {
@@ -81,8 +81,8 @@ internal class AbstractStorage(
     }
 
     @WorkerThread
-    private fun resolvePersistenceStrategy() =
-        when (consentProvider.getConsent()) {
+    private fun resolvePersistenceStrategy(datadogContext: DatadogContext) =
+        when (datadogContext.trackingConsent) {
             TrackingConsent.GRANTED -> grantedPersistenceStrategy
             TrackingConsent.PENDING -> pendingPersistenceStrategy
             TrackingConsent.NOT_GRANTED -> notGrantedPersistenceStrategy

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AbstractStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AbstractStorageTest.kt
@@ -108,12 +108,13 @@ internal class AbstractStorageTest {
         @Forgery fakeBatchEvent: RawBatchEvent
     ) {
         // Given
-        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.GRANTED
+        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         whenever(mockGrantedPersistenceStrategy.write(any(), anyOrNull(), any())) doReturn fakeResult
         var result: Boolean? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
-            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, null, fakeEventType)
+            result = it.getArgument<EventBatchWriter>(0)
+                .write(fakeBatchEvent, null, fakeEventType)
         }
 
         // When
@@ -136,13 +137,14 @@ internal class AbstractStorageTest {
         @StringForgery fakeBatchMetadata: String
     ) {
         // Given
-        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.GRANTED
+        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         val batchMetadata = fakeBatchMetadata.toByteArray()
         whenever(mockGrantedPersistenceStrategy.write(any(), anyOrNull(), any())) doReturn fakeResult
         var result: Boolean? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
-            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, batchMetadata, fakeEventType)
+            result = it.getArgument<EventBatchWriter>(0)
+                .write(fakeBatchEvent, batchMetadata, fakeEventType)
         }
 
         // When
@@ -161,13 +163,13 @@ internal class AbstractStorageTest {
     @Test
     fun `M provide writer W writeCurrentBatch()+currentMetadata() {consent=granted, batchMetadata=null}`() {
         // Given
-        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.GRANTED
+        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
         whenever(mockGrantedPersistenceStrategy.currentMetadata()) doReturn null
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         whenever(mockGrantedPersistenceStrategy.currentMetadata()) doReturn null
         var resultMetadata: ByteArray? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
-            resultMetadata = (it.getArgument(0) as? EventBatchWriter)?.currentMetadata()
+            resultMetadata = it.getArgument<EventBatchWriter>(0).currentMetadata()
         }
 
         // When
@@ -188,13 +190,13 @@ internal class AbstractStorageTest {
         @StringForgery fakeBatchMetadata: String
     ) {
         // Given
-        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.GRANTED
+        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         val batchMetadata = fakeBatchMetadata.toByteArray()
         whenever(mockGrantedPersistenceStrategy.currentMetadata()) doReturn batchMetadata
         var resultMetadata: ByteArray? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
-            resultMetadata = (it.getArgument(0) as? EventBatchWriter)?.currentMetadata()
+            resultMetadata = it.getArgument<EventBatchWriter>(0).currentMetadata()
         }
 
         // When
@@ -216,12 +218,12 @@ internal class AbstractStorageTest {
         @Forgery fakeBatchEvent: RawBatchEvent
     ) {
         // Given
-        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.PENDING
+        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         whenever(mockPendingPersistenceStrategy.write(any(), anyOrNull(), any())) doReturn fakeResult
         var result: Boolean? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
-            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, null, fakeEventType)
+            result = it.getArgument<EventBatchWriter>(0).write(fakeBatchEvent, null, fakeEventType)
         }
 
         // When
@@ -244,13 +246,13 @@ internal class AbstractStorageTest {
         @StringForgery fakeBatchMetadata: String
     ) {
         // Given
-        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.PENDING
+        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         val batchMetadata = fakeBatchMetadata.toByteArray()
         whenever(mockPendingPersistenceStrategy.write(any(), anyOrNull(), any())) doReturn fakeResult
         var result: Boolean? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
-            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, batchMetadata, fakeEventType)
+            result = it.getArgument<EventBatchWriter>(0).write(fakeBatchEvent, batchMetadata, fakeEventType)
         }
 
         // When
@@ -269,11 +271,11 @@ internal class AbstractStorageTest {
     @Test
     fun `M provide writer W writeCurrentBatch()+currentMetadata() {consent=pending, batchMetadata=null}`() {
         // Given
-        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.PENDING
+        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         var resultMetadata: ByteArray? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
-            resultMetadata = (it.getArgument(0) as? EventBatchWriter)?.currentMetadata()
+            resultMetadata = it.getArgument<EventBatchWriter>(0).currentMetadata()
         }
         whenever(mockPendingPersistenceStrategy.currentMetadata()) doReturn null
 
@@ -295,12 +297,12 @@ internal class AbstractStorageTest {
         @StringForgery fakeBatchMetadata: String
     ) {
         // Given
-        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.PENDING
+        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         val batchMetadata = fakeBatchMetadata.toByteArray()
         var resultMetadata: ByteArray? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
-            resultMetadata = (it.getArgument(0) as? EventBatchWriter)?.currentMetadata()
+            resultMetadata = it.getArgument<EventBatchWriter>(0).currentMetadata()
         }
         whenever(mockPendingPersistenceStrategy.currentMetadata()) doReturn batchMetadata
 
@@ -323,12 +325,12 @@ internal class AbstractStorageTest {
         @StringForgery fakeBatchMetadata: String
     ) {
         // Given
-        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.NOT_GRANTED
+        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.NOT_GRANTED)
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         val batchMetadata = fakeBatchMetadata.toByteArray()
         var result: Boolean? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
-            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, batchMetadata, fakeEventType)
+            result = it.getArgument<EventBatchWriter>(0).write(fakeBatchEvent, batchMetadata, fakeEventType)
         }
 
         // When
@@ -346,11 +348,11 @@ internal class AbstractStorageTest {
     @Test
     fun `M provide no op writer W writeCurrentBatch()+currentMetadata() {consent=not_granted}`() {
         // Given
-        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.NOT_GRANTED
+        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.NOT_GRANTED)
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         var resultMetadata: ByteArray? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
-            resultMetadata = (it.getArgument(0) as? EventBatchWriter)?.currentMetadata()
+            resultMetadata = it.getArgument<EventBatchWriter>(0).currentMetadata()
         }
 
         // When

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
@@ -20,7 +20,6 @@ import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileReaderWriter
-import com.datadog.android.core.internal.privacy.ConsentProvider
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
@@ -114,9 +113,6 @@ internal class ConsentAwareStorageTest {
     @Forgery
     lateinit var mockGrantedRootParentFile: File
 
-    @Mock
-    lateinit var mockConsentProvider: ConsentProvider
-
     @StringForgery
     lateinit var fakeFeatureName: String
 
@@ -124,8 +120,7 @@ internal class ConsentAwareStorageTest {
     var fakePendingBatches: Int = 0
 
     @BeforeEach
-    fun `set up`(forge: Forge) {
-        whenever(mockConsentProvider.getConsent()) doReturn forge.aValueFrom(TrackingConsent::class.java)
+    fun `set up`() {
         whenever(mockPendingOrchestrator.getRootDir()) doReturn File(mockPendingRootParentFile, fakeRootDirName)
         whenever(mockGrantedOrchestrator.getRootDir()) doReturn File(mockGrantedRootParentFile, fakeRootDirName)
         whenever(mockPendingOrchestrator.getRootDirName()) doReturn fakeRootDirName
@@ -146,7 +141,6 @@ internal class ConsentAwareStorageTest {
             internalLogger = mockInternalLogger,
             filePersistenceConfig = mockFilePersistenceConfig,
             metricsDispatcher = mockMetricsDispatcher,
-            consentProvider = mockConsentProvider,
             featureName = fakeFeatureName
         )
     }
@@ -157,7 +151,7 @@ internal class ConsentAwareStorageTest {
     fun `M provide writer W writeCurrentBatch() {consent=granted}`() {
         // Given
         val mockCallback = mock<(EventBatchWriter) -> Unit>()
-        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.GRANTED
+        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
 
         // When
         testedStorage.writeCurrentBatch(fakeDatadogContext, callback = mockCallback)
@@ -179,7 +173,7 @@ internal class ConsentAwareStorageTest {
     fun `M provide writer W writeCurrentBatch() {consent=pending}`() {
         // Given
         val mockCallback = mock<(EventBatchWriter) -> Unit>()
-        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.PENDING
+        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
 
         // When
         testedStorage.writeCurrentBatch(fakeDatadogContext, callback = mockCallback)
@@ -201,7 +195,7 @@ internal class ConsentAwareStorageTest {
     fun `M provide no-op writer W writeCurrentBatch() {not_granted}`() {
         // Given
         val mockCallback = mock<(EventBatchWriter) -> Unit>()
-        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.NOT_GRANTED
+        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.NOT_GRANTED)
 
         // When
         testedStorage.writeCurrentBatch(fakeDatadogContext, callback = mockCallback)
@@ -237,7 +231,6 @@ internal class ConsentAwareStorageTest {
             internalLogger = mockInternalLogger,
             filePersistenceConfig = mockFilePersistenceConfig,
             metricsDispatcher = mockMetricsDispatcher,
-            consentProvider = mockConsentProvider,
             featureName = fakeFeatureName
         )
 
@@ -280,7 +273,6 @@ internal class ConsentAwareStorageTest {
             internalLogger = mockInternalLogger,
             filePersistenceConfig = mockFilePersistenceConfig,
             metricsDispatcher = mockMetricsDispatcher,
-            consentProvider = mockConsentProvider,
             featureName = fakeFeatureName
         )
         var accumulator: Byte = 0
@@ -298,7 +290,7 @@ internal class ConsentAwareStorageTest {
                 eventType = fakeEventType
             )
         }
-        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.GRANTED
+        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
         whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
         val mockMetaFile = mock<File>().apply { whenever(exists()) doReturn true }
         whenever(mockMetaReaderWriter.readData(mockMetaFile)) doAnswer {
@@ -459,7 +451,6 @@ internal class ConsentAwareStorageTest {
             internalLogger = mockInternalLogger,
             filePersistenceConfig = mockFilePersistenceConfig,
             metricsDispatcher = mockMetricsDispatcher,
-            consentProvider = mockConsentProvider,
             featureName = fakeFeatureName
         )
 
@@ -590,7 +581,6 @@ internal class ConsentAwareStorageTest {
             internalLogger = mockInternalLogger,
             filePersistenceConfig = mockFilePersistenceConfig,
             metricsDispatcher = mockMetricsDispatcher,
-            consentProvider = mockConsentProvider,
             featureName = fakeFeatureName
         )
 
@@ -649,7 +639,6 @@ internal class ConsentAwareStorageTest {
             internalLogger = mockInternalLogger,
             filePersistenceConfig = mockFilePersistenceConfig,
             metricsDispatcher = mockMetricsDispatcher,
-            consentProvider = mockConsentProvider,
             featureName = fakeFeatureName
         )
 
@@ -712,7 +701,6 @@ internal class ConsentAwareStorageTest {
             internalLogger = mockInternalLogger,
             filePersistenceConfig = mockFilePersistenceConfig,
             metricsDispatcher = mockMetricsDispatcher,
-            consentProvider = mockConsentProvider,
             featureName = fakeFeatureName,
             benchmarkUploads = mockBenchmarkUploads
         )
@@ -756,7 +744,6 @@ internal class ConsentAwareStorageTest {
             internalLogger = mockInternalLogger,
             filePersistenceConfig = mockFilePersistenceConfig,
             metricsDispatcher = mockMetricsDispatcher,
-            consentProvider = mockConsentProvider,
             featureName = fakeFeatureName,
             benchmarkUploads = mockBenchmarkUploads
         )


### PR DESCRIPTION
### What does this PR do?

This change makes the logic to resolve file orchestrator for the event write operation to read tracking consent from `DatadogContext` passed with `withWriteContext` call instead of doing the resolution independently.

This makes an alignment with iOS SDK.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

