### PR TITLE
RUM-4247 Allow 24h batch backlog for RUM

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -263,8 +263,9 @@ internal class RumFeature(
         )
     }
 
-    override val storageConfiguration: FeatureStorageConfiguration =
-        FeatureStorageConfiguration.DEFAULT
+    override val storageConfiguration: FeatureStorageConfiguration = FeatureStorageConfiguration.DEFAULT.copy(
+        oldBatchThreshold = RUM_TTL_24H
+    )
 
     override fun onStop() {
         sdkCore.removeEventReceiver(name)
@@ -639,6 +640,7 @@ internal class RumFeature(
         internal const val TELEMETRY_SESSION_REPLAY_SKIP_FRAME = "sr_skipped_frame"
         internal const val FLUSH_AND_STOP_MONITOR_MESSAGE_TYPE = "flush_and_stop_monitor"
 
+        internal val RUM_TTL_24H = TimeUnit.HOURS.toMillis(24)
         internal const val ALL_IN_SAMPLE_RATE: Float = 100f
         internal const val DEFAULT_SAMPLE_RATE: Float = 100f
         internal const val DEFAULT_TELEMETRY_SAMPLE_RATE: Float = 20f

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -165,6 +165,15 @@ internal class RumFeatureTest {
     }
 
     @Test
+    fun `M allow 24h storage W init()`() {
+        // When
+        val config = testedFeature.storageConfiguration
+
+        // Then
+        assertThat(config.oldBatchThreshold).isEqualTo(24L * 60L * 60L * 1000L)
+    }
+
+    @Test
     fun `M store sample rate W initialize()`() {
         // When
         testedFeature.onInitialize(appContext.mockInstance)


### PR DESCRIPTION
### What does this PR do?

Allow batches to be uploaded up to 24h after being recorded. 

### Motivation

Increase the number of data we can send and align with other platforms. 

> [!NOTE]
> Relates to [ios #2302](https://github.com/DataDog/dd-sdk-ios/pull/2302)