### PR TITLE
Fix GsonExt flaky test

### DIFF
--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/gson/GsonExtTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/gson/GsonExtTest.kt
@@ -123,7 +123,7 @@ internal class GsonExtTest {
     @Test
     fun `M return null W safeGetAsLong{a non long JsonPrimitive}`(forge: Forge) {
         // Given
-        val fakeNonLongJsonPrimitive = JsonPrimitive(forge.aString())
+        val fakeNonLongJsonPrimitive = JsonPrimitive(forge.anAlphabeticalString())
         val expectedLogMessage = BROKEN_JSON_ERROR_MESSAGE_FORMAT.format(
             fakeNonLongJsonPrimitive.toString(),
             JSON_PRIMITIVE_TYPE


### PR DESCRIPTION
### What does this PR do?

`forge.aString()` can generate numerical string like: "1", "23", etc, which make test fail,
 change to `anAlphabeticalString` which doesn't contain any number.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

