### PR TITLE
[RUM-11251][FO]: Fix RumVitalEvent serialization logic

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -82,6 +82,7 @@ data class com.datadog.android.rum.RumConfiguration
     fun setActionEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ActionEvent>): Builder
     fun setErrorEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ErrorEvent>): Builder
     fun setLongTaskEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.LongTaskEvent>): Builder
+    fun setVitalEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.RumVitalEvent>): Builder
     fun trackBackgroundEvents(Boolean): Builder
     fun trackFrustrations(Boolean): Builder
     fun setVitalsUpdateFrequency(com.datadog.android.rum.configuration.VitalsUpdateFrequency): Builder

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -117,6 +117,7 @@ public final class com/datadog/android/rum/RumConfiguration$Builder {
 	public final fun setSlowFramesConfiguration (Lcom/datadog/android/rum/configuration/SlowFramesConfiguration;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setTelemetrySampleRate (F)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setViewEventMapper (Lcom/datadog/android/rum/event/ViewEventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
+	public final fun setVitalEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setVitalsUpdateFrequency (Lcom/datadog/android/rum/configuration/VitalsUpdateFrequency;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun trackAnonymousUser (Z)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun trackBackgroundEvents (Z)Lcom/datadog/android/rum/RumConfiguration$Builder;

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
@@ -22,6 +22,7 @@ import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
+import com.datadog.android.rum.model.RumVitalEvent
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.rum.tracking.ActionTrackingStrategy
 import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
@@ -216,6 +217,17 @@ data class RumConfiguration internal constructor(
          */
         fun setLongTaskEventMapper(eventMapper: EventMapper<LongTaskEvent>): Builder {
             rumConfig = rumConfig.copy(longTaskEventMapper = eventMapper)
+            return this
+        }
+
+        /**
+         * Sets the [EventMapper] for the RUM [RumVitalEvent]. You can use this interface implementation
+         * to modify the [RumVitalEvent] attributes before serialisation.
+         *
+         * @param eventMapper the [EventMapper] implementation.
+         */
+        fun setVitalEventMapper(eventMapper: EventMapper<RumVitalEvent>): Builder {
+            rumConfig = rumConfig.copy(vitalEventMapper = eventMapper)
             return this
         }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -90,6 +90,7 @@ import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
+import com.datadog.android.rum.model.RumVitalEvent
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.rum.tracking.ActionTrackingStrategy
 import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
@@ -329,6 +330,7 @@ internal class RumFeature(
                     resourceEventMapper = configuration.resourceEventMapper,
                     actionEventMapper = configuration.actionEventMapper,
                     longTaskEventMapper = configuration.longTaskEventMapper,
+                    vitalEventMapper = configuration.vitalEventMapper,
                     telemetryConfigurationMapper = configuration.telemetryConfigurationMapper,
                     internalLogger = sdkCore.internalLogger
                 ),
@@ -641,6 +643,7 @@ internal class RumFeature(
         val resourceEventMapper: EventMapper<ResourceEvent>,
         val actionEventMapper: EventMapper<ActionEvent>,
         val longTaskEventMapper: EventMapper<LongTaskEvent>,
+        val vitalEventMapper: EventMapper<RumVitalEvent>,
         val telemetryConfigurationMapper: EventMapper<TelemetryConfigurationEvent>,
         val backgroundEventTracking: Boolean,
         val trackFrustrations: Boolean,
@@ -692,6 +695,7 @@ internal class RumFeature(
             resourceEventMapper = NoOpEventMapper(),
             actionEventMapper = NoOpEventMapper(),
             longTaskEventMapper = NoOpEventMapper(),
+            vitalEventMapper = NoOpEventMapper(),
             telemetryConfigurationMapper = NoOpEventMapper(),
             backgroundEventTracking = false,
             trackFrustrations = true,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapper.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapper.kt
@@ -13,6 +13,7 @@ import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
+import com.datadog.android.rum.model.RumVitalEvent
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.telemetry.model.TelemetryConfigurationEvent
 import com.datadog.android.telemetry.model.TelemetryDebugEvent
@@ -26,6 +27,7 @@ internal data class RumEventMapper(
     val resourceEventMapper: EventMapper<ResourceEvent> = NoOpEventMapper(),
     val actionEventMapper: EventMapper<ActionEvent> = NoOpEventMapper(),
     val longTaskEventMapper: EventMapper<LongTaskEvent> = NoOpEventMapper(),
+    val vitalEventMapper: EventMapper<RumVitalEvent> = NoOpEventMapper(),
     val telemetryConfigurationMapper: EventMapper<TelemetryConfigurationEvent> = NoOpEventMapper(),
     private val internalLogger: InternalLogger
 ) : EventMapper<Any> {
@@ -60,6 +62,7 @@ internal data class RumEventMapper(
             }
             is ResourceEvent -> resourceEventMapper.map(event)
             is LongTaskEvent -> longTaskEventMapper.map(event)
+            is RumVitalEvent -> vitalEventMapper.map(event)
             is TelemetryConfigurationEvent -> telemetryConfigurationMapper.map(event)
             is TelemetryDebugEvent,
             is TelemetryUsageEvent,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
@@ -25,6 +25,7 @@ import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
+import com.datadog.android.rum.model.RumVitalEvent
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.rum.tracking.ActionTrackingStrategy
 import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
@@ -444,6 +445,24 @@ internal class RumConfigurationBuilderTest {
         assertThat(rumConfiguration.featureConfiguration).isEqualTo(
             RumFeature.DEFAULT_RUM_CONFIG.copy(
                 longTaskEventMapper = eventMapper
+            )
+        )
+    }
+
+    @Test
+    fun `M build config with RUM Vital eventMapper W seVitalEventMapper() & build()`() {
+        // Given
+        val eventMapper: EventMapper<RumVitalEvent> = mock()
+
+        // When
+        val rumConfiguration = testedBuilder
+            .setVitalEventMapper(eventMapper)
+            .build()
+
+        // Then
+        assertThat(rumConfiguration.featureConfiguration).isEqualTo(
+            RumFeature.DEFAULT_RUM_CONFIG.copy(
+                vitalEventMapper = eventMapper
             )
         )
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
+import com.datadog.android.rum.model.RumVitalEvent
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.android.rum.utils.forge.aRumEvent
@@ -65,6 +66,9 @@ internal class RumEventMapperTest {
     lateinit var mockLongTaskEventMapper: EventMapper<LongTaskEvent>
 
     @Mock
+    lateinit var mockVitalEventMapper: EventMapper<RumVitalEvent>
+
+    @Mock
     lateinit var mockTelemetryConfigurationMapper: EventMapper<TelemetryConfigurationEvent>
 
     @Mock
@@ -80,6 +84,7 @@ internal class RumEventMapperTest {
             resourceEventMapper = mockResourceEventMapper,
             errorEventMapper = mockErrorEventMapper,
             longTaskEventMapper = mockLongTaskEventMapper,
+            vitalEventMapper = mockVitalEventMapper,
             telemetryConfigurationMapper = mockTelemetryConfigurationMapper,
             internalLogger = mockInternalLogger
         )
@@ -163,6 +168,20 @@ internal class RumEventMapperTest {
         // GIVEN
         val fakeRumEvent = forge.getForgery<LongTaskEvent>()
         whenever(mockLongTaskEventMapper.map(fakeRumEvent)).thenReturn(fakeRumEvent)
+
+        // WHEN
+        val mappedRumEvent = testedRumEventMapper.map(fakeRumEvent)
+
+        // THEN
+        assertThat(mappedRumEvent).isNotNull
+        assertThat(mappedRumEvent).isEqualTo(fakeRumEvent)
+    }
+
+    @Test
+    fun `M map the bundled event W map { RumVitalEvent }`(forge: Forge) {
+        // GIVEN
+        val fakeRumEvent = forge.getForgery<RumVitalEvent>()
+        whenever(mockVitalEventMapper.map(fakeRumEvent)).thenReturn(fakeRumEvent)
 
         // WHEN
         val mappedRumEvent = testedRumEventMapper.map(fakeRumEvent)
@@ -388,6 +407,26 @@ internal class RumEventMapperTest {
     }
 
     @Test
+    fun `M return null event W map returns null object { RumVitalEvent }`(forge: Forge) {
+        // GIVEN
+        val fakeRumEvent = forge.getForgery<RumVitalEvent>()
+        whenever(mockVitalEventMapper.map(fakeRumEvent))
+            .thenReturn(null)
+
+        // WHEN
+        val mappedRumEvent = testedRumEventMapper.map(fakeRumEvent)
+
+        // THEN
+        assertThat(mappedRumEvent).isNull()
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.INFO,
+            InternalLogger.Target.USER,
+            RumEventMapper.EVENT_NULL_WARNING_MESSAGE.format(Locale.US, fakeRumEvent)
+
+        )
+    }
+
+    @Test
     fun `M use the original event W map returns different object { ViewEvent }`(forge: Forge) {
         // GIVEN
         val fakeRumEvent = forge.getForgery<ViewEvent>()
@@ -492,6 +531,26 @@ internal class RumEventMapperTest {
     }
 
     @Test
+    fun `M return null event W map returns different object { RumVitalEvent }`(forge: Forge) {
+        // GIVEN
+        val fakeRumEvent = forge.getForgery<RumVitalEvent>()
+        whenever(mockVitalEventMapper.map(fakeRumEvent))
+            .thenReturn(forge.getForgery())
+
+        // WHEN
+        val mappedRumEvent = testedRumEventMapper.map(fakeRumEvent)
+
+        // THEN
+        assertThat(mappedRumEvent).isNull()
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(Locale.US, fakeRumEvent)
+
+        )
+    }
+
+    @Test
     fun `M use the original event W map returns a copy { ViewEvent }`(forge: Forge) {
         // GIVEN
         val fakeRumEvent = forge.getForgery<ViewEvent>()
@@ -579,6 +638,25 @@ internal class RumEventMapperTest {
         // GIVEN
         val fakeRumEvent = forge.getForgery<LongTaskEvent>()
         whenever(mockLongTaskEventMapper.map(fakeRumEvent))
+            .thenReturn(fakeRumEvent.copy())
+
+        // WHEN
+        val mappedRumEvent = testedRumEventMapper.map(fakeRumEvent)
+
+        // THEN
+        assertThat(mappedRumEvent).isNull()
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(Locale.US, fakeRumEvent)
+
+        )
+    }
+    @Test
+    fun `M return null event W map returns a copy { RumVitalEvent }`(forge: Forge) {
+        // GIVEN
+        val fakeRumEvent = forge.getForgery<RumVitalEvent>()
+        whenever(mockVitalEventMapper.map(fakeRumEvent))
             .thenReturn(fakeRumEvent.copy())
 
         // WHEN

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
@@ -652,6 +652,7 @@ internal class RumEventMapperTest {
 
         )
     }
+
     @Test
     fun `M return null event W map returns a copy { RumVitalEvent }`(forge: Forge) {
         // GIVEN

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
@@ -45,6 +45,7 @@ internal class ConfigurationRumForgeryFactory :
             resourceEventMapper = mock(),
             errorEventMapper = mock(),
             longTaskEventMapper = mock(),
+            vitalEventMapper = mock(),
             telemetryConfigurationMapper = mock(),
             longTaskTrackingStrategy = mock(),
             backgroundEventTracking = forge.aBool(),

--- a/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ForgeExt.kt
+++ b/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ForgeExt.kt
@@ -61,4 +61,5 @@ fun Forge.useCommonRumFactories() {
     addFactory(LongTaskEventForgeryFactory())
     addFactory(ResourceTimingForgeryFactory())
     addFactory(AccessibilityForgeryFactory())
+    addFactory(RumVitalEventForgeryFactory())
 }

--- a/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/RumVitalEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/RumVitalEventForgeryFactory.kt
@@ -1,0 +1,78 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.utils.forge
+
+import com.datadog.android.rum.model.RumVitalEvent
+import com.datadog.android.rum.model.RumVitalEvent.FailureReason
+import com.datadog.android.rum.model.RumVitalEvent.RumVitalEventSessionType
+import com.datadog.android.rum.model.RumVitalEvent.RumVitalEventVitalType
+import com.datadog.android.rum.model.RumVitalEvent.StepType
+import com.datadog.tools.unit.forge.exhaustiveAttributes
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import fr.xgouchet.elmyr.jvm.ext.aTimestamp
+import java.net.URL
+import java.util.UUID
+
+class RumVitalEventForgeryFactory : ForgeryFactory<RumVitalEvent> {
+    override fun getForgery(forge: Forge): RumVitalEvent {
+        return RumVitalEvent(
+            date = forge.aTimestamp(),
+            application = RumVitalEvent.Application(forge.getForgery<UUID>().toString()),
+            service = forge.aNullable { anAlphabeticalString() },
+            session = RumVitalEvent.RumVitalEventSession(
+                id = forge.getForgery<UUID>().toString(),
+                type = RumVitalEventSessionType.USER,
+                hasReplay = forge.aNullable { aBool() }
+            ),
+            source = forge.aNullable { aValueFrom(RumVitalEvent.RumVitalEventSource::class.java) },
+            ciTest = forge.aNullable {
+                RumVitalEvent.CiTest(anHexadecimalString())
+            },
+            os = forge.aNullable {
+                RumVitalEvent.Os(
+                    name = forge.aString(),
+                    version = "${forge.aSmallInt()}.${forge.aSmallInt()}.${forge.aSmallInt()}",
+                    versionMajor = forge.aSmallInt().toString()
+                )
+            },
+            device = forge.aNullable {
+                RumVitalEvent.Device(
+                    name = forge.aString(),
+                    model = forge.aString(),
+                    brand = forge.aString(),
+                    type = forge.aValueFrom(RumVitalEvent.DeviceType::class.java),
+                    architecture = forge.aString()
+                )
+            },
+            context = forge.aNullable {
+                RumVitalEvent.Context(
+                    additionalProperties = forge.exhaustiveAttributes()
+                )
+            },
+            dd = RumVitalEvent.Dd(
+                session = forge.aNullable { RumVitalEvent.DdSession(getForgery()) },
+                browserSdkVersion = forge.aNullable { aStringMatching("\\d+\\.\\d+\\.\\d+") }
+            ),
+            ddtags = forge.aNullable { ddTagsString() },
+            view = RumVitalEvent.RumVitalEventView(
+                id = forge.getForgery<UUID>().toString(),
+                referrer = forge.aNullable { getForgery<URL>().toString() },
+                url = forge.aStringMatching("https://[a-z]+.[a-z]{3}/[a-z0-9_/]+"),
+                name = forge.aNullable { anAlphabeticalString() }
+            ),
+            vital = RumVitalEvent.RumVitalEventVital(
+                id = forge.aString(),
+                type = forge.aValueFrom(RumVitalEventVitalType::class.java),
+                operationKey = forge.aNullable { aString() },
+                name = forge.anAlphabeticalString(),
+                stepType = forge.aValueFrom(StepType::class.java),
+                failureReason = forge.aNullable { aValueFrom(FailureReason::class.java) }
+            )
+        )
+    }
+}

--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/DatadogFeaturesInitializer.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/DatadogFeaturesInitializer.kt
@@ -130,6 +130,10 @@ internal class DatadogFeaturesInitializer @Inject constructor(
                 event.context?.additionalProperties?.put(ATTR_IS_MAPPED, true)
                 event
             }
+            setVitalEventMapper { event ->
+                event.context?.additionalProperties?.put(ATTR_IS_MAPPED, true)
+                event
+            }
             enableComposeActionTracking()
         }.build()
     }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -336,6 +336,10 @@ class SampleApplication : Application() {
                 event.context?.additionalProperties?.put(ATTR_IS_MAPPED, true)
                 event
             }
+            .setVitalEventMapper { event ->
+                event.context?.additionalProperties?.put(ATTR_IS_MAPPED, true)
+                event
+            }
             .trackBackgroundEvents(true)
             .trackAnonymousUser(true)
             .enableComposeActionTracking()


### PR DESCRIPTION
### What does this PR do?

It turned out that vital event wasn't sent to backend because there was no serialization logic added.
_(back-end wasn't ready at the previous iterations, so it was hard to notice any issues)_

I've added serialization same way it's done for other events like `LongTaskEvent`, `ViewEvent` etc.
As (according to schema) `RumVitalEvent` also contains `usr`, `context` and `account` sanitization for those attributes was also added. 

I've also added support for `setVitalEventMapper ` and added custom mapper for `sample` and `benchmarking` apps.

Please let me know if some of those changes were unnecessary. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

