### PR TITLE
RUM-9958: Fix datadog core creation in baseline benchmark run

### DIFF
--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/di/activity/DatadogActivityModule.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/di/activity/DatadogActivityModule.kt
@@ -47,8 +47,8 @@ internal interface DatadogActivityModule {
             context: Context,
             config: BenchmarkConfig
         ): SdkCore {
-            check(config.run != SyntheticsRun.Baseline) {
-                "Datadog must not be initialized in baseline run"
+            if (config.run == SyntheticsRun.Baseline) {
+                return Datadog.getInstance() // returns NoOpInternalSdkCore under the hood
             }
 
             return Datadog.initialize(


### PR DESCRIPTION
### What does this PR do?

Unfortunately in my previous [pr](https://github.com/DataDog/dd-sdk-android/pull/2647) I made a mistake. All baseline benchmark runs started crashing (except session replay ones).

For example for LogsCustom scenario we still use `Logger` in baseline run [link](https://github.com/DataDog/dd-sdk-android/blob/develop/sample/benchmark/src/main/java/com/datadog/benchmark/sample/ui/logscustom/LogsScreenViewModel.kt#L77), but it should be the no-op one. When it gets created [here](https://github.com/DataDog/dd-sdk-android/blob/develop/sample/benchmark/src/main/java/com/datadog/benchmark/sample/di/activity/DatadogActivityModule.kt#L83), it requires `sdkCore`, that tries to get created but crashes [here](https://github.com/DataDog/dd-sdk-android/blob/develop/sample/benchmark/src/main/java/com/datadog/benchmark/sample/di/activity/DatadogActivityModule.kt#L50).

Fix is to create a no-op core in baseline run. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

