### PR TITLE
Fix RUM feature context in telemetry

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -71,7 +71,11 @@ internal class TelemetryEventHandler(
         eventIDsSeenInCurrentSession.add(event.identity)
         totalEventsSeenInCurrentSession++
         sdkCore.getFeature(Feature.RUM_FEATURE_NAME)?.withWriteContext(
-            withFeatureContexts = setOf(Feature.SESSION_REPLAY_FEATURE_NAME, Feature.TRACING_FEATURE_NAME)
+            withFeatureContexts = setOf(
+                Feature.SESSION_REPLAY_FEATURE_NAME,
+                Feature.TRACING_FEATURE_NAME,
+                Feature.RUM_FEATURE_NAME
+            )
         ) { datadogContext, writeScope ->
             val timestamp = wrappedEvent.eventTime.timestamp + datadogContext.time.serverTimeOffsetMs
             val telemetryEvent: Any? = when (event) {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -203,7 +203,7 @@ internal class TelemetryEventHandlerTest {
 
         whenever(
             mockRumFeatureScope.withWriteContext(
-                eq(setOf(Feature.SESSION_REPLAY_FEATURE_NAME, Feature.TRACING_FEATURE_NAME)),
+                eq(setOf(Feature.SESSION_REPLAY_FEATURE_NAME, Feature.TRACING_FEATURE_NAME, Feature.RUM_FEATURE_NAME)),
                 any()
             )
         ) doAnswer {


### PR DESCRIPTION
### What does this PR do?

Before the context from the RUM feature wasn't included in the telemetry logs. But it should be, because we attach the data like `application_id` and `session_id` to the events [here](https://github.com/DataDog/dd-sdk-android/blob/867f1d9d58df8f90418eb6d45132a7f0e8a74a8c/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt#L196).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

