### PR TITLE
RUM-10672: Stop telemetry for compose checkbox and radiobutton

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
@@ -46,8 +46,8 @@ internal object ComposeReflection {
     val ShapeField = BackgroundElementClass?.getDeclaredFieldSafe("shape")
 
     val DrawBehindElementClass = getClassSafe("androidx.compose.ui.draw.DrawBehindElement")
-    val CheckboxKtClass = getClassSafe("androidx.compose.material.CheckboxKt\$CheckboxImpl\$1\$1")
-    val RadioButtonKtClass = getClassSafe("androidx.compose.material.RadioButtonKt\$RadioButton\$2\$1")
+    val CheckboxKtClass = getClassSafe("androidx.compose.material.CheckboxKt\$CheckboxImpl\$1\$1", false)
+    val RadioButtonKtClass = getClassSafe("androidx.compose.material.RadioButtonKt\$RadioButton\$2\$1", false)
     val CheckDrawingCacheClass = getClassSafe("androidx.compose.material.CheckDrawingCache")
 
     val BorderColorField = CheckboxKtClass?.getDeclaredFieldSafe("\$borderColor\$delegate")


### PR DESCRIPTION
### What does this PR do?
The reflection by which we get attributes for radiobuttons and checkboxes in Compose is fragile and generates a lot of telemetry. Until we can find an alternative method to get the attributes, this PR removes the telemetry for these components.

### Motivation
Volume of telemetry generated.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

