### PR TITLE
RUM-3100 generate checksum xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ config/*
 # Kotlin
 .kotlin/
 
+# dd-sdk-android tools
 gh_token
 sdk_classpath
 detekt_classpath
+**/verification-metadata.xml
+!gradle/verification-metadata.xml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -518,6 +518,11 @@ publish:release-core:
   script:
     - !reference [.snippets, set-publishing-credentials]
     - ./gradlew :dd-sdk-android-core:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - dd-sdk-android-core/verification-metadata.xml
 
 publish:release-internal:
   tags: [ "arch:amd64" ]
@@ -530,210 +535,13 @@ publish:release-internal:
   script:
     - !reference [ .snippets, set-publishing-credentials ]
     - ./gradlew :dd-sdk-android-internal:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - dd-sdk-android-internal/verification-metadata.xml
 
-publish:release-coil:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-    - develop
-  image: $CI_IMAGE_DOCKER
-  stage: publish
-  timeout: 30m
-  script:
-    - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :integrations:dd-sdk-android-coil:publishToSonatype --stacktrace --no-daemon
-
-publish:release-compose:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-    - develop
-  image: $CI_IMAGE_DOCKER
-  stage: publish
-  timeout: 30m
-  script:
-    - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :integrations:dd-sdk-android-compose:publishToSonatype --stacktrace --no-daemon
-
-publish:release-fresco:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-    - develop
-  image: $CI_IMAGE_DOCKER
-  stage: publish
-  timeout: 30m
-  script:
-    - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :integrations:dd-sdk-android-fresco:publishToSonatype --stacktrace --no-daemon
-
-publish:release-glide:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-    - develop
-  image: $CI_IMAGE_DOCKER
-  stage: publish
-  timeout: 30m
-  script:
-    - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :integrations:dd-sdk-android-glide:publishToSonatype --stacktrace --no-daemon
-
-publish:release-trace-coroutines:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-    - develop
-  image: $CI_IMAGE_DOCKER
-  stage: publish
-  timeout: 30m
-  script:
-    - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :integrations:dd-sdk-android-trace-coroutines:publishToSonatype --stacktrace --no-daemon
-
-publish:release-rum-coroutines:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-    - develop
-  image: $CI_IMAGE_DOCKER
-  stage: publish
-  timeout: 30m
-  script:
-    - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :integrations:dd-sdk-android-rum-coroutines:publishToSonatype --stacktrace --no-daemon
-
-publish:release-ndk:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-    - develop
-  image: $CI_IMAGE_DOCKER
-  stage: publish
-  timeout: 30m
-  script:
-    - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :features:dd-sdk-android-ndk:publishToSonatype --stacktrace --no-daemon
-
-publish:release-rx:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-    - develop
-  image: $CI_IMAGE_DOCKER
-  stage: publish
-  timeout: 30m
-  script:
-    - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :integrations:dd-sdk-android-rx:publishToSonatype --stacktrace --no-daemon
-
-publish:release-sqldelight:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-    - develop
-  image: $CI_IMAGE_DOCKER
-  stage: publish
-  timeout: 30m
-  script:
-    - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :integrations:dd-sdk-android-sqldelight:publishToSonatype --stacktrace --no-daemon
-
-publish:release-timber:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-    - develop
-  image: $CI_IMAGE_DOCKER
-  stage: publish
-  timeout: 30m
-  script:
-    - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :integrations:dd-sdk-android-timber:publishToSonatype --stacktrace --no-daemon
-
-publish:release-android-tv:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-    - develop
-  image: $CI_IMAGE_DOCKER
-  stage: publish
-  timeout: 30m
-  script:
-    - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :integrations:dd-sdk-android-tv:publishToSonatype --stacktrace --no-daemon
-
-publish:release-session-replay:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-    - develop
-  image: $CI_IMAGE_DOCKER
-  stage: publish
-  timeout: 30m
-  script:
-    - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :features:dd-sdk-android-session-replay:publishToSonatype --stacktrace --no-daemon
-
-publish:release-session-replay-material:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-    - develop
-  image: $CI_IMAGE_DOCKER
-  stage: publish
-  timeout: 30m
-  script:
-    - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :features:dd-sdk-android-session-replay-material:publishToSonatype --stacktrace --no-daemon
-
-publish:release-session-replay-compose:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-    - develop
-  image: $CI_IMAGE_DOCKER
-  stage: publish
-  timeout: 30m
-  script:
-    - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :features:dd-sdk-android-session-replay-compose:publishToSonatype --stacktrace --no-daemon
-
-publish:release-logs:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-    - develop
-  image: $CI_IMAGE_DOCKER
-  stage: publish
-  timeout: 30m
-  script:
-    - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :features:dd-sdk-android-logs:publishToSonatype --stacktrace --no-daemon
-
-publish:release-okhttp:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-    - develop
-  image: $CI_IMAGE_DOCKER
-  stage: publish
-  timeout: 30m
-  script:
-    - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :integrations:dd-sdk-android-okhttp:publishToSonatype --stacktrace --no-daemon
-
-publish:release-okhttp-otel:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-    - develop
-  image: $CI_IMAGE_DOCKER
-  stage: publish
-  timeout: 30m
-  script:
-    - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :integrations:dd-sdk-android-okhttp-otel:publishToSonatype --stacktrace --no-daemon
+# region Publish features/*
 
 publish:release-trace:
   tags: [ "arch:amd64" ]
