### PR TITLE
RUM-10314: Read feature context only when explicitly requested by the caller

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -108,9 +108,9 @@ interface com.datadog.android.api.feature.FeatureEventReceiver
   fun onReceive(Any)
 interface com.datadog.android.api.feature.FeatureScope
   val dataStore: com.datadog.android.api.storage.datastore.DataStoreHandler
-  fun withWriteContext((com.datadog.android.api.context.DatadogContext) -> Unit)
-  fun withContext((com.datadog.android.api.context.DatadogContext) -> Unit)
-  fun getWriteContextSync(): Pair<com.datadog.android.api.context.DatadogContext, EventWriteScope>?
+  fun withWriteContext(Set<String> = emptySet(), (com.datadog.android.api.context.DatadogContext) -> Unit)
+  fun withContext(Set<String> = emptySet(), (com.datadog.android.api.context.DatadogContext) -> Unit)
+  fun getWriteContextSync(Set<String> = emptySet()): Pair<com.datadog.android.api.context.DatadogContext, EventWriteScope>?
   fun sendEvent(Any)
   fun <T: Feature> unwrap(): T
 typealias EventWriteScope = ((com.datadog.android.api.storage.EventBatchWriter) -> Unit) -> Unit
@@ -191,7 +191,7 @@ interface com.datadog.android.core.InternalSdkCore : com.datadog.android.api.fea
   fun writeLastFatalAnrSent(Long)
   fun getPersistenceExecutorService(): java.util.concurrent.ExecutorService
   fun getAllFeatures(): List<com.datadog.android.api.feature.FeatureScope>
