### PR TITLE
RUM-9504 remove deprecated startResource

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -104,7 +104,6 @@ interface com.datadog.android.rum.RumMonitor
   fun addAction(RumActionType, String, Map<String, Any?>)
   fun startAction(RumActionType, String, Map<String, Any?>)
   fun stopAction(RumActionType, String, Map<String, Any?> = emptyMap())
-  DEPRECATED fun startResource(String, String, String, Map<String, Any?> = emptyMap())
   fun startResource(String, RumResourceMethod, String, Map<String, Any?> = emptyMap())
   fun stopResource(String, Int?, Long?, RumResourceKind, Map<String, Any?>)
   fun stopResourceWithError(String, Int?, String, RumErrorSource, Throwable, Map<String, Any?> = emptyMap())

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -163,7 +163,6 @@ public abstract interface class com/datadog/android/rum/RumMonitor {
 	public abstract fun setDebug (Z)V
 	public abstract fun startAction (Lcom/datadog/android/rum/RumActionType;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun startResource (Ljava/lang/String;Lcom/datadog/android/rum/RumResourceMethod;Ljava/lang/String;Ljava/util/Map;)V
-	public abstract fun startResource (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun startView (Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun stopAction (Lcom/datadog/android/rum/RumActionType;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun stopResource (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Long;Lcom/datadog/android/rum/RumResourceKind;Ljava/util/Map;)V
@@ -175,7 +174,6 @@ public abstract interface class com/datadog/android/rum/RumMonitor {
 
 public final class com/datadog/android/rum/RumMonitor$DefaultImpls {
 	public static synthetic fun startResource$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Lcom/datadog/android/rum/RumResourceMethod;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
-	public static synthetic fun startResource$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun startView$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun stopAction$default (Lcom/datadog/android/rum/RumMonitor;Lcom/datadog/android/rum/RumActionType;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun stopResourceWithError$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -121,28 +121,6 @@ interface RumMonitor {
      * @see [stopResource]
      * @see [stopResourceWithError]
      */
-    @Deprecated(
-        "This method is deprecated and will be removed in the future versions." +
-            " Use `startResource` method which takes `RumHttpMethod` as `method` parameter instead."
-    )
-    fun startResource(
-        key: String,
-        method: String,
-        url: String,
-        attributes: Map<String, Any?> = emptyMap()
-    )
-
-    /**
-     * Notify that a new Resource is being loaded, linked with the [key] instance.
-     * @param key the instance that represents the resource being loaded (usually your
-     * request or network call instance).
-     * @param method the method used to load the resource (E.g., for network: "GET" or "POST")
-     * @param url the url or local path of the resource being loaded
-     * @param attributes additional custom attributes to attach to the resource. Attributes can be
-     * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK.
-     * @see [stopResource]
-     * @see [stopResourceWithError]
-     */
     fun startResource(
         key: String,
         method: RumResourceMethod,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -201,44 +201,6 @@ internal class DatadogRumMonitor(
         )
     }
 
-    @Deprecated(
-        "This method is deprecated and will be removed in the future versions." +
-            " Use `startResource` method which takes `RumHttpMethod` as `method` parameter instead."
-    )
-    override fun startResource(
-        key: String,
-        method: String,
-        url: String,
-        attributes: Map<String, Any?>
-    ) {
-        // enum value names may be changed if obfuscation is aggressive
-        val rumResourceMethod = when (method.uppercase(Locale.US)) {
-            "POST" -> RumResourceMethod.POST
-            "GET" -> RumResourceMethod.GET
-            "HEAD" -> RumResourceMethod.HEAD
-            "PUT" -> RumResourceMethod.PUT
-            "DELETE" -> RumResourceMethod.DELETE
-            "PATCH" -> RumResourceMethod.PATCH
-            "CONNECT" -> RumResourceMethod.CONNECT
-            "TRACE" -> RumResourceMethod.TRACE
-            "OPTIONS" -> RumResourceMethod.OPTIONS
-            else -> {
-                sdkCore.internalLogger.log(
-                    InternalLogger.Level.WARN,
-                    InternalLogger.Target.USER,
-                    {
-                        "Unsupported HTTP method %s reported, using GET instead".format(
-                            Locale.US,
-                            method
-                        )
-                    }
-                )
-                RumResourceMethod.GET
-            }
-        }
-        startResource(key, rumResourceMethod, url, attributes)
-    }
-
     override fun startResource(
         key: String,
         method: RumResourceMethod,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -93,7 +93,6 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
-import java.util.Locale
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -430,61 +429,6 @@ internal class DatadogRumMonitorTest {
             val event = firstValue as RumRawEvent.StopAction
             assertThat(event.type).isEqualTo(type)
             assertThat(event.name).isEqualTo(name)
-            assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
-        }
-        verifyNoMoreInteractions(mockScope, mockWriter)
-    }
-
-    @Test
-    fun `M delegate event to rootScope W startResource() { deprecated, known http method }`(
-        @StringForgery key: String,
-        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String,
-        forge: Forge
-    ) {
-        val method = forge.anElementFrom(
-            "GeT",
-            "PoSt",
-            "pUt",
-            "HeAd",
-            "DeLeTe",
-            "pAtCh",
-            "cOnnEct",
-            "TrAcE",
-            "oPtIoNs"
-        )
-        @Suppress("DEPRECATION")
-        testedMonitor.startResource(key, method, url, fakeAttributes)
-        Thread.sleep(PROCESSING_DELAY)
-
-        argumentCaptor<RumRawEvent> {
-            verify(mockScope).handleEvent(capture(), same(mockWriter))
-
-            val event = firstValue as RumRawEvent.StartResource
-            assertThat(event.key).isEqualTo(key)
-            assertThat(event.method.name).isEqualTo(method.uppercase(Locale.US))
-            assertThat(event.url).isEqualTo(url)
-            assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
-        }
-        verifyNoMoreInteractions(mockScope, mockWriter)
-    }
-
-    @Test
-    fun `M delegate event to rootScope W startResource() { deprecated, unknown http method }`(
-        @StringForgery key: String,
-        @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
-    ) {
-        @Suppress("DEPRECATION")
-        testedMonitor.startResource(key, method, url, fakeAttributes)
-        Thread.sleep(PROCESSING_DELAY)
-
-        argumentCaptor<RumRawEvent> {
-            verify(mockScope).handleEvent(capture(), same(mockWriter))
-
-            val event = firstValue as RumRawEvent.StartResource
-            assertThat(event.key).isEqualTo(key)
-            assertThat(event.method).isEqualTo(RumResourceMethod.GET)
-            assertThat(event.url).isEqualTo(url)
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
         }
         verifyNoMoreInteractions(mockScope, mockWriter)


### PR DESCRIPTION
### What does this PR do?

Remove the deprecated `RumMonitor.startResource()` method