@@ -746,6 +554,11 @@ publish:release-trace:
   script:
     - !reference [.snippets, set-publishing-credentials]
     - ./gradlew :features:dd-sdk-android-trace:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - features/dd-sdk-android-trace/verification-metadata.xml
 
 publish:release-trace-otel:
   tags: [ "arch:amd64" ]
@@ -758,8 +571,13 @@ publish:release-trace-otel:
   script:
     - !reference [.snippets, set-publishing-credentials]
     - ./gradlew :features:dd-sdk-android-trace-otel:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - features/dd-sdk-android-trace-otel/verification-metadata.xml
 
-publish:release-webview:
+publish:release-logs:
   tags: [ "arch:amd64" ]
   only:
     - tags
@@ -769,7 +587,12 @@ publish:release-webview:
   timeout: 30m
   script:
     - !reference [.snippets, set-publishing-credentials]
-    - ./gradlew :features:dd-sdk-android-webview:publishToSonatype --stacktrace --no-daemon
+    - ./gradlew :features:dd-sdk-android-logs:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - features/dd-sdk-android-logs/verification-metadata.xml
 
 publish:release-rum:
   tags: [ "arch:amd64" ]
@@ -782,6 +605,306 @@ publish:release-rum:
   script:
     - !reference [.snippets, set-publishing-credentials]
     - ./gradlew :features:dd-sdk-android-rum:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - features/dd-sdk-android-rum/verification-metadata.xml
