### PR TITLE
Make `AndroidMDrawableToColorMapper` and `AndroidQDrawableToColorMapper` internal

### DIFF
--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -113,19 +113,6 @@ class com.datadog.android.sessionreplay.recorder.wrappers.BitmapWrapper
 class com.datadog.android.sessionreplay.recorder.wrappers.CanvasWrapper
   constructor(com.datadog.android.api.InternalLogger)
   fun createCanvas(android.graphics.Bitmap): android.graphics.Canvas?
-open class com.datadog.android.sessionreplay.utils.AndroidMDrawableToColorMapper : DrawableToColorMapper
-  constructor(List<DrawableToColorMapper> = emptyList())
-  override fun mapDrawableToColor(android.graphics.drawable.Drawable, com.datadog.android.api.InternalLogger): Int?
-  protected open fun resolveShapeDrawable(android.graphics.drawable.ShapeDrawable, com.datadog.android.api.InternalLogger): Int
-  protected open fun resolveColorDrawable(android.graphics.drawable.ColorDrawable): Int?
-  protected open fun resolveLayerDrawable(android.graphics.drawable.LayerDrawable, com.datadog.android.api.InternalLogger, (Int, android.graphics.drawable.Drawable) -> Boolean = { _, _ -> true }): Int?
-  protected open fun resolveGradientDrawable(android.graphics.drawable.GradientDrawable, com.datadog.android.api.InternalLogger): Int?
-  protected fun mergeColorAndAlpha(Int, Int): Int
-  companion object 
-open class com.datadog.android.sessionreplay.utils.AndroidQDrawableToColorMapper : AndroidMDrawableToColorMapper
-  constructor(List<DrawableToColorMapper> = emptyList())
-  override fun resolveGradientDrawable(android.graphics.drawable.GradientDrawable, com.datadog.android.api.InternalLogger): Int?
-  companion object 
 interface com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
   fun jobStarted()
   fun jobFinished()

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -1542,34 +1542,6 @@ public final class com/datadog/android/sessionreplay/recorder/wrappers/CanvasWra
 	public final fun createCanvas (Landroid/graphics/Bitmap;)Landroid/graphics/Canvas;
 }
 
