### PR TITLE
RUM-9854: Introduce event processing thread

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -108,9 +108,11 @@ interface com.datadog.android.api.feature.FeatureEventReceiver
   fun onReceive(Any)
 interface com.datadog.android.api.feature.FeatureScope
   val dataStore: com.datadog.android.api.storage.datastore.DataStoreHandler
-  fun withWriteContext((com.datadog.android.api.context.DatadogContext, com.datadog.android.api.storage.EventBatchWriter) -> Unit)
+  fun withWriteContext((com.datadog.android.api.context.DatadogContext) -> Unit)
+  fun getWriteContextSync(): Pair<com.datadog.android.api.context.DatadogContext, EventWriteScope>?
   fun sendEvent(Any)
   fun <T: Feature> unwrap(): T
+typealias EventWriteScope = ((com.datadog.android.api.storage.EventBatchWriter) -> Unit) -> Unit
 fun <R: Any?> com.datadog.android.api.InternalLogger.measureMethodCallPerf(Class<*>, String, Float = 100f, () -> R): R
 interface com.datadog.android.api.feature.FeatureSdkCore : com.datadog.android.api.SdkCore
   val internalLogger: com.datadog.android.api.InternalLogger
@@ -308,6 +310,7 @@ fun Collection<ByteArray>.join(ByteArray, ByteArray = ByteArray(0), ByteArray = 
 fun java.util.concurrent.Executor.executeSafe(String, com.datadog.android.api.InternalLogger, Runnable)
 fun java.util.concurrent.ScheduledExecutorService.scheduleSafe(String, Long, java.util.concurrent.TimeUnit, com.datadog.android.api.InternalLogger, Runnable): java.util.concurrent.ScheduledFuture<*>?
 fun java.util.concurrent.ExecutorService.submitSafe(String, com.datadog.android.api.InternalLogger, Runnable): java.util.concurrent.Future<*>?
+fun <T> java.util.concurrent.ExecutorService.submitSafe(String, com.datadog.android.api.InternalLogger, java.util.concurrent.Callable<T>): java.util.concurrent.Future<T>?
 val NULL_MAP_VALUE: Object
 object com.datadog.android.core.internal.utils.JsonSerializer
   fun toJsonElement(Any?): com.google.gson.JsonElement

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -342,6 +342,7 @@ public abstract interface class com/datadog/android/api/feature/FeatureEventRece
 
 public abstract interface class com/datadog/android/api/feature/FeatureScope {
 	public abstract fun getDataStore ()Lcom/datadog/android/api/storage/datastore/DataStoreHandler;
+	public abstract fun getWriteContextSync ()Lkotlin/Pair;
 	public abstract fun sendEvent (Ljava/lang/Object;)V
 	public abstract fun unwrap ()Lcom/datadog/android/api/feature/Feature;
 	public abstract fun withWriteContext (Lkotlin/jvm/functions/Function2;)V
@@ -812,6 +813,7 @@ public final class com/datadog/android/core/internal/utils/ConcurrencyExtKt {
 	public static final fun executeSafe (Ljava/util/concurrent/Executor;Ljava/lang/String;Lcom/datadog/android/api/InternalLogger;Ljava/lang/Runnable;)V
 	public static final fun scheduleSafe (Ljava/util/concurrent/ScheduledExecutorService;Ljava/lang/String;JLjava/util/concurrent/TimeUnit;Lcom/datadog/android/api/InternalLogger;Ljava/lang/Runnable;)Ljava/util/concurrent/ScheduledFuture;
 	public static final fun submitSafe (Ljava/util/concurrent/ExecutorService;Ljava/lang/String;Lcom/datadog/android/api/InternalLogger;Ljava/lang/Runnable;)Ljava/util/concurrent/Future;
+	public static final fun submitSafe (Ljava/util/concurrent/ExecutorService;Ljava/lang/String;Lcom/datadog/android/api/InternalLogger;Ljava/util/concurrent/Callable;)Ljava/util/concurrent/Future;
 }
 
 public final class com/datadog/android/core/internal/utils/JsonSerializer {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureScope.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureScope.kt
@@ -10,6 +10,7 @@ import androidx.annotation.AnyThread
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.datastore.DataStoreHandler
+import com.datadog.android.lint.InternalApi
 
 /**
  * Represents a Datadog feature.
@@ -24,14 +25,23 @@ interface FeatureScope {
     /**
      * Utility to write an event, asynchronously.
      * @param callback an operation called with an up-to-date [DatadogContext]
-     * and an [EventBatchWriter]. Callback will be executed on a worker thread from I/O pool.
-     * [DatadogContext] will have a state created at the moment this method is called, before the
-     * thread switch for the callback invocation.
+     * and an [EventWriteScope]. Callback will be executed on a single context processing worker thread.
+     * [DatadogContext] will have a state created at the moment this method is called.
      */
     @AnyThread
     fun withWriteContext(
-        callback: (DatadogContext, EventBatchWriter) -> Unit
+        callback: (datadogContext: DatadogContext, write: EventWriteScope) -> Unit
     )
+
+    // TODO RUM-9852 Implement better passthrough mechanism for the JVM crash scenario
+    /**
+     * Same as [withWriteContext] but will be executed in the blocking manner.
+     *
+     * **NOTE**: This API is for the internal use only and is not guaranteed to be stable.
+     */
+    @AnyThread
+    @InternalApi
+    fun getWriteContextSync(): Pair<DatadogContext, EventWriteScope>?
 
     /**
      * Send event to a given feature. It will be sent in a synchronous way.
@@ -45,3 +55,9 @@ interface FeatureScope {
      */
     fun <T : Feature> unwrap(): T
 }
+
+/**
+ * Scope for the event write operation which is invoked on the worker thread from I/O pool, which is different
+ * from the context processing worker thread used for [FeatureScope.withWriteContext] callback invocation.
+ */
+typealias EventWriteScope = ((EventBatchWriter) -> Unit) -> Unit

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -179,12 +179,14 @@ internal class DatadogCore(
     /** @inheritDoc */
     @AnyThread
     override fun clearAllData() {
-        features.values.forEach {
-            it.clearAllData()
-        }
-        getPersistenceExecutorService().executeSafe("Clear all data", internalLogger) {
-            coreFeature.deleteLastViewEvent()
-            coreFeature.deleteLastFatalAnrSent()
+        coreFeature.contextExecutorService.executeSafe("DatadogCore.clearAllData", internalLogger) {
+            features.values.forEach {
+                it.clearAllData()
+            }
+            getPersistenceExecutorService().executeSafe("Clear all data", internalLogger) {
+                coreFeature.deleteLastViewEvent()
+                coreFeature.deleteLastFatalAnrSent()
+            }
         }
     }
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AsyncEventWriteScope.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AsyncEventWriteScope.kt
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.persistence
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.feature.EventWriteScope
+import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.core.internal.utils.executeSafe
+import java.util.concurrent.Executor
+
+internal class AsyncEventWriteScope(
+    private val executor: Executor,
+    private val writer: EventBatchWriter,
+    private val featureWriteLock: Any,
+    private val featureName: String,
+    private val internalLogger: InternalLogger
+) : EventWriteScope {
+    override fun invoke(block: (EventBatchWriter) -> Unit) {
+        executor.executeSafe("eventWriteScopeInvoke-$featureName", internalLogger) {
+            // since writing may not be atomic: we can write batch data + batch metadata, there is a gap between
+            // getting file for writing and write op, we sync file operation with a feature-wide lock
+            synchronized(featureWriteLock) {
+                block.invoke(writer)
+            }
+        }
+    }
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/Storage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/Storage.kt
@@ -9,7 +9,7 @@ package com.datadog.android.core.internal.persistence
 import androidx.annotation.AnyThread
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.context.DatadogContext
-import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.core.internal.metrics.RemovalReason
 import com.datadog.tools.annotation.NoOpImplementation
 
@@ -20,16 +20,13 @@ import com.datadog.tools.annotation.NoOpImplementation
 internal interface Storage {
 
     /**
-     * Utility to write data, asynchronously.
+     * Utility to get the scope for the writing operation, synchronously.
      * @param datadogContext the context for the write operation
-     * @param callback an operation to perform with a [EventBatchWriter] that will target the current
-     * writeable Batch
      */
     @AnyThread
-    fun writeCurrentBatch(
-        datadogContext: DatadogContext,
-        callback: (EventBatchWriter) -> Unit
-    )
+    fun getEventWriteScope(
+        datadogContext: DatadogContext
+    ): EventWriteScope
 
     /**
      * Utility to read a batch, synchronously.

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
@@ -79,6 +79,7 @@ import java.util.Collections
 import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
@@ -746,11 +747,15 @@ internal class DatadogCoreTest {
         )
         val mockCoreFeature = mock<CoreFeature>()
         testedCore.coreFeature = mockCoreFeature
-        val mockExecutorService: FlushableExecutorService = mock()
-        whenever(mockCoreFeature.persistenceExecutorService) doReturn mockExecutorService
-        whenever(mockExecutorService.execute(any())) doAnswer {
-            val runnable = it.arguments.first() as Runnable
-            runnable.run()
+        val mockPersistenceExecutor = mock<FlushableExecutorService>()
+        val mockContextExecutor = mock<ThreadPoolExecutor>()
+        whenever(mockCoreFeature.persistenceExecutorService) doReturn mockPersistenceExecutor
+        whenever(mockCoreFeature.contextExecutorService) doReturn mockContextExecutor
+        whenever(mockPersistenceExecutor.execute(any())) doAnswer {
+            it.getArgument<Runnable>(0).run()
+        }
+        whenever(mockContextExecutor.execute(any())) doAnswer {
+            it.getArgument<Runnable>(0).run()
         }
 
         // When

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AbstractStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AbstractStorageTest.kt
@@ -50,7 +50,7 @@ import org.mockito.quality.Strictness
 @ForgeConfiguration(Configurator::class)
 internal class AbstractStorageTest {
 
-    lateinit var testedStorage: AbstractStorage
+    private lateinit var testedStorage: AbstractStorage
 
     @Mock
     lateinit var mockPersistenceStrategyFactory: PersistenceStrategy.Factory
@@ -100,10 +100,10 @@ internal class AbstractStorageTest {
         )
     }
 
-    // region Storage.writeCurrentBatch
+    // region Storage.getEventWriteScope
 
     @Test
-    fun `M provide writer W writeCurrentBatch()+write() {consent=granted, batchMetadata=null}`(
+    fun `M provide writer W getEventWriteScope()+invoke() {consent=granted, batchMetadata=null}`(
         @BoolForgery fakeResult: Boolean,
         @Forgery fakeBatchEvent: RawBatchEvent
     ) {
@@ -118,7 +118,8 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
+        testedStorage.getEventWriteScope(fakeDatadogContext)
+            .invoke(mockWriteCallback)
 
         // Then
         assertThat(result).isEqualTo(fakeResult)
@@ -131,7 +132,7 @@ internal class AbstractStorageTest {
     }
 
     @Test
-    fun `M provide writer W writeCurrentBatch()+write() {consent=granted, batchMetadata!=null}`(
+    fun `M provide writer W getEventWriteScope()+invoke() {consent=granted, batchMetadata!=null}`(
         @BoolForgery fakeResult: Boolean,
         @Forgery fakeBatchEvent: RawBatchEvent,
         @StringForgery fakeBatchMetadata: String
@@ -148,7 +149,8 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
+        testedStorage.getEventWriteScope(fakeDatadogContext)
+            .invoke(mockWriteCallback)
 
         // Then
         assertThat(result).isEqualTo(fakeResult)
@@ -161,19 +163,19 @@ internal class AbstractStorageTest {
     }
 
     @Test
-    fun `M provide writer W writeCurrentBatch()+currentMetadata() {consent=granted, batchMetadata=null}`() {
+    fun `M provide writer W getEventWriteScope()+currentMetadata() {consent=granted, batchMetadata=null}`() {
         // Given
         fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
         whenever(mockGrantedPersistenceStrategy.currentMetadata()) doReturn null
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
-        whenever(mockGrantedPersistenceStrategy.currentMetadata()) doReturn null
         var resultMetadata: ByteArray? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
             resultMetadata = it.getArgument<EventBatchWriter>(0).currentMetadata()
         }
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
+        testedStorage.getEventWriteScope(fakeDatadogContext)
+            .invoke(mockWriteCallback)
 
         // Then
         assertThat(resultMetadata).isNull()
@@ -186,7 +188,7 @@ internal class AbstractStorageTest {
     }
 
     @Test
-    fun `M provide writer W writeCurrentBatch()+currentMetadata() {consent=granted, batchMetadata!=null}`(
+    fun `M provide writer W getEventWriteScope()+currentMetadata() {consent=granted, batchMetadata!=null}`(
         @StringForgery fakeBatchMetadata: String
     ) {
         // Given
@@ -200,7 +202,8 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
+        testedStorage.getEventWriteScope(fakeDatadogContext)
+            .invoke(mockWriteCallback)
 
         // Then
         assertThat(resultMetadata).isEqualTo(batchMetadata)
@@ -213,7 +216,7 @@ internal class AbstractStorageTest {
     }
 
     @Test
-    fun `M provide writer W writeCurrentBatch()+write() {consent=pending, batchMetadata=null}`(
+    fun `M provide writer W getEventWriteScope()+write() {consent=pending, batchMetadata=null}`(
         @BoolForgery fakeResult: Boolean,
         @Forgery fakeBatchEvent: RawBatchEvent
     ) {
@@ -227,7 +230,8 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
+        testedStorage.getEventWriteScope(fakeDatadogContext)
+            .invoke(mockWriteCallback)
 
         // Then
         assertThat(result).isEqualTo(fakeResult)
@@ -240,7 +244,7 @@ internal class AbstractStorageTest {
     }
 
     @Test
-    fun `M provide writer W writeCurrentBatch()+write() {consent=pending, batchMetadata!=null}`(
+    fun `M provide writer W getEventWriteScope()+write() {consent=pending, batchMetadata!=null}`(
         @BoolForgery fakeResult: Boolean,
         @Forgery fakeBatchEvent: RawBatchEvent,
         @StringForgery fakeBatchMetadata: String
@@ -256,7 +260,8 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
+        testedStorage.getEventWriteScope(fakeDatadogContext)
+            .invoke(mockWriteCallback)
 
         // Then
         assertThat(result).isEqualTo(fakeResult)
@@ -269,7 +274,7 @@ internal class AbstractStorageTest {
     }
 
     @Test
-    fun `M provide writer W writeCurrentBatch()+currentMetadata() {consent=pending, batchMetadata=null}`() {
+    fun `M provide writer W getEventWriteScope()+currentMetadata() {consent=pending, batchMetadata=null}`() {
         // Given
         fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
@@ -280,7 +285,8 @@ internal class AbstractStorageTest {
         whenever(mockPendingPersistenceStrategy.currentMetadata()) doReturn null
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
+        testedStorage.getEventWriteScope(fakeDatadogContext)
+            .invoke(mockWriteCallback)
 
         // Then
         assertThat(resultMetadata).isNull()
@@ -293,7 +299,7 @@ internal class AbstractStorageTest {
     }
 
     @Test
-    fun `M provide writer W writeCurrentBatch()+currentMetadata() {consent=pending, batchMetadata!=null}`(
+    fun `M provide writer W getEventWriteScope()+currentMetadata() {consent=pending, batchMetadata!=null}`(
         @StringForgery fakeBatchMetadata: String
     ) {
         // Given
@@ -307,7 +313,8 @@ internal class AbstractStorageTest {
         whenever(mockPendingPersistenceStrategy.currentMetadata()) doReturn batchMetadata
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
+        testedStorage.getEventWriteScope(fakeDatadogContext)
+            .invoke(mockWriteCallback)
 
         // Then
         assertThat(resultMetadata).isEqualTo(batchMetadata)
@@ -320,7 +327,7 @@ internal class AbstractStorageTest {
     }
 
     @Test
-    fun `M provide no op writer W writeCurrentBatch()+write() {consent=not_granted}`(
+    fun `M provide no-op writer W getEventWriteScope()+write() {consent=not_granted}`(
         @Forgery fakeBatchEvent: RawBatchEvent,
         @StringForgery fakeBatchMetadata: String
     ) {
@@ -334,7 +341,8 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
+        testedStorage.getEventWriteScope(fakeDatadogContext)
+            .invoke(mockWriteCallback)
 
         // Then
         assertThat(result).isFalse()
@@ -346,7 +354,7 @@ internal class AbstractStorageTest {
     }
 
     @Test
-    fun `M provide no op writer W writeCurrentBatch()+currentMetadata() {consent=not_granted}`() {
+    fun `M provide no-op writer W getEventWriteScope()+currentMetadata() {consent=not_granted}`() {
         // Given
         fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.NOT_GRANTED)
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
@@ -356,7 +364,8 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(fakeDatadogContext, mockWriteCallback)
+        testedStorage.getEventWriteScope(fakeDatadogContext)
+            .invoke(mockWriteCallback)
 
         // Then
         assertThat(resultMetadata).isNull()

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AsyncEventWriteScopeTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AsyncEventWriteScopeTest.kt
@@ -1,0 +1,124 @@
+package com.datadog.android.core.internal.persistence
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.feature.EventWriteScope
+import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
+import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+class AsyncEventWriteScopeTest {
+
+    private lateinit var testedScope: EventWriteScope
+
+    @Mock
+    lateinit var mockEventBatchWriter: EventBatchWriter
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @Mock
+    lateinit var mockExecutor: Executor
+
+    @StringForgery
+    lateinit var fakeFeatureName: String
+
+    private val fakeWriteLock = Any()
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(mockExecutor.execute(any())) doAnswer {
+            it.getArgument<Runnable>(0)
+                .run()
+        }
+
+        testedScope =
+            AsyncEventWriteScope(mockExecutor, mockEventBatchWriter, fakeWriteLock, fakeFeatureName, mockInternalLogger)
+    }
+
+    @Test
+    fun `M invoke with writer W invoke()`() {
+        // Given
+        val mockCallback = mock<(EventBatchWriter) -> Unit>()
+
+        // When
+        testedScope.invoke(mockCallback)
+
+        // Then
+        verify(mockCallback).invoke(mockEventBatchWriter)
+    }
+
+    @Test
+    fun `M do sequential metadata write W invoke() { multithreaded }`(
+        @IntForgery(min = 2, max = 10) threadsCount: Int,
+        @Forgery fakeEventType: EventType,
+        forge: Forge
+    ) {
+        // Given
+        val executor = Executors.newFixedThreadPool(threadsCount)
+        var accumulator: Byte = 0
+        val event = forge.aString().toByteArray()
+        // each write operation is going to increase value in meta by 1
+        // in the end if some write operation was parallel to another, total number in meta
+        // won't be equal to the number of threads
+        // if write operations are parallel, there is a chance that there will be a conflict
+        // updating the meta (applying different updates to the same original state).
+        val callback: (EventBatchWriter) -> Unit = {
+            val value = it.currentMetadata()?.first() ?: 0
+            it.write(
+                event = RawBatchEvent(data = event),
+                batchMetadata = byteArrayOf((value + 1).toByte()),
+                eventType = fakeEventType
+            )
+        }
+
+        whenever(mockEventBatchWriter.currentMetadata()) doAnswer { byteArrayOf(accumulator) }
+        whenever(
+            mockEventBatchWriter.write(any(), any(), any())
+        ) doAnswer {
+            val value = it.getArgument<ByteArray>(1).first()
+            accumulator = value
+            true
+        }
+
+        // When
+        repeat(threadsCount) {
+            AsyncEventWriteScope(executor, mockEventBatchWriter, fakeWriteLock, fakeFeatureName, mockInternalLogger)
+                .invoke(callback)
+        }
+        executor.shutdown()
+        executor.awaitTermination(1, TimeUnit.SECONDS)
+
+        // Then
+        assertThat(accumulator).isEqualTo(threadsCount.toByte())
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/config/CoreFeatureTestConfiguration.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/config/CoreFeatureTestConfiguration.kt
@@ -37,6 +37,7 @@ import java.nio.file.Files
 import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.ThreadPoolExecutor
 
 internal class CoreFeatureTestConfiguration<T : Context>(
     val appContext: ApplicationContextTestConfiguration<T>
@@ -58,6 +59,7 @@ internal class CoreFeatureTestConfiguration<T : Context>(
     lateinit var mockUploadExecutor: ScheduledThreadPoolExecutor
     lateinit var mockOkHttpClient: OkHttpClient
     lateinit var mockPersistenceExecutor: FlushableExecutorService
+    lateinit var mockContextExecutorService: ThreadPoolExecutor
     lateinit var mockKronosClock: KronosClock
     lateinit var mockContextRef: WeakReference<Context?>
     lateinit var mockFirstPartyHostHeaderTypeResolver: DefaultFirstPartyHostHeaderTypeResolver
@@ -109,6 +111,7 @@ internal class CoreFeatureTestConfiguration<T : Context>(
 
     private fun createMocks() {
         mockPersistenceExecutor = mock()
+        mockContextExecutorService = mock()
         mockUploadExecutor = mock()
         mockOkHttpClient = mock()
         mockKronosClock = mock()
@@ -143,6 +146,7 @@ internal class CoreFeatureTestConfiguration<T : Context>(
         whenever(mockInstance.featuresContext) doReturn fakeFeaturesContext
 
         whenever(mockInstance.persistenceExecutorService) doReturn mockPersistenceExecutor
+        whenever(mockInstance.contextExecutorService) doReturn mockContextExecutorService
         whenever(mockInstance.uploadExecutorService) doReturn mockUploadExecutor
         whenever(mockInstance.okHttpClient) doReturn mockOkHttpClient
         whenever(mockInstance.kronosClock) doReturn mockKronosClock

--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -97,6 +97,7 @@ datadog:
       - "com.datadog.android.core.internal.utils.executeSafe"
       - "com.datadog.android.core.internal.utils.scheduleSafe"
       - "com.datadog.android.api.feature.FeatureScope.withWriteContext"
+      - "com.datadog.android.api.feature.EventWriteScope.invoke"
     mainThreadSwitchingCalls:
       - "android.widget.LinearLayout.post"
   TodoWithoutTask:
@@ -222,6 +223,7 @@ datadog:
       - "java.util.concurrent.ScheduledThreadPoolExecutor.awaitTermination(kotlin.Long, java.util.concurrent.TimeUnit?):java.lang.InterruptedException"
       - "java.util.concurrent.ScheduledThreadPoolExecutor.constructor(kotlin.Int):java.lang.IllegalArgumentException"
       - "java.util.concurrent.ScheduledThreadPoolExecutor.schedule(java.lang.Runnable, kotlin.Long, java.util.concurrent.TimeUnit):java.util.concurrent.RejectedExecutionException,java.lang.NullPointerException"
+      - "java.util.concurrent.ThreadPoolExecutor.awaitTermination(kotlin.Long, java.util.concurrent.TimeUnit?):java.lang.InterruptedException"
       - "java.util.concurrent.ThreadPoolExecutor.constructor(kotlin.Int, kotlin.Int, kotlin.Long, java.util.concurrent.TimeUnit, java.util.concurrent.BlockingQueue):java.lang.NullPointerException,java.lang.IllegalArgumentException"
       # endregion
       # region Java misc
@@ -685,6 +687,7 @@ datadog:
       - "java.util.Queue.isEmpty()"
       - "java.util.Queue.isNotEmpty()"
       - "java.util.Queue.poll()"
+      - "java.util.concurrent.Callable(kotlin.Function0)"
       - "java.util.concurrent.ConcurrentHashMap.constructor()"
       - "java.util.concurrent.ConcurrentHashMap.getOrPut(kotlin.String?, kotlin.Function0)"
       - "java.util.concurrent.ConcurrentHashMap.putIfAbsent(kotlin.String, com.datadog.android.rum.internal.metric.slowframes.DefaultUISlownessMetricDispatcher.SlowFramesTelemetry)"
@@ -703,6 +706,7 @@ datadog:
       - "java.util.concurrent.ExecutorService.shutdownNow()"
       - "java.util.concurrent.Executors.newSingleThreadExecutor()"
       - "java.util.concurrent.LinkedBlockingDeque.constructor()"
+      - "java.util.concurrent.LinkedBlockingQueue.constructor()"
       - "java.util.concurrent.RejectedExecutionHandler(kotlin.Function2)"
       - "java.util.concurrent.ScheduledExecutorService.shutdownNow()"
       - "java.util.concurrent.ScheduledThreadPoolExecutor.afterExecute(java.lang.Runnable?, kotlin.Throwable?)"
@@ -719,6 +723,7 @@ datadog:
       - "java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(kotlin.Long)"
       - "java.util.concurrent.TimeUnit.SECONDS.toMillis(kotlin.Long)"
       - "java.util.concurrent.TimeUnit.SECONDS.toNanos(kotlin.Long)"
+      - "java.util.concurrent.ThreadPoolExecutor.shutdownNow()"
       - "java.util.concurrent.atomic.AtomicBoolean.compareAndSet(kotlin.Boolean, kotlin.Boolean)"
       - "java.util.concurrent.atomic.AtomicBoolean.constructor(kotlin.Boolean)"
       - "java.util.concurrent.atomic.AtomicBoolean.get()"

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
@@ -55,7 +55,7 @@ internal class DatadogLogHandler(
         if (sampler.sample(Unit)) {
             if (logsFeature != null) {
                 val threadName = Thread.currentThread().name
-                logsFeature.withWriteContext { datadogContext, eventBatchWriter ->
+                logsFeature.withWriteContext { datadogContext, writeScope ->
                     val log = createLog(
                         level,
                         datadogContext,
@@ -67,7 +67,9 @@ internal class DatadogLogHandler(
                         resolvedTimeStamp
                     )
                     if (log != null) {
-                        writer.write(eventBatchWriter, log, EventType.DEFAULT)
+                        writeScope {
+                            writer.write(it, log, EventType.DEFAULT)
+                        }
                     }
                 }
             } else {
@@ -126,7 +128,7 @@ internal class DatadogLogHandler(
         if (sampler.sample(Unit)) {
             if (logsFeature != null) {
                 val threadName = Thread.currentThread().name
-                logsFeature.withWriteContext { datadogContext, eventBatchWriter ->
+                logsFeature.withWriteContext { datadogContext, writeScope ->
                     val log = createLog(
                         level,
                         datadogContext,
@@ -140,7 +142,9 @@ internal class DatadogLogHandler(
                         resolvedTimeStamp
                     )
                     if (log != null) {
-                        writer.write(eventBatchWriter, log, EventType.DEFAULT)
+                        writeScope {
+                            writer.write(it, log, EventType.DEFAULT)
+                        }
                     }
                 }
             } else {

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.log.internal.logger
 
 import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
@@ -100,6 +101,9 @@ internal class DatadogLogHandlerTest {
     lateinit var mockRumFeature: FeatureScope
 
     @Mock
+    lateinit var mockEventWriteScope: EventWriteScope
+
+    @Mock
     lateinit var mockEventBatchWriter: EventBatchWriter
 
     @Mock
@@ -137,9 +141,13 @@ internal class DatadogLogHandlerTest {
             mockSdkCore.getFeature(Feature.LOGS_FEATURE_NAME)
         ) doReturn mockLogsFeatureScope
         whenever(mockLogsFeatureScope.unwrap<LogsFeature>()) doReturn mockLogsFeature
+        whenever(mockEventWriteScope.invoke(any())) doAnswer {
+            val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
+            callback.invoke(mockEventBatchWriter)
+        }
         whenever(mockLogsFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventBatchWriter)
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+            callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
 
         whenever(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
@@ -77,7 +77,7 @@ internal class DatadogLateCrashReporter(
             return
         }
 
-        rumFeature.withWriteContext { datadogContext, eventBatchWriter ->
+        rumFeature.withWriteContext { datadogContext, writeScope ->
             val toSendErrorEvent = resolveErrorEventFromViewEvent(
                 datadogContext,
                 ErrorEvent.SourceType.tryFromSource(sourceType),
@@ -90,10 +90,12 @@ internal class DatadogLateCrashReporter(
                 null,
                 lastViewEvent
             )
-            rumWriter.write(eventBatchWriter, toSendErrorEvent, EventType.CRASH)
-            if (lastViewEvent.isWithinSessionAvailability) {
-                val updatedViewEvent = updateViewEvent(lastViewEvent)
-                rumWriter.write(eventBatchWriter, updatedViewEvent, EventType.CRASH)
+            writeScope {
+                rumWriter.write(it, toSendErrorEvent, EventType.CRASH)
+                if (lastViewEvent.isWithinSessionAvailability) {
+                    val updatedViewEvent = updateViewEvent(lastViewEvent)
+                    rumWriter.write(it, updatedViewEvent, EventType.CRASH)
+                }
             }
         }
     }
@@ -121,7 +123,7 @@ internal class DatadogLateCrashReporter(
                 return
             }
 
-            rumFeature.withWriteContext { datadogContext, eventBatchWriter ->
+            rumFeature.withWriteContext { datadogContext, writeScope ->
                 // means we are too late, last view event belongs to the ongoing session
                 if (lastViewEvent.session.id == datadogContext.rumSessionId) return@withWriteContext
 
@@ -144,12 +146,14 @@ internal class DatadogLateCrashReporter(
                     threadDumps,
                     lastViewEvent
                 )
-                rumWriter.write(eventBatchWriter, toSendErrorEvent, EventType.CRASH)
-                if (lastViewEvent.isWithinSessionAvailability) {
-                    val updatedViewEvent = updateViewEvent(lastViewEvent)
-                    rumWriter.write(eventBatchWriter, updatedViewEvent, EventType.CRASH)
+                writeScope {
+                    rumWriter.write(it, toSendErrorEvent, EventType.CRASH)
+                    if (lastViewEvent.isWithinSessionAvailability) {
+                        val updatedViewEvent = updateViewEvent(lastViewEvent)
+                        rumWriter.write(it, updatedViewEvent, EventType.CRASH)
+                    }
+                    sdkCore.writeLastFatalAnrSent(anrExitInfo.timestamp)
                 }
-                sdkCore.writeLastFatalAnrSent(anrExitInfo.timestamp)
             }
         }
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
@@ -7,6 +7,8 @@
 package com.datadog.android.rum.internal.domain.scope
 
 import androidx.annotation.WorkerThread
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.rum.GlobalRumMonitor
@@ -68,7 +70,12 @@ internal class RumActionScope(
     // endregion
 
     @WorkerThread
-    override fun handleEvent(event: RumRawEvent, writer: DataWriter<Any>): RumScope? {
+    override fun handleEvent(
+        event: RumRawEvent,
+        datadogContext: DatadogContext,
+        writeScope: EventWriteScope,
+        writer: DataWriter<Any>
+    ): RumScope? {
         val now = event.eventTime.nanoTime
         val isInactive = now - lastInteractionNanos > inactivityThresholdNs
         val isLongDuration = now - startedNanos > maxDurationNs
@@ -77,16 +84,21 @@ internal class RumActionScope(
         val shouldStop = isInactive && ongoingResourceKeys.isEmpty() && !isOngoing
 
         when {
-            shouldStop -> sendAction(lastInteractionNanos, writer)
-            isLongDuration -> sendAction(now, writer)
-            event is RumRawEvent.SendCustomActionNow -> sendAction(lastInteractionNanos, writer)
-            event is RumRawEvent.StartView -> onStartView(now, writer)
-            event is RumRawEvent.StopView -> onStopView(now, writer)
-            event is RumRawEvent.StopSession -> onStopSession(now, writer)
+            shouldStop -> sendAction(lastInteractionNanos, datadogContext, writeScope, writer)
+            isLongDuration -> sendAction(now, datadogContext, writeScope, writer)
+            event is RumRawEvent.SendCustomActionNow -> sendAction(
+                lastInteractionNanos,
+                datadogContext,
+                writeScope,
+                writer
+            )
+            event is RumRawEvent.StartView -> onStartView(now, datadogContext, writeScope, writer)
+            event is RumRawEvent.StopView -> onStopView(now, datadogContext, writeScope, writer)
+            event is RumRawEvent.StopSession -> onStopSession(now, datadogContext, writeScope, writer)
             event is RumRawEvent.StopAction -> onStopAction(event, now)
             event is RumRawEvent.StartResource -> onStartResource(event, now)
             event is RumRawEvent.StopResource -> onStopResource(event, now)
-            event is RumRawEvent.AddError -> onError(event, now, writer)
+            event is RumRawEvent.AddError -> onError(event, now, datadogContext, writeScope, writer)
             event is RumRawEvent.StopResourceWithError -> onResourceError(event.key, now)
             event is RumRawEvent.StopResourceWithStackTrace -> onResourceError(event.key, now)
             event is RumRawEvent.AddLongTask -> onLongTask(now)
@@ -110,29 +122,35 @@ internal class RumActionScope(
     @WorkerThread
     private fun onStartView(
         now: Long,
+        datadogContext: DatadogContext,
+        writeScope: EventWriteScope,
         writer: DataWriter<Any>
     ) {
         // another view starts, complete this action
         ongoingResourceKeys.clear()
-        sendAction(now, writer)
+        sendAction(now, datadogContext, writeScope, writer)
     }
 
     @WorkerThread
     private fun onStopView(
         now: Long,
+        datadogContext: DatadogContext,
+        writeScope: EventWriteScope,
         writer: DataWriter<Any>
     ) {
         ongoingResourceKeys.clear()
-        sendAction(now, writer)
+        sendAction(now, datadogContext, writeScope, writer)
     }
 
     @WorkerThread
     private fun onStopSession(
         now: Long,
+        datadogContext: DatadogContext,
+        writeScope: EventWriteScope,
         writer: DataWriter<Any>
     ) {
         ongoingResourceKeys.clear()
-        sendAction(now, writer)
+        sendAction(now, datadogContext, writeScope, writer)
     }
 
     private fun onStopAction(
@@ -171,6 +189,8 @@ internal class RumActionScope(
     private fun onError(
         event: RumRawEvent.AddError,
         now: Long,
+        datadogContext: DatadogContext,
+        writeScope: EventWriteScope,
         writer: DataWriter<Any>
     ) {
         lastInteractionNanos = now
@@ -178,7 +198,7 @@ internal class RumActionScope(
 
         if (event.isFatal) {
             crashCount++
-            sendAction(now, writer)
+            sendAction(now, datadogContext, writeScope, writer)
         }
     }
 
@@ -200,6 +220,8 @@ internal class RumActionScope(
     @Suppress("LongMethod", "ComplexMethod")
     private fun sendAction(
         endNanos: Long,
+        datadogContext: DatadogContext,
+        writeScope: EventWriteScope,
         writer: DataWriter<Any>
     ) {
         if (sent) return
@@ -240,7 +262,7 @@ internal class RumActionScope(
             frustrations.add(ActionEvent.Type.ERROR_TAP)
         }
 
-        sdkCore.newRumEventWriteOperation(writer) { datadogContext ->
+        sdkCore.newRumEventWriteOperation(datadogContext, writeScope, writer) {
             val user = datadogContext.userInfo
             val hasReplay = featuresContextResolver.resolveViewHasReplay(
                 datadogContext,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumScope.kt
@@ -7,6 +7,8 @@
 package com.datadog.android.rum.internal.domain.scope
 
 import androidx.annotation.WorkerThread
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.tools.annotation.NoOpImplementation
@@ -23,6 +25,8 @@ internal interface RumScope {
     @WorkerThread
     fun handleEvent(
         event: RumRawEvent,
+        datadogContext: DatadogContext,
+        writeScope: EventWriteScope,
         writer: DataWriter<Any>
     ): RumScope?
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -7,6 +7,8 @@
 package com.datadog.android.rum.internal.domain.scope
 
 import androidx.annotation.WorkerThread
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.NoOpDataWriter
@@ -118,6 +120,8 @@ internal class RumSessionScope(
     @WorkerThread
     override fun handleEvent(
         event: RumRawEvent,
+        datadogContext: DatadogContext,
+        writeScope: EventWriteScope,
         writer: DataWriter<Any>
     ): RumScope? {
         if (event is RumRawEvent.ResetSession) {
@@ -131,7 +135,7 @@ internal class RumSessionScope(
         val actualWriter = if (sessionState == State.TRACKED) writer else noOpWriter
 
         if (event !is RumRawEvent.SdkInit) {
-            childScope = childScope?.handleEvent(event, actualWriter)
+            childScope = childScope?.handleEvent(event, datadogContext, writeScope, actualWriter)
         }
 
         return if (isSessionComplete()) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -70,7 +70,7 @@ internal class TelemetryEventHandler(
 
         eventIDsSeenInCurrentSession.add(event.identity)
         totalEventsSeenInCurrentSession++
-        sdkCore.getFeature(Feature.RUM_FEATURE_NAME)?.withWriteContext { datadogContext, eventBatchWriter ->
+        sdkCore.getFeature(Feature.RUM_FEATURE_NAME)?.withWriteContext { datadogContext, writeScope ->
             val timestamp = wrappedEvent.eventTime.timestamp + datadogContext.time.serverTimeOffsetMs
             val telemetryEvent: Any? = when (event) {
                 is InternalTelemetryEvent.Log.Debug -> {
@@ -135,7 +135,9 @@ internal class TelemetryEventHandler(
                 }
             }
             if (telemetryEvent != null) {
-                writer.write(eventBatchWriter, telemetryEvent, EventType.TELEMETRY)
+                writeScope {
+                    writer.write(it, telemetryEvent, EventType.TELEMETRY)
+                }
             }
         }
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.internal.domain.scope
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.context.NetworkInfo
+import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
@@ -91,6 +92,12 @@ internal class RumActionScopeTest {
     @Mock
     lateinit var mockEventBatchWriter: EventBatchWriter
 
+    @Mock
+    lateinit var mockEventWriteScope: EventWriteScope
+
+    @Mock
+    lateinit var mockFeaturesContextResolver: FeaturesContextResolver
+
     lateinit var fakeType: RumActionType
 
     @StringForgery
@@ -120,9 +127,6 @@ internal class RumActionScopeTest {
 
     @BoolForgery
     var fakeHasReplay: Boolean = false
-
-    @Mock
-    lateinit var mockFeaturesContextResolver: FeaturesContextResolver
 
     @BoolForgery
     var fakeTrackFrustrations: Boolean = true
@@ -158,9 +162,13 @@ internal class RumActionScopeTest {
         whenever(rumMonitor.mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
         whenever(rumMonitor.mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
+        whenever(mockEventWriteScope.invoke(any())) doAnswer {
+            val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
+            callback.invoke(mockEventBatchWriter)
+        }
         whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventBatchWriter)
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+            callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
         whenever(
             mockFeaturesContextResolver.resolveViewHasReplay(
@@ -222,12 +230,12 @@ internal class RumActionScopeTest {
     ) {
         // When
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
         fakeEvent = RumRawEvent.StopResource(key, statusCode, size, kind, emptyMap())
-        val result2 = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result2 = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
-        val result3 = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result3 = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -272,7 +280,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isSameAs(testedScope)
@@ -291,15 +299,15 @@ internal class RumActionScopeTest {
     ) {
         // When
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
         fakeEvent = RumRawEvent.StopResource(key2, statusCode, size, kind, emptyMap())
-        val result2 = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result2 = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
-        val result3 = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result3 = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isSameAs(testedScope)
@@ -318,7 +326,7 @@ internal class RumActionScopeTest {
     ) {
         // When
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
         fakeEvent = RumRawEvent.StopResourceWithError(
             key,
@@ -328,9 +336,9 @@ internal class RumActionScopeTest {
             throwable,
             emptyMap()
         )
-        val result2 = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result2 = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
-        val result3 = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result3 = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -379,7 +387,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isSameAs(testedScope)
@@ -402,7 +410,7 @@ internal class RumActionScopeTest {
 
         // When
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
         fakeEvent = RumRawEvent.StopResourceWithStackTrace(
             key,
@@ -413,9 +421,9 @@ internal class RumActionScopeTest {
             errorType,
             emptyMap()
         )
-        val result2 = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result2 = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
-        val result3 = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result3 = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -463,7 +471,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isSameAs(testedScope)
@@ -483,7 +491,7 @@ internal class RumActionScopeTest {
     ) {
         // When
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
         val fakeEvent2 = RumRawEvent.StopResourceWithError(
             key2,
@@ -493,9 +501,9 @@ internal class RumActionScopeTest {
             throwable,
             emptyMap()
         )
-        val result2 = testedScope.handleEvent(fakeEvent2, mockWriter)
+        val result2 = testedScope.handleEvent(fakeEvent2, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
-        val result3 = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result3 = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         verifyNoInteractions(mockWriter)
@@ -521,7 +529,7 @@ internal class RumActionScopeTest {
 
         // When
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
         val fakeEvent2 = RumRawEvent.StopResourceWithStackTrace(
             key2,
@@ -532,9 +540,9 @@ internal class RumActionScopeTest {
             errorType,
             emptyMap()
         )
-        val result2 = testedScope.handleEvent(fakeEvent2, mockWriter)
+        val result2 = testedScope.handleEvent(fakeEvent2, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
-        val result3 = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result3 = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         verifyNoInteractions(mockWriter)
@@ -553,12 +561,12 @@ internal class RumActionScopeTest {
 
         // When
         fakeEvent = RumRawEvent.StartResource(key.toString(), url, method, emptyMap())
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
         fakeEvent = mockEvent()
         key = null
         System.gc()
-        val result2 = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result2 = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -602,7 +610,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -625,9 +633,9 @@ internal class RumActionScopeTest {
             threads = emptyList(),
             attributes = emptyMap()
         )
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
-        val result2 = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result2 = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -675,7 +683,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -688,9 +696,9 @@ internal class RumActionScopeTest {
     ) {
         // When
         fakeEvent = RumRawEvent.AddLongTask(duration, target)
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
-        val result2 = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result2 = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -734,7 +742,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -756,7 +764,7 @@ internal class RumActionScopeTest {
             threads = emptyList(),
             attributes = emptyMap()
         )
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -804,7 +812,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -825,7 +833,7 @@ internal class RumActionScopeTest {
             threads = emptyList(),
             attributes = emptyMap()
         )
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         fakeEvent = RumRawEvent.AddError(
             message,
             source,
@@ -835,7 +843,7 @@ internal class RumActionScopeTest {
             threads = emptyList(),
             attributes = emptyMap()
         )
-        val result2 = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result2 = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -883,7 +891,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -898,7 +906,7 @@ internal class RumActionScopeTest {
 
         // When
         fakeEvent = RumRawEvent.StartView(RumScopeKey.from(Object()), emptyMap())
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -942,7 +950,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -956,7 +964,7 @@ internal class RumActionScopeTest {
 
         // When
         fakeEvent = RumRawEvent.StartView(RumScopeKey.from(Object()), emptyMap())
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -1000,7 +1008,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1014,7 +1022,7 @@ internal class RumActionScopeTest {
 
         // When
         fakeEvent = RumRawEvent.StartView(RumScopeKey.from(Object()), emptyMap())
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -1064,7 +1072,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1080,7 +1088,7 @@ internal class RumActionScopeTest {
 
         // When
         fakeEvent = RumRawEvent.StartView(RumScopeKey.from(Object()), emptyMap())
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -1129,7 +1137,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1143,7 +1151,7 @@ internal class RumActionScopeTest {
 
         // When
         fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Object()), emptyMap())
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -1187,7 +1195,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1201,7 +1209,7 @@ internal class RumActionScopeTest {
 
         // When
         fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Object()), emptyMap())
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -1245,7 +1253,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1259,7 +1267,7 @@ internal class RumActionScopeTest {
 
         // When
         fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Object()), emptyMap())
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -1308,7 +1316,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1324,7 +1332,7 @@ internal class RumActionScopeTest {
 
         // When
         fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Object()), emptyMap())
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -1373,7 +1381,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1387,7 +1395,7 @@ internal class RumActionScopeTest {
 
         // When
         fakeEvent = RumRawEvent.StopSession()
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -1431,7 +1439,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1445,7 +1453,7 @@ internal class RumActionScopeTest {
 
         // When
         fakeEvent = RumRawEvent.StopSession()
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -1489,7 +1497,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1503,7 +1511,7 @@ internal class RumActionScopeTest {
 
         // When
         fakeEvent = RumRawEvent.StopSession()
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -1552,7 +1560,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1568,7 +1576,7 @@ internal class RumActionScopeTest {
 
         // When
         fakeEvent = RumRawEvent.StopSession()
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -1617,7 +1625,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1660,7 +1668,7 @@ internal class RumActionScopeTest {
 
         // When
         Thread.sleep(TEST_INACTIVITY_MS)
-        val result = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -1705,7 +1713,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1741,7 +1749,7 @@ internal class RumActionScopeTest {
 
         // When
         Thread.sleep(TEST_INACTIVITY_MS)
-        val result = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -1786,7 +1794,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1806,7 +1814,7 @@ internal class RumActionScopeTest {
         whenever(rumMonitor.mockInstance.getAttributes()) doReturn fakeGlobalAttributes
 
         // When
-        val result = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -1851,7 +1859,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1862,7 +1870,7 @@ internal class RumActionScopeTest {
         Thread.sleep(TEST_INACTIVITY_MS)
 
         // When
-        val result = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -1907,7 +1915,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1921,7 +1929,7 @@ internal class RumActionScopeTest {
 
         // When
         Thread.sleep(TEST_INACTIVITY_MS)
-        val result = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -1966,7 +1974,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1980,7 +1988,7 @@ internal class RumActionScopeTest {
 
         // When
         Thread.sleep(TEST_INACTIVITY_MS)
-        val result = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -2029,7 +2037,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -2045,7 +2053,7 @@ internal class RumActionScopeTest {
 
         // When
         Thread.sleep(TEST_INACTIVITY_MS)
-        val result = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -2093,7 +2101,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -2102,8 +2110,8 @@ internal class RumActionScopeTest {
     fun `M send Action only once W handleEvent(any) twice`() {
         // When
         Thread.sleep(TEST_INACTIVITY_MS)
-        val result = testedScope.handleEvent(mockEvent(), mockWriter)
-        val result2 = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        val result2 = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -2148,7 +2156,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
         assertThat(result2).isNull()
@@ -2163,7 +2171,7 @@ internal class RumActionScopeTest {
         fakeEvent = RumRawEvent.StartView(RumScopeKey.from(Object()), emptyMap())
 
         // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -2221,7 +2229,7 @@ internal class RumActionScopeTest {
         fakeEvent = RumRawEvent.StartView(RumScopeKey.from(Object()), emptyMap())
 
         // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -2266,7 +2274,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         assertThat(result).isNull()
     }
 
@@ -2279,7 +2287,7 @@ internal class RumActionScopeTest {
         fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Object()), emptyMap())
 
         // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -2337,7 +2345,7 @@ internal class RumActionScopeTest {
         fakeEvent = RumRawEvent.StopSession()
 
         // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -2382,7 +2390,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         assertThat(result).isNull()
     }
 
@@ -2397,7 +2405,7 @@ internal class RumActionScopeTest {
         fakeEvent = mockEvent()
 
         // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -2442,7 +2450,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         assertThat(result).isNull()
     }
 
@@ -2452,7 +2460,7 @@ internal class RumActionScopeTest {
         fakeEvent = mockEvent()
 
         // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         verifyNoInteractions(mockWriter, mockParentScope)
@@ -2467,9 +2475,9 @@ internal class RumActionScopeTest {
     ) {
         // When
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
-        val result2 = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result2 = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         verifyNoInteractions(mockWriter, mockParentScope)
@@ -2485,9 +2493,9 @@ internal class RumActionScopeTest {
     ) {
         // When
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_MAX_DURATION_MS)
-        val result2 = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result2 = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -2532,7 +2540,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -2542,7 +2550,7 @@ internal class RumActionScopeTest {
     fun `M send Action after timeout W handleEvent(any)`() {
         // When
         Thread.sleep(TEST_INACTIVITY_MS)
-        val result = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -2587,7 +2595,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -2597,7 +2605,7 @@ internal class RumActionScopeTest {
         // When
         Thread.sleep(TEST_INACTIVITY_MS)
         testedScope.type = RumActionType.CUSTOM
-        val result = testedScope.handleEvent(mockEvent(), mockWriter)
+        val result = testedScope.handleEvent(mockEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -2642,7 +2650,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -2652,7 +2660,7 @@ internal class RumActionScopeTest {
         // When
         testedScope.type = RumActionType.CUSTOM
         val event = RumRawEvent.SendCustomActionNow()
-        val result = testedScope.handleEvent(event, mockWriter)
+        val result = testedScope.handleEvent(event, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -2697,7 +2705,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -2735,7 +2743,7 @@ internal class RumActionScopeTest {
             threads = emptyList(),
             attributes = emptyMap()
         )
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
 
         fakeEvent = RumRawEvent.StartAction(
@@ -2744,7 +2752,7 @@ internal class RumActionScopeTest {
             false,
             emptyMap()
         )
-        val result2 = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result2 = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -2788,7 +2796,7 @@ internal class RumActionScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
-        verify(mockParentScope, never()).handleEvent(any(), any())
+        verify(mockParentScope, never()).handleEvent(any(), any(), any(), any())
         verifyNoMoreInteractions(mockWriter)
 
         assertThat(result).isSameAs(testedScope)
@@ -2802,7 +2810,7 @@ internal class RumActionScopeTest {
 
         // When
         testedScope.type = RumActionType.CUSTOM
-        testedScope.handleEvent(event, mockWriter)
+        testedScope.handleEvent(event, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         verify(rumMonitor.mockInstance as AdvancedRumMonitor)
@@ -2820,7 +2828,7 @@ internal class RumActionScopeTest {
         // When
         testedScope.type = RumActionType.CUSTOM
         whenever(mockWriter.write(eq(mockEventBatchWriter), isA<ActionEvent>(), eq(EventType.DEFAULT))) doReturn false
-        testedScope.handleEvent(event, mockWriter)
+        testedScope.handleEvent(event, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         verify(rumMonitor.mockInstance as AdvancedRumMonitor)
@@ -2841,7 +2849,7 @@ internal class RumActionScopeTest {
         testedScope.type = RumActionType.CUSTOM
         whenever(mockWriter.write(eq(mockEventBatchWriter), isA<ActionEvent>(), eq(EventType.DEFAULT)))
             .doThrow(forge.anException())
-        testedScope.handleEvent(event, mockWriter)
+        testedScope.handleEvent(event, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         verify(rumMonitor.mockInstance as AdvancedRumMonitor)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -10,6 +10,7 @@ import android.app.ActivityManager.RunningAppProcessInfo
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.context.TimeInfo
+import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
@@ -108,6 +109,18 @@ internal class RumViewManagerScopeTest {
     @Mock
     lateinit var mockViewChangedListener: RumViewChangedListener
 
+    @Mock
+    lateinit var mockNetworkSettledResourceIdentifier: InitialResourceIdentifier
+
+    @Mock
+    lateinit var mockLastInteractionIdentifier: LastInteractionIdentifier
+
+    @Mock
+    lateinit var mockSlowFramesListener: SlowFramesListener
+
+    @Mock
+    lateinit var mockEventWriteScope: EventWriteScope
+
     @Forgery
     lateinit var fakeParentContext: RumContext
 
@@ -119,15 +132,6 @@ internal class RumViewManagerScopeTest {
 
     @Forgery
     lateinit var fakeTime: TimeInfo
-
-    @Mock
-    lateinit var mockNetworkSettledResourceIdentifier: InitialResourceIdentifier
-
-    @Mock
-    lateinit var mockLastInteractionIdentifier: LastInteractionIdentifier
-
-    @Mock
-    lateinit var mockSlowFramesListener: SlowFramesListener
 
     @BoolForgery
     var fakeTrackFrustrations: Boolean = true
@@ -141,7 +145,7 @@ internal class RumViewManagerScopeTest {
         whenever(mockSdkCore.time) doReturn fakeTime
 
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
-        whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
+        whenever(mockChildScope.handleEvent(any(), any(), any(), any())) doReturn mockChildScope
         whenever(mockChildScope.isActive()) doReturn true
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockSlowFramesListener.resolveReport(any(), any(), any())) doReturn fakeViewUIPerformanceReport
@@ -181,10 +185,10 @@ internal class RumViewManagerScopeTest {
         testedScope.childrenScopes.add(mockChildScope)
 
         // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
-        verify(mockChildScope).handleEvent(fakeEvent, mockWriter)
+        verify(mockChildScope).handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         assertThat(result).isSameAs(testedScope)
         verifyNoInteractions(mockWriter)
     }
@@ -194,10 +198,17 @@ internal class RumViewManagerScopeTest {
         // Given
         val fakeEvent: RumRawEvent = mock()
         testedScope.childrenScopes.add(mockChildScope)
-        whenever(mockChildScope.handleEvent(fakeEvent, mockWriter)) doReturn mockChildScope
+        whenever(
+            mockChildScope.handleEvent(
+                fakeEvent,
+                fakeDatadogContext,
+                mockEventWriteScope,
+                mockWriter
+            )
+        ) doReturn mockChildScope
 
         // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(testedScope.childrenScopes).containsExactly(mockChildScope)
@@ -210,10 +221,17 @@ internal class RumViewManagerScopeTest {
         // Given
         val fakeEvent: RumRawEvent = mock()
         testedScope.childrenScopes.add(mockChildScope)
-        whenever(mockChildScope.handleEvent(fakeEvent, mockWriter)) doReturn null
+        whenever(
+            mockChildScope.handleEvent(
+                fakeEvent,
+                fakeDatadogContext,
+                mockEventWriteScope,
+                mockWriter
+            )
+        ) doReturn null
 
         // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(testedScope.childrenScopes).isEmpty()
@@ -234,7 +252,7 @@ internal class RumViewManagerScopeTest {
         testedScope.applicationDisplayed = true
 
         // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(testedScope.childrenScopes).hasSize(1)
@@ -261,7 +279,7 @@ internal class RumViewManagerScopeTest {
         testedScope.applicationDisplayed = false
 
         // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(testedScope.childrenScopes).hasSize(1)
@@ -286,18 +304,20 @@ internal class RumViewManagerScopeTest {
         // Given
         val fakeEvent = forge.startViewEvent()
         testedScope.applicationDisplayed = true
-        testedScope.handleEvent(fakeEvent, mockWriter)
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         testedScope.handleEvent(
             RumRawEvent.AddFeatureFlagEvaluation(
                 forge.anAlphabeticalString(),
                 forge.anAlphaNumericalString()
             ),
+            fakeDatadogContext,
+            mockEventWriteScope,
             mockWriter
         )
         val secondViewEvent = forge.startViewEvent()
 
         // When
-        testedScope.handleEvent(secondViewEvent, mockWriter)
+        testedScope.handleEvent(secondViewEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(testedScope.childrenScopes).hasSize(1)
@@ -315,14 +335,14 @@ internal class RumViewManagerScopeTest {
         // Given
         val firstViewEvent = forge.startViewEvent()
         testedScope.applicationDisplayed = true
-        testedScope.handleEvent(firstViewEvent, mockWriter)
+        testedScope.handleEvent(firstViewEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         val stopFirstViewEvent = RumRawEvent.StopView(firstViewEvent.key, emptyMap())
-        testedScope.handleEvent(stopFirstViewEvent, mockWriter)
+        testedScope.handleEvent(stopFirstViewEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // When
         Thread.sleep(fakeSleepMs)
         val secondViewEvent = forge.startViewEvent()
-        testedScope.handleEvent(secondViewEvent, mockWriter)
+        testedScope.handleEvent(secondViewEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         val messageBuilderCaptor = argumentCaptor<() -> String>()
@@ -350,12 +370,12 @@ internal class RumViewManagerScopeTest {
         // Given
         val firstViewEvent = forge.startViewEvent()
         testedScope.applicationDisplayed = true
-        testedScope.handleEvent(firstViewEvent, mockWriter)
+        testedScope.handleEvent(firstViewEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // When
         Thread.sleep(15)
         val secondViewEvent = forge.startViewEvent()
-        testedScope.handleEvent(secondViewEvent, mockWriter)
+        testedScope.handleEvent(secondViewEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         mockInternalLogger.verifyLog(
@@ -379,7 +399,7 @@ internal class RumViewManagerScopeTest {
         val fakeEvent = forge.validBackgroundEvent()
 
         // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(testedScope.childrenScopes).hasSize(1)
@@ -405,11 +425,11 @@ internal class RumViewManagerScopeTest {
         testedScope.applicationDisplayed = true
         testedScope.childrenScopes.add(mockChildScope)
         whenever(mockChildScope.isActive()) doReturn false
-        whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
+        whenever(mockChildScope.handleEvent(any(), any(), any(), any())) doReturn mockChildScope
         val fakeEvent = forge.validBackgroundEvent()
 
         // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(testedScope.childrenScopes).hasSize(2)
@@ -452,7 +472,7 @@ internal class RumViewManagerScopeTest {
         val fakeEvent = forge.validBackgroundEvent()
 
         // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(testedScope.childrenScopes).hasSize(1)
@@ -480,7 +500,7 @@ internal class RumViewManagerScopeTest {
         val fakeEvent = forge.invalidBackgroundEvent()
 
         // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(testedScope.childrenScopes).hasSize(0)
@@ -501,7 +521,7 @@ internal class RumViewManagerScopeTest {
         )
 
         // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(testedScope.childrenScopes).hasSize(0)
@@ -533,7 +553,7 @@ internal class RumViewManagerScopeTest {
         val fakeEvent = forge.validBackgroundEvent()
 
         // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(testedScope.childrenScopes).hasSize(0)
@@ -563,11 +583,11 @@ internal class RumViewManagerScopeTest {
         )
         testedScope.childrenScopes.add(mockChildScope)
         whenever(mockChildScope.isActive()) doReturn true
-        whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
+        whenever(mockChildScope.handleEvent(any(), any(), any(), any())) doReturn mockChildScope
         val fakeEvent = forge.validBackgroundEvent()
 
         // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(testedScope.childrenScopes).hasSize(1)
@@ -600,7 +620,7 @@ internal class RumViewManagerScopeTest {
         val fakeEvent = forge.validBackgroundEvent()
 
         // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         mockInternalLogger.verifyLog(
@@ -624,7 +644,7 @@ internal class RumViewManagerScopeTest {
         val fakeAppStartEvent = forge.applicationStartedEvent()
 
         // When
-        testedScope.handleEvent(fakeAppStartEvent, mockWriter)
+        testedScope.handleEvent(fakeAppStartEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(testedScope.childrenScopes).hasSize(1)
@@ -666,12 +686,12 @@ internal class RumViewManagerScopeTest {
         )
         testedScope.childrenScopes.add(mockChildScope)
         whenever(mockChildScope.isActive()) doReturn true
-        whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
+        whenever(mockChildScope.handleEvent(any(), any(), any(), any())) doReturn mockChildScope
 
         val fakeEvent = forge.applicationStartedEvent()
 
         // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(testedScope.childrenScopes).hasSize(1)
@@ -704,7 +724,7 @@ internal class RumViewManagerScopeTest {
         val fakeEvent = forge.applicationStartedEvent()
 
         // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         verifyNoInteractions(mockWriter)
@@ -724,14 +744,18 @@ internal class RumViewManagerScopeTest {
         val mockRumFeatureScope: FeatureScope = mock()
         val mockEventBatchWriter: EventBatchWriter = mock()
         whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
+        whenever(mockEventWriteScope.invoke(any())) doAnswer {
+            val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
+            callback.invoke(mockEventBatchWriter)
+        }
         whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventBatchWriter)
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+            callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
         val fakeAppStartEvent = forge.applicationStartedEvent()
 
         // When
-        testedScope.handleEvent(fakeAppStartEvent, mockWriter)
+        testedScope.handleEvent(fakeAppStartEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         argumentCaptor<ActionEvent> {
@@ -757,7 +781,7 @@ internal class RumViewManagerScopeTest {
         val fakeAppStartEvent = forge.applicationStartedEvent()
 
         // When
-        testedScope.handleEvent(fakeAppStartEvent, mockWriter)
+        testedScope.handleEvent(fakeAppStartEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         verifyNoInteractions(mockWriter)
@@ -773,7 +797,8 @@ internal class RumViewManagerScopeTest {
         testedScope.applicationDisplayed = true
 
         // When
-        val result = testedScope.handleEvent(RumRawEvent.StopSession(), mockWriter)
+        val result =
+            testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(result).isNull()
@@ -785,10 +810,18 @@ internal class RumViewManagerScopeTest {
         // Given
         testedScope.applicationDisplayed = true
         testedScope.childrenScopes.add(mockChildScope)
-        whenever(mockChildScope.handleEvent(any(), eq(mockWriter))) doReturn mockChildScope
+        whenever(
+            mockChildScope.handleEvent(
+                any(),
+                eq(fakeDatadogContext),
+                eq(mockEventWriteScope),
+                eq(mockWriter)
+            )
+        ) doReturn mockChildScope
 
         // When
-        val result = testedScope.handleEvent(RumRawEvent.StopSession(), mockWriter)
+        val result =
+            testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(result).isSameAs(testedScope)
@@ -801,12 +834,26 @@ internal class RumViewManagerScopeTest {
         testedScope.childrenScopes.add(mockChildScope)
         val stopEvent = RumRawEvent.StopSession()
         val fakeEvent: RumRawEvent = mock()
-        whenever(mockChildScope.handleEvent(stopEvent, mockWriter)) doReturn mockChildScope
-        whenever(mockChildScope.handleEvent(fakeEvent, mockWriter)) doReturn null
+        whenever(
+            mockChildScope.handleEvent(
+                stopEvent,
+                fakeDatadogContext,
+                mockEventWriteScope,
+                mockWriter
+            )
+        ) doReturn mockChildScope
+        whenever(
+            mockChildScope.handleEvent(
+                fakeEvent,
+                fakeDatadogContext,
+                mockEventWriteScope,
+                mockWriter
+            )
+        ) doReturn null
 
         // When
-        val firstResult = testedScope.handleEvent(stopEvent, mockWriter)
-        val secondResult = testedScope.handleEvent(fakeEvent, mockWriter)
+        val firstResult = testedScope.handleEvent(stopEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+        val secondResult = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(firstResult).isSameAs(testedScope)
@@ -816,7 +863,8 @@ internal class RumViewManagerScopeTest {
     @Test
     fun `M not display application W stopped`() {
         // When
-        val result = testedScope.handleEvent(RumRawEvent.StopSession(), mockWriter)
+        val result =
+            testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         assertThat(result).isNull()
         assertThat(testedScope.applicationDisplayed).isFalse
@@ -828,11 +876,11 @@ internal class RumViewManagerScopeTest {
         forge: Forge
     ) {
         // Given
-        testedScope.handleEvent(RumRawEvent.StopSession(), mockWriter)
+        testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
         val fakeEvent = forge.startViewEvent()
 
         // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(testedScope.childrenScopes).isEmpty()
@@ -844,11 +892,11 @@ internal class RumViewManagerScopeTest {
     ) {
         // Given
         testedScope.applicationDisplayed = true
-        testedScope.handleEvent(RumRawEvent.StopSession(), mockWriter)
+        testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
         val fakeEvent = forge.startViewEvent()
 
         // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         assertThat(testedScope.childrenScopes).isEmpty()
@@ -867,7 +915,7 @@ internal class RumViewManagerScopeTest {
         testedScope.applicationDisplayed = true
 
         // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         mockInternalLogger.verifyApiUsage(
@@ -891,7 +939,7 @@ internal class RumViewManagerScopeTest {
         testedScope.childrenScopes.add(mockChildScope)
 
         // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
         mockInternalLogger.verifyApiUsage(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.telemetry.internal
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.context.DeviceInfo
+import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
@@ -118,6 +119,9 @@ internal class TelemetryEventHandlerTest {
     lateinit var mockEventBatchWriter: EventBatchWriter
 
     @Mock
+    lateinit var mockEventWriteScope: EventWriteScope
+
+    @Mock
     lateinit var mockDeviceInfo: DeviceInfo
 
     @Mock
@@ -192,9 +196,15 @@ internal class TelemetryEventHandlerTest {
         whenever(
             mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)
         ) doReturn mockRumFeatureScope
+
+        whenever(mockEventWriteScope.invoke(any())) doAnswer {
+            val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
+            callback.invoke(mockEventBatchWriter)
+        }
+
         whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventBatchWriter)
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+            callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriter.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriter.kt
@@ -20,17 +20,19 @@ internal class SessionReplayResourcesWriter(
 ) : ResourcesWriter {
     override fun write(enrichedResource: EnrichedResource) {
         sdkCore.getFeature(SESSION_REPLAY_RESOURCES_FEATURE_NAME)
-            ?.withWriteContext { datadogContext, eventBatchWriter ->
-                synchronized(this) {
-                    val serializedMetadata = enrichedResource.asBinaryMetadata(datadogContext.rumApplicationId)
-                    eventBatchWriter.write(
-                        event = RawBatchEvent(
-                            data = enrichedResource.resource,
-                            metadata = serializedMetadata
-                        ),
-                        batchMetadata = null,
-                        eventType = EventType.DEFAULT
-                    )
+            ?.withWriteContext { datadogContext, writeScope ->
+                writeScope {
+                    synchronized(this@SessionReplayResourcesWriter) {
+                        val serializedMetadata = enrichedResource.asBinaryMetadata(datadogContext.rumApplicationId)
+                        it.write(
+                            event = RawBatchEvent(
+                                data = enrichedResource.resource,
+                                metadata = serializedMetadata
+                            ),
+                            batchMetadata = null,
+                            eventType = EventType.DEFAULT
+                        )
+                    }
                 }
             }
     }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayRecordWriterTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayRecordWriterTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.storage
 
 import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.EventBatchWriter
@@ -60,6 +61,9 @@ internal class SessionReplayRecordWriterTest {
     @Mock
     lateinit var mockEventBatchWriter: EventBatchWriter
 
+    @Mock
+    lateinit var mockEventWriteScope: EventWriteScope
+
     @BeforeEach
     fun `set up`() {
         whenever(mockEventBatchWriter.write(anyOrNull(), anyOrNull(), any()))
@@ -75,9 +79,13 @@ internal class SessionReplayRecordWriterTest {
     fun `M write the record in a batch W write`(forge: Forge) {
         // Given
         val fakeRecord = forge.forgeEnrichedRecord()
+        whenever(mockEventWriteScope.invoke(any())) doAnswer {
+            val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
+            callback.invoke(mockEventBatchWriter)
+        }
         whenever(mockSessionReplayFeature.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventBatchWriter)
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+            callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
 
         // When
@@ -117,9 +125,13 @@ internal class SessionReplayRecordWriterTest {
             .thenReturn(false)
 
         val fakeRecord = forge.forgeEnrichedRecord()
+        whenever(mockEventWriteScope.invoke(any())) doAnswer {
+            val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
+            callback.invoke(mockEventBatchWriter)
+        }
         whenever(mockSessionReplayFeature.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventBatchWriter)
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+            callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
 
         // When

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriterTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriterTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.storage
 
 import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
@@ -50,14 +51,17 @@ internal class SessionReplayResourcesWriterTest {
     @Mock
     lateinit var mockResourcesFeature: FeatureScope
 
+    @Mock
+    lateinit var mockEventBatchWriter: EventBatchWriter
+
+    @Mock
+    lateinit var mockEventWriteScope: EventWriteScope
+
     @Forgery
     lateinit var fakeEnrichedResource: EnrichedResource
 
     @Forgery
     lateinit var fakeRumApplicationId: UUID
-
-    @Mock
-    lateinit var mockEventBatchWriter: EventBatchWriter
 
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
@@ -78,9 +82,13 @@ internal class SessionReplayResourcesWriterTest {
     @Test
     fun `M write the resource W write()`() {
         // Given
+        whenever(mockEventWriteScope.invoke(any())) doAnswer {
+            val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
+            callback.invoke(mockEventBatchWriter)
+        }
         whenever(mockResourcesFeature.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventBatchWriter)
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+            callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
         fakeDatadogContext = fakeDatadogContext.copy(
             featuresContext = fakeDatadogContext.featuresContext

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/data/OtelTraceWriter.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/data/OtelTraceWriter.kt
@@ -40,16 +40,18 @@ internal class OtelTraceWriter(
     override fun write(trace: List<DDSpan>?) {
         if (trace == null) return
         sdkCore.getFeature(Feature.TRACING_FEATURE_NAME)
-            ?.withWriteContext { datadogContext, eventBatchWriter ->
+            ?.withWriteContext { datadogContext, writeScope ->
                 // TODO RUM-4092 Add the capability in the serializer to handle multiple spans in one payload
-                trace
-                    .filter {
-                        it.samplingPriority() !in DROP_SAMPLING_PRIORITIES
-                    }
-                    .forEach { span ->
-                        @Suppress("ThreadSafety") // called in the worker context
-                        writeSpan(datadogContext, eventBatchWriter, span)
-                    }
+                writeScope {
+                    trace
+                        .filter {
+                            it.samplingPriority() !in DROP_SAMPLING_PRIORITIES
+                        }
+                        .forEach { span ->
+                            @Suppress("ThreadSafety") // called in the worker context
+                            writeSpan(datadogContext, it, span)
+                        }
+                }
             }
     }
 

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/data/TraceWriter.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/data/TraceWriter.kt
@@ -39,14 +39,16 @@ internal class TraceWriter(
     override fun write(trace: List<DDSpan>?) {
         if (trace == null) return
         sdkCore.getFeature(Feature.TRACING_FEATURE_NAME)
-            ?.withWriteContext { datadogContext, eventBatchWriter ->
-                trace
-                    .filter {
-                        it.samplingPriority == null || it.samplingPriority !in DROP_SAMPLING_PRIORITIES
-                    }
-                    .forEach { span ->
-                        writeSpan(datadogContext, eventBatchWriter, span)
-                    }
+            ?.withWriteContext { datadogContext, writeScope ->
+                writeScope {
+                    trace
+                        .filter {
+                            it.samplingPriority == null || it.samplingPriority !in DROP_SAMPLING_PRIORITIES
+                        }
+                        .forEach { span ->
+                            writeSpan(datadogContext, it, span)
+                        }
+                }
             }
     }
 

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/OtelTraceWriterTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/OtelTraceWriterTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.trace.internal.data
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
@@ -76,6 +77,9 @@ internal class OtelTraceWriterTest {
     @Mock
     lateinit var mockEventBatchWriter: EventBatchWriter
 
+    @Mock
+    lateinit var mockEventWriteScope: EventWriteScope
+
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
@@ -87,9 +91,13 @@ internal class OtelTraceWriterTest {
             mockSdkCore.getFeature(Feature.TRACING_FEATURE_NAME)
         ) doReturn mockTracingFeatureScope
 
+        whenever(mockEventWriteScope.invoke(any())) doAnswer {
+            val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
+            callback.invoke(mockEventBatchWriter)
+        }
         whenever(mockTracingFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventBatchWriter)
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+            callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
 
         whenever(mockEventMapper.map(any())) doAnswer { it.getArgument(0) }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/TraceWriterTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/TraceWriterTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.trace.internal.data
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
@@ -77,6 +78,9 @@ internal class TraceWriterTest {
     @Mock
     lateinit var mockEventBatchWriter: EventBatchWriter
 
+    @Mock
+    lateinit var mockEventWriteScope: EventWriteScope
+
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
@@ -88,9 +92,13 @@ internal class TraceWriterTest {
             mockSdkCore.getFeature(Feature.TRACING_FEATURE_NAME)
         ) doReturn mockTracingFeatureScope
 
+        whenever(mockEventWriteScope.invoke(any())) doAnswer {
+            val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
+            callback.invoke(mockEventBatchWriter)
+        }
         whenever(mockTracingFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventBatchWriter)
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+            callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
 
         whenever(mockEventMapper.map(any())) doAnswer { it.getArgument(0) }

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumer.kt
@@ -26,16 +26,18 @@ internal class WebViewLogEventConsumer(
     sampleRate: Float
 ) : WebViewEventConsumer<Pair<JsonObject, String>> {
 
-    val sampler: Sampler<Unit> = RateBasedSampler(sampleRate)
+    private val sampler: Sampler<Unit> = RateBasedSampler(sampleRate)
 
     override fun consume(event: Pair<JsonObject, String>) {
         if (event.second == USER_LOG_EVENT_TYPE) {
             if (sampler.sample(Unit)) {
                 sdkCore.getFeature(WebViewLogsFeature.WEB_LOGS_FEATURE_NAME)
-                    ?.withWriteContext { datadogContext, eventBatchWriter ->
+                    ?.withWriteContext { datadogContext, writeScope ->
                         val rumContext = rumContextProvider.getRumContext(datadogContext)
-                        val mappedEvent = map(event.first, datadogContext, rumContext)
-                        userLogsWriter.write(eventBatchWriter, mappedEvent, EventType.DEFAULT)
+                        writeScope {
+                            val mappedEvent = map(event.first, datadogContext, rumContext)
+                            userLogsWriter.write(it, mappedEvent, EventType.DEFAULT)
+                        }
                     }
             }
         }

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventConsumer.kt
@@ -29,7 +29,7 @@ internal class WebViewReplayEventConsumer(
 
     override fun consume(event: JsonObject) {
         sdkCore.getFeature(WebViewReplayFeature.WEB_REPLAY_FEATURE_NAME)
-            ?.withWriteContext { datadogContext, eventBatchWriter ->
+            ?.withWriteContext { datadogContext, writeScope ->
                 val rumContext = contextProvider.getRumContext(datadogContext)
                 val sessionReplayFeatureContext = datadogContext.featuresContext[
                     Feature.SESSION_REPLAY_FEATURE_NAME
@@ -41,8 +41,10 @@ internal class WebViewReplayEventConsumer(
                     rumContext.sessionState == "TRACKED" &&
                     sessionReplayEnabled
                 ) {
-                    map(event, datadogContext, rumContext)?.let { mappedEvent ->
-                        dataWriter.write(eventBatchWriter, mappedEvent, EventType.DEFAULT)
+                    writeScope {
+                        map(event, datadogContext, rumContext)?.let { mappedEvent ->
+                            dataWriter.write(it, mappedEvent, EventType.DEFAULT)
+                        }
                     }
                 }
             }

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
@@ -37,7 +37,7 @@ internal class WebViewRumEventConsumer(
             )
         )
         sdkCore.getFeature(WebViewRumFeature.WEB_RUM_FEATURE_NAME)
-            ?.withWriteContext { datadogContext, eventBatchWriter ->
+            ?.withWriteContext { datadogContext, writeScope ->
                 val rumContext = contextProvider.getRumContext(datadogContext)
                 if (rumContext != null && rumContext.sessionState == "TRACKED") {
                     val sessionReplayFeatureContext = datadogContext.featuresContext[
@@ -46,8 +46,10 @@ internal class WebViewRumEventConsumer(
                     val sessionReplayEnabled = sessionReplayFeatureContext?.get(
                         WebViewReplayEventConsumer.SESSION_REPLAY_ENABLED_KEY
                     ) as? Boolean ?: false
-                    val mappedEvent = map(event, datadogContext, rumContext, sessionReplayEnabled)
-                    dataWriter.write(eventBatchWriter, mappedEvent, EventType.DEFAULT)
+                    writeScope {
+                        val mappedEvent = map(event, datadogContext, rumContext, sessionReplayEnabled)
+                        dataWriter.write(it, mappedEvent, EventType.DEFAULT)
+                    }
                 }
             }
     }

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumerTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumerTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.webview.internal.log
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.DataWriter
@@ -76,6 +77,9 @@ internal class WebViewLogEventConsumerTest {
     @Mock
     lateinit var mockEventBatchWriter: EventBatchWriter
 
+    @Mock
+    lateinit var mockEventWriteScope: EventWriteScope
+
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
@@ -100,9 +104,13 @@ internal class WebViewLogEventConsumerTest {
         ) doReturn mockWebViewLogsFeatureScope
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
 
+        whenever(mockEventWriteScope.invoke(any())) doAnswer {
+            val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
+            callback.invoke(mockEventBatchWriter)
+        }
         whenever(mockWebViewLogsFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventBatchWriter)
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+            callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
 
         testedConsumer = WebViewLogEventConsumer(

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventConsumerTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventConsumerTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.webview.internal.replay
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
@@ -88,6 +89,9 @@ internal class WebViewReplayEventConsumerTest {
     @Mock
     lateinit var mockEventBatchWriter: EventBatchWriter
 
+    @Mock
+    lateinit var mockEventWriteScope: EventWriteScope
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         fakeSessionReplayFeatureContext = forge.aMap {
@@ -113,9 +117,13 @@ internal class WebViewReplayEventConsumerTest {
         whenever(
             mockSdkCore.getFeature(WebViewReplayFeature.WEB_REPLAY_FEATURE_NAME)
         ) doReturn mockSessionReplayFeatureScope
+        whenever(mockEventWriteScope.invoke(any())) doAnswer {
+            val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
+            callback.invoke(mockEventBatchWriter)
+        }
         whenever(mockSessionReplayFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventBatchWriter)
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+            callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
 

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumerTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumerTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.webview.internal.rum
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
@@ -100,14 +101,17 @@ internal class WebViewRumEventConsumerTest {
     @Mock
     lateinit var mockEventBatchWriter: EventBatchWriter
 
+    @Mock
+    lateinit var mockEventWriteScope: EventWriteScope
+
+    @Mock
+    lateinit var mockOffsetProvider: TimestampOffsetProvider
+
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
     @Forgery
     lateinit var fakeRumContext: RumContext
-
-    @Mock
-    lateinit var mockOffsetProvider: TimestampOffsetProvider
 
     @BoolForgery
     var fakeSessionReplayEnabled = false
@@ -143,9 +147,13 @@ internal class WebViewRumEventConsumerTest {
             mockSdkCore.getFeature(WebViewRumFeature.WEB_RUM_FEATURE_NAME)
         ) doReturn mockWebViewRumFeatureScope
 
+        whenever(mockEventWriteScope.invoke(any())) doAnswer {
+            val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
+            callback.invoke(mockEventBatchWriter)
+        }
         whenever(mockWebViewRumFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventBatchWriter)
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+            callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(

--- a/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/FeatureScopeTest.kt
+++ b/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/FeatureScopeTest.kt
@@ -101,13 +101,15 @@ class FeatureScopeTest : MockServerTest() {
 
         // When
         checkNotNull(featureScope)
-        featureScope.withWriteContext { _, eventBatchWriter ->
+        featureScope.withWriteContext { _, writeScope ->
             fakeBatchData.forEach { rawBatchEvent ->
-                eventBatchWriter.write(
-                    rawBatchEvent,
-                    fakeBatchMetadata,
-                    eventType
-                )
+                writeScope {
+                    it.write(
+                        rawBatchEvent,
+                        fakeBatchMetadata,
+                        eventType
+                    )
+                }
             }
         }
 
@@ -133,13 +135,15 @@ class FeatureScopeTest : MockServerTest() {
         testedInternalSdkCore.registerFeature(stubFeature)
         val featureScope = testedInternalSdkCore.getFeature(fakeFeatureName)
         checkNotNull(featureScope)
-        featureScope.withWriteContext { _, eventBatchWriter ->
+        featureScope.withWriteContext { _, writeScope ->
             fakeBatchData.forEach { rawBatchEvent ->
-                eventBatchWriter.write(
-                    rawBatchEvent,
-                    fakeBatchMetadata,
-                    eventType
-                )
+                writeScope {
+                    it.write(
+                        rawBatchEvent,
+                        fakeBatchMetadata,
+                        eventType
+                    )
+                }
             }
         }
 
@@ -170,13 +174,15 @@ class FeatureScopeTest : MockServerTest() {
 
         // When
         checkNotNull(featureScope)
-        featureScope.withWriteContext { _, eventBatchWriter ->
+        featureScope.withWriteContext { _, writeScope ->
             fakeBatchData.forEach { rawBatchEvent ->
-                eventBatchWriter.write(
-                    rawBatchEvent,
-                    null,
-                    eventType
-                )
+                writeScope {
+                    it.write(
+                        rawBatchEvent,
+                        null,
+                        eventType
+                    )
+                }
             }
         }
 
@@ -208,13 +214,15 @@ class FeatureScopeTest : MockServerTest() {
 
         // When
         checkNotNull(featureScope)
-        featureScope.withWriteContext { _, eventBatchWriter ->
+        featureScope.withWriteContext { _, writeScope ->
             fakeBatchData.forEach { rawBatchEvent ->
-                eventBatchWriter.write(
-                    rawBatchEvent,
-                    fakeBatchMetadata,
-                    eventType
-                )
+                writeScope {
+                    it.write(
+                        rawBatchEvent,
+                        fakeBatchMetadata,
+                        eventType
+                    )
+                }
             }
         }
 
@@ -244,13 +252,15 @@ class FeatureScopeTest : MockServerTest() {
 
         // When
         checkNotNull(featureScope)
-        featureScope.withWriteContext { _, eventBatchWriter ->
+        featureScope.withWriteContext { _, writeScope ->
             fakeBatchData.forEach { rawBatchEvent ->
-                eventBatchWriter.write(
-                    rawBatchEvent,
-                    fakeBatchMetadata,
-                    eventType
-                )
+                writeScope {
+                    it.write(
+                        rawBatchEvent,
+                        fakeBatchMetadata,
+                        eventType
+                    )
+                }
             }
         }
 
@@ -274,13 +284,15 @@ class FeatureScopeTest : MockServerTest() {
         testedInternalSdkCore.registerFeature(stubFeature)
         val featureScope = testedInternalSdkCore.getFeature(fakeFeatureName)
         checkNotNull(featureScope)
-        featureScope.withWriteContext { _, eventBatchWriter ->
+        featureScope.withWriteContext { _, writeScope ->
             fakeBatchData.forEach { rawBatchEvent ->
-                eventBatchWriter.write(
-                    rawBatchEvent,
-                    fakeBatchMetadata,
-                    eventType
-                )
+                writeScope {
+                    it.write(
+                        rawBatchEvent,
+                        fakeBatchMetadata,
+                        eventType
+                    )
+                }
             }
         }
 
@@ -311,13 +323,15 @@ class FeatureScopeTest : MockServerTest() {
         testedInternalSdkCore.registerFeature(stubFeature)
         val featureScope = testedInternalSdkCore.getFeature(fakeFeatureName)
         checkNotNull(featureScope)
-        featureScope.withWriteContext { _, eventBatchWriter ->
+        featureScope.withWriteContext { _, writeScope ->
             fakeBatchData.forEach { rawBatchEvent ->
-                eventBatchWriter.write(
-                    rawBatchEvent,
-                    fakeBatchMetadata,
-                    eventType
-                )
+                writeScope {
+                    it.write(
+                        rawBatchEvent,
+                        fakeBatchMetadata,
+                        eventType
+                    )
+                }
             }
         }
 
@@ -352,13 +366,15 @@ class FeatureScopeTest : MockServerTest() {
         Datadog.stopInstance()
 
         // When
-        featureScope.withWriteContext { _, eventBatchWriter ->
+        featureScope.withWriteContext { _, writeScope ->
             fakeBatchData.forEach { rawBatchEvent ->
-                eventBatchWriter.write(
-                    rawBatchEvent,
-                    fakeBatchMetadata,
-                    eventType
-                )
+                writeScope {
+                    it.write(
+                        rawBatchEvent,
+                        fakeBatchMetadata,
+                        eventType
+                    )
+                }
             }
         }
 

--- a/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/PendingToGrantedAsyncTest.kt
+++ b/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/PendingToGrantedAsyncTest.kt
@@ -99,12 +99,14 @@ class PendingToGrantedAsyncTest(
         }.start()
         Thread {
             fakeBatchData.forEach { rawBatchEvent ->
-                featureScope.withWriteContext { _, eventBatchWriter ->
-                    eventBatchWriter.write(
-                        rawBatchEvent,
-                        fakeBatchMetadata,
-                        eventType
-                    )
+                featureScope.withWriteContext { _, writeScope ->
+                    writeScope {
+                        it.write(
+                            rawBatchEvent,
+                            fakeBatchMetadata,
+                            eventType
+                        )
+                    }
                 }
             }
             countDownLatch.countDown()

--- a/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/PendingToGrantedCustomPersistenceAsyncTest.kt
+++ b/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/PendingToGrantedCustomPersistenceAsyncTest.kt
@@ -109,12 +109,14 @@ class PendingToGrantedCustomPersistenceAsyncTest(
         }.start()
         Thread {
             fakeBatchData.forEach { rawBatchEvent ->
-                featureScope.withWriteContext { _, eventBatchWriter ->
-                    eventBatchWriter.write(
-                        rawBatchEvent,
-                        fakeBatchMetadata,
-                        eventType
-                    )
+                featureScope.withWriteContext { _, writeScope ->
+                    writeScope {
+                        it.write(
+                            rawBatchEvent,
+                            fakeBatchMetadata,
+                            eventType
+                        )
+                    }
                 }
             }
             countDownLatch.countDown()

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubFeatureScope.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubFeatureScope.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.core.stub
 
 import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.EventBatchWriter
@@ -57,9 +58,16 @@ internal class StubFeatureScope(
     // region FeatureScope
 
     override fun withWriteContext(
-        callback: (DatadogContext, EventBatchWriter) -> Unit
+        callback: (DatadogContext, EventWriteScope) -> Unit
     ) {
-        callback(datadogContextProvider(), eventBatchWriter)
+        callback(
+            datadogContextProvider(),
+            { it.invoke(eventBatchWriter) }
+        )
+    }
+
+    override fun getWriteContextSync(): Pair<DatadogContext, EventWriteScope>? {
+        return datadogContextProvider() to { it.invoke(eventBatchWriter) }
     }
 
     override fun sendEvent(event: Any) {

--- a/tools/noopfactory/src/test/resources/gen/NoOpSimpleInterface.kt
+++ b/tools/noopfactory/src/test/resources/gen/NoOpSimpleInterface.kt
@@ -4,9 +4,11 @@ package com.example
 
 import java.util.Date
 import kotlin.ByteArray
+import kotlin.Function0
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
+import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
 import kotlin.collections.Set
@@ -57,4 +59,8 @@ internal class NoOpSimpleInterface : SimpleInterface {
     override fun doSomethingWithMapReturn(): Map<String, String> = emptyMap()
 
     override fun doSomethingWithSetReturn(): Set<String> = emptySet()
+
+    override fun functionalReturnType(): Function0<Unit> = {}
+
+    override fun functionalAliasReturnType(): FunctionalReturn = {}
 }

--- a/tools/noopfactory/src/test/resources/src/SimpleInterface.kt
+++ b/tools/noopfactory/src/test/resources/src/SimpleInterface.kt
@@ -44,4 +44,10 @@ interface SimpleInterface {
     val mapProperty: Map<String, String>
 
     var setProperty: Set<String>
+
+    fun functionalReturnType(): () -> Unit
+
+    fun functionalAliasReturnType(): FunctionalReturn
 }
+
+typealias FunctionalReturn = (String) -> Unit


### PR DESCRIPTION
### What does this PR do?

This PR adds a dedicated context event processing thread which will be used when `FeatureScope.withWriteContext` is called.

Before this change when `FeatureScope.withWriteContext` was called, the content of the block was executed on the thread from I/O pool and block arguments were `DatadogContext` and `EventBatchWriter`.

After this change the block arguments are `DatadogContext` and `EventWriteScope`, where `EventWriteScope` is block-accepting lambda where argument is `EventWriteScope`. This allows now have 2 pipelines inside `withWriteContext` call:

* the content of the block passed to the `withWriteContext` will be executed on the single context processing thread shared between all the features.
* the context of the block passed to the `EventWriteScope` will be executed on the thread from I/O pool.

To illustrate it better:

```
// before
withWriteContext { datadogContext, eventBatchWriter ->
  // all on the I/O thread
  // ...
  // there is no switch to the I/O thread inside the write call, because we are already on the I/O thread
  eventBatchWriter.write(...)
}

// after
withWriteContext { datadogContext, writeScope ->
  // on the context processing thread
  // ...
  writeScope { eventBatchWriter ->
    // on the I/O thread
    eventBatchWriter.write(...)
  }
}
```

This will allow to introduce the wait mechanism for the feature context synchronization without imposing such wait on the client thread.

Also this PR moves `withWriteContext` call up to the root scope in the RUM processing, so that we can have context earlier.

The diff looks big, but its majority is in the tests where the main volume of changes comes from formatting and renaming.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

