### PR TITLE
RUM-10099: Create a new RumViewScope when the session is renewed

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -992,6 +992,7 @@ datadog:
       - "kotlin.collections.MutableList.add(com.datadog.android.core.internal.persistence.tlvformat.TLVBlock)"
       - "kotlin.collections.MutableList.add(com.datadog.android.plugin.DatadogPlugin)"
       - "kotlin.collections.MutableList.add(com.datadog.android.rum.internal.domain.scope.RumScope)"
+      - "kotlin.collections.MutableList.add(com.datadog.android.rum.internal.domain.scope.RumViewScope)"
       - "kotlin.collections.MutableList.add(com.datadog.android.rum.internal.vitals.FrameStateListener)"
       - "kotlin.collections.MutableList.add(com.datadog.android.rum.model.ActionEvent.Type)"
       - "kotlin.collections.MutableList.add(com.datadog.android.sessionreplay.compose.internal.data.Parameter)"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumScope.kt
@@ -36,8 +36,4 @@ internal interface RumScope {
      * @return the context related to this scope
      */
     fun getRumContext(): RumContext
-
-    companion object {
-        internal const val SYNTHETICS_LOGCAT_TAG = "DatadogSynthetics"
-    }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -14,6 +14,7 @@ import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
+import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
 import com.datadog.android.rum.internal.utils.percent
@@ -60,7 +61,7 @@ internal class RumSessionScope(
     private val noOpWriter = NoOpDataWriter<Any>()
 
     @Suppress("LongParameterList")
-    internal var childScope: RumScope? = RumViewManagerScope(
+    internal var childScope: RumViewManagerScope? = RumViewManagerScope(
         this,
         sdkCore,
         sessionEndedMetricDispatcher,
@@ -121,7 +122,7 @@ internal class RumSessionScope(
         writer: DataWriter<Any>
     ): RumScope? {
         if (event is RumRawEvent.ResetSession) {
-            renewSession(System.nanoTime(), StartReason.EXPLICIT_STOP)
+            renewSession(event.eventTime, StartReason.EXPLICIT_STOP)
         } else if (event is RumRawEvent.StopSession) {
             stopSession()
         }
@@ -131,7 +132,7 @@ internal class RumSessionScope(
         val actualWriter = if (sessionState == State.TRACKED) writer else noOpWriter
 
         if (event !is RumRawEvent.SdkInit) {
-            childScope = childScope?.handleEvent(event, actualWriter)
+            childScope = childScope?.handleEvent(event, actualWriter) as? RumViewManagerScope
         }
 
         return if (isSessionComplete()) {
@@ -197,29 +198,30 @@ internal class RumSessionScope(
                 } else {
                     StartReason.MAX_DURATION
                 }
-                renewSession(nanoTime, reason)
+                renewSession(event.eventTime, reason)
             }
             lastUserInteractionNs.set(nanoTime)
         } else if (isExpired) {
             if (backgroundTrackingEnabled && (isBackgroundEvent || isSdkInitInBackground)) {
-                renewSession(nanoTime, StartReason.BACKGROUND_LAUNCH)
+                renewSession(event.eventTime, StartReason.BACKGROUND_LAUNCH)
                 lastUserInteractionNs.set(nanoTime)
             } else {
                 sessionState = State.EXPIRED
             }
         } else if (isTimedOut) {
-            renewSession(nanoTime, StartReason.MAX_DURATION)
+            renewSession(event.eventTime, StartReason.MAX_DURATION)
         }
 
         updateSessionStateForSessionReplay(sessionState, sessionId)
     }
 
-    private fun renewSession(nanoTime: Long, reason: StartReason) {
+    private fun renewSession(time: Time, reason: StartReason) {
         val keepSession = random.nextFloat() < sampleRate.percent()
         startReason = reason
         sessionState = if (keepSession) State.TRACKED else State.NOT_TRACKED
         sessionId = UUID.randomUUID().toString()
-        sessionStartNs.set(nanoTime)
+        sessionStartNs.set(time.nanoTime)
+        childScope?.renewViewScopes(time)
         if (keepSession) {
             sessionEndedMetricDispatcher.startMetric(
                 sessionId = sessionId,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -56,11 +56,18 @@ internal class RumViewManagerScope(
             lastInteractionIdentifier = lastInteractionIdentifier
         )
 
-    internal val childrenScopes = mutableListOf<RumScope>()
+    internal val childrenScopes = mutableListOf<RumViewScope>()
     internal var stopped = false
     private var lastStoppedViewTime: Time? = null
 
     // region RumScope
+    fun renewViewScopes(eventTime: Time) {
+        val newChildScope = childrenScopes.map { rumViewScope ->
+            rumViewScope.renew(eventTime)
+        }
+        childrenScopes.clear()
+        childrenScopes.addAll(newChildScope)
+    }
 
     @WorkerThread
     override fun handleEvent(event: RumRawEvent, writer: DataWriter<Any>): RumScope? {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
-import android.util.Log
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
@@ -81,20 +80,9 @@ internal open class RumViewScope(
     private var globalAttributes: Map<String, Any?> = resolveGlobalAttributes(sdkCore)
     private val internalAttributes: MutableMap<String, Any?> = mutableMapOf()
 
-    private var sessionId: String = parentScope.getRumContext().sessionId
-    internal var viewId: String = UUID.randomUUID().toString()
-        set(value) {
-            oldViewIds += field
-            field = value
-            val rumContext = getRumContext()
-            if (rumContext.syntheticsTestId != null) {
-                Log.i(RumScope.SYNTHETICS_LOGCAT_TAG, "_dd.application.id=${rumContext.applicationId}")
-                Log.i(RumScope.SYNTHETICS_LOGCAT_TAG, "_dd.session.id=${rumContext.sessionId}")
-                Log.i(RumScope.SYNTHETICS_LOGCAT_TAG, "_dd.view.id=$viewId")
-            }
-        }
+    private val sessionId: String = parentScope.getRumContext().sessionId
+    internal val viewId: String = UUID.randomUUID().toString()
 
-    private val oldViewIds = mutableSetOf<String>()
     private val startedNanos: Long = eventTime.nanoTime
     internal var stoppedNanos: Long = eventTime.nanoTime
     internal var viewLoadingTime: Long? = null
@@ -171,9 +159,9 @@ internal open class RumViewScope(
 
         val rumContext = parentScope.getRumContext()
         if (rumContext.syntheticsTestId != null) {
-            Log.i(RumScope.SYNTHETICS_LOGCAT_TAG, "_dd.application.id=${rumContext.applicationId}")
-            Log.i(RumScope.SYNTHETICS_LOGCAT_TAG, "_dd.session.id=${rumContext.sessionId}")
-            Log.i(RumScope.SYNTHETICS_LOGCAT_TAG, "_dd.view.id=$viewId")
+            logSynthetics("_dd.application.id", rumContext.applicationId)
+            logSynthetics("_dd.session.id", rumContext.sessionId)
+            logSynthetics("_dd.view.id", viewId)
         }
         networkSettledMetricResolver.viewWasCreated(eventTime.nanoTime)
         interactionToNextViewMetricResolver.onViewCreated(viewId, eventTime.nanoTime)
@@ -233,27 +221,44 @@ internal open class RumViewScope(
     }
 
     override fun getRumContext(): RumContext {
-        val parentContext = parentScope.getRumContext()
-        if (parentContext.sessionId != sessionId) {
-            sessionId = parentContext.sessionId
-            viewId = UUID.randomUUID().toString()
-        }
-
-        return parentContext
-            .copy(
-                viewId = viewId,
-                viewName = key.name,
-                viewUrl = url,
-                actionId = (activeActionScope as? RumActionScope)?.actionId,
-                viewType = type,
-                viewTimestamp = eventTimestamp,
-                viewTimestampOffset = serverTimeOffsetInMs,
-                hasReplay = false
-            )
+        return parentScope.getRumContext().copy(
+            viewId = viewId,
+            viewName = key.name,
+            viewUrl = url,
+            actionId = (activeActionScope as? RumActionScope)?.actionId,
+            viewType = type,
+            viewTimestamp = eventTimestamp,
+            viewTimestampOffset = serverTimeOffsetInMs,
+            hasReplay = false
+        )
     }
 
     override fun isActive(): Boolean {
         return !stopped
+    }
+
+    internal fun renew(newEventTime: Time): RumViewScope {
+        return RumViewScope(
+            parentScope = this,
+            sdkCore = sdkCore,
+            sessionEndedMetricDispatcher = sessionEndedMetricDispatcher,
+            key = key,
+            eventTime = newEventTime,
+            initialAttributes = eventAttributes,
+            viewChangedListener = viewChangedListener,
+            firstPartyHostHeaderTypeResolver = firstPartyHostHeaderTypeResolver,
+            cpuVitalMonitor = cpuVitalMonitor,
+            memoryVitalMonitor = memoryVitalMonitor,
+            frameRateVitalMonitor = frameRateVitalMonitor,
+            featuresContextResolver = featuresContextResolver,
+            type = type,
+            trackFrustrations = trackFrustrations,
+            sampleRate = sampleRate,
+            interactionToNextViewMetricResolver = interactionToNextViewMetricResolver,
+            networkSettledMetricResolver = networkSettledMetricResolver,
+            viewEndedMetricDispatcher = viewEndedMetricDispatcher,
+            slowFramesListener = slowFramesListener
+        )
     }
 
     // endregion
@@ -729,7 +734,7 @@ internal open class RumViewScope(
         event: RumRawEvent.ResourceSent,
         writer: DataWriter<Any>
     ) {
-        if (event.viewId == viewId || event.viewId in oldViewIds) {
+        if (event.viewId == viewId) {
             pendingResourceCount--
             resourceCount++
             networkSettledMetricResolver.resourceWasStopped(
@@ -747,7 +752,7 @@ internal open class RumViewScope(
         event: RumRawEvent.ActionSent,
         writer: DataWriter<Any>
     ) {
-        if (event.viewId == viewId || event.viewId in oldViewIds) {
+        if (event.viewId == viewId) {
             pendingActionCount--
             actionCount++
             frustrationCount += event.frustrationCount
@@ -767,7 +772,7 @@ internal open class RumViewScope(
         event: RumRawEvent.LongTaskSent,
         writer: DataWriter<Any>
     ) {
-        if (event.viewId == viewId || event.viewId in oldViewIds) {
+        if (event.viewId == viewId) {
             pendingLongTaskCount--
             longTaskCount++
             if (event.isFrozenFrame) {
@@ -783,7 +788,7 @@ internal open class RumViewScope(
         event: RumRawEvent.ErrorSent,
         writer: DataWriter<Any>
     ) {
-        if (event.viewId == viewId || event.viewId in oldViewIds) {
+        if (event.viewId == viewId) {
             pendingErrorCount--
             errorCount++
             if (event.resourceId != null && event.resourceEndTimestampInNanos != null) {
@@ -799,20 +804,20 @@ internal open class RumViewScope(
     }
 
     private fun onResourceDropped(event: RumRawEvent.ResourceDropped) {
-        if (event.viewId == viewId || event.viewId in oldViewIds) {
+        if (event.viewId == viewId) {
             networkSettledMetricResolver.resourceWasDropped(event.resourceId)
             pendingResourceCount--
         }
     }
 
     private fun onActionDropped(event: RumRawEvent.ActionDropped) {
-        if (event.viewId == viewId || event.viewId in oldViewIds) {
+        if (event.viewId == viewId) {
             pendingActionCount--
         }
     }
 
     private fun onErrorDropped(event: RumRawEvent.ErrorDropped) {
-        if (event.viewId == viewId || event.viewId in oldViewIds) {
+        if (event.viewId == viewId) {
             pendingErrorCount--
             if (event.resourceId != null) {
                 networkSettledMetricResolver.resourceWasDropped(event.resourceId)
@@ -821,7 +826,7 @@ internal open class RumViewScope(
     }
 
     private fun onLongTaskDropped(event: RumRawEvent.LongTaskDropped) {
-        if (event.viewId == viewId || event.viewId in oldViewIds) {
+        if (event.viewId == viewId) {
             pendingLongTaskCount--
             if (event.isFrozenFrame) {
                 pendingFrozenFrameCount--
@@ -1421,6 +1426,14 @@ internal open class RumViewScope(
         } else {
             null
         }
+    }
+
+    private fun logSynthetics(key: String, value: String) {
+        sdkCore.internalLogger.log(
+            level = InternalLogger.Level.INFO,
+            target = InternalLogger.Target.USER,
+            messageBuilder = { "$key=$value" }
+        )
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -45,8 +45,6 @@ import com.datadog.android.rum.internal.domain.scope.RumRawEvent
 import com.datadog.android.rum.internal.domain.scope.RumScope
 import com.datadog.android.rum.internal.domain.scope.RumScopeKey
 import com.datadog.android.rum.internal.domain.scope.RumSessionScope
-import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
-import com.datadog.android.rum.internal.domain.scope.RumViewScope
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
 import com.datadog.android.rum.internal.vitals.VitalMonitor
@@ -746,11 +744,10 @@ internal class DatadogRumMonitor(
         debugListener?.let {
             val applicationScope = rootScope as? RumApplicationScope
             val sessionScope = applicationScope?.activeSession as? RumSessionScope
-            val viewManagerScope = sessionScope?.childScope as? RumViewManagerScope
+            val viewManagerScope = sessionScope?.childScope
             if (viewManagerScope != null) {
                 it.onReceiveRumActiveViews(
                     viewManagerScope.childrenScopes
-                        .filterIsInstance<RumViewScope>()
                         .filter { viewScope -> viewScope.isActive() }
                         .mapNotNull { viewScope -> viewScope.getRumContext().viewName }
                 )

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -311,7 +311,6 @@ internal class RumApplicationScopeTest {
         check(viewManager is RumViewManagerScope)
         assertThat(viewManager.childrenScopes).isNotEmpty
         val viewScope = viewManager.childrenScopes.first()
-        check(viewScope is RumViewScope)
         assertThat(viewScope.key).isEqualTo(fakeKey)
         assertThat(viewScope.eventAttributes).isEqualTo(mockAttributes)
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -79,7 +79,7 @@ internal class RumViewManagerScopeTest {
     lateinit var mockParentScope: RumScope
 
     @Mock
-    lateinit var mockChildScope: RumScope
+    lateinit var mockChildScope: RumViewScope
 
     @Mock
     lateinit var mockWriter: DataWriter<Any>
@@ -902,6 +902,22 @@ internal class RumViewManagerScopeTest {
             ),
             15f
         )
+    }
+
+    @Test
+    fun `M renew all the child scopes W renewViewScopes`(forge: Forge) {
+        // Given
+        val eventTime = Time()
+        repeat(forge.aSmallInt()) {
+            testedScope.handleEvent(forge.startViewEvent(eventTime), mockWriter)
+        }
+
+        // When
+        val oldScopes = testedScope.childrenScopes.toList()
+        testedScope.renewViewScopes(eventTime)
+
+        // Then
+        assertThat(testedScope.childrenScopes).isNotEqualTo(oldScopes)
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -396,35 +396,6 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M update the viewId W getRumContext() with parent sessionId changed`(
-        @Forgery newSessionId: UUID
-    ) {
-        // Given
-        val initialViewId = testedScope.viewId
-        val context = testedScope.getRumContext()
-        whenever(mockParentScope.getRumContext())
-            .doReturn(fakeParentContext.copy(sessionId = newSessionId.toString()))
-
-        // When
-        val updatedContext = testedScope.getRumContext()
-
-        // Then
-        assertThat(context.actionId).isNull()
-        assertThat(context.viewId).isEqualTo(initialViewId)
-        assertThat(context.viewName).isEqualTo(fakeKey.name)
-        assertThat(context.viewUrl).isEqualTo(fakeUrl)
-        assertThat(context.sessionId).isEqualTo(fakeParentContext.sessionId)
-        assertThat(context.applicationId).isEqualTo(fakeParentContext.applicationId)
-
-        assertThat(updatedContext.actionId).isNull()
-        assertThat(updatedContext.viewId).isNotEqualTo(initialViewId)
-        assertThat(context.viewName).isEqualTo(fakeKey.name)
-        assertThat(updatedContext.viewUrl).isEqualTo(fakeUrl)
-        assertThat(updatedContext.sessionId).isEqualTo(newSessionId.toString())
-        assertThat(updatedContext.applicationId).isEqualTo(fakeParentContext.applicationId)
-    }
-
-    @Test
     fun `M update the context with the viewType W initializing`(forge: Forge) {
         // Given
         val fakeViewEventType = forge.aValueFrom(RumViewType::class.java)
@@ -2030,79 +2001,6 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M send event W handleEvent(ErrorSent) on active view {viewId changed}`(
-        @LongForgery(1) pending: Long,
-        @Forgery fakeNewViewId: UUID
-    ) {
-        // Given
-        fakeEvent = RumRawEvent.ErrorSent(testedScope.viewId)
-        testedScope.pendingErrorCount = pending
-        testedScope.viewId = fakeNewViewId.toString()
-
-        // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // Then
-        argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
-            assertThat(lastValue)
-                .apply {
-                    hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
-                    hasName(fakeKey.name)
-                    hasUrl(fakeUrl)
-                    hasDurationGreaterThan(1)
-                    hasVersion(2)
-                    hasErrorCount(1)
-                    hasCrashCount(0)
-                    hasResourceCount(0)
-                    hasActionCount(0)
-                    hasFrustrationCount(0)
-                    hasLongTaskCount(0)
-                    hasFrozenFrameCount(0)
-                    hasCpuMetric(null)
-                    hasMemoryMetric(null, null)
-                    hasRefreshRateMetric(null, null)
-                    isActive(true)
-                    isSlowRendered(false)
-                    hasNoCustomTimings()
-                    hasUserInfo(fakeDatadogContext.userInfo)
-                    hasAccountInfo(fakeDatadogContext.accountInfo)
-                    hasViewId(testedScope.viewId)
-                    hasApplicationId(fakeParentContext.applicationId)
-                    hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
-                    hasNoSyntheticsTest()
-                    hasStartReason(fakeParentContext.sessionStartReason)
-                    // TODO RUMM-3316 if viewId changes, we need to relink replay as well.
-                    hasReplay(false)
-                    containsExactlyContextAttributes(fakeAttributes)
-                    hasSource(fakeSourceViewEvent)
-                    hasDeviceInfo(
-                        fakeDatadogContext.deviceInfo.deviceName,
-                        fakeDatadogContext.deviceInfo.deviceModel,
-                        fakeDatadogContext.deviceInfo.deviceBrand,
-                        fakeDatadogContext.deviceInfo.deviceType.toViewSchemaType(),
-                        fakeDatadogContext.deviceInfo.architecture
-                    )
-                    hasOsInfo(
-                        fakeDatadogContext.deviceInfo.osName,
-                        fakeDatadogContext.deviceInfo.osVersion,
-                        fakeDatadogContext.deviceInfo.osMajorVersion
-                    )
-                    hasSlownessInfo(fakeSlowRecords)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
-                    hasServiceName(fakeDatadogContext.service)
-                    hasVersion(fakeDatadogContext.version)
-                    hasSessionActive(fakeParentContext.isSessionActive)
-                    hasSampleRate(fakeSampleRate)
-                }
-        }
-        verifyNoMoreInteractions(mockWriter)
-        assertThat(result).isSameAs(testedScope)
-        assertThat(testedScope.pendingErrorCount).isEqualTo(pending - 1)
-    }
-
-    @Test
     fun `M do nothing W handleEvent(ErrorSent) on active view {unknown viewId}`(
         @Forgery viewUuid: UUID,
         @LongForgery(1) pending: Long
@@ -2168,86 +2066,6 @@ internal class RumViewScopeTest {
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
                     hasReplayStats(fakeReplayStats)
-                    containsExactlyContextAttributes(fakeAttributes)
-                    hasSource(fakeSourceViewEvent)
-                    hasDeviceInfo(
-                        fakeDatadogContext.deviceInfo.deviceName,
-                        fakeDatadogContext.deviceInfo.deviceModel,
-                        fakeDatadogContext.deviceInfo.deviceBrand,
-                        fakeDatadogContext.deviceInfo.deviceType.toViewSchemaType(),
-                        fakeDatadogContext.deviceInfo.architecture
-                    )
-                    hasOsInfo(
-                        fakeDatadogContext.deviceInfo.osName,
-                        fakeDatadogContext.deviceInfo.osVersion,
-                        fakeDatadogContext.deviceInfo.osMajorVersion
-                    )
-                    hasSlownessInfo(fakeSlowRecords)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
-                    hasServiceName(fakeDatadogContext.service)
-                    hasVersion(fakeDatadogContext.version)
-                    hasSessionActive(fakeParentContext.isSessionActive)
-                    hasSampleRate(fakeSampleRate)
-                }
-        }
-        verifyNoMoreInteractions(mockWriter)
-        verify(mockNetworkSettledMetricResolver).resourceWasStopped(
-            InternalResourceContext(
-                fakeResourceEvent.resourceId,
-                fakeResourceEvent.resourceEndTimestampInNanos
-            )
-        )
-        assertThat(result).isSameAs(testedScope)
-        assertThat(testedScope.pendingResourceCount).isEqualTo(pending - 1)
-    }
-
-    @Test
-    fun `M send event W handleEvent(ResourceSent) on active view {viewId changed}`(
-        @LongForgery(1) pending: Long,
-        @Forgery fakeNewViewId: UUID,
-        forge: Forge
-    ) {
-        // Given
-        testedScope.pendingResourceCount = pending
-        val fakeResourceEvent = forge.getForgery<RumRawEvent.ResourceSent>().copy(testedScope.viewId)
-        testedScope.viewId = fakeNewViewId.toString()
-
-        // When
-        val result = testedScope.handleEvent(fakeResourceEvent, mockWriter)
-
-        // Then
-        argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
-            assertThat(lastValue)
-                .apply {
-                    hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
-                    hasName(fakeKey.name)
-                    hasUrl(fakeUrl)
-                    hasDurationGreaterThan(1)
-                    hasVersion(2)
-                    hasErrorCount(0)
-                    hasCrashCount(0)
-                    hasResourceCount(1)
-                    hasActionCount(0)
-                    hasFrustrationCount(0)
-                    hasLongTaskCount(0)
-                    hasFrozenFrameCount(0)
-                    hasCpuMetric(null)
-                    hasMemoryMetric(null, null)
-                    hasRefreshRateMetric(null, null)
-                    isActive(true)
-                    isSlowRendered(false)
-                    hasNoCustomTimings()
-                    hasUserInfo(fakeDatadogContext.userInfo)
-                    hasAccountInfo(fakeDatadogContext.accountInfo)
-                    hasViewId(testedScope.viewId)
-                    hasApplicationId(fakeParentContext.applicationId)
-                    hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
-                    hasNoSyntheticsTest()
-                    hasStartReason(fakeParentContext.sessionStartReason)
-                    // TODO RUMM-3316 if viewId changes, we need to relink replay as well.
-                    hasReplay(false)
                     containsExactlyContextAttributes(fakeAttributes)
                     hasSource(fakeSourceViewEvent)
                     hasDeviceInfo(
@@ -2378,82 +2196,6 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M send event W handleEvent(ActionSent) on active view {viewId changed}`(
-        @LongForgery(1) pending: Long,
-        @IntForgery(0) frustrationCount: Int,
-        @Forgery fakeNewViewId: UUID,
-        @Forgery actionType: ActionEvent.ActionEventActionType,
-        @LongForgery(0) actionEventTimestamp: Long
-    ) {
-        // Given
-        fakeEvent = RumRawEvent.ActionSent(testedScope.viewId, frustrationCount, actionType, actionEventTimestamp)
-        testedScope.pendingActionCount = pending
-        testedScope.viewId = fakeNewViewId.toString()
-
-        // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // Then
-        argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
-            assertThat(lastValue)
-                .apply {
-                    hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
-                    hasName(fakeKey.name)
-                    hasUrl(fakeUrl)
-                    hasDurationGreaterThan(1)
-                    hasVersion(2)
-                    hasErrorCount(0)
-                    hasCrashCount(0)
-                    hasResourceCount(0)
-                    hasActionCount(1)
-                    hasFrustrationCount(frustrationCount.toLong())
-                    hasLongTaskCount(0)
-                    hasFrozenFrameCount(0)
-                    hasCpuMetric(null)
-                    hasMemoryMetric(null, null)
-                    hasRefreshRateMetric(null, null)
-                    isActive(true)
-                    isSlowRendered(false)
-                    hasNoCustomTimings()
-                    hasUserInfo(fakeDatadogContext.userInfo)
-                    hasAccountInfo(fakeDatadogContext.accountInfo)
-                    hasViewId(testedScope.viewId)
-                    hasApplicationId(fakeParentContext.applicationId)
-                    hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
-                    hasNoSyntheticsTest()
-                    hasStartReason(fakeParentContext.sessionStartReason)
-                    // TODO RUMM-3316 if viewId changes, we need to relink replay as well.
-                    hasReplay(false)
-                    containsExactlyContextAttributes(fakeAttributes)
-                    hasSource(fakeSourceViewEvent)
-                    hasDeviceInfo(
-                        fakeDatadogContext.deviceInfo.deviceName,
-                        fakeDatadogContext.deviceInfo.deviceModel,
-                        fakeDatadogContext.deviceInfo.deviceBrand,
-                        fakeDatadogContext.deviceInfo.deviceType.toViewSchemaType(),
-                        fakeDatadogContext.deviceInfo.architecture
-                    )
-                    hasOsInfo(
-                        fakeDatadogContext.deviceInfo.osName,
-                        fakeDatadogContext.deviceInfo.osVersion,
-                        fakeDatadogContext.deviceInfo.osMajorVersion
-                    )
-                    hasSlownessInfo(fakeSlowRecords)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
-                    hasServiceName(fakeDatadogContext.service)
-                    hasVersion(fakeDatadogContext.version)
-                    hasSessionActive(fakeParentContext.isSessionActive)
-                    hasSampleRate(fakeSampleRate)
-                }
-        }
-        verifyNoMoreInteractions(mockWriter)
-        assertThat(result).isSameAs(testedScope)
-        assertThat(testedScope.pendingActionCount).isEqualTo(pending - 1)
-    }
-
-    @Test
     fun `M do nothing W handleEvent(ActionSent) on active view {unknown viewId}`(
         @Forgery viewUuid: UUID,
         @LongForgery(1) pending: Long,
@@ -2551,82 +2293,6 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M send event W handleEvent(LongTaskSent) on active view {not frozen, viewId changed}`(
-        @LongForgery(1) pendingLongTask: Long,
-        @LongForgery(1) pendingFrozenFrame: Long,
-        @Forgery fakeNewViewId: UUID
-    ) {
-        // Given
-        fakeEvent = RumRawEvent.LongTaskSent(testedScope.viewId)
-        testedScope.pendingLongTaskCount = pendingLongTask
-        testedScope.pendingFrozenFrameCount = pendingFrozenFrame
-        testedScope.viewId = fakeNewViewId.toString()
-
-        // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // Then
-        argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
-            assertThat(lastValue)
-                .apply {
-                    hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
-                    hasName(fakeKey.name)
-                    hasUrl(fakeUrl)
-                    hasDurationGreaterThan(1)
-                    hasVersion(2)
-                    hasErrorCount(0)
-                    hasCrashCount(0)
-                    hasResourceCount(0)
-                    hasActionCount(0)
-                    hasFrustrationCount(0)
-                    hasLongTaskCount(1)
-                    hasFrozenFrameCount(0)
-                    hasCpuMetric(null)
-                    hasMemoryMetric(null, null)
-                    hasRefreshRateMetric(null, null)
-                    isActive(true)
-                    isSlowRendered(false)
-                    hasNoCustomTimings()
-                    hasUserInfo(fakeDatadogContext.userInfo)
-                    hasAccountInfo(fakeDatadogContext.accountInfo)
-                    hasViewId(testedScope.viewId)
-                    hasApplicationId(fakeParentContext.applicationId)
-                    hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
-                    hasNoSyntheticsTest()
-                    hasStartReason(fakeParentContext.sessionStartReason)
-                    // TODO RUMM-3316 if viewId changes, we need to relink replay as well.
-                    hasReplay(false)
-                    containsExactlyContextAttributes(fakeAttributes)
-                    hasSource(fakeSourceViewEvent)
-                    hasDeviceInfo(
-                        fakeDatadogContext.deviceInfo.deviceName,
-                        fakeDatadogContext.deviceInfo.deviceModel,
-                        fakeDatadogContext.deviceInfo.deviceBrand,
-                        fakeDatadogContext.deviceInfo.deviceType.toViewSchemaType(),
-                        fakeDatadogContext.deviceInfo.architecture
-                    )
-                    hasOsInfo(
-                        fakeDatadogContext.deviceInfo.osName,
-                        fakeDatadogContext.deviceInfo.osVersion,
-                        fakeDatadogContext.deviceInfo.osMajorVersion
-                    )
-                    hasSlownessInfo(fakeSlowRecords)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
-                    hasServiceName(fakeDatadogContext.service)
-                    hasVersion(fakeDatadogContext.version)
-                    hasSessionActive(fakeParentContext.isSessionActive)
-                    hasSampleRate(fakeSampleRate)
-                }
-        }
-        verifyNoMoreInteractions(mockWriter)
-        assertThat(result).isSameAs(testedScope)
-        assertThat(testedScope.pendingLongTaskCount).isEqualTo(pendingLongTask - 1)
-        assertThat(testedScope.pendingFrozenFrameCount).isEqualTo(pendingFrozenFrame)
-    }
-
-    @Test
     fun `M send event W handleEvent(LongTaskSent) on active view {frozen}`(
         @LongForgery(1) pendingLongTask: Long,
         @LongForgery(1) pendingFrozenFrame: Long
@@ -2672,82 +2338,6 @@ internal class RumViewScopeTest {
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
                     hasReplayStats(fakeReplayStats)
-                    containsExactlyContextAttributes(fakeAttributes)
-                    hasSource(fakeSourceViewEvent)
-                    hasDeviceInfo(
-                        fakeDatadogContext.deviceInfo.deviceName,
-                        fakeDatadogContext.deviceInfo.deviceModel,
-                        fakeDatadogContext.deviceInfo.deviceBrand,
-                        fakeDatadogContext.deviceInfo.deviceType.toViewSchemaType(),
-                        fakeDatadogContext.deviceInfo.architecture
-                    )
-                    hasOsInfo(
-                        fakeDatadogContext.deviceInfo.osName,
-                        fakeDatadogContext.deviceInfo.osVersion,
-                        fakeDatadogContext.deviceInfo.osMajorVersion
-                    )
-                    hasSlownessInfo(fakeSlowRecords)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
-                    hasServiceName(fakeDatadogContext.service)
-                    hasVersion(fakeDatadogContext.version)
-                    hasSessionActive(fakeParentContext.isSessionActive)
-                    hasSampleRate(fakeSampleRate)
-                }
-        }
-        verifyNoMoreInteractions(mockWriter)
-        assertThat(result).isSameAs(testedScope)
-        assertThat(testedScope.pendingLongTaskCount).isEqualTo(pendingLongTask - 1)
-        assertThat(testedScope.pendingFrozenFrameCount).isEqualTo(pendingFrozenFrame - 1)
-    }
-
-    @Test
-    fun `M send event W handleEvent(LongTaskSent) on active view {frozen, viewId changed}`(
-        @LongForgery(1) pendingLongTask: Long,
-        @LongForgery(1) pendingFrozenFrame: Long,
-        @Forgery fakeNewViewId: UUID
-    ) {
-        // Given
-        fakeEvent = RumRawEvent.LongTaskSent(testedScope.viewId, true)
-        testedScope.pendingLongTaskCount = pendingLongTask
-        testedScope.pendingFrozenFrameCount = pendingFrozenFrame
-        testedScope.viewId = fakeNewViewId.toString()
-
-        // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // Then
-        argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
-            assertThat(lastValue)
-                .apply {
-                    hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
-                    hasName(fakeKey.name)
-                    hasUrl(fakeUrl)
-                    hasDurationGreaterThan(1)
-                    hasVersion(2)
-                    hasErrorCount(0)
-                    hasCrashCount(0)
-                    hasResourceCount(0)
-                    hasActionCount(0)
-                    hasFrustrationCount(0)
-                    hasLongTaskCount(1)
-                    hasFrozenFrameCount(1)
-                    hasCpuMetric(null)
-                    hasMemoryMetric(null, null)
-                    hasRefreshRateMetric(null, null)
-                    isActive(true)
-                    isSlowRendered(false)
-                    hasNoCustomTimings()
-                    hasUserInfo(fakeDatadogContext.userInfo)
-                    hasAccountInfo(fakeDatadogContext.accountInfo)
-                    hasViewId(testedScope.viewId)
-                    hasApplicationId(fakeParentContext.applicationId)
-                    hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
-                    hasNoSyntheticsTest()
-                    hasStartReason(fakeParentContext.sessionStartReason)
-                    // TODO RUMM-3316 if viewId changes, we need to relink replay as well.
-                    hasReplay(false)
                     containsExactlyContextAttributes(fakeAttributes)
                     hasSource(fakeSourceViewEvent)
                     hasDeviceInfo(
@@ -4150,43 +3740,11 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M decrease pending Action W handleEvent(ActionDropped) on active view {viewId changed}`(
-        @LongForgery(1) pending: Long,
-        @Forgery fakeNewViewId: UUID
-    ) {
-        // Given
-        testedScope.pendingActionCount = pending
-        fakeEvent = RumRawEvent.ActionDropped(testedScope.viewId)
-        testedScope.viewId = fakeNewViewId.toString()
-
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        assertThat(testedScope.pendingActionCount).isEqualTo(pending - 1)
-        assertThat(result).isSameAs(testedScope)
-    }
-
-    @Test
     fun `M decrease pending Action W handleEvent(ActionDropped) on stopped view`() {
         // Given
         testedScope.pendingActionCount = 1
         fakeEvent = RumRawEvent.ActionDropped(testedScope.viewId)
         testedScope.stopped = true
-
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        assertThat(testedScope.pendingActionCount).isEqualTo(0)
-        assertThat(result).isNull()
-    }
-
-    @Test
-    fun `M decrease pending Action W handleEvent(ActionDropped) on stopped view {viewId changed}`(
-        @Forgery fakeNewViewId: UUID
-    ) {
-        // Given
-        testedScope.pendingActionCount = 1
-        fakeEvent = RumRawEvent.ActionDropped(testedScope.viewId)
-        testedScope.stopped = true
-        testedScope.viewId = fakeNewViewId.toString()
 
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
@@ -4393,26 +3951,6 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M decrease pending Resource W handleEvent(ResourceDropped) on active view {viewId changed}`(
-        @LongForgery(1) pending: Long,
-        @Forgery fakeNewViewId: UUID,
-        forge: Forge
-    ) {
-        // Given
-        testedScope.pendingResourceCount = pending
-        val fakeResourceDropped = forge.getForgery<RumRawEvent.ResourceDropped>().copy(viewId = testedScope.viewId)
-        testedScope.viewId = fakeNewViewId.toString()
-
-        // When
-        val result = testedScope.handleEvent(fakeResourceDropped, mockWriter)
-
-        // Then
-        assertThat(testedScope.pendingResourceCount).isEqualTo(pending - 1)
-        assertThat(result).isSameAs(testedScope)
-        verify(mockNetworkSettledMetricResolver).resourceWasDropped(fakeResourceDropped.resourceId)
-    }
-
-    @Test
     fun `M decrease pending Resource W handleEvent(ResourceDropped) on stopped view`(
         forge: Forge
     ) {
@@ -4420,26 +3958,6 @@ internal class RumViewScopeTest {
         testedScope.pendingResourceCount = 1
         val fakeResourceDropped = forge.getForgery<RumRawEvent.ResourceDropped>().copy(viewId = testedScope.viewId)
         testedScope.stopped = true
-
-        // When
-        val result = testedScope.handleEvent(fakeResourceDropped, mockWriter)
-
-        // Then
-        assertThat(testedScope.pendingResourceCount).isEqualTo(0)
-        assertThat(result).isNull()
-        verify(mockNetworkSettledMetricResolver).resourceWasDropped(fakeResourceDropped.resourceId)
-    }
-
-    @Test
-    fun `M decrease pending Resource W handleEvent(ResourceDropped) on stopped view {viewId changed}`(
-        @Forgery fakeNewViewId: UUID,
-        forge: Forge
-    ) {
-        // Given
-        testedScope.pendingResourceCount = 1
-        val fakeResourceDropped = forge.getForgery<RumRawEvent.ResourceDropped>().copy(viewId = testedScope.viewId)
-        testedScope.stopped = true
-        testedScope.viewId = fakeNewViewId.toString()
 
         // When
         val result = testedScope.handleEvent(fakeResourceDropped, mockWriter)
@@ -6197,43 +5715,11 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M decrease pending Error W handleEvent(ErrorDropped) on active view {viewId changed}`(
-        @LongForgery(1) pending: Long,
-        @Forgery fakeNewViewId: UUID
-    ) {
-        // Given
-        testedScope.pendingErrorCount = pending
-        fakeEvent = RumRawEvent.ErrorDropped(testedScope.viewId)
-        testedScope.viewId = fakeNewViewId.toString()
-
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        assertThat(testedScope.pendingErrorCount).isEqualTo(pending - 1)
-        assertThat(result).isSameAs(testedScope)
-    }
-
-    @Test
     fun `M decrease pending Error W handleEvent(ErrorDropped) on stopped view`() {
         // Given
         testedScope.pendingErrorCount = 1
         fakeEvent = RumRawEvent.ErrorDropped(testedScope.viewId)
         testedScope.stopped = true
-
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        assertThat(testedScope.pendingErrorCount).isEqualTo(0)
-        assertThat(result).isNull()
-    }
-
-    @Test
-    fun `M decrease pending Error W handleEvent(ErrorDropped) on stopped view {viewId changed}`(
-        @Forgery fakeNewViewId: UUID
-    ) {
-        // Given
-        testedScope.pendingErrorCount = 1
-        fakeEvent = RumRawEvent.ErrorDropped(testedScope.viewId)
-        testedScope.stopped = true
-        testedScope.viewId = fakeNewViewId.toString()
 
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
@@ -6721,27 +6207,6 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M decrease pending Long Task W handleEvent(LongTaskDropped) on active view {not frozen, viewId changed}`(
-        @LongForgery(1) pendingLongTask: Long,
-        @LongForgery(1) pendingFrozenFrame: Long,
-        @Forgery fakeNewViewId: UUID
-    ) {
-        // Given
-        testedScope.pendingLongTaskCount = pendingLongTask
-        testedScope.pendingFrozenFrameCount = pendingFrozenFrame
-        fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, false)
-        testedScope.viewId = fakeNewViewId.toString()
-
-        // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // Then
-        assertThat(testedScope.pendingLongTaskCount).isEqualTo(pendingLongTask - 1)
-        assertThat(testedScope.pendingFrozenFrameCount).isEqualTo(pendingFrozenFrame)
-        assertThat(result).isSameAs(testedScope)
-    }
-
-    @Test
     fun `M decrease pending LT and FF W handleEvent(LongTaskDropped) on active view {frozen}`(
         @LongForgery(1) pendingLongTask: Long,
         @LongForgery(1) pendingFrozenFrame: Long
@@ -6750,27 +6215,6 @@ internal class RumViewScopeTest {
         testedScope.pendingLongTaskCount = pendingLongTask
         testedScope.pendingFrozenFrameCount = pendingFrozenFrame
         fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, true)
-
-        // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // Then
-        assertThat(testedScope.pendingLongTaskCount).isEqualTo(pendingLongTask - 1)
-        assertThat(testedScope.pendingFrozenFrameCount).isEqualTo(pendingFrozenFrame - 1)
-        assertThat(result).isSameAs(testedScope)
-    }
-
-    @Test
-    fun `M decrease pending LT and FF W handleEvent(LongTaskDropped) on active view {frozen, viewId changed}`(
-        @LongForgery(1) pendingLongTask: Long,
-        @LongForgery(1) pendingFrozenFrame: Long,
-        @Forgery fakeNewViewId: UUID
-    ) {
-        // Given
-        testedScope.pendingLongTaskCount = pendingLongTask
-        testedScope.pendingFrozenFrameCount = pendingFrozenFrame
-        fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, true)
-        testedScope.viewId = fakeNewViewId.toString()
 
         // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
@@ -6799,52 +6243,12 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M decrease pending LT W handleEvent(LongTaskDropped) on stopped view {not frozen, viewId changed}`(
-        @Forgery fakeNewViewId: UUID
-    ) {
-        // Given
-        testedScope.pendingLongTaskCount = 1
-        testedScope.pendingFrozenFrameCount = 0
-        fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, false)
-        testedScope.stopped = true
-        testedScope.viewId = fakeNewViewId.toString()
-
-        // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // Then
-        assertThat(testedScope.pendingLongTaskCount).isEqualTo(0)
-        assertThat(testedScope.pendingFrozenFrameCount).isEqualTo(0)
-        assertThat(result).isNull()
-    }
-
-    @Test
     fun `M decrease pending LT and FF W handleEvent(LongTaskDropped) on stopped view {frozen}`() {
         // Given
         testedScope.pendingLongTaskCount = 1
         testedScope.pendingFrozenFrameCount = 1
         fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, true)
         testedScope.stopped = true
-
-        // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // Then
-        assertThat(testedScope.pendingLongTaskCount).isEqualTo(0)
-        assertThat(testedScope.pendingLongTaskCount).isEqualTo(0)
-        assertThat(result).isNull()
-    }
-
-    @Test
-    fun `M decrease pending LT and FF W handleEvent(LongTaskDropped) on stopped view {frozen, viewId changed}`(
-        @Forgery fakeNewViewId: UUID
-    ) {
-        // Given
-        testedScope.pendingLongTaskCount = 1
-        testedScope.pendingFrozenFrameCount = 1
-        fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, true)
-        testedScope.stopped = true
-        testedScope.viewId = fakeNewViewId.toString()
 
         // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
@@ -9891,6 +9295,38 @@ internal class RumViewScopeTest {
 
         // Then
         mockViewEndedMetricDispatcher.onViewLoadingTimeResolved(expectedDuration)
+    }
+
+    @Test
+    fun `M return a new RumViewScope W renew the current one`() {
+        // Given
+        val expectedTime = Time(nanoTime = fakeEventTime.nanoTime)
+
+        // When
+        val newScope = testedScope.renew(expectedTime)
+
+        assertThat(newScope.key).isEqualTo(testedScope.key)
+        assertThat(newScope.firstPartyHostHeaderTypeResolver).isEqualTo(testedScope.firstPartyHostHeaderTypeResolver)
+        assertThat(newScope.cpuVitalMonitor).isEqualTo(testedScope.cpuVitalMonitor)
+        assertThat(newScope.memoryVitalMonitor).isEqualTo(testedScope.memoryVitalMonitor)
+        assertThat(newScope.frameRateVitalMonitor).isEqualTo(testedScope.frameRateVitalMonitor)
+        assertThat(newScope.type).isEqualTo(testedScope.type)
+        assertThat(newScope.sampleRate).isEqualTo(testedScope.sampleRate)
+        assertThat(newScope.url).isEqualTo(testedScope.url)
+        assertThat(newScope.eventAttributes).isEqualTo(testedScope.eventAttributes)
+        assertThat(newScope.stoppedNanos).isEqualTo(expectedTime.nanoTime)
+        assertThat(newScope.viewLoadingTime).isNull()
+        assertThat(newScope.activeActionScope).isNull()
+        assertThat(newScope.activeResourceScopes).isEmpty()
+        assertThat(newScope.pendingResourceCount).isEqualTo(0)
+        assertThat(newScope.pendingActionCount).isEqualTo(0)
+        assertThat(newScope.pendingErrorCount).isEqualTo(0)
+        assertThat(newScope.pendingLongTaskCount).isEqualTo(0)
+        assertThat(newScope.pendingFrozenFrameCount).isEqualTo(0)
+        assertThat(newScope.version).isEqualTo(1)
+        assertThat(newScope.customTimings).isEmpty()
+        assertThat(newScope.featureFlags).isEmpty()
+        assertThat(newScope.stopped).isEqualTo(false)
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -1812,13 +1812,10 @@ internal class DatadogRumMonitorTest {
             }
         }
         val expectedViewNames = viewScopes.mapNotNull { it.getRumContext().viewName }
-        val otherScopes = forge.aList {
-            forge.anElementFrom(mock(), mock<RumActionScope>(), mock<RumResourceScope>())
-        }
         whenever(mockRumApplicationScope.activeSession) doReturn mockSessionScope
         whenever(mockSessionScope.childScope) doReturn mockViewManagerScope
         whenever(mockViewManagerScope.childrenScopes)
-            .thenReturn((viewScopes + otherScopes).toMutableList())
+            .thenReturn(viewScopes.toMutableList())
 
         // When
         testedMonitor.notifyDebugListenerWithState()
@@ -1848,14 +1845,10 @@ internal class DatadogRumMonitorTest {
             }
         }
         val expectedViewNames = emptyList<String>()
-        val otherScopes = forge.aList {
-            forge.anElementFrom(mock(), mock<RumActionScope>(), mock<RumResourceScope>())
-        }
         whenever(mockRumApplicationScope.activeSession) doReturn mockSessionScope
         whenever(mockSessionScope.childScope) doReturn mockViewManagerScope
         whenever(mockViewManagerScope.childrenScopes)
-            .thenReturn((viewScopes + otherScopes).toMutableList())
-
+            .thenReturn(viewScopes.toMutableList())
         // When
         testedMonitor.notifyDebugListenerWithState()
 


### PR DESCRIPTION
### What does this PR do?

Major Changes in this PR:
* `RumViewScope`
    * `sessionId`, `viewId` and `eventTime` become `val` in `RumViewScope`, they will not be able to renew in the same `RumViewScope` instance.
    * `oldViewIds` is removed, `RumViewScope` doesn't remember this anymore since `viewId` now is immutable.
    * Event callback doesn't check `oldViewIds` anymore before handling the event since `oldViewIds` is removed, meaning that we don't handle the pending event from the old view scope now.
* `RumViewManagerScope`
   * when the scope is asked to renew, it will clone all the children scope with the new event time and replace them.
* `RumSessionScope`
   * when session needs to renew, call proactively `RumViewManagerScope` to renew the children scope.
   * Replace the renew session timestamp with the event time, otherwise the session start time will be later than the first event in the session, which is not logical.

### Motivation

RUM-10099

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

