### PR TITLE
RUM-9016: DrawableUtils performance improvement

### DIFF
--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/InternalTelemetryEventForgeryFactory.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/InternalTelemetryEventForgeryFactory.kt
@@ -12,6 +12,7 @@ import fr.xgouchet.elmyr.ForgeryFactory
 
 class InternalTelemetryEventForgeryFactory : ForgeryFactory<InternalTelemetryEvent> {
 
+    @Suppress("MagicNumber")
     override fun getForgery(forge: Forge): InternalTelemetryEvent {
         val random = forge.anInt(min = 0, max = 6)
         return when (random) {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtils.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtils.kt
@@ -112,7 +112,7 @@ internal class DrawableUtils(
         } else {
             // erase the canvas
             // needed because overdrawing an already used bitmap causes unusual visual artifacts
-            canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.MULTIPLY)
+            canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR)
 
             drawable.setBounds(0, 0, canvas.width, canvas.height)
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtilsTest.kt
@@ -9,6 +9,8 @@ package com.datadog.android.sessionreplay.internal.utils
 import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.PorterDuff
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.Drawable.ConstantState
 import android.util.AndroidRuntimeException
@@ -38,6 +40,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -423,6 +426,25 @@ internal class DrawableUtilsTest {
             { it == "$DRAWABLE_DRAW_FINISHED_WITH_RUNTIME_EXCEPTION ${mockDrawable.javaClass.canonicalName}" },
             exceptionType
         )
+    }
+
+    @Test
+    fun `M use CLEAR mode W createBitmapOfApproxSizeFromDrawable() { when drawing on canvas }`() {
+        // Given
+        whenever(mockDrawable.intrinsicWidth).thenReturn(10)
+        whenever(mockDrawable.intrinsicHeight).thenReturn(10)
+
+        // When
+        testedDrawableUtils.createBitmapOfApproxSizeFromDrawable(
+            drawable = mockDrawable,
+            drawableWidth = mockDrawable.intrinsicWidth,
+            drawableHeight = mockDrawable.intrinsicHeight,
+            displayMetrics = mockDisplayMetrics,
+            bitmapCreationCallback = mockBitmapCreationCallback
+        )
+
+        // Then
+        verify(mockCanvas).drawColor(eq(Color.TRANSPARENT), eq(PorterDuff.Mode.CLEAR))
     }
 
     companion object {

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubInternalLogger.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubInternalLogger.kt
@@ -16,6 +16,7 @@ internal class StubInternalLogger : InternalLogger {
 
     val telemetryEventsWritten = mutableListOf<StubTelemetryEvent>()
 
+    @Suppress("MagicNumber")
     override fun log(
         level: InternalLogger.Level,
         target: InternalLogger.Target,


### PR DESCRIPTION
### What does this PR do?
Modifies

```canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.MULTIPLY)```

to 

```canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR)```


This is a more efficient way to clear the canvas and results in a 20% improvement in cpu for this method (approximately 8.8ms -> 7.3ms in the benchmarking I did). 


### Motivation
Improve efficiency of drawable handling.

### Additional Notes
I added some suppress annotation to silence old detekt warnings about magic number usage.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

