### PR TITLE
RUM-10040: Perform lazy capture of `DatadogContext` at the span creation

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -109,6 +109,7 @@ interface com.datadog.android.api.feature.FeatureEventReceiver
 interface com.datadog.android.api.feature.FeatureScope
   val dataStore: com.datadog.android.api.storage.datastore.DataStoreHandler
   fun withWriteContext((com.datadog.android.api.context.DatadogContext) -> Unit)
+  fun withContext((com.datadog.android.api.context.DatadogContext) -> Unit)
   fun getWriteContextSync(): Pair<com.datadog.android.api.context.DatadogContext, EventWriteScope>?
   fun sendEvent(Any)
   fun <T: Feature> unwrap(): T

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -345,6 +345,7 @@ public abstract interface class com/datadog/android/api/feature/FeatureScope {
 	public abstract fun getWriteContextSync ()Lkotlin/Pair;
 	public abstract fun sendEvent (Ljava/lang/Object;)V
 	public abstract fun unwrap ()Lcom/datadog/android/api/feature/Feature;
+	public abstract fun withContext (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun withWriteContext (Lkotlin/jvm/functions/Function2;)V
 }
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureScope.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureScope.kt
@@ -25,12 +25,23 @@ interface FeatureScope {
     /**
      * Utility to write an event, asynchronously.
      * @param callback an operation called with an up-to-date [DatadogContext]
-     * and an [EventWriteScope]. Callback will be executed on a single context processing worker thread.
+     * and an [EventWriteScope]. Callback will be executed on a single context processing worker thread. Execution of
+     * [EventWriteScope] will be done on a worker thread from I/O pool.
      * [DatadogContext] will have a state created at the moment this method is called.
      */
     @AnyThread
     fun withWriteContext(
         callback: (datadogContext: DatadogContext, write: EventWriteScope) -> Unit
+    )
+
+    /**
+     * Utility to read current [DatadogContext], asynchronously.
+     * @param callback an operation called with an up-to-date [DatadogContext].
+     * [DatadogContext] will have a state created at the moment this method is called.
+     */
+    @AnyThread
+    fun withContext(
+        callback: (datadogContext: DatadogContext) -> Unit
     )
 
     // TODO RUM-9852 Implement better passthrough mechanism for the JVM crash scenario

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -185,6 +185,16 @@ internal class SdkFeature(
             }
     }
 
+    override fun withContext(callback: (datadogContext: DatadogContext) -> Unit) {
+        coreFeature.contextExecutorService
+            .executeSafe("withContext-${wrappedFeature.name}", internalLogger) {
+                val contextProvider = coreFeature.contextProvider
+                if (contextProvider is NoOpContextProvider) return@executeSafe
+                val context = contextProvider.context
+                callback(context)
+            }
+    }
+
     override fun getWriteContextSync(): Pair<DatadogContext, EventWriteScope>? {
         val operationName = "getWriteContextSync-${wrappedFeature.name}"
         return coreFeature.contextExecutorService

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -522,6 +522,38 @@ internal class SdkFeatureTest {
     }
 
     @Test
+    fun `M provide Datadog context W withContext(callback)`(
+        @Forgery fakeContext: DatadogContext
+    ) {
+        // Given
+        testedFeature.storage = mockStorage
+        val callback = mock<(DatadogContext) -> Unit>()
+        whenever(coreFeature.mockInstance.contextProvider.context) doReturn fakeContext
+
+        // When
+        testedFeature.withContext(callback = callback)
+
+        // Then
+        verify(callback).invoke(fakeContext)
+    }
+
+    @Test
+    fun `M do nothing W withContext(callback) { no Datadog context }`() {
+        // Given
+        testedFeature.storage = mockStorage
+        val callback = mock<(DatadogContext) -> Unit>()
+
+        whenever(coreFeature.mockInstance.contextProvider) doReturn NoOpContextProvider()
+
+        // When
+        testedFeature.withContext(callback = callback)
+
+        // Then
+        verifyNoInteractions(mockStorage)
+        verifyNoInteractions(callback)
+    }
+
+    @Test
     fun `M provide write context W getWriteContextSync()`(
         @Forgery fakeContext: DatadogContext,
         @Mock mockEventWriteScope: EventWriteScope

--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -4,6 +4,10 @@ class com.datadog.android.internal.collections.EvictingQueue<T> : java.util.Queu
   override fun add(T): Boolean
   override fun offer(T): Boolean
   override fun addAll(Collection<T>): Boolean
+class com.datadog.android.internal.concurrent.CompletableFuture<T: Any>
+  var value: T
+  fun isComplete(): Boolean
+  fun complete(T)
 interface com.datadog.android.internal.profiler.BenchmarkCounter
   fun add(Long, Map<String, String>)
 interface com.datadog.android.internal.profiler.BenchmarkMeter

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -22,6 +22,13 @@ public final class com/datadog/android/internal/collections/EvictingQueue : java
 	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
 }
 
+public final class com/datadog/android/internal/concurrent/CompletableFuture {
+	public fun <init> ()V
+	public final fun complete (Ljava/lang/Object;)V
+	public final fun getValue ()Ljava/lang/Object;
+	public final fun isComplete ()Z
+}
+
 public abstract interface class com/datadog/android/internal/profiler/BenchmarkCounter {
 	public abstract fun add (JLjava/util/Map;)V
 }

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/concurrent/CompletableFuture.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/concurrent/CompletableFuture.kt
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.concurrent
+
+/**
+ * java.util.concurrent.CompletableFuture is available only starting from API 24, so here
+ * is a simple class mimicking very basics of it.
+ */
+@Suppress("UndocumentedPublicFunction", "UndocumentedPublicProperty")
+class CompletableFuture<T : Any> {
+    @Volatile
+    lateinit var value: T
+        private set
+
+    fun isComplete(): Boolean = this::value.isInitialized
+
+    fun complete(value: T) {
+        if (isComplete()) return
+        this.value = value
+    }
+}

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/collections/EvictingQueueTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/collections/EvictingQueueTest.kt
@@ -3,9 +3,8 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2016-Present Datadog, Inc.
  */
-package com.datadog.internal.collections
+package com.datadog.android.internal.collections
 
-import com.datadog.android.internal.collections.EvictingQueue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/concurrent/CompletableFutureTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/concurrent/CompletableFutureTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.concurrent
+
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+
+@Extensions(
+    ExtendWith(ForgeExtension::class)
+)
+class CompletableFutureTest {
+
+    @Test
+    fun `M return value W value { future is completed }`(
+        @StringForgery fakeValue: String
+    ) {
+        // Given
+        val future = CompletableFuture<String>()
+        future.complete(fakeValue)
+
+        // When
+        val value = future.value
+
+        // Then
+        assertThat(value).isEqualTo(fakeValue)
+    }
+
+    @RepeatedTest(10)
+    fun `M return value W value { future is completed, different threads }`(
+        @StringForgery fakeValue: String
+    ) {
+        // Given
+        val future = CompletableFuture<String>()
+        Thread {
+            future.complete(fakeValue)
+        }.apply {
+            start()
+            join()
+        }
+
+        // When
+        val value = future.value
+
+        // Then
+        assertThat(value).isEqualTo(fakeValue)
+    }
+
+    @Test
+    fun `M set value only once W value { multiple complete calls }`(
+        @StringForgery fakeValue: String,
+        @StringForgery anotherFakeValue: String
+    ) {
+        // Given
+        val future = CompletableFuture<String>()
+        future.complete(fakeValue)
+        future.complete(anotherFakeValue)
+
+        // When
+        val value = future.value
+
+        // Then
+        assertThat(value).isEqualTo(fakeValue)
+    }
+
+    @Test
+    fun `M throw error W value { future is not completed }`() {
+        // Given
+        val future = CompletableFuture<String>()
+
+        // When + Then
+        assertThrows<UninitializedPropertyAccessException> {
+            future.value
+        }
+    }
+
+    @Test
+    fun `M return true W isComplete() { future is completed }`(
+        @StringForgery fakeValue: String
+    ) {
+        // Given
+        val future = CompletableFuture<String>()
+        future.complete(fakeValue)
+
+        // When
+        val result = future.isComplete()
+
+        // Then
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `M return false W isComplete() { future is not completed }`() {
+        // Given
+        val future = CompletableFuture<String>()
+
+        // When
+        val result = future.isComplete()
+
+        // Then
+        assertThat(result).isFalse()
+    }
+}

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/forge/Configurator.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/forge/Configurator.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.internal.forge
+package com.datadog.android.internal.forge
 
 import com.datadog.android.internal.tests.elmyr.InternalTelemetryErrorLogForgeryFactory
 import com.datadog.tools.unit.forge.BaseConfigurator

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/telemetry/InternalTelemetryErrorEventTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/telemetry/InternalTelemetryErrorEventTest.kt
@@ -4,9 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.internal.telemetry
+package com.datadog.android.internal.telemetry
 
-import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.tools.unit.forge.aThrowable
 import fr.xgouchet.elmyr.Forge

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/utils/ByteArrayExtTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/utils/ByteArrayExtTest.kt
@@ -4,9 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.internal.utils
+package com.datadog.android.internal.utils
 
-import com.datadog.android.internal.utils.toHexString
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/utils/StringBuilderExtKtTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/utils/StringBuilderExtKtTest.kt
@@ -4,9 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.internal.utils
+package com.datadog.android.internal.utils
 
-import com.datadog.android.internal.utils.appendIfNotEmpty
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/utils/ThrowableExtTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/utils/ThrowableExtTest.kt
@@ -4,10 +4,9 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.internal.utils
+package com.datadog.android.internal.utils
 
-import com.datadog.android.internal.utils.loggableStackTrace
-import com.datadog.internal.forge.Configurator
+import com.datadog.android.internal.forge.Configurator
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration

--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -1420,6 +1420,7 @@ datadog:
       - "io.opentracing.Span.setError(kotlin.Throwable)"
       - "io.opentracing.Span.setTag(kotlin.String?, kotlin.Number?)"
       - "io.opentracing.Span.setTag(kotlin.String?, kotlin.String?)"
+      - "io.opentracing.Span.setTag(io.opentracing.tag.Tag?, com.datadog.android.internal.concurrent.CompletableFuture?)"
       - "io.opentracing.Span.setTag(io.opentracing.tag.Tag?, kotlin.String?)"
       - "io.opentracing.SpanContext.toSpanId()"
       - "io.opentracing.SpanContext.toTraceId()"

--- a/features/dd-sdk-android-trace-otel/api/dd-sdk-android-trace-otel.api
+++ b/features/dd-sdk-android-trace-otel/api/dd-sdk-android-trace-otel.api
@@ -80,6 +80,7 @@ public class com/datadog/opentelemetry/trace/OtelSpanBuilder : io/opentelemetry/
 	public fun setAttribute (Ljava/lang/String;J)Lio/opentelemetry/api/trace/SpanBuilder;
 	public fun setAttribute (Ljava/lang/String;Ljava/lang/String;)Lio/opentelemetry/api/trace/SpanBuilder;
 	public fun setAttribute (Ljava/lang/String;Z)Lio/opentelemetry/api/trace/SpanBuilder;
+	public fun setLazyDatadogContext (Lcom/datadog/android/internal/concurrent/CompletableFuture;)Lio/opentelemetry/api/trace/SpanBuilder;
 	public fun setNoParent ()Lio/opentelemetry/api/trace/SpanBuilder;
 	public fun setParent (Lio/opentelemetry/context/Context;)Lio/opentelemetry/api/trace/SpanBuilder;
 	public fun setSpanKind (Lio/opentelemetry/api/trace/SpanKind;)Lio/opentelemetry/api/trace/SpanBuilder;

--- a/features/dd-sdk-android-trace-otel/build.gradle.kts
+++ b/features/dd-sdk-android-trace-otel/build.gradle.kts
@@ -56,6 +56,7 @@ android {
 dependencies {
     api(project(":dd-sdk-android-core"))
     api(project(":features:dd-sdk-android-trace"))
+    implementation(project(":dd-sdk-android-internal"))
     api(libs.openTelemetryApi)
     implementation(libs.kotlin)
     implementation(libs.androidXAnnotation)

--- a/features/dd-sdk-android-trace-otel/src/main/java/com/datadog/opentelemetry/trace/OtelSpanBuilder.java
+++ b/features/dd-sdk-android-trace-otel/src/main/java/com/datadog/opentelemetry/trace/OtelSpanBuilder.java
@@ -19,6 +19,9 @@ import static java.util.Locale.ROOT;
 import androidx.annotation.NonNull;
 
 import com.datadog.android.api.InternalLogger;
+import com.datadog.android.api.context.DatadogContext;
+import com.datadog.android.internal.concurrent.CompletableFuture;
+import com.datadog.android.trace.internal.SpanAttributes;
 import com.datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import com.datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 
@@ -32,7 +35,6 @@ import io.opentelemetry.context.Context;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Logger;
 
 public class OtelSpanBuilder implements SpanBuilder {
     private final AgentTracer.SpanBuilder delegate;
@@ -159,6 +161,14 @@ public class OtelSpanBuilder implements SpanBuilder {
                 this.delegate.withTag(key.getKey(), value);
                 break;
         }
+        return this;
+    }
+
+    /**
+     * This is internal method and should not be used outside of SDK.
+     */
+    public SpanBuilder setLazyDatadogContext(CompletableFuture<DatadogContext> context) {
+        this.delegate.withTag(SpanAttributes.DATADOG_INITIAL_CONTEXT, context);
         return this;
     }
 

--- a/features/dd-sdk-android-trace-otel/src/main/kotlin/com/datadog/android/trace/opentelemetry/OtelTracerProvider.kt
+++ b/features/dd-sdk-android-trace-otel/src/main/kotlin/com/datadog/android/trace/opentelemetry/OtelTracerProvider.kt
@@ -11,9 +11,10 @@ import androidx.annotation.IntRange
 import com.datadog.android.Datadog
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
+import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
-import com.datadog.android.log.LogAttributes
+import com.datadog.android.internal.concurrent.CompletableFuture
 import com.datadog.android.trace.InternalCoreWriterProvider
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.opentelemetry.internal.DatadogContextStorageWrapper
@@ -21,6 +22,7 @@ import com.datadog.android.trace.opentelemetry.internal.NoOpCoreTracerWriter
 import com.datadog.android.trace.opentelemetry.internal.addActiveTraceToContext
 import com.datadog.android.trace.opentelemetry.internal.executeIfJavaFunctionPackageExists
 import com.datadog.android.trace.opentelemetry.internal.removeActiveTraceFromContext
+import com.datadog.opentelemetry.trace.OtelSpanBuilder
 import com.datadog.opentelemetry.trace.OtelTracerBuilder
 import com.datadog.trace.api.IdGenerationStrategy
 import com.datadog.trace.api.config.TracerConfig
@@ -310,31 +312,18 @@ class OtelTracerProvider internal constructor(
 
     private fun resolveSpanBuilderDecorator(): (SpanBuilder) -> SpanBuilder {
         return if (bundleWithRumEnabled) {
-            resolveDecoratorFromRumContext()
+            resolveDecoratorWithRumContext()
         } else {
             NO_OP_SPAN_BUILDER_DECORATOR
         }
     }
 
-    private fun resolveDecoratorFromRumContext(): (SpanBuilder) -> SpanBuilder = { spanBuilder ->
-        val rumContext = sdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)
-        val applicationId = rumContext[RUM_APPLICATION_ID_KEY] as? String
-        val sessionId = rumContext[RUM_SESSION_ID_KEY] as? String
-        val viewId = rumContext[RUM_VIEW_ID_KEY] as? String
-        val actionId = rumContext[RUM_ACTION_ID_KEY] as? String
-        if (applicationId != null && sessionId != null && viewId != null) {
-            spanBuilder.setAttribute(LogAttributes.RUM_APPLICATION_ID, applicationId)
-            spanBuilder.setAttribute(LogAttributes.RUM_SESSION_ID, sessionId)
-            spanBuilder.setAttribute(LogAttributes.RUM_VIEW_ID, viewId)
-            if (actionId != null) {
-                spanBuilder.setAttribute(LogAttributes.RUM_ACTION_ID, actionId)
-            }
-        } else {
-            internalLogger.log(
-                InternalLogger.Level.WARN,
-                InternalLogger.Target.USER,
-                { RUM_CONTEXT_MISSING_ERROR_MESSAGE }
-            )
+    private fun resolveDecoratorWithRumContext(): (SpanBuilder) -> SpanBuilder = { spanBuilder ->
+        val rumFeature = sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
+        if (rumFeature != null) {
+            val lazyContext = CompletableFuture<DatadogContext>()
+            rumFeature.withContext { lazyContext.complete(it) }
+            (spanBuilder as? OtelSpanBuilder)?.setLazyDatadogContext(lazyContext)
         }
         spanBuilder
     }

--- a/features/dd-sdk-android-trace-otel/src/test/kotlin/com/datadog/android/trace/opentelemetry/OtelTracerBuilderProviderTest.kt
+++ b/features/dd-sdk-android-trace-otel/src/test/kotlin/com/datadog/android/trace/opentelemetry/OtelTracerBuilderProviderTest.kt
@@ -8,12 +8,14 @@ package com.datadog.android.trace.opentelemetry
 
 import android.content.Context
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
-import com.datadog.android.log.LogAttributes
+import com.datadog.android.internal.concurrent.CompletableFuture
 import com.datadog.android.trace.InternalCoreWriterProvider
 import com.datadog.android.trace.TracingHeaderType
+import com.datadog.android.trace.internal.SpanAttributes
 import com.datadog.android.trace.opentelemetry.internal.NoOpCoreTracerWriter
 import com.datadog.android.trace.opentelemetry.utils.verifyLog
 import com.datadog.android.utils.forge.Configurator
@@ -34,6 +36,7 @@ import com.datadog.trace.core.DDSpan
 import com.datadog.trace.core.DDSpanContext
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.DoubleForgery
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
@@ -46,16 +49,13 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.doReturnConsecutively
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -666,13 +666,21 @@ internal class OtelTracerBuilderProviderTest {
 
     // region bundle with RUM
 
+    @Suppress("UNCHECKED_CAST")
     @Test
-    fun `M build a Span with RUM context W startSpan`() {
+    fun `M build a Span with lazy Datadog context W startSpan()`(
+        @Forgery fakeInitialDatadogContext: DatadogContext
+    ) {
         // Given
         val tracer = testedOtelTracerProviderBuilder
             .build()
             .tracerBuilder(fakeInstrumentationName)
             .build()
+        val mockRumFeatureScope = mock<FeatureScope>()
+        whenever(mockRumFeatureScope.withContext(any())) doAnswer {
+            it.getArgument<(DatadogContext) -> Unit>(0).invoke(fakeInitialDatadogContext)
+        }
+        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
 
         // When
         val span = tracer
@@ -683,73 +691,13 @@ internal class OtelTracerBuilderProviderTest {
         span.end()
 
         // Then
-        assertThat(context.tags).containsEntry(LogAttributes.RUM_APPLICATION_ID, fakeApplicationId)
-        assertThat(context.tags).containsEntry(LogAttributes.RUM_SESSION_ID, fakeSessionId)
-        assertThat(context.tags).containsEntry(LogAttributes.RUM_VIEW_ID, fakeViewId)
-        assertThat(context.tags).containsEntry(LogAttributes.RUM_ACTION_ID, fakeActionId)
+        assertThat(context.tags).containsKey(SpanAttributes.DATADOG_INITIAL_CONTEXT)
+        val lazyContext = context.tags[SpanAttributes.DATADOG_INITIAL_CONTEXT] as CompletableFuture<DatadogContext>
+        assertThat(lazyContext.value).isEqualTo(fakeInitialDatadogContext)
     }
 
     @Test
-    fun `M bundle the span with current RUM context W startSpan`(forge: Forge) {
-        // Given
-        val fakeApppicationId1: String = forge.anHexadecimalString()
-        val fakeSessionId1: String = forge.anHexadecimalString()
-        val fakeViewId1: String = forge.anHexadecimalString()
-        val fakeActionId1: String = forge.anHexadecimalString()
-        val fakeApppicationId2: String = forge.anHexadecimalString()
-        val fakeSessionId2: String = forge.anHexadecimalString()
-        val fakeViewId2: String = forge.anHexadecimalString()
-        val fakeActionId2: String = forge.anHexadecimalString()
-        val fakeRumContext1 = mutableMapOf(
-            OtelTracerProvider.RUM_APPLICATION_ID_KEY to fakeApppicationId1,
-            OtelTracerProvider.RUM_SESSION_ID_KEY to fakeSessionId1,
-            OtelTracerProvider.RUM_VIEW_ID_KEY to fakeViewId1,
-            OtelTracerProvider.RUM_ACTION_ID_KEY to fakeActionId1
-        )
-        val fakeRumContext2 = mutableMapOf(
-            OtelTracerProvider.RUM_APPLICATION_ID_KEY to fakeApppicationId2,
-            OtelTracerProvider.RUM_SESSION_ID_KEY to fakeSessionId2,
-            OtelTracerProvider.RUM_VIEW_ID_KEY to fakeViewId2,
-            OtelTracerProvider.RUM_ACTION_ID_KEY to fakeActionId2
-        )
-        whenever(mockSdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)) doReturnConsecutively
-            listOf(fakeRumContext1, fakeRumContext2)
-        val tracer = testedOtelTracerProviderBuilder
-            .build()
-            .tracerBuilder(fakeInstrumentationName)
-            .build()
-
-        // When
-        val span1 = tracer
-            .spanBuilder(fakeOperationName)
-            .startSpan()
-        val delegateSpan1: DDSpan = span1.getFieldValue("delegate")
-        val context1 = delegateSpan1.context()
-        span1.end()
-
-        // Then
-        assertThat(context1.tags).containsEntry(LogAttributes.RUM_APPLICATION_ID, fakeApppicationId1)
-        assertThat(context1.tags).containsEntry(LogAttributes.RUM_SESSION_ID, fakeSessionId1)
-        assertThat(context1.tags).containsEntry(LogAttributes.RUM_VIEW_ID, fakeViewId1)
-        assertThat(context1.tags).containsEntry(LogAttributes.RUM_ACTION_ID, fakeActionId1)
-
-        // When
-        val span2 = tracer
-            .spanBuilder(fakeOperationName)
-            .startSpan()
-        val delegateSpan2: DDSpan = span2.getFieldValue("delegate")
-        val context2 = delegateSpan2.context()
-        span2.end()
-
-        // Then
-        assertThat(context2.tags).containsEntry(LogAttributes.RUM_APPLICATION_ID, fakeApppicationId2)
-        assertThat(context2.tags).containsEntry(LogAttributes.RUM_SESSION_ID, fakeSessionId2)
-        assertThat(context2.tags).containsEntry(LogAttributes.RUM_VIEW_ID, fakeViewId2)
-        assertThat(context2.tags).containsEntry(LogAttributes.RUM_ACTION_ID, fakeActionId2)
-    }
-
-    @Test
-    fun `M build a Span without RUM context W startSpan { bundleWithRum = false }`() {
+    fun `M build a Span without lazy Datadog context W startSpan() { bundleWithRum = false }`() {
         // Given
         val tracer = testedOtelTracerProviderBuilder
             .setBundleWithRumEnabled(false)
@@ -766,52 +714,18 @@ internal class OtelTracerBuilderProviderTest {
         span.end()
 
         // Then
-        assertThat(context.tags).doesNotContainKey(LogAttributes.RUM_APPLICATION_ID)
-        assertThat(context.tags).doesNotContainKey(LogAttributes.RUM_SESSION_ID)
-        assertThat(context.tags).doesNotContainKey(LogAttributes.RUM_VIEW_ID)
-        assertThat(context.tags).doesNotContainKey(LogAttributes.RUM_ACTION_ID)
-    }
-
-    @ParameterizedTest
-    @MethodSource("brokenRumContextProvider")
-    fun `M send a warning log W startSpan { bundle with RUM and broken RUM context }`(
-        fakeBrokenRumContext: Map<String, String>
-    ) {
-        // Given
-        whenever(mockSdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)) doReturn fakeBrokenRumContext
-        val tracer = testedOtelTracerProviderBuilder
-            .build()
-            .tracerBuilder(fakeInstrumentationName)
-            .build()
-
-        // When
-        val span = tracer
-            .spanBuilder(fakeOperationName)
-            .startSpan()
-        val delegateSpan: DDSpan = span.getFieldValue("delegate")
-        val context = delegateSpan.context()
-        span.end()
-
-        // Then
-        mockInternalLogger.verifyLog(
-            InternalLogger.Level.WARN,
-            InternalLogger.Target.USER,
-            OtelTracerProvider.RUM_CONTEXT_MISSING_ERROR_MESSAGE
-        )
-        assertThat(context.tags).doesNotContainKey(LogAttributes.RUM_APPLICATION_ID)
-        assertThat(context.tags).doesNotContainKey(LogAttributes.RUM_SESSION_ID)
-        assertThat(context.tags).doesNotContainKey(LogAttributes.RUM_VIEW_ID)
-        assertThat(context.tags).doesNotContainKey(LogAttributes.RUM_ACTION_ID)
+        assertThat(context.tags).doesNotContainKey(SpanAttributes.DATADOG_INITIAL_CONTEXT)
+        verify(mockSdkCore, never()).getFeature(Feature.RUM_FEATURE_NAME)
     }
 
     @Test
-    fun `M send span and do not log W startSpan { bundle with RUM and no RUM action id }`() {
+    fun `M build a Span without lazy Datadog context W startSpan() { bundleWithRum = true, RUM not initialized }`() {
         // Given
-        fakeRumContext.remove(OtelTracerProvider.RUM_ACTION_ID_KEY)
         val tracer = testedOtelTracerProviderBuilder
             .build()
             .tracerBuilder(fakeInstrumentationName)
             .build()
+        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn null
 
         // When
         val span = tracer
@@ -822,18 +736,7 @@ internal class OtelTracerBuilderProviderTest {
         span.end()
 
         // Then
-        verify(mockInternalLogger, never()).log(
-            eq(InternalLogger.Level.WARN),
-            eq(listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY)),
-            eq { OtelTracerProvider.RUM_CONTEXT_MISSING_ERROR_MESSAGE },
-            anyOrNull(),
-            any(),
-            anyOrNull()
-        )
-        assertThat(context.tags).containsEntry(LogAttributes.RUM_APPLICATION_ID, fakeApplicationId)
-        assertThat(context.tags).containsEntry(LogAttributes.RUM_SESSION_ID, fakeSessionId)
-        assertThat(context.tags).containsEntry(LogAttributes.RUM_VIEW_ID, fakeViewId)
-        assertThat(context.tags).doesNotContainKey(LogAttributes.RUM_ACTION_ID)
+        assertThat(context.tags).doesNotContainKey(SpanAttributes.DATADOG_INITIAL_CONTEXT)
     }
 
     // endregion

--- a/features/dd-sdk-android-trace/api/apiSurface
+++ b/features/dd-sdk-android-trace/api/apiSurface
@@ -29,6 +29,8 @@ data class com.datadog.android.trace.TraceConfiguration
     fun build(): TraceConfiguration
 interface com.datadog.android.trace.event.SpanEventMapper : com.datadog.android.event.EventMapper<com.datadog.android.trace.model.SpanEvent>
   override fun map(com.datadog.android.trace.model.SpanEvent): com.datadog.android.trace.model.SpanEvent
+object com.datadog.android.trace.internal.SpanAttributes
+  const val DATADOG_INITIAL_CONTEXT: String
 fun <T> android.database.sqlite.SQLiteDatabase.transactionTraced(String, Boolean = true, io.opentracing.Span.(android.database.sqlite.SQLiteDatabase) -> T): T
 data class com.datadog.android.trace.model.SpanEvent
   constructor(kotlin.String, kotlin.String, kotlin.String, kotlin.String, kotlin.String, kotlin.String, kotlin.Long, kotlin.Long, kotlin.Long = 0L, Metrics, Meta)

--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -64,6 +64,11 @@ public abstract interface class com/datadog/android/trace/event/SpanEventMapper 
 	public abstract fun map (Lcom/datadog/android/trace/model/SpanEvent;)Lcom/datadog/android/trace/model/SpanEvent;
 }
 
+public final class com/datadog/android/trace/internal/SpanAttributes {
+	public static final field DATADOG_INITIAL_CONTEXT Ljava/lang/String;
+	public static final field INSTANCE Lcom/datadog/android/trace/internal/SpanAttributes;
+}
+
 public final class com/datadog/android/trace/model/SpanEvent {
 	public static final field Companion Lcom/datadog/android/trace/model/SpanEvent$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JJJLcom/datadog/android/trace/model/SpanEvent$Metrics;Lcom/datadog/android/trace/model/SpanEvent$Meta;)V

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/AndroidTracer.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/AndroidTracer.kt
@@ -11,9 +11,11 @@ import androidx.annotation.FloatRange
 import com.datadog.android.Datadog
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
+import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
-import com.datadog.android.log.LogAttributes
+import com.datadog.android.internal.concurrent.CompletableFuture
+import com.datadog.android.trace.internal.SpanAttributes
 import com.datadog.android.trace.internal.TracingFeature
 import com.datadog.android.trace.internal.addActiveTraceToContext
 import com.datadog.android.trace.internal.data.NoOpWriter
@@ -27,6 +29,7 @@ import com.datadog.opentracing.DDTracer
 import com.datadog.opentracing.LogHandler
 import io.opentracing.Span
 import io.opentracing.log.Fields
+import io.opentracing.tag.Tag
 import java.security.SecureRandom
 import java.util.Properties
 import java.util.Random
@@ -264,15 +267,15 @@ class AndroidTracer internal constructor(
     // region Internal
 
     private fun DDSpanBuilder.withRumContext(): DDSpanBuilder {
-        return if (bundleWithRum) {
-            val rumContext = sdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)
-            withTag(LogAttributes.RUM_APPLICATION_ID, rumContext["application_id"] as? String)
-                .withTag(LogAttributes.RUM_SESSION_ID, rumContext["session_id"] as? String)
-                .withTag(LogAttributes.RUM_VIEW_ID, rumContext["view_id"] as? String)
-                .withTag(LogAttributes.RUM_ACTION_ID, rumContext["action_id"] as? String)
-        } else {
-            this
+        if (bundleWithRum) {
+            val rumFeature = sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
+            if (rumFeature != null) {
+                val lazyContext = CompletableFuture<DatadogContext>()
+                rumFeature.withContext { lazyContext.complete(it) }
+                withTag(DATADOG_CONTEXT_TAG, lazyContext)
+            }
         }
+        return this
     }
 
     // endregion
@@ -299,6 +302,14 @@ class AndroidTracer internal constructor(
         internal const val SPAN_ID_BIT_SIZE = 63
 
         internal const val LOG_STATUS = "status"
+
+        internal val DATADOG_CONTEXT_TAG = object : Tag<CompletableFuture<DatadogContext>> {
+            override fun getKey(): String = SpanAttributes.DATADOG_INITIAL_CONTEXT
+
+            override fun set(span: Span?, value: CompletableFuture<DatadogContext>?) {
+                span?.setTag(this, value)
+            }
+        }
 
         /**
          * Helper method to attach a Throwable to a specific Span.

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/SpanAttributes.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/SpanAttributes.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.internal
+
+/**
+ * Common attributes used by spans.
+ */
+@Suppress("PackageNameVisibility")
+object SpanAttributes {
+    /**
+     *  Internal attribute representing [DatadogContext] captured at the span start.
+     */
+    const val DATADOG_INITIAL_CONTEXT: String = "_dd.datadog_initial_context"
+}

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/data/OtelTraceWriter.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/data/OtelTraceWriter.kt
@@ -16,6 +16,9 @@ import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.event.EventMapper
 import com.datadog.android.event.NoOpEventMapper
+import com.datadog.android.internal.concurrent.CompletableFuture
+import com.datadog.android.log.LogAttributes
+import com.datadog.android.trace.internal.SpanAttributes
 import com.datadog.android.trace.internal.domain.event.ContextAwareMapper
 import com.datadog.android.trace.internal.storage.ContextAwareSerializer
 import com.datadog.android.trace.model.SpanEvent
@@ -41,12 +44,14 @@ internal class OtelTraceWriter(
         if (trace == null) return
         sdkCore.getFeature(Feature.TRACING_FEATURE_NAME)
             ?.withWriteContext { datadogContext, writeScope ->
+                val writeSpans = trace
+                    .filter {
+                        it.samplingPriority() !in DROP_SAMPLING_PRIORITIES
+                    }
+                    .map { it.bundleWithRum() }
                 // TODO RUM-4092 Add the capability in the serializer to handle multiple spans in one payload
                 writeScope {
-                    trace
-                        .filter {
-                            it.samplingPriority() !in DROP_SAMPLING_PRIORITIES
-                        }
+                    writeSpans
                         .forEach { span ->
                             @Suppress("ThreadSafety") // called in the worker context
                             writeSpan(datadogContext, it, span)
@@ -69,6 +74,34 @@ internal class OtelTraceWriter(
     }
 
     // endregion
+
+    @Suppress("UNCHECKED_CAST")
+    private fun DDSpan.bundleWithRum(): DDSpan {
+        val initialDatadogContext = tags[SpanAttributes.DATADOG_INITIAL_CONTEXT]
+            as? CompletableFuture<DatadogContext>
+        setTag(SpanAttributes.DATADOG_INITIAL_CONTEXT, null as String?)
+        if (initialDatadogContext != null) {
+            if (initialDatadogContext.isComplete()) {
+                val rumContext = initialDatadogContext.value
+                    .featuresContext[Feature.RUM_FEATURE_NAME]
+                    .orEmpty()
+                setTag(
+                    LogAttributes.RUM_APPLICATION_ID,
+                    rumContext["application_id"] as? String
+                )
+                setTag(LogAttributes.RUM_SESSION_ID, rumContext["session_id"] as? String)
+                setTag(LogAttributes.RUM_VIEW_ID, rumContext["view_id"] as? String)
+                setTag(LogAttributes.RUM_ACTION_ID, rumContext["action_id"] as? String)
+            } else {
+                internalLogger.log(
+                    InternalLogger.Level.ERROR,
+                    InternalLogger.Target.USER,
+                    { INITIAL_DATADOG_CONTEXT_NOT_AVAILABLE_ERROR }
+                )
+            }
+        }
+        return this
+    }
 
     @WorkerThread
     private fun writeSpan(
@@ -97,6 +130,8 @@ internal class OtelTraceWriter(
 
     companion object {
         internal const val ERROR_SERIALIZING = "Error serializing %s model"
+        internal const val INITIAL_DATADOG_CONTEXT_NOT_AVAILABLE_ERROR = "Initial span creation Datadog context" +
+            " is not available at the write time."
         internal val DROP_SAMPLING_PRIORITIES = setOf(PrioritySampling.SAMPLER_DROP, PrioritySampling.USER_DROP)
     }
 }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/data/TraceWriter.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/data/TraceWriter.kt
@@ -15,6 +15,9 @@ import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.event.EventMapper
+import com.datadog.android.internal.concurrent.CompletableFuture
+import com.datadog.android.log.LogAttributes
+import com.datadog.android.trace.AndroidTracer
 import com.datadog.android.trace.internal.domain.event.ContextAwareMapper
 import com.datadog.android.trace.internal.storage.ContextAwareSerializer
 import com.datadog.android.trace.model.SpanEvent
@@ -40,11 +43,13 @@ internal class TraceWriter(
         if (trace == null) return
         sdkCore.getFeature(Feature.TRACING_FEATURE_NAME)
             ?.withWriteContext { datadogContext, writeScope ->
+                val writeSpans = trace
+                    .filter {
+                        it.samplingPriority == null || it.samplingPriority !in DROP_SAMPLING_PRIORITIES
+                    }
+                    .map { it.bundleWithRum() }
                 writeScope {
-                    trace
-                        .filter {
-                            it.samplingPriority == null || it.samplingPriority !in DROP_SAMPLING_PRIORITIES
-                        }
+                    writeSpans
                         .forEach { span ->
                             writeSpan(datadogContext, it, span)
                         }
@@ -61,6 +66,34 @@ internal class TraceWriter(
     }
 
     // endregion
+
+    @Suppress("UNCHECKED_CAST")
+    private fun DDSpan.bundleWithRum(): DDSpan {
+        val initialDatadogContext = tags[AndroidTracer.DATADOG_CONTEXT_TAG.key]
+            as? CompletableFuture<DatadogContext>
+        setTag(AndroidTracer.DATADOG_CONTEXT_TAG, null)
+        if (initialDatadogContext != null) {
+            if (initialDatadogContext.isComplete()) {
+                val rumContext = initialDatadogContext.value
+                    .featuresContext[Feature.RUM_FEATURE_NAME]
+                    .orEmpty()
+                setTag(
+                    LogAttributes.RUM_APPLICATION_ID,
+                    rumContext["application_id"] as? String
+                )
+                setTag(LogAttributes.RUM_SESSION_ID, rumContext["session_id"] as? String)
+                setTag(LogAttributes.RUM_VIEW_ID, rumContext["view_id"] as? String)
+                setTag(LogAttributes.RUM_ACTION_ID, rumContext["action_id"] as? String)
+            } else {
+                internalLogger.log(
+                    InternalLogger.Level.ERROR,
+                    InternalLogger.Target.USER,
+                    { INITIAL_DATADOG_CONTEXT_NOT_AVAILABLE_ERROR }
+                )
+            }
+        }
+        return this
+    }
 
     @WorkerThread
     private fun writeSpan(
@@ -93,6 +126,8 @@ internal class TraceWriter(
 
     companion object {
         internal const val ERROR_SERIALIZING = "Error serializing %s model"
+        internal const val INITIAL_DATADOG_CONTEXT_NOT_AVAILABLE_ERROR = "Initial span creation Datadog context" +
+            " is not available at the write time."
         internal val DROP_SAMPLING_PRIORITIES = setOf(PrioritySampling.SAMPLER_DROP, PrioritySampling.USER_DROP)
         private val KEEP_SAMPLING_PRIORITIES = setOf(PrioritySampling.SAMPLER_KEEP, PrioritySampling.USER_KEEP)
         internal val KEEP_AND_UNSET_SAMPLING_PRIORITIES = KEEP_SAMPLING_PRIORITIES + PrioritySampling.UNSET

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/AndroidTracerTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/AndroidTracerTest.kt
@@ -8,10 +8,12 @@ package com.datadog.android.trace
 
 import android.util.Log
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
-import com.datadog.android.log.LogAttributes
+import com.datadog.android.internal.concurrent.CompletableFuture
+import com.datadog.android.trace.internal.SpanAttributes
 import com.datadog.android.trace.internal.TracingFeature
 import com.datadog.android.trace.internal.utils.traceIdAsHexString
 import com.datadog.android.trace.utils.verifyLog
@@ -218,257 +220,64 @@ internal class AndroidTracerTest {
             .isEqualTo(span.traceId)
     }
 
-    @Test
-    fun `M inject RumContext W buildSpan { bundleWithRum enabled and RumFeature initialized }`(
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) operationName: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) serviceName: String
-    ) {
-        val tracer = AndroidTracer.Builder(mockSdkCore)
-            .setService(serviceName)
-            .build()
+    // region bundleWithRum
 
-        val span = tracer.buildSpan(operationName).start() as DDSpan
-        val meta = span.meta
-        assertThat(meta[LogAttributes.RUM_APPLICATION_ID])
-            .isEqualTo(fakeRumApplicationId)
-        assertThat(meta[LogAttributes.RUM_SESSION_ID])
-            .isEqualTo(fakeRumSessionId)
-        val viewId = fakeRumViewId
-        if (viewId == null) {
-            assertThat(meta.containsKey(LogAttributes.RUM_VIEW_ID)).isFalse()
-        } else {
-            assertThat(meta[LogAttributes.RUM_VIEW_ID]).isEqualTo(viewId)
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `M inject lazy Datadog context W buildSpan { bundleWithRum enabled }`(
+        @Forgery fakeDatadogContext: DatadogContext,
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) fakeOperationName: String
+    ) {
+        // Given
+        val mockRumFeatureScope = mock<FeatureScope>()
+        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
+        whenever(mockRumFeatureScope.withContext(any())) doAnswer {
+            it.getArgument<(DatadogContext) -> Unit>(0).invoke(fakeDatadogContext)
         }
-        val actionId = fakeRumActionId
-        if (actionId == null) {
-            assertThat(meta.containsKey(LogAttributes.RUM_ACTION_ID)).isFalse()
-        } else {
-            assertThat(meta[LogAttributes.RUM_ACTION_ID]).isEqualTo(actionId)
-        }
-    }
-
-    @Test
-    fun `M inject Rum ViewId W buildSpan { bundleWithRum enabled and ViewId not null }`(
-        forge: Forge
-    ) {
-        // Given
-        val fakeViewId = forge.getForgery<UUID>().toString()
-        whenever(
-            mockSdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)
-        ) doReturn mapOf(
-            "application_id" to fakeRumApplicationId,
-            "session_id" to fakeRumSessionId,
-            "view_id" to fakeViewId,
-            "action_id" to fakeRumActionId
-        )
-        val fakeOperationName = forge.anAlphaNumericalString()
         val tracer = AndroidTracer.Builder(mockSdkCore)
             .build()
 
         // When
         val span = tracer.buildSpan(fakeOperationName).start() as DDSpan
-        val meta = span.meta
 
         // Then
-        assertThat(meta[LogAttributes.RUM_VIEW_ID]).isEqualTo(fakeViewId)
+        val lazyContext = span.tags[SpanAttributes.DATADOG_INITIAL_CONTEXT] as CompletableFuture<DatadogContext>
+        assertThat(lazyContext.value).isEqualTo(fakeDatadogContext)
     }
 
     @Test
-    fun `M not inject Rum ViewId W buildSpan { bundleWithRum enabled and ViewId is missing }`(
-        forge: Forge
+    fun `M not inject lazy Datadog context W buildSpan { bundleWithRum = false }`(
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) fakeOperationName: String
     ) {
         // Given
-        whenever(
-            mockSdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)
-        ) doReturn mapOf(
-            "application_id" to fakeRumApplicationId,
-            "session_id" to fakeRumSessionId,
-            "action_id" to fakeRumActionId
-        )
-        val fakeOperationName = forge.anAlphaNumericalString()
-        val tracer = AndroidTracer.Builder(mockSdkCore)
-            .build()
-
-        // When
-        val span = tracer.buildSpan(fakeOperationName).start() as DDSpan
-        val meta = span.meta
-
-        // Then
-        assertThat(meta.containsKey(LogAttributes.RUM_VIEW_ID)).isFalse()
-    }
-
-    @Test
-    fun `M not inject Rum ViewId W buildSpan { bundleWithRum enabled and ViewId is null }`(
-        forge: Forge
-    ) {
-        // Given
-        whenever(
-            mockSdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)
-        ) doReturn mapOf(
-            "application_id" to fakeRumApplicationId,
-            "session_id" to fakeRumSessionId,
-            "view_id" to null,
-            "action_id" to fakeRumActionId
-        )
-        val fakeOperationName = forge.anAlphaNumericalString()
-        val tracer = AndroidTracer.Builder(mockSdkCore)
-            .build()
-
-        // When
-        val span = tracer.buildSpan(fakeOperationName).start() as DDSpan
-        val meta = span.meta
-
-        // Then
-        assertThat(meta.containsKey(LogAttributes.RUM_VIEW_ID)).isFalse()
-    }
-
-    @Test
-    fun `M inject Rum actionId W buildSpan { bundleWithRum enabled and ActionId not null }`(
-        forge: Forge
-    ) {
-        // Given
-        val fakeActionId = forge.getForgery<UUID>().toString()
-        whenever(
-            mockSdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)
-        ) doReturn mapOf(
-            "application_id" to fakeRumApplicationId,
-            "session_id" to fakeRumSessionId,
-            "view_id" to fakeRumActionId,
-            "action_id" to fakeActionId
-        )
-        val fakeOperationName = forge.anAlphaNumericalString()
-        val tracer = AndroidTracer.Builder(mockSdkCore)
-            .build()
-
-        // When
-        val span = tracer.buildSpan(fakeOperationName).start() as DDSpan
-        val meta = span.meta
-
-        // Then
-        assertThat(meta[LogAttributes.RUM_ACTION_ID]).isEqualTo(fakeActionId)
-    }
-
-    @Test
-    fun `M not inject Rum ActionId W buildSpan { bundleWithRum enabled and ActionId is missing }`(
-        forge: Forge
-    ) {
-        // Given
-        whenever(
-            mockSdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)
-        ) doReturn mapOf(
-            "application_id" to fakeRumApplicationId,
-            "session_id" to fakeRumSessionId,
-            "view_id" to fakeRumActionId
-        )
-        val fakeOperationName = forge.anAlphaNumericalString()
-        val tracer = AndroidTracer.Builder(mockSdkCore)
-            .build()
-
-        // When
-        val span = tracer.buildSpan(fakeOperationName).start() as DDSpan
-        val meta = span.meta
-
-        // Then
-        assertThat(meta.containsKey(LogAttributes.RUM_ACTION_ID)).isFalse()
-    }
-
-    @Test
-    fun `M not inject Rum ActionId W buildSpan { bundleWithRum enabled and ActionId is null }`(
-        forge: Forge
-    ) {
-        // Given
-        whenever(
-            mockSdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)
-        ) doReturn mapOf(
-            "application_id" to fakeRumApplicationId,
-            "session_id" to fakeRumSessionId,
-            "view_id" to fakeRumActionId,
-            "action_id" to null
-        )
-        val fakeOperationName = forge.anAlphaNumericalString()
-        val tracer = AndroidTracer.Builder(mockSdkCore)
-            .build()
-
-        // When
-        val span = tracer.buildSpan(fakeOperationName).start() as DDSpan
-        val meta = span.meta
-
-        // Then
-        assertThat(meta.containsKey(LogAttributes.RUM_ACTION_ID)).isFalse()
-    }
-
-    @Test
-    fun `M not inject RumContext W buildSpan { RumFeature not initialized }`(
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) operationName: String
-    ) {
-        // GIVEN
-        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn null
-        whenever(mockSdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)) doReturn emptyMap()
-
-        val tracer = AndroidTracer.Builder(mockSdkCore)
-            .build()
-
-        // WHEN
-        val span = tracer.buildSpan(operationName).start() as DDSpan
-
-        // THEN
-        val meta = span.meta
-        assertThat(meta[LogAttributes.RUM_APPLICATION_ID])
-            .isNull()
-        assertThat(meta[LogAttributes.RUM_SESSION_ID])
-            .isNull()
-    }
-
-    @Test
-    fun `M inject RumContext W buildSpan { RumFeature is initialized after AndroidTracer is built }`(
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) operationName: String
-    ) {
-        // GIVEN
-        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn null
-        whenever(mockSdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)) doReturn emptyMap()
-
-        val tracer = AndroidTracer.Builder(mockSdkCore)
-            .build()
-
-        whenever(mockSdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)) doReturn mapOf(
-            "application_id" to fakeRumApplicationId,
-            "session_id" to fakeRumSessionId,
-            "view_id" to fakeRumViewId,
-            "action_id" to fakeRumActionId
-        )
-
-        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mock()
-
-        // WHEN
-        val span = tracer.buildSpan(operationName).start() as DDSpan
-
-        // THEN
-        val meta = span.meta
-        assertThat(meta[LogAttributes.RUM_APPLICATION_ID])
-            .isEqualTo(fakeRumApplicationId)
-        assertThat(meta[LogAttributes.RUM_SESSION_ID])
-            .isEqualTo(fakeRumSessionId)
-    }
-
-    @Test
-    fun `M not inject RumContext W buildSpan { bundleWithRum disabled }`(
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) operationName: String
-    ) {
-        // GIVEN
         val tracer = AndroidTracer.Builder(mockSdkCore)
             .setBundleWithRumEnabled(false)
             .build()
 
-        // WHEN
-        val span = tracer.buildSpan(operationName).start() as DDSpan
+        // When
+        val span = tracer.buildSpan(fakeOperationName).start() as DDSpan
 
-        // THEN
-        val meta = span.meta
-        assertThat(meta[LogAttributes.RUM_APPLICATION_ID])
-            .isNull()
-        assertThat(meta[LogAttributes.RUM_SESSION_ID])
-            .isNull()
+        // Then
+        assertThat(span.tags).doesNotContainKey(SpanAttributes.DATADOG_INITIAL_CONTEXT)
     }
+
+    @Test
+    fun `M not inject lazy Datadog context W buildSpan { bundleWithRum = true, RUM not initialized }`(
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) fakeOperationName: String
+    ) {
+        // Given
+        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn null
+        val tracer = AndroidTracer.Builder(mockSdkCore)
+            .build()
+
+        // When
+        val span = tracer.buildSpan(fakeOperationName).start() as DDSpan
+
+        // Then
+        assertThat(span.tags).doesNotContainKey(SpanAttributes.DATADOG_INITIAL_CONTEXT)
+    }
+
+    // endregion
 
     @Test
     fun `it will build a valid Tracer`(

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/OtelTraceWriterTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/OtelTraceWriterTest.kt
@@ -16,6 +16,9 @@ import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.event.EventMapper
+import com.datadog.android.internal.concurrent.CompletableFuture
+import com.datadog.android.log.LogAttributes
+import com.datadog.android.trace.internal.SpanAttributes
 import com.datadog.android.trace.internal.domain.event.ContextAwareMapper
 import com.datadog.android.trace.internal.storage.ContextAwareSerializer
 import com.datadog.android.trace.model.SpanEvent
@@ -27,6 +30,7 @@ import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -35,9 +39,12 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -45,6 +52,7 @@ import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.util.Locale
+import java.util.UUID
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -141,6 +149,186 @@ internal class OtelTraceWriterTest {
         }
         verifyNoMoreInteractions(mockEventBatchWriter)
     }
+
+    // region RUM context
+
+    @Test
+    fun `M write spans W write() { with RUM context }`(
+        @Forgery fakeApplicationId: UUID,
+        @Forgery fakeSessionId: UUID,
+        @Forgery fakeViewId: UUID,
+        @Forgery fakeActionId: UUID,
+        forge: Forge
+    ) {
+        // GIVEN
+        val fakeInitialDatadogContext = forge.getForgery<DatadogContext>().let {
+            it.copy(
+                featuresContext = it.featuresContext + mapOf(
+                    Feature.RUM_FEATURE_NAME to mapOf(
+                        "application_id" to fakeApplicationId.toString(),
+                        "session_id" to fakeSessionId.toString(),
+                        "view_id" to fakeViewId.toString(),
+                        "action_id" to fakeActionId.toString()
+                    )
+                )
+            )
+        }
+        val fakeLazyContext = CompletableFuture<DatadogContext>().apply { complete(fakeInitialDatadogContext) }
+        val ddSpans = createNonEmptyDdSpans(forge, includeDropSamplingPriority = false)
+            .map {
+                it.apply {
+                    whenever(tags) doReturn mapOf(SpanAttributes.DATADOG_INITIAL_CONTEXT to fakeLazyContext)
+                }
+            }
+
+        whenever(mockLegacyMapper.map(eq(fakeDatadogContext), any())) doReturn forge.getForgery<SpanEvent>()
+        whenever(mockSerializer.serialize(eq(fakeDatadogContext), any())) doReturn forge.aString()
+
+        // WHEN
+        testedWriter.write(ddSpans)
+
+        // THEN
+        argumentCaptor<DDSpan> {
+            verify(mockLegacyMapper, times(ddSpans.size)).map(eq(fakeDatadogContext), capture())
+            allValues.forEach {
+                verify(it).setTag(LogAttributes.RUM_APPLICATION_ID, fakeApplicationId.toString())
+                verify(it).setTag(LogAttributes.RUM_VIEW_ID, fakeViewId.toString())
+                verify(it).setTag(LogAttributes.RUM_SESSION_ID, fakeSessionId.toString())
+                verify(it).setTag(LogAttributes.RUM_ACTION_ID, fakeActionId.toString())
+                verify(it).setTag(SpanAttributes.DATADOG_INITIAL_CONTEXT, null as String?)
+            }
+        }
+
+        ddSpans.forEach {
+            it.finish()
+        }
+    }
+
+    @Test
+    fun `M write spans W write() { without RUM context when empty }`(
+        forge: Forge
+    ) {
+        // GIVEN
+        val fakeInitialDatadogContext = forge.getForgery<DatadogContext>().let {
+            it.copy(
+                featuresContext = it.featuresContext + mapOf(
+                    Feature.RUM_FEATURE_NAME to emptyMap<String, Any?>()
+                )
+            )
+        }
+        val fakeLazyContext = CompletableFuture<DatadogContext>().apply { complete(fakeInitialDatadogContext) }
+        val ddSpans = createNonEmptyDdSpans(forge, includeDropSamplingPriority = false)
+            .map {
+                it.apply {
+                    whenever(tags) doReturn mapOf(SpanAttributes.DATADOG_INITIAL_CONTEXT to fakeLazyContext)
+                }
+            }
+
+        whenever(mockLegacyMapper.map(eq(fakeDatadogContext), any())) doReturn forge.getForgery<SpanEvent>()
+        whenever(mockSerializer.serialize(eq(fakeDatadogContext), any())) doReturn forge.aString()
+
+        // WHEN
+        testedWriter.write(ddSpans)
+
+        // THEN
+        argumentCaptor<DDSpan> {
+            verify(mockLegacyMapper, times(ddSpans.size)).map(eq(fakeDatadogContext), capture())
+            allValues.forEach {
+                verify(it, never()).setTag(eq(LogAttributes.RUM_APPLICATION_ID), any<String>())
+                verify(it, never()).setTag(eq(LogAttributes.RUM_SESSION_ID), any<String>())
+                verify(it, never()).setTag(eq(LogAttributes.RUM_VIEW_ID), any<String>())
+                verify(it, never()).setTag(eq(LogAttributes.RUM_ACTION_ID), any<String>())
+                verify(it).setTag(SpanAttributes.DATADOG_INITIAL_CONTEXT, null as String?)
+            }
+            assertThat(allValues).isEqualTo(ddSpans)
+        }
+
+        ddSpans.forEach {
+            it.finish()
+        }
+    }
+
+    @Test
+    fun `M write spans W write() { without RUM context, lazy Datadog context is not complete }`(
+        forge: Forge
+    ) {
+        // GIVEN
+        val fakeLazyContext = CompletableFuture<DatadogContext>()
+        val ddSpans = createNonEmptyDdSpans(forge, includeDropSamplingPriority = false)
+            .map {
+                it.apply {
+                    whenever(tags) doReturn mapOf(SpanAttributes.DATADOG_INITIAL_CONTEXT to fakeLazyContext)
+                }
+            }
+
+        whenever(mockLegacyMapper.map(eq(fakeDatadogContext), any())) doReturn forge.getForgery<SpanEvent>()
+        whenever(mockSerializer.serialize(eq(fakeDatadogContext), any())) doReturn forge.aString()
+
+        // WHEN
+        testedWriter.write(ddSpans)
+
+        // THEN
+        argumentCaptor<DDSpan> {
+            verify(mockLegacyMapper, times(ddSpans.size)).map(eq(fakeDatadogContext), capture())
+            allValues.forEach {
+                verify(it, never()).setTag(eq(LogAttributes.RUM_APPLICATION_ID), any<String>())
+                verify(it, never()).setTag(eq(LogAttributes.RUM_SESSION_ID), any<String>())
+                verify(it, never()).setTag(eq(LogAttributes.RUM_VIEW_ID), any<String>())
+                verify(it, never()).setTag(eq(LogAttributes.RUM_ACTION_ID), any<String>())
+                verify(it).setTag(SpanAttributes.DATADOG_INITIAL_CONTEXT, null as String?)
+            }
+            assertThat(allValues).isEqualTo(ddSpans)
+        }
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            InternalLogger.Target.USER,
+            TraceWriter.INITIAL_DATADOG_CONTEXT_NOT_AVAILABLE_ERROR,
+            mode = times(ddSpans.size)
+        )
+
+        ddSpans.forEach {
+            it.finish()
+        }
+    }
+
+    @Test
+    fun `M write spans W write() { without RUM context, lazy Datadog context is of wrong type }`(
+        forge: Forge
+    ) {
+        // GIVEN
+        val ddSpans = createNonEmptyDdSpans(forge, includeDropSamplingPriority = false)
+            .map {
+                it.apply {
+                    whenever(tags) doReturn mapOf(SpanAttributes.DATADOG_INITIAL_CONTEXT to Any())
+                }
+            }
+
+        whenever(mockLegacyMapper.map(eq(fakeDatadogContext), any())) doReturn forge.getForgery<SpanEvent>()
+        whenever(mockSerializer.serialize(eq(fakeDatadogContext), any())) doReturn forge.aString()
+
+        // WHEN
+        testedWriter.write(ddSpans)
+
+        // THEN
+        argumentCaptor<DDSpan> {
+            verify(mockLegacyMapper, times(ddSpans.size)).map(eq(fakeDatadogContext), capture())
+            allValues.forEach {
+                verify(it, never()).setTag(eq(LogAttributes.RUM_APPLICATION_ID), any<String>())
+                verify(it, never()).setTag(eq(LogAttributes.RUM_SESSION_ID), any<String>())
+                verify(it, never()).setTag(eq(LogAttributes.RUM_VIEW_ID), any<String>())
+                verify(it, never()).setTag(eq(LogAttributes.RUM_ACTION_ID), any<String>())
+                verify(it).setTag(SpanAttributes.DATADOG_INITIAL_CONTEXT, null as String?)
+            }
+            assertThat(allValues).isEqualTo(ddSpans)
+        }
+        verifyNoInteractions(mockInternalLogger)
+
+        ddSpans.forEach {
+            it.finish()
+        }
+    }
+
+    // endregion
 
     @Test
     fun `M not write spans with drop sampling priority W write()`(forge: Forge) {

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/TraceWriterTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/TraceWriterTest.kt
@@ -16,6 +16,9 @@ import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.event.EventMapper
+import com.datadog.android.internal.concurrent.CompletableFuture
+import com.datadog.android.log.LogAttributes
+import com.datadog.android.trace.AndroidTracer
 import com.datadog.android.trace.internal.domain.event.ContextAwareMapper
 import com.datadog.android.trace.internal.storage.ContextAwareSerializer
 import com.datadog.android.trace.model.SpanEvent
@@ -28,6 +31,7 @@ import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -36,9 +40,11 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -46,6 +52,7 @@ import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.util.Locale
+import java.util.UUID
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -147,6 +154,178 @@ internal class TraceWriterTest {
             it.finish()
         }
     }
+
+    // region RUM context
+
+    @Test
+    fun `M write spans W write() { with RUM context }`(
+        @Forgery fakeApplicationId: UUID,
+        @Forgery fakeSessionId: UUID,
+        @Forgery fakeViewId: UUID,
+        @Forgery fakeActionId: UUID,
+        forge: Forge
+    ) {
+        // GIVEN
+        val fakeInitialDatadogContext = forge.getForgery<DatadogContext>().let {
+            it.copy(
+                featuresContext = it.featuresContext + mapOf(
+                    Feature.RUM_FEATURE_NAME to mapOf(
+                        "application_id" to fakeApplicationId.toString(),
+                        "session_id" to fakeSessionId.toString(),
+                        "view_id" to fakeViewId.toString(),
+                        "action_id" to fakeActionId.toString()
+                    )
+                )
+            )
+        }
+        val fakeLazyContext = CompletableFuture<DatadogContext>().apply { complete(fakeInitialDatadogContext) }
+        val ddSpans = generateSpanListWithPriorities(forge, TraceWriter.KEEP_AND_UNSET_SAMPLING_PRIORITIES)
+            .map {
+                it.apply { setTag(AndroidTracer.DATADOG_CONTEXT_TAG, fakeLazyContext) }
+            }
+
+        whenever(mockLegacyMapper.map(eq(fakeDatadogContext), any())) doReturn forge.getForgery<SpanEvent>()
+        whenever(mockSerializer.serialize(eq(fakeDatadogContext), any())) doReturn forge.aString()
+
+        // WHEN
+        testedWriter.write(ddSpans)
+
+        // THEN
+        argumentCaptor<DDSpan> {
+            verify(mockLegacyMapper, times(ddSpans.size)).map(eq(fakeDatadogContext), capture())
+            allValues.forEach {
+                assertThat(it.tags[LogAttributes.RUM_APPLICATION_ID]).isEqualTo(fakeApplicationId.toString())
+                assertThat(it.tags[LogAttributes.RUM_SESSION_ID]).isEqualTo(fakeSessionId.toString())
+                assertThat(it.tags[LogAttributes.RUM_VIEW_ID]).isEqualTo(fakeViewId.toString())
+                assertThat(it.tags[LogAttributes.RUM_ACTION_ID]).isEqualTo(fakeActionId.toString())
+                assertThat(it.tags).doesNotContainKey(AndroidTracer.DATADOG_CONTEXT_TAG.key)
+            }
+        }
+
+        ddSpans.forEach {
+            it.finish()
+        }
+    }
+
+    @Test
+    fun `M write spans W write() { without RUM context when empty }`(
+        forge: Forge
+    ) {
+        // GIVEN
+        val fakeInitialDatadogContext = forge.getForgery<DatadogContext>().let {
+            it.copy(
+                featuresContext = it.featuresContext + mapOf(
+                    Feature.RUM_FEATURE_NAME to emptyMap<String, Any?>()
+                )
+            )
+        }
+        val fakeLazyContext = CompletableFuture<DatadogContext>().apply { complete(fakeInitialDatadogContext) }
+        val ddSpans = generateSpanListWithPriorities(forge, TraceWriter.KEEP_AND_UNSET_SAMPLING_PRIORITIES)
+            .map {
+                it.apply { setTag(AndroidTracer.DATADOG_CONTEXT_TAG, fakeLazyContext) }
+            }
+
+        whenever(mockLegacyMapper.map(eq(fakeDatadogContext), any())) doReturn forge.getForgery<SpanEvent>()
+        whenever(mockSerializer.serialize(eq(fakeDatadogContext), any())) doReturn forge.aString()
+
+        // WHEN
+        testedWriter.write(ddSpans)
+
+        // THEN
+        argumentCaptor<DDSpan> {
+            verify(mockLegacyMapper, times(ddSpans.size)).map(eq(fakeDatadogContext), capture())
+            allValues.forEach {
+                assertThat(it.tags).doesNotContainKey(LogAttributes.RUM_APPLICATION_ID)
+                assertThat(it.tags).doesNotContainKey(LogAttributes.RUM_SESSION_ID)
+                assertThat(it.tags).doesNotContainKey(LogAttributes.RUM_VIEW_ID)
+                assertThat(it.tags).doesNotContainKey(LogAttributes.RUM_ACTION_ID)
+                assertThat(it.tags).doesNotContainKey(AndroidTracer.DATADOG_CONTEXT_TAG.key)
+            }
+            assertThat(allValues).isEqualTo(ddSpans)
+        }
+
+        ddSpans.forEach {
+            it.finish()
+        }
+    }
+
+    @Test
+    fun `M write spans W write() { without RUM context, lazy Datadog context is not complete }`(
+        forge: Forge
+    ) {
+        // GIVEN
+        val fakeLazyContext = CompletableFuture<DatadogContext>()
+        val ddSpans = generateSpanListWithPriorities(forge, TraceWriter.KEEP_AND_UNSET_SAMPLING_PRIORITIES)
+            .map {
+                it.apply { setTag(AndroidTracer.DATADOG_CONTEXT_TAG, fakeLazyContext) }
+            }
+
+        whenever(mockLegacyMapper.map(eq(fakeDatadogContext), any())) doReturn forge.getForgery<SpanEvent>()
+        whenever(mockSerializer.serialize(eq(fakeDatadogContext), any())) doReturn forge.aString()
+
+        // WHEN
+        testedWriter.write(ddSpans)
+
+        // THEN
+        argumentCaptor<DDSpan> {
+            verify(mockLegacyMapper, times(ddSpans.size)).map(eq(fakeDatadogContext), capture())
+            allValues.forEach {
+                assertThat(it.tags).doesNotContainKey(LogAttributes.RUM_APPLICATION_ID)
+                assertThat(it.tags).doesNotContainKey(LogAttributes.RUM_SESSION_ID)
+                assertThat(it.tags).doesNotContainKey(LogAttributes.RUM_VIEW_ID)
+                assertThat(it.tags).doesNotContainKey(LogAttributes.RUM_ACTION_ID)
+                assertThat(it.tags).doesNotContainKey(AndroidTracer.DATADOG_CONTEXT_TAG.key)
+            }
+            assertThat(allValues).isEqualTo(ddSpans)
+        }
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            InternalLogger.Target.USER,
+            TraceWriter.INITIAL_DATADOG_CONTEXT_NOT_AVAILABLE_ERROR,
+            mode = times(ddSpans.size)
+        )
+
+        ddSpans.forEach {
+            it.finish()
+        }
+    }
+
+    @Test
+    fun `M write spans W write() { without RUM context, lazy Datadog context is of wrong type }`(
+        forge: Forge
+    ) {
+        // GIVEN
+        val ddSpans = generateSpanListWithPriorities(forge, TraceWriter.KEEP_AND_UNSET_SAMPLING_PRIORITIES)
+            .map {
+                it.apply { setTag(AndroidTracer.DATADOG_CONTEXT_TAG.key, forge.aString()) }
+            }
+
+        whenever(mockLegacyMapper.map(eq(fakeDatadogContext), any())) doReturn forge.getForgery<SpanEvent>()
+        whenever(mockSerializer.serialize(eq(fakeDatadogContext), any())) doReturn forge.aString()
+
+        // WHEN
+        testedWriter.write(ddSpans)
+
+        // THEN
+        argumentCaptor<DDSpan> {
+            verify(mockLegacyMapper, times(ddSpans.size)).map(eq(fakeDatadogContext), capture())
+            allValues.forEach {
+                assertThat(it.tags).doesNotContainKey(LogAttributes.RUM_APPLICATION_ID)
+                assertThat(it.tags).doesNotContainKey(LogAttributes.RUM_SESSION_ID)
+                assertThat(it.tags).doesNotContainKey(LogAttributes.RUM_VIEW_ID)
+                assertThat(it.tags).doesNotContainKey(LogAttributes.RUM_ACTION_ID)
+                assertThat(it.tags).doesNotContainKey(AndroidTracer.DATADOG_CONTEXT_TAG.key)
+            }
+            assertThat(allValues).isEqualTo(ddSpans)
+        }
+        verifyNoInteractions(mockInternalLogger)
+
+        ddSpans.forEach {
+            it.finish()
+        }
+    }
+
+    // endregion
 
     @Test
     fun `M not write spans with drop sampling priority W write() { drop sampling decision }`(forge: Forge) {

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubFeatureScope.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubFeatureScope.kt
@@ -66,6 +66,10 @@ internal class StubFeatureScope(
         )
     }
 
+    override fun withContext(callback: (datadogContext: DatadogContext) -> Unit) {
+        callback(datadogContextProvider())
+    }
+
     override fun getWriteContextSync(): Pair<DatadogContext, EventWriteScope>? {
         return datadogContextProvider() to { it.invoke(eventBatchWriter) }
     }


### PR DESCRIPTION
### What does this PR do?

Right now when span is started and `bundleWithRum=true` in OpenTracing or OpenTelemetry tracers configuration, we are doing a call to get RUM context in the synchronous way, thus blocking a caller thread.

With the migration to the context processing thread, we cannot allow long blocking on the caller thread, so in this PR we do a lazy capture of the `DatadogContext` at the span creation time and add a captor as a span tag.

Later on it is safe to access value captured at the span write stage, because `withWriteContext` will also be executed on the context processing thread, meaning by that time the call we did before (`withContext`) to capture initial context will be completed.

This PR aims to glue the blocking/sync API of tracing and async API of the event/context processing.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

