### PR TITLE
RUM-10409: fix effective sample rate calculation for SessionEndedMetricDispatcher

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
@@ -20,6 +20,7 @@ import com.datadog.android.rum.internal.RumAnonymousIdentifierManager
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.metric.SessionEndedMetricDispatcher
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
+import com.datadog.android.rum.internal.utils.percent
 import com.datadog.android.telemetry.internal.TelemetryEventHandler
 
 /**
@@ -109,7 +110,11 @@ object Rum {
         sdkCore: InternalSdkCore,
         rumFeature: RumFeature
     ): DatadogRumMonitor {
-        val sessionEndedMetricDispatcher = SessionEndedMetricDispatcher(internalLogger = sdkCore.internalLogger)
+        val sessionEndedMetricDispatcher = SessionEndedMetricDispatcher(
+            internalLogger = sdkCore.internalLogger,
+            sessionSamplingRate = rumFeature.configuration.sampleRate.percent().toFloat()
+        )
+
         return DatadogRumMonitor(
             applicationId = rumFeature.applicationId,
             sdkCore = sdkCore,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
@@ -20,7 +20,6 @@ import com.datadog.android.rum.internal.RumAnonymousIdentifierManager
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.metric.SessionEndedMetricDispatcher
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
-import com.datadog.android.rum.internal.utils.percent
 import com.datadog.android.telemetry.internal.TelemetryEventHandler
 
 /**
@@ -112,7 +111,7 @@ object Rum {
     ): DatadogRumMonitor {
         val sessionEndedMetricDispatcher = SessionEndedMetricDispatcher(
             internalLogger = sdkCore.internalLogger,
-            sessionSamplingRate = rumFeature.configuration.sampleRate.percent().toFloat()
+            sessionSamplingRate = rumFeature.configuration.sampleRate
         )
 
         return DatadogRumMonitor(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcher.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcher.kt
@@ -12,7 +12,10 @@ import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
 import com.datadog.android.rum.model.ViewEvent
 import java.util.concurrent.ConcurrentHashMap
 
-internal class SessionEndedMetricDispatcher(private val internalLogger: InternalLogger) :
+internal class SessionEndedMetricDispatcher(
+    private val internalLogger: InternalLogger,
+    private val sessionSamplingRate: Float
+) :
     SessionMetricDispatcher {
 
     private val metricsBySessionId = ConcurrentHashMap<String, SessionEndedMetric>()
@@ -38,6 +41,7 @@ internal class SessionEndedMetricDispatcher(private val internalLogger: Internal
             internalLogger.logMetric(
                 messageBuilder = { SessionEndedMetric.RUM_SESSION_ENDED_METRIC_NAME },
                 additionalProperties = metric.toMetricAttributes(ntpOffsetAtEndMs),
+                creationSampleRate = sessionSamplingRate,
                 samplingRate = 15.0f
             )
         }


### PR DESCRIPTION
### What does this PR do?

Fixes wrong effective sampling rate value computation for SessionEndedMetricDispatcher. 
Before this fix, sessionSampling rate was not take into a count for effective sampling rate of such events


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

