### PR TITLE
RUM-10575: Bump Kotlin version used to 2.0.21

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/JavadocConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/JavadocConfig.kt
@@ -7,20 +7,16 @@
 package com.datadog.gradle.config
 
 import org.gradle.api.Project
-import org.jetbrains.dokka.gradle.DokkaTask
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.dokka.gradle.DokkaExtension
 import java.nio.file.Paths
 
 fun Project.javadocConfig() {
-    tasks.withType(DokkaTask::class.java).configureEach {
-        val toOutputDirectory = layout.buildDirectory
-            .dir(Paths.get("reports", "javadoc").toString())
-        outputDirectory.set(toOutputDirectory)
-        doFirst {
-            toOutputDirectory.get().asFile.let {
-                if (!it.exists()) {
-                    it.mkdirs()
-                }
-            }
+    extensions.configure(DokkaExtension::class.java) {
+        dokkaPublications.named("javadoc") {
+            val toOutputDirectory = layout.buildDirectory
+                .dir(Paths.get("reports", "javadoc").toString())
+            outputDirectory.set(toOutputDirectory)
         }
     }
 }

--- a/dd-sdk-android-core/build.gradle.kts
+++ b/dd-sdk-android-core/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/dd-sdk-android-core/transitiveDependencies
+++ b/dd-sdk-android-core/transitiveDependencies
@@ -18,7 +18,7 @@ com.squareup.okhttp3:okhttp:4.12.0                              :  771 Kb
 com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    5 Mb

--- a/dd-sdk-android-internal/build.gradle.kts
+++ b/dd-sdk-android-internal/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/dd-sdk-android-internal/transitiveDependencies
+++ b/dd-sdk-android-internal/transitiveDependencies
@@ -1,7 +1,7 @@
 Dependencies List
 
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              : 1695 Kb
+Total transitive dependencies size                              : 1723 Kb
 

--- a/features/dd-sdk-android-logs/build.gradle.kts
+++ b/features/dd-sdk-android-logs/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/features/dd-sdk-android-logs/transitiveDependencies
+++ b/features/dd-sdk-android-logs/transitiveDependencies
@@ -2,8 +2,8 @@ Dependencies List
 
 androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
 com.google.code.gson:gson:2.10.1                                :  276 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              : 2031 Kb
+Total transitive dependencies size                              :    2 Mb
 

--- a/features/dd-sdk-android-ndk/build.gradle.kts
+++ b/features/dd-sdk-android-ndk/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/features/dd-sdk-android-ndk/transitiveDependencies
+++ b/features/dd-sdk-android-ndk/transitiveDependencies
@@ -5,7 +5,7 @@ com.squareup.okhttp3:okhttp:4.12.0                              :  771 Kb
 com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    2 Mb

--- a/features/dd-sdk-android-rum/build.gradle.kts
+++ b/features/dd-sdk-android-rum/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/features/dd-sdk-android-rum/transitiveDependencies
+++ b/features/dd-sdk-android-rum/transitiveDependencies
@@ -38,7 +38,7 @@ com.squareup.okhttp3:okhttp:4.12.0                              :  771 Kb
 com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4          :   19 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4         : 1442 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb

--- a/features/dd-sdk-android-session-replay-compose/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-compose/build.gradle.kts
@@ -17,11 +17,12 @@ plugins {
     // Build
     id("com.android.library")
     kotlin("android")
+    alias(libs.plugins.composeCompilerPlugin)
 
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")
@@ -46,9 +47,6 @@ android {
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.androidXComposeCompilerExtension.get()
     }
 }
 

--- a/features/dd-sdk-android-session-replay-compose/transitiveDependencies
+++ b/features/dd-sdk-android-session-replay-compose/transitiveDependencies
@@ -46,7 +46,7 @@ androidx.versionedparcelable:versionedparcelable:1.1.1          :   30 Kb
 com.google.code.gson:gson:2.10.1                                :  276 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4          :   19 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4         : 1442 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb

--- a/features/dd-sdk-android-session-replay-material/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-material/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/features/dd-sdk-android-session-replay-material/transitiveDependencies
+++ b/features/dd-sdk-android-session-replay-material/transitiveDependencies
@@ -40,7 +40,7 @@ androidx.viewpager:viewpager:1.0.0                              :   52 Kb
 androidx.viewpager2:viewpager2:1.0.0                            :   60 Kb
 com.google.android.material:material:1.3.0                      : 1535 Kb
 com.google.code.gson:gson:2.10.1                                :  276 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    8 Mb

--- a/features/dd-sdk-android-session-replay/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/features/dd-sdk-android-session-replay/transitiveDependencies
+++ b/features/dd-sdk-android-session-replay/transitiveDependencies
@@ -31,7 +31,7 @@ com.squareup.okhttp3:okhttp:4.12.0                              :  771 Kb
 com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    6 Mb

--- a/features/dd-sdk-android-trace-internal/build.gradle.kts
+++ b/features/dd-sdk-android-trace-internal/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/features/dd-sdk-android-trace-internal/transitiveDependencies
+++ b/features/dd-sdk-android-trace-internal/transitiveDependencies
@@ -7,7 +7,7 @@ io.opentracing:opentracing-api:0.32.0                           :   18 Kb
 io.opentracing:opentracing-noop:0.32.0                          :   10 Kb
 io.opentracing:opentracing-util:0.32.0                          :   10 Kb
 org.jctools:jctools-core:3.3.0                                  :  328 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    2 Mb

--- a/features/dd-sdk-android-trace-otel/build.gradle.kts
+++ b/features/dd-sdk-android-trace-otel/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/features/dd-sdk-android-trace-otel/transitiveDependencies
+++ b/features/dd-sdk-android-trace-otel/transitiveDependencies
@@ -6,8 +6,8 @@ io.opentelemetry:opentelemetry-context:1.4.0                    :   42 Kb
 io.opentracing:opentracing-api:0.32.0                           :   18 Kb
 io.opentracing:opentracing-noop:0.32.0                          :   10 Kb
 io.opentracing:opentracing-util:0.32.0                          :   10 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              : 1915 Kb
+Total transitive dependencies size                              : 1943 Kb
 

--- a/features/dd-sdk-android-trace/build.gradle.kts
+++ b/features/dd-sdk-android-trace/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/features/dd-sdk-android-trace/transitiveDependencies
+++ b/features/dd-sdk-android-trace/transitiveDependencies
@@ -7,7 +7,7 @@ io.opentracing:opentracing-api:0.32.0                           :   18 Kb
 io.opentracing:opentracing-noop:0.32.0                          :   10 Kb
 io.opentracing:opentracing-util:0.32.0                          :   10 Kb
 org.jctools:jctools-core:3.3.0                                  :  328 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    2 Mb

--- a/features/dd-sdk-android-webview/build.gradle.kts
+++ b/features/dd-sdk-android-webview/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/features/dd-sdk-android-webview/transitiveDependencies
+++ b/features/dd-sdk-android-webview/transitiveDependencies
@@ -2,8 +2,8 @@ Dependencies List
 
 androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
 com.google.code.gson:gson:2.10.1                                :  276 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              : 2031 Kb
+Total transitive dependencies size                              :    2 Mb
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,8 @@
 org.gradle.jvmargs=-Xmx4096m
 android.useAndroidX=true
 android.experimental.enableTestFixturesKotlinSupport=true
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 
 # Allows Kotlin with target JVM compat 17 to be built on JDK 21
 kotlin.jvm.target.validation.mode = IGNORE

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Commons
-kotlin = "1.9.24"
-kotlinSP = "1.9.24-1.0.20"
+kotlin = "2.0.21"
+kotlinSP = "2.0.21-1.0.28"
 gson = "2.10.1"
 okHttp = "4.12.0"
 kronosNTP = "0.0.1-alpha11"
@@ -16,7 +16,6 @@ androidXAppCompat = "1.4.2" # Next version will bring coroutines
 androidXCar = "1.4.0"
 androidXCollection = "1.4.5"
 androidXComposeBom = "2023.10.01" # Next version will bring coroutines
-androidXComposeCompilerExtension = "1.5.14"
 androidXComposeNavigation = "2.6.0"
 androidXComposeRuntime = "1.5.14"
 androidXConstraintLayout = "2.0.4"
@@ -62,7 +61,7 @@ kspTesting = "1.5.0"
 
 # Tools
 detekt = "1.23.0"
-dokka = "1.8.20"
+dokka = "2.0.0"
 unmock = "0.9.0"
 robolectric = "4.4_r1-robolectric-r2"
 androidLint = "31.0.2"
@@ -382,4 +381,5 @@ traceCore = [
 versionsGradlePlugin = { id = "com.github.ben-manes.versions", version.ref = "versionsGradlePlugin" }
 nexusPublishGradlePlugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublishGradlePlugin" }
 datadogGradlePlugin = { id = "com.datadoghq.dd-sdk-android-gradle-plugin", version.ref = "datadogPlugin" }
+composeCompilerPlugin = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 

--- a/integrations/dd-sdk-android-coil/build.gradle.kts
+++ b/integrations/dd-sdk-android-coil/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/integrations/dd-sdk-android-coil/transitiveDependencies
+++ b/integrations/dd-sdk-android-coil/transitiveDependencies
@@ -9,7 +9,7 @@ io.coil-kt:coil-base:1.0.0                                      :  395 Kb
 io.coil-kt:coil:1.0.0                                           :   15 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4          :   19 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4         : 1442 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb

--- a/integrations/dd-sdk-android-compose/build.gradle.kts
+++ b/integrations/dd-sdk-android-compose/build.gradle.kts
@@ -18,11 +18,12 @@ plugins {
     // Build
     id("com.android.library")
     kotlin("android")
+    alias(libs.plugins.composeCompilerPlugin)
 
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")
@@ -45,9 +46,6 @@ android {
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.androidXComposeCompilerExtension.get()
     }
 }
 
@@ -85,7 +83,7 @@ kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
 androidLibraryConfig()
 taskConfig<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions {
-        freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
+        optIn.add("kotlin.RequiresOptIn")
     }
 }
 junitConfig()

--- a/integrations/dd-sdk-android-compose/transitiveDependencies
+++ b/integrations/dd-sdk-android-compose/transitiveDependencies
@@ -42,7 +42,7 @@ androidx.savedstate:savedstate:1.2.1                            :   19 Kb
 androidx.versionedparcelable:versionedparcelable:1.1.1          :   30 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4          :   19 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4         : 1442 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb

--- a/integrations/dd-sdk-android-fresco/build.gradle.kts
+++ b/integrations/dd-sdk-android-fresco/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/integrations/dd-sdk-android-fresco/transitiveDependencies
+++ b/integrations/dd-sdk-android-fresco/transitiveDependencies
@@ -16,7 +16,7 @@ com.squareup.okhttp3:okhttp:4.12.0                              :  771 Kb
 com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    4 Mb

--- a/integrations/dd-sdk-android-glide/build.gradle.kts
+++ b/integrations/dd-sdk-android-glide/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/integrations/dd-sdk-android-glide/transitiveDependencies
+++ b/integrations/dd-sdk-android-glide/transitiveDependencies
@@ -45,7 +45,7 @@ com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
 io.opentracing:opentracing-api:0.32.0                           :   18 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4          :   19 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4         : 1442 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb

--- a/integrations/dd-sdk-android-okhttp-otel/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp-otel/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/integrations/dd-sdk-android-okhttp-otel/transitiveDependencies
+++ b/integrations/dd-sdk-android-okhttp-otel/transitiveDependencies
@@ -9,7 +9,7 @@ io.opentracing:opentracing-noop:0.32.0                          :   10 Kb
 io.opentracing:opentracing-util:0.32.0                          :   10 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    2 Mb

--- a/integrations/dd-sdk-android-okhttp/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/integrations/dd-sdk-android-okhttp/transitiveDependencies
+++ b/integrations/dd-sdk-android-okhttp/transitiveDependencies
@@ -8,7 +8,7 @@ io.opentracing:opentracing-noop:0.32.0                          :   10 Kb
 io.opentracing:opentracing-util:0.32.0                          :   10 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    2 Mb

--- a/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/integrations/dd-sdk-android-rum-coroutines/transitiveDependencies
+++ b/integrations/dd-sdk-android-rum-coroutines/transitiveDependencies
@@ -2,7 +2,7 @@ Dependencies List
 
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4         : 1442 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 

--- a/integrations/dd-sdk-android-rx/build.gradle.kts
+++ b/integrations/dd-sdk-android-rx/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/integrations/dd-sdk-android-rx/transitiveDependencies
+++ b/integrations/dd-sdk-android-rx/transitiveDependencies
@@ -5,7 +5,7 @@ com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
 io.reactivex.rxjava3:rxjava:3.0.0                               :    2 Mb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 org.reactivestreams:reactive-streams:1.0.3                      :   11 Kb
 

--- a/integrations/dd-sdk-android-sqldelight/build.gradle.kts
+++ b/integrations/dd-sdk-android-sqldelight/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/integrations/dd-sdk-android-sqldelight/transitiveDependencies
+++ b/integrations/dd-sdk-android-sqldelight/transitiveDependencies
@@ -11,7 +11,7 @@ io.opentracing:opentracing-noop:0.32.0                          :   10 Kb
 io.opentracing:opentracing-util:0.32.0                          :   10 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    2 Mb

--- a/integrations/dd-sdk-android-timber/build.gradle.kts
+++ b/integrations/dd-sdk-android-timber/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/integrations/dd-sdk-android-timber/transitiveDependencies
+++ b/integrations/dd-sdk-android-timber/transitiveDependencies
@@ -1,8 +1,8 @@
 Dependencies List
 
 com.jakewharton.timber:timber:5.0.1                             :   31 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:20.1.0                                :   25 Kb
 
-Total transitive dependencies size                              : 1735 Kb
+Total transitive dependencies size                              : 1763 Kb
 

--- a/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/integrations/dd-sdk-android-trace-coroutines/transitiveDependencies
+++ b/integrations/dd-sdk-android-trace-coroutines/transitiveDependencies
@@ -3,7 +3,7 @@ Dependencies List
 io.opentracing:opentracing-api:0.32.0                           :   18 Kb
 io.opentracing:opentracing-noop:0.32.0                          :   10 Kb
 io.opentracing:opentracing-util:0.32.0                          :   10 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.4.2         : 1635 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 

--- a/integrations/dd-sdk-android-tv/build.gradle.kts
+++ b/integrations/dd-sdk-android-tv/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     // Publish
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
 
     // Analysis tools
     id("com.github.ben-manes.versions")

--- a/integrations/dd-sdk-android-tv/transitiveDependencies
+++ b/integrations/dd-sdk-android-tv/transitiveDependencies
@@ -37,7 +37,7 @@ androidx.versionedparcelable:versionedparcelable:1.1.1          :   30 Kb
 androidx.viewpager:viewpager:1.0.0                              :   52 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4          :   19 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4         : 1442 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb

--- a/reliability/single-fit/logs/build.gradle.kts
+++ b/reliability/single-fit/logs/build.gradle.kts
@@ -6,7 +6,6 @@
 
 import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -59,5 +58,4 @@ unMock {
 androidLibraryConfig()
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
 junitConfig()
-javadocConfig()
 dependencyUpdateConfig()

--- a/reliability/single-fit/okhttp/build.gradle.kts
+++ b/reliability/single-fit/okhttp/build.gradle.kts
@@ -6,7 +6,6 @@
 
 import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -67,5 +66,4 @@ unMock {
 androidLibraryConfig()
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
 junitConfig()
-javadocConfig()
 dependencyUpdateConfig()

--- a/reliability/single-fit/rum/build.gradle.kts
+++ b/reliability/single-fit/rum/build.gradle.kts
@@ -6,7 +6,6 @@
 
 import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -62,5 +61,4 @@ unMock {
 androidLibraryConfig()
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
 junitConfig()
-javadocConfig()
 dependencyUpdateConfig()

--- a/reliability/single-fit/trace/build.gradle.kts
+++ b/reliability/single-fit/trace/build.gradle.kts
@@ -6,7 +6,6 @@
 
 import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -72,5 +71,4 @@ unMock {
 androidLibraryConfig()
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
 junitConfig()
-javadocConfig()
 dependencyUpdateConfig()

--- a/sample/automotive/build.gradle.kts
+++ b/sample/automotive/build.gradle.kts
@@ -79,7 +79,7 @@ dependencies {
 kotlinConfig(evaluateWarningsAsErrors = false)
 taskConfig<KotlinCompile> {
     compilerOptions {
-        freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
+        optIn.add("kotlin.RequiresOptIn")
     }
 }
 junitConfig()

--- a/sample/benchmark/build.gradle.kts
+++ b/sample/benchmark/build.gradle.kts
@@ -9,6 +9,7 @@ import com.datadog.gradle.plugin.InstrumentationMode
 plugins {
     id("com.android.application")
     kotlin("android")
+    alias(libs.plugins.composeCompilerPlugin)
     kotlin("kapt")
     kotlin("plugin.serialization")
     id("kotlin-parcelize")
@@ -42,9 +43,6 @@ android {
     buildFeatures {
         compose = true
         viewBinding = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.androidXComposeRuntime.get()
     }
     val bmPassword = System.getenv("BM_STORE_PASSWD")
     signingConfigs {

--- a/sample/benchmark/transitiveDependencies
+++ b/sample/benchmark/transitiveDependencies
@@ -114,11 +114,11 @@ io.opentracing:opentracing-noop:0.32.0                          :   10 Kb
 io.opentracing:opentracing-util:0.32.0                          :   10 Kb
 jakarta.inject:jakarta.inject-api:2.0.1                         :   10 Kb
 javax.inject:javax.inject:1                                     :    2 Kb
-org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.9.24   :    9 Kb
-org.jetbrains.kotlin:kotlin-parcelize-runtime:1.9.24            :    6 Kb
+org.jetbrains.kotlin:kotlin-android-extensions-runtime:2.0.21   :    9 Kb
+org.jetbrains.kotlin:kotlin-parcelize-runtime:2.0.21            :    6 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22                  :  963 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22                  :  969 b 
-org.jetbrains.kotlin:kotlin-stdlib:1.9.24                       : 1678 Kb
+org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3          :   20 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3         : 1514 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.7.3             :  953 b 

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -18,9 +18,10 @@ import com.datadog.gradle.plugin.InstrumentationMode
 plugins {
     id("com.android.application")
     kotlin("android")
+    alias(libs.plugins.composeCompilerPlugin)
     kotlin("kapt")
     id("com.github.ben-manes.versions")
-    id("org.jetbrains.dokka")
+    id("org.jetbrains.dokka-javadoc")
     id("com.squareup.sqldelight")
     id("com.google.devtools.ksp")
     alias(libs.plugins.datadogGradlePlugin)
@@ -67,10 +68,6 @@ android {
 
     buildFeatures {
         compose = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.androidXComposeRuntime.get()
     }
 
     testOptions {
@@ -235,7 +232,7 @@ dependencies {
 kotlinConfig(evaluateWarningsAsErrors = false)
 taskConfig<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions {
-        freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
+        optIn.add("kotlin.RequiresOptIn")
     }
 }
 junitConfig()

--- a/sample/tv/build.gradle.kts
+++ b/sample/tv/build.gradle.kts
@@ -110,7 +110,7 @@ dependencies {
 kotlinConfig(evaluateWarningsAsErrors = false)
 taskConfig<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions {
-        freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
+        optIn.add("kotlin.RequiresOptIn")
     }
 }
 junitConfig()

--- a/sample/vendor-lib/build.gradle.kts
+++ b/sample/vendor-lib/build.gradle.kts
@@ -7,7 +7,6 @@
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
 import com.datadog.gradle.config.java17
-import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
 import com.datadog.gradle.config.sampleAppConfig
@@ -86,9 +85,8 @@ dependencies {
 kotlinConfig(evaluateWarningsAsErrors = false)
 taskConfig<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions {
-        freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
+        optIn.add("kotlin.RequiresOptIn")
     }
 }
 junitConfig()
-javadocConfig()
 dependencyUpdateConfig()

--- a/tools/noopfactory/build.gradle.kts
+++ b/tools/noopfactory/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
 kotlinConfig()
 taskConfig<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions {
-        freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
+        optIn.add("kotlin.RequiresOptIn")
     }
 }
 junitConfig()


### PR DESCRIPTION
### What does this PR do?

This PR bumps Kotlin version used to 2.0.21 and also updates Dokka version used.

Explicit reference to the Compose Compiler extension is also removed, because it is now managed by Compose Plugin.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