+
+publish:release-ndk:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+    - develop
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    - ./gradlew :features:dd-sdk-android-ndk:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - features/dd-sdk-android-ndk/verification-metadata.xml
+
+publish:release-session-replay:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+    - develop
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    - ./gradlew :features:dd-sdk-android-session-replay:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - features/dd-sdk-android-session-replay/verification-metadata.xml
+
+publish:release-session-replay-material:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+    - develop
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    - ./gradlew :features:dd-sdk-android-session-replay-material:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - features/dd-sdk-android-session-replay-material/verification-metadata.xml
+
+publish:release-session-replay-compose:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+    - develop
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    - ./gradlew :features:dd-sdk-android-session-replay-compose:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - features/dd-sdk-android-session-replay-compose/verification-metadata.xml
+
+publish:release-webview:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+    - develop
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    - ./gradlew :features:dd-sdk-android-webview:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - features/dd-sdk-android-webview/verification-metadata.xml
+
+# endregion
+
+# region Publish integrations/*
+
+publish:release-coil:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+    - develop
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    - ./gradlew :integrations:dd-sdk-android-coil:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - integrations/dd-sdk-android-coil/verification-metadata.xml
+
+publish:release-compose:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+    - develop
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    - ./gradlew :integrations:dd-sdk-android-compose:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - integrations/dd-sdk-android-compose/verification-metadata.xml
+
+publish:release-fresco:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+    - develop
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    - ./gradlew :integrations:dd-sdk-android-fresco:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - integrations/dd-sdk-android-fresco/verification-metadata.xml
+
+publish:release-glide:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+    - develop
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    - ./gradlew :integrations:dd-sdk-android-glide:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - integrations/dd-sdk-android-glide/verification-metadata.xml
+
+publish:release-trace-coroutines:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+    - develop
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    - ./gradlew :integrations:dd-sdk-android-trace-coroutines:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - integrations/dd-sdk-android-trace-coroutines/verification-metadata.xml
+
+publish:release-rum-coroutines:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+    - develop
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    - ./gradlew :integrations:dd-sdk-android-rum-coroutines:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - integrations/dd-sdk-android-rum-coroutines/verification-metadata.xml
+
+publish:release-rx:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+    - develop
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    - ./gradlew :integrations:dd-sdk-android-rx:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - integrations/dd-sdk-android-rx/verification-metadata.xml
+
+publish:release-sqldelight:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+    - develop
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    - ./gradlew :integrations:dd-sdk-android-sqldelight:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - integrations/dd-sdk-android-sqldelight/verification-metadata.xml
+
+publish:release-timber:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+    - develop
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    - ./gradlew :integrations:dd-sdk-android-timber:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - integrations/dd-sdk-android-timber/verification-metadata.xml
+
+publish:release-android-tv:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+    - develop
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    - ./gradlew :integrations:dd-sdk-android-tv:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - integrations/dd-sdk-android-tv/verification-metadata.xml
+
+publish:release-okhttp:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+    - develop
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    - ./gradlew :integrations:dd-sdk-android-okhttp:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - integrations/dd-sdk-android-okhttp/verification-metadata.xml
+
+publish:release-okhttp-otel:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+    - develop
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    - ./gradlew :integrations:dd-sdk-android-okhttp-otel:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - integrations/dd-sdk-android-okhttp-otel/verification-metadata.xml
+
+# endregion
 
 publish:release-benchmark:
   tags: [ "arch:amd64" ]
@@ -794,6 +917,12 @@ publish:release-benchmark:
   script:
     - !reference [.snippets, set-publishing-credentials]
     - ./gradlew :tools:benchmark:publishToSonatype --stacktrace --no-daemon
+  artifacts:
+    when: on_success
+    expire_in: 7 days
+    paths:
+      - tools/benchmark/verification-metadata.xml
+
 
 # SLACK NOTIFICATIONS
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1004,3 +1004,44 @@ notify:dogfood-gradle-plugin:
     - pip3 install GitPython requests
     - aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gh_token --with-decryption --query "Parameter.Value" --out text >> ./gh_token
     - python3 dogfood.py -v $CI_COMMIT_TAG -t gradle-plugin
