### PR TITLE
Enhancement of Compose Actions tracking reflection

### DIFF
--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeUtils.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeUtils.kt
@@ -52,6 +52,7 @@ internal class LayoutNodeUtils {
                     }
                 } else {
                     when (modifier::class.qualifiedName) {
+                        CLASS_NAME_SELECTABLE_ELEMENT,
                         CLASS_NAME_CLICKABLE_ELEMENT,
                         CLASS_NAME_COMBINED_CLICKABLE_ELEMENT -> {
                             role = role ?: getRole(modifier)
@@ -87,11 +88,12 @@ internal class LayoutNodeUtils {
     }
 
     @Suppress("UnsafeThirdPartyFunctionCall")
-    // Function is wrapped with `runSafe` in the call site.
-    private fun getRole(obj: Any): Role {
-        val roleField = obj::class.java.getDeclaredField("role")
-        roleField.isAccessible = true
-        return roleField.get(obj) as Role
+    private fun getRole(obj: Any): Role? {
+        return runSafe {
+            val roleField = obj::class.java.getDeclaredField("role")
+            roleField.isAccessible = true
+            roleField.get(obj) as? Role
+        }
     }
 
     fun getLayoutNodeBoundsInWindow(node: LayoutNode): Rect? {
@@ -135,5 +137,7 @@ internal class LayoutNodeUtils {
             "androidx.compose.foundation.ScrollingLayoutElement"
         private const val CLASS_NAME_SCROLLABLE_ELEMENT =
             "androidx.compose.foundation.gestures.ScrollableElement"
+        private const val CLASS_NAME_SELECTABLE_ELEMENT =
+            "androidx.compose.foundation.selection.SelectableElement"
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR enhances compose actions tracking reflection on two points:
* When seeing `SelectableElement` modifier, we treat it also as a clickable target, in this case when user taps on the selectable item, a RUM tap action will be sent as well.
* Fix reflection issue when getting the `role` of the element, before if it fails, the whole action tracking will abort, with this PR, the `role` will return null, and action tracking continues.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

