### PR TITLE
RUM-10413: Mark `CoreFeature` properties used to create `DatadogContext` as volatile

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -127,24 +127,41 @@ internal class CoreFeature(
     internal var userInfoProvider: MutableUserInfoProvider = NoOpMutableUserInfoProvider()
     internal var accountInfoProvider: MutableAccountInfoProvider = NoOpMutableAccountInfoProvider()
     internal var contextProvider: ContextProvider = NoOpContextProvider()
+    internal var packageVersionProvider: AppVersionProvider = NoOpAppVersionProvider()
+    internal var androidInfoProvider: AndroidInfoProvider = NoOpAndroidInfoProvider()
 
     internal lateinit var okHttpClient: OkHttpClient
     internal var kronosClock: KronosClock? = null
 
+    @Volatile
     internal var clientToken: String = ""
-    internal var packageName: String = ""
-    internal var packageVersionProvider: AppVersionProvider = NoOpAppVersionProvider()
+
+    @Volatile
     internal var serviceName: String = ""
+
+    @Volatile
     internal var sourceName: String = DEFAULT_SOURCE_NAME
+
+    @Volatile
     internal var sdkVersion: String = DEFAULT_SDK_VERSION
+
+    @Volatile
     internal var isMainProcess: Boolean = true
+
+    @Volatile
     internal var envName: String = ""
+
+    @Volatile
     internal var variant: String = ""
     internal var batchSize: BatchSize = BatchSize.MEDIUM
     internal var uploadFrequency: UploadFrequency = UploadFrequency.AVERAGE
     internal var batchProcessingLevel: BatchProcessingLevel = BatchProcessingLevel.MEDIUM
     internal var ndkCrashHandler: NdkCrashHandler = NoOpNdkCrashHandler()
+
+    @Volatile
     internal var site: DatadogSite = DatadogSite.US1
+
+    @Volatile
     internal var appBuildId: String? = null
     internal var customUploadSchedulerStrategy: UploadSchedulerStrategy? = null
 
@@ -156,7 +173,6 @@ internal class CoreFeature(
     internal var localDataEncryption: Encryption? = null
     internal var persistenceStrategyFactory: PersistenceStrategy.Factory? = null
     internal lateinit var storageDir: File
-    internal lateinit var androidInfoProvider: AndroidInfoProvider
 
     internal val appStartTimeNs: Long
         get() = appStartTimeProvider.appStartTimeNs
@@ -440,7 +456,6 @@ internal class CoreFeature(
     }
 
     private fun readApplicationInformation(appContext: Context, configuration: Configuration) {
-        packageName = appContext.packageName
         packageVersionProvider = DefaultAppVersionProvider(
             getPackageInfo(appContext)?.let {
                 // we need to use the deprecated method because getLongVersionCode method is only
@@ -460,6 +475,7 @@ internal class CoreFeature(
 
     private fun getPackageInfo(appContext: Context): PackageInfo? {
         return try {
+            val packageName = appContext.packageName
             with(appContext.packageManager) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0))
@@ -682,7 +698,6 @@ internal class CoreFeature(
 
     private fun cleanupApplicationInfo() {
         clientToken = ""
-        packageName = ""
         packageVersionProvider = NoOpAppVersionProvider()
         serviceName = ""
         sourceName = DEFAULT_SOURCE_NAME

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/system/DefaultAppVersionProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/system/DefaultAppVersionProvider.kt
@@ -10,15 +10,11 @@ import java.util.concurrent.atomic.AtomicReference
 
 internal class DefaultAppVersionProvider(initialVersion: String) : AppVersionProvider {
 
-    private val value: AtomicReference<String>
+    private val value = AtomicReference(initialVersion)
 
     override var version: String
         get() = value.get()
         set(value) {
             this.value.set(value)
         }
-
-    init {
-        this.value = AtomicReference(initialVersion)
-    }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -321,7 +321,6 @@ internal class CoreFeatureTest {
 
         // Then
         assertThat(testedFeature.clientToken).isEqualTo(fakeConfig.clientToken)
-        assertThat(testedFeature.packageName).isEqualTo(appContext.fakePackageName)
         assertThat(testedFeature.packageVersionProvider.version).isEqualTo(appContext.fakeVersionName)
         assertThat(testedFeature.serviceName).isEqualTo(fakeConfig.service)
         assertThat(testedFeature.envName).isEqualTo(fakeConfig.env)
@@ -344,7 +343,6 @@ internal class CoreFeatureTest {
 
         // Then
         assertThat(testedFeature.clientToken).isEqualTo(fakeConfig.clientToken)
-        assertThat(testedFeature.packageName).isEqualTo(appContext.fakePackageName)
         assertThat(testedFeature.packageVersionProvider.version)
             .isEqualTo(appContext.fakeVersionName)
         assertThat(testedFeature.serviceName).isEqualTo(fakeConfig.service)
@@ -367,7 +365,6 @@ internal class CoreFeatureTest {
 
         // Then
         assertThat(testedFeature.clientToken).isEqualTo(fakeConfig.clientToken)
-        assertThat(testedFeature.packageName).isEqualTo(appContext.fakePackageName)
         assertThat(testedFeature.packageVersionProvider.version)
             .isEqualTo(appContext.fakeVersionName)
         assertThat(testedFeature.serviceName).isEqualTo(appContext.fakePackageName)
@@ -395,7 +392,6 @@ internal class CoreFeatureTest {
 
         // Then
         assertThat(testedFeature.clientToken).isEqualTo(fakeConfig.clientToken)
-        assertThat(testedFeature.packageName).isEqualTo(appContext.fakePackageName)
         assertThat(testedFeature.packageVersionProvider.version)
             .isEqualTo(appContext.fakeVersionCode.toString())
         assertThat(testedFeature.serviceName).isEqualTo(fakeConfig.service)
@@ -425,7 +421,6 @@ internal class CoreFeatureTest {
 
         // Then
         assertThat(testedFeature.clientToken).isEqualTo(fakeConfig.clientToken)
-        assertThat(testedFeature.packageName).isEqualTo(appContext.fakePackageName)
         assertThat(testedFeature.packageVersionProvider.version)
             .isEqualTo(CoreFeature.DEFAULT_APP_VERSION)
         assertThat(testedFeature.serviceName).isEqualTo(fakeConfig.service)
@@ -460,7 +455,6 @@ internal class CoreFeatureTest {
 
         // Then
         assertThat(testedFeature.clientToken).isEqualTo(fakeConfig.clientToken)
-        assertThat(testedFeature.packageName).isEqualTo(appContext.fakePackageName)
         assertThat(testedFeature.packageVersionProvider.version).isEqualTo(
             CoreFeature.DEFAULT_APP_VERSION
         )
@@ -695,7 +689,6 @@ internal class CoreFeatureTest {
 
         // Then
         assertThat(testedFeature.clientToken).isEqualTo(fakeConfig.clientToken)
-        assertThat(testedFeature.packageName).isEqualTo(appContext.fakePackageName)
         assertThat(testedFeature.packageVersionProvider.version)
             .isEqualTo(appContext.fakeVersionName)
         assertThat(testedFeature.serviceName).isEqualTo(fakeConfig.service)
@@ -1251,7 +1244,6 @@ internal class CoreFeatureTest {
 
         // Then
         assertThat(testedFeature.clientToken).isEqualTo("")
-        assertThat(testedFeature.packageName).isEqualTo("")
         assertThat(testedFeature.packageVersionProvider.version).isEqualTo("")
         assertThat(testedFeature.serviceName).isEqualTo("")
         assertThat(testedFeature.envName).isEqualTo("")

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/config/CoreFeatureTestConfiguration.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/config/CoreFeatureTestConfiguration.kt
@@ -126,7 +126,6 @@ internal class CoreFeatureTestConfiguration<T : Context>(
         whenever(mockInstance.isMainProcess) doReturn true
         whenever(mockInstance.envName) doReturn fakeEnvName
         whenever(mockInstance.serviceName) doReturn fakeServiceName
-        whenever(mockInstance.packageName) doReturn appContext.fakePackageName
         whenever(mockInstance.packageVersionProvider) doReturn mockAppVersionProvider
         whenever(mockInstance.variant) doReturn appContext.fakeVariant
         whenever(mockInstance.sourceName) doReturn fakeSourceName


### PR DESCRIPTION
### What does this PR do?

We need to mark some properties of `CoreFeature` as volatile: they are set from one thread and will be read from another thread - context processing thread.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

