### PR TITLE
RUM-10269: Fix `NullPointerException` in `isOnSecondaryDisplay` method

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewUtilsInternal.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewUtilsInternal.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder
 
 import android.annotation.SuppressLint
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.view.Display
 import android.view.View
 import android.view.ViewStub
@@ -32,8 +33,16 @@ internal class ViewUtilsInternal {
         return view.id in systemViewIds || view is ViewStub || view is ActionBarContextView
     }
 
-    internal fun isOnSecondaryDisplay(view: View): Boolean =
-        view.display.displayId != Display.DEFAULT_DISPLAY
+    internal fun isOnSecondaryDisplay(view: View): Boolean {
+        val display = view.display
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            display != null &&
+                display.displayId != Display.DEFAULT_DISPLAY &&
+                display.displayId != Display.INVALID_DISPLAY
+        } else {
+            display != null && display.displayId != Display.DEFAULT_DISPLAY
+        }
+    }
 
     @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
     internal fun isToolbar(view: View): Boolean {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewUtilsInternalTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewUtilsInternalTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder
 
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.view.Display
 import android.view.View
 import android.view.ViewStub
@@ -15,6 +16,7 @@ import androidx.appcompat.widget.ActionBarContextView
 import androidx.appcompat.widget.Toolbar
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.resources.DefaultImageWireframeHelper
+import com.datadog.tools.unit.annotations.TestTargetApi
 import com.datadog.tools.unit.extensions.ApiLevelExtension
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.IntForgery
@@ -28,6 +30,7 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -337,8 +340,9 @@ internal class ViewUtilsInternalTest {
         @IntForgery(min = Display.DEFAULT_DISPLAY + 1) fakeDisplayId: Int
     ) {
         // Given
-        whenever(mockView.display).thenReturn(mock())
-        whenever(mockView.display?.displayId).thenReturn(fakeDisplayId)
+        val mockDisplay = mock<Display>()
+        whenever(mockView.display) doReturn mockDisplay
+        whenever(mockDisplay.displayId) doReturn fakeDisplayId
 
         // When
         val isOnSecondaryDisplay = testViewUtilsInternal.isOnSecondaryDisplay(mockView)
@@ -352,8 +356,40 @@ internal class ViewUtilsInternalTest {
         @Mock mockView: View
     ) {
         // Given
-        whenever(mockView.display).thenReturn(mock())
-        whenever(mockView.display?.displayId).thenReturn(Display.DEFAULT_DISPLAY)
+        val mockDisplay = mock<Display>()
+        whenever(mockView.display) doReturn mockDisplay
+        whenever(mockDisplay.displayId) doReturn Display.DEFAULT_DISPLAY
+
+        // When
+        val isOnSecondaryDisplay = testViewUtilsInternal.isOnSecondaryDisplay(mockView)
+
+        // Then
+        assertThat(isOnSecondaryDisplay).isFalse
+    }
+
+    @Test
+    @TestTargetApi(Build.VERSION_CODES.M)
+    fun `M return false W isOnSecondaryDisplay { invalid display }`(
+        @Mock mockView: View
+    ) {
+        // Given
+        val mockDisplay = mock<Display>()
+        whenever(mockView.display) doReturn mockDisplay
+        whenever(mockDisplay.displayId) doReturn Display.INVALID_DISPLAY
+
+        // When
+        val isOnSecondaryDisplay = testViewUtilsInternal.isOnSecondaryDisplay(mockView)
+
+        // Then
+        assertThat(isOnSecondaryDisplay).isFalse
+    }
+
+    @Test
+    fun `M return false W isOnSecondaryDisplay { no display }`(
+        @Mock mockView: View
+    ) {
+        // Given
+        whenever(mockView.display) doReturn null
 
         // When
         val isOnSecondaryDisplay = testViewUtilsInternal.isOnSecondaryDisplay(mockView)


### PR DESCRIPTION
### What does this PR do?

There is an NPE in `ViewUtilsInternalTest.isOnSecondaryDisplay` method due to the possibility `View.getDisplay` returning `null`. It is possible when:

> return The logical display, or null if the view is not currently attached to a window.

Full stacktrace:

```
java.lang.NullPointerException: Attempt to invoke virtual method 'int android.view.Display.getDisplayId()' on a null object reference
	at com.datadog.android.sessionreplay.internal.recorder.ViewUtilsInternal.isOnSecondaryDisplay$dd_sdk_android_session_replay_release(ViewUtilsInternal.java:36)
	at com.datadog.android.sessionreplay.internal.recorder.TreeViewTraversal.traverse(TreeViewTraversal.java:49)
	at com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.convertViewToNode(SnapshotProducer.java:70)
	at com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.convertViewToNode(SnapshotProducer.java:89)
	at com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.convertViewToNode(SnapshotProducer.java:89)
	at com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.convertViewToNode(SnapshotProducer.java:89)
	at com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.convertViewToNode(SnapshotProducer.java:89)
	at com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.convertViewToNode(SnapshotProducer.java:89)
	at com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.convertViewToNode(SnapshotProducer.java:89)
	at com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.convertViewToNode(SnapshotProducer.java:89)
	at com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.convertViewToNode(SnapshotProducer.java:89)
	at com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.convertViewToNode(SnapshotProducer.java:89)
	at com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.convertViewToNode(SnapshotProducer.java:89)
	at com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.convertViewToNode(SnapshotProducer.java:89)
	at com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.convertViewToNode(SnapshotProducer.java:89)
	at com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.convertViewToNode(SnapshotProducer.java:89)
	at com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.convertViewToNode(SnapshotProducer.java:89)
	at com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.produce(SnapshotProducer.java:42)
	at com.datadog.android.sessionreplay.internal.recorder.listener.WindowsOnDrawListener$snapshotRunnable$1$run$nodes$1.invoke(WindowsOnDrawListener.java:71)
	at com.datadog.android.sessionreplay.internal.recorder.listener.WindowsOnDrawListener$snapshotRunnable$1$run$nodes$1.invoke(WindowsOnDrawListener.java:62)
	at com.datadog.android.api.feature.FeatureScopeExtKt.measureMethodCallPerf(FeatureScopeExtKt.java:35)
	at com.datadog.android.sessionreplay.internal.recorder.listener.WindowsOnDrawListener$snapshotRunnable$1.run(WindowsOnDrawListener.java:62)
	at com.datadog.android.sessionreplay.internal.recorder.Debouncer$executeRunnable$1.invoke(Debouncer.java:47)
	at com.datadog.android.sessionreplay.internal.recorder.Debouncer$executeRunnable$1.invoke(Debouncer.java:46)
	at com.datadog.android.sessionreplay.internal.recorder.Debouncer.runInTimeBalance(Debouncer.java:58)
	at com.datadog.android.sessionreplay.internal.recorder.Debouncer.executeRunnable(Debouncer.java:46)
	at com.datadog.android.sessionreplay.internal.recorder.Debouncer.debounce$dd_sdk_android_session_replay_release(Debouncer.java:38)
	at com.datadog.android.sessionreplay.internal.recorder.listener.WindowsOnDrawListener.onDraw(WindowsOnDrawListener.java:47)
	at android.view.ViewTreeObserver.dispatchOnDraw(ViewTreeObserver.java:1165)
	at android.view.ViewRootImpl.draw(ViewRootImpl.java:5556)
	at android.view.ViewRootImpl.performDraw(ViewRootImpl.java:5330)
	at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:4486)
	at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:3116)
	at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:10885)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1301)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1309)
	at android.view.Choreographer.doCallbacks(Choreographer.java:923)
	at android.view.Choreographer.doFrame(Choreographer.java:852)
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1283)
	at android.os.Handler.handleCallback(Handler.java:942)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:226)
	at android.os.Looper.loop(Looper.java:313)
	at android.app.ActivityThread.main(ActivityThread.java:8762)
	at java.lang.reflect.Method.invoke(Native Method:0)
	at <redacted>(unknown:2)
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

