### PR TITLE
RUM-10316 - properties referencing support

### DIFF
--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReaderTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReaderTest.kt
@@ -80,6 +80,7 @@ class JsonSchemaReaderTest(
                 arrayOf("minimal", Person),
                 arrayOf("required", Product),
                 arrayOf("external_nested_description", Shipping),
+                arrayOf("external_nested_description_properties", Shipping),
                 arrayOf("enum", Style),
                 arrayOf("all_of", User),
                 arrayOf("all_of_merged", UserMerged),

--- a/buildSrc/src/test/resources/input/external_nested_description_properties.json
+++ b/buildSrc/src/test/resources/input/external_nested_description_properties.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Shipping",
+  "type": "object",
+  "properties": {
+    "item": {
+      "type": "string"
+    },
+    "destination": {
+      "$ref": "properties.json#/properties/billing_address"
+    }
+  },
+  "required": [
+    "item",
+    "destination"
+  ]
+}

--- a/buildSrc/src/test/resources/input/properties.json
+++ b/buildSrc/src/test/resources/input/properties.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Customer",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "billing_address": { "$ref": "#/definitions/address" },
+    "shipping_address": { "$ref": "#/definitions/address" }
+  },
+  "definitions": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "street_address": {
+          "type": "string"
+        },
+        "city": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "street_address",
+        "city",
+        "state"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### What does this PR do?

In order to align `os` and `device` properties across different events we need to have single source of truth for `device` and `os` objects. Current `JsonSchemaReader` supports referencing only if referenced object was declared in `definitions` object. 

This PR adds support for referencing object declared in `properties`. Note that only whole object referencing is supported because referencing by id requires name resolution, which makes referenced type a bit different every time it referenced.

see [/external_nested_description_properties.json](https://github.com/DataDog/dd-sdk-android/compare/feature/v3...tvaleev/feature/RUM-10316-properties-ref-support?expand=1#diff-9531c9c12b39b22e54422de1b17ca0bc57ac00185bbe01af4f8ebf65c34d66f4) for example of new syntax supported

### Motivation

We need this change in order to use rum/_common_schema.json as a source for `device` and `os` objects. 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

