### PR TITLE
Remove `ContentPainterElement` Class Reflection from Telemetry

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
@@ -87,7 +87,10 @@ internal object ComposeReflection {
 
     // Region of Coil
 
-    val ContentPainterModifierClass = getClassSafe("coil.compose.ContentPainterModifier")
+    val ContentPainterModifierClass = getClassSafe(
+        "coil.compose.ContentPainterModifier",
+        isCritical = false
+    )
     val PainterFieldOfContentPainterModifier =
         ContentPainterModifierClass?.getDeclaredFieldSafe("painter")
 


### PR DESCRIPTION
### What does this PR do?

`ContentPainterElement` class reflection contributes a high volume to our telemetry log while we don't have any action on that, because it becomes a normal case if the client is using `coil3` instead of `coil2`, so removing it from Telemetry


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

