### PR TITLE
RUM-10224: Add octo sts policy for read access

### DIFF
--- a/.github/chainguard/self.gitlab.read.sts.yaml
+++ b/.github/chainguard/self.gitlab.read.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/dd-sdk-android:ref_type:branch:ref:*"
+
+permissions:
+  contents: read


### PR DESCRIPTION
### What does this PR do?

This policy is for GitLab CI in `dd-sdk-android` to be able to access release info about our own repo (for [this](https://github.com/DataDog/dd-sdk-android/blob/develop/ci/pipelines/check-release-pipeline.yml)).

[Docs](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts) for dd-octo-sts.

I am following [this](https://github.com/DataDog/dd-octo-sts-sandbox/blob/main/.github/chainguard/self.gitlab.read.sts.yaml#L3) example, but putting `*` so that any branch could access.

For creating PRs in shopist and mobile app I plan to create policies in their repos.

I will start actually using `dd-octo-sts` for `check-release-pipeline` in the next pr, because the policy yamls only from default branches are checked ([link](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts#%3Apass%3A-Trust-Policies)). And our default branch is `develop`.

I have no idea if this file works and there is no way to [test](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts#I-struggle-to-get-the-trust-policy-right.-Is-there-a-way-to-test-a-trust-policy-on-a-feature-branch%3F).

I'll have to test after merging.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

