### PR TITLE
RUM-11404: Add Github action to close stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,38 @@
+name: 'Automatically close stale issues'
+
+on:
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: |
+            This issue has been automatically marked as stale because it has not had recent activity and has the `awaiting-response` label.
+            
+            It will be closed if no further activity occurs within 3 days.
+
+          # The label that will be added to the issues when automatically marked as stale
+          stale-issue-label: 'stale'
+          # The label that will be added to the issues when automatically marked as stale
+          close-issue-label: 'automatically closed'
+          # Only target issues with 'awaiting-response' label
+          only-labels: 'awaiting response'
+          # Mark issues as stale after 14 days
+          days-before-issue-stale: 14
+          # Close issues after 3 days of being marked stale
+          days-before-issue-close: 3
+          # Automatically remove the stale label when the issues or the pull requests are updated
+          remove-stale-when-updated: true
+          # Specify the reason used when closing issues: `completed` or `not_planned`
+          close-issue-reason: completed
+          # Run the stale workflow as dry-run.
+          # No GitHub API calls that can alter the issues and pull requests will happen.
+          # Useful to debug or when you want to configure the stale workflow safely.
+          debug-only: true


### PR DESCRIPTION
### What does this PR do?

This PR adds a Github action to automatically close stale issues.

It is a similar move done already for iOS SDK, see the [related PR there](https://github.com/DataDog/dd-sdk-ios/pull/2392) for more details.

Note: for now this PR has this action only in the debug mode with manual run, so it can be tested once PR is merged.

Once everything is tested, the follow-up PR will add automated run.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

