### PR TITLE
Fix proguard rules for Method Called Metrics

### DIFF
--- a/features/dd-sdk-android-rum/consumer-rules.pro
+++ b/features/dd-sdk-android-rum/consumer-rules.pro
@@ -1,2 +1,4 @@
--keepnames class com.datadog.android.rum.internal.domain.scope.RumRawEvent { *; }
--keepnames class com.datadog.android.rum.internal.domain.scope.RumRawEvent$* { *; }
+# Kept for our internal telemetry
+-keepnames class com.datadog.android.rum.internal.monitor.DatadogRumMonitor
+-keepnames class com.datadog.android.rum.internal.domain.scope.RumRawEvent
+-keepnames class * extends com.datadog.android.rum.internal.domain.scope.RumRawEvent

--- a/features/dd-sdk-android-session-replay/consumer-rules.pro
+++ b/features/dd-sdk-android-session-replay/consumer-rules.pro
@@ -5,6 +5,7 @@
 
 # Kept for our internal telemetry
 -keepnames class com.datadog.android.sessionreplay.internal.recorder.listener.WindowsOnDrawListener
+-keepnames class com.datadog.android.sessionreplay.internal.recorder.TreeViewTraversal
 -keepnames class * extends com.datadog.android.sessionreplay.recorder.mapper.WireframeMapper
 -keepnames class * extends com.datadog.android.sessionreplay.internal.async.RecordedDataQueueItem
 


### PR DESCRIPTION
### What does this PR do?

We have "Method Called" Metrics in both RUM `DatadogRumMonitor` class and Session Replay `TreeViewTraversal` class,
their class name will be assigned as the attribute of "caller_class". However they can be obfuscated in release build, so we need to put them in the "consumer-rules.pro" file to keep the class name.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

