### PR TITLE
RUM-11386: Make Navigation3 tracking listen to lifecycle

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -536,7 +536,10 @@ datadog:
       - "androidx.compose.runtime.DisposableEffect(kotlin.Any?, kotlin.Any?, kotlin.Function1)"
       - "androidx.compose.runtime.DisposableEffectScope.onDispose(kotlin.Function0)"
       - "androidx.compose.runtime.LaunchedEffect(kotlin.Any?, kotlin.coroutines.SuspendFunction1)"
+      - "androidx.compose.runtime.LaunchedEffect(kotlin.Any?, kotlin.Any?, kotlin.coroutines.SuspendFunction1)"
       - "androidx.compose.runtime.LaunchedEffect(kotlin.Any?, kotlin.Any?, kotlin.Any?, kotlin.coroutines.SuspendFunction1)"
+      - "androidx.compose.runtime.produceState(kotlin.Boolean, kotlin.Any?, kotlin.coroutines.SuspendFunction1)"
+      - "androidx.compose.runtime.ProduceStateScope.awaitDispose(kotlin.Function0)"
       - "androidx.compose.runtime.remember(kotlin.Any?, kotlin.Any?, kotlin.Function0)"
       - "androidx.compose.runtime.remember(kotlin.Function0)"
       - "androidx.compose.runtime.rememberUpdatedState(com.datadog.android.rum.tracking.ComponentPredicate)"
@@ -582,6 +585,8 @@ datadog:
       - "androidx.fragment.app.FragmentManager.unregisterFragmentLifecycleCallbacks(androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks)"
       - "androidx.lifecycle.Lifecycle.addObserver(androidx.lifecycle.LifecycleObserver)"
       - "androidx.lifecycle.Lifecycle.removeObserver(androidx.lifecycle.LifecycleObserver)"
+      - "androidx.lifecycle.Lifecycle.State.isAtLeast(androidx.lifecycle.Lifecycle.State)"
+      - "androidx.lifecycle.LifecycleEventObserver(kotlin.Function2)"
       - "androidx.navigation.NavController.addOnDestinationChangedListener(androidx.navigation.NavController.OnDestinationChangedListener)"
       - "androidx.navigation.NavController.removeOnDestinationChangedListener(androidx.navigation.NavController.OnDestinationChangedListener)"
       - "androidx.recyclerview.widget.RecyclerView.findContainingViewHolder(android.view.View)"
@@ -1276,7 +1281,7 @@ datadog:
       - "kotlin.Triple.constructor(kotlin.Nothing?, kotlin.Nothing?, kotlin.Nothing?)"
       # endregion
       # region Kotlin String
-      - "kotlin.Any?.takeIf(kotlin.Function1)"
+      - "kotlin.Any?.hashCode()"
       - "kotlin.CharSequence.isNullOrEmpty()"
       - "kotlin.String.all(kotlin.Function1)"
       - "kotlin.String.codePoints()"

--- a/integrations/dd-sdk-android-compose/api/apiSurface
+++ b/integrations/dd-sdk-android-compose/api/apiSurface
@@ -1,13 +1,17 @@
-open class com.datadog.android.compose.AcceptAllNavKeyPredicate<T> : com.datadog.android.rum.tracking.ComponentPredicate<T>
+open class com.datadog.android.compose.AcceptAllNavKeyPredicate<T: Any> : com.datadog.android.rum.tracking.ComponentPredicate<T>
   override fun accept(T): Boolean
   override fun getViewName(T): String?
   override fun equals(Any?): Boolean
   override fun hashCode(): Int
-interface com.datadog.android.compose.AttributesResolver<T>
+interface com.datadog.android.compose.AttributesResolver<T: Any>
   fun resolveAttributes(T): Map<String, Any?>?
+interface com.datadog.android.compose.BackStackKeyResolver<T: Any>
+  fun getStableKey(T): String
 annotation com.datadog.android.compose.ComposeInstrumentation
 fun androidx.compose.ui.Modifier.datadog(String, Boolean = false): androidx.compose.ui.Modifier
 annotation com.datadog.android.compose.ExperimentalTrackingApi
