### PR TITLE
Remove workaround when checking dd-sdk-android-benchmark-internal is published

### DIFF
--- a/ci/scripts/check_latest_release_is_published.sh
+++ b/ci/scripts/check_latest_release_is_published.sh
@@ -18,11 +18,5 @@ for artifactId in $(./gradlew -q listAllPublishedArtifactIds); do
     echo "Release $tag_name exists for $artifactId"
   else
     echo "Release $tag_name doesn't exist for $artifactId"
-    # TODO remove this check when
-    # https://github.com/DataDog/dd-sdk-android/commit/ccd79322895a6ba135e2b73b32005fb4aeb5c31c
-    # is released
-    if [ $artifactId != "dd-sdk-android-benchmark-internal" ]; then
-      exit 1
-    fi
   fi
 done


### PR DESCRIPTION
Not needed anymore because starting from 2.23.0 release we publish the benchmark module with new artifactId (`dd-sdk-android-benchmark-internal`).

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

