### PR TITLE
Speed up some tests in `FeatureScopeTest` by reducing unconditional wait time

### DIFF
--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -24,7 +24,6 @@ internal class Configurator :
         forge.addFactory(CustomAttributesForgeryFactory())
         forge.addFactory(ConfigurationForgeryFactory())
         forge.addFactory(ConfigurationCoreForgeryFactory())
-        forge.addFactory(ConfigurationForgeryFactory())
         forge.addFactory(FilePersistenceConfigForgeryFactory())
         forge.addFactory(AndroidInfoProviderForgeryFactory())
         forge.addFactory(FeatureStorageConfigurationForgeryFactory())

--- a/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/BaseTest.kt
+++ b/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/BaseTest.kt
@@ -14,6 +14,10 @@ abstract class BaseTest {
     companion object {
         internal val LONG_WAIT_MS = TimeUnit.SECONDS.toMillis(60)
         internal val MEDIUM_WAIT_MS = TimeUnit.SECONDS.toMillis(30)
+
+        // TODO RUM-9917 Avoid using unconditional wait locks
+        // to align with UploadFrequency max value + 1s for async execution
+        internal val UPLOAD_CYCLE_MAX_WAIT_MS = TimeUnit.SECONDS.toMillis(6)
         internal const val SHORT_WAIT_MS = 500L
     }
 }

--- a/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/FeatureScopeTest.kt
+++ b/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/FeatureScopeTest.kt
@@ -31,6 +31,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * Instrumentation tests for the feature scope.
@@ -205,6 +207,7 @@ class FeatureScopeTest : MockServerTest() {
         ) as InternalSdkCore
         testedInternalSdkCore.registerFeature(stubFeature)
         val featureScope = testedInternalSdkCore.getFeature(fakeFeatureName)
+        val countDownLatch = CountDownLatch(fakeBatchData.size)
 
         // When
         checkNotNull(featureScope)
@@ -215,11 +218,14 @@ class FeatureScopeTest : MockServerTest() {
                     fakeBatchMetadata,
                     eventType
                 )
+                countDownLatch.countDown()
             }
         }
 
         // Then
-        Thread.sleep(MEDIUM_WAIT_MS)
+        countDownLatch.await(MEDIUM_WAIT_MS, TimeUnit.MILLISECONDS)
+        // TODO RUM-9917 Avoid using unconditional wait locks
+        Thread.sleep(UPLOAD_CYCLE_MAX_WAIT_MS)
         MockWebServerAssert.assertThat(getMockServerWrapper())
             .withConfiguration(fakeConfiguration)
             .withTrackingConsent(trackingConsent)
@@ -241,6 +247,7 @@ class FeatureScopeTest : MockServerTest() {
         ) as InternalSdkCore
         testedInternalSdkCore.registerFeature(stubFeature)
         val featureScope = testedInternalSdkCore.getFeature(fakeFeatureName)
+        val countDownLatch = CountDownLatch(fakeBatchData.size)
 
         // When
         checkNotNull(featureScope)
@@ -251,11 +258,14 @@ class FeatureScopeTest : MockServerTest() {
                     fakeBatchMetadata,
                     eventType
                 )
+                countDownLatch.countDown()
             }
         }
 
         // Then
-        Thread.sleep(MEDIUM_WAIT_MS)
+        countDownLatch.await(MEDIUM_WAIT_MS, TimeUnit.MILLISECONDS)
+        // TODO RUM-9917 Avoid using unconditional wait locks
+        Thread.sleep(UPLOAD_CYCLE_MAX_WAIT_MS)
         MockWebServerAssert.assertThat(getMockServerWrapper())
             .withConfiguration(fakeConfiguration)
             .withTrackingConsent(trackingConsent)
