### PR TITLE
RUM-11555: Implement AppStartupTypeDetector

### DIFF
--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -1,3 +1,12 @@
+public final class com/datadog/android/rum/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field MIN_SDK I
+	public static final field TARGET_SDK I
+	public fun <init> ()V
+}
+
 public final class com/datadog/android/rum/CloseableExtKt {
 	public static final fun useMonitored (Ljava/io/Closeable;Lcom/datadog/android/api/SdkCore;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public static synthetic fun useMonitored$default (Ljava/io/Closeable;Lcom/datadog/android/api/SdkCore;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;

--- a/features/dd-sdk-android-rum/build.gradle.kts
+++ b/features/dd-sdk-android-rum/build.gradle.kts
@@ -5,6 +5,7 @@
  */
 @file:Suppress("StringLiteralDuplication")
 
+import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
 import com.datadog.gradle.config.detektCustomConfig
@@ -47,12 +48,26 @@ android {
             Paths.get(rootDir.path, "consumer-rules.pro").toString(),
             "consumer-rules.pro"
         )
+        buildConfigField(
+            "int",
+            "MIN_SDK",
+            "${AndroidConfig.MIN_SDK}"
+        )
+        buildConfigField(
+            "int",
+            "TARGET_SDK",
+            "${AndroidConfig.TARGET_SDK}"
+        )
     }
 
     namespace = "com.datadog.android.rum"
 
     testFixtures {
         enable = true
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetector.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetector.kt
@@ -24,7 +24,7 @@ internal interface RumAppStartupDetector {
             sdkCore: InternalSdkCore,
             listener: Listener
         ): RumAppStartupDetector {
-            val impl = RumAppStartupDetectorImpl(
+            return RumAppStartupDetectorImpl(
                 application = application,
                 buildSdkVersionProvider = BuildSdkVersionProvider.DEFAULT,
                 appStartupTimeProvider = { sdkCore.appStartTimeNs },
@@ -32,7 +32,6 @@ internal interface RumAppStartupDetector {
                 timeProviderNanos = { System.nanoTime() },
                 listener
             )
-            return impl
         }
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetector.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetector.kt
@@ -1,0 +1,38 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.startup
+
+import android.app.Application
+import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.core.internal.system.BuildSdkVersionProvider
+import com.datadog.android.rum.DdRumContentProvider
+
+internal interface RumAppStartupDetector {
+    interface Listener {
+        fun onAppStartupDetected(scenario: RumStartupScenario)
+    }
+
+    fun destroy()
+
+    companion object {
+        fun create(
+            application: Application,
+            sdkCore: InternalSdkCore,
+            listener: Listener
+        ): RumAppStartupDetector {
+            val impl = RumAppStartupDetectorImpl(
+                application = application,
+                buildSdkVersionProvider = BuildSdkVersionProvider.DEFAULT,
+                appStartupTimeProvider = { sdkCore.appStartTimeNs },
+                processImportanceProvider = { DdRumContentProvider.processImportance },
+                timeProviderNanos = { System.nanoTime() },
+                listener
+            )
+            return impl
+        }
+    }
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImpl.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImpl.kt
@@ -28,7 +28,7 @@ internal class RumAppStartupDetectorImpl(
 
     private var numberOfActivities: Int = 0
     private var isChangingConfigurations: Boolean = false
-    private var isFirstActivityForProcess = true
+    private var isFirstActivityForProcess: Boolean = true
 
     init {
         application.registerActivityLifecycleCallbacks(this)
@@ -107,7 +107,6 @@ internal class RumAppStartupDetectorImpl(
         }
 
         isFirstActivityForProcess = false
-        isChangingConfigurations = false
     }
 
     override fun destroy() {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImpl.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImpl.kt
@@ -12,6 +12,7 @@ import android.app.Application
 import android.os.Build
 import android.os.Bundle
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
+import java.lang.ref.WeakReference
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -78,26 +79,27 @@ internal class RumAppStartupDetectorImpl(
 
             val gap = (now - processStartTime).nanoseconds
             val hasSavedInstanceStateBundle = savedInstanceState != null
+            val weakActivity = WeakReference(activity)
 
             val scenario = if (isFirstActivityForProcess) {
                 if (!processStartedInForeground || gap > START_GAP_THRESHOLD) {
                     RumStartupScenario.WarmFirstActivity(
                         initialTimeNanos = now,
                         hasSavedInstanceStateBundle = hasSavedInstanceStateBundle,
-                        activity = activity
+                        activity = weakActivity
                     )
                 } else {
                     RumStartupScenario.Cold(
                         initialTimeNanos = processStartTime,
                         hasSavedInstanceStateBundle = hasSavedInstanceStateBundle,
-                        activity = activity
+                        activity = weakActivity
                     )
                 }
             } else {
                 RumStartupScenario.WarmAfterActivityDestroyed(
                     initialTimeNanos = now,
                     hasSavedInstanceStateBundle = hasSavedInstanceStateBundle,
-                    activity = activity
+                    activity = weakActivity
                 )
             }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImpl.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImpl.kt
@@ -15,8 +15,6 @@ import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
 
-private val START_GAP_THRESHOLD = 5.seconds
-
 internal class RumAppStartupDetectorImpl(
     private val application: Application,
     private val buildSdkVersionProvider: BuildSdkVersionProvider,
@@ -111,5 +109,9 @@ internal class RumAppStartupDetectorImpl(
 
     override fun destroy() {
         application.unregisterActivityLifecycleCallbacks(this)
+    }
+
+    companion object {
+        private val START_GAP_THRESHOLD = 5.seconds
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImpl.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImpl.kt
@@ -1,0 +1,116 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.startup
+
+import android.app.Activity
+import android.app.ActivityManager
+import android.app.Application
+import android.os.Build
+import android.os.Bundle
+import com.datadog.android.core.internal.system.BuildSdkVersionProvider
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
+
+private val START_GAP_THRESHOLD = 5.seconds
+
+internal class RumAppStartupDetectorImpl(
+    private val application: Application,
+    private val buildSdkVersionProvider: BuildSdkVersionProvider,
+    private val appStartupTimeProvider: () -> Long,
+    private val processImportanceProvider: () -> Int,
+    private val timeProviderNanos: () -> Long,
+    private val listener: RumAppStartupDetector.Listener
+) : RumAppStartupDetector, Application.ActivityLifecycleCallbacks {
+
+    private var numberOfActivities: Int = 0
+    private var isChangingConfigurations: Boolean = false
+    private var isFirstActivityForProcess = true
+
+    init {
+        application.registerActivityLifecycleCallbacks(this)
+    }
+
+    override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
+        if (buildSdkVersionProvider.version >= Build.VERSION_CODES.Q) {
+            onBeforeActivityCreated(activity, savedInstanceState)
+        }
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        if (buildSdkVersionProvider.version < Build.VERSION_CODES.Q) {
+            onBeforeActivityCreated(activity, savedInstanceState)
+        }
+    }
+
+    override fun onActivityDestroyed(activity: Activity) {
+        numberOfActivities--
+        if (numberOfActivities == 0) {
+            isChangingConfigurations = activity.isChangingConfigurations
+        }
+    }
+
+    override fun onActivityPaused(activity: Activity) {
+    }
+
+    override fun onActivityResumed(activity: Activity) {
+    }
+
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+    }
+
+    override fun onActivityStarted(activity: Activity) {
+    }
+
+    override fun onActivityStopped(activity: Activity) {
+    }
+
+    private fun onBeforeActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        numberOfActivities++
+        val now = timeProviderNanos()
+
+        if (numberOfActivities == 1 && !isChangingConfigurations) {
+            val processStartTime = appStartupTimeProvider()
+
+            val processStartedInForeground =
+                processImportanceProvider() == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+
+            val gap = (now - processStartTime).nanoseconds
+            val hasSavedInstanceStateBundle = savedInstanceState != null
+
+            val scenario = if (isFirstActivityForProcess) {
+                if (!processStartedInForeground || gap > START_GAP_THRESHOLD) {
+                    RumStartupScenario.WarmFirstActivity(
+                        initialTimeNanos = now,
+                        hasSavedInstanceStateBundle = hasSavedInstanceStateBundle,
+                        activity = activity
+                    )
+                } else {
+                    RumStartupScenario.Cold(
+                        initialTimeNanos = processStartTime,
+                        hasSavedInstanceStateBundle = hasSavedInstanceStateBundle,
+                        activity = activity
+                    )
+                }
+            } else {
+                RumStartupScenario.WarmAfterActivityDestroyed(
+                    initialTimeNanos = now,
+                    hasSavedInstanceStateBundle = hasSavedInstanceStateBundle,
+                    activity = activity
+                )
+            }
+
+            listener.onAppStartupDetected(scenario)
+        }
+
+        isFirstActivityForProcess = false
+        isChangingConfigurations = false
+    }
+
+    override fun destroy() {
+        application.unregisterActivityLifecycleCallbacks(this)
+    }
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumStartupScenario.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumStartupScenario.kt
@@ -7,27 +7,28 @@
 package com.datadog.android.rum.internal.startup
 
 import android.app.Activity
+import java.lang.ref.WeakReference
 
 internal sealed interface RumStartupScenario {
     val initialTimeNanos: Long
     val hasSavedInstanceStateBundle: Boolean
-    val activity: Activity
+    val activity: WeakReference<Activity>
 
     data class Cold(
         override val initialTimeNanos: Long,
         override val hasSavedInstanceStateBundle: Boolean,
-        override val activity: Activity
+        override val activity: WeakReference<Activity>
     ) : RumStartupScenario
 
     data class WarmFirstActivity(
         override val initialTimeNanos: Long,
         override val hasSavedInstanceStateBundle: Boolean,
-        override val activity: Activity
+        override val activity: WeakReference<Activity>
     ) : RumStartupScenario
 
     data class WarmAfterActivityDestroyed(
         override val initialTimeNanos: Long,
         override val hasSavedInstanceStateBundle: Boolean,
-        override val activity: Activity
+        override val activity: WeakReference<Activity>
     ) : RumStartupScenario
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumStartupScenario.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumStartupScenario.kt
@@ -14,19 +14,19 @@ internal sealed interface RumStartupScenario {
     val hasSavedInstanceStateBundle: Boolean
     val activity: WeakReference<Activity>
 
-    data class Cold(
+    class Cold(
         override val initialTimeNanos: Long,
         override val hasSavedInstanceStateBundle: Boolean,
         override val activity: WeakReference<Activity>
     ) : RumStartupScenario
 
-    data class WarmFirstActivity(
+    class WarmFirstActivity(
         override val initialTimeNanos: Long,
         override val hasSavedInstanceStateBundle: Boolean,
         override val activity: WeakReference<Activity>
     ) : RumStartupScenario
 
-    data class WarmAfterActivityDestroyed(
+    class WarmAfterActivityDestroyed(
         override val initialTimeNanos: Long,
         override val hasSavedInstanceStateBundle: Boolean,
         override val activity: WeakReference<Activity>

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumStartupScenario.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumStartupScenario.kt
@@ -1,0 +1,33 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.startup
+
+import android.app.Activity
+
+internal sealed interface RumStartupScenario {
+    val initialTimeNanos: Long
+    val hasSavedInstanceStateBundle: Boolean
+    val activity: Activity
+
+    data class Cold(
+        override val initialTimeNanos: Long,
+        override val hasSavedInstanceStateBundle: Boolean,
+        override val activity: Activity
+    ) : RumStartupScenario
+
+    data class WarmFirstActivity(
+        override val initialTimeNanos: Long,
+        override val hasSavedInstanceStateBundle: Boolean,
+        override val activity: Activity
+    ) : RumStartupScenario
+
+    data class WarmAfterActivityDestroyed(
+        override val initialTimeNanos: Long,
+        override val hasSavedInstanceStateBundle: Boolean,
+        override val activity: Activity
+    ) : RumStartupScenario
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImplTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImplTest.kt
@@ -1,0 +1,436 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.startup
+
+import android.app.Activity
+import android.app.ActivityManager.RunningAppProcessInfo.IMPORTANCE_CACHED
+import android.app.ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+import android.app.Application
+import android.os.Build
+import android.os.Bundle
+import com.datadog.android.core.internal.system.BuildSdkVersionProvider
+import com.datadog.android.rum.utils.forge.Configurator
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class RumAppStartupDetectorImplTest {
+    @Mock
+    private lateinit var application: Application
+
+    @Mock
+    private lateinit var listener: RumAppStartupDetector.Listener
+
+    @IntForgery(min = Build.VERSION_CODES.M, max = Build.VERSION_CODES.BAKLAVA)
+    private var fakeBuildSdkVersion: Int = 0
+
+    @Mock
+    private lateinit var buildSdkVersionProvider: BuildSdkVersionProvider
+
+    @Mock
+    private lateinit var activity: Activity
+
+    private var currentTime: Duration = 0.nanoseconds
+
+    @BeforeEach
+    fun `set up`() {
+        currentTime = 0.nanoseconds
+        whenever(activity.isChangingConfigurations) doReturn false
+    }
+
+    @Test
+    fun `M detect Cold scenario W RumAppStartupDetectorImpl {IMPORTANCE_FOREGROUND and small gap}`(
+        forge: Forge,
+        @BoolForgery hasSavedInstanceStateBundle: Boolean
+    ) {
+        val detector = createDetector(
+            processImportance = IMPORTANCE_FOREGROUND
+        )
+        launchColdAndVerify(
+            forge = forge,
+            detector = detector,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle
+        )
+    }
+
+    @Test
+    fun `M detect WarmFirstActivity scenario W RumAppStartupDetectorImpl {IMPORTANCE_CACHED and small gap}`(
+        forge: Forge,
+        @BoolForgery hasSavedInstanceStateBundle: Boolean
+    ) {
+        // Given
+        val detector = createDetector(
+            processImportance = IMPORTANCE_CACHED
+        )
+
+        currentTime += 3.seconds
+
+        // When
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle
+        )
+
+        // Then
+        listener.verifyScenarioDetected(
+            RumStartupScenario.WarmFirstActivity(
+                initialTimeNanos = currentTime.inWholeNanoseconds,
+                hasSavedInstanceStateBundle = hasSavedInstanceStateBundle,
+                activity = activity
+            )
+        )
+        verifyNoMoreInteractions(listener)
+    }
+
+    @Test
+    fun `M detect WarmFirstActivity scenario W RumAppStartupDetectorImpl {IMPORTANCE_FOREGROUND and large gap}`(
+        forge: Forge,
+        @BoolForgery hasSavedInstanceStateBundle: Boolean
+    ) {
+        val detector = createDetector(
+            processImportance = IMPORTANCE_FOREGROUND
+        )
+
+        currentTime += 6.seconds
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle
+        )
+
+        listener.verifyScenarioDetected(
+            RumStartupScenario.WarmFirstActivity(
+                initialTimeNanos = currentTime.inWholeNanoseconds,
+                hasSavedInstanceStateBundle = hasSavedInstanceStateBundle,
+                activity = activity
+            )
+        )
+        verifyNoMoreInteractions(listener)
+    }
+
+    @Test
+    fun `M detect WarmAfterActivityDestroyed scenario W RumAppStartupDetectorImpl {1st Cold scenario}`(
+        forge: Forge,
+        @BoolForgery hasSavedInstanceStateBundle: Boolean,
+        @BoolForgery hasSavedInstanceStateBundle2: Boolean
+    ) {
+        // Given
+        val detector = createDetector(
+            processImportance = IMPORTANCE_FOREGROUND
+        )
+
+        launchColdAndVerify(
+            forge = forge,
+            detector = detector,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle
+        )
+
+        // When
+        detector.onActivityDestroyed(activity)
+
+        currentTime += 30.seconds
+
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle2
+        )
+
+        // Then
+        listener.verifyScenarioDetected(
+            RumStartupScenario.WarmAfterActivityDestroyed(
+                initialTimeNanos = currentTime.inWholeNanoseconds,
+                hasSavedInstanceStateBundle = hasSavedInstanceStateBundle2,
+                activity = activity
+            )
+        )
+        verifyNoMoreInteractions(listener)
+    }
+
+    @Test
+    fun `M not detect any scenario W RumAppStartupDetectorImpl {1st Cold scenario and configuration change}`(
+        forge: Forge,
+        @BoolForgery hasSavedInstanceStateBundle: Boolean
+    ) {
+        // Given
+        val detector = createDetector(
+            processImportance = IMPORTANCE_FOREGROUND
+        )
+
+        launchColdAndVerify(
+            forge = forge,
+            detector = detector,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle
+        )
+
+        whenever(activity.isChangingConfigurations) doReturn true
+
+        // When
+        detector.onActivityDestroyed(activity)
+
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle
+        )
+
+        // Then
+        verifyNoMoreInteractions(listener)
+    }
+
+    @Test
+    fun `M not detect W RumAppStartupDetectorImpl {1st Cold, 1st activity stopped and another activity created}`(
+        forge: Forge,
+        @BoolForgery hasSavedInstanceStateBundle: Boolean,
+        @BoolForgery hasSavedInstanceStateBundle2: Boolean
+    ) {
+        // Given
+        val detector = createDetector(
+            processImportance = IMPORTANCE_FOREGROUND
+        )
+
+        launchColdAndVerify(
+            forge = forge,
+            detector = detector,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle
+        )
+
+        // When
+        detector.onActivityStarted(activity)
+        detector.onActivityResumed(activity)
+        detector.onActivityPaused(activity)
+        detector.onActivityStopped(activity)
+
+        val activity2 = mock<Activity>()
+
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity2,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle2
+        )
+
+        // Then
+        verifyNoMoreInteractions(listener)
+    }
+
+    @Test
+    fun `M detect WarmAfterActivityDestroyed W RumAppStartupDetector {1st Cold, activity destroyed another created}`(
+        forge: Forge,
+        @BoolForgery hasSavedInstanceStateBundle: Boolean,
+        @BoolForgery hasSavedInstanceStateBundle2: Boolean
+    ) {
+        // Given
+        val detector = createDetector(
+            processImportance = IMPORTANCE_FOREGROUND
+        )
+
+        launchColdAndVerify(
+            forge = forge,
+            detector = detector,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle
+        )
+
+        // When
+        detector.onActivityStarted(activity)
+        detector.onActivityResumed(activity)
+        detector.onActivityPaused(activity)
+        detector.onActivityStopped(activity)
+        detector.onActivityDestroyed(activity)
+
+        currentTime += 30.seconds
+
+        val activity2 = mock<Activity>()
+
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity2,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle2
+        )
+
+        // Then
+        listener.verifyScenarioDetected(
+            RumStartupScenario.WarmAfterActivityDestroyed(
+                initialTimeNanos = currentTime.inWholeNanoseconds,
+                hasSavedInstanceStateBundle = hasSavedInstanceStateBundle2,
+                activity = activity2
+            )
+        )
+
+        verifyNoMoreInteractions(listener)
+    }
+
+    @Test
+    fun `M detect WarmAfterActivityDestroyed W RumAppStartupDetector {2 activities created, destroyed and 3rd created}`(
+        forge: Forge,
+        @BoolForgery hasSavedInstanceStateBundle: Boolean,
+        @BoolForgery hasSavedInstanceStateBundle2: Boolean,
+        @BoolForgery hasSavedInstanceStateBundle3: Boolean
+    ) {
+        // Given
+        val detector = createDetector(
+            processImportance = IMPORTANCE_FOREGROUND
+        )
+
+        launchColdAndVerify(
+            forge = forge,
+            detector = detector,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle
+        )
+
+        // When
+        detector.onActivityStarted(activity)
+        detector.onActivityResumed(activity)
+        detector.onActivityPaused(activity)
+        detector.onActivityStopped(activity)
+
+        currentTime += 30.seconds
+
+        val activity2 = mock<Activity>()
+
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity2,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle2
+        )
+
+        verifyNoMoreInteractions(listener)
+
+        detector.onActivityStarted(activity2)
+        detector.onActivityResumed(activity2)
+        detector.onActivityPaused(activity2)
+        detector.onActivityStopped(activity2)
+        detector.onActivityDestroyed(activity2)
+
+        detector.onActivityDestroyed(activity)
+
+        currentTime += 30.seconds
+
+        val activity3 = mock<Activity>()
+
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity3,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle3
+        )
+
+        // Then
+        listener.verifyScenarioDetected(
+            RumStartupScenario.WarmAfterActivityDestroyed(
+                initialTimeNanos = currentTime.inWholeNanoseconds,
+                hasSavedInstanceStateBundle = hasSavedInstanceStateBundle3,
+                activity = activity3
+            )
+        )
+
+        verifyNoMoreInteractions(listener)
+    }
+
+    private fun launchColdAndVerify(
+        forge: Forge,
+        detector: RumAppStartupDetectorImpl,
+        hasSavedInstanceStateBundle: Boolean
+    ) {
+        // Given
+        currentTime += 3.seconds
+
+        // When
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle
+        )
+
+        // Then
+        listener.verifyScenarioDetected(
+            RumStartupScenario.Cold(
+                initialTimeNanos = 0,
+                hasSavedInstanceStateBundle = hasSavedInstanceStateBundle,
+                activity = activity
+            )
+        )
+        verifyNoMoreInteractions(listener)
+    }
+
+    private fun createDetector(processImportance: Int): RumAppStartupDetectorImpl {
+        whenever(buildSdkVersionProvider.version) doReturn fakeBuildSdkVersion
+        val detector = RumAppStartupDetectorImpl(
+            application = application,
+            buildSdkVersionProvider = buildSdkVersionProvider,
+            appStartupTimeProvider = { 0 },
+            processImportanceProvider = { processImportance },
+            timeProviderNanos = { currentTime.inWholeNanoseconds },
+            listener
+        )
+
+        verify(application).registerActivityLifecycleCallbacks(any())
+        verifyNoMoreInteractions(application)
+
+        return detector
+    }
+
+    private fun triggerBeforeCreated(
+        forge: Forge,
+        detector: RumAppStartupDetectorImpl,
+        activity: Activity,
+        hasSavedInstanceStateBundle: Boolean
+    ) {
+        val bundle = if (hasSavedInstanceStateBundle) {
+            Bundle().apply {
+                putString(forge.anAlphabeticalString(), forge.anAlphabeticalString())
+            }
+        } else {
+            null
+        }
+        if (fakeBuildSdkVersion >= Build.VERSION_CODES.Q) {
+            detector.onActivityPreCreated(activity, bundle)
+        } else {
+            detector.onActivityCreated(activity, bundle)
+        }
+    }
+
+    private fun RumAppStartupDetector.Listener.verifyScenarioDetected(scenario: RumStartupScenario) {
+        verify(this).onAppStartupDetected(eq(scenario))
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This is the first PR in the series of PRs about app launch improvements.

It implements the algorithm of detecting application start type according to the algorithm described in the RFC [here](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/5439422959/RFC+-+App+Launch+Observability+in+Android#Distinguishing-between-SCENARIO_WARM_FIRST_ACTIVITY-and-SCENARIO_WARM_AFTER_ON_DESTROY).

Implemention of TTID calculation and other changes will be in the next PRs.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

