### PR TITLE
RUM-10224: GitHub app migration for PAT

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -64,6 +64,10 @@ stages:
     - export OSSRH_USERNAME=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_username --with-decryption --query "Parameter.Value" --out text)
     - export OSSRH_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_password --with-decryption --query "Parameter.Value" --out text)
     - export GPG_PUBLIC_FINGERPRINT=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.gpg_public_key --with-decryption --query "Parameter.Value" --out text | gpg --import --import-options show-only | grep -E -o -e "[A-F0-9]{40}")
+  set-github-installation-token:
+    - export GITHUB_APP_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gh_app_client_id --with-decryption --query "Parameter.Value" --out text)
+    - export GITHUB_APP_INSTALLATION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gh_app_installation_id --with-decryption --query "Parameter.Value" --out text)
+    - export GITHUB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gh_app_private_key --with-decryption --query "Parameter.Value" --out text | bash ./create_github_installation_token.sh "$GITHUB_APP_CLIENT_ID" "$GITHUB_APP_INSTALLATION_ID")
 
 # CI IMAGE
 
@@ -970,23 +974,6 @@ notify:publish-release-failure:
     - 'MESSAGE_TEXT=":status_alert: $CI_PROJECT_NAME $CI_COMMIT_TAG publish pipeline <$BUILD_URL|$COMMIT_MESSAGE> failed."'
     - postmessage "#mobile-sdk-ops" "$MESSAGE_TEXT"
 
-notify:prepare-github-token:
-  tags: [ "arch:amd64" ]
-  only:
-    - tags
-  image: $CI_IMAGE_DOCKER
-  stage: notify
-  when: on_success
-  script:
-    - aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gh_app_private_key --with-decryption --query "Parameter.Value" --out text >> ./gh_private_key.pem
-    - export GITHUB_APP_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gh_app_client_id --with-decryption --query "Parameter.Value" --out text)
-    - export GITHUB_APP_INSTALLATION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gh_app_installation_id --with-decryption --query "Parameter.Value" --out text)
-    - echo "GITHUB_TOKEN=$(bash ./create_github_installation_token.sh)" >> github.env
-  artifacts:
-    reports:
-      dotenv: github.env
-    access: none
-
 notify:dogfood-app:
   tags: [ "arch:amd64" ]
   only:
@@ -994,9 +981,8 @@ notify:dogfood-app:
   image: $CI_IMAGE_DOCKER
   stage: notify
   when: on_success
-  needs:
-    - notify:prepare-github-token
   script:
+    - !reference [ .snippets, set-github-installation-token ]
     - pip3 install GitPython requests
     - python3 dogfood.py -v $CI_COMMIT_TAG -t app
 
@@ -1007,9 +993,8 @@ notify:dogfood-demo:
   image: $CI_IMAGE_DOCKER
   stage: notify
   when: on_success
-  needs:
-    - notify:prepare-github-token
   script:
+    - !reference [ .snippets, set-github-installation-token ]
     - pip3 install GitPython requests
     - python3 dogfood.py -v $CI_COMMIT_TAG -t demo
 
@@ -1021,6 +1006,7 @@ notify:dogfood-gradle-plugin:
   stage: notify
   when: on_success
   script:
+    - !reference [ .snippets, set-github-installation-token ]
     - pip3 install GitPython requests
     - python3 dogfood.py -v $CI_COMMIT_TAG -t gradle-plugin
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -970,7 +970,7 @@ notify:publish-release-failure:
     - 'MESSAGE_TEXT=":status_alert: $CI_PROJECT_NAME $CI_COMMIT_TAG publish pipeline <$BUILD_URL|$COMMIT_MESSAGE> failed."'
     - postmessage "#mobile-sdk-ops" "$MESSAGE_TEXT"
 
-notify:dogfood-app:
+notify:prepare-github-token:
   tags: [ "arch:amd64" ]
   only:
     - tags
@@ -978,8 +978,26 @@ notify:dogfood-app:
   stage: notify
   when: on_success
   script:
+    - aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gh_app_private_key --with-decryption --query "Parameter.Value" --out text >> ./gh_private_key.pem
+    - export GITHUB_APP_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gh_app_client_id --with-decryption --query "Parameter.Value" --out text)
+    - export GITHUB_APP_INSTALLATION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gh_app_installation_id --with-decryption --query "Parameter.Value" --out text)
+    - echo "GITHUB_TOKEN=$(bash ./create_github_installation_token.sh)" >> github.env
+  artifacts:
+    reports:
+      dotenv: github.env
+    access: none
+
+notify:dogfood-app:
+  tags: [ "arch:amd64" ]
+  only:
+    - tags
+  image: $CI_IMAGE_DOCKER
+  stage: notify
+  when: on_success
+  needs:
+    - notify:prepare-github-token
+  script:
     - pip3 install GitPython requests
