### PR TITLE
RUM-10422: Handle the case when `DatadogContext` is requested when SDK is getting deinitialized

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -177,6 +177,7 @@ internal class SdkFeature(
     ) {
         coreFeature.contextExecutorService
             .executeSafe("withWriteContext-${wrappedFeature.name}", internalLogger) {
+                if (coreFeature.initialized.get() == false) return@executeSafe
                 val context = contextProvider.getContext(withFeatureContexts)
                 val eventBatchWriteScope = storage.getEventWriteScope(context)
                 callback(context, eventBatchWriteScope)
@@ -189,6 +190,7 @@ internal class SdkFeature(
     ) {
         coreFeature.contextExecutorService
             .executeSafe("withContext-${wrappedFeature.name}", internalLogger) {
+                if (coreFeature.initialized.get() == false) return@executeSafe
                 val context = contextProvider.getContext(withFeatureContexts)
                 callback(context)
             }
@@ -203,6 +205,7 @@ internal class SdkFeature(
                 operationName,
                 internalLogger,
                 Callable {
+                    if (coreFeature.initialized.get() == false) return@Callable null
                     val context = contextProvider.getContext(withFeatureContexts)
                     val eventBatchWriteScope = storage.getEventWriteScope(context)
                     context to eventBatchWriteScope


### PR DESCRIPTION
### What does this PR do?

There is an edge case when calling `withWriteContext`/`withContext`/... if we are in the process of SDK deinitialization.

When starting the task submitted to the context processing queue we would like to check if `CoreFeature` is still alive.

Normally, in the `CoreFeature.stop` we are calling `shutdownNow` for the executors which interrupts the threads, but just in case if the stop approach is different in the future we just put one more check.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

