### PR TITLE
RUM-10120: Better project-type dependency resolution for Detekt custom rules execution

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/DetektCustomConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/DetektCustomConfig.kt
@@ -8,6 +8,7 @@ package com.datadog.gradle.config
 
 import com.android.build.gradle.LibraryExtension
 import org.gradle.api.Project
+import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileTree
 import org.gradle.api.internal.file.UnionFileTree
@@ -17,9 +18,7 @@ import org.gradle.api.tasks.JavaExec
 import java.io.File
 import java.util.Properties
 
-fun Project.detektCustomConfig(
-    vararg moduleDependencies: String
-) {
+fun Project.detektCustomConfig() {
     val ext = extensions.findByType(LibraryExtension::class.java)
 
     tasks.register("printDetektClasspath") {
@@ -98,6 +97,23 @@ fun Project.detektCustomConfig(
         args("-i", projectDir.absolutePath)
         args("-ex", "**/*.kts")
         args("--jvm-target", "11")
+
+        val moduleDependencies = configurations
+            .filter { it.name == "implementation" || it.name == "api" }
+            .flatMap { it.dependencies.filterIsInstance<ProjectDependency>() }
+            .map { it.path }
+            .toSet()
+            .let {
+                // api configurations have canBeResolved=false, so we cannot go inside them to see transitive
+                // module dependencies, so including common modules
+                if (project.path == ":dd-sdk-android-internal") {
+                    it
+                } else if (project.path == ":dd-sdk-android-core") {
+                    it + ":dd-sdk-android-internal"
+                } else {
+                    it + setOf(":dd-sdk-android-core", ":dd-sdk-android-internal")
+                }
+            }
 
         val externalDependencies = File("${projectDir.absolutePath}/detekt_classpath").readText()
         val moduleDependenciesClasses = moduleDependencies.map {

--- a/features/dd-sdk-android-logs/build.gradle.kts
+++ b/features/dd-sdk-android-logs/build.gradle.kts
@@ -88,4 +88,4 @@ publishingConfig(
     "The Logs feature to use with the Datadog monitoring " +
         "library for Android applications."
 )
-detektCustomConfig(":dd-sdk-android-core", ":dd-sdk-android-internal")
+detektCustomConfig()

--- a/features/dd-sdk-android-ndk/build.gradle.kts
+++ b/features/dd-sdk-android-ndk/build.gradle.kts
@@ -109,4 +109,4 @@ dependencyUpdateConfig()
 publishingConfig(
     "An NDK integration to use with the Datadog monitoring library for Android applications."
 )
-detektCustomConfig(":dd-sdk-android-core")
+detektCustomConfig()

--- a/features/dd-sdk-android-rum/build.gradle.kts
+++ b/features/dd-sdk-android-rum/build.gradle.kts
@@ -118,4 +118,4 @@ publishingConfig(
     "The RUM feature to use with the Datadog monitoring " +
         "library for Android applications."
 )
-detektCustomConfig(":dd-sdk-android-core", ":dd-sdk-android-internal")
+detektCustomConfig()

--- a/features/dd-sdk-android-session-replay-compose/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-compose/build.gradle.kts
@@ -87,8 +87,4 @@ dependencyUpdateConfig()
 publishingConfig(
     "Session Replay Extension Support for Jetpack Compose."
 )
-detektCustomConfig(
-    ":dd-sdk-android-core",
-    ":dd-sdk-android-internal",
-    ":features:dd-sdk-android-session-replay"
-)
+detektCustomConfig()

--- a/features/dd-sdk-android-session-replay-material/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-material/build.gradle.kts
@@ -70,4 +70,4 @@ dependencyUpdateConfig()
 publishingConfig(
     "Session Replay Extension Support for Material UI components."
 )
-detektCustomConfig(":dd-sdk-android-core", ":dd-sdk-android-internal", ":features:dd-sdk-android-session-replay")
+detektCustomConfig()

--- a/features/dd-sdk-android-session-replay/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay/build.gradle.kts
@@ -90,4 +90,4 @@ publishingConfig(
     "The Session Replay feature to use with the Datadog monitoring " +
         "library for Android applications."
 )
-detektCustomConfig(":dd-sdk-android-core", ":dd-sdk-android-internal")
+detektCustomConfig()

--- a/features/dd-sdk-android-trace-otel/build.gradle.kts
+++ b/features/dd-sdk-android-trace-otel/build.gradle.kts
@@ -88,4 +88,4 @@ dependencyUpdateConfig()
 publishingConfig(
     "The tracing library for Android, providing OpenTelemetry compatibility."
 )
-detektCustomConfig(":dd-sdk-android-core", ":features:dd-sdk-android-trace")
+detektCustomConfig()

--- a/features/dd-sdk-android-trace/build.gradle.kts
+++ b/features/dd-sdk-android-trace/build.gradle.kts
@@ -93,4 +93,4 @@ publishingConfig(
     "The Tracing feature to use with the Datadog monitoring " +
         "library for Android applications."
 )
-detektCustomConfig(":dd-sdk-android-core", ":dd-sdk-android-internal")
+detektCustomConfig()

--- a/features/dd-sdk-android-webview/build.gradle.kts
+++ b/features/dd-sdk-android-webview/build.gradle.kts
@@ -81,4 +81,4 @@ publishingConfig(
     "The WebView integration feature to use with the Datadog monitoring " +
         "library for Android applications."
 )
-detektCustomConfig(":dd-sdk-android-internal")
+detektCustomConfig()

--- a/integrations/dd-sdk-android-coil/build.gradle.kts
+++ b/integrations/dd-sdk-android-coil/build.gradle.kts
@@ -67,4 +67,4 @@ dependencyUpdateConfig()
 publishingConfig(
     "A Coil integration to use with the Datadog monitoring library for Android applications."
 )
-detektCustomConfig(":dd-sdk-android-core", ":dd-sdk-android-internal", ":features:dd-sdk-android-rum")
+detektCustomConfig()

--- a/integrations/dd-sdk-android-compose/build.gradle.kts
+++ b/integrations/dd-sdk-android-compose/build.gradle.kts
@@ -93,4 +93,4 @@ publishingConfig(
     "A Jetpack Compose integration to use with the Datadog monitoring library" +
         " for Android applications."
 )
-detektCustomConfig(":dd-sdk-android-core", ":dd-sdk-android-internal", ":features:dd-sdk-android-rum")
+detektCustomConfig()

--- a/integrations/dd-sdk-android-fresco/build.gradle.kts
+++ b/integrations/dd-sdk-android-fresco/build.gradle.kts
@@ -67,4 +67,4 @@ dependencyUpdateConfig()
 publishingConfig(
     "A Fresco integration to use with the Datadog monitoring library for Android applications."
 )
-detektCustomConfig(":dd-sdk-android-core", ":dd-sdk-android-internal", ":features:dd-sdk-android-rum")
+detektCustomConfig()

--- a/integrations/dd-sdk-android-glide/build.gradle.kts
+++ b/integrations/dd-sdk-android-glide/build.gradle.kts
@@ -68,9 +68,4 @@ dependencyUpdateConfig()
 publishingConfig(
     "A Glide integration to use with the Datadog monitoring library for Android applications."
 )
-detektCustomConfig(
-    ":dd-sdk-android-core",
-    ":dd-sdk-android-internal",
-    ":features:dd-sdk-android-rum",
-    ":integrations:dd-sdk-android-okhttp"
-)
+detektCustomConfig()

--- a/integrations/dd-sdk-android-okhttp-otel/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp-otel/build.gradle.kts
@@ -67,9 +67,4 @@ dependencyUpdateConfig()
 publishingConfig(
     "An OkHttp collection of extensions to be used in conjunction with OpenTelemetry Datadog SDK."
 )
-detektCustomConfig(
-    ":dd-sdk-android-core",
-    ":dd-sdk-android-internal",
-    ":features:dd-sdk-android-trace-otel",
-    ":integrations:dd-sdk-android-okhttp"
-)
+detektCustomConfig()

--- a/integrations/dd-sdk-android-okhttp/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp/build.gradle.kts
@@ -84,9 +84,4 @@ dependencyUpdateConfig()
 publishingConfig(
     "An OkHttp monitoring integration to use with the Datadog monitoring library for Android applications."
 )
-detektCustomConfig(
-    ":dd-sdk-android-core",
-    ":dd-sdk-android-internal",
-    ":features:dd-sdk-android-rum",
-    ":features:dd-sdk-android-trace"
-)
+detektCustomConfig()

--- a/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
@@ -65,4 +65,4 @@ dependencyUpdateConfig()
 publishingConfig(
     "A RUM Coroutines extension library to use with the Datadog monitoring library for Android applications."
 )
-detektCustomConfig(":dd-sdk-android-core", ":dd-sdk-android-internal", ":features:dd-sdk-android-rum")
+detektCustomConfig()

--- a/integrations/dd-sdk-android-rx/build.gradle.kts
+++ b/integrations/dd-sdk-android-rx/build.gradle.kts
@@ -67,4 +67,4 @@ dependencyUpdateConfig()
 publishingConfig(
     "A RxJava integration to use with the Datadog monitoring library for Android applications."
 )
-detektCustomConfig(":dd-sdk-android-core", ":dd-sdk-android-internal", ":features:dd-sdk-android-rum")
+detektCustomConfig()

--- a/integrations/dd-sdk-android-sqldelight/build.gradle.kts
+++ b/integrations/dd-sdk-android-sqldelight/build.gradle.kts
@@ -68,9 +68,4 @@ dependencyUpdateConfig()
 publishingConfig(
     "A SQLDelight integration to use with the Datadog monitoring library for Android applications."
 )
-detektCustomConfig(
-    ":dd-sdk-android-core",
-    ":dd-sdk-android-internal",
-    ":features:dd-sdk-android-rum",
-    ":features:dd-sdk-android-trace"
-)
+detektCustomConfig()

--- a/integrations/dd-sdk-android-timber/build.gradle.kts
+++ b/integrations/dd-sdk-android-timber/build.gradle.kts
@@ -66,4 +66,4 @@ dependencyUpdateConfig()
 publishingConfig(
     "A Timber integration to use with the Datadog monitoring library for Android applications."
 )
-detektCustomConfig(":dd-sdk-android-core", ":dd-sdk-android-internal", ":features:dd-sdk-android-logs")
+detektCustomConfig()

--- a/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
@@ -65,4 +65,4 @@ dependencyUpdateConfig()
 publishingConfig(
     "A Trace Coroutines extension library to use with the Datadog monitoring library for Android applications."
 )
-detektCustomConfig(":dd-sdk-android-core", ":dd-sdk-android-internal", ":features:dd-sdk-android-trace")
+detektCustomConfig()

--- a/integrations/dd-sdk-android-tv/build.gradle.kts
+++ b/integrations/dd-sdk-android-tv/build.gradle.kts
@@ -65,4 +65,4 @@ dependencyUpdateConfig()
 publishingConfig(
     "An Android TV integration to use with the Datadog monitoring library for Android applications."
 )
-detektCustomConfig(":dd-sdk-android-core", ":dd-sdk-android-internal", ":features:dd-sdk-android-rum")
+detektCustomConfig()


### PR DESCRIPTION
### What does this PR do?

I noticed that during custom Detekt rules job execution there were some warnings regarding the types that cannot be resolved.

This PR removes (mostly) the need to specify project dependencies for Detekt run, although there is a pitfall: `api` configuration cannot be resolved, so we cannot know transitive project dependencies. Maybe this can be solved with detached configuration, but for now let's just specify most common modules `:dd-sdk-android-core` and `:dd-sdk-android-internal` by default for everything.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

