### PR TITLE
RUM-10347: Avoid polling for `RumContext` in `VitalReaderRunnable`

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -233,10 +233,8 @@ internal class DatadogCore(
             feature.featureContextLock.writeLock().safeTryWithLock(1, TimeUnit.SECONDS) {
                 val currentContext = feature.featureContext
                 updateCallback(currentContext)
-                features.forEach { (key, feature) ->
-                    if (key != featureName) {
-                        feature.notifyContextUpdated(featureName, currentContext)
-                    }
+                features.values.forEach {
+                    it.notifyContextUpdated(featureName, currentContext)
                 }
             }
         }
@@ -312,11 +310,9 @@ internal class DatadogCore(
         } else {
             feature.setContextUpdateListener(listener)
             features.forEach {
-                if (it.key != featureName) {
-                    val currentContext = getFeatureContext(it.key, false)
-                    if (currentContext.isNotEmpty()) {
-                        listener.onContextUpdate(it.key, currentContext)
-                    }
+                val currentContext = getFeatureContext(it.key, false)
+                if (currentContext.isNotEmpty()) {
+                    listener.onContextUpdate(it.key, currentContext)
                 }
             }
         }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
@@ -72,7 +72,6 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -349,7 +348,7 @@ internal class DatadogCoreTest {
             verify(otherFeature).notifyContextUpdated(feature, fakeContext)
             verifyNoMoreInteractions(otherFeature)
         }
-        verify(mockFeature, never()).notifyContextUpdated(feature, fakeContext)
+        verify(mockFeature).notifyContextUpdated(feature, fakeContext)
     }
 
     @Test
@@ -745,7 +744,10 @@ internal class DatadogCoreTest {
         @StringForgery feature: String
     ) {
         // Given
-        val mockFeature = mock<SdkFeature>()
+        val mockFeature = mock<SdkFeature>().apply {
+            whenever(featureContext) doReturn mutableMapOf()
+            whenever(featureContextLock) doReturn ReentrantReadWriteLock()
+        }
         val mockContextUpdateListener = mock<FeatureContextUpdateReceiver>()
         testedCore.features[feature] = mockFeature
 
@@ -764,6 +766,7 @@ internal class DatadogCoreTest {
         // Given
         val mockFeature = mock<SdkFeature>().apply {
             whenever(featureContext) doReturn mutableMapOf<String, Any?>()
+            whenever(featureContextLock) doReturn ReentrantReadWriteLock()
         }
         val mockContextUpdateListener = mock<FeatureContextUpdateReceiver>()
         testedCore.features[feature] = mockFeature
@@ -790,6 +793,7 @@ internal class DatadogCoreTest {
         // Given
         val mockFeature = mock<SdkFeature>().apply {
             whenever(featureContext) doReturn mutableMapOf<String, Any?>()
+            whenever(featureContextLock) doReturn ReentrantReadWriteLock()
         }
         val mockContextUpdateListener = mock<FeatureContextUpdateReceiver>()
         testedCore.features[feature] = mockFeature
@@ -822,6 +826,7 @@ internal class DatadogCoreTest {
         // Given
         val mockFeature = mock<SdkFeature>().apply {
             whenever(featureContext) doReturn mutableMapOf<String, Any?>()
+            whenever(featureContextLock) doReturn ReentrantReadWriteLock()
         }
         val mockContextUpdateListener = mock<FeatureContextUpdateReceiver>()
         testedCore.features[feature] = mockFeature

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/VitalReaderRunnable.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/VitalReaderRunnable.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.rum.internal.vitals
 
 import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureContextUpdateReceiver
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.internal.utils.scheduleSafe
 import com.datadog.android.rum.internal.domain.RumContext
@@ -20,12 +21,13 @@ internal class VitalReaderRunnable(
     val observer: VitalObserver,
     val executor: ScheduledExecutorService,
     private val periodMs: Long
-) : Runnable {
+) : Runnable, FeatureContextUpdateReceiver {
+
+    @Volatile
+    internal var currentRumContext: RumContext? = null
 
     override fun run() {
-        val rumContext =
-            RumContext.fromFeatureContext(sdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME))
-        val rumViewType = rumContext.viewType
+        val rumViewType = currentRumContext?.viewType
         if (rumViewType == RumViewType.FOREGROUND) {
             val data = reader.readVitalData()
             if (data != null) {
@@ -39,5 +41,11 @@ internal class VitalReaderRunnable(
             sdkCore.internalLogger,
             this
         )
+    }
+
+    override fun onContextUpdate(featureName: String, event: Map<String, Any?>) {
+        if (featureName == Feature.RUM_FEATURE_NAME) {
+            currentRumContext = RumContext.fromFeatureContext(event)
+        }
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnableTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnableTest.kt
@@ -6,16 +6,13 @@
 
 package com.datadog.android.rum.internal.anr
 
-import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import com.datadog.android.core.feature.event.ThreadDump
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
-import com.datadog.android.rum.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.rum.utils.config.GlobalRumMonitorTestConfiguration
-import com.datadog.android.rum.utils.config.MainLooperTestConfiguration
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -210,14 +207,12 @@ internal class ANRDetectorRunnableTest {
         private const val TEST_ANR_THRESHOLD_MS = 500L
         private const val TEST_ANR_TEST_DELAY_MS = 50L
 
-        val appContext = ApplicationContextTestConfiguration(Context::class.java)
         val rumMonitor = GlobalRumMonitorTestConfiguration()
-        val mainLooper = MainLooperTestConfiguration()
 
         @TestConfigurationsProvider
         @JvmStatic
         fun getTestConfigurations(): List<TestConfiguration> {
-            return listOf(appContext, rumMonitor, mainLooper)
+            return listOf(rumMonitor)
         }
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -241,6 +241,7 @@ internal class DatadogRumMonitorTest {
 
     @Test
     fun `creates root scope`() {
+        // Given
         testedMonitor = DatadogRumMonitor(
             fakeApplicationId,
             mockSdkCore,
@@ -262,7 +263,10 @@ internal class DatadogRumMonitorTest {
             mockSlowFramesListener
         )
 
+        // When
         val rootScope = testedMonitor.rootScope
+
+        // Then
         assertThat(rootScope.sampleRate).isEqualTo(fakeSampleRate)
         assertThat(rootScope.backgroundTrackingEnabled).isEqualTo(fakeBackgroundTrackingEnabled)
     }
@@ -272,8 +276,10 @@ internal class DatadogRumMonitorTest {
         @StringForgery(type = StringForgeryType.ASCII) key: String,
         @StringForgery name: String
     ) {
+        // When
         testedMonitor.startView(key, name, fakeAttributes)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -340,6 +346,7 @@ internal class DatadogRumMonitorTest {
 
     @Test
     fun `M send null sessionId W getCurrentSessionId { session started, sampled out }`() {
+        // Given
         testedMonitor = DatadogRumMonitor(
             fakeApplicationId,
             mockSdkCore,
@@ -374,8 +381,10 @@ internal class DatadogRumMonitorTest {
     fun `M delegate event to rootScope W stopView()`(
         @StringForgery(type = StringForgeryType.ASCII) key: String
     ) {
+        // When
         testedMonitor.stopView(key, fakeAttributes)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -396,12 +405,10 @@ internal class DatadogRumMonitorTest {
         @Forgery type: RumActionType,
         @StringForgery name: String
     ) {
-        whenever(mockExecutorService.execute(any())) doAnswer {
-            it.getArgument<Runnable>(0).run()
-        }
-
+        // When
         testedMonitor.addAction(type, name, fakeAttributes)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -424,8 +431,10 @@ internal class DatadogRumMonitorTest {
         @Forgery type: RumActionType,
         @StringForgery name: String
     ) {
+        // When
         testedMonitor.startAction(type, name, fakeAttributes)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -448,8 +457,10 @@ internal class DatadogRumMonitorTest {
         @Forgery type: RumActionType,
         @StringForgery name: String
     ) {
+        // When
         testedMonitor.stopAction(type, name, fakeAttributes)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -535,8 +546,10 @@ internal class DatadogRumMonitorTest {
         @Forgery method: RumResourceMethod,
         @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
+        // When
         testedMonitor.startResource(key, method, url, fakeAttributes)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -561,8 +574,10 @@ internal class DatadogRumMonitorTest {
         @LongForgery(0, 1024) size: Long,
         @Forgery kind: RumResourceKind
     ) {
+        // When
         testedMonitor.stopResource(key, statusCode, size, kind, fakeAttributes)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -586,8 +601,10 @@ internal class DatadogRumMonitorTest {
         @StringForgery key: String,
         @Forgery kind: RumResourceKind
     ) {
+        // When
         testedMonitor.stopResource(key, null, null, kind, fakeAttributes)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -614,6 +631,7 @@ internal class DatadogRumMonitorTest {
         @IntForgery(200, 600) statusCode: Int,
         @Forgery throwable: Throwable
     ) {
+        // When
         testedMonitor.stopResourceWithError(
             key,
             statusCode,
@@ -623,6 +641,7 @@ internal class DatadogRumMonitorTest {
             fakeAttributes
         )
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -651,6 +670,7 @@ internal class DatadogRumMonitorTest {
         @StringForgery(type = StringForgeryType.ASCII_EXTENDED) stackTrace: String,
         @StringForgery errorType: String
     ) {
+        // When
         testedMonitor.stopResourceWithError(
             key,
             statusCode,
@@ -661,6 +681,7 @@ internal class DatadogRumMonitorTest {
             fakeAttributes
         )
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -688,8 +709,10 @@ internal class DatadogRumMonitorTest {
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable
     ) {
+        // When
         testedMonitor.stopResourceWithError(key, null, message, source, throwable, fakeAttributes)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -715,8 +738,10 @@ internal class DatadogRumMonitorTest {
         @Forgery method: RumResourceMethod,
         @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
+        // When
         testedMonitor.startResource(key, method, url, fakeAttributes)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -741,8 +766,10 @@ internal class DatadogRumMonitorTest {
         @LongForgery(0, 1024) size: Long,
         @Forgery kind: RumResourceKind
     ) {
+        // When
         testedMonitor.stopResource(key, statusCode, size, kind, fakeAttributes)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -766,8 +793,10 @@ internal class DatadogRumMonitorTest {
         @Forgery key: ResourceId,
         @Forgery kind: RumResourceKind
     ) {
+        // When
         testedMonitor.stopResource(key, null, null, kind, fakeAttributes)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -794,6 +823,7 @@ internal class DatadogRumMonitorTest {
         @IntForgery(200, 600) statusCode: Int,
         @Forgery throwable: Throwable
     ) {
+        // When
         testedMonitor.stopResourceWithError(
             key,
             statusCode,
@@ -803,6 +833,7 @@ internal class DatadogRumMonitorTest {
             fakeAttributes
         )
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -831,6 +862,7 @@ internal class DatadogRumMonitorTest {
         @StringForgery(type = StringForgeryType.ASCII_EXTENDED) stackTrace: String,
         @StringForgery errorType: String
     ) {
+        // When
         testedMonitor.stopResourceWithError(
             key,
             statusCode,
@@ -841,6 +873,7 @@ internal class DatadogRumMonitorTest {
             fakeAttributes
         )
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -868,8 +901,10 @@ internal class DatadogRumMonitorTest {
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable
     ) {
+        // When
         testedMonitor.stopResourceWithError(key, null, message, source, throwable, fakeAttributes)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -895,8 +930,10 @@ internal class DatadogRumMonitorTest {
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable
     ) {
+        // When
         testedMonitor.addError(message, source, throwable, fakeAttributes)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -924,8 +961,10 @@ internal class DatadogRumMonitorTest {
         @Forgery source: RumErrorSource,
         @StringForgery stacktrace: String
     ) {
+        // When
         testedMonitor.addErrorWithStacktrace(message, source, stacktrace, fakeAttributes)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -951,8 +990,10 @@ internal class DatadogRumMonitorTest {
     fun `M delegate event to rootScope W waitForResourceTiming()`(
         @StringForgery key: String
     ) {
+        // When
         testedMonitor.waitForResourceTiming(key)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -973,8 +1014,10 @@ internal class DatadogRumMonitorTest {
         @StringForgery key: String,
         @Forgery timing: ResourceTiming
     ) {
+        // When
         testedMonitor.addResourceTiming(key, timing)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -992,11 +1035,13 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
-    fun `M delegate event to rootScope W addCustomTiming()`(
+    fun `M delegate event to rootScope W addTiming()`(
         @StringForgery name: String
     ) {
+        // When
         testedMonitor.addTiming(name)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -1014,7 +1059,7 @@ internal class DatadogRumMonitorTest {
 
     @Test
     @OptIn(ExperimentalRumApi::class)
-    fun `M delegate event to rootScope W addViewLoadTime()`(
+    fun `M delegate event to rootScope W addViewLoadingTime()`(
         @BoolForgery fakeOverwrite: Boolean
     ) {
         testedMonitor.addViewLoadingTime(fakeOverwrite)
@@ -1095,8 +1140,10 @@ internal class DatadogRumMonitorTest {
 
     @Test
     fun `M delegate event to rootScope W resetSession()`() {
+        // When
         testedMonitor.resetSession()
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(mockApplicationScope).handleEvent(
                 capture(),
@@ -1963,22 +2010,7 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
-    fun `M delegate event to rootScope W sendWebViewEvent()`() {
-        // When
-        testedMonitor.sendWebViewEvent()
-
-        // Then
-        verify(mockApplicationScope).handleEvent(
-            argThat { this is RumRawEvent.WebViewEvent },
-            same(fakeDatadogContext),
-            same(mockEventWriteScope),
-            same(mockWriter)
-        )
-        verifyNoMoreInteractions(mockWriter)
-    }
-
-    @Test
-    fun `M shutdown with wait the persistence executor W drainAndShutdownExecutors()`() {
+    fun `M shutdown with wait the persistence executor W drainExecutorService()`() {
         // Given
         val mockExecutorService: ExecutorService = mock()
         testedMonitor = DatadogRumMonitor(
@@ -2174,7 +2206,7 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
-    fun `M call sessionEndedMetricDispatcher W addSkippedFrame`(
+    fun `M call sessionEndedMetricDispatcher W addSessionReplaySkippedFrame`(
         @IntForgery(min = 0, max = 100) count: Int,
         @StringForgery(type = StringForgeryType.ASCII) key: String,
         @StringForgery name: String
@@ -2211,6 +2243,21 @@ internal class DatadogRumMonitorTest {
 
         // Then
         verify(mockSessionEndedMetricDispatcher, times(count)).onSessionReplaySkippedFrameTracked(any())
+    }
+
+    @Test
+    fun `M delegate event to rootScope W sendWebViewEvent()`() {
+        // When
+        testedMonitor.sendWebViewEvent()
+
+        // Then
+        verify(mockApplicationScope).handleEvent(
+            argThat { this is RumRawEvent.WebViewEvent },
+            same(fakeDatadogContext),
+            same(mockEventWriteScope),
+            same(mockWriter)
+        )
+        verifyNoMoreInteractions(mockWriter)
     }
 
     @Test
@@ -2262,7 +2309,7 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
-    fun `M handle synthetics test attributes W setSyntheticsTestAttribute()`(
+    fun `M handle synthetics test attributes W setSyntheticsAttribute()`(
         @StringForgery fakeTestId: String,
         @StringForgery fakeResultId: String
     ) {

--- a/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/FeatureSdkCoreTest.kt
+++ b/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/FeatureSdkCoreTest.kt
@@ -468,25 +468,6 @@ class FeatureSdkCoreTest : MockServerTest() {
     }
 
     @Test
-    fun mustNotReceiveContextUpdate_when_contextUpdateReceiverRegistered_contextUpdateOnSameFeature() {
-        // Given
-        val stubContextUpdateReceiver = StubContextUpdateReceiver()
-        val fakeKeyValues = forge.aMap { anAlphabeticalString() to anAlphabeticalString() }
-        testedFeatureSdkCore.registerFeature(stubFeature)
-        testedFeatureSdkCore.setContextUpdateReceiver(stubFeature.name, stubContextUpdateReceiver)
-
-        // When
-        testedFeatureSdkCore.updateFeatureContext(stubFeature.name, useContextThread = false) {
-            fakeKeyValues.forEach { (key, value) ->
-                it[key] = value
-            }
-        }
-
-        // Then
-        assertThat(stubContextUpdateReceiver.getReceivedEvents()).isEmpty()
-    }
-
-    @Test
     fun mustReceiveNoContextUpdate_when_contextUpdateReceiverNotRegistered() {
         // Given
         val stubContextUpdateReceiver = StubContextUpdateReceiver()


### PR DESCRIPTION
### What does this PR do?

`VitalReaderRunnable` currently calls `getFeatureContext` to check if `RumContext` has `FOREGROUND` type.

The problem is that these calls may happen quite often, like every 100ms, putting some pressure on the context thread and feature context locking mechanism.

This PR switches to another approach: `VitalReaderRunnable` will just listen for the `RumContext` updates, this should remove the performance pressure.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

