### PR TITLE
Introduce _RumInternalProxy.setRumSessionTypeOverride

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -159,6 +159,9 @@ enum com.datadog.android.rum.RumResourceMethod
   - CONNECT
 interface com.datadog.android.rum.RumSessionListener
   fun onSessionStarted(String, Boolean)
+enum com.datadog.android.rum.RumSessionType
+  - SYNTHETICS
+  - USER
 class com.datadog.android.rum._RumInternalProxy
   fun addLongTask(Long, String)
   fun updatePerformanceMetric(RumPerformanceMetric, Double)
@@ -169,6 +172,7 @@ class com.datadog.android.rum._RumInternalProxy
     fun setTelemetryConfigurationEventMapper(com.datadog.android.rum.RumConfiguration.Builder, com.datadog.android.event.EventMapper<com.datadog.android.telemetry.model.TelemetryConfigurationEvent>): com.datadog.android.rum.RumConfiguration.Builder
     fun setAdditionalConfiguration(com.datadog.android.rum.RumConfiguration.Builder, Map<String, Any>): com.datadog.android.rum.RumConfiguration.Builder
     fun setComposeActionTrackingStrategy(com.datadog.android.rum.RumConfiguration.Builder, com.datadog.android.rum.tracking.ActionTrackingStrategy): com.datadog.android.rum.RumConfiguration.Builder
+    fun setRumSessionTypeOverride(com.datadog.android.rum.RumConfiguration.Builder, RumSessionType): com.datadog.android.rum.RumConfiguration.Builder
 data class com.datadog.android.rum.configuration.SlowFramesConfiguration
   constructor(Int = DEFAULT_SLOW_FRAME_RECORDS_MAX_AMOUNT, Long = DEFAULT_FROZEN_FRAME_THRESHOLD_NS, Long = DEFAULT_CONTINUOUS_SLOW_FRAME_THRESHOLD_NS, Long = DEFAULT_FREEZE_DURATION_NS, Long = DEFAULT_VIEW_LIFETIME_THRESHOLD_NS)
   companion object 

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -235,6 +235,13 @@ public abstract interface class com/datadog/android/rum/RumSessionListener {
 	public abstract fun onSessionStarted (Ljava/lang/String;Z)V
 }
 
