### PR TITLE
RUM-9345: Use reflection to retrieve semantics information in modifier

### DIFF
--- a/integrations/dd-sdk-android-compose/build.gradle.kts
+++ b/integrations/dd-sdk-android-compose/build.gradle.kts
@@ -39,6 +39,9 @@ plugins {
 
 android {
     namespace = "com.datadog.android.compose"
+    defaultConfig {
+        consumerProguardFiles("consumer-rules.pro")
+    }
     buildFeatures {
         compose = true
     }

--- a/integrations/dd-sdk-android-compose/consumer-rules.pro
+++ b/integrations/dd-sdk-android-compose/consumer-rules.pro
@@ -1,0 +1,7 @@
+# Keep the Compose internals class name. We need this in the RUM actions tracking.
+-keep class androidx.compose.foundation.ClickableElement {
+    <fields>;
+}
+-keep class androidx.compose.foundation.CombinedClickableElement {
+    <fields>;
+}


### PR DESCRIPTION
### What does this PR do?

Using internal field `collapsedSemantics` of `LayoutNode` may not work in all the build types, so this PR replaces it with classic reflection to retrieve the additional semantics information for the node.

Also fix the catch `Throwable` instead of `Exception`.

### Motivation

RUM-9345


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

