### PR TITLE
Update changelog-to-confluence: Update secret names

### DIFF
--- a/.github/workflows/changelog-to-confluence.yaml
+++ b/.github/workflows/changelog-to-confluence.yaml
@@ -23,9 +23,9 @@ jobs:
             - name: Publish Markdown to Confluence
               uses: markdown-confluence/publish-action@7767a0a7f438bb1497ee7ffd7d3d685b81dfe700 # v5
               with:
-                  confluenceBaseUrl: ${{ secrets.CONFLUENCE_BASE_URL }}
+                  confluenceBaseUrl: ${{ secrets.DATADOG_CONFLUENCE_BASE_URL }}
                   confluenceParentId: ${{ secrets.CONFLUENCE_PARENT_ID }}
-                  atlassianUserName: ${{ secrets.ATLASSIAN_USERNAME }}
-                  atlassianApiToken: ${{ secrets.ATLASSIAN_API_TOKEN }}
+                  atlassianUserName: ${{ secrets.CONFLUENCE_ROBOT_RUM_EMAIL }}
+                  atlassianApiToken: ${{ secrets.CONFLUENCE_ROBOT_RUM_API_KEY }}
                   contentRoot: '.'
                   folderToPublish: 'publish_folder'


### PR DESCRIPTION
### What does this PR do?

- Updates secrets names on the Github Workflow

### Motivation

- Easier maintanenaince in the future

### Additional Notes

- Remove previous github Secrets from the repo  
  - `CONFLUENCE_BASE_URL`  
  - `ATLASSIAN_USERNAME`
  - `ATLASSIAN_API_TOKEN`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

