### PR TITLE
RUM-8875 Add `updateExternalRefreshRate` to internal RUM API

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -162,6 +162,7 @@ interface com.datadog.android.rum.RumSessionListener
 class com.datadog.android.rum._RumInternalProxy
   fun addLongTask(Long, String)
   fun updatePerformanceMetric(RumPerformanceMetric, Double)
+  fun updateExternalRefreshRate(Double)
   fun setInternalViewAttribute(String, Any?)
   fun setSyntheticsAttribute(String?, String?)
   fun enableJankStatsTracking(android.app.Activity)

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -241,6 +241,7 @@ public final class com/datadog/android/rum/_RumInternalProxy {
 	public final fun enableJankStatsTracking (Landroid/app/Activity;)V
 	public final fun setInternalViewAttribute (Ljava/lang/String;Ljava/lang/Object;)V
 	public final fun setSyntheticsAttribute (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun updateExternalRefreshRate (D)V
 	public final fun updatePerformanceMetric (Lcom/datadog/android/rum/RumPerformanceMetric;D)V
 }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
@@ -45,6 +45,10 @@ class _RumInternalProxy internal constructor(private val rumMonitor: AdvancedRum
         rumMonitor.updatePerformanceMetric(metric, value)
     }
 
+    fun updateExternalRefreshRate(frameTimeNanos: Long) {
+        rumMonitor.updateExternalRefreshRate(frameTimeNanos)
+    }
+
     fun setInternalViewAttribute(key: String, value: Any?) {
         rumMonitor.setInternalViewAttribute(key, value)
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
@@ -45,8 +45,8 @@ class _RumInternalProxy internal constructor(private val rumMonitor: AdvancedRum
         rumMonitor.updatePerformanceMetric(metric, value)
     }
 
-    fun updateExternalRefreshRate(frameTimeNanos: Long) {
-        rumMonitor.updateExternalRefreshRate(frameTimeNanos)
+    fun updateExternalRefreshRate(frameTimeSeconds: Double) {
+        rumMonitor.updateExternalRefreshRate(frameTimeSeconds)
     }
 
     fun setInternalViewAttribute(key: String, value: Any?) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -217,6 +217,11 @@ internal sealed class RumRawEvent {
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 
+    internal data class UpdateExternalRefreshRate(
+        val frameTimeNanos: Long,
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
+
     internal data class SetInternalViewAttribute(
         val key: String,
         val value: Any?,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -218,7 +218,7 @@ internal sealed class RumRawEvent {
     ) : RumRawEvent()
 
     internal data class UpdateExternalRefreshRate(
-        val frameTimeNanos: Long,
+        val frameTimeSeconds: Double,
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -375,7 +375,8 @@ internal class RumViewManagerScope(
             RumRawEvent.LongTaskSent::class.java,
             RumRawEvent.ResourceDropped::class.java,
             RumRawEvent.ResourceSent::class.java,
-            RumRawEvent.UpdatePerformanceMetric::class.java
+            RumRawEvent.UpdatePerformanceMetric::class.java,
+            RumRawEvent.UpdateExternalRefreshRate::class.java
         )
 
         internal const val RUM_BACKGROUND_VIEW_ID = "com.datadog.background.view"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -643,9 +643,9 @@ internal open class RumViewScope(
     ) {
         if (stopped) return
 
-        // Convert frame time (nanoseconds) to refresh rate (Hz)
-        val refreshRateHz = if (event.frameTimeNanos > 0) {
-            1_000_000_000.0 / event.frameTimeNanos.toDouble()
+        // Convert frame time (seconds) to refresh rate (Hz)
+        val refreshRateHz = if (event.frameTimeSeconds > 0) {
+            1.0 / event.frameTimeSeconds
         } else {
             return // Invalid frame time
         }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -146,6 +146,8 @@ internal open class RumViewScope(
 
     private val performanceMetrics: MutableMap<RumPerformanceMetric, VitalInfo> = mutableMapOf()
 
+    private var externalRefreshRateInfo: VitalInfo? = null
+
     // endregion
 
     init {
@@ -205,6 +207,7 @@ internal open class RumViewScope(
             is RumRawEvent.StopSession -> onStopSession(event, writer)
 
             is RumRawEvent.UpdatePerformanceMetric -> onUpdatePerformanceMetric(event)
+            is RumRawEvent.UpdateExternalRefreshRate -> onUpdateExternalRefreshRate(event)
             is RumRawEvent.AddViewLoadingTime -> onAddViewLoadingTime(event, writer)
 
             else -> delegateEventToChildren(event, writer)
@@ -635,6 +638,31 @@ internal open class RumViewScope(
         )
     }
 
+    private fun onUpdateExternalRefreshRate(
+        event: RumRawEvent.UpdateExternalRefreshRate
+    ) {
+        if (stopped) return
+
+        // Convert frame time (nanoseconds) to refresh rate (Hz)
+        val refreshRateHz = if (event.frameTimeNanos > 0) {
+            1_000_000_000.0 / event.frameTimeNanos.toDouble()
+        } else {
+            return // Invalid frame time
+        }
+
+        val currentInfo = externalRefreshRateInfo ?: VitalInfo.EMPTY
+        val newSampleCount = currentInfo.sampleCount + 1
+
+        // Calculate incremental mean using the same algorithm as performance metrics
+        val meanValue = (refreshRateHz + (currentInfo.sampleCount * currentInfo.meanValue)) / newSampleCount
+        externalRefreshRateInfo = VitalInfo(
+            newSampleCount,
+            min(refreshRateHz, currentInfo.minValue),
+            max(refreshRateHz, currentInfo.maxValue),
+            meanValue
+        )
+    }
+
     @WorkerThread
     private fun onSetInternalViewAttribute(event: RumRawEvent.SetInternalViewAttribute) {
         if (stopped) return
@@ -905,7 +933,8 @@ internal open class RumViewScope(
 
         val timings = resolveCustomTimings()
         val memoryInfo = lastMemoryInfo
-        val refreshRateInfo = lastFrameRateInfo
+        // Use external refresh rate data if available, otherwise fall back to internal data
+        val refreshRateInfo = externalRefreshRateInfo ?: lastFrameRateInfo
         val isSlowRendered = resolveRefreshRateInfo(refreshRateInfo) ?: false
         // make a copy - by the time we iterate over it on another thread, it may already be changed
         val eventFeatureFlags = featureFlags.toMutableMap()

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -49,7 +49,7 @@ internal interface AdvancedRumMonitor : RumMonitor, AdvancedNetworkRumMonitor {
 
     fun updatePerformanceMetric(metric: RumPerformanceMetric, value: Double)
 
-    fun updateExternalRefreshRate(frameTimeNanos: Long)
+    fun updateExternalRefreshRate(frameTimeSeconds: Double)
 
     fun setInternalViewAttribute(key: String, value: Any?)
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -49,6 +49,8 @@ internal interface AdvancedRumMonitor : RumMonitor, AdvancedNetworkRumMonitor {
 
     fun updatePerformanceMetric(metric: RumPerformanceMetric, value: Double)
 
+    fun updateExternalRefreshRate(frameTimeNanos: Long)
+
     fun setInternalViewAttribute(key: String, value: Any?)
 
     fun setSyntheticsAttribute(testId: String, resultId: String)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -631,6 +631,10 @@ internal class DatadogRumMonitor(
         handleEvent(RumRawEvent.UpdatePerformanceMetric(metric, value))
     }
 
+    override fun updateExternalRefreshRate(frameTimeNanos: Long) {
+        handleEvent(RumRawEvent.UpdateExternalRefreshRate(frameTimeNanos))
+    }
+
     override fun setInternalViewAttribute(key: String, value: Any?) {
         handleEvent(RumRawEvent.SetInternalViewAttribute(key, value))
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -631,8 +631,8 @@ internal class DatadogRumMonitor(
         handleEvent(RumRawEvent.UpdatePerformanceMetric(metric, value))
     }
 
-    override fun updateExternalRefreshRate(frameTimeNanos: Long) {
-        handleEvent(RumRawEvent.UpdateExternalRefreshRate(frameTimeNanos))
+    override fun updateExternalRefreshRate(frameTimeSeconds: Double) {
+        handleEvent(RumRawEvent.UpdateExternalRefreshRate(frameTimeSeconds))
     }
 
     override fun setInternalViewAttribute(key: String, value: Any?) {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumInternalProxyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumInternalProxyTest.kt
@@ -10,6 +10,7 @@ import android.app.Activity
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.DoubleForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -66,17 +67,17 @@ internal class RumInternalProxyTest {
 
     @Test
     fun `M proxy updateExternalRefreshRate to RumMonitor W updateExternalRefreshRate()`(
-        @LongForgery frameTimeNanos: Long
+        @DoubleForgery(min = 0.001, max = 1.0) frameTimeSeconds: Double
     ) {
         // Given
         val mockRumMonitor = mock(AdvancedRumMonitor::class.java)
         val proxy = _RumInternalProxy(mockRumMonitor)
 
         // When
-        proxy.updateExternalRefreshRate(frameTimeNanos)
+        proxy.updateExternalRefreshRate(frameTimeSeconds)
 
         // Then
-        verify(mockRumMonitor).updateExternalRefreshRate(frameTimeNanos)
+        verify(mockRumMonitor).updateExternalRefreshRate(frameTimeSeconds)
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumInternalProxyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumInternalProxyTest.kt
@@ -65,6 +65,21 @@ internal class RumInternalProxyTest {
     }
 
     @Test
+    fun `M proxy updateExternalRefreshRate to RumMonitor W updateExternalRefreshRate()`(
+        @LongForgery frameTimeNanos: Long
+    ) {
+        // Given
+        val mockRumMonitor = mock(AdvancedRumMonitor::class.java)
+        val proxy = _RumInternalProxy(mockRumMonitor)
+
+        // When
+        proxy.updateExternalRefreshRate(frameTimeNanos)
+
+        // Then
+        verify(mockRumMonitor).updateExternalRefreshRate(frameTimeNanos)
+    }
+
+    @Test
     fun `M proxy enableJankStatsTracking to RumMonitor W enableJankStatsTracking()`() {
         // Given
         val mockRumMonitor = mock(AdvancedRumMonitor::class.java)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
@@ -150,6 +150,14 @@ internal fun Forge.updatePerformanceMetricEvent(): RumRawEvent.UpdatePerformance
     )
 }
 
+internal fun Forge.updateExternalRefreshRateEvent(): RumRawEvent.UpdateExternalRefreshRate {
+    val time = Time()
+    return RumRawEvent.UpdateExternalRefreshRate(
+        frameTimeSeconds = aDouble(),
+        eventTime = time
+    )
+}
+
 internal fun Forge.addFeatureFlagEvaluationEvent(): RumRawEvent.AddFeatureFlagEvaluation {
     val time = Time()
     return RumRawEvent.AddFeatureFlagEvaluation(
@@ -206,6 +214,7 @@ internal fun Forge.anyRumEvent(excluding: List<KClass<out RumRawEvent>> = listOf
         strictSameTypePair(RumRawEvent.AddFeatureFlagEvaluation::class, { addFeatureFlagEvaluationEvent() }),
         strictSameTypePair(RumRawEvent.AddCustomTiming::class, { addCustomTimingEvent() }),
         strictSameTypePair(RumRawEvent.UpdatePerformanceMetric::class, { updatePerformanceMetricEvent() }),
+        strictSameTypePair(RumRawEvent.UpdateExternalRefreshRate::class, { updateExternalRefreshRateEvent() }),
         strictSameTypePair(RumRawEvent.AddViewLoadingTime::class, { addViewLoadingTimeEvent() })
     )
     return this.anElementFrom(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -7870,12 +7870,12 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         // GIVEN
-        val frameTimeNanos = forge.aLong(min = 1_000_000L, max = 50_000_000L) // 1ms to 50ms
-        val expectedRefreshRate = 1_000_000_000.0 / frameTimeNanos.toDouble()
+        val frameTimeSeconds = forge.aDouble(min = 0.001, max = 0.05) // 1ms to 50ms
+        val expectedRefreshRate = 1.0 / frameTimeSeconds
 
         // WHEN
         testedScope.handleEvent(
-            RumRawEvent.UpdateExternalRefreshRate(frameTimeNanos),
+            RumRawEvent.UpdateExternalRefreshRate(frameTimeSeconds),
             mockWriter
         )
         val result = testedScope.handleEvent(
@@ -7898,8 +7898,8 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         // GIVEN
-        val frameTimesNanos = forge.aList(size = 5) {
-            aLong(min = 8_000_000L, max = 20_000_000L) // ~50-125 FPS range
+        val frameTimesSeconds = forge.aList(size = 5) {
+            aDouble(min = 0.008, max = 0.02) // ~50-125 FPS range
         }
 
         var sum = 0.0
@@ -7908,8 +7908,8 @@ internal class RumViewScopeTest {
         val refreshRates = mutableListOf<Double>()
 
         // WHEN
-        frameTimesNanos.forEach { frameTime ->
-            val refreshRate = 1_000_000_000.0 / frameTime.toDouble()
+        frameTimesSeconds.forEach { frameTime ->
+            val refreshRate = 1.0 / frameTime
             refreshRates.add(refreshRate)
             sum += refreshRate
             min = kotlin.math.min(min, refreshRate)
@@ -7941,7 +7941,7 @@ internal class RumViewScopeTest {
     fun `M ignore invalid frame time W handleEvent(UpdateExternalRefreshRate+KeepAlive) { zero frame time }`() {
         // WHEN
         testedScope.handleEvent(
-            RumRawEvent.UpdateExternalRefreshRate(0L),
+            RumRawEvent.UpdateExternalRefreshRate(0.0),
             mockWriter
         )
         val result = testedScope.handleEvent(
@@ -7964,7 +7964,7 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         // GIVEN
-        val negativeFrameTime = -forge.aLong(min = 1L, max = 1_000_000L)
+        val negativeFrameTime = -forge.aDouble(min = 0.001, max = 1.0)
 
         // WHEN
         testedScope.handleEvent(
@@ -7991,8 +7991,8 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         // GIVEN
-        val externalFrameTime = forge.aLong(min = 16_000_000L, max = 17_000_000L) // ~60 FPS
-        val expectedExternalRefreshRate = 1_000_000_000.0 / externalFrameTime.toDouble()
+        val externalFrameTime = forge.aDouble(min = 0.016, max = 0.017) // ~60 FPS
+        val expectedExternalRefreshRate = 1.0 / externalFrameTime
 
         val internalRefreshRate = forge.aDouble(min = 30.0, max = 45.0) // Different range
         val listenerCaptor = argumentCaptor<VitalListener> {
@@ -8059,11 +8059,11 @@ internal class RumViewScopeTest {
     ) {
         // GIVEN
         testedScope.handleEvent(RumRawEvent.StopView(fakeKey, emptyMap()), mockWriter)
-        val frameTimeNanos = forge.aLong(min = 16_000_000L, max = 17_000_000L)
+        val frameTimeSeconds = forge.aDouble(min = 0.016, max = 0.017)
 
         // WHEN
         val result = testedScope.handleEvent(
-            RumRawEvent.UpdateExternalRefreshRate(frameTimeNanos),
+            RumRawEvent.UpdateExternalRefreshRate(frameTimeSeconds),
             mockWriter
         )
 
@@ -8075,13 +8075,13 @@ internal class RumViewScopeTest {
     @Test
     fun `M accumulate external refresh rate samples correctly W multiple updates`() {
         // GIVEN
-        val frameTime1 = 16_666_667L // 60 FPS
-        val frameTime2 = 33_333_333L // 30 FPS
-        val frameTime3 = 11_111_111L // 90 FPS
+        val frameTime1 = 1.0 / 60.0 // 60 FPS
+        val frameTime2 = 1.0 / 30.0 // 30 FPS
+        val frameTime3 = 1.0 / 90.0 // 90 FPS
 
-        val refreshRate1 = 1_000_000_000.0 / frameTime1.toDouble()
-        val refreshRate2 = 1_000_000_000.0 / frameTime2.toDouble()
-        val refreshRate3 = 1_000_000_000.0 / frameTime3.toDouble()
+        val refreshRate1 = 1.0 / frameTime1
+        val refreshRate2 = 1.0 / frameTime2
+        val refreshRate3 = 1.0 / frameTime3
 
         val expectedAverage = (refreshRate1 + refreshRate2 + refreshRate3) / 3.0
         val expectedMin = kotlin.math.min(refreshRate2, kotlin.math.min(refreshRate1, refreshRate3))

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -1999,6 +1999,27 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
+    fun `M handle external refresh rate update W updateExternalRefreshRate()`(
+        forge: Forge
+    ) {
+        // Given
+        val frameTimeNanos = forge.aLong(min = 1_000_000L, max = 50_000_000L)
+
+        // When
+        testedMonitor.updateExternalRefreshRate(frameTimeNanos)
+        Thread.sleep(PROCESSING_DELAY)
+
+        // Then
+        argumentCaptor<RumRawEvent.UpdateExternalRefreshRate> {
+            verify(mockScope).handleEvent(
+                capture(),
+                eq(mockWriter)
+            )
+            assertThat(lastValue.frameTimeNanos).isEqualTo(frameTimeNanos)
+        }
+    }
+
+    @Test
     fun `M delegate internal view attributes W setInternalViewAttribute()`(
         forge: Forge
     ) {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -2003,10 +2003,10 @@ internal class DatadogRumMonitorTest {
         forge: Forge
     ) {
         // Given
-        val frameTimeNanos = forge.aLong(min = 1_000_000L, max = 50_000_000L)
+        val frameTimeSeconds = forge.aDouble(min = 0.001, max = 1.0)
 
         // When
-        testedMonitor.updateExternalRefreshRate(frameTimeNanos)
+        testedMonitor.updateExternalRefreshRate(frameTimeSeconds)
         Thread.sleep(PROCESSING_DELAY)
 
         // Then
@@ -2015,7 +2015,7 @@ internal class DatadogRumMonitorTest {
                 capture(),
                 eq(mockWriter)
             )
-            assertThat(lastValue.frameTimeNanos).isEqualTo(frameTimeNanos)
+            assertThat(lastValue.frameTimeSeconds).isEqualTo(frameTimeSeconds)
         }
     }
 


### PR DESCRIPTION
refs: RUM-8875

### What does this PR do?

This PR adds a new `updateExternalRefreshRate` function to the internal `AdvancedRumMonitor` interface, then updates `RumViewScope` so that it will populate `refresh_rate_average` and related properties based on the data received via this API function, if any such calls have been made.

If no calls have been made to `updateExternalRefreshRate` in the context of the current view, `RumViewScope` will continue to use the data collected from `frameRateVitalListener` as before.

Regardless of whether any calls are made to `updateExternalRefreshRate`, the vitals monitoring system within `com.datadog.android.rum.internal.vitals` will continue operating exactly as it does now. We make no attempt to disable or otherwise interfere with the `frameRateVitalListener`.

### Motivation

Per [RUM-8875](https://datadoghq.atlassian.net/browse/RUM-8875): `FPSVitalListener` uses `JankStats` to sample framerate metrics, but this approach does not work with Unity on Android, as Unity manages its rendering pipeline internally in a way that doesn't expose frame timing information to `JankStats`. As a result, Unity apps simply do not receive useful data for `refresh_rate_average` et al. in RUM View events.

Providing a new `updateExternalRefreshRate` will allow the Unity SDK to periodically self-report frame timing data collected from the Unity runtime, ensuring that the Android SDK can populate refresh-rate-related View properties with useful data.

### Additional Notes

I'm new to this codebase and I'm not terribly familiar with Kotlin, so please feel free to treat these changes with extra scrutiny.

#### Summary of code changes

- **`AdvancedRumMonitor.kt`**: Add `fun updateExternalRefreshRate(frameTimeSeconds: Double)` to `AdvancedRumMonitor` interface
- **`apiSurface`**: Regenerated
- **`dd-sdk-android-rum.api`**: Regenerated
- **`_RumInternalProxy.kt`**: Proxy calls to `AdvancedRum` impl
- **`RumRawEvent.kt`**: Define `UpdateExternalRefreshRate` event
- **`RumViewManagerScope.kt`**: Register that event in `silentOrphanEventTypes`, so that calls to `updateExternalRefreshRate` made when no view is active will be dropped without error
- **`RumViewScope.kt`**:
    - Add `externalRefreshRateInfo` as a nullable `VitalInfo` property
    - Handle `UpdateExternalRefreshRate` events by calling `onUpdateExternalRefreshRate`
    - In `onUpdateExternalRefreshRate`, set or update `externalRefreshRateInfo` property based on supplied value, guarding against divide-by-zero
    - When constructing view events, prefer `externalRefreshRateInfo` for refresh rate metrics if set; use `lastFrameRateInfo` otherwise
- **`DatadogRumMonitor.kt`**:
    - Handle `updateExternalRefreshRate` calls by constructing an `UpdateExternalRefreshRate` event and passing it to `handleEvent`

#### Summary of tests added

- **`RumInternalProxyTest.kt`**: Add a test to exercise proxying of internal API calls for new function
- **`RumRawEventExt.kt`**: Ensure that new event type is included in `Forge.anyRumEvent`
- **`RumViewScopeTest.kt`**: Add test coverage for changes to `RumViewScope`, asserting that:
    - if an external refresh rate sample is supplied, that value is written to subsequent view events
    - when multiple samples are supplied, they are averaged as expected
    - if a refresh rate of zero seconds is supplied, it is ignored and no divide by zero occurs
    - if a negative refresh rate is supplied, it is ignored
    - if refresh rate samples have been received from both `updateExternalRefreshRate` _and_ the internal `JankStats` listener, the external data will be preferred
    - if only internal `JankStats` data is present, it will be used as normal
    - if the view is stopped, external refresh rate events will be ignored
    - both average and min are computed precisely and accurately from external samples

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)


[RUM-8875]: https://datadoghq.atlassian.net/browse/RUM-8875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