### PR TITLE
Remove `Project.exec` usage

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/CheckGeneratedFileTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/CheckGeneratedFileTask.kt
@@ -9,16 +9,18 @@ package com.datadog.gradle.plugin
 import com.datadog.gradle.utils.execShell
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Internal
+import org.gradle.process.ExecOperations
 import java.io.File
 
 abstract class CheckGeneratedFileTask(
-    @Internal val genTaskName: String
+    @Internal val genTaskName: String,
+    private val execOperations: ExecOperations
 ) : DefaultTask() {
 
     // region Task
 
     fun verifyGeneratedFileExists(targetFile: File) {
-        val lines = project.execShell(
+        val lines = execOperations.execShell(
             "git",
             "diff",
             "--color=never",

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/CheckApiSurfaceTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/CheckApiSurfaceTask.kt
@@ -10,10 +10,15 @@ import com.datadog.gradle.plugin.CheckGeneratedFileTask
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
 import java.io.File
+import javax.inject.Inject
 
-open class CheckApiSurfaceTask : CheckGeneratedFileTask(
-    genTaskName = ApiSurfacePlugin.TASK_GEN_KOTLIN_API_SURFACE
+open class CheckApiSurfaceTask @Inject constructor(
+    execOperations: ExecOperations
+) : CheckGeneratedFileTask(
+    genTaskName = ApiSurfacePlugin.TASK_GEN_KOTLIN_API_SURFACE,
+    execOperations
 ) {
 
     @InputFile

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/gitclone/GitCloneDependenciesTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/gitclone/GitCloneDependenciesTask.kt
@@ -10,10 +10,14 @@ import com.datadog.gradle.utils.execShell
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
 import java.io.File
 import java.nio.file.Files.createTempDirectory
+import javax.inject.Inject
 
-open class GitCloneDependenciesTask : DefaultTask() {
+open class GitCloneDependenciesTask @Inject constructor(
+    private val execOperations: ExecOperations
+) : DefaultTask() {
 
     @get: Input
     var extension: GitCloneDependenciesExtension =
@@ -60,7 +64,7 @@ open class GitCloneDependenciesTask : DefaultTask() {
         target: File
     ) {
         println(" --- Cloning ${dependency.originRepository} into ${target.absolutePath}")
-        project.execShell(
+        execOperations.execShell(
             "git",
             "clone",
             "--branch",
@@ -135,7 +139,7 @@ open class GitCloneDependenciesTask : DefaultTask() {
 
     private fun deleteClone(target: File) {
         println(" --- Deleting temp folder ${target.absolutePath}")
-        project.execShell("rm", "-r", target.absolutePath)
+        execOperations.execShell("rm", "-r", target.absolutePath)
         println(" --- Deleted")
     }
 

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/transdeps/CheckTransitiveDependenciesTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/transdeps/CheckTransitiveDependenciesTask.kt
@@ -9,10 +9,15 @@ package com.datadog.gradle.plugin.transdeps
 import com.datadog.gradle.plugin.CheckGeneratedFileTask
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
 import java.io.File
+import javax.inject.Inject
 
-open class CheckTransitiveDependenciesTask : CheckGeneratedFileTask(
-    genTaskName = TransitiveDependenciesPlugin.TASK_GEN_TRANSITIVE_DEPS
+open class CheckTransitiveDependenciesTask @Inject constructor(
+    execOperations: ExecOperations
+) : CheckGeneratedFileTask(
+    genTaskName = TransitiveDependenciesPlugin.TASK_GEN_TRANSITIVE_DEPS,
+    execOperations
 ) {
 
     @InputFile

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/utils/SystemUtils.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/utils/SystemUtils.kt
@@ -6,14 +6,14 @@
 
 package com.datadog.gradle.utils
 
-import org.gradle.api.Project
+import org.gradle.process.ExecOperations
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStreamReader
 
-fun Project.execShell(vararg command: String): List<String> {
+fun ExecOperations.execShell(vararg command: String): List<String> {
     val outputStream = ByteArrayOutputStream()
-    this.exec {
+    exec {
         commandLine(*command)
         standardOutput = outputStream
     }


### PR DESCRIPTION
### What does this PR do?

`Project.exec` usage is [deprecated](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#exec(org.gradle.api.Action)) since Gradle 8.11 and this API will be removed in Gradle 9.0.

This PR switched to the `ExecOperations.exec` usage to avoid deprecation warning in the build logs.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

