### PR TITLE
RUM-9923 Custom endpoint URL are taken as is

### DIFF
--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/LogsConfiguration.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/LogsConfiguration.kt
@@ -27,6 +27,7 @@ data class LogsConfiguration internal constructor(
 
         /**
          * Let the Logs feature target a custom server.
+         * The provided url should be the full endpoint url, e.g.: https://example.com/logs/upload
          */
         fun useCustomEndpoint(endpoint: String): Builder {
             customEndpointUrl = endpoint

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/net/LogsRequestFactory.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/net/LogsRequestFactory.kt
@@ -57,10 +57,11 @@ internal class LogsRequestFactory(
     }
 
     private fun buildUrl(source: String, context: DatadogContext): String {
-        return "%s/api/v2/logs?%s=%s"
+        val baseUrl = customEndpointUrl ?: (context.site.intakeEndpoint + "/api/v2/logs")
+        return "%s?%s=%s"
             .format(
                 Locale.US,
-                customEndpointUrl ?: context.site.intakeEndpoint,
+                baseUrl,
                 RequestFactory.QUERY_PARAM_SOURCE,
                 source
             )

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsConfigurationBuilderTest.kt
@@ -44,7 +44,7 @@ internal class LogsConfigurationBuilderTest {
 
     @Test
     fun `M build configuration with custom site W useCustomEndpoint() and build()`(
-        @StringForgery(regex = "https://[a-z]+\\.com") logsEndpointUrl: String
+        @StringForgery(regex = "https://[a-z]+\\.com(/[a-z]+)+") logsEndpointUrl: String
     ) {
         // When
         val logsConfiguration = testedBuilder.useCustomEndpoint(logsEndpointUrl).build()

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/net/LogsRequestFactoryTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/net/LogsRequestFactoryTest.kt
@@ -93,7 +93,7 @@ internal class LogsRequestFactoryTest {
     @Suppress("NAME_SHADOWING")
     @Test
     fun `M create a proper request W create() { custom endpoint }`(
-        @StringForgery(regex = "https://[a-z]+\\.com") fakeEndpoint: String,
+        @StringForgery(regex = "https://[a-z]+\\.com(/[a-z]+)+") fakeEndpoint: String,
         @Forgery batchData: List<RawBatchEvent>,
         @StringForgery batchMetadata: String,
         @Forgery executionContext: RequestExecutionContext,
@@ -111,10 +111,7 @@ internal class LogsRequestFactoryTest {
 
         // Then
         requireNotNull(request)
-        assertThat(request.url).isEqualTo(
-            "$fakeEndpoint/api/v2/logs?" +
-                "ddsource=${fakeDatadogContext.source}"
-        )
+        assertThat(request.url).isEqualTo("$fakeEndpoint?ddsource=${fakeDatadogContext.source}")
         assertThat(request.contentType).isEqualTo(RequestFactory.CONTENT_TYPE_JSON)
         assertThat(request.headers.minus(RequestFactory.HEADER_REQUEST_ID)).isEqualTo(
             mapOf(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
@@ -247,6 +247,7 @@ data class RumConfiguration internal constructor(
 
         /**
          * Let the RUM feature target a custom server.
+         * The provided url should be the full endpoint url, e.g.: https://example.com/rum/upload
          */
         fun useCustomEndpoint(endpoint: String): Builder {
             rumConfig = rumConfig.copy(customEndpointUrl = endpoint)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/net/RumRequestFactory.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/net/RumRequestFactory.kt
@@ -19,7 +19,6 @@ import com.datadog.android.rum.internal.domain.event.RumViewEventFilter
 import java.security.DigestException
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
-import java.util.Locale
 import java.util.UUID
 
 internal class RumRequestFactory(
@@ -70,13 +69,9 @@ internal class RumRequestFactory(
 
         )
 
-        val intakeUrl = "%s/api/v2/rum".format(
-            Locale.US,
-            customEndpointUrl ?: context.site.intakeEndpoint
-        )
-
-        return intakeUrl + queryParams.map { "${it.key}=${it.value}" }
-            .joinToString("&", prefix = "?")
+        val intakeUrl = customEndpointUrl ?: (context.site.intakeEndpoint + "/api/v2/rum")
+        val queryParameters = queryParams.map { "${it.key}=${it.value}" }.joinToString("&", prefix = "?")
+        return intakeUrl + queryParameters
     }
 
     private fun buildHeaders(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
@@ -131,7 +131,7 @@ internal class RumConfigurationBuilderTest {
 
     @Test
     fun `M build config with custom endpoint W useCustomEndpoint() and build()`(
-        @StringForgery(regex = "https://[a-z]+\\.com") rumUrl: String
+        @StringForgery(regex = "https://[a-z]+\\.com(/[a-z]+)+") rumUrl: String
     ) {
         // When
         val rumConfiguration = testedBuilder

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/net/RumRequestFactoryTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/net/RumRequestFactoryTest.kt
@@ -80,7 +80,8 @@ internal class RumRequestFactoryTest {
 
         // Then
         requireNotNull(request)
-        assertThat(request.url).isEqualTo(expectedUrl(fakeDatadogContext.site.intakeEndpoint))
+        val expectedUrl = expectedUrl(fakeDatadogContext.site.intakeEndpoint + "/api/v2/rum")
+        assertThat(request.url).isEqualTo(expectedUrl)
         assertThat(request.contentType).isEqualTo(RequestFactory.CONTENT_TYPE_TEXT_UTF8)
         assertThat(
             request.headers.minus(
@@ -111,7 +112,7 @@ internal class RumRequestFactoryTest {
     @Suppress("NAME_SHADOWING")
     @Test
     fun `M create a proper request W create() { custom endpoint }`(
-        @StringForgery(regex = "https://[a-z]+\\.com") fakeEndpoint: String,
+        @StringForgery(regex = "https://[a-z]+\\.com(/[a-z]+)+") fakeEndpoint: String,
         @Forgery batchData: List<RawBatchEvent>,
         @StringForgery batchMetadata: String,
         forge: Forge
@@ -173,7 +174,7 @@ internal class RumRequestFactoryTest {
             queryTags.add("${RumRequestFactory.LAST_FAILURE_STATUS_KEY}:${fakeExecutionContext.previousResponseCode}")
         }
 
-        return "$endpointUrl/api/v2/rum?ddsource=${fakeDatadogContext.source}" +
+        return "$endpointUrl?ddsource=${fakeDatadogContext.source}" +
             "&ddtags=${queryTags.joinToString(",")}"
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
@@ -99,6 +99,7 @@ data class SessionReplayConfiguration internal constructor(
 
         /**
          * Let the Session Replay target a custom server.
+         * The provided url should be the full endpoint url, e.g.: https://example.com/replay/upload
          */
         fun useCustomEndpoint(endpoint: String): Builder {
             customEndpointUrl = endpoint

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/net/ResourcesRequestFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/net/ResourcesRequestFactory.kt
@@ -16,7 +16,6 @@ import okhttp3.RequestBody
 import okio.Buffer
 import java.io.EOFException
 import java.io.IOException
-import java.util.Locale
 import java.util.UUID
 
 internal class ResourcesRequestFactory(
@@ -94,16 +93,10 @@ internal class ResourcesRequestFactory(
     }
 
     private fun buildUrl(datadogContext: DatadogContext): String {
-        return String.format(
-            Locale.US,
-            UPLOAD_URL,
-            customEndpointUrl ?: datadogContext.site.intakeEndpoint,
-            "replay"
-        )
+        return customEndpointUrl ?: (datadogContext.site.intakeEndpoint + "/api/v2/replay")
     }
 
     companion object {
-        private const val UPLOAD_URL = "%s/api/v2/%s"
         internal const val APPLICATION_ID = "application_id"
         internal const val UPLOAD_DESCRIPTION = "Session Replay Resource Upload Request"
         internal const val ERROR_CONVERTING_BODY_TO_BYTEARRAY = "Error converting request body to bytearray"

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/net/SegmentRequestFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/net/SegmentRequestFactory.kt
@@ -14,7 +14,6 @@ import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.sessionreplay.internal.exception.InvalidPayloadFormatException
 import okhttp3.RequestBody
 import okio.Buffer
-import java.util.Locale
 import java.util.UUID
 
 internal class SegmentRequestFactory(
@@ -42,12 +41,7 @@ internal class SegmentRequestFactory(
     }
 
     private fun buildUrl(datadogContext: DatadogContext): String {
-        return String.format(
-            Locale.US,
-            UPLOAD_URL,
-            customEndpointUrl ?: datadogContext.site.intakeEndpoint,
-            "replay"
-        )
+        return customEndpointUrl ?: (datadogContext.site.intakeEndpoint + "/api/v2/replay")
     }
 
     private fun resolveHeaders(datadogContext: DatadogContext, requestId: String): Map<String, String> {
@@ -85,8 +79,4 @@ internal class SegmentRequestFactory(
     }
 
     // endregion
-
-    companion object {
-        private const val UPLOAD_URL = "%s/api/v2/%s"
-    }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
@@ -79,7 +79,7 @@ internal class SessionReplayConfigurationBuilderTest {
 
     @Test
     fun `M build config with custom site W useCustomEndpoint() and build()`(
-        @StringForgery(regex = "https://[a-z]+\\.com") sessionReplayUrl: String
+        @StringForgery(regex = "https://[a-z]+\\.com(/[a-z]+)+") sessionReplayUrl: String
     ) {
         // When
         testedBuilder = SessionReplayConfiguration.Builder(fakeSampleRate)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/net/ResourcesRequestFactoryTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/net/ResourcesRequestFactoryTest.kt
@@ -127,12 +127,12 @@ internal class ResourcesRequestFactoryTest {
         assertThat(requestBody).isEqualTo(mockRequestBody.toByteArray())
 
         assertThat(request.description).isEqualTo(UPLOAD_DESCRIPTION)
-        assertThat(request.url).isEqualTo(expectedUrl(fakeDatadogContext.site.intakeEndpoint))
+        assertThat(request.url).isEqualTo("${fakeDatadogContext.site.intakeEndpoint}/api/v2/replay")
     }
 
     @Test
     fun `M  return valid request W create() { custom endpoint }`(
-        @StringForgery(regex = "https://[a-z]+\\.com") fakeEndpoint: String
+        @StringForgery(regex = "https://[a-z]+\\.com(/[a-z]+)+") fakeEndpoint: String
     ) {
         // Given
         testedRequestFactory = ResourcesRequestFactory(
@@ -151,14 +151,10 @@ internal class ResourcesRequestFactoryTest {
 
         // Then
         requireNotNull(request)
-        assertThat(request.url).isEqualTo(expectedUrl(fakeEndpoint))
+        assertThat(request.url).isEqualTo(fakeEndpoint)
         assertThat(request.id).isEqualTo(request.headers[RequestFactory.HEADER_REQUEST_ID])
         assertThat(request.description).isEqualTo(UPLOAD_DESCRIPTION)
         assertThat(request.body).isEqualTo(mockRequestBody.toByteArray())
-    }
-
-    private fun expectedUrl(endpointUrl: String): String {
-        return "$endpointUrl/api/v2/replay"
     }
 
     private fun RequestBody.toByteArray(): ByteArray {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/net/SegmentRequestFactoryTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/net/SegmentRequestFactoryTest.kt
@@ -114,7 +114,7 @@ internal class SegmentRequestFactoryTest {
 
         // Then
         requireNotNull(request)
-        assertThat(request.url).isEqualTo(expectedUrl(fakeDatadogContext.site.intakeEndpoint))
+        assertThat(request.url).isEqualTo("${fakeDatadogContext.site.intakeEndpoint}/api/v2/replay")
         assertThat(request.contentType).isEqualTo(fakeMediaType.toString())
         assertThat(request.headers.minus(RequestFactory.HEADER_REQUEST_ID)).isEqualTo(
             mapOf(
@@ -131,7 +131,7 @@ internal class SegmentRequestFactoryTest {
 
     @Test
     fun `M return a valid Request W create { custom endpoint }`(
-        @StringForgery(regex = "https://[a-z]+\\.com") fakeEndpoint: String
+        @StringForgery(regex = "https://[a-z]+\\.com(/[a-z]+)+") fakeEndpoint: String
     ) {
         // When
         testedRequestFactory = SegmentRequestFactory(
@@ -148,7 +148,7 @@ internal class SegmentRequestFactoryTest {
 
         // Then
         requireNotNull(request)
-        assertThat(request.url).isEqualTo(expectedUrl(fakeEndpoint))
+        assertThat(request.url).isEqualTo(fakeEndpoint)
         assertThat(request.contentType).isEqualTo(fakeMediaType.toString())
         assertThat(request.headers.minus(RequestFactory.HEADER_REQUEST_ID)).isEqualTo(
             mapOf(
@@ -188,10 +188,6 @@ internal class SegmentRequestFactoryTest {
     // endregion
 
     // region Internal
-
-    private fun expectedUrl(endpointUrl: String): String {
-        return "$endpointUrl/api/v2/replay"
-    }
 
     private fun RequestBody.toByteArray(): ByteArray {
         val buffer = Buffer()

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/TraceConfiguration.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/TraceConfiguration.kt
@@ -28,6 +28,7 @@ data class TraceConfiguration internal constructor(
 
         /**
          * Let the Tracing feature target a custom server.
+         * The provided url should be the full endpoint url, e.g.: https://example.com/trace/upload
          */
         fun useCustomEndpoint(endpoint: String): Builder {
             customEndpointUrl = endpoint

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/TracesRequestFactory.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/TracesRequestFactory.kt
@@ -13,7 +13,6 @@ import com.datadog.android.api.net.RequestExecutionContext
 import com.datadog.android.api.net.RequestFactory
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.internal.utils.join
-import java.util.Locale
 import java.util.UUID
 
 internal class TracesRequestFactory(
@@ -29,13 +28,11 @@ internal class TracesRequestFactory(
     ): Request? {
         val requestId = UUID.randomUUID().toString()
 
+        val baseUrl = customEndpointUrl ?: (context.site.intakeEndpoint + "/api/v2/spans")
         return Request(
             id = requestId,
             description = "Traces Request",
-            url = "%s/api/v2/spans".format(
-                Locale.US,
-                customEndpointUrl ?: context.site.intakeEndpoint
-            ),
+            url = baseUrl,
             headers = buildHeaders(
                 requestId,
                 context.clientToken,

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TraceConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TraceConfigurationBuilderTest.kt
@@ -62,7 +62,7 @@ internal class TraceConfigurationBuilderTest {
 
     @Test
     fun `M build configuration with custom site W useCustomEndpoint() and build()`(
-        @StringForgery(regex = "https://[a-z]+\\.com") tracesEndpointUrl: String
+        @StringForgery(regex = "https://[a-z]+\\.com(/[a-z]+)+") tracesEndpointUrl: String
     ) {
         // When
         val traceConfiguration = testedBuilder.useCustomEndpoint(tracesEndpointUrl).build()

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/TracesRequestFactoryTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/TracesRequestFactoryTest.kt
@@ -87,7 +87,7 @@ internal class TracesRequestFactoryTest {
     @Suppress("NAME_SHADOWING")
     @Test
     fun `M create a proper request W create() { custom endpoint }`(
-        @StringForgery(regex = "https://[a-z]+\\.com") fakeEndpoint: String,
+        @StringForgery(regex = "https://[a-z]+\\.com(/[a-z]+)+") fakeEndpoint: String,
         @Forgery batchData: List<RawBatchEvent>,
         @StringForgery batchMetadata: String,
         @Forgery executionContext: RequestExecutionContext,
@@ -102,7 +102,7 @@ internal class TracesRequestFactoryTest {
 
         // Then
         requireNotNull(request)
-        assertThat(request.url).isEqualTo("$fakeEndpoint/api/v2/spans")
+        assertThat(request.url).isEqualTo(fakeEndpoint)
         assertThat(request.contentType).isEqualTo(RequestFactory.CONTENT_TYPE_TEXT_UTF8)
         assertThat(request.headers.minus(RequestFactory.HEADER_REQUEST_ID)).isEqualTo(
             mapOf(

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/utils/StringExtensions.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/utils/StringExtensions.kt
@@ -7,13 +7,13 @@
 package com.datadog.android.sdk.utils
 
 internal fun String.isTracesUrl(): Boolean {
-    return this.matches(Regex("(.*)/traces/(.*)"))
+    return this.matches(Regex("(.*)/traces(.*)"))
 }
 
 internal fun String.isLogsUrl(): Boolean {
-    return this.matches(Regex("(.*)/logs/(.*)"))
+    return this.matches(Regex("(.*)/logs(.*)"))
 }
 
 internal fun String.isRumUrl(): Boolean {
-    return this.matches(Regex("(.*)/rum/(.*)"))
+    return this.matches(Regex("(.*)/rum(.*)"))
 }

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
@@ -29,10 +29,10 @@ internal object RuntimeConfig {
     const val CONTENT_TYPE_TEXT = "text/plain;charset=UTF-8"
     private const val LOCALHOST = "http://localhost"
 
-    var logsEndpointUrl: String = LOCALHOST
-    var tracesEndpointUrl: String = LOCALHOST
-    var rumEndpointUrl: String = LOCALHOST
-    var sessionReplayEndpointUrl: String = LOCALHOST
+    var logsEndpointUrl: String = "$LOCALHOST/logs"
+    var tracesEndpointUrl: String = "$LOCALHOST/traces"
+    var rumEndpointUrl: String = "$LOCALHOST/rum"
+    var sessionReplayEndpointUrl: String = "$LOCALHOST/session-replay"
 
     val LONG_TASK_LARGE_THRESHOLD = Long.MAX_VALUE
 

--- a/reliability/single-fit/logs/src/test/kotlin/com/datadog/android/logs/integration/LoggerTest.kt
+++ b/reliability/single-fit/logs/src/test/kotlin/com/datadog/android/logs/integration/LoggerTest.kt
@@ -140,7 +140,7 @@ class LoggerTest {
 
         // Then
         checkNotNull(request)
-        assertThat(request.url).isEqualTo("$fakeEndpoint/api/v2/logs?ddsource=$expectedSource")
+        assertThat(request.url).isEqualTo("$fakeEndpoint?ddsource=$expectedSource")
         assertThat(request.headers).containsEntry("DD-API-KEY", expectedClientToken)
         assertThat(request.headers).containsEntry("DD-EVP-ORIGIN", expectedSource)
         assertThat(request.headers).containsEntry("DD-EVP-ORIGIN-VERSION", expectedSdkVersion)

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/RumConfigurationTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/RumConfigurationTest.kt
@@ -407,7 +407,7 @@ class RumConfigurationTest {
 
         // Then
         checkNotNull(request)
-        assertThat(request.url).isEqualTo("$fakeEndpoint/api/v2/rum?ddsource=$expectedSource&ddtags=$expectedTags")
+        assertThat(request.url).isEqualTo("$fakeEndpoint?ddsource=$expectedSource&ddtags=$expectedTags")
         assertThat(request.headers).containsEntry("DD-API-KEY", expectedClientToken)
         assertThat(request.headers).containsEntry("DD-EVP-ORIGIN", expectedSource)
         assertThat(request.headers).containsEntry("DD-EVP-ORIGIN-VERSION", expectedSdkVersion)

--- a/reliability/single-fit/trace/src/test/kotlin/com/datadog/android/trace/integration/opentracing/TraceConfigurationTest.kt
+++ b/reliability/single-fit/trace/src/test/kotlin/com/datadog/android/trace/integration/opentracing/TraceConfigurationTest.kt
@@ -126,7 +126,7 @@ class TraceConfigurationTest {
 
         // Then
         checkNotNull(request)
-        assertThat(request.url).isEqualTo("$fakeEndpoint/api/v2/spans")
+        assertThat(request.url).isEqualTo(fakeEndpoint)
         assertThat(request.headers).containsEntry("DD-API-KEY", expectedClientToken)
         assertThat(request.headers).containsEntry("DD-EVP-ORIGIN", expectedSource)
         assertThat(request.headers).containsEntry("DD-EVP-ORIGIN-VERSION", expectedSdkVersion)


### PR DESCRIPTION
### What does this PR do?

Align setting custom endpoint URL behavior with other platforms

### Motivation

Originally, on Android, we would only set the host, expecting the custom endpoint to have a path matching our own intake path (usually in the form `{host}/api/v2/{track}`. 

We now aim to have the same behaviour across platforms, so we take the provided url as is.