### PR TITLE
RUM-11121: Make accessibility send only mutations

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -629,6 +629,7 @@ datadog:
       - "com.google.gson.JsonArray.map(kotlin.Function1)"
       - "com.google.gson.JsonArray.size()"
       - "com.google.gson.JsonObject.add(kotlin.String?, com.google.gson.JsonElement?)"
+      - "com.google.gson.JsonObject.addProperty(kotlin.String?, kotlin.Boolean?)"
       - "com.google.gson.JsonObject.addProperty(kotlin.String?, kotlin.Number?)"
       - "com.google.gson.JsonObject.addProperty(kotlin.String?, kotlin.String?)"
       - "com.google.gson.JsonObject.constructor()"

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -70,6 +70,7 @@ data class com.datadog.android.rum.RumConfiguration
   class Builder
     constructor(String)
     fun setSessionSampleRate(Float): Builder
+    fun collectAccessibility(Boolean): Builder
     fun setTelemetrySampleRate(Float): Builder
     fun trackUserInteractions(Array<com.datadog.android.rum.tracking.ViewAttributesProvider> = emptyArray(), com.datadog.android.rum.tracking.InteractionPredicate = NoOpInteractionPredicate()): Builder
     fun disableUserInteractionTracking(): Builder
@@ -174,7 +175,6 @@ class com.datadog.android.rum._RumInternalProxy
     fun setAdditionalConfiguration(com.datadog.android.rum.RumConfiguration.Builder, Map<String, Any>): com.datadog.android.rum.RumConfiguration.Builder
     fun setComposeActionTrackingStrategy(com.datadog.android.rum.RumConfiguration.Builder, com.datadog.android.rum.tracking.ActionTrackingStrategy): com.datadog.android.rum.RumConfiguration.Builder
     fun setRumSessionTypeOverride(com.datadog.android.rum.RumConfiguration.Builder, RumSessionType): com.datadog.android.rum.RumConfiguration.Builder
-    fun collectAccessibilitySettings(com.datadog.android.rum.RumConfiguration.Builder): com.datadog.android.rum.RumConfiguration.Builder
 data class com.datadog.android.rum.configuration.SlowFramesConfiguration
   constructor(Int = DEFAULT_SLOW_FRAME_RECORDS_MAX_AMOUNT, Long = DEFAULT_FROZEN_FRAME_THRESHOLD_NS, Long = DEFAULT_CONTINUOUS_SLOW_FRAME_THRESHOLD_NS, Long = DEFAULT_FREEZE_DURATION_NS, Long = DEFAULT_VIEW_LIFETIME_THRESHOLD_NS)
   companion object 

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -1696,7 +1696,7 @@ data class com.datadog.android.rum.model.RumVitalEvent
       fun fromJson(kotlin.String): Container
       fun fromJsonObject(com.google.gson.JsonObject): Container
   data class RumVitalEventVital
-    constructor(RumVitalEventVitalType, kotlin.String, kotlin.String? = null, kotlin.String? = null, kotlin.Number? = null, Custom? = null)
+    constructor(RumVitalEventVitalType, kotlin.String, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Number? = null, Custom? = null, StepType? = null, FailureReason? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): RumVitalEventVital
@@ -1810,9 +1810,27 @@ data class com.datadog.android.rum.model.RumVitalEvent
   enum RumVitalEventVitalType
     constructor(kotlin.String)
     - DURATION
+    - STEP
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): RumVitalEventVitalType
+  enum StepType
+    constructor(kotlin.String)
+    - START
+    - UPDATE
+    - RETRY
+    - END
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): StepType
+  enum FailureReason
+    constructor(kotlin.String)
+    - ERROR
+    - ABANDONED
+    - OTHER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): FailureReason
   enum Plan
     constructor(kotlin.Number)
     - PLAN_1
@@ -1833,7 +1851,7 @@ data class com.datadog.android.rum.model.RumVitalEvent
     companion object 
       fun fromJson(kotlin.String): SessionPrecondition
 data class com.datadog.android.rum.model.ViewAccessibilityProperties
-  constructor(kotlin.String? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null)
+  constructor(kotlin.String? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null)
   fun toJson(): com.google.gson.JsonElement
   companion object 
     fun fromJson(kotlin.String): ViewAccessibilityProperties
@@ -2009,7 +2027,7 @@ data class com.datadog.android.rum.model.ViewEvent
       fun fromJson(kotlin.String): Performance
       fun fromJsonObject(com.google.gson.JsonObject): Performance
   data class Accessibility
-    constructor(kotlin.String? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null)
+    constructor(kotlin.String? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Accessibility

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -5051,6 +5051,21 @@ public final class com/datadog/android/rum/model/RumVitalEvent$EffectiveType$Com
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$EffectiveType;
 }
 
