### PR TITLE
RUM-10224: Use octo-sts to create pr in dd-sdk-android-gradle-plugin

### DIFF
--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -981,10 +981,13 @@ notify:dogfood-gradle-plugin:
   only:
     - tags
   image: $CI_IMAGE_DOCKER
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   stage: notify
   when: on_success
   script:
-    - !reference [ .common-snippets, set-github-installation-token ]
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/dd-sdk-android-gradle-plugin --policy all.gitlab.pr)
     - pip3 install GitPython requests
     - python3 ./ci/scripts/dogfood.py -v $CI_COMMIT_TAG -t gradle-plugin
 


### PR DESCRIPTION
### What does this PR do?

Now when creating pr with sdk version update in `dd-sdk-android-gradle-plugin` we use GitHub token obtained from `dd-octo-sts`.

Mobile app and shopist in future prs.

It [works](https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/389).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

