### PR TITLE
RUM-11016: Fix `clearUserInfo` API by adapting it to the context queue

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -181,7 +181,9 @@ internal class DatadogCore(
     /** @inheritDoc */
     @AnyThread
     override fun clearUserInfo() {
-        coreFeature.userInfoProvider.clearUserInfo()
+        coreFeature.contextExecutorService.executeSafe("DatadogCore.clearUserInfo", internalLogger) {
+            coreFeature.userInfoProvider.clearUserInfo()
+        }
     }
 
     /** @inheritDoc */

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
@@ -253,8 +253,11 @@ internal class DatadogCoreTest {
     ) {
         // Given
         val uuid = forge.getForgery<UUID>()
+        testedCore.coreFeature = mock()
+        whenever(testedCore.coreFeature.initialized).thenReturn(AtomicBoolean(true))
         val mockUserInfoProvider = mock<MutableUserInfoProvider>()
-        testedCore.coreFeature.userInfoProvider = mockUserInfoProvider
+        whenever(testedCore.coreFeature.userInfoProvider) doReturn mockUserInfoProvider
+        whenever(testedCore.coreFeature.contextExecutorService) doReturn mockContextExecutorService
 
         // When
         testedCore.setAnonymousId(uuid)
@@ -266,8 +269,11 @@ internal class DatadogCoreTest {
     @Test
     fun `M clear anonymousId W setAnonymousId(null)`() {
         // Given
+        testedCore.coreFeature = mock()
+        whenever(testedCore.coreFeature.initialized).thenReturn(AtomicBoolean(true))
         val mockUserInfoProvider = mock<MutableUserInfoProvider>()
-        testedCore.coreFeature.userInfoProvider = mockUserInfoProvider
+        whenever(testedCore.coreFeature.userInfoProvider) doReturn mockUserInfoProvider
+        whenever(testedCore.coreFeature.contextExecutorService) doReturn mockContextExecutorService
 
         // When
         testedCore.setAnonymousId(null)
@@ -314,10 +320,13 @@ internal class DatadogCoreTest {
     }
 
     @Test
-    fun `M clear user info W clearUserInfo() is called`() {
+    fun `M clear user info W clearUserInfo()`() {
         // Given
+        testedCore.coreFeature = mock()
+        whenever(testedCore.coreFeature.initialized).thenReturn(AtomicBoolean(true))
         val mockUserInfoProvider = mock<MutableUserInfoProvider>()
-        testedCore.coreFeature.userInfoProvider = mockUserInfoProvider
+        whenever(testedCore.coreFeature.userInfoProvider) doReturn mockUserInfoProvider
+        whenever(testedCore.coreFeature.contextExecutorService) doReturn mockContextExecutorService
 
         // When
         testedCore.clearUserInfo()
@@ -368,6 +377,22 @@ internal class DatadogCoreTest {
             emptyMap()
         )
         verify(mockAccountInfoProvider).addExtraInfo(extraInfo = fakeExtraProperties)
+    }
+
+    @Test
+    fun `M clear account info W clearAccountInfo()`() {
+        // Given
+        testedCore.coreFeature = mock()
+        whenever(testedCore.coreFeature.initialized).thenReturn(AtomicBoolean(true))
+        val mockAccountInfoProvider = mock<MutableAccountInfoProvider>()
+        whenever(testedCore.coreFeature.accountInfoProvider) doReturn mockAccountInfoProvider
+        whenever(testedCore.coreFeature.contextExecutorService) doReturn mockContextExecutorService
+
+        // When
+        testedCore.clearAccountInfo()
+
+        // Then
+        verify(mockAccountInfoProvider).clearAccountInfo()
     }
 
     // region update + read feature context

--- a/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/SdkCoreTest.kt
+++ b/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/SdkCoreTest.kt
@@ -27,7 +27,6 @@ import fr.xgouchet.elmyr.jvm.useJvmFactories
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -124,7 +123,6 @@ class SdkCoreTest : MockServerTest() {
     }
 
     @Test
-    @Ignore("RUM-11016 disabling because it's flaky")
     fun must_clearUserInformation_when_clearUserInfo() {
         // Given
         testedSdkCore.setUserInfo(fakeUserId, fakeUserName, fakeUserEmail, fakeUserAdditionalProperties)


### PR DESCRIPTION
### What does this PR do?

This PR adapts `Datadog.clearUserInfo` API to the context queue usage, it removes the flakiness caused by the concurrency.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