+public final class com/datadog/android/rum/model/RumVitalEvent$FailureReason : java/lang/Enum {
+	public static final field ABANDONED Lcom/datadog/android/rum/model/RumVitalEvent$FailureReason;
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$FailureReason$Companion;
+	public static final field ERROR Lcom/datadog/android/rum/model/RumVitalEvent$FailureReason;
+	public static final field OTHER Lcom/datadog/android/rum/model/RumVitalEvent$FailureReason;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$FailureReason;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$FailureReason;
+	public static fun values ()[Lcom/datadog/android/rum/model/RumVitalEvent$FailureReason;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$FailureReason$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$FailureReason;
+}
+
 public final class com/datadog/android/rum/model/RumVitalEvent$Interface : java/lang/Enum {
 	public static final field BLUETOOTH Lcom/datadog/android/rum/model/RumVitalEvent$Interface;
 	public static final field CELLULAR Lcom/datadog/android/rum/model/RumVitalEvent$Interface;
@@ -5205,24 +5220,30 @@ public final class com/datadog/android/rum/model/RumVitalEvent$RumVitalEventView
 
 public final class com/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital {
 	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital$Companion;
-	public fun <init> (Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/RumVitalEvent$Custom;)V
-	public synthetic fun <init> (Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/RumVitalEvent$Custom;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/RumVitalEvent$Custom;Lcom/datadog/android/rum/model/RumVitalEvent$StepType;Lcom/datadog/android/rum/model/RumVitalEvent$FailureReason;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/RumVitalEvent$Custom;Lcom/datadog/android/rum/model/RumVitalEvent$StepType;Lcom/datadog/android/rum/model/RumVitalEvent$FailureReason;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/Number;
-	public final fun component6 ()Lcom/datadog/android/rum/model/RumVitalEvent$Custom;
-	public final fun copy (Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/RumVitalEvent$Custom;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/RumVitalEvent$Custom;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Number;
+	public final fun component7 ()Lcom/datadog/android/rum/model/RumVitalEvent$Custom;
+	public final fun component8 ()Lcom/datadog/android/rum/model/RumVitalEvent$StepType;
+	public final fun component9 ()Lcom/datadog/android/rum/model/RumVitalEvent$FailureReason;
+	public final fun copy (Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/RumVitalEvent$Custom;Lcom/datadog/android/rum/model/RumVitalEvent$StepType;Lcom/datadog/android/rum/model/RumVitalEvent$FailureReason;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/RumVitalEvent$Custom;Lcom/datadog/android/rum/model/RumVitalEvent$StepType;Lcom/datadog/android/rum/model/RumVitalEvent$FailureReason;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVital;
 	public final fun getCustom ()Lcom/datadog/android/rum/model/RumVitalEvent$Custom;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getDuration ()Ljava/lang/Number;
+	public final fun getFailureReason ()Lcom/datadog/android/rum/model/RumVitalEvent$FailureReason;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
+	public final fun getParentId ()Ljava/lang/String;
+	public final fun getStepType ()Lcom/datadog/android/rum/model/RumVitalEvent$StepType;
 	public final fun getType ()Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
@@ -5237,6 +5258,7 @@ public final class com/datadog/android/rum/model/RumVitalEvent$RumVitalEventVita
 public final class com/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType : java/lang/Enum {
 	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType$Companion;
 	public static final field DURATION Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;
+	public static final field STEP Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$RumVitalEventVitalType;
@@ -5279,6 +5301,22 @@ public final class com/datadog/android/rum/model/RumVitalEvent$Status : java/lan
 
 public final class com/datadog/android/rum/model/RumVitalEvent$Status$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$Status;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$StepType : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/rum/model/RumVitalEvent$StepType$Companion;
+	public static final field END Lcom/datadog/android/rum/model/RumVitalEvent$StepType;
+	public static final field RETRY Lcom/datadog/android/rum/model/RumVitalEvent$StepType;
+	public static final field START Lcom/datadog/android/rum/model/RumVitalEvent$StepType;
+	public static final field UPDATE Lcom/datadog/android/rum/model/RumVitalEvent$StepType;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$StepType;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$StepType;
+	public static fun values ()[Lcom/datadog/android/rum/model/RumVitalEvent$StepType;
+}
+
+public final class com/datadog/android/rum/model/RumVitalEvent$StepType$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumVitalEvent$StepType;
 }
 
 public final class com/datadog/android/rum/model/RumVitalEvent$Synthetics {
@@ -5361,8 +5399,8 @@ public final class com/datadog/android/rum/model/RumVitalEvent$Viewport$Companio
 public final class com/datadog/android/rum/model/ViewAccessibilityProperties {
 	public static final field Companion Lcom/datadog/android/rum/model/ViewAccessibilityProperties$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ljava/lang/Boolean;
 	public final fun component11 ()Ljava/lang/Boolean;
@@ -5377,6 +5415,7 @@ public final class com/datadog/android/rum/model/ViewAccessibilityProperties {
 	public final fun component2 ()Ljava/lang/Boolean;
 	public final fun component20 ()Ljava/lang/Boolean;
 	public final fun component21 ()Ljava/lang/Boolean;
+	public final fun component22 ()Ljava/lang/Boolean;
 	public final fun component3 ()Ljava/lang/Boolean;
 	public final fun component4 ()Ljava/lang/Boolean;
 	public final fun component5 ()Ljava/lang/Boolean;
@@ -5384,8 +5423,8 @@ public final class com/datadog/android/rum/model/ViewAccessibilityProperties {
 	public final fun component7 ()Ljava/lang/Boolean;
 	public final fun component8 ()Ljava/lang/Boolean;
 	public final fun component9 ()Ljava/lang/Boolean;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lcom/datadog/android/rum/model/ViewAccessibilityProperties;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewAccessibilityProperties;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewAccessibilityProperties;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lcom/datadog/android/rum/model/ViewAccessibilityProperties;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewAccessibilityProperties;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewAccessibilityProperties;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewAccessibilityProperties;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewAccessibilityProperties;
@@ -5402,6 +5441,7 @@ public final class com/datadog/android/rum/model/ViewAccessibilityProperties {
 	public final fun getReduceMotionEnabled ()Ljava/lang/Boolean;
 	public final fun getReduceTransparencyEnabled ()Ljava/lang/Boolean;
 	public final fun getReducedAnimationsEnabled ()Ljava/lang/Boolean;
+	public final fun getRtlEnabled ()Ljava/lang/Boolean;
 	public final fun getScreenReaderEnabled ()Ljava/lang/Boolean;
 	public final fun getShakeToUndoEnabled ()Ljava/lang/Boolean;
 	public final fun getShouldDifferentiateWithoutColor ()Ljava/lang/Boolean;
@@ -5484,8 +5524,8 @@ public final class com/datadog/android/rum/model/ViewEvent {
 public final class com/datadog/android/rum/model/ViewEvent$Accessibility {
 	public static final field Companion Lcom/datadog/android/rum/model/ViewEvent$Accessibility$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ljava/lang/Boolean;
 	public final fun component11 ()Ljava/lang/Boolean;
@@ -5500,6 +5540,7 @@ public final class com/datadog/android/rum/model/ViewEvent$Accessibility {
 	public final fun component2 ()Ljava/lang/Boolean;
 	public final fun component20 ()Ljava/lang/Boolean;
 	public final fun component21 ()Ljava/lang/Boolean;
+	public final fun component22 ()Ljava/lang/Boolean;
 	public final fun component3 ()Ljava/lang/Boolean;
 	public final fun component4 ()Ljava/lang/Boolean;
 	public final fun component5 ()Ljava/lang/Boolean;
@@ -5507,8 +5548,8 @@ public final class com/datadog/android/rum/model/ViewEvent$Accessibility {
 	public final fun component7 ()Ljava/lang/Boolean;
 	public final fun component8 ()Ljava/lang/Boolean;
 	public final fun component9 ()Ljava/lang/Boolean;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lcom/datadog/android/rum/model/ViewEvent$Accessibility;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewEvent$Accessibility;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewEvent$Accessibility;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lcom/datadog/android/rum/model/ViewEvent$Accessibility;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewEvent$Accessibility;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewEvent$Accessibility;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$Accessibility;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewEvent$Accessibility;
@@ -5525,6 +5566,7 @@ public final class com/datadog/android/rum/model/ViewEvent$Accessibility {
 	public final fun getReduceMotionEnabled ()Ljava/lang/Boolean;
 	public final fun getReduceTransparencyEnabled ()Ljava/lang/Boolean;
 	public final fun getReducedAnimationsEnabled ()Ljava/lang/Boolean;
+	public final fun getRtlEnabled ()Ljava/lang/Boolean;
 	public final fun getScreenReaderEnabled ()Ljava/lang/Boolean;
 	public final fun getShakeToUndoEnabled ()Ljava/lang/Boolean;
 	public final fun getShouldDifferentiateWithoutColor ()Ljava/lang/Boolean;

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -104,6 +104,7 @@ public final class com/datadog/android/rum/RumConfiguration {
 public final class com/datadog/android/rum/RumConfiguration$Builder {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun build ()Lcom/datadog/android/rum/RumConfiguration;
+	public final fun collectAccessibility (Z)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun disableUserInteractionTracking ()Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setActionEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setErrorEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
@@ -253,7 +254,6 @@ public final class com/datadog/android/rum/_RumInternalProxy {
 }
 
 public final class com/datadog/android/rum/_RumInternalProxy$Companion {
-	public final fun collectAccessibilitySettings (Lcom/datadog/android/rum/RumConfiguration$Builder;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setAdditionalConfiguration (Lcom/datadog/android/rum/RumConfiguration$Builder;Ljava/util/Map;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setComposeActionTrackingStrategy (Lcom/datadog/android/rum/RumConfiguration$Builder;Lcom/datadog/android/rum/tracking/ActionTrackingStrategy;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setRumSessionTypeOverride (Lcom/datadog/android/rum/RumConfiguration$Builder;Lcom/datadog/android/rum/RumSessionType;)Lcom/datadog/android/rum/RumConfiguration$Builder;

--- a/features/dd-sdk-android-rum/src/main/json/rum/_view-accessibility-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/_view-accessibility-schema.json
@@ -110,6 +110,11 @@
       "type": "boolean",
       "description": "Indicates whether the text-to-speech selection feature is enabled.",
       "readOnly": true
+    },
+    "rtl_enabled": {
+      "type": "boolean",
+      "description": "Indicates whether the right-to-left support is enabled.",
+      "readOnly": true
     }
   }
 }

--- a/features/dd-sdk-android-rum/src/main/json/rum/vital-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/vital-schema.json
@@ -28,12 +28,18 @@
             "type": {
               "type": "string",
               "description": "Type of the vital",
-              "enum": ["duration"],
+              "enum": ["duration", "step"],
               "readOnly": true
             },
             "id": {
               "type": "string",
               "description": "UUID of the vital",
+              "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+              "readOnly": true
+            },
+            "parent_id": {
+              "type": "string",
+              "description": "UUID for linking the step vital to the parent event, if applicable",
               "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
               "readOnly": true
             },
@@ -60,6 +66,18 @@
                 "minimum": 0,
                 "readOnly": true
               },
+              "readOnly": true
+            },
+            "step_type": {
+              "type": "string",
+              "description": "Type of the step that triggered the vital, if applicable",
+              "enum": ["start", "update", "retry", "end"],
+              "readOnly": true
+            },
+            "failure_reason": {
+              "type": "string",
+              "description": "Reason for the failure of the step, if applicable",
+              "enum": ["error", "abandoned", "other"],
               "readOnly": true
             }
           },

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
@@ -141,7 +141,7 @@ object Rum {
             lastInteractionIdentifier = rumFeature.lastInteractionIdentifier,
             slowFramesListener = rumFeature.slowFramesListener,
             rumSessionTypeOverride = rumFeature.configuration.rumSessionTypeOverride,
-            accessibilityReader = rumFeature.accessibilityReader
+            accessibilitySnapshotManager = rumFeature.accessibilitySnapshotManager
         )
     }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
@@ -60,6 +60,17 @@ data class RumConfiguration internal constructor(
         }
 
         /**
+         * Whether to collect accessibility attributes inside the RUM view update event.
+         * This is disabled by default.
+         *
+         * @param enabled whether collecting accessibility attributes is enabled or not.
+         */
+        fun collectAccessibility(enabled: Boolean): Builder {
+            rumConfig = rumConfig.copy(collectAccessibility = enabled)
+            return this
+        }
+
+        /**
          * Sets the sample rate for Internal Telemetry (info related to the work of the
          * SDK internals). Default value is 20.
          *
@@ -387,15 +398,5 @@ data class RumConfiguration internal constructor(
             rumConfig = rumConfig.copy(rumSessionTypeOverride = rumSessionTypeOverride)
             return this
         }
-
-        /**
-         * Sets a flag to collect accessibility settings inside the RUM view end event.
-         * By default these settings are not collected.
-         */
-        internal fun collectAccessibilitySettings(): Builder {
-            rumConfig = rumConfig.copy(collectAccessibilitySettings = true)
-            return this
-        }
-        // endregion
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
@@ -115,11 +115,5 @@ class _RumInternalProxy internal constructor(private val rumMonitor: AdvancedRum
         ): Builder {
             return builder.setRumSessionTypeOverride(rumSessionTypeOverride)
         }
-
-        fun collectAccessibilitySettings(
-            builder: Builder
-        ): Builder {
-            return builder.collectAccessibilitySettings()
-        }
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -165,9 +165,11 @@ internal class RumFeature(
     override fun onInitialize(appContext: Context) {
         this.appContext = appContext
 
-        accessibilityReader =
-            DatadogAccessibilityReader(applicationContext = appContext, internalLogger = sdkCore.internalLogger)
-        accessibilitySnapshotManager = DefaultAccessibilitySnapshotManager(accessibilityReader)
+        if (configuration.collectAccessibility) {
+            accessibilityReader =
+                DatadogAccessibilityReader(applicationContext = appContext, internalLogger = sdkCore.internalLogger)
+            accessibilitySnapshotManager = DefaultAccessibilitySnapshotManager(accessibilityReader)
+        }
 
         initialResourceIdentifier = configuration.initialResourceIdentifier
         lastInteractionIdentifier = configuration.lastInteractionIdentifier
@@ -303,7 +305,12 @@ internal class RumFeature(
         anrDetectorRunnable?.stop()
         vitalExecutorService = NoOpScheduledExecutorService()
         sessionListener = NoOpRumSessionListener()
-        accessibilityReader.cleanup()
+
+        if (configuration.collectAccessibility) {
+            accessibilityReader.cleanup()
+            accessibilityReader = NoOpAccessibilityReader()
+            accessibilitySnapshotManager = NoOpAccessibilitySnapshotManager()
+        }
 
         GlobalRumMonitor.unregister(sdkCore)
     }
@@ -647,7 +654,7 @@ internal class RumFeature(
         val additionalConfig: Map<String, Any>,
         val trackAnonymousUser: Boolean,
         val rumSessionTypeOverride: RumSessionType?,
-        val collectAccessibilitySettings: Boolean
+        val collectAccessibility: Boolean
     )
 
     internal companion object {
@@ -698,7 +705,7 @@ internal class RumFeature(
             trackAnonymousUser = true,
             slowFramesConfiguration = null,
             rumSessionTypeOverride = null,
-            collectAccessibilitySettings = false
+            collectAccessibility = false
         )
 
         internal const val EVENT_MESSAGE_PROPERTY = "message"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -44,8 +44,11 @@ import com.datadog.android.rum.internal.anr.ANRDetectorRunnable
 import com.datadog.android.rum.internal.debug.UiRumDebugListener
 import com.datadog.android.rum.internal.domain.RumDataWriter
 import com.datadog.android.rum.internal.domain.accessibility.AccessibilityReader
+import com.datadog.android.rum.internal.domain.accessibility.AccessibilitySnapshotManager
 import com.datadog.android.rum.internal.domain.accessibility.DatadogAccessibilityReader
+import com.datadog.android.rum.internal.domain.accessibility.DefaultAccessibilitySnapshotManager
 import com.datadog.android.rum.internal.domain.accessibility.NoOpAccessibilityReader
+import com.datadog.android.rum.internal.domain.accessibility.NoOpAccessibilitySnapshotManager
 import com.datadog.android.rum.internal.domain.event.RumEventMapper
 import com.datadog.android.rum.internal.domain.event.RumEventMetaDeserializer
 import com.datadog.android.rum.internal.domain.event.RumEventMetaSerializer
@@ -149,6 +152,8 @@ internal class RumFeature(
     internal var lastInteractionIdentifier: LastInteractionIdentifier? = NoOpLastInteractionIdentifier()
     internal var slowFramesListener: SlowFramesListener? = null
     internal var accessibilityReader: AccessibilityReader = NoOpAccessibilityReader()
+    internal var accessibilitySnapshotManager: AccessibilitySnapshotManager =
+        NoOpAccessibilitySnapshotManager()
 
     private val lateCrashEventHandler by lazy { lateCrashReporterFactory(sdkCore as InternalSdkCore) }
 
@@ -160,10 +165,9 @@ internal class RumFeature(
     override fun onInitialize(appContext: Context) {
         this.appContext = appContext
 
-        if (configuration.collectAccessibilitySettings) {
-            accessibilityReader =
-                DatadogAccessibilityReader(applicationContext = appContext, internalLogger = sdkCore.internalLogger)
-        }
+        accessibilityReader =
+            DatadogAccessibilityReader(applicationContext = appContext, internalLogger = sdkCore.internalLogger)
+        accessibilitySnapshotManager = DefaultAccessibilitySnapshotManager(accessibilityReader)
 
         initialResourceIdentifier = configuration.initialResourceIdentifier
         lastInteractionIdentifier = configuration.lastInteractionIdentifier

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
@@ -33,9 +33,16 @@ internal class RumDataWriter(
         ) ?: return false
 
         val batchEvent = if (element is ViewEvent) {
+            val hasAccessibility = if (element.view.accessibility != null) {
+                isAccessibilityPopulated(element.view.accessibility)
+            } else {
+                false
+            }
+
             val eventMeta = RumEventMeta.View(
                 viewId = element.view.id,
-                documentVersion = element.dd.documentVersion
+                documentVersion = element.dd.documentVersion,
+                hasAccessibility = hasAccessibility
             )
             val serializedEventMeta =
                 eventMetaSerializer.serializeToByteArray(eventMeta, sdkCore.internalLogger)
@@ -66,6 +73,33 @@ internal class RumDataWriter(
         when (data) {
             is ViewEvent -> sdkCore.writeLastViewEvent(rawData)
         }
+    }
+
+    private fun isAccessibilityPopulated(accessibility: ViewEvent.Accessibility): Boolean {
+        return setOf<Any?>(
+            accessibility.textSize,
+            accessibility.assistiveSwitchEnabled,
+            accessibility.assistiveTouchEnabled,
+            accessibility.boldTextEnabled,
+            accessibility.buttonShapesEnabled,
+            accessibility.closedCaptioningEnabled,
+            accessibility.grayscaleEnabled,
+            accessibility.increaseContrastEnabled,
+            accessibility.invertColorsEnabled,
+            accessibility.monoAudioEnabled,
+            accessibility.onOffSwitchLabelsEnabled,
+            accessibility.reduceMotionEnabled,
+            accessibility.reduceTransparencyEnabled,
+            accessibility.reducedAnimationsEnabled,
+            accessibility.rtlEnabled,
+            accessibility.screenReaderEnabled,
+            accessibility.shakeToUndoEnabled,
+            accessibility.shouldDifferentiateWithoutColor,
+            accessibility.singleAppModeEnabled,
+            accessibility.speakScreenEnabled,
+            accessibility.speakSelectionEnabled,
+            accessibility.videoAutoplayEnabled
+        ).any { it != null }
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/accessibility/Accessibility.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/accessibility/Accessibility.kt
@@ -15,14 +15,16 @@ package com.datadog.android.rum.internal.domain.accessibility
  * @property isClosedCaptioningEnabled Whether closed captions are enabled
  * @property isReducedAnimationsEnabled Whether animations are disabled/reduced
  * @property isScreenPinningEnabled Whether the device is in single-app mode
+ * @property isRtlEnabled Whether right to left layout is enabled
  */
 internal data class Accessibility(
-    val textSize: Float? = null,
+    val textSize: String? = null,
     val isScreenReaderEnabled: Boolean? = null,
     val isColorInversionEnabled: Boolean? = null,
     val isClosedCaptioningEnabled: Boolean? = null,
     val isReducedAnimationsEnabled: Boolean? = null,
-    val isScreenPinningEnabled: Boolean? = null
+    val isScreenPinningEnabled: Boolean? = null,
+    val isRtlEnabled: Boolean? = null
 ) {
     fun toMap(): Map<String, Any> = buildMap {
         textSize?.let { put(TEXT_SIZE_KEY, it) }
@@ -31,6 +33,7 @@ internal data class Accessibility(
         isClosedCaptioningEnabled?.let { put(CLOSED_CAPTIONING_ENABLED_KEY, it) }
         isReducedAnimationsEnabled?.let { put(REDUCED_ANIMATIONS_ENABLED_KEY, it) }
         isScreenPinningEnabled?.let { put(SCREEN_PINNING_ENABLED_KEY, it) }
+        isRtlEnabled?.let { put(RTL_ENABLED, it) }
     }
 
     companion object {
@@ -40,5 +43,18 @@ internal data class Accessibility(
         internal const val CLOSED_CAPTIONING_ENABLED_KEY = "closed_captioning_enabled"
         internal const val REDUCED_ANIMATIONS_ENABLED_KEY = "reduced_animations_enabled"
         internal const val SCREEN_PINNING_ENABLED_KEY = "single_app_mode_enabled"
+        internal const val RTL_ENABLED = "rtl_enabled"
+
+        internal fun fromMap(map: Map<String, Any>): Accessibility {
+            return Accessibility(
+                textSize = map[TEXT_SIZE_KEY] as? String,
+                isScreenReaderEnabled = map[SCREEN_READER_ENABLED_KEY] as? Boolean,
+                isColorInversionEnabled = map[COLOR_INVERSION_ENABLED_KEY] as? Boolean,
+                isClosedCaptioningEnabled = map[CLOSED_CAPTIONING_ENABLED_KEY] as? Boolean,
+                isReducedAnimationsEnabled = map[REDUCED_ANIMATIONS_ENABLED_KEY] as? Boolean,
+                isScreenPinningEnabled = map[SCREEN_PINNING_ENABLED_KEY] as? Boolean,
+                isRtlEnabled = map[RTL_ENABLED] as? Boolean
+            )
+        }
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/accessibility/AccessibilitySnapshotManager.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/accessibility/AccessibilitySnapshotManager.kt
@@ -9,7 +9,6 @@ package com.datadog.android.rum.internal.domain.accessibility
 import com.datadog.tools.annotation.NoOpImplementation
 
 @NoOpImplementation
-internal interface AccessibilityReader {
-    fun getState(): Map<String, Any>
-    fun cleanup()
+internal interface AccessibilitySnapshotManager {
+    fun latestSnapshot(): Accessibility
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/accessibility/DatadogAccessibilityReader.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/accessibility/DatadogAccessibilityReader.kt
@@ -87,10 +87,8 @@ internal class DatadogAccessibilityReader(
         // do nothing - there's nothing we're holding onto that takes up any significant memory
     }
 
-    override fun onConfigurationChanged(p0: Configuration) {
-        val newRtlLayout = p0.layoutDirection
-        val isRtlEnabled = newRtlLayout == View.LAYOUT_DIRECTION_RTL
-
+    override fun onConfigurationChanged(configuration: Configuration) {
+        val isRtlEnabled = getRtlEnabled()
         val newTextSize = getTextSize()
         updateState {
             it.copy(textSize = newTextSize, isRtlEnabled = isRtlEnabled)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/accessibility/DatadogAccessibilityReader.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/accessibility/DatadogAccessibilityReader.kt
@@ -18,6 +18,7 @@ import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
 import android.provider.Settings.Secure.ACCESSIBILITY_DISPLAY_INVERSION_ENABLED
+import android.view.View
 import android.view.accessibility.AccessibilityManager
 import android.view.accessibility.AccessibilityManager.TouchExplorationStateChangeListener
 import com.datadog.android.api.InternalLogger
@@ -87,8 +88,13 @@ internal class DatadogAccessibilityReader(
     }
 
     override fun onConfigurationChanged(p0: Configuration) {
+        val newRtlLayout = p0.layoutDirection
+        val isRtlEnabled = newRtlLayout == View.LAYOUT_DIRECTION_RTL
+
         val newTextSize = getTextSize()
-        updateState { it.copy(textSize = newTextSize) }
+        updateState {
+            it.copy(textSize = newTextSize, isRtlEnabled = isRtlEnabled)
+        }
     }
 
     @Synchronized
@@ -125,7 +131,8 @@ internal class DatadogAccessibilityReader(
             isColorInversionEnabled = isDisplayInversionEnabled(),
             isScreenPinningEnabled = isLockToScreenEnabled(),
             isReducedAnimationsEnabled = isReducedAnimationsEnabled(),
-            isClosedCaptioningEnabled = isClosedCaptioningEnabled()
+            isClosedCaptioningEnabled = isClosedCaptioningEnabled(),
+            isRtlEnabled = getRtlEnabled()
         )
     }
 
@@ -190,8 +197,12 @@ internal class DatadogAccessibilityReader(
         )
     }
 
-    private fun getTextSize(): Float {
-        return resources.configuration.fontScale
+    private fun getTextSize(): String {
+        return resources.configuration.fontScale.toString()
+    }
+
+    private fun getRtlEnabled(): Boolean {
+        return resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL
     }
 
     private fun isScreenReaderEnabled(accessibilityManager: AccessibilityManager?): Boolean? {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/accessibility/DefaultAccessibilitySnapshotManager.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/accessibility/DefaultAccessibilitySnapshotManager.kt
@@ -1,0 +1,34 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.domain.accessibility
+
+internal class DefaultAccessibilitySnapshotManager(
+    private val accessibilityReader: AccessibilityReader
+) : AccessibilitySnapshotManager {
+    private val lastSnapshot = mutableMapOf<String, Any>()
+
+    @Synchronized
+    override fun latestSnapshot(): Accessibility {
+        val newAccessibilityState = accessibilityReader.getState()
+        val newSnapshot = mutableMapOf<String, Any>()
+
+        // remove the ones we saw already
+        for (key in newAccessibilityState.keys) {
+            val newValue = newAccessibilityState[key]
+                ?: continue
+
+            val oldValue = lastSnapshot[key]
+
+            if (newValue != oldValue) {
+                newSnapshot[key] = newValue
+                lastSnapshot[key] = newValue
+            }
+        }
+
+        return Accessibility.fromMap(newSnapshot)
+    }
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMeta.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMeta.kt
@@ -67,7 +67,6 @@ internal sealed class RumEventMeta {
                         val hasAccessibilityElement = model.get(HAS_ACCESSIBILITY_KEY)
                         val hasAccessibility = when {
                             hasAccessibilityElement == null -> false // Missing field (backward compatibility)
-                            hasAccessibilityElement.isJsonNull -> null // Explicit null in JSON
                             else -> hasAccessibilityElement.asBoolean // Valid boolean value
                         }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMeta.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMeta.kt
@@ -11,7 +11,6 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParseException
 import com.google.gson.JsonParser
 import java.util.Locale
-import kotlin.jvm.Throws
 
 internal sealed class RumEventMeta {
 
@@ -27,7 +26,8 @@ internal sealed class RumEventMeta {
 
     data class View(
         val viewId: String,
-        val documentVersion: Long
+        val documentVersion: Long,
+        val hasAccessibility: Boolean? = false
     ) : RumEventMeta() {
 
         override val type: String = VIEW_TYPE_VALUE
@@ -37,6 +37,7 @@ internal sealed class RumEventMeta {
 
             model.addProperty(VIEW_ID_KEY, viewId)
             model.addProperty(DOCUMENT_VERSION_KEY, documentVersion)
+            model.addProperty(HAS_ACCESSIBILITY_KEY, hasAccessibility)
 
             return model
         }
@@ -50,6 +51,7 @@ internal sealed class RumEventMeta {
         const val TYPE_KEY = "type"
         const val VIEW_TYPE_VALUE = "view"
         const val VIEW_ID_KEY = "viewId"
+        const val HAS_ACCESSIBILITY_KEY = "hasAccessibility"
         const val DOCUMENT_VERSION_KEY = "documentVersion"
 
         @Suppress("ThrowsCount", "ThrowingInternalException")
@@ -62,8 +64,14 @@ internal sealed class RumEventMeta {
                     VIEW_TYPE_VALUE -> {
                         val viewId = model.get(VIEW_ID_KEY).asString
                         val docVersion = model.get(DOCUMENT_VERSION_KEY).asLong
+                        val hasAccessibilityElement = model.get(HAS_ACCESSIBILITY_KEY)
+                        val hasAccessibility = when {
+                            hasAccessibilityElement == null -> false // Missing field (backward compatibility)
+                            hasAccessibilityElement.isJsonNull -> null // Explicit null in JSON
+                            else -> hasAccessibilityElement.asBoolean // Valid boolean value
+                        }
 
-                        View(viewId, docVersion)
+                        View(viewId, docVersion, hasAccessibility)
                     }
 
                     else -> {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumViewEventFilter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumViewEventFilter.kt
@@ -37,10 +37,12 @@ internal class RumViewEventFilter(
             if (viewMetaByEvent.containsKey(it)) {
                 @Suppress("UnsafeThirdPartyFunctionCall") // we checked the key before
                 val viewMeta = viewMetaByEvent.getValue(it)
-                // we need to leave only view event with a max doc version for a give viewId in the
-                // batch, because backend will do the same during the reduce process
+
+                // we need to leave only view events with accessibility OR view event with a max doc version
+                // for a give viewId in the batch, because backend will do the same during the reduce process
                 @Suppress("UnsafeThirdPartyFunctionCall") // if there is a meta, there is a max doc version
-                viewMeta.documentVersion == maxDocVersionByViewId.getValue(viewMeta.viewId)
+                viewMeta.hasAccessibility == true ||
+                    viewMeta.documentVersion == maxDocVersionByViewId.getValue(viewMeta.viewId)
             } else {
                 true
             }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
@@ -18,7 +18,7 @@ import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
-import com.datadog.android.rum.internal.domain.accessibility.AccessibilityReader
+import com.datadog.android.rum.internal.domain.accessibility.AccessibilitySnapshotManager
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
 import com.datadog.android.rum.internal.vitals.VitalMonitor
@@ -43,7 +43,7 @@ internal class RumApplicationScope(
     internal val lastInteractionIdentifier: LastInteractionIdentifier?,
     private val slowFramesListener: SlowFramesListener?,
     private val rumSessionTypeOverride: RumSessionType?,
-    private val accessibilityReader: AccessibilityReader
+    private val accessibilitySnapshotManager: AccessibilitySnapshotManager
 ) : RumScope, RumViewChangedListener {
 
     private var rumContext = RumContext(applicationId = applicationId)
@@ -67,7 +67,7 @@ internal class RumApplicationScope(
             lastInteractionIdentifier = lastInteractionIdentifier,
             slowFramesListener = slowFramesListener,
             rumSessionTypeOverride = rumSessionTypeOverride,
-            accessibilityReader = accessibilityReader
+            accessibilitySnapshotManager = accessibilitySnapshotManager
         )
     )
 
@@ -164,7 +164,7 @@ internal class RumApplicationScope(
             lastInteractionIdentifier = lastInteractionIdentifier,
             slowFramesListener = slowFramesListener,
             rumSessionTypeOverride = rumSessionTypeOverride,
-            accessibilityReader = accessibilityReader
+            accessibilitySnapshotManager = accessibilitySnapshotManager
         )
         childScopes.add(newSession)
         if (event !is RumRawEvent.StartView) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -16,7 +16,7 @@ import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
-import com.datadog.android.rum.internal.domain.accessibility.AccessibilityReader
+import com.datadog.android.rum.internal.domain.accessibility.AccessibilitySnapshotManager
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
 import com.datadog.android.rum.internal.utils.percent
@@ -46,7 +46,7 @@ internal class RumSessionScope(
     networkSettledResourceIdentifier: InitialResourceIdentifier,
     lastInteractionIdentifier: LastInteractionIdentifier?,
     slowFramesListener: SlowFramesListener?,
-    private val accessibilityReader: AccessibilityReader,
+    private val accessibilitySnapshotManager: AccessibilitySnapshotManager,
     private val sessionInactivityNanos: Long = DEFAULT_SESSION_INACTIVITY_NS,
     private val sessionMaxDurationNanos: Long = DEFAULT_SESSION_MAX_DURATION_NS,
     rumSessionTypeOverride: RumSessionType?
@@ -82,7 +82,7 @@ internal class RumSessionScope(
         slowFramesListener = slowFramesListener,
         lastInteractionIdentifier = lastInteractionIdentifier,
         rumSessionTypeOverride = rumSessionTypeOverride,
-        accessibilityReader = accessibilityReader
+        accessibilitySnapshotManager = accessibilitySnapshotManager
     )
 
     init {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -19,7 +19,7 @@ import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
-import com.datadog.android.rum.internal.domain.accessibility.AccessibilityReader
+import com.datadog.android.rum.internal.domain.accessibility.AccessibilitySnapshotManager
 import com.datadog.android.rum.internal.metric.SessionEndedMetric
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.ViewEndedMetricDispatcher
@@ -51,7 +51,7 @@ internal class RumViewManagerScope(
     private val slowFramesListener: SlowFramesListener?,
     lastInteractionIdentifier: LastInteractionIdentifier?,
     private val rumSessionTypeOverride: RumSessionType?,
-    private val accessibilityReader: AccessibilityReader
+    private val accessibilitySnapshotManager: AccessibilitySnapshotManager
 ) : RumScope {
 
     private val interactionToNextViewMetricResolver: InteractionToNextViewMetricResolver =
@@ -239,7 +239,7 @@ internal class RumViewManagerScope(
             networkSettledResourceIdentifier = initialResourceIdentifier,
             slowFramesListener = slowFramesListener,
             rumSessionTypeOverride = rumSessionTypeOverride,
-            accessibilityReader = accessibilityReader
+            accessibilitySnapshotManager = accessibilitySnapshotManager
         )
         applicationDisplayed = true
         childrenScopes.add(viewScope)
@@ -318,7 +318,7 @@ internal class RumViewManagerScope(
             viewEndedMetricDispatcher = viewEndedMetricDispatcher,
             slowFramesListener = slowFramesListener,
             rumSessionTypeOverride = rumSessionTypeOverride,
-            accessibilityReader = accessibilityReader
+            accessibilitySnapshotManager = accessibilitySnapshotManager
         )
     }
 
@@ -358,7 +358,7 @@ internal class RumViewManagerScope(
             viewEndedMetricDispatcher = viewEndedMetricDispatcher,
             slowFramesListener = slowFramesListener,
             rumSessionTypeOverride = rumSessionTypeOverride,
-            accessibilityReader = accessibilityReader
+            accessibilitySnapshotManager = accessibilitySnapshotManager
         )
     }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -1064,7 +1064,8 @@ internal open class RumViewScope(
                         singleAppModeEnabled = accessibilityState.isScreenPinningEnabled,
                         screenReaderEnabled = accessibilityState.isScreenReaderEnabled,
                         closedCaptioningEnabled = accessibilityState.isClosedCaptioningEnabled,
-                        reducedAnimationsEnabled = accessibilityState.isReducedAnimationsEnabled
+                        reducedAnimationsEnabled = accessibilityState.isReducedAnimationsEnabled,
+                        rtlEnabled = accessibilityState.isRtlEnabled
                     ),
                     performance = performance,
                     networkSettledTime = timeToSettled,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -984,6 +984,17 @@ internal open class RumViewScope(
             )
         }
 
+        val accessibilityState = accessibilitySnapshotManager.latestSnapshot()
+        val accessibility = ViewEvent.Accessibility(
+            textSize = accessibilityState.textSize,
+            invertColorsEnabled = accessibilityState.isColorInversionEnabled,
+            singleAppModeEnabled = accessibilityState.isScreenPinningEnabled,
+            screenReaderEnabled = accessibilityState.isScreenReaderEnabled,
+            closedCaptioningEnabled = accessibilityState.isClosedCaptioningEnabled,
+            reducedAnimationsEnabled = accessibilityState.isReducedAnimationsEnabled,
+            rtlEnabled = accessibilityState.isRtlEnabled
+        )
+
         val performance = (internalAttributes[RumAttributes.FLUTTER_FIRST_BUILD_COMPLETE] as? Number)?.let {
             ViewEvent.Performance(
                 fbc = ViewEvent.Fbc(
@@ -1025,8 +1036,6 @@ internal open class RumViewScope(
                 else -> ViewEvent.ViewEventSessionType.SYNTHETICS
             }
 
-            val accessibilityState = accessibilitySnapshotManager.latestSnapshot()
-
             ViewEvent(
                 date = eventTimestamp,
                 featureFlags = ViewEvent.Context(additionalProperties = eventFeatureFlags),
@@ -1058,16 +1067,8 @@ internal open class RumViewScope(
                     flutterBuildTime = eventFlutterBuildTime,
                     flutterRasterTime = eventFlutterRasterTime,
                     jsRefreshRate = eventJsRefreshRate,
-                    accessibility = ViewEvent.Accessibility(
-                        textSize = accessibilityState.textSize,
-                        invertColorsEnabled = accessibilityState.isColorInversionEnabled,
-                        singleAppModeEnabled = accessibilityState.isScreenPinningEnabled,
-                        screenReaderEnabled = accessibilityState.isScreenReaderEnabled,
-                        closedCaptioningEnabled = accessibilityState.isClosedCaptioningEnabled,
-                        reducedAnimationsEnabled = accessibilityState.isReducedAnimationsEnabled,
-                        rtlEnabled = accessibilityState.isRtlEnabled
-                    ),
                     performance = performance,
+                    accessibility = accessibility,
                     networkSettledTime = timeToSettled,
                     interactionToNextViewTime = interactionToNextViewTime,
                     loadingTime = viewLoadingTime,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -39,7 +39,7 @@ import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.debug.RumDebugListener
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
-import com.datadog.android.rum.internal.domain.accessibility.AccessibilityReader
+import com.datadog.android.rum.internal.domain.accessibility.AccessibilitySnapshotManager
 import com.datadog.android.rum.internal.domain.asTime
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.internal.domain.scope.RumApplicationScope
@@ -83,7 +83,7 @@ internal class DatadogRumMonitor(
     lastInteractionIdentifier: LastInteractionIdentifier?,
     slowFramesListener: SlowFramesListener?,
     rumSessionTypeOverride: RumSessionType?,
-    accessibilityReader: AccessibilityReader
+    accessibilitySnapshotManager: AccessibilitySnapshotManager
 ) : RumMonitor, AdvancedRumMonitor {
 
     internal var rootScope: RumScope = RumApplicationScope(
@@ -102,7 +102,7 @@ internal class DatadogRumMonitor(
         lastInteractionIdentifier = lastInteractionIdentifier,
         slowFramesListener = slowFramesListener,
         rumSessionTypeOverride = rumSessionTypeOverride,
-        accessibilityReader = accessibilityReader
+        accessibilitySnapshotManager = accessibilitySnapshotManager
     )
 
     internal val keepAliveRunnable = Runnable {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
@@ -635,16 +635,16 @@ internal class RumConfigurationBuilderTest {
     }
 
     @Test
-    fun `M enable accessibility settings collection W collectAccessibilitySettings`() {
+    fun `M enable accessibility settings collection W collectAccessibility`() {
         // When
         val rumConfiguration = testedBuilder
-            .collectAccessibilitySettings()
+            .collectAccessibility(enabled = true)
             .build()
 
         // Then
         assertThat(rumConfiguration.featureConfiguration).isEqualTo(
             RumFeature.DEFAULT_RUM_CONFIG.copy(
-                collectAccessibilitySettings = true
+                collectAccessibility = true
             )
         )
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/attribute/AccessibilityTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/attribute/AccessibilityTest.kt
@@ -43,7 +43,7 @@ internal class AccessibilityTest {
     ) {
         // Given
         val accessibility = Accessibility(
-            textSize = textSize,
+            textSize = textSize.toString(),
             isScreenReaderEnabled = isScreenReaderEnabled,
             isColorInversionEnabled = isColorInversionEnabled,
             isClosedCaptioningEnabled = isClosedCaptioningEnabled,
@@ -57,7 +57,7 @@ internal class AccessibilityTest {
         // Then
         assertThat(result).containsExactlyInAnyOrderEntriesOf(
             mapOf(
-                Accessibility.TEXT_SIZE_KEY to textSize,
+                Accessibility.TEXT_SIZE_KEY to textSize.toString(),
                 Accessibility.SCREEN_READER_ENABLED_KEY to isScreenReaderEnabled,
                 Accessibility.COLOR_INVERSION_ENABLED_KEY to isColorInversionEnabled,
                 Accessibility.CLOSED_CAPTIONING_ENABLED_KEY to isClosedCaptioningEnabled,
@@ -82,7 +82,7 @@ internal class AccessibilityTest {
     fun `M exclude null values from map W toMap() { mixed null and non-null values }`() {
         // Given
         val accessibility = Accessibility(
-            textSize = 1.5f,
+            textSize = "1.5f",
             isScreenReaderEnabled = null,
             isColorInversionEnabled = true,
             isClosedCaptioningEnabled = false,
@@ -96,7 +96,7 @@ internal class AccessibilityTest {
         // Then
         assertThat(result).containsExactlyInAnyOrderEntriesOf(
             mapOf(
-                Accessibility.TEXT_SIZE_KEY to 1.5f,
+                Accessibility.TEXT_SIZE_KEY to "1.5f",
                 Accessibility.COLOR_INVERSION_ENABLED_KEY to true,
                 Accessibility.CLOSED_CAPTIONING_ENABLED_KEY to false,
                 Accessibility.SCREEN_PINNING_ENABLED_KEY to true

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/accessibility/DatadogAccessibilityReaderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/accessibility/DatadogAccessibilityReaderTest.kt
@@ -173,7 +173,7 @@ internal class DatadogAccessibilityReaderTest {
         assertThat(result[REDUCED_ANIMATIONS_ENABLED_KEY]).isNull()
         assertThat(result[SCREEN_PINNING_ENABLED_KEY] as Boolean).isFalse()
         assertThat(result[COLOR_INVERSION_ENABLED_KEY]).isNull()
-        assertThat(result[TEXT_SIZE_KEY]).isEqualTo(1.0f)
+        assertThat(result[TEXT_SIZE_KEY]).isEqualTo("1.0")
     }
 
     @Test
@@ -226,7 +226,7 @@ internal class DatadogAccessibilityReaderTest {
         val result = testedReader.getState()
 
         // Then
-        assertThat(result[TEXT_SIZE_KEY]).isEqualTo(textSize)
+        assertThat(result[TEXT_SIZE_KEY]).isEqualTo(textSize.toString())
         assertThat(result[SCREEN_READER_ENABLED_KEY]).isEqualTo(isScreenReaderEnabled)
         assertThat(result[SCREEN_PINNING_ENABLED_KEY]).isEqualTo(isScreenPinningEnabled)
         assertThat(result[COLOR_INVERSION_ENABLED_KEY]).isEqualTo(isColorInversionEnabled)
@@ -247,7 +247,7 @@ internal class DatadogAccessibilityReaderTest {
         val result = testedReader.getState()
 
         // Then
-        assertThat(result[TEXT_SIZE_KEY]).isEqualTo(fontScale)
+        assertThat(result[TEXT_SIZE_KEY]).isEqualTo(fontScale.toString())
     }
     // endregion
 
@@ -495,7 +495,7 @@ internal class DatadogAccessibilityReaderTest {
 
         // Establish initial state
         val initialResult = testedReader.getState()
-        assertThat(initialResult[TEXT_SIZE_KEY]).isEqualTo(originalFontScale)
+        assertThat(initialResult[TEXT_SIZE_KEY]).isEqualTo(originalFontScale.toString())
 
         // Change configuration
         val newConfiguration = Configuration().apply { fontScale = newFontScale }
@@ -506,7 +506,7 @@ internal class DatadogAccessibilityReaderTest {
 
         // Then
         val result = testedReader.getState()
-        assertThat(result[TEXT_SIZE_KEY]).isEqualTo(newFontScale)
+        assertThat(result[TEXT_SIZE_KEY]).isEqualTo(newFontScale.toString())
     }
 
     @Test
@@ -524,7 +524,7 @@ internal class DatadogAccessibilityReaderTest {
 
         // Then
         val result = testedReader.getState()
-        assertThat(result[TEXT_SIZE_KEY]).isEqualTo(fontScale)
+        assertThat(result[TEXT_SIZE_KEY]).isEqualTo(fontScale.toString())
         assertThat(result).isEqualTo(initialResult)
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/accessibility/DefaultAccessibilitySnapshotManagerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/accessibility/DefaultAccessibilitySnapshotManagerTest.kt
@@ -1,0 +1,321 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.domain.accessibility
+
+import com.datadog.android.rum.internal.domain.accessibility.Accessibility.Companion.CLOSED_CAPTIONING_ENABLED_KEY
+import com.datadog.android.rum.internal.domain.accessibility.Accessibility.Companion.COLOR_INVERSION_ENABLED_KEY
+import com.datadog.android.rum.internal.domain.accessibility.Accessibility.Companion.REDUCED_ANIMATIONS_ENABLED_KEY
+import com.datadog.android.rum.internal.domain.accessibility.Accessibility.Companion.SCREEN_PINNING_ENABLED_KEY
+import com.datadog.android.rum.internal.domain.accessibility.Accessibility.Companion.SCREEN_READER_ENABLED_KEY
+import com.datadog.android.rum.internal.domain.accessibility.Accessibility.Companion.TEXT_SIZE_KEY
+import com.datadog.android.rum.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.FloatForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class DefaultAccessibilitySnapshotManagerTest {
+
+    @Mock
+    lateinit var mockAccessibilityReader: AccessibilityReader
+
+    private lateinit var testedManager: DefaultAccessibilitySnapshotManager
+
+    @BeforeEach
+    fun setup() {
+        testedManager = DefaultAccessibilitySnapshotManager(mockAccessibilityReader)
+    }
+
+    @Test
+    fun `M return empty accessibility W latestSnapshot() { no accessibility data }`() {
+        // Given
+        whenever(mockAccessibilityReader.getState()) doReturn emptyMap()
+
+        // When
+        val result = testedManager.latestSnapshot()
+
+        // Then
+        assertThat(result).isEqualTo(Accessibility())
+    }
+
+    @Test
+    fun `M return all changes W latestSnapshot() { first call with complete data }`(
+        @FloatForgery textSize: Float,
+        @BoolForgery screenReader: Boolean,
+        @BoolForgery colorInversion: Boolean,
+        @BoolForgery closedCaptioning: Boolean,
+        @BoolForgery reducedAnimations: Boolean,
+        @BoolForgery screenPinning: Boolean
+    ) {
+        // Given
+        val accessibilityState = mapOf(
+            TEXT_SIZE_KEY to textSize.toString(),
+            SCREEN_READER_ENABLED_KEY to screenReader,
+            COLOR_INVERSION_ENABLED_KEY to colorInversion,
+            CLOSED_CAPTIONING_ENABLED_KEY to closedCaptioning,
+            REDUCED_ANIMATIONS_ENABLED_KEY to reducedAnimations,
+            SCREEN_PINNING_ENABLED_KEY to screenPinning
+        )
+        whenever(mockAccessibilityReader.getState()) doReturn accessibilityState
+
+        // When
+        val result = testedManager.latestSnapshot()
+
+        // Then
+        assertThat(result).isEqualTo(
+            Accessibility(
+                textSize = textSize.toString(),
+                isScreenReaderEnabled = screenReader,
+                isColorInversionEnabled = colorInversion,
+                isClosedCaptioningEnabled = closedCaptioning,
+                isReducedAnimationsEnabled = reducedAnimations,
+                isScreenPinningEnabled = screenPinning
+            )
+        )
+    }
+
+    @Test
+    fun `M return empty accessibility W latestSnapshot() { second call with same data }`(
+        @FloatForgery textSize: Float,
+        @BoolForgery screenReader: Boolean
+    ) {
+        // Given
+        val accessibilityState = mapOf(
+            TEXT_SIZE_KEY to textSize.toString(),
+            SCREEN_READER_ENABLED_KEY to screenReader
+        )
+        whenever(mockAccessibilityReader.getState()) doReturn accessibilityState
+
+        // When - First call
+        testedManager.latestSnapshot()
+
+        // When - Second call with same data
+        val result = testedManager.latestSnapshot()
+
+        // Then
+        assertThat(result).isEqualTo(Accessibility())
+    }
+
+    @Test
+    fun `M return only changed values W latestSnapshot() { some values changed }`(
+        forge: Forge,
+        @FloatForgery initialTextSize: Float,
+        @BoolForgery screenReader: Boolean,
+        @BoolForgery colorInversion: Boolean
+    ) {
+        // Given
+        val initialState = mapOf(
+            TEXT_SIZE_KEY to initialTextSize,
+            SCREEN_READER_ENABLED_KEY to screenReader,
+            COLOR_INVERSION_ENABLED_KEY to colorInversion
+        )
+
+        val newTextSize = rerollFloat(initialTextSize, forge)
+
+        val changedState = mapOf(
+            TEXT_SIZE_KEY to newTextSize.toString(), // Changed
+            SCREEN_READER_ENABLED_KEY to screenReader, // Same
+            COLOR_INVERSION_ENABLED_KEY to colorInversion // Same
+        )
+
+        whenever(mockAccessibilityReader.getState())
+            .doReturn(initialState)
+            .doReturn(changedState)
+
+        // When
+        testedManager.latestSnapshot() // First call
+        val result = testedManager.latestSnapshot() // Second call
+
+        // Then - Only changed value should be returned
+        assertThat(result).isEqualTo(
+            Accessibility(textSize = newTextSize.toString())
+        )
+    }
+
+    @Test
+    fun `M return only new values W latestSnapshot() { new accessibility settings added }`(
+        @FloatForgery textSize: Float,
+        @BoolForgery screenReader: Boolean,
+        @BoolForgery colorInversion: Boolean
+    ) {
+        // Given
+        val initialState = mapOf(
+            TEXT_SIZE_KEY to textSize.toString()
+        )
+        val expandedState = mapOf(
+            TEXT_SIZE_KEY to textSize.toString(),
+            SCREEN_READER_ENABLED_KEY to screenReader,
+            COLOR_INVERSION_ENABLED_KEY to colorInversion
+        )
+
+        whenever(mockAccessibilityReader.getState())
+            .doReturn(initialState)
+            .doReturn(expandedState)
+
+        // When
+        testedManager.latestSnapshot() // First call
+        val result = testedManager.latestSnapshot() // Second call
+
+        // Then - Only new values should be returned
+        assertThat(result).isEqualTo(
+            Accessibility(
+                isScreenReaderEnabled = screenReader,
+                isColorInversionEnabled = colorInversion
+            )
+        )
+    }
+
+    @Test
+    fun `M not report change W latestSnapshot() { value changes from non-null to null }`(
+        @FloatForgery textSize: Float,
+        @BoolForgery screenReader: Boolean
+    ) {
+        // Given
+        val initialState = mapOf(
+            TEXT_SIZE_KEY to textSize.toString(),
+            SCREEN_READER_ENABLED_KEY to screenReader,
+            COLOR_INVERSION_ENABLED_KEY to true
+        )
+        val stateWithNull = mapOf(
+            TEXT_SIZE_KEY to textSize.toString(),
+            SCREEN_READER_ENABLED_KEY to screenReader
+        )
+
+        whenever(mockAccessibilityReader.getState())
+            .doReturn(initialState)
+            .doReturn(stateWithNull)
+
+        // When
+        testedManager.latestSnapshot() // First call
+        val result = testedManager.latestSnapshot() // Second call
+
+        // Then - No changes should be reported (null values are filtered)
+        assertThat(result).isEqualTo(Accessibility())
+    }
+
+    @Test
+    fun `M report change W latestSnapshot() { value changes from null to non-null }`(
+        @FloatForgery textSize: Float,
+        @BoolForgery colorInversion: Boolean
+    ) {
+        // Given
+        val initialState = mapOf(
+            TEXT_SIZE_KEY to textSize.toString()
+        )
+        val stateWithValue = mapOf(
+            TEXT_SIZE_KEY to textSize.toString(),
+            COLOR_INVERSION_ENABLED_KEY to colorInversion // Changed from null to value
+        )
+
+        whenever(mockAccessibilityReader.getState())
+            .doReturn(initialState)
+            .doReturn(stateWithValue)
+
+        // When
+        testedManager.latestSnapshot() // First call
+        val result = testedManager.latestSnapshot() // Second call
+
+        // Then - New non-null value should be reported
+        assertThat(result).isEqualTo(
+            Accessibility(isColorInversionEnabled = colorInversion)
+        )
+    }
+
+    @Test
+    fun `M handle missing keys gracefully W latestSnapshot() { key disappears from state }`(
+        @FloatForgery textSize: Float,
+        @BoolForgery screenReader: Boolean,
+        @BoolForgery colorInversion: Boolean
+    ) {
+        // Given
+        val completeState = mapOf(
+            TEXT_SIZE_KEY to textSize.toString(),
+            SCREEN_READER_ENABLED_KEY to screenReader,
+            COLOR_INVERSION_ENABLED_KEY to colorInversion
+        )
+        val incompleteState = mapOf(
+            TEXT_SIZE_KEY to textSize.toString(),
+            SCREEN_READER_ENABLED_KEY to screenReader
+            // COLOR_INVERSION_ENABLED_KEY missing
+        )
+
+        whenever(mockAccessibilityReader.getState())
+            .doReturn(completeState)
+            .doReturn(incompleteState)
+
+        // When
+        testedManager.latestSnapshot() // First call
+        val result = testedManager.latestSnapshot() // Second call
+
+        // Then - No changes should be reported for missing keys (they become null)
+        assertThat(result).isEqualTo(Accessibility())
+    }
+
+    @Test
+    fun `M maintain state consistency W latestSnapshot() { multiple sequential calls }`(
+        forge: Forge,
+        @FloatForgery textSize1: Float
+    ) {
+        // Given
+        val textSize2 = rerollFloat(textSize1, forge)
+        val textSize3 = rerollFloat(textSize2, forge)
+
+        val state1 = mapOf(TEXT_SIZE_KEY to textSize1.toString())
+        val state2 = mapOf(TEXT_SIZE_KEY to textSize2.toString())
+        val state3 = mapOf(TEXT_SIZE_KEY to textSize2.toString()) // Same as state2
+        val state4 = mapOf(TEXT_SIZE_KEY to textSize3.toString())
+
+        whenever(mockAccessibilityReader.getState())
+            .doReturn(state1)
+            .doReturn(state2)
+            .doReturn(state3)
+            .doReturn(state4)
+
+        // When & Then
+        val result1 = testedManager.latestSnapshot()
+        assertThat(result1.textSize).isEqualTo(textSize1.toString())
+
+        val result2 = testedManager.latestSnapshot()
+        assertThat(result2.textSize).isEqualTo(textSize2.toString())
+
+        val result3 = testedManager.latestSnapshot()
+        assertThat(result3).isEqualTo(Accessibility()) // No change
+
+        val result4 = testedManager.latestSnapshot()
+        assertThat(result4.textSize).isEqualTo(textSize3.toString())
+    }
+
+    /**
+     * Ensure the float value is not the same as the original
+     * this avoids some flakiness that we could have in the tests due to values being randomly the same
+     */
+    private fun rerollFloat(originalValue: Float, forge: Forge): Float {
+        var newValue = originalValue
+        while (newValue == originalValue) {
+            newValue = forge.aFloat()
+        }
+        return newValue
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -19,7 +19,7 @@ import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.domain.RumContext
-import com.datadog.android.rum.internal.domain.accessibility.AccessibilityReader
+import com.datadog.android.rum.internal.domain.accessibility.AccessibilitySnapshotManager
 import com.datadog.android.rum.internal.domain.state.ViewUIPerformanceReport
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
@@ -72,7 +72,7 @@ internal class RumApplicationScopeTest {
     lateinit var mockEvent: RumRawEvent
 
     @Mock
-    lateinit var mockAccessibilityReader: AccessibilityReader
+    lateinit var mockAccessibilitySnapshotManager: AccessibilitySnapshotManager
 
     @Mock
     lateinit var mockWriter: DataWriter<Any>
@@ -158,7 +158,7 @@ internal class RumApplicationScopeTest {
             lastInteractionIdentifier = mockLastInteractionIdentifier,
             slowFramesListener = mockSlowFramesListener,
             rumSessionTypeOverride = fakeRumSessionType,
-            accessibilityReader = mockAccessibilityReader
+            accessibilitySnapshotManager = mockAccessibilitySnapshotManager
         )
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -139,6 +139,7 @@ internal class RumApplicationScopeTest {
         whenever(mockSdkCore.time) doReturn fakeTimeInfoAtScopeStart
         whenever(mockSdkCore.internalLogger) doReturn mock()
         whenever(mockSlowFramesListener.resolveReport(any(), any(), any())) doReturn viewUIPerformanceReport
+        whenever(mockAccessibilitySnapshotManager.latestSnapshot()) doReturn mock()
 
         fakeRumSessionType = forge.aNullable { aValueFrom(RumSessionType::class.java) }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -16,7 +16,7 @@ import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.domain.RumContext
-import com.datadog.android.rum.internal.domain.accessibility.AccessibilityReader
+import com.datadog.android.rum.internal.domain.accessibility.AccessibilitySnapshotManager
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
 import com.datadog.android.rum.internal.vitals.VitalMonitor
@@ -85,7 +85,7 @@ internal class RumSessionScopeTest {
     lateinit var mockFrameRateVitalMonitor: VitalMonitor
 
     @Mock
-    lateinit var mockAccessibilityReader: AccessibilityReader
+    lateinit var mockAccessibilitySnapshotManager: AccessibilitySnapshotManager
 
     @Mock
     lateinit var mockSessionListener: RumSessionListener
@@ -1325,7 +1325,7 @@ internal class RumSessionScopeTest {
             sessionInactivityNanos = TEST_INACTIVITY_NS,
             sessionMaxDurationNanos = TEST_MAX_DURATION_NS,
             rumSessionTypeOverride = fakeRumSessionType,
-            accessibilityReader = mockAccessibilityReader
+            accessibilitySnapshotManager = mockAccessibilitySnapshotManager
         )
 
         if (withMockChildScope) {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -25,7 +25,7 @@ import com.datadog.android.rum.internal.anr.ANRDetectorRunnable
 import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
-import com.datadog.android.rum.internal.domain.accessibility.AccessibilityReader
+import com.datadog.android.rum.internal.domain.accessibility.AccessibilitySnapshotManager
 import com.datadog.android.rum.internal.domain.state.ViewUIPerformanceReport
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
@@ -126,7 +126,7 @@ internal class RumViewManagerScopeTest {
     lateinit var mockNetworkSettledResourceIdentifier: InitialResourceIdentifier
 
     @Mock
-    lateinit var mockAccessibilityReader: AccessibilityReader
+    lateinit var mockAccessibilitySnapshotManager: AccessibilitySnapshotManager
 
     @Mock
     lateinit var mockLastInteractionIdentifier: LastInteractionIdentifier
@@ -172,7 +172,7 @@ internal class RumViewManagerScopeTest {
             lastInteractionIdentifier = mockLastInteractionIdentifier,
             slowFramesListener = mockSlowFramesListener,
             rumSessionTypeOverride = fakeRumSessionType,
-            accessibilityReader = mockAccessibilityReader
+            accessibilitySnapshotManager = mockAccessibilitySnapshotManager
         )
     }
 
@@ -540,7 +540,7 @@ internal class RumViewManagerScopeTest {
             lastInteractionIdentifier = mockLastInteractionIdentifier,
             slowFramesListener = mockSlowFramesListener,
             rumSessionTypeOverride = fakeRumSessionType,
-            accessibilityReader = mockAccessibilityReader
+            accessibilitySnapshotManager = mockAccessibilitySnapshotManager
         )
         testedScope.applicationDisplayed = true
         val fakeEvent = forge.validBackgroundEvent()
@@ -574,7 +574,7 @@ internal class RumViewManagerScopeTest {
             lastInteractionIdentifier = mockLastInteractionIdentifier,
             slowFramesListener = mockSlowFramesListener,
             rumSessionTypeOverride = fakeRumSessionType,
-            accessibilityReader = mockAccessibilityReader
+            accessibilitySnapshotManager = mockAccessibilitySnapshotManager
         )
         testedScope.childrenScopes.add(mockChildScope)
         whenever(mockChildScope.isActive()) doReturn true
@@ -611,7 +611,7 @@ internal class RumViewManagerScopeTest {
             lastInteractionIdentifier = mockLastInteractionIdentifier,
             slowFramesListener = mockSlowFramesListener,
             rumSessionTypeOverride = fakeRumSessionType,
-            accessibilityReader = mockAccessibilityReader
+            accessibilitySnapshotManager = mockAccessibilitySnapshotManager
         )
         testedScope.applicationDisplayed = true
         val fakeEvent = forge.validBackgroundEvent()
@@ -681,7 +681,7 @@ internal class RumViewManagerScopeTest {
             lastInteractionIdentifier = mockLastInteractionIdentifier,
             slowFramesListener = mockSlowFramesListener,
             rumSessionTypeOverride = fakeRumSessionType,
-            accessibilityReader = mockAccessibilityReader
+            accessibilitySnapshotManager = mockAccessibilitySnapshotManager
         )
         testedScope.childrenScopes.add(mockChildScope)
         whenever(mockChildScope.isActive()) doReturn true
@@ -719,7 +719,7 @@ internal class RumViewManagerScopeTest {
             lastInteractionIdentifier = mockLastInteractionIdentifier,
             slowFramesListener = mockSlowFramesListener,
             rumSessionTypeOverride = fakeRumSessionType,
-            accessibilityReader = mockAccessibilityReader
+            accessibilitySnapshotManager = mockAccessibilitySnapshotManager
         )
         testedScope.stopped = true
         val fakeEvent = forge.applicationStartedEvent()

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -152,6 +152,7 @@ internal class RumViewManagerScopeTest {
         whenever(mockChildScope.isActive()) doReturn true
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockSlowFramesListener.resolveReport(any(), any(), any())) doReturn fakeViewUIPerformanceReport
+        whenever(mockAccessibilitySnapshotManager.latestSnapshot()) doReturn mock()
 
         fakeRumSessionType = forge.aNullable { aValueFrom(RumSessionType::class.java) }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -36,7 +36,7 @@ import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.collections.toEvictingQueue
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
-import com.datadog.android.rum.internal.domain.accessibility.AccessibilityReader
+import com.datadog.android.rum.internal.domain.accessibility.AccessibilitySnapshotManager
 import com.datadog.android.rum.internal.domain.state.SlowFrameRecord
 import com.datadog.android.rum.internal.domain.state.ViewUIPerformanceReport
 import com.datadog.android.rum.internal.metric.NoValueReason
@@ -153,7 +153,7 @@ internal class RumViewScopeTest {
     lateinit var mockCpuVitalMonitor: VitalMonitor
 
     @Mock
-    lateinit var mockAccessibilityReader: AccessibilityReader
+    lateinit var mockAccessibilitySnapshotManager: AccessibilitySnapshotManager
 
     @Mock
     lateinit var mockMemoryVitalMonitor: VitalMonitor
@@ -270,6 +270,7 @@ internal class RumViewScopeTest {
         whenever(mockInteractionToNextViewMetricResolver.resolveMetric(any())) doReturn
             fakeInteractionToNextViewMetricValue
         val isValidSource = forge.aBool()
+        whenever(mockAccessibilitySnapshotManager.latestSnapshot()) doReturn mock()
 
         val fakeSource = if (isValidSource) {
             forge.anElementFrom(
@@ -9671,7 +9672,7 @@ internal class RumViewScopeTest {
         slowFramesListener = slowFramesMetricListener,
         viewEndedMetricDispatcher = viewEndedMetricDispatcher,
         rumSessionTypeOverride = fakeRumSessionType,
-        accessibilityReader = mockAccessibilityReader
+        accessibilitySnapshotManager = mockAccessibilitySnapshotManager
     )
 
     data class RumRawEventData(val event: RumRawEvent, val viewKey: RumScopeKey)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -32,7 +32,7 @@ import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.debug.RumDebugListener
 import com.datadog.android.rum.internal.domain.RumContext
-import com.datadog.android.rum.internal.domain.accessibility.AccessibilityReader
+import com.datadog.android.rum.internal.domain.accessibility.AccessibilitySnapshotManager
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.internal.domain.scope.RumActionScope
 import com.datadog.android.rum.internal.domain.scope.RumApplicationScope
@@ -122,7 +122,7 @@ internal class DatadogRumMonitorTest {
     lateinit var mockHandler: Handler
 
     @Mock
-    lateinit var mockAccessibilityReader: AccessibilityReader
+    lateinit var mockAccessibilitySnapshotManager: AccessibilitySnapshotManager
 
     @Mock
     lateinit var mockResolver: FirstPartyHostHeaderTypeResolver
@@ -222,7 +222,7 @@ internal class DatadogRumMonitorTest {
             lastInteractionIdentifier = mockLastInteractionIdentifier,
             slowFramesListener = mockSlowFramesListener,
             rumSessionTypeOverride = fakeRumSessionType,
-            accessibilityReader = mockAccessibilityReader
+            accessibilitySnapshotManager = mockAccessibilitySnapshotManager
         )
         testedMonitor.rootScope = mockScope
     }
@@ -249,7 +249,7 @@ internal class DatadogRumMonitorTest {
             lastInteractionIdentifier = mockLastInteractionIdentifier,
             slowFramesListener = mockSlowFramesListener,
             rumSessionTypeOverride = fakeRumSessionType,
-            accessibilityReader = mockAccessibilityReader
+            accessibilitySnapshotManager = mockAccessibilitySnapshotManager
         )
 
         val rootScope = testedMonitor.rootScope
@@ -313,7 +313,7 @@ internal class DatadogRumMonitorTest {
             lastInteractionIdentifier = mockLastInteractionIdentifier,
             slowFramesListener = mockSlowFramesListener,
             rumSessionTypeOverride = fakeRumSessionType,
-            accessibilityReader = mockAccessibilityReader
+            accessibilitySnapshotManager = mockAccessibilitySnapshotManager
         )
         val completableFuture = CompletableFuture<String>()
         testedMonitor.start()
@@ -355,7 +355,7 @@ internal class DatadogRumMonitorTest {
             lastInteractionIdentifier = mockLastInteractionIdentifier,
             slowFramesListener = mockSlowFramesListener,
             rumSessionTypeOverride = fakeRumSessionType,
-            accessibilityReader = mockAccessibilityReader
+            accessibilitySnapshotManager = mockAccessibilitySnapshotManager
         )
 
         val completableFuture = CompletableFuture<String>()
@@ -1704,7 +1704,7 @@ internal class DatadogRumMonitorTest {
             lastInteractionIdentifier = mockLastInteractionIdentifier,
             slowFramesListener = mockSlowFramesListener,
             rumSessionTypeOverride = fakeRumSessionType,
-            accessibilityReader = mockAccessibilityReader
+            accessibilitySnapshotManager = mockAccessibilitySnapshotManager
         )
 
         // When
@@ -1754,7 +1754,7 @@ internal class DatadogRumMonitorTest {
             lastInteractionIdentifier = mockLastInteractionIdentifier,
             slowFramesListener = mockSlowFramesListener,
             rumSessionTypeOverride = fakeRumSessionType,
-            accessibilityReader = mockAccessibilityReader
+            accessibilitySnapshotManager = mockAccessibilitySnapshotManager
         )
 
         // When
@@ -1790,7 +1790,7 @@ internal class DatadogRumMonitorTest {
             initialResourceIdentifier = mockNetworkSettledResourceIdentifier,
             lastInteractionIdentifier = mockLastInteractionIdentifier,
             slowFramesListener = mockSlowFramesListener,
-            accessibilityReader = mockAccessibilityReader,
+            accessibilitySnapshotManager = mockAccessibilitySnapshotManager,
             rumSessionTypeOverride = null
         )
         whenever(mockExecutorService.isShutdown).thenReturn(true)
@@ -1989,7 +1989,7 @@ internal class DatadogRumMonitorTest {
             lastInteractionIdentifier = mockLastInteractionIdentifier,
             slowFramesListener = mockSlowFramesListener,
             rumSessionTypeOverride = fakeRumSessionType,
-            accessibilityReader = mockAccessibilityReader
+            accessibilitySnapshotManager = mockAccessibilitySnapshotManager
         )
         testedMonitor.startView(key, name, attributes)
         // When

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -197,6 +197,7 @@ internal class DatadogRumMonitorTest {
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockSdkCore.time) doReturn fakeTimeInfo
         whenever(mockSlowFramesListener.resolveReport(any(), any(), any())) doReturn fakeViewUIPerformanceReport
+        whenever(mockAccessibilitySnapshotManager.latestSnapshot()) doReturn mock()
 
         fakeAttributes = forge.exhaustiveAttributes()
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/AccessibilityForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/AccessibilityForgeryFactory.kt
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.utils.forge
+
+import com.datadog.android.rum.model.ViewEvent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class AccessibilityForgeryFactory : ForgeryFactory<ViewEvent.Accessibility> {
+    override fun getForgery(forge: Forge): ViewEvent.Accessibility {
+        return ViewEvent.Accessibility(
+            textSize = forge.aNullable { forge.aString() },
+            rtlEnabled = forge.aNullable { forge.aBool() },
+            screenReaderEnabled = forge.aNullable { forge.aBool() },
+            increaseContrastEnabled = forge.aNullable { forge.aBool() },
+            reducedAnimationsEnabled = forge.aNullable { forge.aBool() },
+            invertColorsEnabled = forge.aNullable { forge.aBool() },
+            singleAppModeEnabled = forge.aNullable { forge.aBool() }
+        )
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
@@ -69,7 +69,7 @@ internal class ConfigurationRumForgeryFactory :
             composeActionTrackingStrategy = mock(),
             slowFramesConfiguration = forge.getForgery(),
             rumSessionTypeOverride = forge.aNullable { aValueFrom(RumSessionType::class.java) },
-            collectAccessibilitySettings = forge.aBool()
+            collectAccessibility = forge.aBool()
         )
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
@@ -50,7 +50,6 @@ internal class Configurator : BaseConfigurator() {
         forge.addFactory(FrameMetricDataForgeryFactory())
         forge.addFactory(ViewUIPerformanceReportForgeryFactory())
         forge.addFactory(SlowFramesConfigurationForgeryFactory())
-        forge.addFactory(AccessibilityForgeryFactory())
 
         // Telemetry schema models
         forge.addFactory(TelemetryDebugEventForgeryFactory())

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
@@ -50,6 +50,7 @@ internal class Configurator : BaseConfigurator() {
         forge.addFactory(FrameMetricDataForgeryFactory())
         forge.addFactory(ViewUIPerformanceReportForgeryFactory())
         forge.addFactory(SlowFramesConfigurationForgeryFactory())
+        forge.addFactory(AccessibilityForgeryFactory())
 
         // Telemetry schema models
         forge.addFactory(TelemetryDebugEventForgeryFactory())

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ViewEventMetaForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ViewEventMetaForgeryFactory.kt
@@ -16,7 +16,7 @@ internal class ViewEventMetaForgeryFactory : ForgeryFactory<RumEventMeta.View> {
         return RumEventMeta.View(
             viewId = forge.getForgery<UUID>().toString(),
             documentVersion = forge.aPositiveLong(strict = true),
-            hasAccessibility = forge.aNullable { forge.aBool() }
+            hasAccessibility = forge.aBool()
         )
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ViewEventMetaForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ViewEventMetaForgeryFactory.kt
@@ -15,7 +15,8 @@ internal class ViewEventMetaForgeryFactory : ForgeryFactory<RumEventMeta.View> {
     override fun getForgery(forge: Forge): RumEventMeta.View {
         return RumEventMeta.View(
             viewId = forge.getForgery<UUID>().toString(),
-            documentVersion = forge.aPositiveLong(strict = true)
+            documentVersion = forge.aPositiveLong(strict = true),
+            hasAccessibility = forge.aNullable { forge.aBool() }
         )
     }
 }

--- a/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/AccessibilityForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/AccessibilityForgeryFactory.kt
@@ -6,13 +6,13 @@
 
 package com.datadog.android.rum.utils.forge
 
-import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.rum.model.ViewEvent.Accessibility
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
-internal class AccessibilityForgeryFactory : ForgeryFactory<ViewEvent.Accessibility> {
-    override fun getForgery(forge: Forge): ViewEvent.Accessibility {
-        return ViewEvent.Accessibility(
+internal class AccessibilityForgeryFactory : ForgeryFactory<Accessibility> {
+    override fun getForgery(forge: Forge): Accessibility {
+        return Accessibility(
             textSize = forge.aNullable { forge.aString() },
             rtlEnabled = forge.aNullable { forge.aBool() },
             screenReaderEnabled = forge.aNullable { forge.aBool() },

--- a/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ForgeExt.kt
+++ b/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ForgeExt.kt
@@ -60,4 +60,5 @@ fun Forge.useCommonRumFactories() {
     addFactory(ErrorEventForgeryFactory())
     addFactory(LongTaskEventForgeryFactory())
     addFactory(ResourceTimingForgeryFactory())
+    addFactory(AccessibilityForgeryFactory())
 }

--- a/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ViewEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ViewEventForgeryFactory.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.rum.utils.forge
 
 import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.rum.model.ViewEvent.Accessibility
 import com.datadog.tools.unit.forge.exhaustiveAttributes
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
@@ -64,7 +65,7 @@ class ViewEventForgeryFactory : ForgeryFactory<ViewEvent> {
                 refreshRateAverage = forge.aNullable { aPositiveDouble() },
                 refreshRateMin = forge.aNullable { aPositiveDouble() },
                 frustration = forge.aNullable { ViewEvent.Frustration(aPositiveLong()) },
-                accessibility = forge.aNullable { forge.getForgery<ViewEvent.Accessibility>() }
+                accessibility = forge.aNullable { forge.getForgery<Accessibility>() }
             ),
             connectivity = forge.aNullable {
                 ViewEvent.Connectivity(

--- a/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ViewEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ViewEventForgeryFactory.kt
@@ -63,7 +63,8 @@ class ViewEventForgeryFactory : ForgeryFactory<ViewEvent> {
                 cpuTicksPerSecond = forge.aNullable { aPositiveDouble() },
                 refreshRateAverage = forge.aNullable { aPositiveDouble() },
                 refreshRateMin = forge.aNullable { aPositiveDouble() },
-                frustration = forge.aNullable { ViewEvent.Frustration(aPositiveLong()) }
+                frustration = forge.aNullable { ViewEvent.Frustration(aPositiveLong()) },
+                accessibility = forge.aNullable { forge.getForgery<ViewEvent.Accessibility>() }
             ),
             connectivity = forge.aNullable {
                 ViewEvent.Connectivity(

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
@@ -7,6 +7,9 @@
 package com.datadog.android.core.stub
 
 import android.app.Application
+import android.content.ContentResolver
+import android.content.res.Configuration
+import android.content.res.Resources
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.AccountInfo
 import com.datadog.android.api.context.DatadogContext
@@ -43,7 +46,13 @@ class StubSDKCore(
     private var datadogContext = forge.getForgery<DatadogContext>().copy(source = "android")
 
     init {
+        val mockResources = mock<Resources>()
+        val mockConfiguration = mock<Configuration>()
+        val mockContentResolver = mock<ContentResolver>()
         whenever(mockContext.packageName) doReturn forge.anAlphabeticalString()
+        whenever(mockContext.resources) doReturn mockResources
+        whenever(mockResources.configuration) doReturn mockConfiguration
+        whenever(mockContext.contentResolver) doReturn mockContentResolver
     }
 
     // region Stub

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -32,7 +32,6 @@ import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.Rum
 import com.datadog.android.rum.RumConfiguration
 import com.datadog.android.rum.RumErrorSource
-import com.datadog.android.rum._RumInternalProxy
 import com.datadog.android.rum.configuration.SlowFramesConfiguration
 import com.datadog.android.rum.tracking.NavigationViewTrackingStrategy
 import com.datadog.android.sample.account.AccountFragment
@@ -340,9 +339,7 @@ class SampleApplication : Application() {
             .trackBackgroundEvents(true)
             .trackAnonymousUser(true)
             .enableComposeActionTracking()
-            .apply {
-                _RumInternalProxy.collectAccessibilitySettings(this)
-            }
+            .collectAccessibility(true)
             .build()
     }
 


### PR DESCRIPTION
### What does this PR do?
**Previous state:**
Accessibility attributes were collected and sent only when the flag `collectAccessibilitySettings` was set, this flag being an internal flag in `RumInternalProxy`. Attributes were sent as custom tags in view update events.

**New state:**
Accessibility attributes will be sent for all users who set the feature flag `collectAccessibility` (which is now public in `RumConfiguration` and has been renamed to match the ios api). The attributes will be sent as part of the view schema and not as custom tags. Additionally these attributes are `send-only-once`, meaning that accessibility attributes are only sent the first time they have a non-null value, and subsequently only if they change.

Api for accessibility:

.collectAccessibility(enabled = true/false)

### Motivation
Part of the effort to expand metadata visibility.

### Additional Notes
Contains an update to the RUM schema to support sending the RTL Enabled attribute - this attribute indicates whether right-to-left layout was set on the user's device. 

Contains a change to how view filtering works. Previously we sent only the view update with the max doc version, however this causes issues with the send-only-once mechanism. Therefore we now send if either the previous condition was true OR the update contains accessibility changes.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