+public final class com/datadog/android/rum/RumSessionType : java/lang/Enum {
+	public static final field SYNTHETICS Lcom/datadog/android/rum/RumSessionType;
+	public static final field USER Lcom/datadog/android/rum/RumSessionType;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/RumSessionType;
+	public static fun values ()[Lcom/datadog/android/rum/RumSessionType;
+}
+
 public final class com/datadog/android/rum/_RumInternalProxy {
 	public static final field Companion Lcom/datadog/android/rum/_RumInternalProxy$Companion;
 	public final fun addLongTask (JLjava/lang/String;)V
@@ -247,6 +254,7 @@ public final class com/datadog/android/rum/_RumInternalProxy {
 public final class com/datadog/android/rum/_RumInternalProxy$Companion {
 	public final fun setAdditionalConfiguration (Lcom/datadog/android/rum/RumConfiguration$Builder;Ljava/util/Map;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setComposeActionTrackingStrategy (Lcom/datadog/android/rum/RumConfiguration$Builder;Lcom/datadog/android/rum/tracking/ActionTrackingStrategy;)Lcom/datadog/android/rum/RumConfiguration$Builder;
+	public final fun setRumSessionTypeOverride (Lcom/datadog/android/rum/RumConfiguration$Builder;Lcom/datadog/android/rum/RumSessionType;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setTelemetryConfigurationEventMapper (Lcom/datadog/android/rum/RumConfiguration$Builder;Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
@@ -139,7 +139,8 @@ object Rum {
             executorService = sdkCore.createSingleThreadExecutorService("rum-pipeline"),
             initialResourceIdentifier = rumFeature.initialResourceIdentifier,
             lastInteractionIdentifier = rumFeature.lastInteractionIdentifier,
-            slowFramesListener = rumFeature.slowFramesListener
+            slowFramesListener = rumFeature.slowFramesListener,
+            rumSessionTypeOverride = rumFeature.configuration.rumSessionTypeOverride
         )
     }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
@@ -378,6 +378,15 @@ data class RumConfiguration internal constructor(
                 rumConfig.copy(composeActionTrackingStrategy = composeActionTrackingStrategy)
             return this
         }
+
+        /**
+         * Set RUM session type that will be propagated to all RUM events and used regardless of
+         * whether the session is happening inside a synthetic test or not.
+         */
+        internal fun setRumSessionTypeOverride(rumSessionTypeOverride: RumSessionType): Builder {
+            rumConfig = rumConfig.copy(rumSessionTypeOverride = rumSessionTypeOverride)
+            return this
+        }
         // endregion
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumSessionType.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumSessionType.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum
+
+import com.datadog.android.lint.InternalApi
+
+/**
+ * Enum representing the RUM session type.
+ */
+@InternalApi
+enum class RumSessionType {
+    SYNTHETICS,
+    USER
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
@@ -104,5 +104,12 @@ class _RumInternalProxy internal constructor(private val rumMonitor: AdvancedRum
         ): Builder {
             return builder.setComposeActionTrackingStrategy(composeActionTrackingStrategy)
         }
+
+        fun setRumSessionTypeOverride(
+            builder: Builder,
+            rumSessionTypeOverride: RumSessionType
+        ): Builder {
+            return builder.setRumSessionTypeOverride(rumSessionTypeOverride)
+        }
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -37,6 +37,7 @@ import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumSessionListener
+import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.configuration.SlowFramesConfiguration
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
 import com.datadog.android.rum.internal.anr.ANRDetectorRunnable
@@ -628,7 +629,8 @@ internal class RumFeature(
         val slowFramesConfiguration: SlowFramesConfiguration?,
         val composeActionTrackingStrategy: ActionTrackingStrategy,
         val additionalConfig: Map<String, Any>,
-        val trackAnonymousUser: Boolean
+        val trackAnonymousUser: Boolean,
+        val rumSessionTypeOverride: RumSessionType?
     )
 
     internal companion object {
@@ -677,7 +679,8 @@ internal class RumFeature(
             composeActionTrackingStrategy = NoOpActionTrackingStrategy(),
             additionalConfig = emptyMap(),
             trackAnonymousUser = true,
-            slowFramesConfiguration = null
+            slowFramesConfiguration = null,
+            rumSessionTypeOverride = null
         )
 
         internal const val EVENT_MESSAGE_PROPERTY = "message"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumSessionTypeExt.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumSessionTypeExt.kt
@@ -1,0 +1,49 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal
+
+import com.datadog.android.rum.RumSessionType
+import com.datadog.android.rum.model.ActionEvent
+import com.datadog.android.rum.model.ErrorEvent
+import com.datadog.android.rum.model.LongTaskEvent
+import com.datadog.android.rum.model.ResourceEvent
+import com.datadog.android.rum.model.ViewEvent
+
+internal fun RumSessionType.toAction(): ActionEvent.ActionEventSessionType {
+    return when (this) {
+        RumSessionType.SYNTHETICS -> ActionEvent.ActionEventSessionType.SYNTHETICS
+        RumSessionType.USER -> ActionEvent.ActionEventSessionType.USER
+    }
+}
+
+internal fun RumSessionType.toResource(): ResourceEvent.ResourceEventSessionType {
+    return when (this) {
+        RumSessionType.SYNTHETICS -> ResourceEvent.ResourceEventSessionType.SYNTHETICS
+        RumSessionType.USER -> ResourceEvent.ResourceEventSessionType.USER
+    }
+}
+
+internal fun RumSessionType.toError(): ErrorEvent.ErrorEventSessionType {
+    return when (this) {
+        RumSessionType.SYNTHETICS -> ErrorEvent.ErrorEventSessionType.SYNTHETICS
+        RumSessionType.USER -> ErrorEvent.ErrorEventSessionType.USER
+    }
+}
+
+internal fun RumSessionType.toView(): ViewEvent.ViewEventSessionType {
+    return when (this) {
+        RumSessionType.SYNTHETICS -> ViewEvent.ViewEventSessionType.SYNTHETICS
+        RumSessionType.USER -> ViewEvent.ViewEventSessionType.USER
+    }
+}
+
+internal fun RumSessionType.toLongTask(): LongTaskEvent.LongTaskEventSessionType {
+    return when (this) {
+        RumSessionType.SYNTHETICS -> LongTaskEvent.LongTaskEventSessionType.SYNTHETICS
+        RumSessionType.USER -> LongTaskEvent.LongTaskEventSessionType.USER
+    }
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
@@ -11,10 +11,12 @@ import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumActionType
+import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.FeaturesContextResolver
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.monitor.StorageEvent
+import com.datadog.android.rum.internal.toAction
 import com.datadog.android.rum.internal.utils.hasUserData
 import com.datadog.android.rum.internal.utils.newRumEventWriteOperation
 import com.datadog.android.rum.model.ActionEvent
@@ -36,7 +38,8 @@ internal class RumActionScope(
     maxDurationMs: Long = ACTION_MAX_DURATION_MS,
     private val featuresContextResolver: FeaturesContextResolver = FeaturesContextResolver(),
     private val trackFrustrations: Boolean,
-    internal val sampleRate: Float
+    internal val sampleRate: Float,
+    private val rumSessionTypeOverride: RumSessionType?
 ) : RumScope {
 
     private val inactivityThresholdNs = TimeUnit.MILLISECONDS.toNanos(inactivityThresholdMs)
@@ -230,11 +233,13 @@ internal class RumActionScope(
                 resultId = rumContext.syntheticsResultId
             )
         }
-        val sessionType = if (syntheticsAttribute == null) {
-            ActionEvent.ActionEventSessionType.USER
-        } else {
-            ActionEvent.ActionEventSessionType.SYNTHETICS
+
+        val sessionType = when {
+            rumSessionTypeOverride != null -> rumSessionTypeOverride.toAction()
+            syntheticsAttribute == null -> ActionEvent.ActionEventSessionType.USER
+            else -> ActionEvent.ActionEventSessionType.SYNTHETICS
         }
+
         val frustrations = mutableListOf<ActionEvent.Type>()
         if (trackFrustrations && eventErrorCount > 0 && actualType == RumActionType.TAP) {
             frustrations.add(ActionEvent.Type.ERROR_TAP)
@@ -351,20 +356,22 @@ internal class RumActionScope(
             timestampOffset: Long,
             featuresContextResolver: FeaturesContextResolver,
             trackFrustrations: Boolean,
-            sampleRate: Float
+            sampleRate: Float,
+            rumSessionTypeOverride: RumSessionType?
         ): RumScope {
             return RumActionScope(
-                parentScope,
-                sdkCore,
-                event.waitForStop,
-                event.eventTime,
-                event.type,
-                event.name,
-                event.attributes,
-                timestampOffset,
+                parentScope = parentScope,
+                sdkCore = sdkCore,
+                waitForStop = event.waitForStop,
+                eventTime = event.eventTime,
+                initialType = event.type,
+                initialName = event.name,
+                initialAttributes = event.attributes,
+                serverTimeOffsetInMs = timestampOffset,
                 featuresContextResolver = featuresContextResolver,
                 trackFrustrations = trackFrustrations,
-                sampleRate = sampleRate
+                sampleRate = sampleRate,
+                rumSessionTypeOverride = rumSessionTypeOverride
             )
         }
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -17,6 +17,7 @@ import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
+import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.FeaturesContextResolver
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
@@ -24,6 +25,8 @@ import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.internal.metric.networksettled.InternalResourceContext
 import com.datadog.android.rum.internal.metric.networksettled.NetworkSettledMetricResolver
 import com.datadog.android.rum.internal.monitor.StorageEvent
+import com.datadog.android.rum.internal.toError
+import com.datadog.android.rum.internal.toResource
 import com.datadog.android.rum.internal.utils.hasUserData
 import com.datadog.android.rum.internal.utils.newRumEventWriteOperation
 import com.datadog.android.rum.model.ErrorEvent
@@ -46,7 +49,8 @@ internal class RumResourceScope(
     internal val firstPartyHostHeaderTypeResolver: FirstPartyHostHeaderTypeResolver,
     private val featuresContextResolver: FeaturesContextResolver,
     internal val sampleRate: Float,
-    internal val networkSettledMetricResolver: NetworkSettledMetricResolver
+    internal val networkSettledMetricResolver: NetworkSettledMetricResolver,
+    private val rumSessionTypeOverride: RumSessionType?
 ) : RumScope {
 
     internal val resourceId: String = UUID.randomUUID().toString()
@@ -199,10 +203,10 @@ internal class RumResourceScope(
                 resultId = rumContext.syntheticsResultId
             )
         }
-        val sessionType = if (syntheticsAttribute == null) {
-            ResourceEvent.ResourceEventSessionType.USER
-        } else {
-            ResourceEvent.ResourceEventSessionType.SYNTHETICS
+        val sessionType = when {
+            rumSessionTypeOverride != null -> rumSessionTypeOverride.toResource()
+            syntheticsAttribute == null -> ResourceEvent.ResourceEventSessionType.USER
+            else -> ResourceEvent.ResourceEventSessionType.SYNTHETICS
         }
 
         @Suppress("UNCHECKED_CAST")
@@ -367,11 +371,13 @@ internal class RumResourceScope(
                 resultId = rumContext.syntheticsResultId
             )
         }
-        val sessionType = if (syntheticsAttribute == null) {
-            ErrorEvent.ErrorEventSessionType.USER
-        } else {
-            ErrorEvent.ErrorEventSessionType.SYNTHETICS
+
+        val sessionType = when {
+            rumSessionTypeOverride != null -> rumSessionTypeOverride.toError()
+            syntheticsAttribute == null -> ErrorEvent.ErrorEventSessionType.USER
+            else -> ErrorEvent.ErrorEventSessionType.SYNTHETICS
         }
+
         sdkCore.newRumEventWriteOperation(writer) { datadogContext ->
             val user = datadogContext.userInfo
             val hasReplay = featuresContextResolver.resolveViewHasReplay(
@@ -524,7 +530,8 @@ internal class RumResourceScope(
             timestampOffset: Long,
             featuresContextResolver: FeaturesContextResolver,
             sampleRate: Float,
-            networkSettledMetricResolver: NetworkSettledMetricResolver
+            networkSettledMetricResolver: NetworkSettledMetricResolver,
+            rumSessionTypeOverride: RumSessionType?
         ): RumScope {
             return RumResourceScope(
                 parentScope = parentScope,
@@ -538,7 +545,8 @@ internal class RumResourceScope(
                 firstPartyHostHeaderTypeResolver = firstPartyHostHeaderTypeResolver,
                 featuresContextResolver = featuresContextResolver,
                 sampleRate = sampleRate,
-                networkSettledMetricResolver = networkSettledMetricResolver
+                networkSettledMetricResolver = networkSettledMetricResolver,
+                rumSessionTypeOverride = rumSessionTypeOverride
             )
         }
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -13,6 +13,7 @@ import com.datadog.android.api.storage.NoOpDataWriter
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.rum.RumSessionListener
+import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
@@ -45,7 +46,8 @@ internal class RumSessionScope(
     lastInteractionIdentifier: LastInteractionIdentifier?,
     slowFramesListener: SlowFramesListener?,
     private val sessionInactivityNanos: Long = DEFAULT_SESSION_INACTIVITY_NS,
-    private val sessionMaxDurationNanos: Long = DEFAULT_SESSION_MAX_DURATION_NS
+    private val sessionMaxDurationNanos: Long = DEFAULT_SESSION_MAX_DURATION_NS,
+    rumSessionTypeOverride: RumSessionType?
 ) : RumScope {
 
     internal var sessionId = RumContext.NULL_UUID
@@ -62,21 +64,22 @@ internal class RumSessionScope(
 
     @Suppress("LongParameterList")
     internal var childScope: RumViewManagerScope? = RumViewManagerScope(
-        this,
-        sdkCore,
-        sessionEndedMetricDispatcher,
-        backgroundTrackingEnabled,
-        trackFrustrations,
-        viewChangedListener,
-        firstPartyHostHeaderTypeResolver,
-        cpuVitalMonitor,
-        memoryVitalMonitor,
-        frameRateVitalMonitor,
-        applicationDisplayed,
-        sampleRate,
-        networkSettledResourceIdentifier,
-        slowFramesListener,
-        lastInteractionIdentifier
+        parentScope = this,
+        sdkCore = sdkCore,
+        sessionEndedMetricDispatcher = sessionEndedMetricDispatcher,
+        backgroundTrackingEnabled = backgroundTrackingEnabled,
+        trackFrustrations = trackFrustrations,
+        viewChangedListener = viewChangedListener,
+        firstPartyHostHeaderTypeResolver = firstPartyHostHeaderTypeResolver,
+        cpuVitalMonitor = cpuVitalMonitor,
+        memoryVitalMonitor = memoryVitalMonitor,
+        frameRateVitalMonitor = frameRateVitalMonitor,
+        applicationDisplayed = applicationDisplayed,
+        sampleRate = sampleRate,
+        initialResourceIdentifier = networkSettledResourceIdentifier,
+        slowFramesListener = slowFramesListener,
+        lastInteractionIdentifier = lastInteractionIdentifier,
+        rumSessionTypeOverride = rumSessionTypeOverride
     )
 
     init {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -15,6 +15,7 @@ import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.rum.DdRumContentProvider
+import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
@@ -47,7 +48,8 @@ internal class RumViewManagerScope(
     internal val sampleRate: Float,
     internal val initialResourceIdentifier: InitialResourceIdentifier,
     private val slowFramesListener: SlowFramesListener?,
-    lastInteractionIdentifier: LastInteractionIdentifier?
+    lastInteractionIdentifier: LastInteractionIdentifier?,
+    private val rumSessionTypeOverride: RumSessionType?
 ) : RumScope {
 
     private val interactionToNextViewMetricResolver: InteractionToNextViewMetricResolver =
@@ -220,20 +222,21 @@ internal class RumViewManagerScope(
     @WorkerThread
     private fun startForegroundView(event: RumRawEvent.StartView, writer: DataWriter<Any>) {
         val viewScope = RumViewScope.fromEvent(
-            this,
-            sessionEndedMetricDispatcher,
-            sdkCore,
-            event,
-            viewChangedListener,
-            firstPartyHostHeaderTypeResolver,
-            cpuVitalMonitor,
-            memoryVitalMonitor,
-            frameRateVitalMonitor,
-            trackFrustrations,
-            sampleRate,
-            interactionToNextViewMetricResolver,
-            initialResourceIdentifier,
-            slowFramesListener
+            parentScope = this,
+            sessionEndedMetricDispatcher = sessionEndedMetricDispatcher,
+            sdkCore = sdkCore,
+            event = event,
+            viewChangedListener = viewChangedListener,
+            firstPartyHostHeaderTypeResolver = firstPartyHostHeaderTypeResolver,
+            cpuVitalMonitor = cpuVitalMonitor,
+            memoryVitalMonitor = memoryVitalMonitor,
+            frameRateVitalMonitor = frameRateVitalMonitor,
+            trackFrustrations = trackFrustrations,
+            sampleRate = sampleRate,
+            interactionToNextViewMetricResolver = interactionToNextViewMetricResolver,
+            networkSettledResourceIdentifier = initialResourceIdentifier,
+            slowFramesListener = slowFramesListener,
+            rumSessionTypeOverride = rumSessionTypeOverride
         )
         applicationDisplayed = true
         childrenScopes.add(viewScope)
@@ -289,28 +292,29 @@ internal class RumViewManagerScope(
         )
 
         return RumViewScope(
-            this,
-            sdkCore,
-            sessionEndedMetricDispatcher,
-            RumScopeKey(
+            parentScope = this,
+            sdkCore = sdkCore,
+            sessionEndedMetricDispatcher = sessionEndedMetricDispatcher,
+            key = RumScopeKey(
                 RUM_BACKGROUND_VIEW_ID,
                 RUM_BACKGROUND_VIEW_URL,
                 RUM_BACKGROUND_VIEW_NAME
             ),
-            event.eventTime,
-            emptyMap(),
-            viewChangedListener,
-            firstPartyHostHeaderTypeResolver,
-            NoOpVitalMonitor(),
-            NoOpVitalMonitor(),
-            NoOpVitalMonitor(),
+            eventTime = event.eventTime,
+            initialAttributes = emptyMap(),
+            viewChangedListener = viewChangedListener,
+            firstPartyHostHeaderTypeResolver = firstPartyHostHeaderTypeResolver,
+            cpuVitalMonitor = NoOpVitalMonitor(),
+            memoryVitalMonitor = NoOpVitalMonitor(),
+            frameRateVitalMonitor = NoOpVitalMonitor(),
             type = viewType,
             trackFrustrations = trackFrustrations,
             sampleRate = sampleRate,
             interactionToNextViewMetricResolver = interactionToNextViewMetricResolver,
             networkSettledMetricResolver = networkSettledMetricResolver,
             viewEndedMetricDispatcher = viewEndedMetricDispatcher,
-            slowFramesListener = slowFramesListener
+            slowFramesListener = slowFramesListener,
+            rumSessionTypeOverride = rumSessionTypeOverride
         )
     }
 
@@ -327,28 +331,29 @@ internal class RumViewManagerScope(
         )
 
         return RumViewScope(
-            this,
-            sdkCore,
-            sessionEndedMetricDispatcher,
-            RumScopeKey(
+            parentScope = this,
+            sdkCore = sdkCore,
+            sessionEndedMetricDispatcher = sessionEndedMetricDispatcher,
+            key = RumScopeKey(
                 RUM_APP_LAUNCH_VIEW_ID,
                 RUM_APP_LAUNCH_VIEW_URL,
                 RUM_APP_LAUNCH_VIEW_NAME
             ),
-            time,
-            emptyMap(),
-            viewChangedListener,
-            firstPartyHostHeaderTypeResolver,
-            NoOpVitalMonitor(),
-            NoOpVitalMonitor(),
-            NoOpVitalMonitor(),
+            eventTime = time,
+            initialAttributes = emptyMap(),
+            viewChangedListener = viewChangedListener,
+            firstPartyHostHeaderTypeResolver = firstPartyHostHeaderTypeResolver,
+            cpuVitalMonitor = NoOpVitalMonitor(),
+            memoryVitalMonitor = NoOpVitalMonitor(),
+            frameRateVitalMonitor = NoOpVitalMonitor(),
             type = viewType,
             trackFrustrations = trackFrustrations,
             sampleRate = sampleRate,
             interactionToNextViewMetricResolver = interactionToNextViewMetricResolver,
             networkSettledMetricResolver = networkSettledMetricResolver,
             viewEndedMetricDispatcher = viewEndedMetricDispatcher,
-            slowFramesListener = slowFramesListener
+            slowFramesListener = slowFramesListener,
+            rumSessionTypeOverride = rumSessionTypeOverride
         )
     }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -31,6 +31,7 @@ import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.RumSessionListener
+import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum._RumInternalProxy
 import com.datadog.android.rum.internal.CombinedRumSessionListener
 import com.datadog.android.rum.internal.RumErrorSourceType
@@ -79,24 +80,26 @@ internal class DatadogRumMonitor(
     internal val executorService: ExecutorService,
     initialResourceIdentifier: InitialResourceIdentifier,
     lastInteractionIdentifier: LastInteractionIdentifier?,
-    slowFramesListener: SlowFramesListener?
+    slowFramesListener: SlowFramesListener?,
+    rumSessionTypeOverride: RumSessionType?
 ) : RumMonitor, AdvancedRumMonitor {
 
     internal var rootScope: RumScope = RumApplicationScope(
-        applicationId,
-        sdkCore,
-        sampleRate,
-        backgroundTrackingEnabled,
-        trackFrustrations,
-        firstPartyHostHeaderTypeResolver,
-        cpuVitalMonitor,
-        memoryVitalMonitor,
-        frameRateVitalMonitor,
+        applicationId = applicationId,
+        sdkCore = sdkCore,
+        sampleRate = sampleRate,
+        backgroundTrackingEnabled = backgroundTrackingEnabled,
+        trackFrustrations = trackFrustrations,
+        firstPartyHostHeaderTypeResolver = firstPartyHostHeaderTypeResolver,
+        cpuVitalMonitor = cpuVitalMonitor,
+        memoryVitalMonitor = memoryVitalMonitor,
+        frameRateVitalMonitor = frameRateVitalMonitor,
         sessionEndedMetricDispatcher = sessionEndedMetricDispatcher,
-        CombinedRumSessionListener(sessionListener, telemetryEventHandler),
-        initialResourceIdentifier,
-        lastInteractionIdentifier,
-        slowFramesListener
+        sessionListener = CombinedRumSessionListener(sessionListener, telemetryEventHandler),
+        initialResourceIdentifier = initialResourceIdentifier,
+        lastInteractionIdentifier = lastInteractionIdentifier,
+        slowFramesListener = slowFramesListener,
+        rumSessionTypeOverride = rumSessionTypeOverride
     )
 
     internal val keepAliveRunnable = Runnable {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
@@ -34,6 +34,7 @@ import com.datadog.android.rum.tracking.ViewAttributesProvider
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.android.telemetry.model.TelemetryConfigurationEvent
+import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.FloatForgery
 import fr.xgouchet.elmyr.annotation.Forgery
@@ -615,5 +616,21 @@ internal class RumConfigurationBuilderTest {
         // Then
         assertThat(rumConfiguration.featureConfiguration.composeActionTrackingStrategy)
             .isSameAs(mockActionTrackingStrategy)
+    }
+
+    @Test
+    fun `M set rumSessionTypeOverride W setRumSessionTypeOverride()`(
+        forge: Forge
+    ) {
+        // Given
+        val rumSessionTypeOverride = forge.aValueFrom(RumSessionType::class.java)
+
+        // When
+        _RumInternalProxy.setRumSessionTypeOverride(testedBuilder, rumSessionTypeOverride)
+        val rumConfiguration = testedBuilder.build()
+
+        // Then
+        assertThat(rumConfiguration.featureConfiguration.rumSessionTypeOverride)
+            .isEqualTo(rumSessionTypeOverride)
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
@@ -278,19 +278,11 @@ internal class ActionEventAssert(actual: ActionEvent) :
         return this
     }
 
-    fun hasUserSession(): ActionEventAssert {
+    fun hasSessionType(expected: ActionEvent.ActionEventSessionType): ActionEventAssert {
         assertThat(actual.session.type)
-            .overridingErrorMessage(
-                "Expected event to have session.type:user but was ${actual.session.type}"
-            ).isEqualTo(ActionEvent.ActionEventSessionType.USER)
-        return this
-    }
-
-    fun hasSyntheticsSession(): ActionEventAssert {
-        assertThat(actual.session.type)
-            .overridingErrorMessage(
-                "Expected event to have session.type:synthetics but was ${actual.session.type}"
-            ).isEqualTo(ActionEvent.ActionEventSessionType.SYNTHETICS)
+            .overridingErrorMessage {
+                "Expected event to have session.type:$expected but was ${actual.session.type}"
+            }.isEqualTo(expected)
         return this
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
@@ -304,19 +304,11 @@ internal class ErrorEventAssert(actual: ErrorEvent) :
         return this
     }
 
-    fun hasUserSession(): ErrorEventAssert {
+    fun hasSessionType(expected: ErrorEvent.ErrorEventSessionType): ErrorEventAssert {
         assertThat(actual.session.type)
             .overridingErrorMessage(
-                "Expected event to have session.type:user but was ${actual.session.type}"
-            ).isEqualTo(ErrorEvent.ErrorEventSessionType.USER)
-        return this
-    }
-
-    fun hasSyntheticsSession(): ErrorEventAssert {
-        assertThat(actual.session.type)
-            .overridingErrorMessage(
-                "Expected event to have session.type:synthetics but was ${actual.session.type}"
-            ).isEqualTo(ErrorEvent.ErrorEventSessionType.SYNTHETICS)
+                "Expected event to have session.type:$expected but was ${actual.session.type}"
+            ).isEqualTo(expected)
         return this
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/LongTaskEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/LongTaskEventAssert.kt
@@ -205,19 +205,11 @@ internal class LongTaskEventAssert(actual: LongTaskEvent) :
         return this
     }
 
-    fun hasUserSession(): LongTaskEventAssert {
+    fun hasSessionType(expected: LongTaskEvent.LongTaskEventSessionType): LongTaskEventAssert {
         assertThat(actual.session.type)
             .overridingErrorMessage(
-                "Expected event to have session.type:user but was ${actual.session.type}"
-            ).isEqualTo(LongTaskEvent.LongTaskEventSessionType.USER)
-        return this
-    }
-
-    fun hasSyntheticsSession(): LongTaskEventAssert {
-        assertThat(actual.session.type)
-            .overridingErrorMessage(
-                "Expected event to have session.type:synthetics but was ${actual.session.type}"
-            ).isEqualTo(LongTaskEvent.LongTaskEventSessionType.SYNTHETICS)
+                "Expected event to have session.type:$expected but was ${actual.session.type}"
+            ).isEqualTo(expected)
         return this
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
@@ -411,19 +411,11 @@ internal class ResourceEventAssert(actual: ResourceEvent) :
         return this
     }
 
-    fun hasUserSession(): ResourceEventAssert {
+    fun hasSessionType(expected: ResourceEvent.ResourceEventSessionType): ResourceEventAssert {
         assertThat(actual.session.type)
             .overridingErrorMessage(
-                "Expected event to have session.type:user but was ${actual.session.type}"
-            ).isEqualTo(ResourceEvent.ResourceEventSessionType.USER)
-        return this
-    }
-
-    fun hasSyntheticsSession(): ResourceEventAssert {
-        assertThat(actual.session.type)
-            .overridingErrorMessage(
-                "Expected event to have session.type:synthetics but was ${actual.session.type}"
-            ).isEqualTo(ResourceEvent.ResourceEventSessionType.SYNTHETICS)
+                "Expected event to have sessionType:$expected but was ${actual.session.type}"
+            ).isEqualTo(expected)
         return this
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
@@ -203,19 +203,11 @@ internal class ViewEventAssert(actual: ViewEvent) :
         return this
     }
 
-    fun hasUserSession(): ViewEventAssert {
+    fun hasSessionType(expected: ViewEvent.ViewEventSessionType): ViewEventAssert {
         assertThat(actual.session.type)
             .overridingErrorMessage(
-                "Expected event to have session.type:user but was ${actual.session.type}"
-            ).isEqualTo(ViewEvent.ViewEventSessionType.USER)
-        return this
-    }
-
-    fun hasSyntheticsSession(): ViewEventAssert {
-        assertThat(actual.session.type)
-            .overridingErrorMessage(
-                "Expected event to have session.type:synthetics but was ${actual.session.type}"
-            ).isEqualTo(ViewEvent.ViewEventSessionType.SYNTHETICS)
+                "Expected event to have session.type:$expected but was ${actual.session.type}"
+            ).isEqualTo(expected)
         return this
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -17,6 +17,7 @@ import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.rum.DdRumContentProvider
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumSessionListener
+import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.state.ViewUIPerformanceReport
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
@@ -126,28 +127,33 @@ internal class RumApplicationScopeTest {
     @Mock
     lateinit var mockSlowFramesListener: SlowFramesListener
 
+    private var fakeRumSessionType: RumSessionType? = null
+
     @BeforeEach
-    fun `set up`() {
+    fun `set up`(forge: Forge) {
         whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
         whenever(mockSdkCore.time) doReturn fakeTimeInfoAtScopeStart
         whenever(mockSdkCore.internalLogger) doReturn mock()
         whenever(mockSlowFramesListener.resolveReport(any(), any(), any())) doReturn viewUIPerformanceReport
 
+        fakeRumSessionType = forge.aNullable { aValueFrom(RumSessionType::class.java) }
+
         testedScope = RumApplicationScope(
-            fakeApplicationId,
-            mockSdkCore,
-            fakeSampleRate,
-            fakeBackgroundTrackingEnabled,
-            fakeTrackFrustrations,
-            mockResolver,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockDispatcher,
-            mockSessionListener,
-            mockNetworkSettledResourceIdentifier,
-            mockLastInteractionIdentifier,
-            mockSlowFramesListener
+            applicationId = fakeApplicationId,
+            sdkCore = mockSdkCore,
+            sampleRate = fakeSampleRate,
+            backgroundTrackingEnabled = fakeBackgroundTrackingEnabled,
+            trackFrustrations = fakeTrackFrustrations,
+            firstPartyHostHeaderTypeResolver = mockResolver,
+            cpuVitalMonitor = mockCpuVitalMonitor,
+            memoryVitalMonitor = mockMemoryVitalMonitor,
+            frameRateVitalMonitor = mockFrameRateVitalMonitor,
+            sessionEndedMetricDispatcher = mockDispatcher,
+            sessionListener = mockSessionListener,
+            initialResourceIdentifier = mockNetworkSettledResourceIdentifier,
+            lastInteractionIdentifier = mockLastInteractionIdentifier,
+            slowFramesListener = mockSlowFramesListener,
+            rumSessionTypeOverride = fakeRumSessionType
         )
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -18,11 +18,13 @@ import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
+import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.assertj.ActionEventAssert.Companion.assertThat
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.internal.monitor.StorageEvent
+import com.datadog.android.rum.internal.toAction
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.rum.utils.forge.Configurator
@@ -119,6 +121,8 @@ internal class RumContinuousActionScopeTest {
     @BoolForgery
     var fakeTrackFrustrations: Boolean = true
 
+    private var fakeRumSessionType: RumSessionType? = null
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         fakeSourceActionEvent = forge.aNullable { aValueFrom(ActionEvent.ActionEventSource::class.java) }
@@ -151,19 +155,22 @@ internal class RumContinuousActionScopeTest {
         }
         whenever(mockWriter.write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))) doReturn true
 
+        fakeRumSessionType = forge.aNullable { aValueFrom(RumSessionType::class.java) }
+
         testedScope = RumActionScope(
-            mockParentScope,
-            rumMonitor.mockSdkCore,
-            true,
-            fakeEventTime,
-            fakeType,
-            fakeName,
-            fakeAttributes,
-            fakeServerOffset,
-            TEST_INACTIVITY_MS,
-            TEST_MAX_DURATION_MS,
+            parentScope = mockParentScope,
+            sdkCore = rumMonitor.mockSdkCore,
+            waitForStop = true,
+            eventTime = fakeEventTime,
+            initialType = fakeType,
+            initialName = fakeName,
+            initialAttributes = fakeAttributes,
+            serverTimeOffsetInMs = fakeServerOffset,
+            inactivityThresholdMs = TEST_INACTIVITY_MS,
+            maxDurationMs = TEST_MAX_DURATION_MS,
             trackFrustrations = true,
-            sampleRate = fakeSampleRate
+            sampleRate = fakeSampleRate,
+            rumSessionTypeOverride = fakeRumSessionType
         )
     }
 
@@ -245,7 +252,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -313,7 +320,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(expectedAttributes)
@@ -384,7 +391,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(expectedAttributes)
@@ -458,7 +465,7 @@ internal class RumContinuousActionScopeTest {
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -551,7 +558,7 @@ internal class RumContinuousActionScopeTest {
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -648,7 +655,7 @@ internal class RumContinuousActionScopeTest {
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -722,7 +729,7 @@ internal class RumContinuousActionScopeTest {
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -809,7 +816,7 @@ internal class RumContinuousActionScopeTest {
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -890,7 +897,7 @@ internal class RumContinuousActionScopeTest {
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -979,7 +986,7 @@ internal class RumContinuousActionScopeTest {
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -1038,7 +1045,7 @@ internal class RumContinuousActionScopeTest {
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -1101,7 +1108,7 @@ internal class RumContinuousActionScopeTest {
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -1164,7 +1171,7 @@ internal class RumContinuousActionScopeTest {
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -1238,7 +1245,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -1314,7 +1321,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -1372,7 +1379,7 @@ internal class RumContinuousActionScopeTest {
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -1435,7 +1442,7 @@ internal class RumContinuousActionScopeTest {
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -1498,7 +1505,7 @@ internal class RumContinuousActionScopeTest {
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -1572,7 +1579,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -1648,7 +1655,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -1710,7 +1717,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -1759,18 +1766,19 @@ internal class RumContinuousActionScopeTest {
         expectedAttributes.putAll(fakeGlobalAttributes)
         whenever(rumMonitor.mockInstance.getAttributes()) doReturn fakeGlobalAttributes
         testedScope = RumActionScope(
-            mockParentScope,
-            rumMonitor.mockSdkCore,
-            true,
-            fakeEventTime,
-            fakeType,
-            fakeName,
-            fakeAttributes,
-            fakeServerOffset,
-            TEST_INACTIVITY_MS,
-            TEST_MAX_DURATION_MS,
+            parentScope = mockParentScope,
+            sdkCore = rumMonitor.mockSdkCore,
+            waitForStop = true,
+            eventTime = fakeEventTime,
+            initialType = fakeType,
+            initialName = fakeName,
+            initialAttributes = fakeAttributes,
+            serverTimeOffsetInMs = fakeServerOffset,
+            inactivityThresholdMs = TEST_INACTIVITY_MS,
+            maxDurationMs = TEST_MAX_DURATION_MS,
             trackFrustrations = fakeTrackFrustrations,
-            sampleRate = fakeSampleRate
+            sampleRate = fakeSampleRate,
+            rumSessionTypeOverride = fakeRumSessionType
         )
         whenever(rumMonitor.mockInstance.getAttributes()) doReturn emptyMap()
         fakeEvent = RumRawEvent.StopAction(fakeType, fakeName, emptyMap())
@@ -1806,7 +1814,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasSyntheticsSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.SYNTHETICS)
                     hasSyntheticsTest(fakeTestId, fakeResultId)
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(expectedAttributes)
@@ -1853,18 +1861,19 @@ internal class RumContinuousActionScopeTest {
         expectedAttributes.putAll(fakeGlobalAttributes)
         whenever(rumMonitor.mockInstance.getAttributes()) doReturn fakeGlobalAttributes
         testedScope = RumActionScope(
-            mockParentScope,
-            rumMonitor.mockSdkCore,
-            true,
-            fakeEventTime,
-            fakeType,
-            fakeName,
-            fakeAttributes,
-            fakeServerOffset,
-            TEST_INACTIVITY_MS,
-            TEST_MAX_DURATION_MS,
+            parentScope = mockParentScope,
+            sdkCore = rumMonitor.mockSdkCore,
+            waitForStop = true,
+            eventTime = fakeEventTime,
+            initialType = fakeType,
+            initialName = fakeName,
+            initialAttributes = fakeAttributes,
+            serverTimeOffsetInMs = fakeServerOffset,
+            inactivityThresholdMs = TEST_INACTIVITY_MS,
+            maxDurationMs = TEST_MAX_DURATION_MS,
             trackFrustrations = fakeTrackFrustrations,
-            sampleRate = fakeSampleRate
+            sampleRate = fakeSampleRate,
+            rumSessionTypeOverride = fakeRumSessionType
         )
         whenever(rumMonitor.mockInstance.getAttributes()) doReturn emptyMap()
         fakeEvent = RumRawEvent.StopAction(fakeType, fakeName, emptyMap())
@@ -1894,7 +1903,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(expectedAttributes)
@@ -1962,7 +1971,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(expectedAttributes)
@@ -2025,7 +2034,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -2098,7 +2107,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -2172,7 +2181,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -2238,7 +2247,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -2307,7 +2316,7 @@ internal class RumContinuousActionScopeTest {
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -2371,7 +2380,7 @@ internal class RumContinuousActionScopeTest {
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -2433,7 +2442,7 @@ internal class RumContinuousActionScopeTest {
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -2498,7 +2507,7 @@ internal class RumContinuousActionScopeTest {
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -2630,7 +2639,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -2694,7 +2703,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)
@@ -2752,7 +2761,7 @@ internal class RumContinuousActionScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(fakeAttributes)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -14,6 +14,7 @@ import com.datadog.android.api.storage.NoOpDataWriter
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.rum.RumSessionListener
+import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
@@ -123,6 +124,8 @@ internal class RumSessionScopeTest {
     @Mock
     lateinit var mockSlowFramesListener: SlowFramesListener
 
+    private var fakeRumSessionType: RumSessionType? = null
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         fakeInitialViewEvent = forge.startViewEvent()
@@ -133,6 +136,8 @@ internal class RumSessionScopeTest {
             mockSessionReplayFeatureScope
         whenever(mockSdkCore.time) doReturn (fakeTimeInfo)
         whenever(mockSdkCore.internalLogger) doReturn mock()
+
+        fakeRumSessionType = forge.aNullable { aValueFrom(RumSessionType::class.java) }
 
         initializeTestedScope()
     }
@@ -1297,24 +1302,25 @@ internal class RumSessionScopeTest {
         backgroundTrackingEnabled: Boolean? = null
     ) {
         testedScope = RumSessionScope(
-            mockParentScope,
-            mockSdkCore,
-            mockSessionEndedMetricDispatcher,
-            sampleRate,
-            backgroundTrackingEnabled ?: fakeBackgroundTrackingEnabled,
-            fakeTrackFrustrations,
-            mockViewChangedListener,
-            mockResolver,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockSessionListener,
+            parentScope = mockParentScope,
+            sdkCore = mockSdkCore,
+            sessionEndedMetricDispatcher = mockSessionEndedMetricDispatcher,
+            sampleRate = sampleRate,
+            backgroundTrackingEnabled = backgroundTrackingEnabled ?: fakeBackgroundTrackingEnabled,
+            trackFrustrations = fakeTrackFrustrations,
+            viewChangedListener = mockViewChangedListener,
+            firstPartyHostHeaderTypeResolver = mockResolver,
+            cpuVitalMonitor = mockCpuVitalMonitor,
+            memoryVitalMonitor = mockMemoryVitalMonitor,
+            frameRateVitalMonitor = mockFrameRateVitalMonitor,
+            sessionListener = mockSessionListener,
             applicationDisplayed = false,
             networkSettledResourceIdentifier = mockNetworkSettledResourceIdentifier,
             lastInteractionIdentifier = mockLastInteractionIdentifier,
             slowFramesListener = mockSlowFramesListener,
-            TEST_INACTIVITY_NS,
-            TEST_MAX_DURATION_NS
+            sessionInactivityNanos = TEST_INACTIVITY_NS,
+            sessionMaxDurationNanos = TEST_MAX_DURATION_NS,
+            rumSessionTypeOverride = fakeRumSessionType
         )
 
         if (withMockChildScope) {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -20,6 +20,7 @@ import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.rum.DdRumContentProvider
 import com.datadog.android.rum.RumErrorSource
+import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.anr.ANRDetectorRunnable
 import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.domain.RumContext
@@ -134,6 +135,8 @@ internal class RumViewManagerScopeTest {
 
     private var fakeSampleRate: Float = 0.0f
 
+    private var fakeRumSessionType: RumSessionType? = null
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         fakeSampleRate = forge.aFloat(min = 0.0f, max = 100.0f)
@@ -145,6 +148,8 @@ internal class RumViewManagerScopeTest {
         whenever(mockChildScope.isActive()) doReturn true
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockSlowFramesListener.resolveReport(any(), any(), any())) doReturn fakeViewUIPerformanceReport
+
+        fakeRumSessionType = forge.aNullable { aValueFrom(RumSessionType::class.java) }
 
         testedScope = RumViewManagerScope(
             mockParentScope,
@@ -161,7 +166,8 @@ internal class RumViewManagerScopeTest {
             sampleRate = fakeSampleRate,
             initialResourceIdentifier = mockNetworkSettledResourceIdentifier,
             lastInteractionIdentifier = mockLastInteractionIdentifier,
-            slowFramesListener = mockSlowFramesListener
+            slowFramesListener = mockSlowFramesListener,
+            rumSessionTypeOverride = fakeRumSessionType
         )
     }
 
@@ -527,7 +533,8 @@ internal class RumViewManagerScopeTest {
             sampleRate = fakeSampleRate,
             initialResourceIdentifier = mockNetworkSettledResourceIdentifier,
             lastInteractionIdentifier = mockLastInteractionIdentifier,
-            slowFramesListener = mockSlowFramesListener
+            slowFramesListener = mockSlowFramesListener,
+            rumSessionTypeOverride = fakeRumSessionType
         )
         testedScope.applicationDisplayed = true
         val fakeEvent = forge.validBackgroundEvent()
@@ -559,7 +566,8 @@ internal class RumViewManagerScopeTest {
             sampleRate = fakeSampleRate,
             initialResourceIdentifier = mockNetworkSettledResourceIdentifier,
             lastInteractionIdentifier = mockLastInteractionIdentifier,
-            slowFramesListener = mockSlowFramesListener
+            slowFramesListener = mockSlowFramesListener,
+            rumSessionTypeOverride = fakeRumSessionType
         )
         testedScope.childrenScopes.add(mockChildScope)
         whenever(mockChildScope.isActive()) doReturn true
@@ -594,7 +602,8 @@ internal class RumViewManagerScopeTest {
             sampleRate = fakeSampleRate,
             initialResourceIdentifier = mockNetworkSettledResourceIdentifier,
             lastInteractionIdentifier = mockLastInteractionIdentifier,
-            slowFramesListener = mockSlowFramesListener
+            slowFramesListener = mockSlowFramesListener,
+            rumSessionTypeOverride = fakeRumSessionType
         )
         testedScope.applicationDisplayed = true
         val fakeEvent = forge.validBackgroundEvent()
@@ -662,7 +671,8 @@ internal class RumViewManagerScopeTest {
             sampleRate = fakeSampleRate,
             initialResourceIdentifier = mockNetworkSettledResourceIdentifier,
             lastInteractionIdentifier = mockLastInteractionIdentifier,
-            slowFramesListener = mockSlowFramesListener
+            slowFramesListener = mockSlowFramesListener,
+            rumSessionTypeOverride = fakeRumSessionType
         )
         testedScope.childrenScopes.add(mockChildScope)
         whenever(mockChildScope.isActive()) doReturn true
@@ -698,7 +708,8 @@ internal class RumViewManagerScopeTest {
             sampleRate = fakeSampleRate,
             initialResourceIdentifier = mockNetworkSettledResourceIdentifier,
             lastInteractionIdentifier = mockLastInteractionIdentifier,
-            slowFramesListener = mockSlowFramesListener
+            slowFramesListener = mockSlowFramesListener,
+            rumSessionTypeOverride = fakeRumSessionType
         )
         testedScope.stopped = true
         val fakeEvent = forge.applicationStartedEvent()

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -25,6 +25,7 @@ import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.RumResourceMethod
+import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.assertj.ActionEventAssert.Companion.assertThat
 import com.datadog.android.rum.assertj.ErrorEventAssert.Companion.assertThat
 import com.datadog.android.rum.assertj.LongTaskEventAssert.Companion.assertThat
@@ -50,6 +51,10 @@ import com.datadog.android.rum.internal.metric.networksettled.NetworkSettledMetr
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.internal.monitor.StorageEvent
+import com.datadog.android.rum.internal.toAction
+import com.datadog.android.rum.internal.toError
+import com.datadog.android.rum.internal.toLongTask
+import com.datadog.android.rum.internal.toView
 import com.datadog.android.rum.internal.vitals.VitalInfo
 import com.datadog.android.rum.internal.vitals.VitalListener
 import com.datadog.android.rum.internal.vitals.VitalMonitor
@@ -248,8 +253,11 @@ internal class RumViewScopeTest {
     private var fakeFreezeRate: Double = 0.0
     private lateinit var fakeSlowRecords: List<ViewEvent.SlowFrame>
 
+    private var fakeRumSessionType: RumSessionType? = null
+
     @BeforeEach
     fun `set up`(forge: Forge) {
+        fakeRumSessionType = forge.aNullable { aValueFrom(RumSessionType::class.java) }
         fakeNetworkSettledMetricValue = forge.aNullable { aPositiveLong() }
         fakeInteractionToNextViewMetricValue = forge.aNullable { aPositiveLong() }
         whenever(mockNetworkSettledMetricResolver.resolveMetric()) doReturn fakeNetworkSettledMetricValue
@@ -872,7 +880,7 @@ internal class RumViewScopeTest {
                 hasViewId(testedScope.viewId)
                 hasApplicationId(fakeParentContext.applicationId)
                 hasSessionId(fakeParentContext.sessionId)
-                hasUserSession()
+                hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                 hasNoSyntheticsTest()
                 hasStartReason(fakeParentContext.sessionStartReason)
                 hasReplay(fakeHasReplay)
@@ -950,7 +958,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     containsExactlyContextAttributes(fakeAttributes)
                     hasStartReason(fakeParentContext.sessionStartReason)
@@ -1030,7 +1038,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     containsExactlyContextAttributes(expectedAttributes)
                     hasStartReason(fakeParentContext.sessionStartReason)
@@ -1116,7 +1124,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(expectedAttributes)
@@ -1199,7 +1207,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(expectedAttributes)
@@ -1278,7 +1286,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     containsExactlyContextAttributes(expectedAttributes)
@@ -1345,7 +1353,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -1430,7 +1438,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -1514,7 +1522,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -1600,7 +1608,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -1689,7 +1697,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -1772,7 +1780,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -1854,7 +1862,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -1968,7 +1976,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -2061,7 +2069,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -2163,7 +2171,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -2259,7 +2267,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -2333,7 +2341,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -2419,7 +2427,7 @@ internal class RumViewScopeTest {
                     hasView(testedScope.viewId, testedScope.key.name, testedScope.url)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(false)
@@ -2487,7 +2495,7 @@ internal class RumViewScopeTest {
                     hasView(testedScope.viewId, testedScope.key.name, testedScope.url)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasSyntheticsSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.SYNTHETICS)
                     hasSyntheticsTest(fakeTestId, fakeResultId)
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(false)
@@ -2556,7 +2564,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -2655,7 +2663,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -2764,7 +2772,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -2865,7 +2873,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -2959,7 +2967,7 @@ internal class RumViewScopeTest {
                     hasView(testedScope.viewId, testedScope.key.name, testedScope.url)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(false)
@@ -3018,7 +3026,7 @@ internal class RumViewScopeTest {
                     hasView(testedScope.viewId, testedScope.key.name, testedScope.url)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(false)
@@ -3097,7 +3105,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -3300,7 +3308,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasSyntheticsSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.SYNTHETICS)
                     hasSyntheticsTest(fakeTestId, fakeResultId)
                     containsExactlyContextAttributes(expectedAttributes)
                     hasStartReason(fakeParentContext.sessionStartReason)
@@ -3501,7 +3509,7 @@ internal class RumViewScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -3571,7 +3579,7 @@ internal class RumViewScopeTest {
                     hasAccountInfo(fakeDatadogContext.accountInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasSyntheticsSession()
+                    hasSessionType(fakeRumSessionType?.toAction() ?: ActionEvent.ActionEventSessionType.SYNTHETICS)
                     hasSyntheticsTest(fakeTestId, fakeResultId)
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -4104,7 +4112,7 @@ internal class RumViewScopeTest {
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(attributes)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasDeviceInfo(
                         fakeDatadogContext.deviceInfo.deviceName,
@@ -4185,7 +4193,7 @@ internal class RumViewScopeTest {
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(attributes)
-                    hasSyntheticsSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.SYNTHETICS)
                     hasSyntheticsTest(fakeTestId, fakeResultId)
                     hasDeviceInfo(
                         fakeDatadogContext.deviceInfo.deviceName,
@@ -4259,7 +4267,7 @@ internal class RumViewScopeTest {
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(attributes)
                     hasSource(fakeSourceErrorEvent)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasDeviceInfo(
                         fakeDatadogContext.deviceInfo.deviceName,
@@ -4332,7 +4340,7 @@ internal class RumViewScopeTest {
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(attributes)
                     hasSource(fakeSourceErrorEvent)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasDeviceInfo(
                         fakeDatadogContext.deviceInfo.deviceName,
@@ -4407,7 +4415,7 @@ internal class RumViewScopeTest {
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(attributes)
                     hasSource(fakeSourceErrorEvent)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasDeviceInfo(
                         fakeDatadogContext.deviceInfo.deviceName,
@@ -4484,7 +4492,7 @@ internal class RumViewScopeTest {
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(attributes)
                     hasSource(fakeSourceErrorEvent)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasDeviceInfo(
                         fakeDatadogContext.deviceInfo.deviceName,
@@ -4554,7 +4562,7 @@ internal class RumViewScopeTest {
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(attributes)
                     hasSource(fakeSourceErrorEvent)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasSampleRate(fakeSampleRate)
                     hasBuildId(fakeDatadogContext.appBuildId)
@@ -4612,13 +4620,13 @@ internal class RumViewScopeTest {
                     hasActionId(fakeActionId)
                     hasErrorType(throwable.javaClass.canonicalName)
                     hasErrorSourceType(sourceType.toSchemaSourceType())
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(attributes)
                     hasSource(fakeSourceErrorEvent)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasDeviceInfo(
                         fakeDatadogContext.deviceInfo.deviceName,
@@ -4690,13 +4698,13 @@ internal class RumViewScopeTest {
                     hasActionId(fakeActionId)
                     hasErrorType(null)
                     hasErrorSourceType(sourceType.toSchemaSourceType())
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(attributes)
                     hasSource(fakeSourceErrorEvent)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasDeviceInfo(
                         fakeDatadogContext.deviceInfo.deviceName,
@@ -4770,13 +4778,13 @@ internal class RumViewScopeTest {
                     hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasErrorCategory(null)
                     hasTimeSinceAppStart(TimeUnit.NANOSECONDS.toMillis(timeSinceAppStart))
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(attributes)
                     hasSource(fakeSourceErrorEvent)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasDeviceInfo(
                         fakeDatadogContext.deviceInfo.deviceName,
@@ -4824,7 +4832,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -4908,7 +4916,7 @@ internal class RumViewScopeTest {
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(mockAttributes)
                     hasSource(fakeSourceErrorEvent)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasDeviceInfo(
                         fakeDatadogContext.deviceInfo.deviceName,
@@ -4982,13 +4990,13 @@ internal class RumViewScopeTest {
                     hasActionId(fakeActionId)
                     hasErrorType(throwable.javaClass.canonicalName)
                     hasErrorSourceType(sourceType.toSchemaSourceType())
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(attributes)
                     hasSource(fakeSourceErrorEvent)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasDeviceInfo(
                         fakeDatadogContext.deviceInfo.deviceName,
@@ -5064,13 +5072,13 @@ internal class RumViewScopeTest {
                     hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasErrorCategory(ErrorEvent.Category.EXCEPTION)
                     hasTimeSinceAppStart(TimeUnit.NANOSECONDS.toMillis(timeSinceAppStart))
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(attributes)
                     hasSource(fakeSourceErrorEvent)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasDeviceInfo(
                         fakeDatadogContext.deviceInfo.deviceName,
@@ -5118,7 +5126,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -5215,7 +5223,7 @@ internal class RumViewScopeTest {
                     // since this crash is coming externally (from cross-platform), expectation is to have it provided
                     // as an attribute from there as well
                     hasTimeSinceAppStart(null)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -5266,7 +5274,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -5345,13 +5353,13 @@ internal class RumViewScopeTest {
                     hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasErrorCategory(ErrorEvent.Category.EXCEPTION)
                     hasTimeSinceAppStart(null)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(attributes)
                     hasSource(fakeSourceErrorEvent)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasDeviceInfo(
                         fakeDatadogContext.deviceInfo.deviceName,
@@ -5426,13 +5434,13 @@ internal class RumViewScopeTest {
                     hasActionId(fakeActionId)
                     hasErrorType(errorType)
                     hasErrorSourceType(sourceType.toSchemaSourceType())
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(attributes)
                     hasSource(fakeSourceErrorEvent)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasDeviceInfo(
                         fakeDatadogContext.deviceInfo.deviceName,
@@ -5509,13 +5517,13 @@ internal class RumViewScopeTest {
                     hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasErrorCategory(ErrorEvent.Category.EXCEPTION)
                     hasTimeSinceAppStart(TimeUnit.NANOSECONDS.toMillis(timeSinceAppStart))
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(attributes)
                     hasSource(fakeSourceErrorEvent)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toError() ?: ErrorEvent.ErrorEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasDeviceInfo(
                         fakeDatadogContext.deviceInfo.deviceName,
@@ -5563,7 +5571,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -5795,7 +5803,7 @@ internal class RumViewScopeTest {
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                     hasStartReason(fakeParentContext.sessionStartReason)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toLongTask() ?: LongTaskEvent.LongTaskEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasReplay(fakeHasReplay)
                     hasSource(fakeSourceLongTaskEvent)
@@ -5850,7 +5858,7 @@ internal class RumViewScopeTest {
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                     hasStartReason(fakeParentContext.sessionStartReason)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toLongTask() ?: LongTaskEvent.LongTaskEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasReplay(fakeHasReplay)
                     hasSource(fakeSourceLongTaskEvent)
@@ -5914,7 +5922,9 @@ internal class RumViewScopeTest {
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                     hasStartReason(fakeParentContext.sessionStartReason)
-                    hasSyntheticsSession()
+                    hasSessionType(
+                        fakeRumSessionType?.toLongTask() ?: LongTaskEvent.LongTaskEventSessionType.SYNTHETICS
+                    )
                     hasSyntheticsTest(fakeTestId, fakeResultId)
                     hasReplay(fakeHasReplay)
                     hasSource(fakeSourceLongTaskEvent)
@@ -5978,7 +5988,9 @@ internal class RumViewScopeTest {
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                     hasStartReason(fakeParentContext.sessionStartReason)
-                    hasSyntheticsSession()
+                    hasSessionType(
+                        fakeRumSessionType?.toLongTask() ?: LongTaskEvent.LongTaskEventSessionType.SYNTHETICS
+                    )
                     hasSyntheticsTest(fakeTestId, fakeResultId)
                     hasReplay(fakeHasReplay)
                     hasSource(fakeSourceLongTaskEvent)
@@ -6042,7 +6054,7 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasStartReason(fakeParentContext.sessionStartReason)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toLongTask() ?: LongTaskEvent.LongTaskEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(expectedAttributes)
@@ -6107,7 +6119,7 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasStartReason(fakeParentContext.sessionStartReason)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toLongTask() ?: LongTaskEvent.LongTaskEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(expectedAttributes)
@@ -6345,7 +6357,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -6425,7 +6437,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -6483,7 +6495,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -6577,7 +6589,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -6669,7 +6681,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -6763,7 +6775,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -6839,7 +6851,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -7107,7 +7119,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -7185,7 +7197,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -7262,7 +7274,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -7349,7 +7361,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -7436,7 +7448,7 @@ internal class RumViewScopeTest {
                     hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
-                    hasUserSession()
+                    hasSessionType(fakeRumSessionType?.toView() ?: ViewEvent.ViewEventSessionType.USER)
                     hasNoSyntheticsTest()
                     hasStartReason(fakeParentContext.sessionStartReason)
                     hasReplay(fakeHasReplay)
@@ -9392,25 +9404,26 @@ internal class RumViewScopeTest {
         viewEndedMetricDispatcher: ViewMetricDispatcher = mockViewEndedMetricDispatcher,
         slowFramesMetricListener: SlowFramesListener = mockSlowFramesListener
     ) = RumViewScope(
-        parentScope,
-        sdkCore,
-        sessionEndedMetricDispatcher,
-        key,
-        eventTime,
-        initialAttributes,
-        viewChangedListener,
-        firstPartyHostHeaderTypeResolver,
-        cpuVitalMonitor,
-        memoryVitalMonitor,
-        frameRateVitalMonitor,
-        featuresContextResolver,
-        type,
-        trackFrustrations,
-        sampleRate,
-        interactionNextViewMetricResolver,
-        networkSettledMetricResolver,
-        slowFramesMetricListener,
-        viewEndedMetricDispatcher
+        parentScope = parentScope,
+        sdkCore = sdkCore,
+        sessionEndedMetricDispatcher = sessionEndedMetricDispatcher,
+        key = key,
+        eventTime = eventTime,
+        initialAttributes = initialAttributes,
+        viewChangedListener = viewChangedListener,
+        firstPartyHostHeaderTypeResolver = firstPartyHostHeaderTypeResolver,
+        cpuVitalMonitor = cpuVitalMonitor,
+        memoryVitalMonitor = memoryVitalMonitor,
+        frameRateVitalMonitor = frameRateVitalMonitor,
+        featuresContextResolver = featuresContextResolver,
+        type = type,
+        trackFrustrations = trackFrustrations,
+        sampleRate = sampleRate,
+        interactionToNextViewMetricResolver = interactionNextViewMetricResolver,
+        networkSettledMetricResolver = networkSettledMetricResolver,
+        slowFramesListener = slowFramesMetricListener,
+        viewEndedMetricDispatcher = viewEndedMetricDispatcher,
+        rumSessionTypeOverride = fakeRumSessionType
     )
 
     data class RumRawEventData(val event: RumRawEvent, val viewKey: RumScopeKey)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -27,6 +27,7 @@ import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.RumSessionListener
+import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.debug.RumDebugListener
@@ -181,6 +182,8 @@ internal class DatadogRumMonitorTest {
     @Mock
     lateinit var mockSlowFramesListener: SlowFramesListener
 
+    private var fakeRumSessionType: RumSessionType? = null
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         whenever(mockExecutorService.execute(any())) doAnswer {
@@ -192,25 +195,29 @@ internal class DatadogRumMonitorTest {
         whenever(mockSlowFramesListener.resolveReport(any(), any(), any())) doReturn fakeViewUIPerformanceReport
 
         fakeAttributes = forge.exhaustiveAttributes()
+
+        fakeRumSessionType = forge.aNullable { aValueFrom(RumSessionType::class.java) }
+
         testedMonitor = DatadogRumMonitor(
-            fakeApplicationId,
-            mockSdkCore,
-            fakeSampleRate,
-            fakeBackgroundTrackingEnabled,
-            fakeTrackFrustrations,
-            mockWriter,
-            mockHandler,
-            mockTelemetryEventHandler,
-            mockSessionEndedMetricDispatcher,
-            mockResolver,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockSessionListener,
-            mockExecutorService,
-            mockNetworkSettledResourceIdentifier,
-            mockLastInteractionIdentifier,
-            mockSlowFramesListener
+            applicationId = fakeApplicationId,
+            sdkCore = mockSdkCore,
+            sampleRate = fakeSampleRate,
+            backgroundTrackingEnabled = fakeBackgroundTrackingEnabled,
+            trackFrustrations = fakeTrackFrustrations,
+            writer = mockWriter,
+            handler = mockHandler,
+            telemetryEventHandler = mockTelemetryEventHandler,
+            sessionEndedMetricDispatcher = mockSessionEndedMetricDispatcher,
+            firstPartyHostHeaderTypeResolver = mockResolver,
+            cpuVitalMonitor = mockCpuVitalMonitor,
+            memoryVitalMonitor = mockMemoryVitalMonitor,
+            frameRateVitalMonitor = mockFrameRateVitalMonitor,
+            sessionListener = mockSessionListener,
+            executorService = mockExecutorService,
+            initialResourceIdentifier = mockNetworkSettledResourceIdentifier,
+            lastInteractionIdentifier = mockLastInteractionIdentifier,
+            slowFramesListener = mockSlowFramesListener,
+            rumSessionTypeOverride = fakeRumSessionType
         )
         testedMonitor.rootScope = mockScope
     }
@@ -218,24 +225,25 @@ internal class DatadogRumMonitorTest {
     @Test
     fun `creates root scope`() {
         testedMonitor = DatadogRumMonitor(
-            fakeApplicationId,
-            mockSdkCore,
-            fakeSampleRate,
-            fakeBackgroundTrackingEnabled,
-            fakeTrackFrustrations,
-            mockWriter,
-            mockHandler,
-            mockTelemetryEventHandler,
-            mockSessionEndedMetricDispatcher,
-            mockResolver,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockSessionListener,
-            mockExecutorService,
-            mockNetworkSettledResourceIdentifier,
-            mockLastInteractionIdentifier,
-            mockSlowFramesListener
+            applicationId = fakeApplicationId,
+            sdkCore = mockSdkCore,
+            sampleRate = fakeSampleRate,
+            backgroundTrackingEnabled = fakeBackgroundTrackingEnabled,
+            trackFrustrations = fakeTrackFrustrations,
+            writer = mockWriter,
+            handler = mockHandler,
+            telemetryEventHandler = mockTelemetryEventHandler,
+            sessionEndedMetricDispatcher = mockSessionEndedMetricDispatcher,
+            firstPartyHostHeaderTypeResolver = mockResolver,
+            cpuVitalMonitor = mockCpuVitalMonitor,
+            memoryVitalMonitor = mockMemoryVitalMonitor,
+            frameRateVitalMonitor = mockFrameRateVitalMonitor,
+            sessionListener = mockSessionListener,
+            executorService = mockExecutorService,
+            initialResourceIdentifier = mockNetworkSettledResourceIdentifier,
+            lastInteractionIdentifier = mockLastInteractionIdentifier,
+            slowFramesListener = mockSlowFramesListener,
+            rumSessionTypeOverride = fakeRumSessionType
         )
 
         val rootScope = testedMonitor.rootScope
@@ -280,24 +288,25 @@ internal class DatadogRumMonitorTest {
     fun `M send correct sessionId W getCurrentSessionId { session started, sampled in }`() {
         // Given
         testedMonitor = DatadogRumMonitor(
-            fakeApplicationId,
-            mockSdkCore,
-            100.0f,
-            fakeBackgroundTrackingEnabled,
-            fakeTrackFrustrations,
-            mockWriter,
-            mockHandler,
-            mockTelemetryEventHandler,
-            mockSessionEndedMetricDispatcher,
-            mockResolver,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockSessionListener,
-            mockExecutorService,
-            mockNetworkSettledResourceIdentifier,
-            mockLastInteractionIdentifier,
-            mockSlowFramesListener
+            applicationId = fakeApplicationId,
+            sdkCore = mockSdkCore,
+            sampleRate = 100.0f,
+            backgroundTrackingEnabled = fakeBackgroundTrackingEnabled,
+            trackFrustrations = fakeTrackFrustrations,
+            writer = mockWriter,
+            handler = mockHandler,
+            telemetryEventHandler = mockTelemetryEventHandler,
+            sessionEndedMetricDispatcher = mockSessionEndedMetricDispatcher,
+            firstPartyHostHeaderTypeResolver = mockResolver,
+            cpuVitalMonitor = mockCpuVitalMonitor,
+            memoryVitalMonitor = mockMemoryVitalMonitor,
+            frameRateVitalMonitor = mockFrameRateVitalMonitor,
+            sessionListener = mockSessionListener,
+            executorService = mockExecutorService,
+            initialResourceIdentifier = mockNetworkSettledResourceIdentifier,
+            lastInteractionIdentifier = mockLastInteractionIdentifier,
+            slowFramesListener = mockSlowFramesListener,
+            rumSessionTypeOverride = fakeRumSessionType
         )
         val completableFuture = CompletableFuture<String>()
         testedMonitor.start()
@@ -320,24 +329,25 @@ internal class DatadogRumMonitorTest {
     @Test
     fun `M send null sessionId W getCurrentSessionId { session started, sampled out }`() {
         testedMonitor = DatadogRumMonitor(
-            fakeApplicationId,
-            mockSdkCore,
-            0.0f,
-            fakeBackgroundTrackingEnabled,
-            fakeTrackFrustrations,
-            mockWriter,
-            mockHandler,
-            mockTelemetryEventHandler,
-            mockSessionEndedMetricDispatcher,
-            mockResolver,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockSessionListener,
-            mockExecutorService,
-            mockNetworkSettledResourceIdentifier,
-            mockLastInteractionIdentifier,
-            mockSlowFramesListener
+            applicationId = fakeApplicationId,
+            sdkCore = mockSdkCore,
+            sampleRate = 0.0f,
+            backgroundTrackingEnabled = fakeBackgroundTrackingEnabled,
+            trackFrustrations = fakeTrackFrustrations,
+            writer = mockWriter,
+            handler = mockHandler,
+            telemetryEventHandler = mockTelemetryEventHandler,
+            sessionEndedMetricDispatcher = mockSessionEndedMetricDispatcher,
+            firstPartyHostHeaderTypeResolver = mockResolver,
+            cpuVitalMonitor = mockCpuVitalMonitor,
+            memoryVitalMonitor = mockMemoryVitalMonitor,
+            frameRateVitalMonitor = mockFrameRateVitalMonitor,
+            sessionListener = mockSessionListener,
+            executorService = mockExecutorService,
+            initialResourceIdentifier = mockNetworkSettledResourceIdentifier,
+            lastInteractionIdentifier = mockLastInteractionIdentifier,
+            slowFramesListener = mockSlowFramesListener,
+            rumSessionTypeOverride = fakeRumSessionType
         )
 
         val completableFuture = CompletableFuture<String>()
@@ -1667,24 +1677,25 @@ internal class DatadogRumMonitorTest {
         val mockExecutor: ScheduledThreadPoolExecutor = mock()
         whenever(mockExecutor.queue).thenReturn(blockingQueue)
         testedMonitor = DatadogRumMonitor(
-            fakeApplicationId,
-            mockSdkCore,
-            fakeSampleRate,
-            fakeBackgroundTrackingEnabled,
-            fakeTrackFrustrations,
-            mockWriter,
-            mockHandler,
-            mockTelemetryEventHandler,
-            mockSessionEndedMetricDispatcher,
-            mockResolver,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockSessionListener,
-            mockExecutor,
-            mockNetworkSettledResourceIdentifier,
-            mockLastInteractionIdentifier,
-            mockSlowFramesListener
+            applicationId = fakeApplicationId,
+            sdkCore = mockSdkCore,
+            sampleRate = fakeSampleRate,
+            backgroundTrackingEnabled = fakeBackgroundTrackingEnabled,
+            trackFrustrations = fakeTrackFrustrations,
+            writer = mockWriter,
+            handler = mockHandler,
+            telemetryEventHandler = mockTelemetryEventHandler,
+            sessionEndedMetricDispatcher = mockSessionEndedMetricDispatcher,
+            firstPartyHostHeaderTypeResolver = mockResolver,
+            cpuVitalMonitor = mockCpuVitalMonitor,
+            memoryVitalMonitor = mockMemoryVitalMonitor,
+            frameRateVitalMonitor = mockFrameRateVitalMonitor,
+            sessionListener = mockSessionListener,
+            executorService = mockExecutor,
+            initialResourceIdentifier = mockNetworkSettledResourceIdentifier,
+            lastInteractionIdentifier = mockLastInteractionIdentifier,
+            slowFramesListener = mockSlowFramesListener,
+            rumSessionTypeOverride = fakeRumSessionType
         )
 
         // When
@@ -1715,24 +1726,25 @@ internal class DatadogRumMonitorTest {
         // Given
         val mockExecutorService: ExecutorService = mock()
         testedMonitor = DatadogRumMonitor(
-            fakeApplicationId,
-            mockSdkCore,
-            fakeSampleRate,
-            fakeBackgroundTrackingEnabled,
-            fakeTrackFrustrations,
-            mockWriter,
-            mockHandler,
-            mockTelemetryEventHandler,
-            mockSessionEndedMetricDispatcher,
-            mockResolver,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockSessionListener,
-            mockExecutorService,
-            mockNetworkSettledResourceIdentifier,
-            mockLastInteractionIdentifier,
-            mockSlowFramesListener
+            applicationId = fakeApplicationId,
+            sdkCore = mockSdkCore,
+            sampleRate = fakeSampleRate,
+            backgroundTrackingEnabled = fakeBackgroundTrackingEnabled,
+            trackFrustrations = fakeTrackFrustrations,
+            writer = mockWriter,
+            handler = mockHandler,
+            telemetryEventHandler = mockTelemetryEventHandler,
+            sessionEndedMetricDispatcher = mockSessionEndedMetricDispatcher,
+            firstPartyHostHeaderTypeResolver = mockResolver,
+            cpuVitalMonitor = mockCpuVitalMonitor,
+            memoryVitalMonitor = mockMemoryVitalMonitor,
+            frameRateVitalMonitor = mockFrameRateVitalMonitor,
+            sessionListener = mockSessionListener,
+            executorService = mockExecutorService,
+            initialResourceIdentifier = mockNetworkSettledResourceIdentifier,
+            lastInteractionIdentifier = mockLastInteractionIdentifier,
+            slowFramesListener = mockSlowFramesListener,
+            rumSessionTypeOverride = fakeRumSessionType
         )
 
         // When
@@ -1767,7 +1779,8 @@ internal class DatadogRumMonitorTest {
             mockExecutorService,
             mockNetworkSettledResourceIdentifier,
             mockLastInteractionIdentifier,
-            mockSlowFramesListener
+            mockSlowFramesListener,
+            null
         )
         whenever(mockExecutorService.isShutdown).thenReturn(true)
 
@@ -1946,24 +1959,25 @@ internal class DatadogRumMonitorTest {
         testedMonitor.startView(key, name, attributes)
         // Given
         testedMonitor = DatadogRumMonitor(
-            fakeApplicationId,
-            mockSdkCore,
-            100.0f,
-            fakeBackgroundTrackingEnabled,
-            fakeTrackFrustrations,
-            mockWriter,
-            mockHandler,
-            mockTelemetryEventHandler,
-            mockSessionEndedMetricDispatcher,
-            mockResolver,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockSessionListener,
-            mockExecutorService,
-            mockNetworkSettledResourceIdentifier,
-            mockLastInteractionIdentifier,
-            mockSlowFramesListener
+            applicationId = fakeApplicationId,
+            sdkCore = mockSdkCore,
+            sampleRate = 100.0f,
+            backgroundTrackingEnabled = fakeBackgroundTrackingEnabled,
+            trackFrustrations = fakeTrackFrustrations,
+            writer = mockWriter,
+            handler = mockHandler,
+            telemetryEventHandler = mockTelemetryEventHandler,
+            sessionEndedMetricDispatcher = mockSessionEndedMetricDispatcher,
+            firstPartyHostHeaderTypeResolver = mockResolver,
+            cpuVitalMonitor = mockCpuVitalMonitor,
+            memoryVitalMonitor = mockMemoryVitalMonitor,
+            frameRateVitalMonitor = mockFrameRateVitalMonitor,
+            sessionListener = mockSessionListener,
+            executorService = mockExecutorService,
+            initialResourceIdentifier = mockNetworkSettledResourceIdentifier,
+            lastInteractionIdentifier = mockLastInteractionIdentifier,
+            slowFramesListener = mockSlowFramesListener,
+            rumSessionTypeOverride = fakeRumSessionType
         )
         testedMonitor.startView(key, name, attributes)
         // When

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.utils.forge
 
+import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.metric.interactiontonextview.NoOpLastInteractionIdentifier
@@ -66,7 +67,8 @@ internal class ConfigurationRumForgeryFactory :
             ),
             trackAnonymousUser = forge.aBool(),
             composeActionTrackingStrategy = mock(),
-            slowFramesConfiguration = forge.getForgery()
+            slowFramesConfiguration = forge.getForgery(),
+            rumSessionTypeOverride = forge.aNullable { aValueFrom(RumSessionType::class.java) }
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?

We want to be able to force `sessionType=user` for sessions that happen in synthetic tests.

Introducing internal api `_RumInternalProxy.setRumSessionType` that sets `sessionType` that will be propagated to all RUM events regardless of whether we have a synthetic test or not.

The pr is big, but most of the changes are related to using named arguments in various places. For example [this](https://github.com/DataDog/dd-sdk-android/blob/3b18911419de9351ec82ddbfd82a72a530ed7e19/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt#L31) constructor has a lot of arguments of primitive types (`bool`, `long`), one can easily make mistake in order of the items. Also some of them have default values and if I create a new argument in this constructor and place it in the end, I have to provide the values for previous arguments manually.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