+class com.datadog.android.compose.HashcodeBackStackKeyResolver<T: Any> : BackStackKeyResolver<T>
+  override fun getStableKey(T): String
 fun trackClick(String, Map<String, Any?> = remember { emptyMap() }, com.datadog.android.api.SdkCore = Datadog.getInstance(), () -> Unit): () -> Unit
 fun TrackInteractionEffect(String, androidx.compose.foundation.interaction.InteractionSource, InteractionType, Map<String, Any?> = emptyMap(), com.datadog.android.api.SdkCore = Datadog.getInstance())
 sealed class com.datadog.android.compose.InteractionType
@@ -16,5 +20,5 @@ sealed class com.datadog.android.compose.InteractionType
   class Scroll : InteractionType
     constructor(androidx.compose.foundation.gestures.ScrollableState, androidx.compose.foundation.gestures.Orientation, Boolean = false)
 fun NavigationViewTrackingEffect(androidx.navigation.NavController, Boolean = true, com.datadog.android.rum.tracking.ComponentPredicate<androidx.navigation.NavDestination> = AcceptAllNavDestinations(), com.datadog.android.api.SdkCore = Datadog.getInstance())
-fun <T> Navigation3TrackingEffect(List<T>, com.datadog.android.rum.tracking.ComponentPredicate<T> = AcceptAllNavKeyPredicate(), AttributesResolver<T>? = null, com.datadog.android.api.SdkCore = Datadog.getInstance())
+fun <T: Any> Navigation3TrackingEffect(List<T>, com.datadog.android.rum.tracking.ComponentPredicate<T> = AcceptAllNavKeyPredicate(), BackStackKeyResolver<T> = HashcodeBackStackKeyResolver(), AttributesResolver<T>? = null, com.datadog.android.api.SdkCore = Datadog.getInstance())
 fun com.datadog.android.rum.RumConfiguration.Builder.enableComposeActionTracking(): com.datadog.android.rum.RumConfiguration.Builder

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/AcceptAllNavKeyPredicate.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/AcceptAllNavKeyPredicate.kt
@@ -9,13 +9,13 @@ package com.datadog.android.compose
 import com.datadog.android.rum.tracking.ComponentPredicate
 
 /**
- * A [ComponentPredicate] that accepts all keys of navigation backstack.
+ * A [ComponentPredicate] that accepts all keys of navigation back stack.
  *
  * This predicate is used when you want to track all navigation keys without any filtering.
  *
  * @param T the type of the component.
  */
