### PR TITLE
RUM-10958: Fix WindowCallbackWrapper NPE

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/FixedWindowCallback.java
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/FixedWindowCallback.java
@@ -1,0 +1,176 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.instrumentation.gestures;
+
+import android.os.Build;
+import android.view.ActionMode;
+import android.view.KeyEvent;
+import android.view.KeyboardShortcutGroup;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.MotionEvent;
+import android.view.SearchEvent;
+import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
+import android.view.accessibility.AccessibilityEvent;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+import com.datadog.android.lint.InternalApi;
+
+import java.util.List;
+
+/**
+ * A wrapper for {@link Window.Callback} that ensures the callback methods are called.
+ * This is to fix an issue where the system calls {@link #onMenuOpened(int, Menu)}
+ * with a null menu parameter.
+ * To track the issue: https://issuetracker.google.com/issues/188568911
+ */
+@InternalApi
+class FixedWindowCallback implements Window.Callback {
+
+    private final Window.Callback delegate;
+
+    FixedWindowCallback(@NonNull Window.Callback delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean dispatchGenericMotionEvent(MotionEvent event) {
+        return delegate.dispatchGenericMotionEvent(event);
+    }
+
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+        return delegate.dispatchKeyEvent(event);
+    }
+
+    @Override
+    public boolean dispatchKeyShortcutEvent(KeyEvent event) {
+        return delegate.dispatchKeyShortcutEvent(event);
+    }
+
+    @Override
+    public boolean dispatchPopulateAccessibilityEvent(AccessibilityEvent event) {
+        return delegate.dispatchPopulateAccessibilityEvent(event);
+    }
+
+    @Override
+    public boolean dispatchTouchEvent(MotionEvent event) {
+        return delegate.dispatchTouchEvent(event);
+    }
+
+    @Override
+    public boolean dispatchTrackballEvent(MotionEvent event) {
+        return delegate.dispatchTrackballEvent(event);
+    }
+
+    @Override
+    public void onActionModeFinished(ActionMode mode) {
+        delegate.onActionModeFinished(mode);
+    }
+
+    @Override
+    public void onActionModeStarted(ActionMode mode) {
+        delegate.onActionModeStarted(mode);
+    }
+
+    @Override
+    public void onAttachedToWindow() {
+        delegate.onAttachedToWindow();
+    }
+
+    @Override
+    public void onContentChanged() {
+        delegate.onContentChanged();
+    }
+
+    @Override
+    public boolean onCreatePanelMenu(int featureId, @Nullable Menu menu) {
+        return delegate.onCreatePanelMenu(featureId, menu);
+    }
+
+    @Nullable
+    @Override
+    public View onCreatePanelView(int featureId) {
+        return delegate.onCreatePanelView(featureId);
+    }
+
+    @Override
+    public void onDetachedFromWindow() {
+        delegate.onDetachedFromWindow();
+    }
+
+    @Override
+    public boolean onMenuItemSelected(int featureId, @Nullable MenuItem item) {
+        return delegate.onMenuItemSelected(featureId, item);
+    }
+
+    @Override
+    public boolean onMenuOpened(int featureId, @Nullable Menu menu) {
+        return delegate.onMenuOpened(featureId, menu);
+    }
+
+    @Override
+    public void onPanelClosed(int featureId, @Nullable Menu menu) {
+        delegate.onPanelClosed(featureId, menu);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    @Override
+    public void onPointerCaptureChanged(boolean hasCapture) {
+        delegate.onPointerCaptureChanged(hasCapture);
+    }
+
+    @Override
+    public boolean onPreparePanel(int featureId, @Nullable View view, @Nullable Menu menu) {
+        return delegate.onPreparePanel(featureId, view, menu);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    @Override
+    public void onProvideKeyboardShortcuts(List<KeyboardShortcutGroup> data, @Nullable Menu menu, int deviceId) {
+        delegate.onProvideKeyboardShortcuts(data, menu, deviceId);
+    }
+
+    @Override
+    public boolean onSearchRequested() {
+        return delegate.onSearchRequested();
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    @Override
+    public boolean onSearchRequested(SearchEvent searchEvent) {
+        return delegate.onSearchRequested(searchEvent);
+    }
+
+    @Override
+    public void onWindowAttributesChanged(WindowManager.LayoutParams attrs) {
+        delegate.onWindowAttributesChanged(attrs);
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        delegate.onWindowFocusChanged(hasFocus);
+    }
+
+    @Nullable
+    @Override
+    public ActionMode onWindowStartingActionMode(ActionMode.Callback callback) {
+        return delegate.onWindowStartingActionMode(callback);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    @Nullable
+    @Override
+    public ActionMode onWindowStartingActionMode(ActionMode.Callback callback, int type) {
+        return delegate.onWindowStartingActionMode(callback, type);
+    }
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapper.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapper.kt
@@ -19,7 +19,6 @@ import com.datadog.android.rum.internal.tracking.NoOpInteractionPredicate
 import com.datadog.android.rum.tracking.InteractionPredicate
 import com.datadog.android.rum.tracking.ViewAttributesProvider
 import java.lang.ref.WeakReference
-import kotlin.Exception
 
 @Suppress("TooGenericExceptionCaught")
 internal class WindowCallbackWrapper(
@@ -34,7 +33,7 @@ internal class WindowCallbackWrapper(
     },
     val targetAttributesProviders: Array<ViewAttributesProvider> = emptyArray(),
     val internalLogger: InternalLogger
-) : Window.Callback by wrappedCallback {
+) : FixedWindowCallback(wrappedCallback) {
 
     internal val windowReference = WeakReference(window)
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapperTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapperTest.kt
@@ -8,11 +8,17 @@ package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.app.Application
 import android.content.res.Resources
+import android.view.ActionMode
 import android.view.KeyEvent
+import android.view.KeyboardShortcutGroup
+import android.view.Menu
 import android.view.MenuItem
 import android.view.MotionEvent
+import android.view.SearchEvent
 import android.view.View
 import android.view.Window
+import android.view.WindowManager
+import android.view.accessibility.AccessibilityEvent
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
@@ -34,12 +40,14 @@ import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
@@ -717,6 +725,414 @@ internal class WindowCallbackWrapperTest {
                 }
             )
         }
+    }
+
+    // endregion
+
+    // region Delegated Window.Callback methods
+
+    @Test
+    fun `M delegate W dispatchKeyShortcutEvent`(
+        @BoolForgery result: Boolean
+    ) {
+        // Given
+        val keyEvent = mock<KeyEvent>()
+        whenever(mockCallback.dispatchKeyShortcutEvent(keyEvent)).thenReturn(result)
+
+        // When
+        val actualResult = testedWrapper.dispatchKeyShortcutEvent(keyEvent)
+
+        // Then
+        verify(mockCallback).dispatchKeyShortcutEvent(keyEvent)
+        assertThat(actualResult).isEqualTo(result)
+    }
+
+    @Test
+    fun `M delegate W dispatchTrackballEvent`(
+        @BoolForgery result: Boolean
+    ) {
+        // Given
+        val motionEvent = mock<MotionEvent>()
+        whenever(mockCallback.dispatchTrackballEvent(motionEvent)).thenReturn(result)
+
+        // When
+        val actualResult = testedWrapper.dispatchTrackballEvent(motionEvent)
+
+        // Then
+        verify(mockCallback).dispatchTrackballEvent(motionEvent)
+        assertThat(actualResult).isEqualTo(result)
+    }
+
+    @Test
+    fun `M delegate W dispatchGenericMotionEvent`(
+        @BoolForgery result: Boolean
+    ) {
+        // Given
+        val motionEvent = mock<MotionEvent>()
+        whenever(mockCallback.dispatchGenericMotionEvent(motionEvent)).thenReturn(result)
+
+        // When
+        val actualResult = testedWrapper.dispatchGenericMotionEvent(motionEvent)
+
+        // Then
+        verify(mockCallback).dispatchGenericMotionEvent(motionEvent)
+        assertThat(actualResult).isEqualTo(result)
+    }
+
+    @Test
+    fun `M delegate W dispatchPopulateAccessibilityEvent`(
+        @BoolForgery result: Boolean
+    ) {
+        // Given
+        val accessibilityEvent = mock<AccessibilityEvent>()
+        whenever(mockCallback.dispatchPopulateAccessibilityEvent(accessibilityEvent)).thenReturn(
+            result
+        )
+
+        // When
+        val actualResult = testedWrapper.dispatchPopulateAccessibilityEvent(accessibilityEvent)
+
+        // Then
+        verify(mockCallback).dispatchPopulateAccessibilityEvent(accessibilityEvent)
+        assertThat(actualResult).isEqualTo(result)
+    }
+
+    @Test
+    fun `M delegate W onCreatePanelView`(
+        @IntForgery featureId: Int
+    ) {
+        // Given
+        val mockView: View = mock()
+        whenever(mockCallback.onCreatePanelView(featureId)).thenReturn(mockView)
+
+        // When
+        val resultView = testedWrapper.onCreatePanelView(featureId)
+
+        // Then
+        verify(mockCallback).onCreatePanelView(featureId)
+        assertThat(resultView).isSameAs(mockView)
+    }
+
+    @Test
+    fun `M delegate W onCreatePanelView {null result}`(
+        @IntForgery featureId: Int
+    ) {
+        // Given
+        whenever(mockCallback.onCreatePanelView(featureId)).thenReturn(null)
+
+        // When
+        val resultView = testedWrapper.onCreatePanelView(featureId)
+
+        // Then
+        verify(mockCallback).onCreatePanelView(featureId)
+        assertThat(resultView).isNull()
+    }
+
+    @Test
+    fun `M delegate W onCreatePanelMenu`(
+        @IntForgery featureId: Int,
+        @BoolForgery result: Boolean
+    ) {
+        // Given
+        val mockMenu = mock<Menu>()
+        whenever(mockCallback.onCreatePanelMenu(featureId, mockMenu)).thenReturn(result)
+
+        // When
+        val actualResult = testedWrapper.onCreatePanelMenu(featureId, mockMenu)
+
+        // Then
+        verify(mockCallback).onCreatePanelMenu(featureId, mockMenu)
+        assertThat(actualResult).isEqualTo(result)
+    }
+
+    @Test
+    fun `M delegate W onPreparePanel`(
+        @IntForgery featureId: Int,
+        @BoolForgery result: Boolean
+    ) {
+        // Given
+        val mockView: View = mock()
+        val mockMenu = mock<Menu>()
+        whenever(mockCallback.onPreparePanel(featureId, mockView, mockMenu)).thenReturn(result)
+
+        // When
+        val actualResult = testedWrapper.onPreparePanel(featureId, mockView, mockMenu)
+
+        // Then
+        verify(mockCallback).onPreparePanel(featureId, mockView, mockMenu)
+        assertThat(actualResult).isEqualTo(result)
+    }
+
+    @Test
+    fun `M delegate W onPreparePanel {null view}`(
+        @IntForgery featureId: Int,
+        @BoolForgery result: Boolean
+    ) {
+        // Given
+        val mockMenu = mock<Menu>()
+        whenever(mockCallback.onPreparePanel(featureId, null, mockMenu)).thenReturn(result)
+
+        // When
+        val actualResult = testedWrapper.onPreparePanel(featureId, null, mockMenu)
+
+        // Then
+        verify(mockCallback).onPreparePanel(featureId, null, mockMenu)
+        assertThat(actualResult).isEqualTo(result)
+    }
+
+    @Test
+    fun `M not crash W onMenuOpened {menu is null}`(
+        @IntForgery featureId: Int,
+        @BoolForgery result: Boolean
+    ) {
+        // Given
+        whenever(mockCallback.onMenuOpened(eq(featureId), any())).thenReturn(result)
+
+        // When
+        val mockMenu: Menu? = null
+
+        // Then
+        assertDoesNotThrow {
+            testedWrapper.onMenuOpened(featureId, mockMenu)
+        }
+    }
+
+    @Test
+    fun `M delegate W onMenuOpened`(
+        @IntForgery featureId: Int,
+        @BoolForgery result: Boolean
+    ) {
+        // Given
+        val mockMenu = mock<Menu>()
+        whenever(mockCallback.onMenuOpened(featureId, mockMenu)).thenReturn(result)
+
+        // When
+        val actualResult = testedWrapper.onMenuOpened(featureId, mockMenu)
+
+        // Then
+        verify(mockCallback).onMenuOpened(featureId, mockMenu)
+        assertThat(actualResult).isEqualTo(result)
+    }
+
+    @Test
+    fun `M delegate W onWindowAttributesChanged`() {
+        // Given
+        val params = mock<WindowManager.LayoutParams>()
+
+        // When
+        testedWrapper.onWindowAttributesChanged(params)
+
+        // Then
+        verify(mockCallback).onWindowAttributesChanged(params)
+    }
+
+    @Test
+    fun `M delegate W onContentChanged`() {
+        // When
+        testedWrapper.onContentChanged()
+
+        // Then
+        verify(mockCallback).onContentChanged()
+    }
+
+    @Test
+    fun `M delegate W onWindowFocusChanged`(
+        @BoolForgery hasFocus: Boolean
+    ) {
+        // When
+        testedWrapper.onWindowFocusChanged(hasFocus)
+
+        // Then
+        verify(mockCallback).onWindowFocusChanged(hasFocus)
+    }
+
+    @Test
+    fun `M delegate W onAttachedToWindow`() {
+        // When
+        testedWrapper.onAttachedToWindow()
+
+        // Then
+        verify(mockCallback).onAttachedToWindow()
+    }
+
+    @Test
+    fun `M delegate W onDetachedFromWindow`() {
+        // When
+        testedWrapper.onDetachedFromWindow()
+
+        // Then
+        verify(mockCallback).onDetachedFromWindow()
+    }
+
+    @Test
+    fun `M delegate W onPanelClosed`(
+        @IntForgery featureId: Int
+    ) {
+        // Given
+        val mockMenu = mock<Menu>()
+
+        // When
+        testedWrapper.onPanelClosed(featureId, mockMenu)
+
+        // Then
+        verify(mockCallback).onPanelClosed(featureId, mockMenu)
+    }
+
+    @Test
+    fun `M delegate W onSearchRequested`(
+        @BoolForgery result: Boolean
+    ) {
+        // Given
+        whenever(mockCallback.onSearchRequested()).thenReturn(result)
+
+        // When
+        val actualResult = testedWrapper.onSearchRequested()
+
+        // Then
+        verify(mockCallback).onSearchRequested()
+        assertThat(actualResult).isEqualTo(result)
+    }
+
+    @Test
+    fun `M delegate W onSearchRequested with event`(
+        @BoolForgery result: Boolean
+    ) {
+        // Given
+        val searchEvent = mock<SearchEvent>()
+        whenever(mockCallback.onSearchRequested(searchEvent)).thenReturn(result)
+
+        // When
+        val actualResult = testedWrapper.onSearchRequested(searchEvent)
+
+        // Then
+        verify(mockCallback).onSearchRequested(searchEvent)
+        assertThat(actualResult).isEqualTo(result)
+    }
+
+    @Test
+    fun `M delegate W onWindowStartingActionMode`() {
+        // Given
+        val callback = mock<ActionMode.Callback>()
+        val mockActionMode: ActionMode = mock()
+        whenever(mockCallback.onWindowStartingActionMode(callback)).thenReturn(mockActionMode)
+
+        // When
+        val resultActionMode = testedWrapper.onWindowStartingActionMode(callback)
+
+        // Then
+        verify(mockCallback).onWindowStartingActionMode(callback)
+        assertThat(resultActionMode).isSameAs(mockActionMode)
+    }
+
+    @Test
+    fun `M delegate W onWindowStartingActionMode {null result}`() {
+        // Given
+        val callback = mock<ActionMode.Callback>()
+        whenever(mockCallback.onWindowStartingActionMode(callback)).thenReturn(null)
+
+        // When
+        val resultActionMode = testedWrapper.onWindowStartingActionMode(callback)
+
+        // Then
+        verify(mockCallback).onWindowStartingActionMode(callback)
+        assertThat(resultActionMode).isNull()
+    }
+
+    @Test
+    fun `M delegate W onWindowStartingActionMode with type`(
+        @IntForgery type: Int
+    ) {
+        // Given
+        val callback = mock<ActionMode.Callback>()
+        val mockActionMode: ActionMode = mock()
+        whenever(mockCallback.onWindowStartingActionMode(callback, type)).thenReturn(mockActionMode)
+
+        // When
+        val resultActionMode = testedWrapper.onWindowStartingActionMode(callback, type)
+
+        // Then
+        verify(mockCallback).onWindowStartingActionMode(callback, type)
+        assertThat(resultActionMode).isSameAs(mockActionMode)
+    }
+
+    @Test
+    fun `M delegate W onWindowStartingActionMode with type {null result}`(
+        @IntForgery type: Int
+    ) {
+        // Given
+        val callback = mock<ActionMode.Callback>()
+        whenever(mockCallback.onWindowStartingActionMode(callback, type)).thenReturn(null)
+
+        // When
+        val resultActionMode = testedWrapper.onWindowStartingActionMode(callback, type)
+
+        // Then
+        verify(mockCallback).onWindowStartingActionMode(callback, type)
+        assertThat(resultActionMode).isNull()
+    }
+
+    @Test
+    fun `M delegate W onActionModeStarted`() {
+        // Given
+        val mode = mock<ActionMode>()
+
+        // When
+        testedWrapper.onActionModeStarted(mode)
+
+        // Then
+        verify(mockCallback).onActionModeStarted(mode)
+    }
+
+    @Test
+    fun `M delegate W onActionModeFinished`() {
+        // Given
+        val mode = mock<ActionMode>()
+
+        // When
+        testedWrapper.onActionModeFinished(mode)
+
+        // Then
+        verify(mockCallback).onActionModeFinished(mode)
+    }
+
+    @Test
+    fun `M delegate W onProvideKeyboardShortcuts`(
+        @IntForgery deviceId: Int
+    ) {
+        // Given
+        val mockMenu = mock<Menu>() // or null
+        val mockData: List<KeyboardShortcutGroup> = listOf(mock())
+
+        // When
+        testedWrapper.onProvideKeyboardShortcuts(mockData, mockMenu, deviceId)
+
+        // Then
+        verify(mockCallback).onProvideKeyboardShortcuts(eq(mockData), eq(mockMenu), eq(deviceId))
+    }
+
+    @Test
+    fun `M delegate W onProvideKeyboardShortcuts {null menu}`(
+        @IntForgery deviceId: Int
+    ) {
+        // Given
+        val mockData: List<KeyboardShortcutGroup> = listOf(mock())
+
+        // When
+        testedWrapper.onProvideKeyboardShortcuts(mockData, null, deviceId)
+
+        // Then
+        verify(mockCallback).onProvideKeyboardShortcuts(eq(mockData), eq(null), eq(deviceId))
+    }
+
+    @Test
+    fun `M delegate W onPointerCaptureChanged`(
+        @BoolForgery hasCapture: Boolean
+    ) {
+        // When
+        testedWrapper.onPointerCaptureChanged(hasCapture)
+
+        // Then
+        verify(mockCallback).onPointerCaptureChanged(hasCapture)
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

Due to a system issue: https://issuetracker.google.com/issues/188568911

A null `menu` argument can be passed into a `@NonNull` java function of `Window.Callback`, 
and since our `WindowCallbackWrapper` delegates from this interface, kotlin function will check nullability then causes the crash.

The fix is to tweak the `@NonNull` declaration to `@Nullable` to get away with Kotlin nullable check.

### Motivation

RUM-10958

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

