### PR TITLE
RUM-11638: Safe serialization of `account.extraInfo`

### DIFF
--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/domain/event/LogEventSerializer.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/domain/event/LogEventSerializer.kt
@@ -42,16 +42,30 @@ internal class LogEventSerializer(
                     .toMutableMap()
             )
         }
+        val account = log.account?.let {
+            val sanitizedAccountAttributes = dataConstraints.validateAttributes(
+                it.additionalProperties,
+                keyPrefix = LogAttributes.ACCOUNT_ATTRIBUTES_GROUP,
+                attributesGroupName = ACCOUNT_EXTRA_GROUP_VERBOSE_NAME
+            )
+            it.copy(
+                additionalProperties = sanitizedAccountAttributes
+                    .safeMapValuesToJson(internalLogger)
+                    .toMutableMap()
+            )
+        }
         return log.copy(
             ddtags = sanitizedTags,
             additionalProperties = sanitizedAttributes
                 .safeMapValuesToJson(internalLogger)
                 .toMutableMap(),
-            usr = usr
+            usr = usr,
+            account = account
         )
     }
 
     companion object {
         internal const val USER_EXTRA_GROUP_VERBOSE_NAME = "user extra information"
+        internal const val ACCOUNT_EXTRA_GROUP_VERBOSE_NAME = "account extra information"
     }
 }

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/utils/forge/LogEventForgeryFactory.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/utils/forge/LogEventForgeryFactory.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.utils.forge
 
+import com.datadog.android.api.context.AccountInfo
 import com.datadog.android.api.context.DeviceInfo
 import com.datadog.android.api.context.DeviceType
 import com.datadog.android.api.context.NetworkInfo
