### PR TITLE
RUM-7855 Remove telemetry target from error logging in PlainBatchFileReaderWriter

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriter.kt
@@ -40,7 +40,7 @@ internal class PlainBatchFileReaderWriter(
         } catch (e: IOException) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
-                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                listOf(InternalLogger.Target.MAINTAINER),
                 { ERROR_WRITE.format(Locale.US, file.path) },
                 e
             )

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriterTest.kt
@@ -177,7 +177,7 @@ internal class PlainBatchFileReaderWriterTest {
         assertThat(file).doesNotExist()
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
-            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            listOf(InternalLogger.Target.MAINTAINER),
             PlainBatchFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path),
             FileNotFoundException::class.java
         )
@@ -204,7 +204,7 @@ internal class PlainBatchFileReaderWriterTest {
         assertThat(result).isFalse()
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
-            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            listOf(InternalLogger.Target.MAINTAINER),
             PlainBatchFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path),
             FileNotFoundException::class.java
         )


### PR DESCRIPTION
### What does this PR do?

This pull request makes a minor change to the `PlainBatchFileReaderWriter` class in the `dd-sdk-android-core` module. It removes the `InternalLogger.Target.TELEMETRY` target from the list of logging targets when an `IOException` occurs.

* [`dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriter.kt`](diffhunk://#diff-02d75a81081031937e3d1e4215678a4463075ea33fd3d7095d685ec6cecc0da2L43-R43): Updated the logging configuration to exclude `InternalLogger.Target.TELEMETRY` from the error logging targets.…ReaderWriter
This error is not actionable as it's caused by lack of space on the user device.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

