### PR TITLE
RUM-9894: Replace addFirst usage in PendingTrace

### DIFF
--- a/features/dd-sdk-android-trace/src/main/java/com/datadog/opentracing/PendingTrace.java
+++ b/features/dd-sdk-android-trace/src/main/java/com/datadog/opentracing/PendingTrace.java
@@ -11,15 +11,22 @@ import androidx.annotation.VisibleForTesting;
 import com.datadog.android.api.InternalLogger;
 import com.datadog.exec.CommonTaskExecutor;
 import com.datadog.exec.CommonTaskExecutor.Task;
-import com.datadog.opentracing.scopemanager.ContinuableScope;
 import com.datadog.legacy.trace.common.util.Clock;
+import com.datadog.opentracing.scopemanager.ContinuableScope;
 
 import java.io.Closeable;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.math.BigInteger;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -355,7 +362,7 @@ public class PendingTrace extends LinkedList<DDSpan> {
     @Override
     public void addFirst(final DDSpan span) {
         synchronized (this) {
-            super.addFirst(span);
+            super.add(0, span);
         }
         completedSpanCount.incrementAndGet();
     }


### PR DESCRIPTION
### What does this PR do?

Replace addFirst usage in PendingTrace, since it can have clash with Android API 35.

### Motivation

RUM-9894


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

