### PR TITLE
Remove default value for the `addAccountExtraInfo` call

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -11,7 +11,7 @@ object com.datadog.android.Datadog
   fun addUserProperties(Map<String, Any?>, com.datadog.android.api.SdkCore = getInstance())
   fun clearAllData(com.datadog.android.api.SdkCore = getInstance())
   fun setAccountInfo(String, String? = null, Map<String, Any?> = emptyMap(), com.datadog.android.api.SdkCore = getInstance())
-  fun addAccountExtraInfo(Map<String, Any?> = emptyMap(), com.datadog.android.api.SdkCore = getInstance())
+  fun addAccountExtraInfo(Map<String, Any?>, com.datadog.android.api.SdkCore = getInstance())
   fun clearAccountInfo(com.datadog.android.api.SdkCore = getInstance())
   fun _internalProxy(String? = null): _InternalProxy
 enum com.datadog.android.DatadogSite
@@ -61,7 +61,7 @@ interface com.datadog.android.api.SdkCore
   fun addUserProperties(Map<String, Any?>)
   fun clearAllData()
   fun setAccountInfo(String, String? = null, Map<String, Any?> = emptyMap())
-  fun addAccountExtraInfo(Map<String, Any?> = emptyMap())
+  fun addAccountExtraInfo(Map<String, Any?>)
   fun clearAccountInfo()
 data class com.datadog.android.api.context.AccountInfo
   constructor(String, String? = null, Map<String, Any?> = emptyMap())

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -12,7 +12,6 @@ public final class com/datadog/android/Datadog {
 	public static final field INSTANCE Lcom/datadog/android/Datadog;
 	public final fun _internalProxy (Ljava/lang/String;)Lcom/datadog/android/_InternalProxy;
 	public static synthetic fun _internalProxy$default (Lcom/datadog/android/Datadog;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/_InternalProxy;
-	public static final fun addAccountExtraInfo ()V
 	public static final fun addAccountExtraInfo (Ljava/util/Map;)V
 	public static final fun addAccountExtraInfo (Ljava/util/Map;Lcom/datadog/android/api/SdkCore;)V
 	public static synthetic fun addAccountExtraInfo$default (Ljava/util/Map;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
@@ -138,7 +137,6 @@ public abstract interface class com/datadog/android/api/SdkCore {
 }
 
 public final class com/datadog/android/api/SdkCore$DefaultImpls {
-	public static synthetic fun addAccountExtraInfo$default (Lcom/datadog/android/api/SdkCore;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun setAccountInfo$default (Lcom/datadog/android/api/SdkCore;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun setUserInfo$default (Lcom/datadog/android/api/SdkCore;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -304,7 +304,7 @@ object Datadog {
      *
      * @param id Account ID.
      * @param name representing the account, if exists.
-     * @param extraInfo Account's custom attributes, if exists.
+     * @param extraInfo Account custom attributes, if exists.
      * @param sdkCore SDK instance to set account information. If not provided, default SDK
      * instance will be used.
      */
@@ -329,14 +329,14 @@ object Datadog {
      * This extra info will be added to already existing extra info that is added
      * to Logs, Traces and RUM events automatically.
      *
-     * @param extraInfo Account's additional custom attributes.
-     * @param sdkCore SDK instance to add account custom attributes. If not provided,
-     * default SDK instance will be used.
+     * @param extraInfo Account additional custom attributes.
+     * @param sdkCore SDK instance to add extra account information. If not provided, default SDK
+     * instance will be used.
      */
     @JvmStatic
     @JvmOverloads
     fun addAccountExtraInfo(
-        extraInfo: Map<String, Any?> = emptyMap(),
+        extraInfo: Map<String, Any?>,
         sdkCore: SdkCore = getInstance()
     ) {
         sdkCore.addAccountExtraInfo(extraInfo)
@@ -345,20 +345,19 @@ object Datadog {
     /**
      * Clear the current account information.
      *
-     * Account information will set to null
+     * Account information will be set to null.
      * Following Logs, Traces, RUM Events will not include the account information anymore.
      *
-     * Any active RUM Session, active RUM View at the time of call will have their `account` attribute cleared
+     * Any active RUM Session, active RUM View at the time of call will have their `account` attribute cleared.
      *
      * If you want to retain the current `account` on the active RUM session,
-     * you need to stop the session first by using `GlobalRumMonitor.get().stopSession()`
+     * you need to stop the session first by using `GlobalRumMonitor.get().stopSession()`.
      *
      * If you want to retain the current `account` on the active RUM views,
      * you need to stop the view first by using `GlobalRumMonitor.get().stopView()`.
      *
-     * @param sdkCore SDK instance to clear account info. If not provided,
-     * default SDK instance will be used.
-     *
+     * @param sdkCore SDK instance to clear account information. If not provided, default SDK
+     * instance will be used.
      */
     @JvmStatic
     @JvmOverloads

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/SdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/SdkCore.kt
@@ -83,13 +83,18 @@ interface SdkCore {
     fun clearAllData()
 
     /**
-     * Sets current account information.
+     * Sets the account information that the user is currently logged into.
      *
-     * Those will be added to logs, traces and RUM events automatically.
+     * This API should be used to assign an identifier for the user's account which represents a
+     * contextual identity within the app, typically tied to business or tenant logic. The
+     * information set here will be added to logs, traces and RUM events.
+     *
+     * This value should be set when user logs in with his account, and cleared by calling
+     * [clearAccountInfo] when he logs out.
      *
      * @param id Account ID.
      * @param name representing the account, if exists.
-     * @param extraInfo Account's custom attributes, if exists.
+     * @param extraInfo Account custom attributes, if exists.
      */
     fun setAccountInfo(
         id: String,
@@ -97,29 +102,32 @@ interface SdkCore {
         extraInfo: Map<String, Any?> = emptyMap()
     )
 
-    /** Add custom attributes to the current account information
+    /**
+     * Add custom attributes to the current account information.
      *
      * This extra info will be added to already existing extra info that is added
-     * to logs traces and RUM events automatically.
+     * to Logs, Traces and RUM events automatically.
      *
-     * @param extraInfo Account's additional custom attributes.
+     * @param extraInfo Account additional custom attributes.
      */
     fun addAccountExtraInfo(
-        extraInfo: Map<String, Any?> = emptyMap()
+        extraInfo: Map<String, Any?>
     )
 
-    /** Clear the current account information
+    /**
+     * Clear the current account information.
      *
-     * Account information will set to null
+     * Account information will be set to null.
      * Following Logs, Traces, RUM Events will not include the account information anymore.
      *
-     * Any active RUM Session, active RUM View at the time of call will have their `account` attribute cleared
+     * Any active RUM Session, active RUM View at the time of call will have their `account` attribute cleared.
      *
      * If you want to retain the current `account` on the active RUM session,
-     * you need to stop the session first by using `GlobalRumMonitor.get().stopSession()`
+     * you need to stop the session first by using `GlobalRumMonitor.get().stopSession()`.
      *
      * If you want to retain the current `account` on the active RUM views,
-     * you need to stop the view first by using `GlobalRumMonitor.get().stopView()`
+     * you need to stop the view first by using `GlobalRumMonitor.get().stopView()`.
+     *
      */
     fun clearAccountInfo()
 }


### PR DESCRIPTION
### What does this PR do?

This PR removes default value for the `addAccountExtraInfo` call, because this method is not supposed to be called with explicit arguments. This change also aligns with iOS SDK API.

In addition, docs for the `account`-related APIs are updated.

@satween This is not a breaking change, because I don't think there is a use-case to call `addAccountExtraInfo` without arguments, but still it is better to note it for the migration doc.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

