### PR TITLE
Some additional accessibility test coverage

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -1203,6 +1203,7 @@ datadog:
       - "kotlin.Any.toString()"
       - "kotlin.Boolean.hashCode()"
       - "kotlin.Boolean.not()"
+      - "kotlin.Boolean.takeIf(kotlin.Function1)"
       - "kotlin.Byte.toInt()"
       - "kotlin.ByteArray.constructor(kotlin.Int)"
       - "kotlin.ByteArray.copyTo(kotlin.Int, kotlin.ByteArray, kotlin.Int, kotlin.Int, com.datadog.android.api.InternalLogger)"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
@@ -60,8 +60,7 @@ data class RumConfiguration internal constructor(
         }
 
         /**
-         * Whether to collect accessibility attributes inside the RUM view update event.
-         * This is disabled by default.
+         * Whether to collect accessibility attributes - this is disabled by default.
          *
          * @param enabled whether collecting accessibility attributes is enabled or not.
          */

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
@@ -33,11 +33,7 @@ internal class RumDataWriter(
         ) ?: return false
 
         val batchEvent = if (element is ViewEvent) {
-            val hasAccessibility = if (element.view.accessibility != null) {
-                isAccessibilityPopulated(element.view.accessibility)
-            } else {
-                false
-            }
+            val hasAccessibility = element.view.accessibility != null
 
             val eventMeta = RumEventMeta.View(
                 viewId = element.view.id,
@@ -73,33 +69,6 @@ internal class RumDataWriter(
         when (data) {
             is ViewEvent -> sdkCore.writeLastViewEvent(rawData)
         }
-    }
-
-    private fun isAccessibilityPopulated(accessibility: ViewEvent.Accessibility): Boolean {
-        return setOf<Any?>(
-            accessibility.textSize,
-            accessibility.assistiveSwitchEnabled,
-            accessibility.assistiveTouchEnabled,
-            accessibility.boldTextEnabled,
-            accessibility.buttonShapesEnabled,
-            accessibility.closedCaptioningEnabled,
-            accessibility.grayscaleEnabled,
-            accessibility.increaseContrastEnabled,
-            accessibility.invertColorsEnabled,
-            accessibility.monoAudioEnabled,
-            accessibility.onOffSwitchLabelsEnabled,
-            accessibility.reduceMotionEnabled,
-            accessibility.reduceTransparencyEnabled,
-            accessibility.reducedAnimationsEnabled,
-            accessibility.rtlEnabled,
-            accessibility.screenReaderEnabled,
-            accessibility.shakeToUndoEnabled,
-            accessibility.shouldDifferentiateWithoutColor,
-            accessibility.singleAppModeEnabled,
-            accessibility.speakScreenEnabled,
-            accessibility.speakSelectionEnabled,
-            accessibility.videoAutoplayEnabled
-        ).any { it != null }
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/accessibility/AccessibilitySnapshotManager.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/accessibility/AccessibilitySnapshotManager.kt
@@ -10,5 +10,5 @@ import com.datadog.tools.annotation.NoOpImplementation
 
 @NoOpImplementation
 internal interface AccessibilitySnapshotManager {
-    fun latestSnapshot(): AccessibilityInfo
+    fun getIfChanged(): AccessibilityInfo?
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -997,16 +997,17 @@ internal open class RumViewScope(
             )
         }
 
-        val accessibilityState = accessibilitySnapshotManager.latestSnapshot()
-        val accessibility = ViewEvent.Accessibility(
-            textSize = accessibilityState.textSize,
-            invertColorsEnabled = accessibilityState.isColorInversionEnabled,
-            singleAppModeEnabled = accessibilityState.isScreenPinningEnabled,
-            screenReaderEnabled = accessibilityState.isScreenReaderEnabled,
-            closedCaptioningEnabled = accessibilityState.isClosedCaptioningEnabled,
-            reducedAnimationsEnabled = accessibilityState.isReducedAnimationsEnabled,
-            rtlEnabled = accessibilityState.isRtlEnabled
-        )
+        val accessibility = accessibilitySnapshotManager.getIfChanged()?.let {
+            ViewEvent.Accessibility(
+                textSize = it.textSize,
+                invertColorsEnabled = it.isColorInversionEnabled,
+                singleAppModeEnabled = it.isScreenPinningEnabled,
+                screenReaderEnabled = it.isScreenReaderEnabled,
+                closedCaptioningEnabled = it.isClosedCaptioningEnabled,
+                reducedAnimationsEnabled = it.isReducedAnimationsEnabled,
+                rtlEnabled = it.isRtlEnabled
+            )
+        }
 
         val batteryInfo = batteryInfoProvider.getState()
         val displayInfo = displayInfoProvider.getState()

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
@@ -17,7 +17,6 @@ import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.rum.model.ViewEvent
-import com.datadog.android.rum.model.ViewEvent.Accessibility
 import com.datadog.android.rum.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
@@ -131,7 +130,7 @@ internal class RumDataWriterTest {
     ) {
         // Given
         whenever(mockSerializer.serialize(fakeViewEvent)) doReturn fakeSerializedEvent
-        val hasAccessibility = isAccessibilityPopulated(fakeViewEvent.view.accessibility)
+        val hasAccessibility = fakeViewEvent.view.accessibility != null
         val eventMeta = RumEventMeta.View(
             viewId = fakeViewEvent.view.id,
             documentVersion = fakeViewEvent.dd.documentVersion,
@@ -161,7 +160,7 @@ internal class RumDataWriterTest {
     ) {
         // Given
         whenever(mockSerializer.serialize(fakeViewEvent)) doReturn fakeSerializedEvent
-        val hasAccessibility = isAccessibilityPopulated(fakeViewEvent.view.accessibility)
+        val hasAccessibility = fakeViewEvent.view.accessibility != null
         val eventMeta = RumEventMeta.View(
             viewId = fakeViewEvent.view.id,
             documentVersion = fakeViewEvent.dd.documentVersion,
@@ -257,13 +256,13 @@ internal class RumDataWriterTest {
     // region accessibility
 
     @Test
-    fun `M hasAccessibility false W write() { empty accessibility object }`(
+    fun `M hasAccessibility false W write() { null accessibility }`(
         forge: Forge
     ) {
         // Given
         val viewEvent = forge.getForgery<ViewEvent>()
         val newView = viewEvent.view.copy(
-            accessibility = Accessibility()
+            accessibility = null
         )
         val newViewEvent = viewEvent.copy(
             view = newView
@@ -282,15 +281,13 @@ internal class RumDataWriterTest {
     }
 
     @Test
-    fun `M hasAccessibility true W write() { populated accessibility object }`(
+    fun `M hasAccessibility true W write() { non-null accessibility }`(
         forge: Forge
     ) {
         // Given
         val viewEvent = forge.getForgery<ViewEvent>()
         val newView = viewEvent.view.copy(
-            accessibility = Accessibility(
-                textSize = "1.3"
-            )
+            accessibility = forge.getForgery()
         )
         val newViewEvent = viewEvent.copy(
             view = newView
@@ -309,34 +306,6 @@ internal class RumDataWriterTest {
     }
 
     // endregion
-
-    private fun isAccessibilityPopulated(accessibility: Accessibility?): Boolean {
-        if (accessibility == null) return false
-        return setOf<Any?>(
-            accessibility.textSize,
-            accessibility.assistiveSwitchEnabled,
-            accessibility.assistiveTouchEnabled,
-            accessibility.boldTextEnabled,
-            accessibility.buttonShapesEnabled,
-            accessibility.closedCaptioningEnabled,
-            accessibility.grayscaleEnabled,
-            accessibility.increaseContrastEnabled,
-            accessibility.invertColorsEnabled,
-            accessibility.monoAudioEnabled,
-            accessibility.onOffSwitchLabelsEnabled,
-            accessibility.reduceMotionEnabled,
-            accessibility.reduceTransparencyEnabled,
-            accessibility.reducedAnimationsEnabled,
-            accessibility.rtlEnabled,
-            accessibility.screenReaderEnabled,
-            accessibility.shakeToUndoEnabled,
-            accessibility.shouldDifferentiateWithoutColor,
-            accessibility.singleAppModeEnabled,
-            accessibility.speakScreenEnabled,
-            accessibility.speakSelectionEnabled,
-            accessibility.videoAutoplayEnabled
-        ).any { it != null }
-    }
 
     companion object {
         val rumMonitor = GlobalRumMonitorTestConfiguration()

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/accessibility/DefaultAccessibilitySnapshotManagerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/accessibility/DefaultAccessibilitySnapshotManagerTest.kt
@@ -44,15 +44,43 @@ internal class DefaultAccessibilitySnapshotManagerTest {
     }
 
     @Test
-    fun `M return empty accessibility W latestSnapshot() { no accessibility data }`() {
+    fun `M return null W latestSnapshot() { new snapshot equals last snapshot }`(forge: Forge) {
+        // Given
+        whenever(mockAccessibilityReader.getState()) doReturn forge.getForgery()
+
+        // When
+        testedManager.getIfChanged()
+        val result = testedManager.getIfChanged()
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M return null W latestSnapshot() { new snapshot to null value }`(forge: Forge) {
+        // Given
+        whenever(mockAccessibilityReader.getState())
+            .thenReturn(forge.getForgery())
+            .thenReturn(AccessibilityInfo())
+
+        // When
+        testedManager.getIfChanged()
+        val result = testedManager.getIfChanged()
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M return null W latestSnapshot() { no accessibility data }`() {
         // Given
         whenever(mockAccessibilityReader.getState()) doReturn AccessibilityInfo()
 
         // When
-        val result = testedManager.latestSnapshot()
+        val result = testedManager.getIfChanged()
 
         // Then
-        assertThat(result).isEqualTo(AccessibilityInfo())
+        assertThat(result).isNull()
     }
 
     @Test
@@ -78,7 +106,7 @@ internal class DefaultAccessibilitySnapshotManagerTest {
         whenever(mockAccessibilityReader.getState()) doReturn accessibilityState
 
         // When
-        val result = testedManager.latestSnapshot()
+        val result = testedManager.getIfChanged()
 
         // Then
         assertThat(result).isEqualTo(
@@ -95,7 +123,7 @@ internal class DefaultAccessibilitySnapshotManagerTest {
     }
 
     @Test
-    fun `M return empty accessibility W latestSnapshot() { second call with same data }`(
+    fun `M return null W latestSnapshot() { second call with same data }`(
         @FloatForgery textSize: Float,
         @BoolForgery screenReader: Boolean
     ) {
@@ -106,14 +134,13 @@ internal class DefaultAccessibilitySnapshotManagerTest {
         )
         whenever(mockAccessibilityReader.getState()) doReturn accessibilityState
 
-        // When - First call
-        testedManager.latestSnapshot()
+        testedManager.getIfChanged()
 
-        // When - Second call with same data
-        val result = testedManager.latestSnapshot()
+        // When (second call)
+        val result = testedManager.getIfChanged()
 
         // Then
-        assertThat(result).isEqualTo(AccessibilityInfo())
+        assertThat(result).isNull()
     }
 
     @Test
@@ -143,10 +170,10 @@ internal class DefaultAccessibilitySnapshotManagerTest {
             .doReturn(changedState)
 
         // When
-        testedManager.latestSnapshot() // First call
-        val result = testedManager.latestSnapshot() // Second call
+        testedManager.getIfChanged() // First call
+        val result = testedManager.getIfChanged() // Second call
 
-        // Then - Only changed value should be returned
+        // Then
         assertThat(result).isEqualTo(
             AccessibilityInfo(textSize = newTextSize.toString())
         )
@@ -173,10 +200,10 @@ internal class DefaultAccessibilitySnapshotManagerTest {
             .doReturn(expandedState)
 
         // When
-        testedManager.latestSnapshot() // First call
-        val result = testedManager.latestSnapshot() // Second call
+        testedManager.getIfChanged() // First call
+        val result = testedManager.getIfChanged() // Second call
 
-        // Then - Only new values should be returned
+        // Then
         assertThat(result).isEqualTo(
             AccessibilityInfo(
                 isScreenReaderEnabled = screenReader,
@@ -206,11 +233,11 @@ internal class DefaultAccessibilitySnapshotManagerTest {
             .doReturn(stateWithNull)
 
         // When
-        testedManager.latestSnapshot() // First call
-        val result = testedManager.latestSnapshot() // Second call
+        testedManager.getIfChanged() // First call
+        val result = testedManager.getIfChanged() // Second call
 
-        // Then - No changes should be reported (null values are filtered)
-        assertThat(result).isEqualTo(AccessibilityInfo())
+        // Then
+        assertThat(result).isNull()
     }
 
     @Test
@@ -236,11 +263,11 @@ internal class DefaultAccessibilitySnapshotManagerTest {
             .doReturn(incompleteState)
 
         // When
-        testedManager.latestSnapshot() // First call
-        val result = testedManager.latestSnapshot() // Second call
+        testedManager.getIfChanged() // First call
+        val result = testedManager.getIfChanged() // Second call
 
-        // Then - No changes should be reported for missing keys (they become null)
-        assertThat(result).isEqualTo(AccessibilityInfo())
+        // Then
+        assertThat(result).isNull()
     }
 
     @Test
@@ -264,17 +291,17 @@ internal class DefaultAccessibilitySnapshotManagerTest {
             .doReturn(state4)
 
         // When & Then
-        val result1 = testedManager.latestSnapshot()
-        assertThat(result1.textSize).isEqualTo(textSize1.toString())
+        val result1 = testedManager.getIfChanged()
+        assertThat(result1?.textSize).isEqualTo(textSize1.toString())
 
-        val result2 = testedManager.latestSnapshot()
-        assertThat(result2.textSize).isEqualTo(textSize2.toString())
+        val result2 = testedManager.getIfChanged()
+        assertThat(result2?.textSize).isEqualTo(textSize2.toString())
 
-        val result3 = testedManager.latestSnapshot()
-        assertThat(result3).isEqualTo(AccessibilityInfo()) // No change
+        val result3 = testedManager.getIfChanged()
+        assertThat(result3).isNull() // No change
 
-        val result4 = testedManager.latestSnapshot()
-        assertThat(result4.textSize).isEqualTo(textSize3.toString())
+        val result4 = testedManager.getIfChanged()
+        assertThat(result4?.textSize).isEqualTo(textSize3.toString())
     }
 
     /**

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/battery/DefaultBatteryInfoProviderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/battery/DefaultBatteryInfoProviderTest.kt
@@ -78,6 +78,7 @@ internal class DefaultBatteryInfoProviderTest {
     // region getBatteryState
 
     @Test
+    @TestTargetApi(Build.VERSION_CODES.Q) // needed or battery level 0 causes flakiness with retrieval code
     fun `M return complete battery info W getBatteryState() { all services available }`(
         @BoolForgery fakeLowPowerMode: Boolean,
         @IntForgery(0, 100) fakeBatteryLevel: Int

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -148,7 +148,7 @@ internal class RumApplicationScopeTest {
         whenever(mockSdkCore.time) doReturn fakeTimeInfoAtScopeStart
         whenever(mockSdkCore.internalLogger) doReturn mock()
         whenever(mockSlowFramesListener.resolveReport(any(), any(), any())) doReturn viewUIPerformanceReport
-        whenever(mockAccessibilitySnapshotManager.latestSnapshot()) doReturn mock()
+        whenever(mockAccessibilitySnapshotManager.getIfChanged()) doReturn mock()
 
         fakeRumSessionType = forge.aNullable { aValueFrom(RumSessionType::class.java) }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -161,7 +161,7 @@ internal class RumViewManagerScopeTest {
         whenever(mockChildScope.isActive()) doReturn true
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockSlowFramesListener.resolveReport(any(), any(), any())) doReturn fakeViewUIPerformanceReport
-        whenever(mockAccessibilitySnapshotManager.latestSnapshot()) doReturn mock()
+        whenever(mockAccessibilitySnapshotManager.getIfChanged()) doReturn mock()
 
         fakeRumSessionType = forge.aNullable { aValueFrom(RumSessionType::class.java) }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -279,7 +279,7 @@ internal class RumViewScopeTest {
         whenever(mockInteractionToNextViewMetricResolver.resolveMetric(any())) doReturn
             fakeInteractionToNextViewMetricValue
         val isValidSource = forge.aBool()
-        whenever(mockAccessibilitySnapshotManager.latestSnapshot()) doReturn mock()
+        whenever(mockAccessibilitySnapshotManager.getIfChanged()) doReturn mock()
 
         val fakeSource = if (isValidSource) {
             forge.anElementFrom(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -206,7 +206,7 @@ internal class DatadogRumMonitorTest {
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockSdkCore.time) doReturn fakeTimeInfo
         whenever(mockSlowFramesListener.resolveReport(any(), any(), any())) doReturn fakeViewUIPerformanceReport
-        whenever(mockAccessibilitySnapshotManager.latestSnapshot()) doReturn mock()
+        whenever(mockAccessibilitySnapshotManager.getIfChanged()) doReturn mock()
 
         fakeAttributes = forge.exhaustiveAttributes()
 

--- a/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/AccessibilityForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/AccessibilityForgeryFactory.kt
@@ -13,13 +13,13 @@ import fr.xgouchet.elmyr.ForgeryFactory
 internal class AccessibilityForgeryFactory : ForgeryFactory<Accessibility> {
     override fun getForgery(forge: Forge): Accessibility {
         return Accessibility(
-            textSize = forge.aNullable { forge.aString() },
-            rtlEnabled = forge.aNullable { forge.aBool() },
-            screenReaderEnabled = forge.aNullable { forge.aBool() },
-            increaseContrastEnabled = forge.aNullable { forge.aBool() },
-            reducedAnimationsEnabled = forge.aNullable { forge.aBool() },
-            invertColorsEnabled = forge.aNullable { forge.aBool() },
-            singleAppModeEnabled = forge.aNullable { forge.aBool() }
+            textSize = forge.aNullable { aString() },
+            rtlEnabled = forge.aNullable { aBool() },
+            screenReaderEnabled = forge.aNullable { aBool() },
+            increaseContrastEnabled = forge.aNullable { aBool() },
+            reducedAnimationsEnabled = forge.aNullable { aBool() },
+            invertColorsEnabled = forge.aNullable { aBool() },
+            singleAppModeEnabled = forge.aNullable { aBool() }
         )
     }
 }

--- a/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/AccessibilityInfoForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/AccessibilityInfoForgeryFactory.kt
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.utils.forge
+
+import com.datadog.android.rum.internal.domain.accessibility.AccessibilityInfo
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class AccessibilityInfoForgeryFactory : ForgeryFactory<AccessibilityInfo> {
+    override fun getForgery(forge: Forge): AccessibilityInfo {
+        return AccessibilityInfo(
+            textSize = forge.aString(),
+            isColorInversionEnabled = forge.aBool(),
+            isClosedCaptioningEnabled = forge.aBool(),
+            isReducedAnimationsEnabled = forge.aBool(),
+            isScreenReaderEnabled = forge.aBool(),
+            isScreenPinningEnabled = forge.aBool(),
+            isRtlEnabled = forge.aBool()
+        )
+    }
+}

--- a/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ForgeExt.kt
+++ b/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ForgeExt.kt
@@ -61,4 +61,5 @@ fun Forge.useCommonRumFactories() {
     addFactory(LongTaskEventForgeryFactory())
     addFactory(ResourceTimingForgeryFactory())
     addFactory(AccessibilityForgeryFactory())
+    addFactory(AccessibilityInfoForgeryFactory())
 }

--- a/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ViewEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ViewEventForgeryFactory.kt
@@ -65,7 +65,7 @@ class ViewEventForgeryFactory : ForgeryFactory<ViewEvent> {
                 refreshRateAverage = forge.aNullable { aPositiveDouble() },
                 refreshRateMin = forge.aNullable { aPositiveDouble() },
                 frustration = forge.aNullable { ViewEvent.Frustration(aPositiveLong()) },
-                accessibility = forge.aNullable { forge.getForgery<Accessibility>() }
+                accessibility = forge.aNullable { getForgery<Accessibility>() }
             ),
             connectivity = forge.aNullable {
                 ViewEvent.Connectivity(


### PR DESCRIPTION
### What does this PR do?
Refactor `DefaultAccessibilitySnapshotManager` to return a nullable object - this simplifies the later logic in terms of knowing if anything changed in the accessibility state. 

Adds some additional test coverage for accessibility around the logic for view reduction

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

