### PR TITLE
[RUM 9903] Updating opentelemetry version

### DIFF
--- a/features/dd-sdk-android-trace-otel/transitiveDependencies
+++ b/features/dd-sdk-android-trace-otel/transitiveDependencies
@@ -1,10 +1,10 @@
 Dependencies List
 
 androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
-io.opentelemetry:opentelemetry-api:1.4.0                        :   78 Kb
-io.opentelemetry:opentelemetry-context:1.4.0                    :   42 Kb
+io.opentelemetry:opentelemetry-api:1.40.0                       :  138 Kb
+io.opentelemetry:opentelemetry-context:1.40.0                   :   46 Kb
 org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              : 1904 Kb
+Total transitive dependencies size                              : 1967 Kb
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -98,9 +98,7 @@ ktorServer = "3.0.0-rc-1"
 
 # Otel
 jctools = "3.3.0"
-openTelemetry = "1.4.0"
-# Only for internal benchmark use
-openTelemetryBenchmark = "1.40.0"
+openTelemetry = "1.40.0"
 re2j = "1.7"
 material3Android = "1.1.2"
 
@@ -269,8 +267,7 @@ ktorClientMock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 # Otel
 jctools = { module = "org.jctools:jctools-core", version.ref = "jctools" }
 openTelemetryApi = { module = "io.opentelemetry:opentelemetry-api", version.ref = "openTelemetry" }
-openTelemetryApiBenchmark = { module = "io.opentelemetry:opentelemetry-api", version.ref = "openTelemetryBenchmark" }
-openTelemetrySdkBenchmark = { module = "io.opentelemetry:opentelemetry-sdk", version.ref = "openTelemetryBenchmark" }
+openTelemetrySdk = { module = "io.opentelemetry:opentelemetry-sdk", version.ref = "openTelemetry" }
 re2j = { module = "com.google.re2j:re2j", version.ref = "re2j" }
 
 [bundles]

--- a/integrations/dd-sdk-android-okhttp-otel/transitiveDependencies
+++ b/integrations/dd-sdk-android-okhttp-otel/transitiveDependencies
@@ -2,8 +2,8 @@ Dependencies List
 
 com.squareup.okhttp3:okhttp:4.12.0                              :  771 Kb
 com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
-io.opentelemetry:opentelemetry-api:1.4.0                        :   78 Kb
-io.opentelemetry:opentelemetry-context:1.4.0                    :   42 Kb
+io.opentelemetry:opentelemetry-api:1.40.0                       :  138 Kb
+io.opentelemetry:opentelemetry-context:1.40.0                   :   46 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
 org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb

--- a/tools/benchmark/build.gradle.kts
+++ b/tools/benchmark/build.gradle.kts
@@ -37,8 +37,8 @@ dependencies {
     implementation(project(":dd-sdk-android-internal"))
     implementation(libs.kotlin)
     implementation(libs.okHttp)
-    implementation(libs.openTelemetryApiBenchmark)
-    implementation(libs.openTelemetrySdkBenchmark)
+    implementation(libs.openTelemetryApi)
+    implementation(libs.openTelemetrySdk)
     implementation(libs.gson)
     testImplementation(project(":tools:unit")) {
         attributes {


### PR DESCRIPTION
### What does this PR do?

- Updating opentelemetry version up to 1.40.0
- Removing separate opentelemetry for benchmark module

### Motivation

1. We was pretty behind (40+ versions) from the latest opentelemetry version. 
2. On the other hand SDK v3 gonna bring many changes and upgrading to 1.40.0 feels bit safer than to the most recent opentelemetry version as we already tested it in benchmark modules. 
3. And last point - we want to reduce the amount of dependencies used in project making benchmarking closer to what we ship to production, so from this moment there will be only one opentelemetry verison for whole project 


### Additional Notes

This branch targets to opentracing-opentelemetry migration branch to be sure that all test passed for the the most recent changes 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

