### PR TITLE
RUM-10191 Report resource with size 0

### DIFF
--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -428,7 +428,7 @@ open class DatadogInterceptor internal constructor(
 
     private fun ResponseBody.contentLengthOrNull(): Long? {
         return contentLength().let {
-            if (it <= 0L) null else it
+            if (it < 0L) null else it
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

A customer had a backend issue where it would return response with status 200 and empty body. 
Those were undetected because a 0 length response report a size `null`.