### PR TITLE
Fix Jetpack compose auto instrumentation telemetry in benchmark app

### DIFF
--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/BenchmarkGlideModule.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/BenchmarkGlideModule.kt
@@ -11,14 +11,11 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.Registry
 import com.bumptech.glide.annotation.GlideModule
 import com.datadog.android.glide.DatadogGlideModule
-import com.datadog.benchmark.sample.di.app.DATADOG_SDK_INSTANCE_NAME
 import okhttp3.OkHttpClient
 import javax.inject.Inject
 
 @GlideModule
-internal class BenchmarkGlideModule : DatadogGlideModule(
-    sdkInstanceName = DATADOG_SDK_INSTANCE_NAME
-) {
+internal class BenchmarkGlideModule : DatadogGlideModule() {
     @Inject
     lateinit var okHttpClient: OkHttpClient
 

--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/di/app/DatadogModule.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/di/app/DatadogModule.kt
@@ -46,7 +46,6 @@ internal interface DatadogModule {
             }
 
             return Datadog.initialize(
-                DATADOG_SDK_INSTANCE_NAME,
                 context,
                 createDatadogConfiguration(),
                 TrackingConsent.GRANTED
@@ -109,8 +108,6 @@ private fun createDatadogConfiguration(): Configuration {
 
     return configBuilder.build()
 }
-
-internal const val DATADOG_SDK_INSTANCE_NAME = "benchmark_datadog_sdk"
 
 // the same as the default one
 private const val CAPACITY_BACK_PRESSURE_STRATEGY = 1024


### PR DESCRIPTION
### What does this PR do?

@ambushwork noticed that [this](https://github.com/DataDog/dd-sdk-android/blob/8a5357467a4cab7c24e5e4052ccd27598084683d/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/DatadogModifier.kt#L39) telemetry stopped being sent from the Benchmark app.

It coincided by time with this merging of [this](https://github.com/DataDog/dd-sdk-android/pull/2689) pr.

The problem is that I introduced a custom sdk core name and the `sendTelemetry` function [uses](https://github.com/DataDog/dd-sdk-android/blob/8a5357467a4cab7c24e5e4052ccd27598084683d/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/Telemetry.kt#L17) default `DatadogSdkCore` instance. It was not found and silently substituted by `NoOpInternalSdkCore` that didn't send any logs.

The fix is to use the default singleton without a custom name.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