-  fun getDatadogContext(): com.datadog.android.api.context.DatadogContext?
+  fun getDatadogContext(Set<String> = emptySet()): com.datadog.android.api.context.DatadogContext?
 class com.datadog.android.core.SdkReference
   constructor(String? = null, (com.datadog.android.api.SdkCore) -> Unit = {})
   fun get(): com.datadog.android.api.SdkCore?

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -342,11 +342,17 @@ public abstract interface class com/datadog/android/api/feature/FeatureEventRece
 
 public abstract interface class com/datadog/android/api/feature/FeatureScope {
 	public abstract fun getDataStore ()Lcom/datadog/android/api/storage/datastore/DataStoreHandler;
-	public abstract fun getWriteContextSync ()Lkotlin/Pair;
+	public abstract fun getWriteContextSync (Ljava/util/Set;)Lkotlin/Pair;
 	public abstract fun sendEvent (Ljava/lang/Object;)V
 	public abstract fun unwrap ()Lcom/datadog/android/api/feature/Feature;
-	public abstract fun withContext (Lkotlin/jvm/functions/Function1;)V
-	public abstract fun withWriteContext (Lkotlin/jvm/functions/Function2;)V
+	public abstract fun withContext (Ljava/util/Set;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun withWriteContext (Ljava/util/Set;Lkotlin/jvm/functions/Function2;)V
+}
+
+public final class com/datadog/android/api/feature/FeatureScope$DefaultImpls {
+	public static synthetic fun getWriteContextSync$default (Lcom/datadog/android/api/feature/FeatureScope;Ljava/util/Set;ILjava/lang/Object;)Lkotlin/Pair;
+	public static synthetic fun withContext$default (Lcom/datadog/android/api/feature/FeatureScope;Ljava/util/Set;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun withWriteContext$default (Lcom/datadog/android/api/feature/FeatureScope;Ljava/util/Set;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 }
 
 public final class com/datadog/android/api/feature/FeatureScopeExtKt {
@@ -533,7 +539,7 @@ public abstract interface class com/datadog/android/core/InternalSdkCore : com/d
 	public abstract fun deleteLastViewEvent ()V
 	public abstract fun getAllFeatures ()Ljava/util/List;
 	public abstract fun getAppStartTimeNs ()J
-	public abstract fun getDatadogContext ()Lcom/datadog/android/api/context/DatadogContext;
+	public abstract fun getDatadogContext (Ljava/util/Set;)Lcom/datadog/android/api/context/DatadogContext;
 	public abstract fun getFirstPartyHostResolver ()Lcom/datadog/android/core/internal/net/FirstPartyHostHeaderTypeResolver;
 	public abstract fun getLastFatalAnrSent ()Ljava/lang/Long;
 	public abstract fun getLastViewEvent ()Lcom/google/gson/JsonObject;
@@ -544,6 +550,10 @@ public abstract interface class com/datadog/android/core/InternalSdkCore : com/d
 	public abstract fun isDeveloperModeEnabled ()Z
 	public abstract fun writeLastFatalAnrSent (J)V
 	public abstract fun writeLastViewEvent ([B)V
+}
+
+public final class com/datadog/android/core/InternalSdkCore$DefaultImpls {
+	public static synthetic fun getDatadogContext$default (Lcom/datadog/android/core/InternalSdkCore;Ljava/util/Set;ILjava/lang/Object;)Lcom/datadog/android/api/context/DatadogContext;
 }
 
 public final class com/datadog/android/core/SdkReference {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureScope.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureScope.kt
@@ -24,6 +24,9 @@ interface FeatureScope {
 
     /**
      * Utility to write an event, asynchronously.
+     * @param withFeatureContexts Feature contexts ([DatadogContext.featuresContext] property) to include
+     * in the [DatadogContext] provided. The value should be the feature names as declared by [Feature.name].
+     * Default is empty, meaning that no feature contexts will be included.
      * @param callback an operation called with an up-to-date [DatadogContext]
      * and an [EventWriteScope]. Callback will be executed on a single context processing worker thread. Execution of
      * [EventWriteScope] will be done on a worker thread from I/O pool.
@@ -31,16 +34,21 @@ interface FeatureScope {
      */
     @AnyThread
     fun withWriteContext(
+        withFeatureContexts: Set<String> = emptySet(),
         callback: (datadogContext: DatadogContext, write: EventWriteScope) -> Unit
     )
 
     /**
      * Utility to read current [DatadogContext], asynchronously.
+     * @param withFeatureContexts Feature contexts ([DatadogContext.featuresContext] property) to include
+     * in the [DatadogContext] provided. The value should be the feature names as declared by [Feature.name].
+     * Default is empty, meaning that no feature contexts will be included.
      * @param callback an operation called with an up-to-date [DatadogContext].
      * [DatadogContext] will have a state created at the moment this method is called.
      */
     @AnyThread
     fun withContext(
+        withFeatureContexts: Set<String> = emptySet(),
         callback: (datadogContext: DatadogContext) -> Unit
     )
 
@@ -48,11 +56,15 @@ interface FeatureScope {
     /**
      * Same as [withWriteContext] but will be executed in the blocking manner.
      *
+     * @param withFeatureContexts Feature contexts ([DatadogContext.featuresContext] property) to include
+     * in the [DatadogContext] provided. The value should be the feature names as declared by [Feature.name].
+     * Default is empty, meaning that no feature contexts will be included.
+     *
      * **NOTE**: This API is for the internal use only and is not guaranteed to be stable.
      */
     @AnyThread
     @InternalApi
-    fun getWriteContextSync(): Pair<DatadogContext, EventWriteScope>?
+    fun getWriteContextSync(withFeatureContexts: Set<String> = emptySet()): Pair<DatadogContext, EventWriteScope>?
 
     /**
      * Send event to a given feature. It will be sent in a synchronous way.

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/InternalSdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/InternalSdkCore.kt
@@ -116,8 +116,11 @@ interface InternalSdkCore : FeatureSdkCore {
     fun getAllFeatures(): List<FeatureScope>
 
     /**
-     * @return the current DatadogContext, or null
+     * @param withFeatureContexts Feature contexts ([DatadogContext.featuresContext] property) to include
+     * in the [DatadogContext] provided. The value should be the feature names as declared by [Feature.name].
+     * Default is empty, meaning that no feature contexts will be included.
+     * @return the current [DatadogContext], or null
      */
     @InternalApi
-    fun getDatadogContext(): DatadogContext?
+    fun getDatadogContext(withFeatureContexts: Set<String> = emptySet()): DatadogContext?
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/ContextProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/ContextProvider.kt
@@ -7,10 +7,16 @@
 package com.datadog.android.core.internal
 
 import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.Feature
 
 internal interface ContextProvider {
     // TODO RUM-3784 lifecycle checks may be needed for the cases when context is requested
     //  when datadog is not initialized yet/anymore (case of UploadWorker, other calls site
     //  should be in sync with lifecycle)
-    val context: DatadogContext
+    /**
+     * @param withFeatureContexts Feature contexts ([DatadogContext.featuresContext] property) to include
+     * in the [DatadogContext] provided. The value should be the feature names as declared by [Feature.name].
+     * Default is empty, meaning that no feature contexts will be included.
+     */
+    fun getContext(withFeatureContexts: Set<String>): DatadogContext
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogContextProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogContextProvider.kt
@@ -16,64 +16,58 @@ internal class DatadogContextProvider(
     private val coreFeature: CoreFeature,
     private val featureContextProvider: FeatureContextProvider
 ) : ContextProvider {
-    override val context: DatadogContext
-        get() {
-            // IMPORTANT All properties should be immutable and be frozen at the state
-            // of the context construction moment
-            return DatadogContext(
-                site = coreFeature.site,
-                clientToken = coreFeature.clientToken,
-                service = coreFeature.serviceName,
-                env = coreFeature.envName,
-                version = coreFeature.packageVersionProvider.version,
-                variant = coreFeature.variant,
-                sdkVersion = coreFeature.sdkVersion,
-                source = coreFeature.sourceName,
-                time = with(coreFeature.timeProvider) {
-                    val deviceTimeMs = getDeviceTimestamp()
-                    val serverTimeMs = getServerTimestamp()
-                    TimeInfo(
-                        deviceTimeNs = TimeUnit.MILLISECONDS.toNanos(deviceTimeMs),
-                        serverTimeNs = TimeUnit.MILLISECONDS.toNanos(serverTimeMs),
-                        serverTimeOffsetNs = TimeUnit.MILLISECONDS
-                            .toNanos(serverTimeMs - deviceTimeMs),
-                        serverTimeOffsetMs = serverTimeMs - deviceTimeMs
-                    )
-                },
-                processInfo = ProcessInfo(
-                    isMainProcess = coreFeature.isMainProcess
-                ),
-                networkInfo = coreFeature.networkInfoProvider.getLatestNetworkInfo(),
-                deviceInfo = with(coreFeature.androidInfoProvider) {
-                    DeviceInfo(
-                        deviceName = deviceName,
-                        deviceBrand = deviceBrand,
-                        deviceType = deviceType,
-                        deviceModel = deviceModel,
-                        deviceBuildId = deviceBuildId,
-                        osName = osName,
-                        osVersion = osVersion,
-                        osMajorVersion = osMajorVersion,
-                        architecture = architecture,
-                        numberOfDisplays = numberOfDisplays
-                    )
-                },
-                userInfo = coreFeature.userInfoProvider.getUserInfo(),
-                trackingConsent = coreFeature.trackingConsentProvider.getConsent(),
-                appBuildId = coreFeature.appBuildId,
-                // toMap call here (and in getFeatureContext) is VERY important - this will make
-                // independent snapshot of the features context which is not affected by the
-                // changes which can be made later by another thread.
-                // Values at the top 2 levels are frozen: feature-name key,
-                // and feature-specific-name key.
-                featuresContext = mutableMapOf<String, Map<String, Any?>>().apply {
-                    featureContextProvider.getFeaturesContexts().forEach {
-                        val value = it.second()
-                        if (value.isNotEmpty()) {
-                            this[it.first] = value.toMap()
-                        }
+    override fun getContext(withFeatureContexts: Set<String>): DatadogContext {
+        // IMPORTANT All properties should be immutable and be frozen at the state
+        // of the context construction moment
+        return DatadogContext(
+            site = coreFeature.site,
+            clientToken = coreFeature.clientToken,
+            service = coreFeature.serviceName,
+            env = coreFeature.envName,
+            version = coreFeature.packageVersionProvider.version,
+            variant = coreFeature.variant,
+            sdkVersion = coreFeature.sdkVersion,
+            source = coreFeature.sourceName,
+            time = with(coreFeature.timeProvider) {
+                val deviceTimeMs = getDeviceTimestamp()
+                val serverTimeMs = getServerTimestamp()
+                TimeInfo(
+                    deviceTimeNs = TimeUnit.MILLISECONDS.toNanos(deviceTimeMs),
+                    serverTimeNs = TimeUnit.MILLISECONDS.toNanos(serverTimeMs),
+                    serverTimeOffsetNs = TimeUnit.MILLISECONDS
+                        .toNanos(serverTimeMs - deviceTimeMs),
+                    serverTimeOffsetMs = serverTimeMs - deviceTimeMs
+                )
+            },
+            processInfo = ProcessInfo(
+                isMainProcess = coreFeature.isMainProcess
+            ),
+            networkInfo = coreFeature.networkInfoProvider.getLatestNetworkInfo(),
+            deviceInfo = with(coreFeature.androidInfoProvider) {
+                DeviceInfo(
+                    deviceName = deviceName,
+                    deviceBrand = deviceBrand,
+                    deviceType = deviceType,
+                    deviceModel = deviceModel,
+                    deviceBuildId = deviceBuildId,
+                    osName = osName,
+                    osVersion = osVersion,
+                    osMajorVersion = osMajorVersion,
+                    architecture = architecture,
+                    numberOfDisplays = numberOfDisplays
+                )
+            },
+            userInfo = coreFeature.userInfoProvider.getUserInfo(),
+            trackingConsent = coreFeature.trackingConsentProvider.getConsent(),
+            appBuildId = coreFeature.appBuildId,
+            featuresContext = mutableMapOf<String, Map<String, Any?>>().apply {
+                withFeatureContexts.forEach {
+                    val featureContext = featureContextProvider.getFeatureContext(it)
+                    if (featureContext.isNotEmpty()) {
+                        this[it] = featureContext
                     }
                 }
-            )
-        }
+            }
+        )
+    }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/FeatureContextProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/FeatureContextProvider.kt
@@ -7,5 +7,8 @@
 package com.datadog.android.core.internal
 
 internal fun interface FeatureContextProvider {
-    fun getFeaturesContexts(): List<Pair<String, () -> Map<String, Any?>>>
+    /**
+     * Returns **frozen** snapshot of the feature context which is not mutated over the time.
+     */
+    fun getFeatureContext(featureName: String): Map<String, Any?>
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/NoOpContextProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/NoOpContextProvider.kt
@@ -18,47 +18,46 @@ import com.datadog.android.privacy.TrackingConsent
 
 internal class NoOpContextProvider : ContextProvider {
     // TODO RUM-3784 this one is quite ugly. Should return type be nullable?
-    override val context: DatadogContext
-        get() = DatadogContext(
-            site = DatadogSite.US1,
-            clientToken = "",
-            service = "",
-            env = "",
-            version = "",
-            variant = "",
-            source = "",
-            sdkVersion = "",
-            time = TimeInfo(
-                deviceTimeNs = 0L,
-                serverTimeNs = 0L,
-                serverTimeOffsetMs = 0L,
-                serverTimeOffsetNs = 0L
-            ),
-            processInfo = ProcessInfo(isMainProcess = true),
-            networkInfo = NetworkInfo(
-                connectivity = NetworkInfo.Connectivity.NETWORK_OTHER,
-                carrierName = null,
-                carrierId = null,
-                upKbps = null,
-                downKbps = null,
-                strength = null,
-                cellularTechnology = null
-            ),
-            deviceInfo = DeviceInfo(
-                deviceName = "",
-                deviceBrand = "",
-                deviceModel = "",
-                deviceType = DeviceType.OTHER,
-                deviceBuildId = "",
-                osName = "",
-                osMajorVersion = "",
-                osVersion = "",
-                architecture = "",
-                numberOfDisplays = null
-            ),
-            userInfo = UserInfo(null, null, null, null, emptyMap()),
-            trackingConsent = TrackingConsent.NOT_GRANTED,
-            appBuildId = null,
-            featuresContext = emptyMap()
-        )
+    override fun getContext(withFeatureContexts: Set<String>) = DatadogContext(
+        site = DatadogSite.US1,
+        clientToken = "",
+        service = "",
+        env = "",
+        version = "",
+        variant = "",
+        source = "",
+        sdkVersion = "",
+        time = TimeInfo(
+            deviceTimeNs = 0L,
+            serverTimeNs = 0L,
+            serverTimeOffsetMs = 0L,
+            serverTimeOffsetNs = 0L
+        ),
+        processInfo = ProcessInfo(isMainProcess = true),
+        networkInfo = NetworkInfo(
+            connectivity = NetworkInfo.Connectivity.NETWORK_OTHER,
+            carrierName = null,
+            carrierId = null,
+            upKbps = null,
+            downKbps = null,
+            strength = null,
+            cellularTechnology = null
+        ),
+        deviceInfo = DeviceInfo(
+            deviceName = "",
+            deviceBrand = "",
+            deviceModel = "",
+            deviceType = DeviceType.OTHER,
+            deviceBuildId = "",
+            osName = "",
+            osMajorVersion = "",
+            osVersion = "",
+            architecture = "",
+            numberOfDisplays = null
+        ),
+        userInfo = UserInfo(null, null, null, null, emptyMap()),
+        trackingConsent = TrackingConsent.NOT_GRANTED,
+        appBuildId = null,
+        featuresContext = emptyMap()
+    )
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/NoOpInternalSdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/NoOpInternalSdkCore.kt
@@ -146,7 +146,7 @@ internal object NoOpInternalSdkCore : InternalSdkCore {
 
     override fun getAllFeatures(): List<FeatureScope> = emptyList()
 
-    override fun getDatadogContext(): DatadogContext? = null
+    override fun getDatadogContext(withFeatureContexts: Set<String>): DatadogContext? = null
 
     // endregion
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -179,32 +179,38 @@ internal class SdkFeature(
     // region FeatureScope
 
     override fun withWriteContext(
+        withFeatureContexts: Set<String>,
         callback: (DatadogContext, EventWriteScope) -> Unit
     ) {
         coreFeature.contextExecutorService
             .executeSafe("withWriteContext-${wrappedFeature.name}", internalLogger) {
-                val context = contextProvider.context
+                val context = contextProvider.getContext(withFeatureContexts)
                 val eventBatchWriteScope = storage.getEventWriteScope(context)
                 callback(context, eventBatchWriteScope)
             }
     }
 
-    override fun withContext(callback: (datadogContext: DatadogContext) -> Unit) {
+    override fun withContext(
+        withFeatureContexts: Set<String>,
+        callback: (datadogContext: DatadogContext) -> Unit
+    ) {
         coreFeature.contextExecutorService
             .executeSafe("withContext-${wrappedFeature.name}", internalLogger) {
-                val context = contextProvider.context
+                val context = contextProvider.getContext(withFeatureContexts)
                 callback(context)
             }
     }
 
-    override fun getWriteContextSync(): Pair<DatadogContext, EventWriteScope>? {
+    override fun getWriteContextSync(
+        withFeatureContexts: Set<String>
+    ): Pair<DatadogContext, EventWriteScope>? {
         val operationName = "getWriteContextSync-${wrappedFeature.name}"
         return coreFeature.contextExecutorService
             .submitSafe(
                 operationName,
                 internalLogger,
                 Callable {
-                    val context = contextProvider.context
+                    val context = contextProvider.getContext(withFeatureContexts)
                     val eventBatchWriteScope = storage.getEventWriteScope(context)
                     context to eventBatchWriteScope
                 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataFlusher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataFlusher.kt
@@ -26,7 +26,7 @@ internal class DataFlusher(
 
     @WorkerThread
     override fun flush(uploader: DataUploader) {
-        val context = contextProvider.context
+        val context = contextProvider.getContext(withFeatureContexts = emptySet())
 
         val toUploadFiles = fileOrchestrator.getFlushableFiles()
         toUploadFiles.forEach {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
@@ -44,7 +44,7 @@ internal class DataUploadRunnable(
         var uploadAttempts = 0
         var lastBatchUploadStatus: UploadStatus? = null
         if (isNetworkAvailable() && isSystemReady()) {
-            val context = contextProvider.context
+            val context = contextProvider.getContext(withFeatureContexts = emptySet())
             var batchConsumerAvailableAttempts = maxBatchesPerJob
             do {
                 benchmarkUploads.incrementBenchmarkUploadsCount(

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -491,19 +491,20 @@ internal class SdkFeatureTest {
     @Test
     fun `M provide write context W withWriteContext(callback)`(
         @Forgery fakeContext: DatadogContext,
+        @StringForgery fakeWithFeatureContexts: Set<String>,
         @Mock mockEventWriteScope: EventWriteScope
     ) {
         // Given
         testedFeature.storage = mockStorage
         val callback = mock<(DatadogContext, EventWriteScope) -> Unit>()
-        whenever(mockContextProvider.context) doReturn fakeContext
+        whenever(mockContextProvider.getContext(fakeWithFeatureContexts)) doReturn fakeContext
 
         whenever(
             mockStorage.getEventWriteScope(fakeContext)
         ) doReturn mockEventWriteScope
 
         // When
-        testedFeature.withWriteContext(callback = callback)
+        testedFeature.withWriteContext(fakeWithFeatureContexts, callback = callback)
 
         // Then
         verify(callback).invoke(
@@ -514,15 +515,16 @@ internal class SdkFeatureTest {
 
     @Test
     fun `M provide Datadog context W withContext(callback)`(
-        @Forgery fakeContext: DatadogContext
+        @Forgery fakeContext: DatadogContext,
+        @StringForgery fakeWithFeatureContexts: Set<String>
     ) {
         // Given
         testedFeature.storage = mockStorage
         val callback = mock<(DatadogContext) -> Unit>()
-        whenever(mockContextProvider.context) doReturn fakeContext
+        whenever(mockContextProvider.getContext(fakeWithFeatureContexts)) doReturn fakeContext
 
         // When
-        testedFeature.withContext(callback = callback)
+        testedFeature.withContext(fakeWithFeatureContexts, callback = callback)
 
         // Then
         verify(callback).invoke(fakeContext)
@@ -531,11 +533,12 @@ internal class SdkFeatureTest {
     @Test
     fun `M provide write context W getWriteContextSync()`(
         @Forgery fakeContext: DatadogContext,
+        @StringForgery fakeWithFeatureContexts: Set<String>,
         @Mock mockEventWriteScope: EventWriteScope
     ) {
         // Given
         testedFeature.storage = mockStorage
-        whenever(mockContextProvider.context) doReturn fakeContext
+        whenever(mockContextProvider.getContext(fakeWithFeatureContexts)) doReturn fakeContext
         whenever(coreFeature.mockInstance.contextExecutorService.submit(any<Callable<*>>())) doAnswer {
             val callable = it.getArgument<Callable<Pair<DatadogContext, EventWriteScope>>>(0)
             mock<Future<*>>().apply {
@@ -548,7 +551,7 @@ internal class SdkFeatureTest {
         ) doReturn mockEventWriteScope
 
         // When
-        val writeContext = testedFeature.getWriteContextSync()
+        val writeContext = testedFeature.getWriteContextSync(fakeWithFeatureContexts)
 
         // Then
         checkNotNull(writeContext)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataFlusherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataFlusherTest.kt
@@ -69,7 +69,7 @@ internal class DataFlusherTest {
 
     @BeforeEach
     fun `set up`() {
-        whenever(mockContextProvider.context) doReturn fakeContext
+        whenever(mockContextProvider.getContext(emptySet())) doReturn fakeContext
 
         testedFlusher = DataFlusher(
             mockContextProvider,

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
@@ -123,7 +123,7 @@ internal class DataUploadRunnableTest {
         whenever(mockUploadSchedulerStrategy.getMsDelayUntilNextUpload(any(), any(), anyOrNull(), anyOrNull()))
             .doReturn(fakeDelayUntilNextUploadMs)
 
-        whenever(mockContextProvider.context) doReturn fakeContext
+        whenever(mockContextProvider.getContext(emptySet())) doReturn fakeContext
 
         testedRunnable = DataUploadRunnable(
             featureName = fakeFeatureName,

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -174,7 +174,12 @@ internal class LogsFeature(
         val attributes = getAttributes()
         // TODO RUM-9852 Implement better passthrough mechanism for the JVM crash scenario
         val writeContext = sdkCore.getFeature(name)
-            ?.getWriteContextSync()
+            ?.getWriteContextSync(
+                withFeatureContexts = setOf(
+                    Feature.RUM_FEATURE_NAME,
+                    Feature.TRACING_FEATURE_NAME
+                )
+            )
         if (writeContext != null) {
             val (datadogContext, writeScope) = writeContext
             val log = logGenerator.generateLog(
@@ -282,7 +287,9 @@ internal class LogsFeature(
         }
 
         sdkCore.getFeature(name)
-            ?.withWriteContext { datadogContext, writeScope ->
+            ?.withWriteContext(
+                withFeatureContexts = setOf(Feature.RUM_FEATURE_NAME)
+            ) { datadogContext, writeScope ->
                 val log = logGenerator.generateLog(
                     logStatus,
                     datadogContext = datadogContext,

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
@@ -55,7 +55,10 @@ internal class DatadogLogHandler(
         if (sampler.sample(Unit)) {
             if (logsFeature != null) {
                 val threadName = Thread.currentThread().name
-                logsFeature.withWriteContext { datadogContext, writeScope ->
+                val withFeatureContexts = mutableSetOf<String>()
+                if (bundleWithRum) withFeatureContexts.add(Feature.RUM_FEATURE_NAME)
+                if (bundleWithTraces) withFeatureContexts.add(Feature.TRACING_FEATURE_NAME)
+                logsFeature.withWriteContext(withFeatureContexts) { datadogContext, writeScope ->
                     val log = createLog(
                         level,
                         datadogContext,
@@ -73,11 +76,7 @@ internal class DatadogLogHandler(
                     }
                 }
             } else {
-                sdkCore.internalLogger.log(
-                    InternalLogger.Level.WARN,
-                    InternalLogger.Target.USER,
-                    { LOGS_FEATURE_NOT_REGISTERED }
-                )
+                logLogsFeatureIsNotRegistered()
             }
         }
 
@@ -93,11 +92,7 @@ internal class DatadogLogHandler(
                     )
                 )
             } else {
-                sdkCore.internalLogger.log(
-                    InternalLogger.Level.INFO,
-                    InternalLogger.Target.USER,
-                    { RUM_FEATURE_NOT_REGISTERED }
-                )
+                logRumFeatureIsNotRegistered()
             }
         }
     }
@@ -128,7 +123,10 @@ internal class DatadogLogHandler(
         if (sampler.sample(Unit)) {
             if (logsFeature != null) {
                 val threadName = Thread.currentThread().name
-                logsFeature.withWriteContext { datadogContext, writeScope ->
+                val withFeatureContexts = mutableSetOf<String>()
+                if (bundleWithRum) withFeatureContexts.add(Feature.RUM_FEATURE_NAME)
+                if (bundleWithTraces) withFeatureContexts.add(Feature.TRACING_FEATURE_NAME)
+                logsFeature.withWriteContext(withFeatureContexts) { datadogContext, writeScope ->
                     val log = createLog(
                         level,
                         datadogContext,
@@ -148,11 +146,7 @@ internal class DatadogLogHandler(
                     }
                 }
             } else {
-                sdkCore.internalLogger.log(
-                    InternalLogger.Level.WARN,
-                    InternalLogger.Target.USER,
-                    { LOGS_FEATURE_NOT_REGISTERED }
-                )
+                logLogsFeatureIsNotRegistered()
             }
         }
 
@@ -168,11 +162,7 @@ internal class DatadogLogHandler(
                     )
                 )
             } else {
-                sdkCore.internalLogger.log(
-                    InternalLogger.Level.INFO,
-                    InternalLogger.Target.USER,
-                    { RUM_FEATURE_NOT_REGISTERED }
-                )
+                logRumFeatureIsNotRegistered()
             }
         }
     }
@@ -236,6 +226,22 @@ internal class DatadogLogHandler(
             threadName = threadName,
             bundleWithRum = bundleWithRum,
             bundleWithTraces = bundleWithTraces
+        )
+    }
+
+    private fun logLogsFeatureIsNotRegistered() {
+        sdkCore.internalLogger.log(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            { LOGS_FEATURE_NOT_REGISTERED }
+        )
+    }
+
+    private fun logRumFeatureIsNotRegistered() {
+        sdkCore.internalLogger.log(
+            InternalLogger.Level.INFO,
+            InternalLogger.Target.USER,
+            { RUM_FEATURE_NOT_REGISTERED }
         )
     }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
@@ -123,7 +123,9 @@ internal class DatadogLateCrashReporter(
                 return
             }
 
-            rumFeature.withWriteContext { datadogContext, writeScope ->
+            rumFeature.withWriteContext(
+                withFeatureContexts = setOf(Feature.RUM_FEATURE_NAME)
+            ) { datadogContext, writeScope ->
                 // means we are too late, last view event belongs to the ongoing session
                 if (lastViewEvent.session.id == datadogContext.rumSessionId) return@withWriteContext
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -70,7 +70,9 @@ internal class TelemetryEventHandler(
 
         eventIDsSeenInCurrentSession.add(event.identity)
         totalEventsSeenInCurrentSession++
-        sdkCore.getFeature(Feature.RUM_FEATURE_NAME)?.withWriteContext { datadogContext, writeScope ->
+        sdkCore.getFeature(Feature.RUM_FEATURE_NAME)?.withWriteContext(
+            withFeatureContexts = setOf(Feature.SESSION_REPLAY_FEATURE_NAME, Feature.TRACING_FEATURE_NAME)
+        ) { datadogContext, writeScope ->
             val timestamp = wrappedEvent.eventTime.timestamp + datadogContext.time.serverTimeOffsetMs
             val telemetryEvent: Any? = when (event) {
                 is InternalTelemetryEvent.Log.Debug -> {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
@@ -105,8 +105,8 @@ internal class DatadogLateCrashReporterTest {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
         }
-        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+        whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(it.arguments.lastIndex)
             callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
 
@@ -719,6 +719,7 @@ internal class DatadogLateCrashReporterTest {
         testedHandler.handleAnrCrash(mockAnrExitInfo, fakeViewEventJson, mockRumWriter)
 
         // Then
+        verify(mockRumFeatureScope).withWriteContext(eq(setOf(Feature.RUM_FEATURE_NAME)), any())
         argumentCaptor<Any> {
             verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
@@ -809,6 +810,7 @@ internal class DatadogLateCrashReporterTest {
         testedHandler.handleAnrCrash(mockAnrExitInfo, fakeViewEventJson, mockRumWriter)
 
         // Then
+        verify(mockRumFeatureScope).withWriteContext(eq(setOf(Feature.RUM_FEATURE_NAME)), any())
         argumentCaptor<Any> {
             verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
@@ -897,6 +899,7 @@ internal class DatadogLateCrashReporterTest {
         testedHandler.handleAnrCrash(mockAnrExitInfo, fakeViewEventJson, mockRumWriter)
 
         // Then
+        verify(mockRumFeatureScope).withWriteContext(eq(setOf(Feature.RUM_FEATURE_NAME)), any())
         argumentCaptor<Any> {
             verify(mockRumWriter, times(1)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
@@ -10,8 +10,6 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.api.feature.EventWriteScope
-import com.datadog.android.api.feature.Feature
-import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
@@ -87,9 +85,6 @@ internal class RumActionScopeTest {
     lateinit var mockInternalLogger: InternalLogger
 
     @Mock
-    lateinit var mockRumFeatureScope: FeatureScope
-
-    @Mock
     lateinit var mockEventBatchWriter: EventBatchWriter
 
     @Mock
@@ -161,14 +156,9 @@ internal class RumActionScopeTest {
         whenever(rumMonitor.mockSdkCore.networkInfo) doReturn fakeNetworkInfoAtScopeStart
         whenever(rumMonitor.mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
-        whenever(rumMonitor.mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
         whenever(mockEventWriteScope.invoke(any())) doAnswer {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
-        }
-        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
         whenever(
             mockFeaturesContextResolver.resolveViewHasReplay(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -10,8 +10,6 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.api.feature.EventWriteScope
-import com.datadog.android.api.feature.Feature
-import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
@@ -84,9 +82,6 @@ internal class RumContinuousActionScopeTest {
     lateinit var mockInternalLogger: InternalLogger
 
     @Mock
-    lateinit var mockRumFeatureScope: FeatureScope
-
-    @Mock
     lateinit var mockEventBatchWriter: EventBatchWriter
 
     @Mock
@@ -147,15 +142,9 @@ internal class RumContinuousActionScopeTest {
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
         whenever(rumMonitor.mockSdkCore.networkInfo) doReturn fakeNetworkInfoAtScopeStart
         whenever(rumMonitor.mockSdkCore.internalLogger) doReturn mockInternalLogger
-
-        whenever(rumMonitor.mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
         whenever(mockEventWriteScope.invoke(any())) doAnswer {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
-        }
-        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
         whenever(mockWriter.write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))) doReturn true
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -10,8 +10,6 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.api.feature.EventWriteScope
-import com.datadog.android.api.feature.Feature
-import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
@@ -106,9 +104,6 @@ internal class RumResourceScopeTest {
     lateinit var mockInternalLogger: InternalLogger
 
     @Mock
-    lateinit var mockRumFeatureScope: FeatureScope
-
-    @Mock
     lateinit var mockEventBatchWriter: EventBatchWriter
 
     @Mock
@@ -198,14 +193,9 @@ internal class RumResourceScopeTest {
                 fakeParentContext.viewId.orEmpty()
             )
         ).thenReturn(fakeHasReplay)
-        whenever(rumMonitor.mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
         whenever(mockEventWriteScope.invoke(any())) doAnswer {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
-        }
-        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
         whenever(mockWriter.write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))) doReturn true
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -11,8 +11,6 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.context.TimeInfo
 import com.datadog.android.api.feature.EventWriteScope
-import com.datadog.android.api.feature.Feature
-import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
@@ -740,18 +738,10 @@ internal class RumViewManagerScopeTest {
         forge: Forge
     ) {
         // Given
-        // Because we have to test that the `application_started` action is written, we need to set
-        // up the feature scope properly
-        val mockRumFeatureScope: FeatureScope = mock()
         val mockEventBatchWriter: EventBatchWriter = mock()
-        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
         whenever(mockEventWriteScope.invoke(any())) doAnswer {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
-        }
-        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
         val fakeAppStartEvent = forge.applicationStartedEvent()
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -12,7 +12,6 @@ import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.api.context.TimeInfo
 import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
-import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
@@ -155,9 +154,6 @@ internal class RumViewScopeTest {
 
     @Mock
     lateinit var mockInternalLogger: InternalLogger
-
-    @Mock
-    lateinit var mockRumFeatureScope: FeatureScope
 
     @Mock
     lateinit var mockEventBatchWriter: EventBatchWriter
@@ -341,17 +337,12 @@ internal class RumViewScopeTest {
         whenever(mockChildScope.handleEvent(any(), any(), any(), any())) doReturn mockChildScope
         whenever(mockActionScope.handleEvent(any(), any(), any(), any())) doReturn mockActionScope
         whenever(mockActionScope.actionId) doReturn fakeActionId
-        whenever(rumMonitor.mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
         whenever(rumMonitor.mockSdkCore.time) doReturn fakeTimeInfoAtScopeStart
         whenever(rumMonitor.mockSdkCore.networkInfo) doReturn fakeNetworkInfoAtScopeStart
         whenever(rumMonitor.mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockEventWriteScope.invoke(any())) doAnswer {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
-        }
-        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
         whenever(mockWriter.write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))) doReturn true
         fakeReplayStats = ViewEvent.ReplayStats(recordsCount = fakeReplayRecordsCount)
@@ -9665,10 +9656,10 @@ internal class RumViewScopeTest {
         // Given
         val writeWorker = Executors.newCachedThreadPool()
         val tasks = mutableListOf<Future<*>>()
-        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+        whenever(mockEventWriteScope.invoke(any())) doAnswer {
+            val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             tasks += writeWorker.submit {
-                callback.invoke(fakeDatadogContext, mockEventWriteScope)
+                callback.invoke(mockEventBatchWriter)
             }
         }
         whenever(mockWriter.write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))) doAnswer {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/utils/SdkCoreExtTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/utils/SdkCoreExtTest.kt
@@ -9,8 +9,6 @@ package com.datadog.android.rum.internal.utils
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.EventWriteScope
-import com.datadog.android.api.feature.Feature
-import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
@@ -55,9 +53,6 @@ import org.mockito.quality.Strictness
 internal class SdkCoreExtTest {
 
     @Mock
-    lateinit var mockRumFeatureScope: FeatureScope
-
-    @Mock
     lateinit var mockEventBatchWriter: EventBatchWriter
 
     @Mock
@@ -84,11 +79,6 @@ internal class SdkCoreExtTest {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
         }
-        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
-            callback.invoke(fakeDatadogContext, mockEventWriteScope)
-        }
-        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockWriter.write(eq(mockEventBatchWriter), any(), any())) doReturn true
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -202,8 +202,13 @@ internal class TelemetryEventHandlerTest {
             callback.invoke(mockEventBatchWriter)
         }
 
-        whenever(mockRumFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+        whenever(
+            mockRumFeatureScope.withWriteContext(
+                eq(setOf(Feature.SESSION_REPLAY_FEATURE_NAME, Feature.TRACING_FEATURE_NAME)),
+                any()
+            )
+        ) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(it.arguments.lastIndex)
             callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -175,7 +175,7 @@ internal class SessionReplayFeature(
 
     override fun onStop() {
         stopRecording()
-        sdkCore.removeContextUpdateReceiver(Feature.RUM_FEATURE_NAME, rumContextProvider)
+        sdkCore.removeContextUpdateReceiver(Feature.SESSION_REPLAY_FEATURE_NAME, rumContextProvider)
         sessionReplayRecorder.unregisterCallbacks()
         sessionReplayRecorder.stopProcessingRecords()
         dataWriter = NoOpRecordWriter()

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriter.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriter.kt
@@ -19,7 +19,9 @@ internal class SessionReplayResourcesWriter(
 ) : ResourcesWriter {
     override fun write(enrichedResource: EnrichedResource) {
         sdkCore.getFeature(Feature.SESSION_REPLAY_RESOURCES_FEATURE_NAME)
-            ?.withWriteContext { datadogContext, writeScope ->
+            ?.withWriteContext(
+                withFeatureContexts = setOf(Feature.RUM_FEATURE_NAME)
+            ) { datadogContext, writeScope ->
                 writeScope {
                     synchronized(this@SessionReplayResourcesWriter) {
                         val serializedMetadata = enrichedResource.asBinaryMetadata(datadogContext.rumApplicationId)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.internal
 import android.app.Application
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureContextUpdateReceiver
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.sessionreplay.NoOpSessionReplayInternalCallback
@@ -129,6 +130,15 @@ internal class SessionReplayFeatureTest {
     }
 
     @Test
+    fun `M set feature context update listener W initialize()`() {
+        // When
+        testedFeature.onInitialize(appContext.mockInstance)
+
+        // Then
+        verify(mockSdkCore).setContextUpdateReceiver(eq(Feature.SESSION_REPLAY_FEATURE_NAME), any())
+    }
+
+    @Test
     fun `M initialize session replay recorder W initialize()`() {
         // Given
         testedFeature = SessionReplayFeature(
@@ -244,6 +254,22 @@ internal class SessionReplayFeatureTest {
 
         // Then
         verify(mockRecorder).unregisterCallbacks()
+    }
+
+    @Test
+    fun `M unregister the feature conttext listener W onStop()`() {
+        // Given
+        testedFeature.onInitialize(appContext.mockInstance)
+
+        // When
+        testedFeature.onStop()
+
+        // Then
+        argumentCaptor<FeatureContextUpdateReceiver> {
+            verify(mockSdkCore).setContextUpdateReceiver(eq(Feature.SESSION_REPLAY_FEATURE_NAME), capture())
+            verify(mockSdkCore).removeContextUpdateReceiver(eq(Feature.SESSION_REPLAY_FEATURE_NAME), capture())
+            assertThat(firstValue).isSameAs(lastValue)
+        }
     }
 
     @Test

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayRecordWriterTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayRecordWriterTest.kt
@@ -31,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
@@ -83,8 +84,8 @@ internal class SessionReplayRecordWriterTest {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
         }
-        whenever(mockSessionReplayFeature.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+        whenever(mockSessionReplayFeature.withWriteContext(eq(emptySet()), any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(it.arguments.lastIndex)
             callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
 
@@ -129,8 +130,8 @@ internal class SessionReplayRecordWriterTest {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
         }
-        whenever(mockSessionReplayFeature.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+        whenever(mockSessionReplayFeature.withWriteContext(any(), any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(it.arguments.lastIndex)
             callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriterTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriterTest.kt
@@ -30,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -85,8 +86,8 @@ internal class SessionReplayResourcesWriterTest {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
         }
-        whenever(mockResourcesFeature.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+        whenever(mockResourcesFeature.withWriteContext(eq(setOf(Feature.RUM_FEATURE_NAME)), any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(it.arguments.lastIndex)
             callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
         fakeDatadogContext = fakeDatadogContext.copy(

--- a/features/dd-sdk-android-trace-otel/src/main/kotlin/com/datadog/android/trace/opentelemetry/OtelTracerProvider.kt
+++ b/features/dd-sdk-android-trace-otel/src/main/kotlin/com/datadog/android/trace/opentelemetry/OtelTracerProvider.kt
@@ -323,7 +323,9 @@ class OtelTracerProvider internal constructor(
         val rumFeature = sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
         if (rumFeature != null) {
             val lazyContext = CompletableFuture<DatadogContext>()
-            rumFeature.withContext { lazyContext.complete(it) }
+            rumFeature.withContext(withFeatureContexts = setOf(Feature.RUM_FEATURE_NAME)) {
+                lazyContext.complete(it)
+            }
             (spanBuilder as? OtelSpanBuilder)?.setLazyDatadogContext(lazyContext)
         }
         spanBuilder

--- a/features/dd-sdk-android-trace-otel/src/test/kotlin/com/datadog/android/trace/opentelemetry/OtelTracerBuilderProviderTest.kt
+++ b/features/dd-sdk-android-trace-otel/src/test/kotlin/com/datadog/android/trace/opentelemetry/OtelTracerBuilderProviderTest.kt
@@ -677,8 +677,8 @@ internal class OtelTracerBuilderProviderTest {
             .tracerBuilder(fakeInstrumentationName)
             .build()
         val mockRumFeatureScope = mock<FeatureScope>()
-        whenever(mockRumFeatureScope.withContext(any())) doAnswer {
-            it.getArgument<(DatadogContext) -> Unit>(0).invoke(fakeInitialDatadogContext)
+        whenever(mockRumFeatureScope.withContext(eq(setOf(Feature.RUM_FEATURE_NAME)), any())) doAnswer {
+            it.getArgument<(DatadogContext) -> Unit>(it.arguments.lastIndex).invoke(fakeInitialDatadogContext)
         }
         whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
 

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/AndroidTracer.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/AndroidTracer.kt
@@ -271,7 +271,9 @@ class AndroidTracer internal constructor(
             val rumFeature = sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
             if (rumFeature != null) {
                 val lazyContext = CompletableFuture<DatadogContext>()
-                rumFeature.withContext { lazyContext.complete(it) }
+                rumFeature.withContext(withFeatureContexts = setOf(Feature.RUM_FEATURE_NAME)) {
+                    lazyContext.complete(it)
+                }
                 withTag(DATADOG_CONTEXT_TAG, lazyContext)
             }
         }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/AndroidTracerTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/AndroidTracerTest.kt
@@ -231,8 +231,8 @@ internal class AndroidTracerTest {
         // Given
         val mockRumFeatureScope = mock<FeatureScope>()
         whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
-        whenever(mockRumFeatureScope.withContext(any())) doAnswer {
-            it.getArgument<(DatadogContext) -> Unit>(0).invoke(fakeDatadogContext)
+        whenever(mockRumFeatureScope.withContext(eq(setOf(Feature.RUM_FEATURE_NAME)), any())) doAnswer {
+            it.getArgument<(DatadogContext) -> Unit>(it.arguments.lastIndex).invoke(fakeDatadogContext)
         }
         val tracer = AndroidTracer.Builder(mockSdkCore)
             .build()

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/OtelTraceWriterTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/OtelTraceWriterTest.kt
@@ -103,8 +103,8 @@ internal class OtelTraceWriterTest {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
         }
-        whenever(mockTracingFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+        whenever(mockTracingFeatureScope.withWriteContext(eq(emptySet()), any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(it.arguments.lastIndex)
             callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
 
@@ -498,7 +498,7 @@ internal class OtelTraceWriterTest {
 
         // THEN
         verify(mockSdkCore).getFeature(Feature.TRACING_FEATURE_NAME)
-        verify(mockTracingFeatureScope).withWriteContext(any())
+        verify(mockTracingFeatureScope).withWriteContext(any(), any())
 
         verifyNoMoreInteractions(mockSdkCore, mockTracingFeatureScope)
     }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/TraceWriterTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/TraceWriterTest.kt
@@ -103,8 +103,8 @@ internal class TraceWriterTest {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
         }
-        whenever(mockTracingFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+        whenever(mockTracingFeatureScope.withWriteContext(eq(emptySet()), any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(it.arguments.lastIndex)
             callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
 
@@ -505,7 +505,7 @@ internal class TraceWriterTest {
 
         // THEN
         verify(mockSdkCore).getFeature(Feature.TRACING_FEATURE_NAME)
-        verify(mockTracingFeatureScope).withWriteContext(any())
+        verify(mockTracingFeatureScope).withWriteContext(any(), any())
 
         verifyNoMoreInteractions(mockSdkCore, mockTracingFeatureScope)
 

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumer.kt
@@ -8,6 +8,7 @@ package com.datadog.android.webview.internal.log
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventType
@@ -32,7 +33,9 @@ internal class WebViewLogEventConsumer(
         if (event.second == USER_LOG_EVENT_TYPE) {
             if (sampler.sample(Unit)) {
                 sdkCore.getFeature(WebViewLogsFeature.WEB_LOGS_FEATURE_NAME)
-                    ?.withWriteContext { datadogContext, writeScope ->
+                    ?.withWriteContext(
+                        withFeatureContexts = setOf(Feature.RUM_FEATURE_NAME)
+                    ) { datadogContext, writeScope ->
                         val rumContext = rumContextProvider.getRumContext(datadogContext)
                         writeScope {
                             val mappedEvent = map(event.first, datadogContext, rumContext)

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventConsumer.kt
@@ -29,7 +29,12 @@ internal class WebViewReplayEventConsumer(
 
     override fun consume(event: JsonObject) {
         sdkCore.getFeature(WebViewReplayFeature.WEB_REPLAY_FEATURE_NAME)
-            ?.withWriteContext { datadogContext, writeScope ->
+            ?.withWriteContext(
+                withFeatureContexts = setOf(
+                    Feature.RUM_FEATURE_NAME,
+                    Feature.SESSION_REPLAY_FEATURE_NAME
+                )
+            ) { datadogContext, writeScope ->
                 val rumContext = contextProvider.getRumContext(datadogContext)
                 val sessionReplayFeatureContext = datadogContext.featuresContext[
                     Feature.SESSION_REPLAY_FEATURE_NAME

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
@@ -37,7 +37,9 @@ internal class WebViewRumEventConsumer(
             )
         )
         sdkCore.getFeature(WebViewRumFeature.WEB_RUM_FEATURE_NAME)
-            ?.withWriteContext { datadogContext, writeScope ->
+            ?.withWriteContext(
+                withFeatureContexts = setOf(Feature.RUM_FEATURE_NAME, Feature.SESSION_REPLAY_FEATURE_NAME)
+            ) { datadogContext, writeScope ->
                 val rumContext = contextProvider.getRumContext(datadogContext)
                 if (rumContext != null && rumContext.sessionState == "TRACKED") {
                     val sessionReplayFeatureContext = datadogContext.featuresContext[

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/WebViewTrackingTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/WebViewTrackingTest.kt
@@ -644,7 +644,10 @@ internal class WebViewTrackingTest {
         // When
         proxy.consumeWebviewEvent(fakeWebEvent.toString())
         argumentCaptor<(DatadogContext, EventWriteScope) -> Unit> {
-            verify(mockWebViewRumFeature).withWriteContext(capture())
+            verify(mockWebViewRumFeature).withWriteContext(
+                eq(setOf(Feature.RUM_FEATURE_NAME, Feature.SESSION_REPLAY_FEATURE_NAME)),
+                capture()
+            )
             firstValue(mockDatadogContext, mockEventWriteScope)
         }
 

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumerTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumerTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.webview.internal.log
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.EventWriteScope
+import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.DataWriter
@@ -108,8 +109,8 @@ internal class WebViewLogEventConsumerTest {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
         }
-        whenever(mockWebViewLogsFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+        whenever(mockWebViewLogsFeatureScope.withWriteContext(eq(setOf(Feature.RUM_FEATURE_NAME)), any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(it.arguments.lastIndex)
             callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
 
@@ -178,7 +179,7 @@ internal class WebViewLogEventConsumerTest {
         )
 
         // Then
-        verify(mockWebViewLogsFeatureScope, never()).withWriteContext(any())
+        verify(mockWebViewLogsFeatureScope, never()).withWriteContext(any(), any())
     }
 
     @Test

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventConsumerTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventConsumerTest.kt
@@ -37,6 +37,7 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -121,8 +122,12 @@ internal class WebViewReplayEventConsumerTest {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
         }
-        whenever(mockSessionReplayFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+        whenever(
+            mockSessionReplayFeatureScope.withWriteContext(
+                eq(setOf(Feature.RUM_FEATURE_NAME, Feature.SESSION_REPLAY_FEATURE_NAME)), any()
+            )
+        ) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(it.arguments.lastIndex)
             callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumerTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumerTest.kt
@@ -151,8 +151,12 @@ internal class WebViewRumEventConsumerTest {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
         }
-        whenever(mockWebViewRumFeatureScope.withWriteContext(any())) doAnswer {
-            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(0)
+        whenever(
+            mockWebViewRumFeatureScope.withWriteContext(
+                eq(setOf(Feature.RUM_FEATURE_NAME, Feature.SESSION_REPLAY_FEATURE_NAME)), any()
+            )
+        ) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(it.arguments.lastIndex)
             callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/cross/CrossFeatureTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/cross/CrossFeatureTest.kt
@@ -283,7 +283,7 @@ class CrossFeatureTest {
     }
 
     @Test
-    fun logsMustNoLinkToTracesWhenCalledBefore() {
+    fun logsMustNotLinkToTracesWhenCalledBefore() {
         // Given
         val fakeOperationName = forge.aString()
         val fakeLogMessage = forge.aString()
@@ -309,7 +309,7 @@ class CrossFeatureTest {
     }
 
     @Test
-    fun logsMustNoLinkToTracesWhenCalledAfter() {
+    fun logsMustNotLinkToTracesWhenCalledAfter() {
         // Given
         val fakeOperationName = forge.aString()
         val fakeLogMessage = forge.aString()

--- a/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/InternalSdkCoreTest.kt
+++ b/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/InternalSdkCoreTest.kt
@@ -164,7 +164,7 @@ class InternalSdkCoreTest : MockServerTest() {
         }
 
         // When
-        val context = testedInternalSdkCore.getDatadogContext()
+        val context = testedInternalSdkCore.getDatadogContext(withFeatureContexts = setOf(fakeFeatureName))
 
         // Then
         checkNotNull(context)
@@ -201,7 +201,7 @@ class InternalSdkCoreTest : MockServerTest() {
             .forEach { it.join(SHORT_WAIT_MS) }
 
         // When
-        val context = testedInternalSdkCore.getDatadogContext()
+        val context = testedInternalSdkCore.getDatadogContext(withFeatureContexts = setOf(fakeFeatureName))
 
         // Then
         checkNotNull(context)
@@ -250,7 +250,7 @@ class InternalSdkCoreTest : MockServerTest() {
             .join(SHORT_WAIT_MS)
 
         // When
-        val context = testedInternalSdkCore.getDatadogContext()
+        val context = testedInternalSdkCore.getDatadogContext(withFeatureContexts = setOf(fakeFeatureName))
 
         // Then
         checkNotNull(context)
@@ -299,7 +299,7 @@ class InternalSdkCoreTest : MockServerTest() {
             .join(SHORT_WAIT_MS)
 
         // When
-        val context = testedInternalSdkCore.getDatadogContext()
+        val context = testedInternalSdkCore.getDatadogContext(withFeatureContexts = setOf(fakeFeatureName))
 
         // Then
         checkNotNull(context)

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubFeatureScope.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubFeatureScope.kt
@@ -58,6 +58,7 @@ internal class StubFeatureScope(
     // region FeatureScope
 
     override fun withWriteContext(
+        withFeatureContexts: Set<String>,
         callback: (DatadogContext, EventWriteScope) -> Unit
     ) {
         callback(
@@ -66,11 +67,11 @@ internal class StubFeatureScope(
         )
     }
 
-    override fun withContext(callback: (datadogContext: DatadogContext) -> Unit) {
+    override fun withContext(withFeatureContexts: Set<String>, callback: (datadogContext: DatadogContext) -> Unit) {
         callback(datadogContextProvider())
     }
 
-    override fun getWriteContextSync(): Pair<DatadogContext, EventWriteScope>? {
+    override fun getWriteContextSync(withFeatureContexts: Set<String>): Pair<DatadogContext, EventWriteScope>? {
         return datadogContextProvider() to { it.invoke(eventBatchWriter) }
     }
 

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
@@ -113,7 +113,7 @@ class StubSDKCore(
     override val firstPartyHostResolver: FirstPartyHostHeaderTypeResolver =
         StubFirstPartyHostHeaderTypeResolver()
 
-    override fun getDatadogContext(): DatadogContext {
+    override fun getDatadogContext(withFeatureContexts: Set<String>): DatadogContext {
         return datadogContext
     }
 


### PR DESCRIPTION
### What does this PR do?

We now have a possibility to update feature context from multiple threads, which imposes the need to use write/read locks.

This means that if `withWithContext`, `withContext`, etc. methods are made which provide `DatadogContext` in the callback, if there is any feature context update is ongoing, we need to wait for its completion (since write lock is acquired, making it impossible to read until unlocked) to put the right value.

However, caller may not need the particular feature context, so this wait may be for nothing.

This PR adds an additional argument `withFeatureContext` to the methods mentioned above which is used to **explicitly** indicate what feature contexts caller is interested in. This makes API a bit more verbose, but at the same time we avoid the possible redundant wait time.

That change won't be needed if all feature updates/reads would happen on the context processing thread, but it is not the case.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

