### PR TITLE
Bump language and API versions to 1.8

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
@@ -20,8 +20,8 @@ fun Project.kotlinConfig(
             jvmTarget.set(jvmBytecodeTarget)
             val isCI = System.getenv("CI").toBoolean()
             allWarningsAsErrors.set(evaluateWarningsAsErrors && isCI)
-            apiVersion.set(KotlinVersion.KOTLIN_1_7)
-            languageVersion.set(KotlinVersion.KOTLIN_1_7)
+            apiVersion.set(KotlinVersion.KOTLIN_1_8)
+            languageVersion.set(KotlinVersion.KOTLIN_1_8)
         }
     }
 }

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -239,10 +239,3 @@ taskConfig<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()
-
-// TODO RUM-11399: Remove this when Kotlin is upgraded to 2.0 or later
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    kotlinOptions {
-        freeCompilerArgs += "-Xskip-metadata-version-check"
-    }
-}


### PR DESCRIPTION
### What does this PR do?

This is a follow up for https://github.com/DataDog/dd-sdk-android/pull/2766, we can probably move `apiVersion` and `languageVersion` further up after this change.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