+
+notify:merge-verification-metadata:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+  image: $CI_IMAGE_DOCKER
+  stage: notify
+  when: on_success
+  dependencies:
+    - publish:release-core
+    - publish:release-internal
+    - publish:release-trace
+    - publish:release-trace-otel
+    - publish:release-logs
+    - publish:release-rum
+    - publish:release-ndk
+    - publish:release-session-replay
+    - publish:release-session-replay-material
+    - publish:release-session-replay-compose
+    - publish:release-webview
+    - publish:release-coil
+    - publish:release-compose
+    - publish:release-fresco
+    - publish:release-glide
+    - publish:release-trace-coroutines
+    - publish:release-rum-coroutines
+    - publish:release-rx
+    - publish:release-sqldelight
+    - publish:release-timber
+    - publish:release-android-tv
+    - publish:release-okhttp
+    - publish:release-okhttp-otel
+    - publish:release-benchmark
+  script:
+    - python3 merge_verification_metadata.py
+  artifacts:
+    when: on_success
+    expire_in: 3 mos
+    paths:
+      - verification-metadata.xml
+

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -44,6 +44,9 @@ dependencies {
     implementation(libs.gson)
     implementation(libs.kotlinPoet)
 
+    // Verification Metadata XML
+    implementation(libs.kotlinXmlBuilder)
+
     // Tests
     testImplementation(libs.jUnit4)
     testImplementation(libs.mockitoKotlin)
@@ -69,6 +72,10 @@ gradlePlugin {
         register("transitiveDependencies") {
             id = "transitiveDependencies" // the alias
             implementationClass = "com.datadog.gradle.plugin.transdeps.TransitiveDependenciesPlugin"
+        }
+        register("verificationXml") {
+            id = "verificationXml" // the alias
+            implementationClass = "com.datadog.gradle.plugin.verification.VerificationXmlPlugin"
         }
     }
 }

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
@@ -65,10 +65,12 @@ fun Project.publishingConfig(
                             url.set("https://www.apache.org/licenses/LICENSE-2.0")
                         }
                     }
+
                     organization {
                         name.set("Datadog")
                         url.set("https://www.datadoghq.com/")
                     }