@@ -19,8 +20,9 @@ import java.util.UUID
 
 internal class LogEventForgeryFactory : ForgeryFactory<LogEvent> {
     override fun getForgery(forge: Forge): LogEvent {
-        val networkInfo: NetworkInfo? = forge.aNullable()
-        val userInfo: UserInfo? = forge.aNullable()
+        val networkInfo = forge.aNullable<NetworkInfo>()
+        val userInfo = forge.aNullable<UserInfo>()
+        val accountInfo = forge.aNullable<AccountInfo>()
         val reservedKeysAsSet = mutableSetOf<String>().apply {
             LogEvent.RESERVED_PROPERTIES.forEach {
                 this.add(it)
@@ -66,6 +68,13 @@ internal class LogEventForgeryFactory : ForgeryFactory<LogEvent> {
 
                 )
             },
+            account = accountInfo?.let {
+                LogEvent.Account(
+                    id = it.id,
+                    name = it.name,
+                    additionalProperties = it.extraInfo.toMutableMap()
+                )
+            },
             network = forge.aNullable {
                 LogEvent.Network(
                     client = LogEvent.Client(
@@ -92,7 +101,11 @@ internal class LogEventForgeryFactory : ForgeryFactory<LogEvent> {
                 name = deviceInfo.deviceName,
                 model = deviceInfo.deviceModel,
                 brand = deviceInfo.deviceBrand,
-                architecture = deviceInfo.architecture
+                architecture = deviceInfo.architecture,
+                locale = forge.aNullable { anAlphabeticalString() },
+                locales = forge.aNullable { aList { anAlphabeticalString() } },
+                timeZone = forge.aNullable { anAlphabeticalString() },
+                powerSavingMode = forge.aNullable { aBool() }
             ),
             dd = LogEvent.Dd(
                 device = LogEvent.DdDevice(
@@ -102,7 +115,8 @@ internal class LogEventForgeryFactory : ForgeryFactory<LogEvent> {
             os = LogEvent.Os(
                 name = deviceInfo.osName,
                 version = deviceInfo.osVersion,
-                versionMajor = deviceInfo.osMajorVersion
+                versionMajor = deviceInfo.osMajorVersion,
+                build = forge.aNullable { anAlphabeticalString() }
             )
         )
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
@@ -107,6 +107,13 @@ internal class RumEventSerializerTest {
                 containsAttributes(usr.additionalProperties)
             }
         }
+        event.account?.let { account ->
+            assertThat(jsonObject).hasField("account") {
+                hasNullableField("id", account.id)
+                hasNullableField("name", account.name)
+                containsAttributes(account.additionalProperties)
+            }
+        }
         event.connectivity?.let { connectivity ->
             assertThat(jsonObject).hasField("connectivity") {
                 hasNullableField("status", connectivity.status.name.lowercase(Locale.US))
@@ -120,6 +127,29 @@ internal class RumEventSerializerTest {
                         hasNullableField("carrier_name", cellular.carrierName)
                     }
                 }
+            }
+        }
+        event.device?.let { device ->
+            assertThat(jsonObject).hasField("device") {
+                hasNullableField("name", device.name)
+                hasNullableField("model", device.model)
+                hasNullableField("brand", device.brand)
+                hasNullableField("type", device.type?.name?.lowercase(Locale.US))
+                hasNullableField("architecture", device.architecture)
+                hasNullableField("locale", device.locale)
+                hasNullableField("locales", device.locales)
+                hasNullableField("time_zone", device.timeZone)
+                hasNullableField("battery_level", device.batteryLevel)
+                hasNullableField("power_saving_mode", device.powerSavingMode)
+                hasNullableField("brightness_level", device.brightnessLevel)
+            }
+        }
+        event.os?.let { os ->
+            assertThat(jsonObject).hasField("os") {
+                hasNullableField("name", os.name)
+                hasNullableField("version", os.version)
+                hasNullableField("version_major", os.versionMajor)
+                hasNullableField("build", os.build)
             }
         }
         event.context?.additionalProperties?.let {
@@ -192,6 +222,13 @@ internal class RumEventSerializerTest {
                 containsAttributes(usr.additionalProperties)
             }
         }
+        event.account?.let { account ->
+            assertThat(jsonObject).hasField("account") {
+                hasNullableField("id", account.id)
+                hasNullableField("name", account.name)
+                containsAttributes(account.additionalProperties)
+            }
+        }
         event.connectivity?.let { connectivity ->
             assertThat(jsonObject).hasField("connectivity") {
                 hasNullableField("status", connectivity.status.name.lowercase(Locale.US))
@@ -205,6 +242,29 @@ internal class RumEventSerializerTest {
                         hasNullableField("carrier_name", cellular.carrierName)
                     }
                 }
+            }
+        }
+        event.device?.let { device ->
+            assertThat(jsonObject).hasField("device") {
+                hasNullableField("name", device.name)
+                hasNullableField("model", device.model)
+                hasNullableField("brand", device.brand)
+                hasNullableField("type", device.type?.name?.lowercase(Locale.US))
+                hasNullableField("architecture", device.architecture)
+                hasNullableField("locale", device.locale)
+                hasNullableField("locales", device.locales)
+                hasNullableField("time_zone", device.timeZone)
+                hasNullableField("battery_level", device.batteryLevel)
+                hasNullableField("power_saving_mode", device.powerSavingMode)
+                hasNullableField("brightness_level", device.brightnessLevel)
+            }
+        }
+        event.os?.let { os ->
+            assertThat(jsonObject).hasField("os") {
+                hasNullableField("name", os.name)
+                hasNullableField("version", os.version)
+                hasNullableField("version_major", os.versionMajor)
+                hasNullableField("build", os.build)
             }
         }
         event.context?.additionalProperties?.let {
@@ -260,6 +320,13 @@ internal class RumEventSerializerTest {
                 containsAttributes(usr.additionalProperties)
             }
         }
+        event.account?.let { account ->
+            assertThat(jsonObject).hasField("account") {
+                hasNullableField("id", account.id)
+                hasNullableField("name", account.name)
+                containsAttributes(account.additionalProperties)
+            }
+        }
         event.connectivity?.let { connectivity ->
             assertThat(jsonObject).hasField("connectivity") {
                 hasNullableField("status", connectivity.status.name.lowercase(Locale.US))
@@ -273,6 +340,29 @@ internal class RumEventSerializerTest {
                         hasNullableField("carrier_name", cellular.carrierName)
                     }
                 }
+            }
+        }
+        event.device?.let { device ->
+            assertThat(jsonObject).hasField("device") {
+                hasNullableField("name", device.name)
+                hasNullableField("model", device.model)
+                hasNullableField("brand", device.brand)
+                hasNullableField("type", device.type?.name?.lowercase(Locale.US))
+                hasNullableField("architecture", device.architecture)
+                hasNullableField("locale", device.locale)
+                hasNullableField("locales", device.locales)
+                hasNullableField("time_zone", device.timeZone)
+                hasNullableField("battery_level", device.batteryLevel)
+                hasNullableField("power_saving_mode", device.powerSavingMode)
+                hasNullableField("brightness_level", device.brightnessLevel)
+            }
+        }
+        event.os?.let { os ->
+            assertThat(jsonObject).hasField("os") {
+                hasNullableField("name", os.name)
+                hasNullableField("version", os.version)
+                hasNullableField("version_major", os.versionMajor)
+                hasNullableField("build", os.build)
             }
         }
         event.context?.additionalProperties?.let {
@@ -324,6 +414,13 @@ internal class RumEventSerializerTest {
                 containsAttributes(usr.additionalProperties)
             }
         }
+        event.account?.let { account ->
+            assertThat(jsonObject).hasField("account") {
+                hasNullableField("id", account.id)
+                hasNullableField("name", account.name)
+                containsAttributes(account.additionalProperties)
+            }
+        }
         event.connectivity?.let { connectivity ->
             assertThat(jsonObject).hasField("connectivity") {
                 hasNullableField("status", connectivity.status.name.lowercase(Locale.US))
@@ -337,6 +434,29 @@ internal class RumEventSerializerTest {
                         hasNullableField("carrier_name", cellular.carrierName)
                     }
                 }
+            }
+        }
+        event.device?.let { device ->
+            assertThat(jsonObject).hasField("device") {
+                hasNullableField("name", device.name)
+                hasNullableField("model", device.model)
+                hasNullableField("brand", device.brand)
+                hasNullableField("type", device.type?.name?.lowercase(Locale.US))
+                hasNullableField("architecture", device.architecture)
+                hasNullableField("locale", device.locale)
+                hasNullableField("locales", device.locales)
+                hasNullableField("time_zone", device.timeZone)
+                hasNullableField("battery_level", device.batteryLevel)
+                hasNullableField("power_saving_mode", device.powerSavingMode)
+                hasNullableField("brightness_level", device.brightnessLevel)
+            }
+        }
+        event.os?.let { os ->
+            assertThat(jsonObject).hasField("os") {
+                hasNullableField("name", os.name)
+                hasNullableField("version", os.version)
+                hasNullableField("version_major", os.versionMajor)
+                hasNullableField("build", os.build)
             }
         }
         event.context?.additionalProperties?.let {
@@ -382,6 +502,13 @@ internal class RumEventSerializerTest {
                 containsAttributes(usr.additionalProperties)
             }
         }
+        event.account?.let { account ->
+            assertThat(jsonObject).hasField("account") {
+                hasNullableField("id", account.id)
+                hasNullableField("name", account.name)
+                containsAttributes(account.additionalProperties)
+            }
+        }
         event.connectivity?.let { connectivity ->
             assertThat(jsonObject).hasField("connectivity") {
                 hasNullableField("status", connectivity.status.name.lowercase(Locale.US))
@@ -395,6 +522,29 @@ internal class RumEventSerializerTest {
                         hasNullableField("carrier_name", cellular.carrierName)
                     }
                 }
+            }
+        }
+        event.device?.let { device ->
+            assertThat(jsonObject).hasField("device") {
+                hasNullableField("name", device.name)
+                hasNullableField("model", device.model)
+                hasNullableField("brand", device.brand)
+                hasNullableField("type", device.type?.name?.lowercase(Locale.US))
+                hasNullableField("architecture", device.architecture)
+                hasNullableField("locale", device.locale)
+                hasNullableField("locales", device.locales)
+                hasNullableField("time_zone", device.timeZone)
+                hasNullableField("battery_level", device.batteryLevel)
+                hasNullableField("power_saving_mode", device.powerSavingMode)
+                hasNullableField("brightness_level", device.brightnessLevel)
+            }
+        }
+        event.os?.let { os ->
+            assertThat(jsonObject).hasField("os") {
+                hasNullableField("name", os.name)
+                hasNullableField("version", os.version)
+                hasNullableField("version_major", os.versionMajor)
+                hasNullableField("build", os.build)
             }
         }
         event.context?.additionalProperties?.let {
@@ -873,6 +1023,9 @@ internal class RumEventSerializerTest {
             .doesNotHaveField("session")
             .doesNotHaveField("view")
             .doesNotHaveField("usr")
+            .doesNotHaveField("account")
+            .doesNotHaveField("os")
+            .doesNotHaveField("device")
             .doesNotHaveField("_dd")
     }
 
@@ -977,6 +1130,14 @@ internal class RumEventSerializerTest {
                 RumEventSerializer.ignoredAttributes
             )
         }
+        fakeEvent.account?.let {
+            verify(mockedDataConstrains).validateAttributes(
+                it.additionalProperties,
+                RumEventSerializer.ACCOUNT_ATTRIBUTE_PREFIX,
+                RumEventSerializer.ACCOUNT_EXTRA_GROUP_VERBOSE_NAME,
+                RumEventSerializer.ignoredAttributes
+            )
+        }
     }
 
     @Test
@@ -996,6 +1157,14 @@ internal class RumEventSerializerTest {
                 it.additionalProperties,
                 RumEventSerializer.USER_ATTRIBUTE_PREFIX,
                 RumEventSerializer.USER_EXTRA_GROUP_VERBOSE_NAME,
+                RumEventSerializer.ignoredAttributes
+            )
+        }
+        fakeEvent.account?.let {
+            verify(mockedDataConstrains).validateAttributes(
+                it.additionalProperties,
+                RumEventSerializer.ACCOUNT_ATTRIBUTE_PREFIX,
+                RumEventSerializer.ACCOUNT_EXTRA_GROUP_VERBOSE_NAME,
                 RumEventSerializer.ignoredAttributes
             )
         }
@@ -1021,6 +1190,14 @@ internal class RumEventSerializerTest {
                 RumEventSerializer.ignoredAttributes
             )
         }