-open class AcceptAllNavKeyPredicate<T> : ComponentPredicate<T> {
+open class AcceptAllNavKeyPredicate<T : Any> : ComponentPredicate<T> {
     override fun accept(component: T): Boolean {
         return true
     }

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/AttributesResolver.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/AttributesResolver.kt
@@ -11,7 +11,7 @@ package com.datadog.android.compose
  *
  * @param T the type of the key of navigation back stack.
  */
-interface AttributesResolver<T> {
+interface AttributesResolver<T : Any> {
 
     /**
      * Resolves attributes for the given backstack key.

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/BackStackKeyResolver.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/BackStackKeyResolver.kt
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.compose
+
+/**
+ * Resolves a stable key for an item in a back stack.
+ * A stable key means that the same item will always return the same key during its lifetime in the
+ * back stack, and that two different items should not return the same key.
+ *
+ * This is used in [com.datadog.android.rum.RumMonitor.startView] and
+ * [com.datadog.android.rum.RumMonitor.stopView] as the key to identify items in the back
+ * stack and track them as Views in RUM.
+ *
+ * @param T the type of item in the back stack.
+ */
+interface BackStackKeyResolver<T : Any> {
+
+    /**
+     * Returns a stable key for the given item.
+     *
+     * @param item the item to get the stable key for.
+     * @return a stable key for the item.
+     */
+    fun getStableKey(item: T): String
+}

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/HashcodeBackStackKeyResolver.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/HashcodeBackStackKeyResolver.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.compose
+
+/**
+ * A [BackStackKeyResolver] that uses the [Any.hashCode] of the item as its stable key.
+ *
+ * @param T the type of item in the back stack.
+ */
+class HashcodeBackStackKeyResolver<T : Any> : BackStackKeyResolver<T> {
+
+    override fun getStableKey(
+        item: T
+    ): String {
+        return item.hashCode().toString()
+    }
+}

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/Navigation3.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/Navigation3.kt
@@ -10,6 +10,12 @@ package com.datadog.android.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.NonRestartableComposable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import com.datadog.android.Datadog
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
@@ -19,8 +25,8 @@ import com.datadog.android.compose.internal.SupportLibrary
 import com.datadog.android.compose.internal.sendTelemetry
 import com.datadog.android.internal.attributes.ViewScopeInstrumentationType
 import com.datadog.android.internal.attributes.enrichWithConstantAttribute
-import com.datadog.android.rum.ExperimentalRumApi
 import com.datadog.android.rum.GlobalRumMonitor
+import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.tracking.ComponentPredicate
 
 /**
@@ -28,18 +34,20 @@ import com.datadog.android.rum.tracking.ComponentPredicate
  * for Jetpack Compose setup.
  *
  * @param T the type of the key of navigation back stack.
- * @param backStack backStack of the navigation to watch.
- * @param keyPredicate to accept the backstack key that will be taken into account as
+ * @param backStack back stack of the navigation to watch.
+ * @param keyPredicate to accept the back stack key that will be taken into account as
  * valid RUM View events.
- * @param attributesResolver to resolve attributes for the current backstack key.
+ * @param backStackKeyResolver to resolve stable keys for the back stack keys.
+ * @param attributesResolver to resolve attributes for the current back stack key.
  * @param sdkCore the SDK instance to use. If not provided, default instance will be used.
  */
 @Composable
 @NonRestartableComposable
-@ExperimentalRumApi
-fun <T> Navigation3TrackingEffect(
+@ExperimentalTrackingApi
+fun <T : Any> Navigation3TrackingEffect(
     backStack: List<T>,
     keyPredicate: ComponentPredicate<T> = AcceptAllNavKeyPredicate(),
+    backStackKeyResolver: BackStackKeyResolver<T> = HashcodeBackStackKeyResolver(),
     attributesResolver: AttributesResolver<T>? = null,
     sdkCore: SdkCore = Datadog.getInstance()
 ) {
@@ -54,6 +62,7 @@ fun <T> Navigation3TrackingEffect(
     InternalNavigation3TrackingStrategy(
         backStack = backStack,
         destinationPredicate = keyPredicate,
+        backStackKeyResolver = backStackKeyResolver,
         attributesResolver = attributesResolver,
         sdkCore = sdkCore
     )
@@ -61,9 +70,10 @@ fun <T> Navigation3TrackingEffect(
 
 @Composable
 @NonRestartableComposable
-internal fun <T> InstrumentedNavigation3TrackingEffect(
+internal fun <T : Any> InstrumentedNavigation3TrackingEffect(
     backStack: List<T>,
     keyPredicate: ComponentPredicate<T> = AcceptAllNavKeyPredicate(),
+    backStackKeyResolver: BackStackKeyResolver<T> = HashcodeBackStackKeyResolver(),
     attributesResolver: AttributesResolver<T>? = null,
     sdkCore: SdkCore = Datadog.getInstance()
 ) {
@@ -79,42 +89,95 @@ internal fun <T> InstrumentedNavigation3TrackingEffect(
         backStack = backStack,
         destinationPredicate = keyPredicate,
         attributesResolver = attributesResolver,
+        backStackKeyResolver = backStackKeyResolver,
         sdkCore = sdkCore
     )
 }
 
 @Composable
 @NonRestartableComposable
-private fun <T> InternalNavigation3TrackingStrategy(
+private fun <T : Any> InternalNavigation3TrackingStrategy(
     backStack: List<T>,
     destinationPredicate: ComponentPredicate<T> = AcceptAllNavKeyPredicate(),
+    backStackKeyResolver: BackStackKeyResolver<T> = HashcodeBackStackKeyResolver(),
     attributesResolver: AttributesResolver<T>? = null,
     sdkCore: SdkCore = Datadog.getInstance()
 ) {
+    val topKey = backStack.lastOrNull() ?: return
+    val isResumed by rememberIsResumed()
     val internalLogger = (sdkCore as? FeatureSdkCore)?.internalLogger ?: InternalLogger.UNBOUND
-    val topKey = backStack.lastOrNull()
-    LaunchedEffect(topKey) {
-        topKey?.takeIf { destinationPredicate.accept(it) }?.let { current ->
-            try {
+    LaunchedEffect(isResumed, topKey) {
+        trackBackStack(
+            topKey = topKey,
+            isResumed = isResumed,
+            keyPredicate = destinationPredicate,
+            backStackKeyResolver = backStackKeyResolver,
+            attributesResolver = attributesResolver,
+            rumMonitor = GlobalRumMonitor.get(sdkCore),
+            internalLogger = internalLogger
+        )
+    }
+}
+
+internal fun <T : Any> trackBackStack(
+    topKey: T,
+    isResumed: Boolean,
+    keyPredicate: ComponentPredicate<T> = AcceptAllNavKeyPredicate(),
+    backStackKeyResolver: BackStackKeyResolver<T>,
+    attributesResolver: AttributesResolver<T>? = null,
+    rumMonitor: RumMonitor,
+    internalLogger: InternalLogger
+) {
+    val viewKey = backStackKeyResolver.getStableKey(topKey)
+    if (isResumed) {
+        try {
+            if (keyPredicate.accept(topKey)) {
                 val attributes =
-                    attributesResolver?.resolveAttributes(current)?.toMutableMap()
+                    attributesResolver?.resolveAttributes(topKey)?.toMutableMap()
                         ?.enrichWithConstantAttribute(ViewScopeInstrumentationType.COMPOSE)
                         ?: emptyMap()
 
-                GlobalRumMonitor.get(sdkCore).startView(
-                    name = destinationPredicate.getViewName(current)
-                        ?: resolveDefaultViewName(current),
-                    key = current.toString(),
+                rumMonitor.startView(
+                    name = keyPredicate.getViewName(topKey)
+                        ?: resolveDefaultViewName(topKey),
+                    key = viewKey,
                     attributes = attributes
                 )
-            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            } else {
                 internalLogger.log(
-                    InternalLogger.Level.ERROR,
-                    listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                    { "Internal operation failed on ComponentPredicate" },
-                    e
+                    InternalLogger.Level.DEBUG,
+                    InternalLogger.Target.USER,
+                    { "The provided keyPredicate did not accept the back stack top key: $topKey" }
                 )
             }
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            internalLogger.log(
+                InternalLogger.Level.ERROR,
+                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                { "Internal operation failed on ComponentPredicate" },
+                e
+            )
+        }
+    } else {
+        rumMonitor.stopView(viewKey)
+    }
+}
+
+@Composable
+private fun rememberIsResumed(): State<Boolean> {
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    return produceState(
+        initialValue = lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED),
+        key1 = lifecycle
+    ) {
+        val observer = LifecycleEventObserver { _, _ ->
+            value = lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
+        }
+        @Suppress("ThreadSafety") // TODO RUM-525 check composable threading rules
+        lifecycle.addObserver(observer)
+        awaitDispose {
+            @Suppress("ThreadSafety") // TODO RUM-525 check composable threading rules
+            lifecycle.removeObserver(observer)
         }
     }
 }

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/HashcodeBackStackKeyResolverTest.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/HashcodeBackStackKeyResolverTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.compose
+
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ForgeExtension::class)
+internal class HashcodeBackStackKeyResolverTest {
+
+    private val testedResolver = HashcodeBackStackKeyResolver<Any>()
+
+    @Test
+    fun `M return item hashcode as string W getStableKey()`(
+        @StringForgery testItem: String
+    ) {
+        // Given
+        val expectedKey = testItem.hashCode().toString()
+
+        // When
+        val actualKey = testedResolver.getStableKey(testItem)
+
+        // Then
+        assertThat(actualKey).isEqualTo(expectedKey)
+    }
+
+    @Test
+    fun `M return item hashcode as string W getStableKey {data class}`(
+        @StringForgery testItemId: String,
+        @IntForgery testItemValue: Int
+    ) {
+        // Given
+        val testItem = TestDataClass(testItemId, testItemValue)
+        val identicalItem = TestDataClass(testItemId, testItemValue)
+        val expectedKey = identicalItem.hashCode().toString()
+
+        // When
+        val actualKey = testedResolver.getStableKey(testItem)
+
+        // Then
+        assertThat(actualKey).isEqualTo(expectedKey)
+    }
+
+    @Test
+    fun `M return item hashcode as string W getStableKey {integer}`(
+        @IntForgery testItem: Int
+    ) {
+        // Given
+        val expectedKey = testItem.hashCode().toString()
+
+        // When
+        val actualKey = testedResolver.getStableKey(testItem)
+
+        // Then
+        assertThat(actualKey).isEqualTo(expectedKey)
+    }
+
+    data class TestDataClass(val id: String, val value: Int)
+}

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/Navigation3Test.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/Navigation3Test.kt
@@ -1,0 +1,152 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.compose
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.internal.attributes.enrichWithConstantAttribute
+import com.datadog.android.rum.RumMonitor
+import com.datadog.android.rum.tracking.ComponentPredicate
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class Navigation3Test {
+
+    @Mock
+    lateinit var mockRumMonitor: RumMonitor
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @Mock
+    lateinit var mockAttributesResolver: AttributesResolver<String>
+
+    @Mock
+    lateinit var mockStackKeyResolver: BackStackKeyResolver<String>
+
+    @StringForgery
+    lateinit var fakeTopKey: String
+
+    @StringForgery
+    lateinit var fakeStableKey: String
+
+    @BeforeEach
+    fun `set up`() {
+        // Default mock behaviour
+        whenever(mockStackKeyResolver.getStableKey(fakeTopKey)) doReturn fakeStableKey
+    }
+
+    @Test
+    fun `M start view W TrackBackStack() { isResumed = true, predicate accepts }`(
+        @StringForgery fakeViewName: String
+    ) {
+        // Given
+        val stubPredicate = StubComponentPredicate(viewName = fakeViewName)
+        val mockAttributesResolver = mock<AttributesResolver<String>>()
+        val expectedAttributes = emptyMap<String, Any?>()
+
+        // When
+        trackBackStack(
+            topKey = fakeTopKey,
+            isResumed = true,
+            keyPredicate = stubPredicate,
+            backStackKeyResolver = mockStackKeyResolver,
+            attributesResolver = mockAttributesResolver,
+            rumMonitor = mockRumMonitor,
+            internalLogger = mockInternalLogger
+        )
+
+        // Then
+        verify(mockRumMonitor).startView(
+            fakeStableKey,
+            fakeViewName,
+            expectedAttributes.toMutableMap()
+                .enrichWithConstantAttribute(ViewScopeInstrumentationType.COMPOSE)
+        )
+        verify(mockRumMonitor, never()).stopView(any(), any())
+    }
+
+    @Test
+    fun `M stop view W TrackBackStack() { isResumed = false, predicate accepts }`() {
+        // Given
+        val stubPredicate = StubComponentPredicate()
+
+        // When
+        trackBackStack(
+            topKey = fakeTopKey,
+            isResumed = false,
+            keyPredicate = stubPredicate,
+            backStackKeyResolver = mockStackKeyResolver,
+            attributesResolver = mockAttributesResolver,
+            rumMonitor = mockRumMonitor,
+            internalLogger = mockInternalLogger
+        )
+
+        // Then
+        verify(mockRumMonitor, never()).startView(
+            any(),
+            any(),
+            any()
+        )
+        verify(mockRumMonitor).stopView(fakeStableKey, emptyMap())
+    }
+
+    @Test
+    fun `M not start view W TrackBackStack() {predicate does not accept }`(@BoolForgery isResumed: Boolean) {
+        // Given
+        val stubPredicate = StubComponentPredicate(accept = false)
+        val mockAttributesResolver = mock<AttributesResolver<String>>()
+
+        // When
+        trackBackStack(
+            topKey = fakeTopKey,
+            isResumed = isResumed,
+            keyPredicate = stubPredicate,
+            backStackKeyResolver = mockStackKeyResolver,
+            attributesResolver = mockAttributesResolver,
+            rumMonitor = mockRumMonitor,
+            internalLogger = mockInternalLogger
+        )
+
+        // Then
+        verify(mockRumMonitor, never()).startView(
+            any(),
+            any(),
+            any()
+        )
+    }
+
+    private class StubComponentPredicate(
+        private val accept: Boolean = true,
+        private val viewName: String? = null
+    ) : ComponentPredicate<String> {
+        override fun accept(component: String): Boolean = accept
+        override fun getViewName(component: String): String? = viewName
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This PR mainly attach the `Navigation3TrackingEffect` to the lifecycle of the lifecycle owner.
Also there is some improvements:
* Move the core logic to a dedicated internal non-composable function so it can be easily unit tested.
* Adding `BackstackKeyResolver` interface which can accept the custom key resolving, by default we resolve it with hashcode.
* 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