-public class com/datadog/android/sessionreplay/utils/AndroidMDrawableToColorMapper : com/datadog/android/sessionreplay/utils/DrawableToColorMapper {
-	public static final field Companion Lcom/datadog/android/sessionreplay/utils/AndroidMDrawableToColorMapper$Companion;
-	public fun <init> ()V
-	public fun <init> (Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun mapDrawableToColor (Landroid/graphics/drawable/Drawable;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Integer;
-	protected final fun mergeColorAndAlpha (II)I
-	protected fun resolveColorDrawable (Landroid/graphics/drawable/ColorDrawable;)Ljava/lang/Integer;
-	protected fun resolveGradientDrawable (Landroid/graphics/drawable/GradientDrawable;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Integer;
-	protected fun resolveLayerDrawable (Landroid/graphics/drawable/LayerDrawable;Lcom/datadog/android/api/InternalLogger;Lkotlin/jvm/functions/Function2;)Ljava/lang/Integer;
-	public static synthetic fun resolveLayerDrawable$default (Lcom/datadog/android/sessionreplay/utils/AndroidMDrawableToColorMapper;Landroid/graphics/drawable/LayerDrawable;Lcom/datadog/android/api/InternalLogger;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/lang/Integer;
-	protected fun resolveShapeDrawable (Landroid/graphics/drawable/ShapeDrawable;Lcom/datadog/android/api/InternalLogger;)I
-}
-
-public final class com/datadog/android/sessionreplay/utils/AndroidMDrawableToColorMapper$Companion {
-}
-
-public class com/datadog/android/sessionreplay/utils/AndroidQDrawableToColorMapper : com/datadog/android/sessionreplay/utils/AndroidMDrawableToColorMapper {
-	public static final field Companion Lcom/datadog/android/sessionreplay/utils/AndroidQDrawableToColorMapper$Companion;
-	public fun <init> ()V
-	public fun <init> (Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	protected fun resolveGradientDrawable (Landroid/graphics/drawable/GradientDrawable;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Integer;
-}
-
-public final class com/datadog/android/sessionreplay/utils/AndroidQDrawableToColorMapper$Companion {
-}
-
 public abstract interface class com/datadog/android/sessionreplay/utils/AsyncJobStatusCallback {
 	public abstract fun jobFinished ()V
 	public abstract fun jobStarted ()V

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapper.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.sessionreplay.utils
+package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 //noinspection SuspiciousImport
 import android.R
@@ -22,12 +22,16 @@ import android.graphics.drawable.ShapeDrawable
 import android.graphics.drawable.StateListDrawable
 import android.graphics.drawable.VectorDrawable
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.utils.ALPHA_SHIFT_ANDROID
+import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
+import com.datadog.android.sessionreplay.utils.MASK_COLOR
+import com.datadog.android.sessionreplay.utils.MAX_ALPHA_VALUE
 
 /**
  * Drawable utility object needed in the Session Replay Wireframe Mappers.
  * This class is meant for internal usage so please use it carefully as it might change in time.
  */
-open class AndroidMDrawableToColorMapper(
+internal open class AndroidMDrawableToColorMapper(
     private val extensionMappers: List<DrawableToColorMapper> = emptyList()
 ) : DrawableToColorMapper {
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidQDrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidQDrawableToColorMapper.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.sessionreplay.utils
+package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 //noinspection SuspiciousImport
 import android.graphics.BlendMode
@@ -15,13 +15,15 @@ import android.graphics.drawable.GradientDrawable
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
+import com.datadog.android.sessionreplay.utils.MAX_ALPHA_VALUE
 
 /**
  * Drawable utility object needed in the Session Replay Wireframe Mappers.
  * This class is meant for internal usage so please use it carefully as it might change in time.
  */
 @RequiresApi(Build.VERSION_CODES.Q)
-open class AndroidQDrawableToColorMapper(
+internal open class AndroidQDrawableToColorMapper(
     extensionMappers: List<DrawableToColorMapper> = emptyList()
 ) : AndroidMDrawableToColorMapper(extensionMappers) {
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/DrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/DrawableToColorMapper.kt
@@ -9,6 +9,8 @@ package com.datadog.android.sessionreplay.utils
 import android.graphics.drawable.Drawable
 import android.os.Build
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.internal.recorder.mapper.AndroidMDrawableToColorMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.AndroidQDrawableToColorMapper
 
 /**
  * A utility interface to convert a [Drawable] to a meaningful color.

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapperTest.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.sessionreplay.utils
+package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 //noinspection SuspiciousImport
 import android.R
@@ -19,7 +19,8 @@ import android.graphics.drawable.StateListDrawable
 import android.os.Build
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
-import com.datadog.android.sessionreplay.utils.AndroidMDrawableToColorMapper.Companion.fillPaintField
+import com.datadog.android.sessionreplay.internal.recorder.mapper.AndroidMDrawableToColorMapper.Companion.fillPaintField
+import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
 import com.datadog.tools.unit.annotations.TestTargetApi
 import com.datadog.tools.unit.extensions.ApiLevelExtension
 import fr.xgouchet.elmyr.annotation.IntForgery

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidQDrawableToColorMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidQDrawableToColorMapperTest.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.sessionreplay.utils
+package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 //noinspection SuspiciousImport
 import android.graphics.BlendModeColorFilter
@@ -12,7 +12,8 @@ import android.graphics.Paint
 import android.graphics.drawable.GradientDrawable
 import android.os.Build
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
-import com.datadog.android.sessionreplay.utils.AndroidMDrawableToColorMapper.Companion.fillPaintField
+import com.datadog.android.sessionreplay.internal.recorder.mapper.AndroidMDrawableToColorMapper.Companion.fillPaintField
+import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
 import com.datadog.tools.unit.annotations.TestTargetApi
 import com.datadog.tools.unit.extensions.ApiLevelExtension
 import fr.xgouchet.elmyr.Forge


### PR DESCRIPTION
### What does this PR do?

These two classes are not used outside of their module, so they can be `internal`.

Yes, it is a change in the public API, but these classes are not supposed to be used by the customers anyway.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

