### PR TITLE
Fix release checking script

### DIFF
--- a/ci/scripts/check_latest_release_is_published.sh
+++ b/ci/scripts/check_latest_release_is_published.sh
@@ -18,5 +18,6 @@ for artifactId in $(./gradlew -q listAllPublishedArtifactIds); do
     echo "Release $tag_name exists for $artifactId"
   else
     echo "Release $tag_name doesn't exist for $artifactId"
+    exit 1
   fi
 done


### PR DESCRIPTION
### What does this PR do?

I noticed that I removed `exit 1` [here](https://github.com/DataDog/dd-sdk-android/pull/2758) by mistake.

In case release artifact doesn't exist we must fail the script, so that the failure is [reported](https://github.com/DataDog/dd-sdk-android/blob/develop/ci/pipelines/check-release-pipeline.yml#L19) to slack.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

