### PR TITLE
RUM-10928: Fix Compose actions tracking telemetry error

### DIFF
--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeUtils.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeUtils.kt
@@ -92,7 +92,7 @@ internal class LayoutNodeUtils {
         return runSafe {
             val roleField = obj::class.java.getDeclaredField("role")
             roleField.isAccessible = true
-            roleField.get(obj) as? Role
+            roleField.get(obj) as? Role?
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

This PR removes the telemetry error "java.lang.NullPointerException: null cannot be cast to non-null type androidx.compose.ui.semantics.Role" by replacing `as? Role` to `as? Role?`. 
Because some `ModifierElement` just don't have `Role` field and we just want to try our luck if some of them can contain `Role` information, if it doesn't we can just skip it. 

### Motivation

RUM-10928

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

