### PR TITLE
RUM-9527: Defer drawable copy to work thread in Session Replay

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolver.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolver.kt
@@ -137,21 +137,24 @@ internal class ResourceResolver(
             return
         }
 
-        val copiedDrawable = drawableCopier.copy(originalDrawable, resources)
-        if (copiedDrawable == null) {
-            resourceResolverCallback.onFailure()
-            return
-        }
-
-        val bitmapFromDrawable =
-            if (copiedDrawable is BitmapDrawable && shouldUseDrawableBitmap(copiedDrawable)) {
-                copiedDrawable.bitmap // cannot be null - we already checked in shouldUseDrawableBitmap
-            } else {
-                null
-            }
-
         // do in the background
         threadPoolExecutor.executeSafe(RESOURCE_RESOLVER_ALIAS, logger) {
+            // Copy the drawable on work thread in order to avoid the new MaterialShapeDrawable
+            // instance to reuse the singleton of `ShapeAppearancePathProvider` from main thread,
+            // causing UI thread drawing crash.
+            val copiedDrawable = drawableCopier.copy(originalDrawable, resources)
+            if (copiedDrawable == null) {
+                resourceResolverCallback.onFailure()
+                return@executeSafe
+            }
+
+            val bitmapFromDrawable =
+                if (copiedDrawable is BitmapDrawable && shouldUseDrawableBitmap(copiedDrawable)) {
+                    copiedDrawable.bitmap // cannot be null - we already checked in shouldUseDrawableBitmap
+                } else {
+                    null
+                }
+
             createBitmapFromDrawable(
                 drawable = originalDrawable,
                 copiedDrawable = copiedDrawable,

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolverTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolverTest.kt
@@ -1090,4 +1090,59 @@ internal class ResourceResolverTest {
             bitmapCreationCallback = any()
         )
     }
+
+    @Test
+    fun `M only copy the drawable in work thread W resolveResourceIdFromDrawable`() {
+        // Given
+        whenever(
+            mockExecutorService.execute(
+                any()
+            )
+        ).then {
+            // do nothing to simulate that work thread doesn't execute the task.
+            mock<Future<Boolean>>()
+        }
+
+        // When
+        testedResourceResolver.resolveResourceIdFromDrawable(
+            resources = mockResources,
+            applicationContext = mockApplicationContext,
+            displayMetrics = mockDisplayMetrics,
+            originalDrawable = mockDrawable,
+            drawableCopier = mockDrawableCopier,
+            drawableWidth = mockDrawable.intrinsicWidth,
+            drawableHeight = mockDrawable.intrinsicHeight,
+            customResourceIdCacheKey = null,
+            resourceResolverCallback = mockSerializerCallback
+        )
+
+        // Then
+        verifyNoInteractions(mockDrawableCopier)
+
+        // Given
+        whenever(
+            mockExecutorService.execute(
+                any()
+            )
+        ).then {
+            (it.arguments[0] as Runnable).run()
+            mock<Future<Boolean>>()
+        }
+
+        // When
+        testedResourceResolver.resolveResourceIdFromDrawable(
+            resources = mockResources,
+            applicationContext = mockApplicationContext,
+            displayMetrics = mockDisplayMetrics,
+            originalDrawable = mockDrawable,
+            drawableCopier = mockDrawableCopier,
+            drawableWidth = mockDrawable.intrinsicWidth,
+            drawableHeight = mockDrawable.intrinsicHeight,
+            customResourceIdCacheKey = null,
+            resourceResolverCallback = mockSerializerCallback
+        )
+
+        // Then
+        verify(mockDrawableCopier).copy(mockDrawable, mockResources)
+    }
 }


### PR DESCRIPTION
### What does this PR do?

This PR defers the drawable copy from main thread to work thread in Session Replay to fix the crash when Android View wants to draw the original drawable on UI thread.

#### Why the crash happens?
To draw the drawable to generate bitmap for Session Replay image wireframe, we will copy the drawable in case of any impact of the original one, for most of the implementations of `Drawable` it has no problem, except `MaterialShapeDrawable`.

`MaterialShapeDrawable` holds an singleton of [`ShapeAppearancePathProvider`](https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/shape/MaterialShapeDrawable.java#L174)on main thread, if we copy the drawable on main thread, the same path held by this singleton will be used for both drawing, which is not allowed by the system. So deferring the copy to the work thread will make it generate a new instance for the thread, and the path will not be shared with main thread any more.

### Motivation

RUM-9527

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

