### PR TITLE
RUM-4234: Update Session Replay batch max age to 5h

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -398,12 +398,13 @@ internal class SessionReplayFeature(
          * max item size = 10 MB,
          * max items per batch = 500,
          * max batch size = 10 MB, SR intake batch limit is 10MB
-         * old batch threshold = 18 hours.
+         * old batch threshold = 5 hours.
          */
         internal val STORAGE_CONFIGURATION: FeatureStorageConfiguration =
             FeatureStorageConfiguration.DEFAULT.copy(
                 maxItemSize = 10 * 1024 * 1024,
-                maxBatchSize = 10 * 1024 * 1024
+                maxBatchSize = 10 * 1024 * 1024,
+                oldBatchThreshold = 5L * 60L * 60L * 1000L
             )
 
         internal const val REQUIRES_APPLICATION_CONTEXT_WARN_MESSAGE = "Session Replay could not " +


### PR DESCRIPTION
### What does this PR do?

Update Session Replay batch max age to 5h to align with Session Replay intake

### Motivation

RUM-4234

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

