### PR TITLE
RUM-9514 remove deprecated userInfo methods

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -8,7 +8,6 @@ object com.datadog.android.Datadog
   fun getVerbosity(): Int
   fun setTrackingConsent(com.datadog.android.privacy.TrackingConsent, com.datadog.android.api.SdkCore = getInstance())
   fun setUserInfo(String, String? = null, String? = null, Map<String, Any?> = emptyMap(), com.datadog.android.api.SdkCore = getInstance())
-  DEPRECATED fun setUserInfo(String? = null, String? = null, String? = null, Map<String, Any?> = emptyMap(), com.datadog.android.api.SdkCore = getInstance())
   fun addUserProperties(Map<String, Any?>, com.datadog.android.api.SdkCore = getInstance())
   fun clearAllData(com.datadog.android.api.SdkCore = getInstance())
   fun _internalProxy(String? = null): _InternalProxy
@@ -54,7 +53,7 @@ interface com.datadog.android.api.SdkCore
   val service: String
   fun isCoreActive(): Boolean
   fun setTrackingConsent(com.datadog.android.privacy.TrackingConsent)
-  fun setUserInfo(String? = null, String? = null, String? = null, Map<String, Any?> = emptyMap())
+  fun setUserInfo(String, String? = null, String? = null, Map<String, Any?> = emptyMap())
   fun addUserProperties(Map<String, Any?>)
   fun clearAllData()
 data class com.datadog.android.api.context.DatadogContext

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -36,13 +36,6 @@ public final class com/datadog/android/Datadog {
 	public static final fun setUserInfo (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public static final fun setUserInfo (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/datadog/android/api/SdkCore;)V
 	public static synthetic fun setUserInfo$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
-	public static final fun setUserInfoDeprecated ()V
-	public static final fun setUserInfoDeprecated (Ljava/lang/String;)V
-	public static final fun setUserInfoDeprecated (Ljava/lang/String;Ljava/lang/String;)V
-	public static final fun setUserInfoDeprecated (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public static final fun setUserInfoDeprecated (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
-	public static final fun setUserInfoDeprecated (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/datadog/android/api/SdkCore;)V
-	public static synthetic fun setUserInfoDeprecated$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
 	public static final fun setVerbosity (I)V
 	public static final fun stopInstance ()V
 	public static final fun stopInstance (Ljava/lang/String;)V

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -260,31 +260,6 @@ object Datadog {
     }
 
     /**
-     * Sets the user information.
-     *
-     * @param id (nullable) a unique user identifier (relevant to your business domain)
-     * @param name (nullable) the user name or alias
-     * @param email (nullable) the user email
-     * @param extraInfo additional information. An extra information can be
-     * nested up to 8 levels deep. Keys using more than 8 levels will be sanitized by SDK.
-     * @param sdkCore SDK instance to set user info in. If not provided, default SDK instance
-     * will be used.
-     */
-    @JvmStatic
-    @JvmOverloads
-    @Deprecated("UserInfo id property is now mandatory.")
-    @JvmName("setUserInfoDeprecated")
-    fun setUserInfo(
-        id: String? = null,
-        name: String? = null,
-        email: String? = null,
-        extraInfo: Map<String, Any?> = emptyMap(),
-        sdkCore: SdkCore = getInstance()
-    ) {
-        sdkCore.setUserInfo(id, name, email, extraInfo)
-    }
-
-    /**
      * Sets additional information on the [UserInfo] object
      *
      * If properties had originally been set with [SdkCore.setUserInfo], they will be preserved.

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/SdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/SdkCore.kt
@@ -50,7 +50,7 @@ interface SdkCore {
     /**
      * Sets the user information.
      *
-     * @param id (nullable) a unique user identifier (relevant to your business domain)
+     * @param id a unique user identifier (relevant to your business domain)
      * @param name (nullable) the user name or alias
      * @param email (nullable) the user email
      * @param extraInfo additional information. An extra information can be
@@ -58,7 +58,7 @@ interface SdkCore {
      */
     @AnyThread
     fun setUserInfo(
-        id: String? = null,
+        id: String,
         name: String? = null,
         email: String? = null,
         extraInfo: Map<String, Any?> = emptyMap()

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -162,7 +162,7 @@ internal class DatadogCore(
     /** @inheritDoc */
     @AnyThread
     override fun setUserInfo(
-        id: String?,
+        id: String,
         name: String?,
         email: String?,
         extraInfo: Map<String, Any?>

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/NoOpInternalSdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/NoOpInternalSdkCore.kt
@@ -80,7 +80,7 @@ internal object NoOpInternalSdkCore : InternalSdkCore {
     override fun setTrackingConsent(consent: TrackingConsent) = Unit
 
     override fun setUserInfo(
-        id: String?,
+        id: String,
         name: String?,
         email: String?,
         extraInfo: Map<String, Any?>

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/user/DatadogUserInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/user/DatadogUserInfoProvider.kt
@@ -20,7 +20,7 @@ internal class DatadogUserInfoProvider(
             dataWriter.write(field)
         }
 
-    override fun setUserInfo(id: String?, name: String?, email: String?, extraInfo: Map<String, Any?>) {
+    override fun setUserInfo(id: String, name: String?, email: String?, extraInfo: Map<String, Any?>) {
         internalUserInfo = internalUserInfo.copy(
             id = id,
             name = name,

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/user/MutableUserInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/user/MutableUserInfoProvider.kt
@@ -12,7 +12,7 @@ import com.datadog.tools.annotation.NoOpImplementation
 internal interface MutableUserInfoProvider : UserInfoProvider {
 
     fun setUserInfo(
-        id: String?,
+        id: String,
         name: String?,
         email: String?,
         extraInfo: Map<String, Any?>

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/user/DatadogUserInfoProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/user/DatadogUserInfoProviderTest.kt
@@ -53,36 +53,51 @@ internal class DatadogUserInfoProviderTest {
 
     @Test
     fun `M return saved userInfo W setUserInfo() and getUserInfo()`(
-        @Forgery userInfo: UserInfo
+        @Forgery userInfo: UserInfo,
+        @StringForgery userId: String
     ) {
+        // Given
+        val nonNullUserId = userInfo.id ?: userId
+        val validUserInfo = userInfo.copy(id = nonNullUserId)
+
         // When
-        testedProvider.setUserInfo(userInfo.id, userInfo.name, userInfo.email, userInfo.additionalProperties)
+        testedProvider.setUserInfo(nonNullUserId, userInfo.name, userInfo.email, userInfo.additionalProperties)
         val result = testedProvider.getUserInfo()
 
         // Then
-        assertThat(result).isEqualTo(userInfo)
+        assertThat(result).isEqualTo(validUserInfo)
     }
 
     @Test
-    fun `M delegate to persister W setUserInfo`(@Forgery userInfo: UserInfo) {
+    fun `M delegate to persister W setUserInfo`(
+        @Forgery userInfo: UserInfo,
+        @StringForgery userId: String
+    ) {
+        // Given
+        val nonNullUserId = userInfo.id ?: userId
+        val validUserInfo = userInfo.copy(id = nonNullUserId)
+
         // When
-        testedProvider.setUserInfo(userInfo.id, userInfo.name, userInfo.email, userInfo.additionalProperties)
+        testedProvider.setUserInfo(nonNullUserId, userInfo.name, userInfo.email, userInfo.additionalProperties)
 
         // Then
-        verify(mockWriter).write(userInfo)
+        verify(mockWriter).write(validUserInfo)
     }
 
     @Test
     fun `M keep existing properties W addUserProperties() is called`(
         @Forgery userInfo: UserInfo,
-        @StringForgery forge: Forge
+        @StringForgery userId: String,
+        forge: Forge
     ) {
         // Given
         val customProperties = forge.exhaustiveAttributes()
-        testedProvider.setUserInfo(userInfo.id, userInfo.name, userInfo.email, customProperties)
+        val nonNullUserId = userInfo.id ?: userId
+        testedProvider.setUserInfo(nonNullUserId, userInfo.name, userInfo.email, customProperties)
 
         // When
         testedProvider.addUserProperties(customProperties)
+
         // Then
         assertThat(
             testedProvider.getUserInfo().additionalProperties
@@ -91,7 +106,7 @@ internal class DatadogUserInfoProviderTest {
 
     @Test
     fun `M use immutable properties W addUserProperties() is called { changing properties values }`(
-        @StringForgery forge: Forge
+        forge: Forge
     ) {
         // Given
         val fakeProperties = forge.exhaustiveAttributes()
@@ -112,7 +127,7 @@ internal class DatadogUserInfoProviderTest {
 
     @Test
     fun `M use immutable properties W addUserProperties() is called { adding properties }`(
-        @StringForgery forge: Forge
+        forge: Forge
     ) {
         // Given
         val fakeProperties = forge.exhaustiveAttributes()
@@ -133,7 +148,7 @@ internal class DatadogUserInfoProviderTest {
 
     @Test
     fun `M use immutable properties W addUserProperties() is called { removing properties }`(
-        @StringForgery forge: Forge
+        forge: Forge
     ) {
         // Given
         val fakeProperties = forge.exhaustiveAttributes()
@@ -155,12 +170,14 @@ internal class DatadogUserInfoProviderTest {
     @Test
     fun `M keep new property key W addUserProperties() is called and the key already exists`(
         @Forgery userInfo: UserInfo,
+        @StringForgery userId: String,
         @StringForgery key: String,
         @StringForgery value1: String,
         @StringForgery value2: String
     ) {
         // Given
-        testedProvider.setUserInfo(userInfo.id, userInfo.name, userInfo.email, mutableMapOf(key to value1))
+        val nonNullUserId = userInfo.id ?: userId
+        testedProvider.setUserInfo(nonNullUserId, userInfo.name, userInfo.email, mutableMapOf(key to value1))
 
         // When
         testedProvider.addUserProperties(mapOf(key to value2))

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
@@ -22,7 +22,6 @@ import com.datadog.android.log.internal.logger.NoOpLogHandler
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
-import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -126,7 +125,7 @@ internal class LoggerBuilderTest {
     }
 
     @Test
-    fun `builder can set a service name`(@Forgery forge: Forge) {
+    fun `builder can set a service name`(forge: Forge) {
         val serviceName = forge.anAlphabeticalString()
 
         val logger = Logger.Builder(mockSdkCore)
@@ -178,7 +177,7 @@ internal class LoggerBuilderTest {
 
     @Test
     fun `builder can enable only logcat logs`(
-        @Forgery forge: Forge
+        forge: Forge
     ) {
         val logcatLogsEnabled = true
         val fakeServiceName = forge.anAlphaNumericalString()
@@ -211,7 +210,7 @@ internal class LoggerBuilderTest {
     }
 
     @Test
-    fun `builder can set the logger name`(@Forgery forge: Forge) {
+    fun `builder can set the logger name`(forge: Forge) {
         val loggerName = forge.anAlphabeticalString()
 
         val logger = Logger.Builder(mockSdkCore)
@@ -243,7 +242,7 @@ internal class LoggerBuilderTest {
     }
 
     @Test
-    fun `builder can set a sample rate`(@Forgery forge: Forge) {
+    fun `builder can set a sample rate`(forge: Forge) {
         val expectedSampleRate = forge.aFloat(min = 0.0f, max = 100.0f)
 
         val logger = Logger.Builder(mockSdkCore).setRemoteSampleRate(expectedSampleRate).build()

--- a/reliability/single-fit/logs/src/test/kotlin/com/datadog/android/logs/integration/LoggerTest.kt
+++ b/reliability/single-fit/logs/src/test/kotlin/com/datadog/android/logs/integration/LoggerTest.kt
@@ -391,13 +391,14 @@ class LoggerTest {
 
     @RepeatedTest(16)
     fun `M send log with custom user info W SDKCore#setUserInfo() + Logger#log()`(
+        @StringForgery fakeUserId: String,
         @StringForgery fakeMessage: String,
         @StringForgery fakeUserKey: String,
         @StringForgery fakeUserValue: String,
         @IntForgery(Log.VERBOSE, 10) fakeLevel: Int
     ) {
         // Given
-        stubSdkCore.setUserInfo(extraInfo = mapOf(fakeUserKey to fakeUserValue))
+        stubSdkCore.setUserInfo(id = fakeUserId, extraInfo = mapOf(fakeUserKey to fakeUserValue))
         val testedLogger = Logger.Builder(stubSdkCore).build()
 
         // When

--- a/reliability/single-fit/trace/src/test/kotlin/com/datadog/android/trace/integration/opentracing/AndroidTracerTest.kt
+++ b/reliability/single-fit/trace/src/test/kotlin/com/datadog/android/trace/integration/opentracing/AndroidTracerTest.kt
@@ -436,12 +436,13 @@ class AndroidTracerTest {
 
     @RepeatedTest(16)
     fun `M send trace with custom user info W SDKCore#setUserInfo() + buildSpan() + start() + finish()`(
+        @StringForgery fakeUserId: String,
         @StringForgery fakeOperation: String,
         @StringForgery fakeUserKey: String,
         @StringForgery fakeUserValue: String
     ) {
         // Given
-        stubSdkCore.setUserInfo(extraInfo = mapOf(fakeUserKey to fakeUserValue))
+        stubSdkCore.setUserInfo(id = fakeUserId, extraInfo = mapOf(fakeUserKey to fakeUserValue))
         val testedTracer = AndroidTracer.Builder(stubSdkCore).build()
 
         // When

--- a/reliability/single-fit/trace/src/test/kotlin/com/datadog/android/trace/integration/otel/OtelTracerProviderTest.kt
+++ b/reliability/single-fit/trace/src/test/kotlin/com/datadog/android/trace/integration/otel/OtelTracerProviderTest.kt
@@ -1156,13 +1156,14 @@ internal class OtelTracerProviderTest {
 
     @RepeatedTest(10)
     fun `M send trace with custom user info W SDKCore#setUserInfo() + buildSpan() + start() + finish()`(
+        @StringForgery fakeUserId: String,
         @StringForgery fakeInstrumentationName: String,
         @StringForgery fakeOperation: String,
         @StringForgery fakeUserKey: String,
         @StringForgery fakeUserValue: String
     ) {
         // Given
-        stubSdkCore.setUserInfo(extraInfo = mapOf(fakeUserKey to fakeUserValue))
+        stubSdkCore.setUserInfo(id = fakeUserId, extraInfo = mapOf(fakeUserKey to fakeUserValue))
         val testedProvider = OtelTracerProvider.Builder(stubSdkCore).setBundleWithRumEnabled(true).build()
         val tracer = testedProvider.tracerBuilder(fakeInstrumentationName).build()
 

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
@@ -177,7 +177,7 @@ class StubSDKCore(
     override val time: TimeInfo = mock()
 
     override fun setUserInfo(
-        id: String?,
+        id: String,
         name: String?,
         email: String?,
         extraInfo: Map<String, Any?>


### PR DESCRIPTION
### What does this PR do?

Remove the option to set a null userId 