@@ -274,6 +284,7 @@ class FeatureScopeTest : MockServerTest() {
         testedInternalSdkCore.registerFeature(stubFeature)
         val featureScope = testedInternalSdkCore.getFeature(fakeFeatureName)
         checkNotNull(featureScope)
+        val countDownLatch = CountDownLatch(fakeBatchData.size)
         featureScope.withWriteContext { _, eventBatchWriter ->
             fakeBatchData.forEach { rawBatchEvent ->
                 eventBatchWriter.write(
@@ -281,6 +292,7 @@ class FeatureScopeTest : MockServerTest() {
                     fakeBatchMetadata,
                     eventType
                 )
+                countDownLatch.countDown()
             }
         }
 
@@ -288,7 +300,13 @@ class FeatureScopeTest : MockServerTest() {
         Datadog.setTrackingConsent(TrackingConsent.NOT_GRANTED)
 
         // Then
-        Thread.sleep(MEDIUM_WAIT_MS)
+        countDownLatch.await(MEDIUM_WAIT_MS, TimeUnit.MILLISECONDS)
+        with(testedInternalSdkCore.getPersistenceExecutorService()) {
+            shutdown()
+            awaitTermination(MEDIUM_WAIT_MS, TimeUnit.MILLISECONDS)
+        }
+        // TODO RUM-9917 Avoid using unconditional wait locks
+        Thread.sleep(UPLOAD_CYCLE_MAX_WAIT_MS)
         MockWebServerAssert.assertThat(getMockServerWrapper())
             .withConfiguration(fakeConfiguration)
             .withTrackingConsent(trackingConsent)
@@ -311,6 +329,7 @@ class FeatureScopeTest : MockServerTest() {
         testedInternalSdkCore.registerFeature(stubFeature)
         val featureScope = testedInternalSdkCore.getFeature(fakeFeatureName)
         checkNotNull(featureScope)
+        val countDownLatch = CountDownLatch(fakeBatchData.size)
         featureScope.withWriteContext { _, eventBatchWriter ->
             fakeBatchData.forEach { rawBatchEvent ->
                 eventBatchWriter.write(
@@ -318,6 +337,7 @@ class FeatureScopeTest : MockServerTest() {
                     fakeBatchMetadata,
                     eventType
                 )
+                countDownLatch.countDown()
             }
         }
 
@@ -326,7 +346,13 @@ class FeatureScopeTest : MockServerTest() {
         Datadog.setTrackingConsent(TrackingConsent.GRANTED)
 
         // Then
-        Thread.sleep(MEDIUM_WAIT_MS)
+        countDownLatch.await(MEDIUM_WAIT_MS, TimeUnit.MILLISECONDS)
+        with(testedInternalSdkCore.getPersistenceExecutorService()) {
+            shutdown()
+            awaitTermination(MEDIUM_WAIT_MS, TimeUnit.MILLISECONDS)
+        }
+        // TODO RUM-9917 Avoid using unconditional wait locks
+        Thread.sleep(UPLOAD_CYCLE_MAX_WAIT_MS)
         MockWebServerAssert.assertThat(getMockServerWrapper())
             .withConfiguration(fakeConfiguration)
             .withTrackingConsent(trackingConsent)
@@ -350,6 +376,7 @@ class FeatureScopeTest : MockServerTest() {
         val featureScope = testedInternalSdkCore.getFeature(fakeFeatureName)
         checkNotNull(featureScope)
         Datadog.stopInstance()
+        val countDownLatch = CountDownLatch(fakeBatchData.size)
 
         // When
         featureScope.withWriteContext { _, eventBatchWriter ->
@@ -359,11 +386,14 @@ class FeatureScopeTest : MockServerTest() {
                     fakeBatchMetadata,
                     eventType
                 )
+                countDownLatch.countDown()
             }
         }
 
         // Then
-        Thread.sleep(MEDIUM_WAIT_MS)
+        countDownLatch.await(MEDIUM_WAIT_MS, TimeUnit.MILLISECONDS)
+        // TODO RUM-9917 Avoid using unconditional wait locks
+        Thread.sleep(UPLOAD_CYCLE_MAX_WAIT_MS)
         MockWebServerAssert.assertThat(getMockServerWrapper())
             .withConfiguration(fakeConfiguration)
             .withTrackingConsent(trackingConsent)


### PR DESCRIPTION
### What does this PR do?

Some instrumented tests in the `FeatureScopeTest` are using unconditional `Thread.sleep` with a wait time of 30 seconds.

This PR brings some improvement in the execution time by introducing more precise waiting (but not eliminating it completely): now we will wait for the all write operations to complete before jumping to the assertion section and the only unconditional wait to use is the wait for the next upload cycle.

This is just a **quick improvement**, there is a TODO item to make it even better in the future.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

