### PR TITLE
RUM-10224: Add DDOCTOSTS_ID_TOKEN to dogfood-app and dogfood-demo

### DIFF
--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -956,6 +956,9 @@ notify:dogfood-app:
   only:
     - tags
   image: $CI_IMAGE_DOCKER
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   stage: notify
   when: on_success
   script:
@@ -968,6 +971,9 @@ notify:dogfood-demo:
   only:
     - tags
   image: $CI_IMAGE_DOCKER
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
   stage: notify
   when: on_success
   script:


### PR DESCRIPTION
### What does this PR do?

I forgot to add `DDOCTOSTS_ID_TOKEN` to these jobs. I already added it to `dogfood-gradle-plugin` from the beginning and it [works now](https://gitlab.ddbuild.io/DataDog/dd-sdk-android/-/jobs/993672689). 

It is needed according to the [docs](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts#%3Agitlab%3A-Via-Gitlab-CI-job).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

