### PR TITLE
Move `LocalAttribute` class and related extension methods to the `internal` module

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -260,24 +260,6 @@ sealed class com.datadog.android.core.feature.event.JvmCrash
     constructor(Throwable, String, List<ThreadDump>)
 data class com.datadog.android.core.feature.event.ThreadDump
   constructor(String, String, String, Boolean)
-interface com.datadog.android.core.internal.attributes.LocalAttribute
-  enum Key
-    constructor(String)
-    - CREATION_SAMPLING_RATE
-    - REPORTING_SAMPLING_RATE
-    - VIEW_SCOPE_INSTRUMENTATION_TYPE
-    override fun toString(): String
-  interface Constant
-    val key: Key
-fun MutableMap<String, Any?>.enrichWithConstantAttribute(LocalAttribute.Constant)
-fun MutableMap<String, Any?>.enrichWithNonNullAttribute(LocalAttribute.Key, Any?)
-fun MutableMap<String, Any?>.enrichWithLocalAttribute(LocalAttribute.Key, Any?)
-enum com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType : LocalAttribute.Constant
-  - MANUAL
-  - COMPOSE
-  - ACTIVITY
-  - FRAGMENT
-  override val key: LocalAttribute.Key
 class com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver : FirstPartyHostHeaderTypeResolver
   constructor(Map<String, Set<com.datadog.android.trace.TracingHeaderType>>)
   override fun isFirstPartyUrl(okhttp3.HttpUrl): Boolean

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -733,38 +733,6 @@ public final class com/datadog/android/core/feature/event/ThreadDump {
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class com/datadog/android/core/internal/attributes/LocalAttribute {
-}
-
-public abstract interface class com/datadog/android/core/internal/attributes/LocalAttribute$Constant {
-	public abstract fun getKey ()Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
-}
-
-public final class com/datadog/android/core/internal/attributes/LocalAttribute$Key : java/lang/Enum {
-	public static final field CREATION_SAMPLING_RATE Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
-	public static final field REPORTING_SAMPLING_RATE Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
-	public static final field VIEW_SCOPE_INSTRUMENTATION_TYPE Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
-	public fun toString ()Ljava/lang/String;
-	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
-	public static fun values ()[Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
-}
-
-public final class com/datadog/android/core/internal/attributes/LocalAttributeKt {
-	public static final fun enrichWithConstantAttribute (Ljava/util/Map;Lcom/datadog/android/core/internal/attributes/LocalAttribute$Constant;)Ljava/util/Map;
-	public static final fun enrichWithLocalAttribute (Ljava/util/Map;Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;Ljava/lang/Object;)Ljava/util/Map;
-	public static final fun enrichWithNonNullAttribute (Ljava/util/Map;Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;Ljava/lang/Object;)Ljava/util/Map;
-}
-
-public final class com/datadog/android/core/internal/attributes/ViewScopeInstrumentationType : java/lang/Enum, com/datadog/android/core/internal/attributes/LocalAttribute$Constant {
-	public static final field ACTIVITY Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
-	public static final field COMPOSE Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
-	public static final field FRAGMENT Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
-	public static final field MANUAL Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
-	public fun getKey ()Lcom/datadog/android/core/internal/attributes/LocalAttribute$Key;
-	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
-	public static fun values ()[Lcom/datadog/android/core/internal/attributes/ViewScopeInstrumentationType;
-}
-
 public final class com/datadog/android/core/internal/net/DefaultFirstPartyHostHeaderTypeResolver : com/datadog/android/core/internal/net/FirstPartyHostHeaderTypeResolver {
 	public fun <init> (Ljava/util/Map;)V
 	public fun getAllHeaderTypes ()Ljava/util/Set;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/logger/SdkInternalLogger.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/logger/SdkInternalLogger.kt
@@ -12,12 +12,12 @@ import com.datadog.android.Datadog
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
-import com.datadog.android.core.internal.attributes.LocalAttribute
-import com.datadog.android.core.internal.attributes.enrichWithNonNullAttribute
 import com.datadog.android.core.internal.metrics.MethodCalledTelemetry
 import com.datadog.android.core.metrics.PerformanceMetric
 import com.datadog.android.core.metrics.TelemetryMetricType
 import com.datadog.android.core.sampling.RateBasedSampler
+import com.datadog.android.internal.attributes.LocalAttribute
+import com.datadog.android.internal.attributes.enrichWithNonNullAttribute
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 
 internal class SdkInternalLogger(

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/logger/SdkInternalLoggerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/logger/SdkInternalLoggerTest.kt
@@ -12,9 +12,9 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
-import com.datadog.android.core.internal.attributes.LocalAttribute
 import com.datadog.android.core.internal.metrics.MethodCalledTelemetry
 import com.datadog.android.core.metrics.TelemetryMetricType
+import com.datadog.android.internal.attributes.LocalAttribute
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.forge.aThrowable

--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -1,3 +1,21 @@
+interface com.datadog.android.internal.attributes.LocalAttribute
+  enum Key
+    constructor(String)
+    - CREATION_SAMPLING_RATE
+    - REPORTING_SAMPLING_RATE
+    - VIEW_SCOPE_INSTRUMENTATION_TYPE
+    override fun toString(): String
+  interface Constant
+    val key: Key
+fun MutableMap<String, Any?>.enrichWithConstantAttribute(LocalAttribute.Constant)
+fun MutableMap<String, Any?>.enrichWithNonNullAttribute(LocalAttribute.Key, Any?)
+fun MutableMap<String, Any?>.enrichWithLocalAttribute(LocalAttribute.Key, Any?)
+enum com.datadog.android.internal.attributes.ViewScopeInstrumentationType : LocalAttribute.Constant
+  - MANUAL
+  - COMPOSE
+  - ACTIVITY
+  - FRAGMENT
+  override val key: LocalAttribute.Key
 class com.datadog.android.internal.collections.EvictingQueue<T> : java.util.Queue<T>
   constructor(Int = Int.MAX_VALUE)
   override val size: Int

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -1,3 +1,35 @@
+public abstract interface class com/datadog/android/internal/attributes/LocalAttribute {
+}
+
+public abstract interface class com/datadog/android/internal/attributes/LocalAttribute$Constant {
+	public abstract fun getKey ()Lcom/datadog/android/internal/attributes/LocalAttribute$Key;
+}
+
+public final class com/datadog/android/internal/attributes/LocalAttribute$Key : java/lang/Enum {
+	public static final field CREATION_SAMPLING_RATE Lcom/datadog/android/internal/attributes/LocalAttribute$Key;
+	public static final field REPORTING_SAMPLING_RATE Lcom/datadog/android/internal/attributes/LocalAttribute$Key;
+	public static final field VIEW_SCOPE_INSTRUMENTATION_TYPE Lcom/datadog/android/internal/attributes/LocalAttribute$Key;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/internal/attributes/LocalAttribute$Key;
+	public static fun values ()[Lcom/datadog/android/internal/attributes/LocalAttribute$Key;
+}
+
+public final class com/datadog/android/internal/attributes/LocalAttributeKt {
+	public static final fun enrichWithConstantAttribute (Ljava/util/Map;Lcom/datadog/android/internal/attributes/LocalAttribute$Constant;)Ljava/util/Map;
+	public static final fun enrichWithLocalAttribute (Ljava/util/Map;Lcom/datadog/android/internal/attributes/LocalAttribute$Key;Ljava/lang/Object;)Ljava/util/Map;
+	public static final fun enrichWithNonNullAttribute (Ljava/util/Map;Lcom/datadog/android/internal/attributes/LocalAttribute$Key;Ljava/lang/Object;)Ljava/util/Map;
+}
+
+public final class com/datadog/android/internal/attributes/ViewScopeInstrumentationType : java/lang/Enum, com/datadog/android/internal/attributes/LocalAttribute$Constant {
+	public static final field ACTIVITY Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType;
+	public static final field COMPOSE Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType;
+	public static final field FRAGMENT Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType;
+	public static final field MANUAL Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType;
+	public fun getKey ()Lcom/datadog/android/internal/attributes/LocalAttribute$Key;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType;
+	public static fun values ()[Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType;
+}
+
 public final class com/datadog/android/internal/collections/EvictingQueue : java/util/Queue {
 	public fun <init> (I)V
 	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/attributes/LocalAttribute.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/attributes/LocalAttribute.kt
@@ -3,15 +3,12 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2016-Present Datadog, Inc.
  */
-package com.datadog.android.core.internal.attributes
-
-import com.datadog.android.lint.InternalApi
+package com.datadog.android.internal.attributes
 
 /**
  * Local attributes are used to pass additional metadata along with the event
  * and are never sent to the backend directly.
  */
-@InternalApi
 interface LocalAttribute {
 
     /**
@@ -20,7 +17,6 @@ interface LocalAttribute {
      *
      * @param string - Unique string value for a local attribute key.
      */
-    @InternalApi
     enum class Key(
         private val string: String
     ) {
@@ -57,7 +53,6 @@ interface LocalAttribute {
      * an attribute and reduces the possibility of inconsistent use of api (when an unsupported value is passed
      * for a particular attribute key).
      */
-    @InternalApi
     interface Constant {
         /** Constant attribute key. For enum constants will be same for all values. */
         val key: Key
@@ -70,7 +65,6 @@ interface LocalAttribute {
  * @param attribute - Constant attribute value that should be added.
  * Key for the attribute will be resolved automatically.
  */
-@InternalApi
 fun MutableMap<String, Any?>.enrichWithConstantAttribute(
     attribute: LocalAttribute.Constant
 ) = enrichWithLocalAttribute(
@@ -84,7 +78,6 @@ fun MutableMap<String, Any?>.enrichWithConstantAttribute(
  * @param key - local attribute key.
  * @param value - attribute value.
  */
-@InternalApi
 fun MutableMap<String, Any?>.enrichWithNonNullAttribute(
     key: LocalAttribute.Key,
     value: Any?
@@ -96,7 +89,6 @@ fun MutableMap<String, Any?>.enrichWithNonNullAttribute(
  * @param key - local attribute key.
  * @param value - attribute value.
  */
-@InternalApi
 fun MutableMap<String, Any?>.enrichWithLocalAttribute(
     key: LocalAttribute.Key,
     value: Any?

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/attributes/ViewScopeInstrumentationType.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/attributes/ViewScopeInstrumentationType.kt
@@ -3,14 +3,11 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2016-Present Datadog, Inc.
  */
-package com.datadog.android.core.internal.attributes
-
-import com.datadog.android.lint.InternalApi
+package com.datadog.android.internal.attributes
 
 /**
  * A set of constants describing the instrumentation that were used to define the view scope.
  */
-@InternalApi
 enum class ViewScopeInstrumentationType : LocalAttribute.Constant {
     /** Tracked manually through the RUMMonitor API. */
     MANUAL,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -13,9 +13,9 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
-import com.datadog.android.core.internal.attributes.LocalAttribute
-import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
+import com.datadog.android.internal.attributes.LocalAttribute
+import com.datadog.android.internal.attributes.ViewScopeInstrumentationType
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.GlobalRumMonitor

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/ViewEndedMetricDispatcher.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/ViewEndedMetricDispatcher.kt
@@ -8,7 +8,7 @@ package com.datadog.android.rum.internal.metric
 import androidx.annotation.VisibleForTesting
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.InternalLogger.Target
-import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.internal.attributes.ViewScopeInstrumentationType
 import com.datadog.android.rum.internal.domain.scope.RumViewType
 
 internal class ViewEndedMetricDispatcher(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityViewTrackingStrategy.kt
@@ -11,9 +11,9 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.MainThread
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
-import com.datadog.android.core.internal.attributes.enrichWithConstantAttribute
 import com.datadog.android.core.internal.utils.scheduleSafe
+import com.datadog.android.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.internal.attributes.enrichWithConstantAttribute
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.internal.utils.resolveViewName

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategy.kt
@@ -13,9 +13,9 @@ import androidx.annotation.MainThread
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.datadog.android.api.feature.Feature
-import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
-import com.datadog.android.core.internal.attributes.enrichWithConstantAttribute
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
+import com.datadog.android.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.internal.attributes.enrichWithConstantAttribute
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.tracking.AndroidXFragmentLifecycleCallbacks

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
@@ -17,8 +17,8 @@ import androidx.navigation.NavDestination
 import androidx.navigation.Navigation
 import androidx.navigation.fragment.NavHostFragment
 import com.datadog.android.api.feature.Feature
-import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
-import com.datadog.android.core.internal.attributes.enrichWithConstantAttribute
+import com.datadog.android.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.internal.attributes.enrichWithConstantAttribute
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.NoOpRumMonitor
 import com.datadog.android.rum.internal.RumFeature

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -13,9 +13,9 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
-import com.datadog.android.core.internal.attributes.LocalAttribute
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.internal.attributes.LocalAttribute
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.telemetry.TracingHeaderTypesSet
 import com.datadog.android.rum.RumSessionListener

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityViewTrackingStrategyTest.kt
@@ -8,8 +8,8 @@ package com.datadog.android.rum
 
 import android.app.Activity
 import android.os.Bundle
-import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
-import com.datadog.android.core.internal.attributes.enrichWithConstantAttribute
+import com.datadog.android.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.internal.attributes.enrichWithConstantAttribute
 import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
 import com.datadog.android.rum.tracking.ComponentPredicate
 import com.datadog.android.rum.tracking.StubComponentPredicate

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/metric/ViewEndedMetricDispatcherTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/metric/ViewEndedMetricDispatcherTest.kt
@@ -7,7 +7,7 @@ package com.datadog.android.rum.metric
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.InternalLogger.Target
-import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.internal.attributes.ViewScopeInstrumentationType
 import com.datadog.android.rum.internal.domain.scope.RumViewType
 import com.datadog.android.rum.internal.metric.NoValueReason
 import com.datadog.android.rum.internal.metric.ViewEndedMetricDispatcher

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategyTest.kt
@@ -17,9 +17,9 @@ import androidx.fragment.app.FragmentManager
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
-import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
-import com.datadog.android.core.internal.attributes.enrichWithConstantAttribute
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
+import com.datadog.android.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.internal.attributes.enrichWithConstantAttribute
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.tracking.AndroidXFragmentLifecycleCallbacks
 import com.datadog.android.rum.internal.tracking.OreoFragmentLifecycleCallbacks

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
@@ -24,7 +24,7 @@ import androidx.navigation.fragment.NavHostFragment
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
-import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.internal.attributes.ViewScopeInstrumentationType
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.rum.utils.forge.Configurator

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -15,8 +15,8 @@ import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
-import com.datadog.android.core.internal.attributes.LocalAttribute
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.internal.attributes.LocalAttribute
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.telemetry.TracingHeaderTypesSet
 import com.datadog.android.internal.utils.loggableStackTrace

--- a/integrations/dd-sdk-android-compose/build.gradle.kts
+++ b/integrations/dd-sdk-android-compose/build.gradle.kts
@@ -52,6 +52,7 @@ android {
 }
 
 dependencies {
+    implementation(project(":dd-sdk-android-internal"))
     implementation(project(":features:dd-sdk-android-rum"))
     implementation(libs.kotlin)
 

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/ComposeNavigationObserver.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/ComposeNavigationObserver.kt
@@ -12,8 +12,8 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
-import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
-import com.datadog.android.core.internal.attributes.enrichWithConstantAttribute
+import com.datadog.android.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.internal.attributes.enrichWithConstantAttribute
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.tracking.AcceptAllNavDestinations
 import com.datadog.android.rum.tracking.ComponentPredicate

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/internal/ComposeNavigationObserverTest.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/internal/ComposeNavigationObserverTest.kt
@@ -10,8 +10,8 @@ import android.os.Bundle
 import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
-import com.datadog.android.core.internal.attributes.LocalAttribute
-import com.datadog.android.core.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.internal.attributes.LocalAttribute
+import com.datadog.android.internal.attributes.ViewScopeInstrumentationType
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.tracking.ComponentPredicate
 import com.datadog.tools.unit.forge.BaseConfigurator


### PR DESCRIPTION
### What does this PR do?

I noticed that we have `LocalAttribute` class and related extension methods in the `core` module and thus extension modules can be leaked into user's space.

This PR moves them to the `internal` module which is always used as `implementation`, so no leak is possible.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

