### PR TITLE
Fix flaky `DatadogRumMonitor` tests

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -205,6 +205,7 @@ internal class DatadogRumMonitorTest {
             val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
             callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
+        whenever(mockRumFeatureScope.getWriteContextSync()) doReturn (fakeDatadogContext to mockEventWriteScope)
 
         fakeAttributes = forge.exhaustiveAttributes()
         testedMonitor = DatadogRumMonitor(


### PR DESCRIPTION
### What does this PR do?

Tests for `DatadogRumMonitor` were flaky because of the missing setup.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

