### PR TITLE
Update Publish Changelog to Confluence: Fix issue with already present page

### DIFF
--- a/.github/workflows/changelog-to-confluence.yaml
+++ b/.github/workflows/changelog-to-confluence.yaml
@@ -17,7 +17,7 @@ jobs:
             - name: Prepare Only Changelog
               run: |
                   mkdir -p publish_folder
-                  cp CHANGELOG.md publish_folder/
+                  cp CHANGELOG.md publish_folder/android-sdk-changelog.md
                   echo "Publishing only CHANGELOG.md"
 
             - name: Publish Markdown to Confluence


### PR DESCRIPTION
### What does this PR do?
With multiple sdk uploading the release notes to the confluence it created an issue with multiple pages with the same name being present. 
This PR addresses gives name a more specific page name to the page being uploaded.

### Motivation
Error in the last github action workflow

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

