### PR TITLE
RUM-9053: Support Coil3 for Session Replay image recording

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/consumer-rules.pro
+++ b/features/dd-sdk-android-session-replay-compose/consumer-rules.pro
@@ -32,6 +32,19 @@
 -keep class androidx.compose.ui.node.LayoutNode {
      *;
 }
+-keep class androidx.compose.ui.node.NodeChain {
+    <fields>;
+}
+-keep class androidx.compose.ui.Modifier$Node{
+    <fields>;
+}
+-keep class coil3.compose.internal.ContentPainterNode{
+    <fields>;
+}
+-keep class coil3.compose.AsyncImagePainter{
+    <methods>;
+}
+
 -keep class androidx.compose.ui.semantics.SemanticsNode {
      <fields>;
 }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
@@ -24,6 +24,11 @@ internal object ComposeReflection {
 
     val LayoutNodeClass = getClassSafe("androidx.compose.ui.node.LayoutNode")
     val GetInteropViewMethod = LayoutNodeClass?.getDeclaredMethodSafe("getInteropView")
+    val NodesFieldOfLayoutNode = LayoutNodeClass?.getDeclaredFieldSafe("nodes")
+    val NodeChainClass = getClassSafe("androidx.compose.ui.node.NodeChain")
+    val HeadFieldOfNodeChain = NodeChainClass?.getDeclaredFieldSafe("head")
+    val ModifierNodeClass = getClassSafe("androidx.compose.ui.Modifier\$Node")
+    val ChildFieldOfModifierNode = ModifierNodeClass?.getDeclaredFieldSafe("child")
 
     val SemanticsNodeClass = getClassSafe("androidx.compose.ui.semantics.SemanticsNode")
     val LayoutNodeField = SemanticsNodeClass?.getDeclaredFieldSafe("layoutNode")
@@ -80,6 +85,8 @@ internal object ComposeReflection {
     val AndroidImageBitmapClass = getClassSafe("androidx.compose.ui.graphics.AndroidImageBitmap")
     val BitmapField = AndroidImageBitmapClass?.getDeclaredFieldSafe("bitmap")
 
+    // Region of Coil
+
     val ContentPainterModifierClass = getClassSafe("coil.compose.ContentPainterModifier")
     val PainterFieldOfContentPainterModifier =
         ContentPainterModifierClass?.getDeclaredFieldSafe("painter")
@@ -96,6 +103,26 @@ internal object ComposeReflection {
         isCritical = false
     )
     val PainterFieldOfAsyncImagePainter = AsyncImagePainterClass?.getDeclaredFieldSafe("_painter")
+
+    // End region of Coil
+
+    // Region of Coil3
+
+    val PainterNodeClass = getClassSafe(
+        "coil3.compose.internal.ContentPainterNode",
+        isCritical = false
+    )
+
+    val PainterFieldOfPainterNode = PainterNodeClass?.getDeclaredFieldSafe("painter")
+
+    val AsyncImagePainter3Class = getClassSafe(
+        "coil3.compose.AsyncImagePainter",
+        isCritical = false
+    )
+    val PainterMethodOfAsync3ImagePainter =
+        AsyncImagePainter3Class?.getDeclaredMethodSafe("getPainter")
+
+    // End region of Coil3
 
     // Region of MultiParagraph text
     val ParagraphInfoListField = MultiParagraph::class.java.getDeclaredFieldSafe(

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
@@ -249,14 +249,20 @@ internal class SemanticsUtils(private val reflectionUtils: ReflectionUtils = Ref
     ): BitmapInfo? {
         var isContextualImage = false
         var painter = reflectionUtils.getLocalImagePainter(semanticsNode)
+
+        // Try to resolve Coil AsyncImagePainter.
         if (painter == null) {
             isContextualImage = true
             painter = reflectionUtils.getAsyncImagePainter(semanticsNode)
         }
-        // TODO RUM-6535: support more painters.
+        // In some versions of Coil, bitmap painter is nested in `AsyncImagePainter`
         if (painter != null && reflectionUtils.isAsyncImagePainter(painter)) {
             isContextualImage = true
             painter = reflectionUtils.getNestedPainter(painter)
+        }
+        // Try to resolve Coil3 painter if is still null.
+        if (painter == null) {
+            painter = reflectionUtils.getCoil3AsyncImagePainter(semanticsNode)
         }
         val bitmap = when (painter) {
             is BitmapPainter -> reflectionUtils.getBitmapInBitmapPainter(painter)


### PR DESCRIPTION
### What does this PR do?

Due to the internal API change of Coil from V2 to V3, we were not able to retrieve the `painter` attribute as before, this PR adds a new way of resolving the `painter` in modifier node chain in Coil3 `AsyncImage` to retrieve the painter for Session Replay image recording.

### Motivation

RUM-9053

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