-    - aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gh_token --with-decryption --query "Parameter.Value" --out text >> ./gh_token
     - python3 dogfood.py -v $CI_COMMIT_TAG -t app
 
 notify:dogfood-demo:
@@ -989,9 +1007,10 @@ notify:dogfood-demo:
   image: $CI_IMAGE_DOCKER
   stage: notify
   when: on_success
+  needs:
+    - notify:prepare-github-token
   script:
     - pip3 install GitPython requests
-    - aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gh_token --with-decryption --query "Parameter.Value" --out text >> ./gh_token
     - python3 dogfood.py -v $CI_COMMIT_TAG -t demo
 
 notify:dogfood-gradle-plugin:
@@ -1003,7 +1022,6 @@ notify:dogfood-gradle-plugin:
   when: on_success
   script:
     - pip3 install GitPython requests
-    - aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gh_token --with-decryption --query "Parameter.Value" --out text >> ./gh_token
     - python3 dogfood.py -v $CI_COMMIT_TAG -t gradle-plugin
 
 notify:merge-verification-metadata:

--- a/create_github_installation_token.sh
+++ b/create_github_installation_token.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+#
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2016-Present Datadog, Inc.
+#
+
+set -o pipefail
+
+pem='./gh_private_key.pem'
+
+now=$(date +%s)
+iat=$((${now} - 60)) # Issues 60 seconds in the past
+exp=$((${now} + 600)) # Expires 10 minutes in the future
+
+b64enc() { openssl base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n'; }
+
+header_json='{
+    "typ":"JWT",
+    "alg":"RS256"
+}'
+# Header encode
+header=$( echo -n "${header_json}" | b64enc )
+
+payload_json="{
+    \"iat\":${iat},
+    \"exp\":${exp},
+    \"iss\":\"${GITHUB_APP_CLIENT_ID}\"
+}"
+
+# Payload encode
+payload=$( echo -n "${payload_json}" | b64enc )
+
+# Signature
+header_payload="${header}"."${payload}"
+signature=$(
+    openssl dgst -sha256 -sign "${pem}" \
+    <(echo -n "${header_payload}") | b64enc
+)
+
+# Create JWT
+jwt_token="${header_payload}"."${signature}"
+
+# Fetch installation token
+installation_token=$(curl \
+  -s \
+  -X POST \
+  -H "Authorization: Bearer $jwt_token" \
+  -H "Accept: application/vnd.github+json" \
+  https://api.github.com/app/installations/$GITHUB_APP_INSTALLATION_ID/access_tokens)
+
+echo $installation_token | jq -r '.token'

--- a/dogfood.py
+++ b/dogfood.py
@@ -100,7 +100,7 @@ def generate_target_code(target: str, temp_dir_path: str, version: str):
 
 def git_clone_repository(repo_name: str, gh_token: str, temp_dir_path: str) -> Tuple[Repo, str]:
     print("Cloning repository " + repo_name)
-    url = "https://" + gh_token + ":x-oauth-basic@github.com/DataDog/" + repo_name
+    url = "https://x-access-token:" + gh_token + "@github.com/DataDog/" + repo_name
     repo = Repo.clone_from(url, temp_dir_path)
     base_name = repo.active_branch.name
     return repo, base_name
@@ -143,10 +143,7 @@ def update_dependant(version: str, target: str, gh_token: str, dry_run: bool) ->
 def run_main() -> int:
     cli_args = parse_arguments(sys.argv[1:])
 
-    # This script expects to have a valid Github Token in a "gh_token" text file
-    # The token needs the `repo` permissions, and for now is a PAT
-    with open('gh_token', 'r') as f:
-        gh_token = f.read().strip()
+    gh_token = os.getenv("GITHUB_TOKEN")
 
     return update_dependant(cli_args.version, cli_args.target, gh_token, cli_args.dry_run)
 


### PR DESCRIPTION
### What does this PR do?

Migrate from a classical PAT to GitHub app installation token for using GitHub api to create PRs in `datadog-android`, `shopist-android`, `dd-sdk-android-gradle-plugin`.

I tested that it works (although I had to modify `gitlab-ci.yaml` a bit, these changes are not in the pr):
1. https://github.com/DataDog/datadog-android/pull/7366
2. https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/382
3. For shopist I couldn't test, because there we use SNAPSHOT version and our current job (without my changes) actually doesn't do anything.

[Here](https://github.com/apps/dd-mobile-sdk-ci) is the app we now use.

RFC [link](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/5190912115/RFC+-+GitHub+PAT+Retirement+in+Mobile+RUM+SDKs).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