+
                     developers {
                         developer {
                             name.set("Datadog")

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/CheckGeneratedFileTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/CheckGeneratedFileTask.kt
@@ -1,0 +1,44 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin
+
+import com.datadog.gradle.utils.execShell
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Internal
+import java.io.File
+
+abstract class CheckGeneratedFileTask(
+    @Internal val genTaskName: String
+) : DefaultTask() {
+
+    // region Task
+
+    fun verifyGeneratedFileExists(targetFile: File) {
+        val lines = project.execShell(
+            "git",
+            "diff",
+            "--color=never",
+            "HEAD",
+            "--",
+            targetFile.absolutePath
+        )
+
+        val additions = lines.filter { it.matches(Regex("^\\+[^+].*$")) }
+        val removals = lines.filter { it.matches(Regex("^-[^-].*$")) }
+
+        if (additions.isNotEmpty() || removals.isNotEmpty()) {
+            error(
+                "Make sure you run the $genTaskName task  before you push your PR.\n" +
+                    additions.joinToString("\n") +
+                    "\n" +
+                    removals.joinToString("\n")
+            )
+        }
+    }
+
+    // endregion
+}

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/CheckApiSurfaceTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/CheckApiSurfaceTask.kt
@@ -6,14 +6,15 @@
 
 package com.datadog.gradle.plugin.apisurface
 
-import com.datadog.gradle.utils.execShell
-import org.gradle.api.DefaultTask
+import com.datadog.gradle.plugin.CheckGeneratedFileTask
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
-open class CheckApiSurfaceTask : DefaultTask() {
+open class CheckApiSurfaceTask : CheckGeneratedFileTask(
+    genTaskName = ApiSurfacePlugin.TASK_GEN_KOTLIN_API_SURFACE
+) {
 
     @InputFile
     lateinit var kotlinSurfaceFile: File
@@ -30,33 +31,9 @@ open class CheckApiSurfaceTask : DefaultTask() {
 
     @TaskAction
     fun applyTask() {
-        verifySurfaceFile(kotlinSurfaceFile)
+        verifyGeneratedFileExists(kotlinSurfaceFile)
         if (javaSurfaceFile.exists()) {
-            verifySurfaceFile(javaSurfaceFile)
-        }
-    }
-
-    private fun verifySurfaceFile(surfaceFile: File) {
-        val lines = project.execShell(
-            "git",
-            "diff",
-            "--color=never",
-            "HEAD",
-            "--",
-            surfaceFile.absolutePath
-        )
-
-        val additions = lines.filter { it.matches(Regex("^\\+[^+].*$")) }
-        val removals = lines.filter { it.matches(Regex("^-[^-].*$")) }
-
-        if (additions.isNotEmpty() || removals.isNotEmpty()) {
-            error(
-                "Make sure you run the ${ApiSurfacePlugin.TASK_GEN_KOTLIN_API_SURFACE} task" +
-                    " before you push your PR.\n" +
-                    additions.joinToString("\n") +
-                    "\n" +
-                    removals.joinToString("\n")
-            )
+            verifyGeneratedFileExists(javaSurfaceFile)
         }
     }
 

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/transdeps/CheckTransitiveDependenciesTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/transdeps/CheckTransitiveDependenciesTask.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.gradle.plugin.transdeps
 
-import com.datadog.gradle.utils.execShell
-import org.gradle.api.DefaultTask
+import com.datadog.gradle.plugin.CheckGeneratedFileTask
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
-open class CheckTransitiveDependenciesTask : DefaultTask() {
+open class CheckTransitiveDependenciesTask : CheckGeneratedFileTask(
+    genTaskName = TransitiveDependenciesPlugin.TASK_GEN_TRANSITIVE_DEPS
+) {
 
     @InputFile
     lateinit var dependenciesFile: File
@@ -26,27 +27,7 @@ open class CheckTransitiveDependenciesTask : DefaultTask() {
 
     @TaskAction
     fun applyTask() {
-        val lines = project.execShell(
-            "git",
-            "diff",
-            "--color=never",
-            "HEAD",
-            "--",
-            dependenciesFile.absolutePath
-        )
-
-        val additions = lines.filter { it.matches(Regex("^\\+[^+].*$")) }
-        val removals = lines.filter { it.matches(Regex("^-[^-].*$")) }
-
-        if (additions.isNotEmpty() || removals.isNotEmpty()) {
-            error(
-                "Make sure you run the ${TransitiveDependenciesPlugin.TASK_GEN_TRANSITIVE_DEPS} task" +
-                    " before you push your PR.\n" +
-                    additions.joinToString("\n") +
-                    "\n" +
-                    removals.joinToString("\n")
-            )
-        }
+        verifyGeneratedFileExists(dependenciesFile)
     }
 
     @InputFile

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/verification/GenerateVerificationXmlTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/verification/GenerateVerificationXmlTask.kt
@@ -1,0 +1,121 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.verification
+
+import com.datadog.gradle.config.AndroidConfig
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+import org.redundent.kotlin.xml.PrintOptions
+import org.redundent.kotlin.xml.xml
+import java.io.File
+import java.security.MessageDigest
+
+open class GenerateVerificationXmlTask : DefaultTask() {
+
+    init {
+        group = "datadog"
+        description =
+            "Generate the verification-metadata.xml for the artifact built from the module"
+    }
+
+    private val md = MessageDigest.getInstance("SHA-256")
+
+    // region Task
+
+    @TaskAction
+    fun applyTask() {
+        val buildDir = project.layout.buildDirectory.asFile.get()
+        val projectDir = project.layout.projectDirectory.asFile
+        val publicationReleaseDir = File(File(buildDir, "publications"), "release")
+        val outputFile = File(projectDir, VerificationXmlPlugin.XML_FILE_NAME)
+
+        val aarFile = File(File(File(buildDir, "outputs"), "aar"), "${project.name}-release.aar")
+        val pomFile = File(publicationReleaseDir, "pom-default.xml")
+        val moduleFile = File(publicationReleaseDir, "module.json")
+
+        val aarSha256 = aarFile.sha256()
+        val pomSha256 = pomFile.sha256()
+        val moduleSha256 = moduleFile.sha256()
+
+        val content = xml(TAG_ROOT) {
+            xmlns = NS_DEPS_VERIF
+            TAG_CONFIGURATION {
+                TAG_VERIF_METADATA { -true.toString() }
+                TAG_VERIF_SIGNATURE { -false.toString() } // TODO RUM-3104 add signature verification
+            }
+            TAG_COMPONENTS {
+                TAG_COMPONENT {
+                    attribute(ATTR_GROUP, project.group)
+                    attribute(ATTR_NAME, project.name)
+                    attribute(ATTR_VERSION, AndroidConfig.VERSION.name)
+                    TAG_ARTIFACT {
+                        attribute(ATTR_NAME, "${project.name}-${AndroidConfig.VERSION.name}.aar")
+                        TAG_SHA256 {
+                            attribute(ATTR_VALUE, aarSha256)
+                            attribute(ATTR_ORIGIN, ORIGIN)
+                        }
+                    }
+                    TAG_ARTIFACT {
+                        attribute(ATTR_NAME, "${project.name}-${AndroidConfig.VERSION.name}.pom")
+                        TAG_SHA256 {
+                            attribute(ATTR_VALUE, pomSha256)
+                            attribute(ATTR_ORIGIN, ORIGIN)
+                        }
+                    }
+                    TAG_ARTIFACT {
+                        attribute(ATTR_NAME, "${project.name}-${AndroidConfig.VERSION.name}.module")
+                        TAG_SHA256 {
+                            attribute(ATTR_VALUE, moduleSha256)
+                            attribute(ATTR_ORIGIN, ORIGIN)
+                        }
+                    }
+                }
+            }
+        }
+        val xmlContent = content.toString(
+            PrintOptions(
+                indent = "   ",
+                pretty = true,
+                singleLineTextElements = true
+            )
+        )
+        outputFile.writeText(XML_PREFIX + xmlContent, Charsets.UTF_8)
+    }
+
+    // endregion
+
+    // region Internal
+
+    fun File.sha256(): String {
+        return md.digest(readBytes()).fold("", { str, byte -> str + "%02x".format(byte) })
+    }
+
+    // endregion
+
+    companion object {
+
+        private const val NS_DEPS_VERIF = "https://schema.gradle.org/dependency-verification"
+        private const val XML_PREFIX = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+
+        private const val TAG_ROOT = "verification-metadata"
+        private const val TAG_CONFIGURATION = "configuration"
+        private const val TAG_VERIF_METADATA = "verify-metadata"
+        private const val TAG_VERIF_SIGNATURE = "verify-signature"
+        private const val TAG_COMPONENTS = "components"
+        private const val TAG_COMPONENT = "component"
+        private const val TAG_SHA256 = "sha256"
+
+        private const val TAG_ARTIFACT = "artifact"
+        private const val ATTR_GROUP = "group"
+        private const val ATTR_NAME = "name"
+        private const val ATTR_VERSION = "version"
+        private const val ATTR_VALUE = "value"
+        private const val ATTR_ORIGIN = "origin"
+
+        private const val ORIGIN = "Datadog"
+    }
+}

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/verification/VerificationXmlPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/verification/VerificationXmlPlugin.kt
@@ -1,0 +1,40 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.verification
+
+import com.android.build.gradle.internal.tasks.factory.dependsOn
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class VerificationXmlPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        val genTask = target.tasks.register(TASK_GEN_VERIFICATION_XML, GenerateVerificationXmlTask::class.java)
+
+        target.afterEvaluate {
+            genTask.dependsOn("bundleReleaseAar")
+            genTask.dependsOn("javaDocReleaseJar")
+            genTask.dependsOn("sourceReleaseJar")
+            genTask.dependsOn("generatePomFileForReleasePublication")
+            genTask.dependsOn("generateMetadataFileForReleasePublication")
+            // TODO RUM-3104 depends on "signReleasePublication"
+
+            getTasksByName("publishToSonatype", false).forEach {
+                it.dependsOn(genTask)
+            }
+            getTasksByName("publishToMavenLocal", false).forEach {
+                it.dependsOn(genTask)
+            }
+        }
+    }
+
+    companion object {
+
+        const val TASK_GEN_VERIFICATION_XML = "generateVerificationXml"
+        const val XML_FILE_NAME = "verification-metadata.xml"
+    }
+}

--- a/dd-sdk-android-core/build.gradle.kts
+++ b/dd-sdk-android-core/build.gradle.kts
@@ -38,6 +38,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/dd-sdk-android-internal/build.gradle.kts
+++ b/dd-sdk-android-internal/build.gradle.kts
@@ -28,6 +28,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/features/dd-sdk-android-logs/build.gradle.kts
+++ b/features/dd-sdk-android-logs/build.gradle.kts
@@ -37,6 +37,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/features/dd-sdk-android-ndk/build.gradle.kts
+++ b/features/dd-sdk-android-ndk/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/features/dd-sdk-android-rum/build.gradle.kts
+++ b/features/dd-sdk-android-rum/build.gradle.kts
@@ -37,6 +37,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/features/dd-sdk-android-session-replay-compose/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-compose/build.gradle.kts
@@ -34,6 +34,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/features/dd-sdk-android-session-replay-material/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-material/build.gradle.kts
@@ -33,6 +33,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/features/dd-sdk-android-session-replay/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay/build.gradle.kts
@@ -36,6 +36,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/features/dd-sdk-android-trace-otel/build.gradle.kts
+++ b/features/dd-sdk-android-trace-otel/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/features/dd-sdk-android-trace/build.gradle.kts
+++ b/features/dd-sdk-android-trace/build.gradle.kts
@@ -36,6 +36,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/features/dd-sdk-android-webview/build.gradle.kts
+++ b/features/dd-sdk-android-webview/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -78,6 +78,7 @@ kotlinAntlrRuntime = "v0.1.0"
 jsonSchemaValidator = "1.12.1"
 binaryCompatibility = "0.17.0"
 dependencyLicense = "0.3"
+kotlinXmlBuilder = "1.9.3"
 
 # Integrations
 sqlDelight = "1.5.5"
@@ -220,6 +221,7 @@ kotlinSP = { module = "com.google.devtools.ksp:symbol-processing-api", version.r
 kotlinGrammarParser = { module = "com.github.kotlinx.ast:grammar-kotlin-parser-antlr-kotlin-jvm", version.ref = "kotlinGrammarParser" }
 kotlinAntlrRuntime = { module = "com.github.drieks.antlr-kotlin:antlr-kotlin-runtime", version.ref = "kotlinAntlrRuntime" }
 jsonSchemaValidator = { module = "com.github.everit-org.json-schema:org.everit.json.schema", version.ref = "jsonSchemaValidator" }
+kotlinXmlBuilder = {module="org.redundent:kotlin-xml-builder", version.ref="kotlinXmlBuilder"}
 
 # Integrations
 sqlDelight = { module = "com.squareup.sqldelight:android-driver", version.ref = "sqlDelight" }

--- a/integrations/dd-sdk-android-coil/build.gradle.kts
+++ b/integrations/dd-sdk-android-coil/build.gradle.kts
@@ -33,6 +33,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/integrations/dd-sdk-android-compose/build.gradle.kts
+++ b/integrations/dd-sdk-android-compose/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
 }
 
 android {

--- a/integrations/dd-sdk-android-fresco/build.gradle.kts
+++ b/integrations/dd-sdk-android-fresco/build.gradle.kts
@@ -33,6 +33,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/integrations/dd-sdk-android-glide/build.gradle.kts
+++ b/integrations/dd-sdk-android-glide/build.gradle.kts
@@ -33,6 +33,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/integrations/dd-sdk-android-okhttp-otel/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp-otel/build.gradle.kts
@@ -33,6 +33,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/integrations/dd-sdk-android-okhttp/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp/build.gradle.kts
@@ -37,6 +37,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
@@ -33,6 +33,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
 }
 
 android {

--- a/integrations/dd-sdk-android-rx/build.gradle.kts
+++ b/integrations/dd-sdk-android-rx/build.gradle.kts
@@ -33,6 +33,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/integrations/dd-sdk-android-sqldelight/build.gradle.kts
+++ b/integrations/dd-sdk-android-sqldelight/build.gradle.kts
@@ -33,6 +33,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/integrations/dd-sdk-android-timber/build.gradle.kts
+++ b/integrations/dd-sdk-android-timber/build.gradle.kts
@@ -33,6 +33,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
@@ -33,6 +33,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
 }
 
 android {

--- a/integrations/dd-sdk-android-tv/build.gradle.kts
+++ b/integrations/dd-sdk-android-tv/build.gradle.kts
@@ -33,6 +33,7 @@ plugins {
     id("com.datadoghq.dependency-license")
     id("apiSurface")
     id("transitiveDependencies")
+    id("verificationXml")
     id("binary-compatibility-validator")
 }
 

--- a/merge_verification_metadata.py
+++ b/merge_verification_metadata.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2019-Present Datadog, Inc
+
+import sys
+import os
+import glob
+
+import xml.etree.ElementTree as ET
+import xml.dom.minidom as MD
+
+from typing import List
+
+
+DEFAULT_NS = "https://schema.gradle.org/dependency-verification"
+NS_PREFIX = "{%s}" % DEFAULT_NS
+NSMAP = {None : DEFAULT_NS}
+
+ROOT_TAG = (NS_PREFIX + "verification-metadata")
+CONFIGURATION_TAG = (NS_PREFIX + "configuration")
+METADATA_TAG = (NS_PREFIX + "verify-metadata")
+SIGNATURES_TAG = (NS_PREFIX + "verify-signatures")
+
+COMPONENTS_TAG = (NS_PREFIX + "components")
+COMPONENT_TAG = (NS_PREFIX + "component")
+
+def run_main() -> int:
+    files = glob.glob('**/verification-metadata.xml', recursive=True)
+
+    # prepare final xml
+    root = ET.Element(ROOT_TAG)
+    configuration = ET.Element(CONFIGURATION_TAG)
+    metadata = ET.Element(METADATA_TAG)
+    metadata.text = "true"
+    configuration.insert(0, metadata)
+    signatures = ET.Element(SIGNATURES_TAG)
+    signatures.text = "false" # TODO RUM-3104 also copy signatures content
+    configuration.insert(1, signatures)
+    root.insert(0, configuration)
+
+    components = ET.Element(COMPONENTS_TAG)
+    root.insert(1, components)
+
+    index = 0
+    for filename in files:
+        data = ET.parse(filename).getroot()
+        for child in data:
+            if child.tag == COMPONENTS_TAG:
+                for component in child:
+                    components.insert(index, component)
+                    index = index + 1
+
+    # remove unnecessary whitespaces in content
+    for elem in root.iter():
+        if elem.text is not None:
+            elem.text = elem.text.strip()
+        if elem.tail is not None:
+            elem.tail = elem.tail.strip()
+
+    raw_xml = ET.tostring(root, method="xml").decode('utf-8')
+    # A bug in the python etree xml api prevents writing standalone xml, so we need
+    # to remove the default namespace:
+    sanitized_xml = raw_xml.replace("<ns0:", "<").replace("</ns0:", "</").replace("xmlns:ns0=", "xmlns=")
+    formatted_xml = MD.parseString(sanitized_xml).toprettyxml(indent="   ", encoding="utf-8")
+
+    with open("verification-metadata.xml", "w") as output_file:
+        output_file.write(formatted_xml.decode('utf-8'))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run_main())


### PR DESCRIPTION
### What does this PR do?


Gradle allows developers to add a `verification-metadata.xml` file to their project to pin dependencies with a specific hash or PGP signature. This prevents attack if the artifact repository is compromised. 

> [!NOTE]
> When publishing an artifact to Maven, the hash is automatically computed, and downloaded by Gradle with the artifact itself. If the `verification-metadata.xml` is present, it will compare the downloaded hash with the one in the xml file and abort the build if they don't match.

In order to improve our customer's trust in our artifact, this PR will generate a `verification-metadata.xml` file for each published artifact (as part of the `publish:<module>` job), and a new job will create a merged `verification-metadata.xml` that we can publish on GitHub and customers can refer to to ensure at any given time that the hash present in Maven is the expected one. 
