### PR TITLE
RUM-11404: Add a schedule for the stale issues Github action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,9 @@
 name: 'Automatically close stale issues'
 
 on:
+  schedule:
+    # Runs every day at 8:00 AM CET
+    - cron: '0 7 * * *'
   workflow_dispatch:
 
 permissions:
@@ -35,4 +38,4 @@ jobs:
           # Run the stale workflow as dry-run.
           # No GitHub API calls that can alter the issues and pull requests will happen.
           # Useful to debug or when you want to configure the stale workflow safely.
-          debug-only: true
+          debug-only: false


### PR DESCRIPTION
### What does this PR do?

Follow-up for https://github.com/DataDog/dd-sdk-android/pull/2826.

Since action is running fine, adding the schedule and disabling debug mode.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

