### PR TITLE
Fix logging format for error messages in PlainBatchFileReaderWriter

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriter.kt
@@ -78,7 +78,7 @@ internal class PlainBatchFileReaderWriter(
             internalLogger.log(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                { "ERROR_READ.format(Locale.US, file.path)" },
+                { ERROR_READ.format(Locale.US, file.path) },
                 e
             )
             emptyList()


### PR DESCRIPTION
This pull request includes a minor change to the `PlainBatchFileReaderWriter` class in the `dd-sdk-android-core` module. The change fixes the logging statement by replacing a string literal with the constant `ERROR_READ` for improved code clarity and maintainability.

* [`dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriter.kt`](diffhunk://#diff-02d75a81081031937e3d1e4215678a4463075ea33fd3d7095d685ec6cecc0da2L81-R81): Replaced the string literal `"ERROR_READ"` with the constant `ERROR_READ` in the logging statement to enhance readability and maintain consistency.### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

