### PR TITLE
RUM-10242: Add AccountInfo data class and provider

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -63,6 +63,8 @@ interface com.datadog.android.api.SdkCore
   fun setAccountInfo(String, String? = null, Map<String, Any?> = emptyMap())
   fun addAccountExtraInfo(Map<String, Any?> = emptyMap())
   fun clearAccountInfo()
+data class com.datadog.android.api.context.AccountInfo
+  constructor(String? = null, String? = null, Map<String, Any?> = emptyMap())
 data class com.datadog.android.api.context.DatadogContext
   constructor(com.datadog.android.DatadogSite, String, String, String, String, String, String, String, TimeInfo, ProcessInfo, NetworkInfo, DeviceInfo, UserInfo, com.datadog.android.privacy.TrackingConsent, String?, Map<String, Map<String, Any?>>)
 data class com.datadog.android.api.context.DeviceInfo

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -149,6 +149,23 @@ public final class com/datadog/android/api/SdkCore$DefaultImpls {
 	public static synthetic fun setUserInfo$default (Lcom/datadog/android/api/SdkCore;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 }
 
+public final class com/datadog/android/api/context/AccountInfo {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/datadog/android/api/context/AccountInfo;
+	public static synthetic fun copy$default (Lcom/datadog/android/api/context/AccountInfo;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/datadog/android/api/context/AccountInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExtraInfo ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/datadog/android/api/context/DatadogContext {
 	public fun <init> (Lcom/datadog/android/DatadogSite;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/api/context/TimeInfo;Lcom/datadog/android/api/context/ProcessInfo;Lcom/datadog/android/api/context/NetworkInfo;Lcom/datadog/android/api/context/DeviceInfo;Lcom/datadog/android/api/context/UserInfo;Lcom/datadog/android/privacy/TrackingConsent;Ljava/lang/String;Ljava/util/Map;)V
 	public final fun component1 ()Lcom/datadog/android/DatadogSite;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/context/AccountInfo.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/context/AccountInfo.kt
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.api.context
+
+/**
+ * Holds information about the current account.
+ * @property id a unique identifier for the account, or null.
+ * @property name the name of the account, or null.
+ * @property extraInfo a dictionary of extra information to the current account.
+ */
+data class AccountInfo(
+    val id: String? = null,
+    val name: String? = null,
+    val extraInfo: Map<String, Any?> = emptyMap()
+)

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/account/AccountInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/account/AccountInfoProvider.kt
@@ -1,0 +1,16 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.account
+
+import com.datadog.android.api.context.AccountInfo
+import com.datadog.tools.annotation.NoOpImplementation
+
+@NoOpImplementation
+internal interface AccountInfoProvider {
+
+    fun getAccountInfo(): AccountInfo?
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/account/DatadogAccountInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/account/DatadogAccountInfoProvider.kt
@@ -1,0 +1,61 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.account
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.context.AccountInfo
+
+internal class DatadogAccountInfoProvider(
+    private val internalLogger: InternalLogger
+) : MutableAccountInfoProvider {
+
+    @Volatile
+    private var internalAccountInfo: AccountInfo? = null
+
+    override fun setAccountInfo(
+        id: String?,
+        name: String?,
+        extraInfo: Map<String, Any?>
+    ) {
+        internalAccountInfo = internalAccountInfo?.copy(
+            id = id,
+            name = name,
+            extraInfo = extraInfo.toMap()
+        ) ?: AccountInfo(
+            id = id,
+            name = name,
+            extraInfo = extraInfo.toMap()
+        )
+    }
+
+    override fun addExtraInfo(extraInfo: Map<String, Any?>) {
+        internalAccountInfo?.let {
+            internalAccountInfo = it.copy(
+                extraInfo = it.extraInfo + extraInfo
+            )
+        } ?: run {
+            internalLogger.log(
+                level = InternalLogger.Level.WARN,
+                target = InternalLogger.Target.USER,
+                messageBuilder = { MSG_ACCOUNT_NULL }
+            )
+        }
+    }
+
+    override fun clearAccountInfo() {
+        internalAccountInfo = null
+    }
+
+    override fun getAccountInfo(): AccountInfo? {
+        return internalAccountInfo
+    }
+
+    companion object {
+        internal const val MSG_ACCOUNT_NULL =
+            "Failed to add Account ExtraInfo because no Account Info exist yet. Please call `setAccountInfo` first."
+    }
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/account/MutableAccountInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/account/MutableAccountInfoProvider.kt
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.account
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+@NoOpImplementation
+internal interface MutableAccountInfoProvider : AccountInfoProvider {
+
+    fun setAccountInfo(
+        id: String?,
+        name: String?,
+        extraInfo: Map<String, Any?>
+    )
+
+    fun addExtraInfo(extraInfo: Map<String, Any?>)
+
+    fun clearAccountInfo()
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/account/DatadogAccountInfoProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/account/DatadogAccountInfoProviderTest.kt
@@ -1,0 +1,318 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.account
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.context.AccountInfo
+import com.datadog.android.core.internal.account.DatadogAccountInfoProvider.Companion.MSG_ACCOUNT_NULL
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.tools.unit.forge.exhaustiveAttributes
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.AdvancedForgery
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.MapForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.verify
+import org.mockito.quality.Strictness
+
+@ExtendWith(ForgeExtension::class)
+@ForgeConfiguration(Configurator::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class DatadogAccountInfoProviderTest {
+
+    private lateinit var testedProvider: DatadogAccountInfoProvider
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @BeforeEach
+    fun `set up`() {
+        testedProvider = DatadogAccountInfoProvider(mockInternalLogger)
+    }
+
+    @Test
+    fun `M return null W getAccountInfo() {account info not set}`() {
+        // When
+        val result = testedProvider.getAccountInfo()
+
+        // Then
+        assertThat(result).isEqualTo(null)
+    }
+
+    @Test
+    fun `M return saved accountInfo W setAccountInfo() and getAccountInfo()`(
+        @Forgery accountInfo: AccountInfo
+    ) {
+        // When
+        testedProvider.setAccountInfo(
+            accountInfo.id,
+            accountInfo.name,
+            accountInfo.extraInfo
+        )
+        val result = testedProvider.getAccountInfo()
+
+        // Then
+        assertThat(result).isEqualTo(accountInfo)
+    }
+
+    @Test
+    fun `M keep existing properties W addExtraInfo() is called`(
+        @Forgery accountInfo: AccountInfo,
+        @StringForgery forge: Forge
+    ) {
+        // Given
+        val fakeExtraInfo = forge.exhaustiveAttributes()
+        testedProvider.setAccountInfo(
+            accountInfo.id,
+            accountInfo.name,
+            fakeExtraInfo
+        )
+
+        // When
+        testedProvider.addExtraInfo(fakeExtraInfo)
+        // Then
+        assertThat(testedProvider.getAccountInfo()?.extraInfo).isEqualTo(fakeExtraInfo)
+    }
+
+    @Test
+    fun `M use immutable properties W addExtraInfo() is called { changing properties values }`(
+        @StringForgery forge: Forge,
+        @StringForgery(type = StringForgeryType.HEXADECIMAL) id: String,
+        @StringForgery name: String
+    ) {
+        // Given
+        val fakeProperties = forge.exhaustiveAttributes()
+        val fakeExpectedProperties = fakeProperties.toMap()
+        val fakeMutableProperties = fakeProperties.toMutableMap()
+        testedProvider.setAccountInfo(id, name, emptyMap())
+        testedProvider.addExtraInfo(fakeMutableProperties)
+
+        // When
+        fakeMutableProperties.keys.forEach {
+            fakeMutableProperties[it] = forge.anAlphabeticalString()
+        }
+
+        // Then
+        assertThat(
+            testedProvider.getAccountInfo()?.extraInfo
+        ).isEqualTo(fakeExpectedProperties)
+    }
+
+    @Test
+    fun `M use immutable properties W addExtraInfo() is called { adding properties }`(
+        @StringForgery forge: Forge,
+        @StringForgery(type = StringForgeryType.HEXADECIMAL) id: String,
+        @StringForgery name: String
+    ) {
+        // Given
+        val fakeProperties = forge.exhaustiveAttributes()
+        val fakeExpectedProperties = fakeProperties.toMap()
+        val fakeMutableProperties = fakeProperties.toMutableMap()
+        testedProvider.setAccountInfo(id, name, emptyMap())
+        testedProvider.addExtraInfo(fakeMutableProperties)
+
+        // When
+        repeat(forge.anInt(1, 10)) {
+            fakeMutableProperties[forge.anAlphabeticalString()] = forge.anAlphabeticalString()
+        }
+
+        // Then
+        assertThat(
+            testedProvider.getAccountInfo()?.extraInfo
+        ).isEqualTo(fakeExpectedProperties)
+    }
+
+    @Test
+    fun `M use immutable properties W addExtraInfo() is called { removing properties }`(
+        @StringForgery forge: Forge,
+        @StringForgery(type = StringForgeryType.HEXADECIMAL) id: String,
+        @StringForgery name: String
+    ) {
+        // Given
+        val fakeProperties = forge.exhaustiveAttributes()
+        val fakeExpectedProperties = fakeProperties.toMap()
+        val fakeMutableProperties = fakeProperties.toMutableMap()
+        testedProvider.setAccountInfo(id, name, emptyMap())
+        testedProvider.addExtraInfo(fakeMutableProperties)
+
+        // When
+        repeat(forge.anInt(1, fakeMutableProperties.size + 1)) {
+            fakeMutableProperties.remove(fakeMutableProperties.keys.random())
+        }
+
+        // Then
+        assertThat(testedProvider.getAccountInfo()?.extraInfo).isEqualTo(fakeExpectedProperties)
+    }
+
+    @Test
+    fun `M keep new property key W addExtraInfo() is called and the key already exists`(
+        @Forgery accountInfo: AccountInfo,
+        @StringForgery key: String,
+        @StringForgery value1: String,
+        @StringForgery value2: String
+    ) {
+        // Given
+        testedProvider.setAccountInfo(
+            accountInfo.id,
+            accountInfo.name,
+            mutableMapOf(key to value1)
+        )
+
+        // When
+        testedProvider.addExtraInfo(mapOf(key to value2))
+
+        // Then
+        assertThat(
+            testedProvider.getAccountInfo()?.extraInfo
+        ).isEqualTo(
+            mapOf(key to value2)
+        )
+    }
+
+    @Test
+    fun `M use immutable values W setAccountInfo { changing properties values }()`(
+        forge: Forge,
+        @StringForgery(type = StringForgeryType.HEXADECIMAL) id: String,
+        @StringForgery name: String,
+        @MapForgery(
+            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)]),
+            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)])
+        ) fakeExtraInfo: Map<String, String>
+    ) {
+        // Given
+        val fakeMutableExtraInfo = fakeExtraInfo.toMutableMap()
+        val fakeExpectedExtraInfo = fakeExtraInfo.toMap()
+        testedProvider.setAccountInfo(id, name, fakeMutableExtraInfo)
+
+        // When
+        fakeMutableExtraInfo.keys.forEach { key ->
+            fakeMutableExtraInfo[key] = forge.anAlphaNumericalString()
+        }
+
+        // Then
+        assertThat(testedProvider.getAccountInfo()?.extraInfo).isEqualTo(
+            fakeExpectedExtraInfo
+        )
+    }
+
+    @Test
+    fun `M use immutable values W setAccountInfo { adding properties }()`(
+        forge: Forge,
+        @StringForgery(type = StringForgeryType.HEXADECIMAL) id: String,
+        @StringForgery name: String,
+        @MapForgery(
+            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)]),
+            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)])
+        ) fakeExtraInfo: Map<String, String>
+    ) {
+        // Given
+        val fakeMutableExtraInfo = fakeExtraInfo.toMutableMap()
+        val fakeExpectedExtraInfo = fakeExtraInfo.toMap()
+        testedProvider.setAccountInfo(id, name, fakeMutableExtraInfo)
+
+        // When
+        repeat(forge.anInt(1, 10)) {
+            fakeMutableExtraInfo[forge.anAlphabeticalString()] = forge.anAlphabeticalString()
+        }
+
+        // Then
+        assertThat(testedProvider.getAccountInfo()?.extraInfo).isEqualTo(
+            fakeExpectedExtraInfo
+        )
+    }
+
+    @Test
+    fun `M use immutable values W setAccountInfo { removing properties }()`(
+        forge: Forge,
+        @StringForgery(type = StringForgeryType.HEXADECIMAL) id: String,
+        @StringForgery name: String,
+        @MapForgery(
+            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)]),
+            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)])
+        ) fakeExtraInfo: Map<String, String>
+    ) {
+        // Given
+        val fakeMutableExtraInfo = fakeExtraInfo.toMutableMap()
+        val fakeExpectedExtraInfo = fakeExtraInfo.toMap()
+        testedProvider.setAccountInfo(id, name, fakeMutableExtraInfo)
+
+        // When
+        repeat(forge.anInt(1, fakeMutableExtraInfo.size + 1)) {
+            fakeMutableExtraInfo.remove(fakeMutableExtraInfo.keys.random())
+        }
+
+        // Then
+        assertThat(testedProvider.getAccountInfo()?.extraInfo).isEqualTo(
+            fakeExpectedExtraInfo
+        )
+    }
+
+    @Test
+    fun `M warn user with log W addExtraInfo { account info null }()`(
+        @MapForgery(
+            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)]),
+            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)])
+        ) fakeExtraInfo: Map<String, String>
+    ) {
+        // Given
+        val fakeMutableExtraInfo = fakeExtraInfo.toMutableMap()
+
+        // When
+        testedProvider.addExtraInfo(fakeMutableExtraInfo)
+
+        // Then
+        assertThat(testedProvider.getAccountInfo()?.extraInfo).isEqualTo(
+            null
+        )
+        argumentCaptor<() -> String> {
+            verify(mockInternalLogger).log(
+                level = eq(InternalLogger.Level.WARN),
+                target = eq(InternalLogger.Target.USER),
+                messageBuilder = capture(),
+                throwable = isNull(),
+                onlyOnce = any(),
+                additionalProperties = isNull()
+            )
+            allValues.forEach {
+                assertThat(it()).isEqualTo(MSG_ACCOUNT_NULL)
+            }
+        }
+    }
+
+    @Test
+    fun `M return null W call clearAccountInfo`(
+        @StringForgery(type = StringForgeryType.HEXADECIMAL) id: String,
+        @StringForgery name: String,
+        @MapForgery(
+            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)]),
+            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)])
+        ) fakeExtraInfo: Map<String, String>
+    ) {
+        // Given
+        val fakeMutableExtraInfo = fakeExtraInfo.toMutableMap()
+        testedProvider.setAccountInfo(id, name, fakeMutableExtraInfo)
+
+        // When
+        testedProvider.clearAccountInfo()
+
+        // Then
+        assertThat(testedProvider.getAccountInfo()).isNull()
+    }
+}

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/AccountInfoForgeryFactory.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/AccountInfoForgeryFactory.kt
@@ -1,0 +1,27 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.tests.elmyr
+
+import com.datadog.android.api.context.AccountInfo
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+class AccountInfoForgeryFactory : ForgeryFactory<AccountInfo> {
+
+    override fun getForgery(forge: Forge): AccountInfo {
+        return AccountInfo(
+            id = forge.aNullable { anHexadecimalString() },
+            name = forge.aNullable { forge.aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
+            extraInfo = forge.exhaustiveAttributes(
+                excludedKeys = setOf(
+                    "id",
+                    "name"
+                )
+            )
+        )
+    }
+}

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ForgeExt.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ForgeExt.kt
@@ -46,6 +46,7 @@ fun <T : Forge> T.useCoreFactories(): T {
     addFactory(ProcessInfoForgeryFactory())
     addFactory(TimeInfoForgeryFactory())
     addFactory(UserInfoForgeryFactory())
+    addFactory(AccountInfoForgeryFactory())
     addFactory(RawBatchEventForgeryFactory())
     addFactory(ThreadDumpForgeryFactory())
     addFactory(RequestExecutionContextForgeryFactory())


### PR DESCRIPTION
### What does this PR do?

* Add `AccountInfo` data class
* Add `DatadogAccountInfoProvider` and `MutableAccountInfoProvider`

Notice: We don't add serialiser and deserialiser for `AccountInfo`  as `UserInfo` because we don't need to persist it for crash report since it will be removed in V3 soon.

### Motivation

RUM-10242


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

