### PR TITLE
Move Okhttp client initialization to background thread.

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -89,10 +89,12 @@ import com.datadog.android.security.Encryption
 import com.google.gson.JsonObject
 import com.lyft.kronos.AndroidClockFactory
 import com.lyft.kronos.KronosClock
+import okhttp3.Call
 import okhttp3.CipherSuite
 import okhttp3.ConnectionSpec
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
+import okhttp3.Request
 import okhttp3.TlsVersion
 import java.io.File
 import java.io.FileNotFoundException
@@ -113,6 +115,14 @@ internal class CoreFeature(
     private val scheduledExecutorServiceFactory: ScheduledExecutorServiceFactory
 ) {
 
+    internal class OkHttpCallFactory(factory: () -> OkHttpClient): Call.Factory {
+        val okhttpClient by lazy(factory)
+
+        override fun newCall(request: Request): Call {
+            return okhttpClient.newCall(request)
+        }
+    }
+
     internal val initialized = AtomicBoolean(false)
     internal var contextRef: WeakReference<Context?> = WeakReference(null)
 
@@ -126,7 +136,7 @@ internal class CoreFeature(
     internal var accountInfoProvider: MutableAccountInfoProvider = NoOpMutableAccountInfoProvider()
     internal var contextProvider: ContextProvider = NoOpContextProvider()
 
-    internal lateinit var okHttpClient: OkHttpClient
+    internal lateinit var callFactory: OkHttpCallFactory
     internal var kronosClock: KronosClock? = null
 
     internal var clientToken: String = ""
@@ -575,37 +585,39 @@ internal class CoreFeature(
 
     @Suppress("SpreadOperator")
     private fun setupOkHttpClient(configuration: Configuration.Core) {
-        val connectionSpec = when {
-            configuration.needsClearTextHttp -> ConnectionSpec.CLEARTEXT
-            else -> ConnectionSpec.Builder(ConnectionSpec.RESTRICTED_TLS)
-                .tlsVersions(TlsVersion.TLS_1_2, TlsVersion.TLS_1_3)
-                .cipherSuites(*RESTRICTED_CIPHER_SUITES)
-                .build()
-        }
+        callFactory = OkHttpCallFactory {
+            val connectionSpec = when {
+                configuration.needsClearTextHttp -> ConnectionSpec.CLEARTEXT
+                else -> ConnectionSpec.Builder(ConnectionSpec.RESTRICTED_TLS)
+                    .tlsVersions(TlsVersion.TLS_1_2, TlsVersion.TLS_1_3)
+                    .cipherSuites(*RESTRICTED_CIPHER_SUITES)
+                    .build()
+            }
 
-        val builder = OkHttpClient.Builder()
-        builder.callTimeout(NETWORK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-            .writeTimeout(NETWORK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-            .protocols(listOf(Protocol.HTTP_2, Protocol.HTTP_1_1))
-            .connectionSpecs(listOf(connectionSpec))
+            val builder = OkHttpClient.Builder()
+            builder.callTimeout(NETWORK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .writeTimeout(NETWORK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .protocols(listOf(Protocol.HTTP_2, Protocol.HTTP_1_1))
+                .connectionSpecs(listOf(connectionSpec))
 
-        if (BuildConfig.DEBUG) {
+            if (BuildConfig.DEBUG) {
+                @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
+                builder.addNetworkInterceptor(CurlInterceptor())
+            } else {
+                @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
+                builder.addInterceptor(GzipRequestInterceptor(internalLogger))
+            }
+
+            if (configuration.proxy != null) {
+                builder.proxy(configuration.proxy)
+                builder.proxyAuthenticator(configuration.proxyAuth)
+            }
+
             @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
-            builder.addNetworkInterceptor(CurlInterceptor())
-        } else {
-            @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
-            builder.addInterceptor(GzipRequestInterceptor(internalLogger))
+            builder.dns(RotatingDnsResolver())
+
+            builder.build()
         }
-
-        if (configuration.proxy != null) {
-            builder.proxy(configuration.proxy)
-            builder.proxyAuthenticator(configuration.proxyAuth)
-        }
-
-        @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
-        builder.dns(RotatingDnsResolver())
-
-        okHttpClient = builder.build()
     }
 
     private fun setupExecutors() {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -381,7 +381,7 @@ internal class SdkFeature(
         return DataOkHttpUploader(
             requestFactory = requestFactory,
             internalLogger = internalLogger,
-            callFactory = coreFeature.okHttpClient,
+            callFactory = coreFeature.callFactory,
             sdkVersion = coreFeature.sdkVersion,
             androidInfoProvider = coreFeature.androidInfoProvider,
             executionTimer = GlobalBenchmark.createExecutionTimer(

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -580,6 +580,21 @@ internal class CoreFeatureTest {
     }
 
     @Test
+    fun `M initialize okhttp only once`() {
+        // When
+        testedFeature.initialize(
+            appContext.mockInstance,
+            fakeSdkInstanceId,
+            fakeConfig.copy(coreConfig = fakeConfig.coreConfig),
+            fakeConsent
+        )
+
+        // Then
+        val okHttpClient = testedFeature.callFactory.okhttpClient
+        assertThat(okHttpClient).isEqualTo(testedFeature.callFactory.okhttpClient)
+    }
+
+    @Test
     fun `M initialize okhttp with strict network policy W initialize()`() {
         // When
         testedFeature.initialize(
@@ -590,7 +605,7 @@ internal class CoreFeatureTest {
         )
 
         // Then
-        val okHttpClient = testedFeature.okHttpClient
+        val okHttpClient = testedFeature.callFactory.okhttpClient
         assertThat(okHttpClient.protocols)
             .containsExactly(Protocol.HTTP_2, Protocol.HTTP_1_1)
         assertThat(okHttpClient.callTimeoutMillis)
@@ -625,7 +640,7 @@ internal class CoreFeatureTest {
         )
 
         // Then
-        val okHttpClient = testedFeature.okHttpClient
+        val okHttpClient = testedFeature.callFactory.okhttpClient
         assertThat(okHttpClient.protocols)
             .containsExactly(Protocol.HTTP_2, Protocol.HTTP_1_1)
         assertThat(okHttpClient.callTimeoutMillis)
@@ -652,7 +667,7 @@ internal class CoreFeatureTest {
         )
 
         // Then
-        val okHttpClient = testedFeature.okHttpClient
+        val okHttpClient = testedFeature.callFactory.okhttpClient
         assertThat(okHttpClient.proxy).isSameAs(proxy)
         assertThat(okHttpClient.proxyAuthenticator).isSameAs(proxyAuth)
     }
@@ -668,7 +683,7 @@ internal class CoreFeatureTest {
         )
 
         // Then
-        val okHttpClient = testedFeature.okHttpClient
+        val okHttpClient = testedFeature.callFactory.okhttpClient
         assertThat(okHttpClient.proxy).isNull()
         assertThat(okHttpClient.proxyAuthenticator).isEqualTo(Authenticator.NONE)
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/config/CoreFeatureTestConfiguration.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/config/CoreFeatureTestConfiguration.kt
@@ -56,8 +56,9 @@ internal class CoreFeatureTestConfiguration<T : Context>(
     lateinit var fakeBatchSize: BatchSize
     var fakeBuildId: String? = null
 
+    lateinit var callFactory: CoreFeature.OkHttpCallFactory
+
     lateinit var mockUploadExecutor: ScheduledThreadPoolExecutor
-    lateinit var mockOkHttpClient: OkHttpClient
     lateinit var mockPersistenceExecutor: FlushableExecutorService
     lateinit var mockKronosClock: KronosClock
     lateinit var mockContextRef: WeakReference<Context?>
@@ -112,7 +113,10 @@ internal class CoreFeatureTestConfiguration<T : Context>(
     private fun createMocks() {
         mockPersistenceExecutor = mock()
         mockUploadExecutor = mock()
-        mockOkHttpClient = mock()
+        callFactory = CoreFeature.OkHttpCallFactory {
+            mock()
+        }
+
         mockKronosClock = mock()
         // Mockito cannot mock WeakReference by some reason
         mockContextRef = WeakReference(appContext.mockInstance)
@@ -147,7 +151,7 @@ internal class CoreFeatureTestConfiguration<T : Context>(
 
         whenever(mockInstance.persistenceExecutorService) doReturn mockPersistenceExecutor
         whenever(mockInstance.uploadExecutorService) doReturn mockUploadExecutor
-        whenever(mockInstance.okHttpClient) doReturn mockOkHttpClient
+        whenever(mockInstance.callFactory) doReturn callFactory
         whenever(mockInstance.kronosClock) doReturn mockKronosClock
         whenever(mockInstance.contextRef) doReturn mockContextRef
         whenever(mockInstance.firstPartyHostHeaderTypeResolver) doReturn mockFirstPartyHostHeaderTypeResolver


### PR DESCRIPTION
### What does this PR do?

Moving OkHttp Client initialization to the background thread.

### Motivation
It's a standard practice to initialize the Okhttp client on the background thread. It's a pretty trivial thing to do since there already exists `Call.Factory` interface. 

### Additional Notes
https://github.com/DataDog/dd-sdk-android/issues/2809

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