+        fakeEvent.account?.let {
+            verify(mockedDataConstrains).validateAttributes(
+                it.additionalProperties,
+                RumEventSerializer.ACCOUNT_ATTRIBUTE_PREFIX,
+                RumEventSerializer.ACCOUNT_EXTRA_GROUP_VERBOSE_NAME,
+                RumEventSerializer.ignoredAttributes
+            )
+        }
     }
 
     @Test
@@ -1043,6 +1220,14 @@ internal class RumEventSerializerTest {
                 RumEventSerializer.ignoredAttributes
             )
         }
+        fakeEvent.account?.let {
+            verify(mockedDataConstrains).validateAttributes(
+                it.additionalProperties,
+                RumEventSerializer.ACCOUNT_ATTRIBUTE_PREFIX,
+                RumEventSerializer.ACCOUNT_EXTRA_GROUP_VERBOSE_NAME,
+                RumEventSerializer.ignoredAttributes
+            )
+        }
     }
 
     @Test
@@ -1062,6 +1247,14 @@ internal class RumEventSerializerTest {
                 it.additionalProperties,
                 RumEventSerializer.USER_ATTRIBUTE_PREFIX,
                 RumEventSerializer.USER_EXTRA_GROUP_VERBOSE_NAME,
+                RumEventSerializer.ignoredAttributes
+            )
+        }
+        fakeEvent.account?.let {
+            verify(mockedDataConstrains).validateAttributes(
+                it.additionalProperties,
+                RumEventSerializer.ACCOUNT_ATTRIBUTE_PREFIX,
+                RumEventSerializer.ACCOUNT_EXTRA_GROUP_VERBOSE_NAME,
                 RumEventSerializer.ignoredAttributes
             )
         }
@@ -1230,6 +1423,42 @@ internal class RumEventSerializerTest {
     }
 
     @Test
+    fun `M drop non-serializable attributes W serialize() with ResourceEvent { account account#additionalProperties }`(
+        @Forgery event: ResourceEvent,
+        forge: Forge
+    ) {
+        // Given
+        val faultyKey = forge.anAlphabeticalString()
+        val faultyObject = object {
+            override fun toString(): String {
+                throw forge.anException()
+            }
+        }
+        val faultyEvent = event.copy(
+            account = event.account?.copy(
+                additionalProperties = event.account?.additionalProperties
+                    ?.toMutableMap()
+                    ?.apply { put(faultyKey, faultyObject) }
+                    .orEmpty()
+                    .toMutableMap()
+            )
+        )
+
+        // When
+        val serialized = testedSerializer.serialize(faultyEvent)
+
+        // Then
+        val jsonObject = JsonParser.parseString(serialized).asJsonObject
+        event.account?.let { account ->
+            assertThat(jsonObject).hasField("account") {
+                hasNullableField("id", account.id)
+                hasNullableField("name", account.name)
+                containsAttributes(account.additionalProperties)
+            }
+        }
+    }
+
+    @Test
     fun `M drop non-serializable attributes W serialize() with ResourceEvent { bad context#additionalProperties }`(
         @Forgery event: ResourceEvent,
         forge: Forge
@@ -1296,6 +1525,42 @@ internal class RumEventSerializerTest {
                 hasNullableField("name", usr.name)
                 hasNullableField("email", usr.email)
                 containsAttributes(usr.additionalProperties)
+            }
+        }
+    }
+
+    @Test
+    fun `M drop non-serializable attributes W serialize() with ActionEvent { bad account#additionalProperties }`(
+        @Forgery event: ActionEvent,
+        forge: Forge
+    ) {
+        // Given
+        val faultyKey = forge.anAlphabeticalString()
+        val faultyObject = object {
+            override fun toString(): String {
+                throw forge.anException()
+            }
+        }
+        val faultyEvent = event.copy(
+            account = event.account?.copy(
+                additionalProperties = event.account?.additionalProperties
+                    ?.toMutableMap()
+                    ?.apply { put(faultyKey, faultyObject) }
+                    .orEmpty()
+                    .toMutableMap()
+            )
+        )
+
+        // When
+        val serialized = testedSerializer.serialize(faultyEvent)
+
+        // Then
+        val jsonObject = JsonParser.parseString(serialized).asJsonObject
+        event.account?.let { account ->
+            assertThat(jsonObject).hasField("account") {
+                hasNullableField("id", account.id)
+                hasNullableField("name", account.name)
+                containsAttributes(account.additionalProperties)
             }
         }
     }
@@ -1372,6 +1637,42 @@ internal class RumEventSerializerTest {
     }
 
     @Test
