### PR TITLE
RUM-9894: Replace `addFirst` usage in PendingTrace

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,8 +4,8 @@ include:
 # SETUP
 
 variables:
-  CURRENT_CI_IMAGE: "13"
-  CI_IMAGE_DOCKER: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/dd-sdk-android:$CURRENT_CI_IMAGE
+  CURRENT_CI_IMAGE: "16"
+  CI_IMAGE_DOCKER: registry.ddbuild.io/ci/dd-sdk-android:$CURRENT_CI_IMAGE
   GIT_DEPTH: 5
 
   DD_SERVICE: "dd-sdk-android"

--- a/features/dd-sdk-android-trace/src/main/java/com/datadog/opentracing/PendingTrace.java
+++ b/features/dd-sdk-android-trace/src/main/java/com/datadog/opentracing/PendingTrace.java
@@ -237,7 +237,7 @@ public class PendingTrace extends LinkedList<DDSpan> {
   @Override
   public void addFirst(final DDSpan span) {
     synchronized (this) {
-      super.addFirst(span);
+      super.add(0, span);
     }
     completedSpanCount.incrementAndGet();
   }


### PR DESCRIPTION
### What does this PR do?

Replace addFirst usage in PendingTrace, since it can have clash with Android API 35.

It contains some additional pipeline fix to pass CI

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

