### PR TITLE
RUM-10224: Use octo-sts to check release

### DIFF
--- a/ci/pipelines/check-release-pipeline.yml
+++ b/ci/pipelines/check-release-pipeline.yml
@@ -10,8 +10,11 @@ check-release:is-published:
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: check-release
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   script:
-    - !reference [ .common-snippets, set-github-installation-token ]
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/dd-sdk-android --policy self.gitlab.read)
     - bash ./ci/scripts/check_latest_release_is_published.sh
 
 notify:report-failure-to-slack:


### PR DESCRIPTION
### What does this PR do?

Use github token obtained from `dd-octo-sts` for requests to GitHub API when checking that release artifacts are published to maven.

It [worked](https://gitlab.ddbuild.io/DataDog/dd-sdk-android/-/jobs/990081334).

[Docs](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts#%3Agitlab%3A-Via-Gitlab-CI-job)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