+    fun `M drop non-serializable attributes W serialize() with ViewEvent { bad account#additionalProperties }`(
+        @Forgery event: ViewEvent,
+        forge: Forge
+    ) {
+        // Given
+        val faultyKey = forge.anAlphabeticalString()
+        val faultyObject = object {
+            override fun toString(): String {
+                throw forge.anException()
+            }
+        }
+        val faultyEvent = event.copy(
+            account = event.account?.copy(
+                additionalProperties = event.account?.additionalProperties
+                    ?.toMutableMap()
+                    ?.apply { put(faultyKey, faultyObject) }
+                    .orEmpty()
+                    .toMutableMap()
+            )
+        )
+
+        // When
+        val serialized = testedSerializer.serialize(faultyEvent)
+
+        // Then
+        val jsonObject = JsonParser.parseString(serialized).asJsonObject
+        event.account?.let { account ->
+            assertThat(jsonObject).hasField("account") {
+                hasNullableField("id", account.id)
+                hasNullableField("name", account.name)
+                containsAttributes(account.additionalProperties)
+            }
+        }
+    }
+
+    @Test
     fun `M drop non-serializable attributes W serialize() with ViewEvent { bad context#additionalProperties }`(
         @Forgery event: ViewEvent,
         forge: Forge
@@ -1443,6 +1744,42 @@ internal class RumEventSerializerTest {
     }
 
     @Test
+    fun `M drop non-serializable attributes W serialize() with ErrorEvent { bad account#additionalProperties }`(
+        @Forgery event: ErrorEvent,
+        forge: Forge
+    ) {
+        // Given
+        val faultyKey = forge.anAlphabeticalString()
+        val faultyObject = object {
+            override fun toString(): String {
+                throw forge.anException()
+            }
+        }
+        val faultyEvent = event.copy(
+            account = event.account?.copy(
+                additionalProperties = event.account?.additionalProperties
+                    ?.toMutableMap()
+                    ?.apply { put(faultyKey, faultyObject) }
+                    .orEmpty()
+                    .toMutableMap()
+            )
+        )
+
+        // When
+        val serialized = testedSerializer.serialize(faultyEvent)
+
+        // Then
+        val jsonObject = JsonParser.parseString(serialized).asJsonObject
+        event.account?.let { account ->
+            assertThat(jsonObject).hasField("account") {
+                hasNullableField("id", account.id)
+                hasNullableField("name", account.name)
+                containsAttributes(account.additionalProperties)
+            }
+        }
+    }
+
+    @Test
     fun `M drop non-serializable attributes W serialize() with ErrorEvent { bad context#additionalProperties }`(
         @Forgery event: ErrorEvent,
         forge: Forge
@@ -1509,6 +1846,42 @@ internal class RumEventSerializerTest {
                 hasNullableField("name", usr.name)
                 hasNullableField("email", usr.email)
                 containsAttributes(usr.additionalProperties)
+            }
+        }
+    }
+
+    @Test
+    fun `M drop non-serializable attributes W serialize() with LongTaskEvent { bad account#additionalProperties }`(
+        @Forgery event: LongTaskEvent,
+        forge: Forge
+    ) {
+        // Given
+        val faultyKey = forge.anAlphabeticalString()
+        val faultyObject = object {
+            override fun toString(): String {
+                throw forge.anException()
+            }
+        }
+        val faultyEvent = event.copy(
+            account = event.account?.copy(
+                additionalProperties = event.account?.additionalProperties
+                    ?.toMutableMap()
+                    ?.apply { put(faultyKey, faultyObject) }
+                    .orEmpty()
+                    .toMutableMap()
+            )
+        )
+
+        // When
+        val serialized = testedSerializer.serialize(faultyEvent)
+
+        // Then
+        val jsonObject = JsonParser.parseString(serialized).asJsonObject
+        event.account?.let { account ->
+            assertThat(jsonObject).hasField("account") {
+                hasNullableField("id", account.id)
+                hasNullableField("name", account.name)
+                containsAttributes(account.additionalProperties)
             }
         }
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/assertj/DeserializedActionEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/assertj/DeserializedActionEventAssert.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.utils.assertj
 import com.datadog.android.rum.model.ActionEvent
 import org.assertj.core.api.AbstractAssert
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
 
 internal class DeserializedActionEventAssert(actual: ActionEvent) :
     AbstractAssert<DeserializedActionEventAssert, ActionEvent>(
@@ -19,15 +20,29 @@ internal class DeserializedActionEventAssert(actual: ActionEvent) :
     fun isEqualTo(expected: ActionEvent): DeserializedActionEventAssert {
         assertThat(actual)
             .usingRecursiveComparison()
-            .ignoringFields("context", "usr")
+            .ignoringFields("context", "usr", "account", "device")
             .isEqualTo(expected)
+        assertThat(actual.device)
+            .usingRecursiveComparison()
+            .ignoringFields("batteryLevel", "brightnessLevel")
+            .isEqualTo(expected.device)
+        assertNumberFieldEquals(actual.device?.batteryLevel, expected.device?.batteryLevel)
+        assertNumberFieldEquals(actual.device?.brightnessLevel, expected.device?.brightnessLevel)
         assertThat(actual.usr)
             .usingRecursiveComparison()
             .ignoringFields("additionalProperties")
             .isEqualTo(expected.usr)
+        assertThat(actual.account)
+            .usingRecursiveComparison()
+            .ignoringFields("additionalProperties")
+            .isEqualTo(expected.account)
         assertProperties(
             actual.usr?.additionalProperties,
             expected.usr?.additionalProperties
+        )
+        assertProperties(
+            actual.account?.additionalProperties,
+            expected.account?.additionalProperties
         )
         assertThat(actual.context)
             .usingRecursiveComparison()
@@ -38,6 +53,16 @@ internal class DeserializedActionEventAssert(actual: ActionEvent) :
             expected.context?.additionalProperties
         )
         return this
+    }
+
+    private fun assertNumberFieldEquals(actual: Number?, expected: Number?) {
+        if (expected == null) {
+            assertThat(actual).isNull()
+        } else {
+            assertThat(actual).isNotNull()
+            assertThat(actual!!.toDouble())
+                .isCloseTo(expected.toDouble(), Offset.offset(0.0000001))
+        }
     }
 
     private fun assertProperties(actual: Map<String, Any?>?, expected: Map<String, Any?>?) {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/assertj/DeserializedLongTaskEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/assertj/DeserializedLongTaskEventAssert.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.utils.assertj
 import com.datadog.android.rum.model.LongTaskEvent
 import org.assertj.core.api.AbstractAssert
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
 
 internal class DeserializedLongTaskEventAssert(actual: LongTaskEvent) :
     AbstractAssert<DeserializedLongTaskEventAssert, LongTaskEvent>(
@@ -19,15 +20,29 @@ internal class DeserializedLongTaskEventAssert(actual: LongTaskEvent) :
     fun isEqualTo(expected: LongTaskEvent): DeserializedLongTaskEventAssert {
         assertThat(actual)
             .usingRecursiveComparison()
-            .ignoringFields("context", "usr")
+            .ignoringFields("context", "usr", "account", "device")
             .isEqualTo(expected)
+        assertThat(actual.device)
+            .usingRecursiveComparison()
+            .ignoringFields("batteryLevel", "brightnessLevel")
+            .isEqualTo(expected.device)
+        assertNumberFieldEquals(actual.device?.batteryLevel, expected.device?.batteryLevel)
+        assertNumberFieldEquals(actual.device?.brightnessLevel, expected.device?.brightnessLevel)
         assertThat(actual.usr)
             .usingRecursiveComparison()
             .ignoringFields("additionalProperties")
             .isEqualTo(expected.usr)
+        assertThat(actual.account)
+            .usingRecursiveComparison()
+            .ignoringFields("additionalProperties")
+            .isEqualTo(expected.account)
         assertProperties(
             actual.usr?.additionalProperties,
             expected.usr?.additionalProperties
+        )
+        assertProperties(
+            actual.account?.additionalProperties,
+            expected.account?.additionalProperties
         )
         assertThat(actual.context)
             .usingRecursiveComparison()
@@ -38,6 +53,16 @@ internal class DeserializedLongTaskEventAssert(actual: LongTaskEvent) :
             expected.context?.additionalProperties
         )
         return this
+    }
+
+    private fun assertNumberFieldEquals(actual: Number?, expected: Number?) {
+        if (expected == null) {
+            assertThat(actual).isNull()
+        } else {
+            assertThat(actual).isNotNull()
+            assertThat(actual!!.toDouble())
+                .isCloseTo(expected.toDouble(), Offset.offset(0.0000001))
+        }
     }
 
     private fun assertProperties(actual: Map<String, Any?>?, expected: Map<String, Any?>?) {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/assertj/DeserializedResourceEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/assertj/DeserializedResourceEventAssert.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.utils.assertj
 import com.datadog.android.rum.model.ResourceEvent
 import org.assertj.core.api.AbstractAssert
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
 
 internal class DeserializedResourceEventAssert(actual: ResourceEvent) :
     AbstractAssert<DeserializedResourceEventAssert, ResourceEvent>(
@@ -19,15 +20,29 @@ internal class DeserializedResourceEventAssert(actual: ResourceEvent) :
     fun isEqualTo(expected: ResourceEvent): DeserializedResourceEventAssert {
         assertThat(actual)
             .usingRecursiveComparison()
-            .ignoringFields("context", "usr")
+            .ignoringFields("context", "usr", "account", "device")
             .isEqualTo(expected)
+        assertThat(actual.device)
+            .usingRecursiveComparison()
+            .ignoringFields("batteryLevel", "brightnessLevel")
+            .isEqualTo(expected.device)
+        assertNumberFieldEquals(actual.device?.batteryLevel, expected.device?.batteryLevel)
+        assertNumberFieldEquals(actual.device?.brightnessLevel, expected.device?.brightnessLevel)
         assertThat(actual.usr)
             .usingRecursiveComparison()
             .ignoringFields("additionalProperties")
             .isEqualTo(expected.usr)
+        assertThat(actual.account)
+            .usingRecursiveComparison()
+            .ignoringFields("additionalProperties")
+            .isEqualTo(expected.account)
         assertProperties(
             actual.usr?.additionalProperties,
             expected.usr?.additionalProperties
+        )
+        assertProperties(
+            actual.account?.additionalProperties,
+            expected.account?.additionalProperties
         )
         assertThat(actual.context)
             .usingRecursiveComparison()
@@ -38,6 +53,16 @@ internal class DeserializedResourceEventAssert(actual: ResourceEvent) :
             expected.context?.additionalProperties
         )
         return this
+    }
+
+    private fun assertNumberFieldEquals(actual: Number?, expected: Number?) {
+        if (expected == null) {
+            assertThat(actual).isNull()
+        } else {
+            assertThat(actual).isNotNull()
+            assertThat(actual!!.toDouble())
+                .isCloseTo(expected.toDouble(), Offset.offset(0.0000001))
+        }
     }
 
     private fun assertProperties(actual: Map<String, Any?>?, expected: Map<String, Any?>?) {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/assertj/DeserializedViewEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/assertj/DeserializedViewEventAssert.kt
@@ -20,7 +20,7 @@ internal class DeserializedViewEventAssert(actual: ViewEvent) :
     fun isEqualTo(expected: ViewEvent): DeserializedViewEventAssert {
         assertThat(actual)
             .usingRecursiveComparison()
-            .ignoringFields("context", "usr", "view")
+            .ignoringFields("context", "usr", "account", "view", "device")
             .isEqualTo(expected)
         assertThat(actual.view)
             .usingRecursiveComparison()
@@ -44,13 +44,27 @@ internal class DeserializedViewEventAssert(actual: ViewEvent) :
             actual.view.cumulativeLayoutShift,
             expected.view.cumulativeLayoutShift
         )
+        assertThat(actual.device)
+            .usingRecursiveComparison()
+            .ignoringFields("batteryLevel", "brightnessLevel")
+            .isEqualTo(expected.device)
+        assertNumberFieldEquals(actual.device?.batteryLevel, expected.device?.batteryLevel)
+        assertNumberFieldEquals(actual.device?.brightnessLevel, expected.device?.brightnessLevel)
         assertThat(actual.usr)
             .usingRecursiveComparison()
             .ignoringFields("additionalProperties")
             .isEqualTo(expected.usr)
+        assertThat(actual.account)
+            .usingRecursiveComparison()
+            .ignoringFields("additionalProperties")
+            .isEqualTo(expected.account)
         assertPropertiesEquals(
             actual.usr?.additionalProperties,
             expected.usr?.additionalProperties
+        )
+        assertPropertiesEquals(
+            actual.account?.additionalProperties,
+            expected.account?.additionalProperties
         )
         assertThat(actual.context)
             .usingRecursiveComparison()

--- a/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ActionEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ActionEventForgeryFactory.kt
@@ -72,6 +72,13 @@ class ActionEventForgeryFactory :
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
+            account = forge.aNullable {
+                ActionEvent.Account(
+                    id = anHexadecimalString(),
+                    name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name"))
+                )
+            },
             application = ActionEvent.Application(forge.getForgery<UUID>().toString()),
             service = forge.aNullable { anAlphabeticalString() },
             session = ActionEvent.ActionEventSession(
@@ -87,7 +94,8 @@ class ActionEventForgeryFactory :
                 ActionEvent.Os(
                     name = forge.aString(),
                     version = "${forge.aSmallInt()}.${forge.aSmallInt()}.${forge.aSmallInt()}",
-                    versionMajor = forge.aSmallInt().toString()
+                    versionMajor = forge.aSmallInt().toString(),
+                    build = forge.aNullable { anAlphabeticalString() }
                 )
             },
             device = forge.aNullable {
@@ -96,7 +104,13 @@ class ActionEventForgeryFactory :
                     model = forge.aString(),
                     brand = forge.aString(),
                     type = forge.aValueFrom(ActionEvent.DeviceType::class.java),
-                    architecture = forge.aString()
+                    architecture = forge.aString(),
+                    locale = forge.aNullable { anAlphabeticalString() },
+                    locales = forge.aNullable { aList { anAlphabeticalString() } },
+                    timeZone = forge.aNullable { anAlphabeticalString() },
+                    batteryLevel = forge.aNullable { aDouble(min = 0.0, max = 100.0) },
+                    powerSavingMode = forge.aNullable { aBool() },
+                    brightnessLevel = forge.aNullable { aDouble(min = 0.0, max = 1.0) }
                 )
             },
             context = forge.aNullable {

--- a/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ErrorEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ErrorEventForgeryFactory.kt
@@ -93,6 +93,13 @@ class ErrorEventForgeryFactory : ForgeryFactory<ErrorEvent> {
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
+            account = forge.aNullable {
+                ErrorEvent.Account(
+                    id = anHexadecimalString(),
+                    name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name"))
+                )
+            },
             action = forge.aNullable { ErrorEvent.Action(aList { getForgery<UUID>().toString() }) },
             application = ErrorEvent.Application(forge.getForgery<UUID>().toString()),
             service = forge.aNullable { anAlphabeticalString() },
@@ -109,7 +116,8 @@ class ErrorEventForgeryFactory : ForgeryFactory<ErrorEvent> {
                 ErrorEvent.Os(
                     name = forge.aString(),
                     version = "${forge.aSmallInt()}.${forge.aSmallInt()}.${forge.aSmallInt()}",
-                    versionMajor = forge.aSmallInt().toString()
+                    versionMajor = forge.aSmallInt().toString(),
+                    build = forge.aNullable { anAlphabeticalString() }
                 )
             },
             device = forge.aNullable {
@@ -118,7 +126,13 @@ class ErrorEventForgeryFactory : ForgeryFactory<ErrorEvent> {
                     model = forge.aString(),
                     brand = forge.aString(),
                     type = forge.aValueFrom(ErrorEvent.DeviceType::class.java),
-                    architecture = forge.aString()
+                    architecture = forge.aString(),
+                    locale = forge.aNullable { anAlphabeticalString() },
+                    locales = forge.aNullable { aList { anAlphabeticalString() } },
+                    timeZone = forge.aNullable { anAlphabeticalString() },
+                    batteryLevel = forge.aNullable { aDouble(min = 0.0, max = 100.0) },
+                    powerSavingMode = forge.aNullable { aBool() },
+                    brightnessLevel = forge.aNullable { aDouble(min = 0.0, max = 1.0) }
                 )
             },
             context = forge.aNullable {

--- a/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/LongTaskEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/LongTaskEventForgeryFactory.kt
@@ -57,6 +57,13 @@ class LongTaskEventForgeryFactory :
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
+            account = forge.aNullable {
+                LongTaskEvent.Account(
+                    id = anHexadecimalString(),
+                    name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name"))
+                )
+            },
             action = forge.aNullable {
                 LongTaskEvent.Action(aList { getForgery<UUID>().toString() })
             },
@@ -75,7 +82,8 @@ class LongTaskEventForgeryFactory :
                 LongTaskEvent.Os(
                     name = forge.aString(),
                     version = "${forge.aSmallInt()}.${forge.aSmallInt()}.${forge.aSmallInt()}",
-                    versionMajor = forge.aSmallInt().toString()
+                    versionMajor = forge.aSmallInt().toString(),
+                    build = forge.aNullable { anAlphabeticalString() }
                 )
             },
             device = forge.aNullable {
@@ -84,7 +92,13 @@ class LongTaskEventForgeryFactory :
                     model = forge.aString(),
                     brand = forge.aString(),
                     type = forge.aValueFrom(LongTaskEvent.DeviceType::class.java),
-                    architecture = forge.aString()
+                    architecture = forge.aString(),
+                    locale = forge.aNullable { anAlphabeticalString() },
+                    locales = forge.aNullable { aList { anAlphabeticalString() } },
+                    timeZone = forge.aNullable { anAlphabeticalString() },
+                    batteryLevel = forge.aNullable { aDouble(min = 0.0, max = 100.0) },
+                    powerSavingMode = forge.aNullable { aBool() },
+                    brightnessLevel = forge.aNullable { aDouble(min = 0.0, max = 1.0) }
                 )
             },
             context = forge.aNullable {

--- a/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ResourceEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ResourceEventForgeryFactory.kt
@@ -94,6 +94,13 @@ class ResourceEventForgeryFactory :
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
+            account = forge.aNullable {
+                ResourceEvent.Account(
+                    id = anHexadecimalString(),
+                    name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name"))
+                )
+            },
             action = forge.aNullable {
                 ResourceEvent.Action(aList { getForgery<UUID>().toString() })
             },
@@ -112,7 +119,8 @@ class ResourceEventForgeryFactory :
                 ResourceEvent.Os(
                     name = forge.aString(),
                     version = "${forge.aSmallInt()}.${forge.aSmallInt()}.${forge.aSmallInt()}",
-                    versionMajor = forge.aSmallInt().toString()
+                    versionMajor = forge.aSmallInt().toString(),
+                    build = forge.aNullable { anAlphabeticalString() }
                 )
             },
             device = forge.aNullable {
@@ -121,7 +129,13 @@ class ResourceEventForgeryFactory :
                     model = forge.aString(),
                     brand = forge.aString(),
                     type = forge.aValueFrom(ResourceEvent.DeviceType::class.java),
-                    architecture = forge.aString()
+                    architecture = forge.aString(),
+                    locale = forge.aNullable { anAlphabeticalString() },
+                    locales = forge.aNullable { aList { anAlphabeticalString() } },
+                    timeZone = forge.aNullable { anAlphabeticalString() },
+                    batteryLevel = forge.aNullable { anInt(min = 0, max = 100) },
+                    powerSavingMode = forge.aNullable { aBool() },
+                    brightnessLevel = forge.aNullable { aDouble(min = 0.0, max = 1.0) }
                 )
             },
             context = forge.aNullable {

--- a/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ViewEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ViewEventForgeryFactory.kt
@@ -94,6 +94,13 @@ class ViewEventForgeryFactory : ForgeryFactory<ViewEvent> {
                     additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
+            account = forge.aNullable {
+                ViewEvent.Account(
+                    id = anHexadecimalString(),
+                    name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name"))
+                )
+            },
             application = ViewEvent.Application(forge.getForgery<UUID>().toString()),
             service = forge.aNullable { anAlphabeticalString() },
             session = ViewEvent.ViewEventSession(
@@ -109,7 +116,8 @@ class ViewEventForgeryFactory : ForgeryFactory<ViewEvent> {
                 ViewEvent.Os(
                     name = forge.aString(),
                     version = "${forge.aSmallInt()}.${forge.aSmallInt()}.${forge.aSmallInt()}",
-                    versionMajor = forge.aSmallInt().toString()
+                    versionMajor = forge.aSmallInt().toString(),
+                    build = forge.aNullable { anAlphabeticalString() }
                 )
             },
             device = forge.aNullable {
@@ -118,7 +126,13 @@ class ViewEventForgeryFactory : ForgeryFactory<ViewEvent> {
                     model = forge.aString(),
                     brand = forge.aString(),
                     type = forge.aValueFrom(ViewEvent.DeviceType::class.java),
-                    architecture = forge.aString()
+                    architecture = forge.aString(),
+                    locale = forge.aNullable { anAlphabeticalString() },
+                    locales = forge.aNullable { aList { anAlphabeticalString() } },
+                    timeZone = forge.aNullable { anAlphabeticalString() },
+                    batteryLevel = forge.aNullable { aDouble(min = 0.0, max = 100.0) },
+                    powerSavingMode = forge.aNullable { aBool() },
+                    brightnessLevel = forge.aNullable { aDouble(min = 0.0, max = 1.0) }
                 )
             },
             context = forge.aNullable {

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/event/SpanEventSerializerTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/event/SpanEventSerializerTest.kt
@@ -34,6 +34,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.util.Date
+import java.util.Locale
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -111,6 +112,46 @@ internal class SpanEventSerializerTest {
     }
 
     @Test
+    fun `M sanitise with the right prefix the account extra info keys W serialize`(
+        forge: Forge
+    ) {
+        // GIVEN
+        val fakeAccountAttributes = forge.exhaustiveAttributes()
+        val fakeSpanEvent = forge.getForgery<SpanEvent>().let {
+            it.copy(
+                meta = it.meta.copy(
+                    account = SpanEvent.Account(
+                        id = forge.anAlphabeticalString(),
+                        name = forge.anAlphabeticalString(),
+                        additionalProperties = fakeAccountAttributes
+                    )
+                )
+            )
+        }
+        val fakeSanitizedAttributes = forge.exhaustiveAttributes(setOf(KEY_ACCOUNT_ID, KEY_ACCOUNT_NAME))
+        whenever(
+            mockDatadogConstraints
+                .validateAttributes(
+                    fakeAccountAttributes,
+                    SpanEventSerializer.META_ACCOUNT_KEY_PREFIX,
+                    reservedKeys = emptySet()
+                )
+        ).thenReturn(fakeSanitizedAttributes)
+
+        // WHEN
+        val serialized = testedSerializer.serialize(fakeDatadogContext, fakeSpanEvent)
+
+        // THEN
+        val jsonObject = JsonParser.parseString(serialized).asJsonObject
+        val spanObject = jsonObject.getAsJsonArray(KEY_SPANS).first() as JsonObject
+        JsonObjectAssert.assertThat(spanObject).hasField(KEY_META) {
+            hasField(KEY_ACCOUNT) {
+                containsExtraAttributesMappedToMetaStrings(fakeSanitizedAttributes)
+            }
+        }
+    }
+
+    @Test
     fun `M sanitise with the right prefix then span metrics keys W serialize`(
         @Forgery fakeSpanEvent: SpanEvent,
         forge: Forge
@@ -172,6 +213,40 @@ internal class SpanEventSerializerTest {
         Assertions.assertThat(jsonObject.get(KEY_ENV).asString).isEqualTo(fakeDatadogContext.env)
     }
 
+    @Test
+    fun `M not throw W serialize() { account#additionalProperties serialization throws }`(
+        @Forgery fakeSpanEvent: SpanEvent,
+        forge: Forge
+    ) {
+        // GIVEN
+        val faultyKey = forge.anAlphabeticalString()
+        val faultyObject = object {
+            override fun toString(): String {
+                throw forge.anException()
+            }
+        }
+        val faultySpanEvent = fakeSpanEvent.copy(
+            meta = fakeSpanEvent.meta.copy(
+                account = fakeSpanEvent.meta.account?.copy(
+                    additionalProperties = fakeSpanEvent.meta.account
+                        ?.additionalProperties
+                        .orEmpty()
+                        .toMutableMap()
+                        .apply { put(faultyKey, faultyObject) }
+                )
+            )
+        )
+
+        // WHEN
+        val serialized = testedSerializer.serialize(fakeDatadogContext, faultySpanEvent)
+
+        // THEN
+        val jsonObject = JsonParser.parseString(serialized).asJsonObject
+        val spanObject = jsonObject.getAsJsonArray(KEY_SPANS).first() as JsonObject
+        assertJsonMatchesInputSpan(spanObject, fakeSpanEvent)
+        Assertions.assertThat(jsonObject.get(KEY_ENV).asString).isEqualTo(fakeDatadogContext.env)
+    }
+
     // endregion
 
     // region Internal
@@ -214,6 +289,19 @@ internal class SpanEventSerializerTest {
                 }
                 hasField(KEY_USR) {
                     hasUserInfo(span)
+                }
+                if (span.meta.account != null) {
+                    hasField(KEY_ACCOUNT) {
+                        hasAccountInfo(span)
+                    }
+                } else {
+                    doesNotHaveField(KEY_ACCOUNT)
+                }
+                hasField(KEY_OS) {
+                    hasOsInfo(span)
+                }
+                hasField(KEY_DEVICE) {
+                    hasDeviceInfo(span)
                 }
                 containsExtraAttributesMappedToMetaStrings(span.meta.additionalProperties)
             }
@@ -334,6 +422,112 @@ internal class SpanEventSerializerTest {
         )
     }
 
+    private fun JsonObjectAssert.hasAccountInfo(
+        spanEvent: SpanEvent
+    ) {
+        val accountName = spanEvent.meta.account?.name
+        val accountId = spanEvent.meta.account?.id
+        if (accountId != null) {
+            hasField(KEY_ACCOUNT_ID, accountId)
+        } else {
+            doesNotHaveField(KEY_ACCOUNT_ID)
+        }
+        if (accountName != null) {
+            hasField(KEY_ACCOUNT_NAME, accountName)
+        } else {
+            doesNotHaveField(KEY_ACCOUNT_NAME)
+        }
+        spanEvent.meta.account?.let {
+            containsExtraAttributesMappedToStrings(
+                it.additionalProperties
+            )
+        }
+    }
+
+    private fun JsonObjectAssert.hasOsInfo(spanEvent: SpanEvent) {
+        val osName = spanEvent.meta.os.name
+        val osBuild = spanEvent.meta.os.build
+        val osVersion = spanEvent.meta.os.version
+        val osVersionMajor = spanEvent.meta.os.versionMajor
+        hasField(KEY_NAME, osName)
+        if (osBuild != null) {
+            hasField(KEY_BUILD, osBuild)
+        } else {
+            doesNotHaveField(KEY_BUILD)
+        }
+        hasField(KEY_VERSION, osVersion)
+        hasField(KEY_VERSION_MAJOR, osVersionMajor)
+    }
+
+    private fun JsonObjectAssert.hasDeviceInfo(spanEvent: SpanEvent) {
+        val deviceType = spanEvent.meta.device.type
+        val deviceName = spanEvent.meta.device.name
+        val deviceModel = spanEvent.meta.device.model
+        val deviceBrand = spanEvent.meta.device.brand
+        val deviceArhitecture = spanEvent.meta.device.architecture
+        val deviceLocale = spanEvent.meta.device.locale
+        val deviceLocales = spanEvent.meta.device.locales
+        val deviceTimezone = spanEvent.meta.device.timeZone
+        val deviceBatteryLevel = spanEvent.meta.device.batteryLevel
+        val devicePowerSavingMode = spanEvent.meta.device.powerSavingMode
+        val deviceBrightnessLevel = spanEvent.meta.device.brightnessLevel
+        if (deviceType != null) {
+            hasField(KEY_TYPE, deviceType.name.lowercase(Locale.US))
+        } else {
+            doesNotHaveField(KEY_TYPE)
+        }
+        if (deviceName != null) {
+            hasField(KEY_NAME, deviceName)
+        } else {
+            doesNotHaveField(KEY_NAME)
+        }
+        if (deviceModel != null) {
+            hasField(KEY_MODEL, deviceModel)
+        } else {
+            doesNotHaveField(KEY_MODEL)
+        }
+        if (deviceBrand != null) {
+            hasField(KEY_BRAND, deviceBrand)
+        } else {
+            doesNotHaveField(KEY_BRAND)
+        }
+        if (deviceArhitecture != null) {
+            hasField(KEY_ARCHITECTURE, deviceArhitecture)
+        } else {
+            doesNotHaveField(KEY_ARCHITECTURE)
+        }
+        if (deviceLocale != null) {
+            hasField(KEY_LOCALE, deviceLocale)
+        } else {
+            doesNotHaveField(KEY_LOCALE)
+        }
+        if (deviceLocales != null) {
+            hasField(KEY_LOCALES, deviceLocales)
+        } else {
+            doesNotHaveField(KEY_LOCALES)
+        }
+        if (deviceTimezone != null) {
+            hasField(KEY_TIME_ZONE, deviceTimezone)
+        } else {
+            doesNotHaveField(KEY_TIME_ZONE)
+        }
+        if (deviceBatteryLevel != null) {
+            hasField(KEY_BATTERY_LEVEL, deviceBatteryLevel)
+        } else {
+            doesNotHaveField(KEY_BATTERY_LEVEL)
+        }
+        if (devicePowerSavingMode != null) {
+            hasField(KEY_POWER_SAVING_MODE, devicePowerSavingMode)
+        } else {
+            doesNotHaveField(KEY_POWER_SAVING_MODE)
+        }
+        if (deviceBrightnessLevel != null) {
+            hasField(KEY_BRIGHTNESS_LEVEL, deviceBrightnessLevel)
+        } else {
+            doesNotHaveField(KEY_BRIGHTNESS_LEVEL)
+        }
+    }
+
     private fun JsonObjectAssert.containsExtraAttributesMappedToStrings(
         attributes: Map<String, Any?>,
         keyNamePrefix: String = ""
@@ -356,47 +550,63 @@ internal class SpanEventSerializerTest {
 
     companion object {
 
-        internal const val DD_SOURCE_ANDROID = "android"
-        internal const val KIND_CLIENT = "client"
+        private const val KIND_CLIENT = "client"
 
         // PAYLOAD TAGS
-        internal const val KEY_SPANS = "spans"
-        internal const val KEY_ENV = "env"
+        private const val KEY_SPANS = "spans"
+        private const val KEY_ENV = "env"
 
         // SPAN TAGS
-        internal const val KEY_START_TIMESTAMP = "start"
-        internal const val KEY_DURATION = "duration"
-        internal const val KEY_SERVICE_NAME = "service"
-        internal const val KEY_APPLICATION_VERSION = "version"
-        internal const val KEY_TRACE_ID = "trace_id"
-        internal const val KEY_SPAN_ID = "span_id"
-        internal const val KEY_PARENT_ID = "parent_id"
-        internal const val KEY_RESOURCE = "resource"
-        internal const val KEY_OPERATION_NAME = "name"
-        internal const val KEY_ERROR = "error"
-        internal const val KEY_TYPE = "type"
-        internal const val KEY_META = "meta"
-        internal const val KEY_NETWORK = "network"
-        internal const val KEY_CLIENT = "client"
-        internal const val KEY_METRICS = "metrics"
-        internal const val KEY_METRICS_TOP_LEVEL = "_top_level"
-        internal const val KEY_DD = "_dd"
-        internal const val KEY_SOURCE = "source"
-        internal const val KEY_SPAN = "span"
-        internal const val KEY_KIND = "kind"
-        internal const val KEY_TRACER = "tracer"
-        internal const val KEY_VERSION = "version"
-        internal const val TYPE_CUSTOM = "custom"
-        internal const val KEY_SIM_CARRIER = "sim_carrier"
-        internal const val KEY_NETWORK_CARRIER_ID: String = "id"
-        internal const val KEY_NETWORK_CARRIER_NAME: String = "name"
-        internal const val KEY_NETWORK_CONNECTIVITY: String = "connectivity"
-        internal const val KEY_NETWORK_DOWN_KBPS: String = "downlink_kbps"
-        internal const val KEY_NETWORK_SIGNAL_STRENGTH: String = "signal_strength"
-        internal const val KEY_NETWORK_UP_KBPS: String = "uplink_kbps"
-        internal const val KEY_USR = "usr"
-        internal const val KEY_USR_NAME = "name"
-        internal const val KEY_USR_EMAIL = "email"
-        internal const val KEY_USR_ID = "id"
+        private const val KEY_START_TIMESTAMP = "start"
+        private const val KEY_DURATION = "duration"
+        private const val KEY_SERVICE_NAME = "service"
+        private const val KEY_APPLICATION_VERSION = "version"
+        private const val KEY_TRACE_ID = "trace_id"
+        private const val KEY_SPAN_ID = "span_id"
+        private const val KEY_PARENT_ID = "parent_id"
+        private const val KEY_RESOURCE = "resource"
+        private const val KEY_OPERATION_NAME = "name"
+        private const val KEY_ERROR = "error"
+        private const val KEY_TYPE = "type"
+        private const val KEY_META = "meta"
+        private const val KEY_NETWORK = "network"
+        private const val KEY_CLIENT = "client"
+        private const val KEY_METRICS = "metrics"
+        private const val KEY_METRICS_TOP_LEVEL = "_top_level"
+        private const val KEY_DD = "_dd"
+        private const val KEY_SOURCE = "source"
+        private const val KEY_SPAN = "span"
+        private const val KEY_KIND = "kind"
+        private const val KEY_TRACER = "tracer"
+        private const val KEY_VERSION = "version"
+        private const val TYPE_CUSTOM = "custom"
+        private const val KEY_SIM_CARRIER = "sim_carrier"
+        private const val KEY_NETWORK_CARRIER_ID: String = "id"
+        private const val KEY_NETWORK_CARRIER_NAME: String = "name"
+        private const val KEY_NETWORK_CONNECTIVITY: String = "connectivity"
+        private const val KEY_NETWORK_DOWN_KBPS: String = "downlink_kbps"
+        private const val KEY_NETWORK_SIGNAL_STRENGTH: String = "signal_strength"
+        private const val KEY_NETWORK_UP_KBPS: String = "uplink_kbps"
+        private const val KEY_USR = "usr"
+        private const val KEY_USR_NAME = "name"
+        private const val KEY_USR_EMAIL = "email"
+        private const val KEY_USR_ID = "id"
+        private const val KEY_ACCOUNT = "account"
+        private const val KEY_ACCOUNT_NAME = "name"
+        private const val KEY_ACCOUNT_ID = "id"
+        private const val KEY_BUILD = "build"
+        private const val KEY_VERSION_MAJOR = "version_major"
+        private const val KEY_OS = "os"
+        private const val KEY_DEVICE = "device"
+        private const val KEY_MODEL = "model"
+        private const val KEY_BRAND = "brand"
+        private const val KEY_ARCHITECTURE = "architecture"
+        private const val KEY_LOCALE = "locale"
+        private const val KEY_LOCALES = "locales"
+        private const val KEY_TIME_ZONE = "time_zone"
+        private const val KEY_BATTERY_LEVEL = "battery_level"
+        private const val KEY_POWER_SAVING_MODE = "power_saving_mode"
+        private const val KEY_BRIGHTNESS_LEVEL = "brightness_level"
+        private const val KEY_NAME = "name"
     }
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/SpanEventForgeryFactory.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/SpanEventForgeryFactory.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.utils.forge
 
+import com.datadog.android.api.context.AccountInfo
 import com.datadog.android.api.context.DeviceInfo
 import com.datadog.android.api.context.DeviceType
 import com.datadog.android.api.context.NetworkInfo
@@ -33,9 +34,10 @@ internal class SpanEventForgeryFactory : ForgeryFactory<SpanEvent> {
         val startTime = TimeUnit.SECONDS.toNanos(System.currentTimeMillis())
         val appPackageVersion = forge.aStringMatching("[0-9]\\.[0-9]\\.[0-9]")
         val tracerVersion = forge.aStringMatching("[0-9]\\.[0-9]\\.[0-9]")
-        val userInfo: UserInfo? = forge.aNullable()
-        val networkInfo: NetworkInfo? = forge.aNullable()
-        val deviceInfo: DeviceInfo = forge.getForgery()
+        val userInfo = forge.aNullable<UserInfo>()
+        val accountInfo = forge.aNullable<AccountInfo>()
+        val networkInfo = forge.aNullable<NetworkInfo>()
+        val deviceInfo = forge.getForgery<DeviceInfo>()
 
         return SpanEvent(
             spanId = spanId,
@@ -59,6 +61,13 @@ internal class SpanEventForgeryFactory : ForgeryFactory<SpanEvent> {
                     additionalProperties = userInfo?.additionalProperties?.toMutableMap()
                         ?: mutableMapOf()
                 ),
+                account = accountInfo?.let {
+                    SpanEvent.Account(
+                        id = it.id,
+                        name = it.name,
+                        additionalProperties = it.extraInfo.toMutableMap()
+                    )
+                },
                 network = SpanEvent.Network(
                     SpanEvent.Client(
                         simCarrier = forge.aNullable {
@@ -78,12 +87,17 @@ internal class SpanEventForgeryFactory : ForgeryFactory<SpanEvent> {
                     name = deviceInfo.deviceName,
                     model = deviceInfo.deviceModel,
                     brand = deviceInfo.deviceBrand,
-                    architecture = deviceInfo.architecture
+                    architecture = deviceInfo.architecture,
+                    locale = forge.aNullable { anAlphabeticalString() },
+                    locales = forge.aNullable { aList { anAlphabeticalString() } },
+                    timeZone = forge.aNullable { anAlphabeticalString() },
+                    powerSavingMode = forge.aNullable { aBool() }
                 ),
                 os = SpanEvent.Os(
                     name = deviceInfo.osName,
                     version = deviceInfo.osVersion,
-                    versionMajor = deviceInfo.osMajorVersion
+                    versionMajor = deviceInfo.osMajorVersion,
+                    build = forge.aNullable { anAlphabeticalString() }
                 ),
                 additionalProperties = meta
             ),


### PR DESCRIPTION
### What does this PR do?

This PR adds safe serialization and sanitization of the `account.extraInfo` attributes provided by the user and also adds a missing test coverage.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

