### PR TITLE
Update `unMock` plugin version, remove `me.xdrop:fuzzywuzzy` dependency, remove deprecated Gradle APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ config/*
 # .log
 *.log
 
+# Kotlin
+.kotlin/
+
 gh_token
 sdk_classpath
 detekt_classpath

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,7 @@ nexusPublishing {
 }
 
 task<Delete>("clean") {
-    delete(rootProject.buildDir)
+    delete(rootProject.layout.buildDirectory)
 }
 
 tasks.register("checkAll") {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
     implementation(libs.kotlinGradlePlugin)
     implementation(libs.androidToolsGradlePlugin)
     implementation(libs.versionsGradlePlugin)
-    implementation(libs.fuzzyWuzzy)
     implementation(libs.dokkaGradlePlugin)
     implementation(libs.dependencyLicenseGradlePlugin)
     implementation(libs.kover)

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/transdeps/GenerateTransitiveDependenciesTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/transdeps/GenerateTransitiveDependenciesTask.kt
@@ -8,7 +8,7 @@ package com.datadog.gradle.plugin.transdeps
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -47,10 +47,12 @@ open class GenerateTransitiveDependenciesTask : DefaultTask() {
         check(configuration.isCanBeResolved) { "$configuration cannot be resolved" }
 
         val sortedArtifacts = if (sortByName) {
-            configuration.files {
-                // ProjectDependency (i.e. local modules) don't have a file associated
-                it !is ProjectDependency
-            }.sortedBy { it.absolutePath }
+            configuration.incoming
+                .artifactView {
+                    componentFilter { it !is ProjectComponentIdentifier }
+                }
+                .files
+                .sortedBy { it.absolutePath }
         } else {
             configuration.sortedBy { -it.length() }
         }

--- a/features/dd-sdk-android-trace-otel/transitiveDependencies
+++ b/features/dd-sdk-android-trace-otel/transitiveDependencies
@@ -3,8 +3,11 @@ Dependencies List
 androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
 io.opentelemetry:opentelemetry-api:1.4.0                        :   78 Kb
 io.opentelemetry:opentelemetry-context:1.4.0                    :   42 Kb
+io.opentracing:opentracing-api:0.32.0                           :   18 Kb
+io.opentracing:opentracing-noop:0.32.0                          :   10 Kb
+io.opentracing:opentracing-util:0.32.0                          :   10 Kb
 org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              : 1876 Kb
+Total transitive dependencies size                              : 1915 Kb
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,8 +63,6 @@ unmock = "0.9.0"
 robolectric = "4.4_r1-robolectric-r2"
 androidLint = "31.0.2"
 
-fuzzyWuzzy = "1.2.0"
-
 versionsGradlePlugin = "0.46.0"
 nexusPublishGradlePlugin = "1.1.0"
 datadogPlugin = "1.17.0-rc1"
@@ -210,8 +208,6 @@ okHttpMock = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okH
 robolectric = { module = "org.robolectric:android-all", version.ref = "robolectric" }
 androidLintApi = { module = "com.android.tools.lint:lint-api", version.ref = "androidLint" }
 androidLintChecks = { module = "com.android.tools.lint:lint-checks", version.ref = "androidLint" }
-
-fuzzyWuzzy = { module = "me.xdrop:fuzzywuzzy", version.ref = "fuzzyWuzzy" }
 
 kotlinPoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinPoet" }
 kotlinPoetKsp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinPoet" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,7 @@ kspTesting = "1.5.0"
 # Tools
 detekt = "1.23.0"
 dokka = "1.8.20"
-unmock = "0.7.9"
+unmock = "0.9.0"
 robolectric = "4.4_r1-robolectric-r2"
 androidLint = "31.0.2"
 

--- a/integrations/dd-sdk-android-glide/transitiveDependencies
+++ b/integrations/dd-sdk-android-glide/transitiveDependencies
@@ -42,6 +42,7 @@ com.github.bumptech.glide:glide:4.11.0                          :  614 Kb
 com.github.bumptech.glide:okhttp3-integration:4.11.0            :    8 Kb
 com.squareup.okhttp3:okhttp:4.12.0                              :  771 Kb
 com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
+io.opentracing:opentracing-api:0.32.0                           :   18 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
 org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
@@ -49,5 +50,5 @@ org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4          :   19 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4         : 1442 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              :    7 Mb
+Total transitive dependencies size                              :    8 Mb
 

--- a/integrations/dd-sdk-android-okhttp-otel/transitiveDependencies
+++ b/integrations/dd-sdk-android-okhttp-otel/transitiveDependencies
@@ -2,6 +2,11 @@ Dependencies List
 
 com.squareup.okhttp3:okhttp:4.12.0                              :  771 Kb
 com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
+io.opentelemetry:opentelemetry-api:1.4.0                        :   78 Kb
+io.opentelemetry:opentelemetry-context:1.4.0                    :   42 Kb
+io.opentracing:opentracing-api:0.32.0                           :   18 Kb
+io.opentracing:opentracing-noop:0.32.0                          :   10 Kb
+io.opentracing:opentracing-util:0.32.0                          :   10 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
 org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb

--- a/integrations/dd-sdk-android-okhttp/transitiveDependencies
+++ b/integrations/dd-sdk-android-okhttp/transitiveDependencies
@@ -4,6 +4,8 @@ androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
 com.squareup.okhttp3:okhttp:4.12.0                              :  771 Kb
 com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
 io.opentracing:opentracing-api:0.32.0                           :   18 Kb
+io.opentracing:opentracing-noop:0.32.0                          :   10 Kb
+io.opentracing:opentracing-util:0.32.0                          :   10 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
 org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb

--- a/integrations/dd-sdk-android-sqldelight/transitiveDependencies
+++ b/integrations/dd-sdk-android-sqldelight/transitiveDependencies
@@ -6,6 +6,9 @@ com.squareup.okhttp3:okhttp:4.12.0                              :  771 Kb
 com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
 com.squareup.sqldelight:android-driver:1.5.5                    :   23 Kb
 com.squareup.sqldelight:runtime-jvm:1.5.5                       :   44 Kb
+io.opentracing:opentracing-api:0.32.0                           :   18 Kb
+io.opentracing:opentracing-noop:0.32.0                          :   10 Kb
+io.opentracing:opentracing-util:0.32.0                          :   10 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
 org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb

--- a/integrations/dd-sdk-android-trace-coroutines/transitiveDependencies
+++ b/integrations/dd-sdk-android-trace-coroutines/transitiveDependencies
@@ -1,5 +1,8 @@
 Dependencies List
 
+io.opentracing:opentracing-api:0.32.0                           :   18 Kb
+io.opentracing:opentracing-noop:0.32.0                          :   10 Kb
+io.opentracing:opentracing-util:0.32.0                          :   10 Kb
 org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.4.2         : 1635 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb

--- a/sample/vendor-lib/build.gradle.kts
+++ b/sample/vendor-lib/build.gradle.kts
@@ -26,7 +26,6 @@ android {
 
     defaultConfig {
         minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
         multiDexEnabled = true
 
         buildFeatures {

--- a/tools/unit/build.gradle.kts
+++ b/tools/unit/build.gradle.kts
@@ -25,7 +25,6 @@ android {
 
     defaultConfig {
         minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
     }
 
     namespace = "com.datadog.tools.unit"


### PR DESCRIPTION
### What does this PR do?

This PR does the following:

* Updates `unMock` plugin version mainly to benefit from the following change https://github.com/bjoernQ/unmock-plugin/pull/83
* Removes unused `me.xdrop:fuzzywuzzy` dependency
* Removes deprecated Gradle APIs to be better compatible with Gradle 9.0
  * `Configuration.files` -> `Configuration.incoming.artifactView` brings a visibility on the lib dependencies used in the project dependencies.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

