### PR TITLE
[RUM-11700][FO] Event date issue

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -262,6 +262,7 @@ internal open class RumViewScope(
     ) {
         sdkCore.newRumEventWriteOperation(datadogContext, writeScope, writer) {
             newVitalEvent(
+                event,
                 datadogContext,
                 name = event.name,
                 operationKey = event.operationKey,
@@ -281,6 +282,7 @@ internal open class RumViewScope(
     ) {
         sdkCore.newRumEventWriteOperation(datadogContext, writeScope, writer) {
             newVitalEvent(
+                event,
                 datadogContext,
                 name = event.name,
                 operationKey = event.operationKey,
@@ -294,6 +296,7 @@ internal open class RumViewScope(
 
     @Suppress("LongMethod")
     private fun newVitalEvent(
+        event: RumRawEvent,
         datadogContext: DatadogContext,
         name: String,
         operationKey: String?,
@@ -325,7 +328,7 @@ internal open class RumViewScope(
         }
 
         return VitalEvent(
-            date = eventTimestamp,
+            date = event.eventTime.timestamp + serverTimeOffsetInMs,
             context = VitalEvent.Context(
                 additionalProperties = getCustomAttributes().toMutableMap().also {
                     it.putAll(eventAttributes)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -8685,7 +8685,7 @@ internal class RumViewScopeTest {
         argumentCaptor<VitalEvent> {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             VitalEventAssert.assertThat(lastValue)
-                .hasDate(fakeEventTime.timestamp + fakeTimeInfoAtScopeStart.serverTimeOffsetMs)
+                .hasDate(event.eventTime.timestamp + fakeTimeInfoAtScopeStart.serverTimeOffsetMs)
                 .hasApplicationId(fakeParentContext.applicationId)
                 .containsExactlyContextAttributes(expectedAttributes)
                 .hasStartReason(fakeParentContext.sessionStartReason)
@@ -8729,7 +8729,7 @@ internal class RumViewScopeTest {
         argumentCaptor<VitalEvent> {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             VitalEventAssert.assertThat(lastValue)
-                .hasDate(fakeEventTime.timestamp + fakeTimeInfoAtScopeStart.serverTimeOffsetMs)
+                .hasDate(event.eventTime.timestamp + fakeTimeInfoAtScopeStart.serverTimeOffsetMs)
                 .hasApplicationId(fakeParentContext.applicationId)
                 .containsExactlyContextAttributes(expectedAttributes)
                 .hasStartReason(fakeParentContext.sessionStartReason)
@@ -8774,7 +8774,7 @@ internal class RumViewScopeTest {
         argumentCaptor<VitalEvent> {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             VitalEventAssert.assertThat(lastValue)
-                .hasDate(fakeEventTime.timestamp + fakeTimeInfoAtScopeStart.serverTimeOffsetMs)
+                .hasDate(event.eventTime.timestamp + fakeTimeInfoAtScopeStart.serverTimeOffsetMs)
                 .hasApplicationId(fakeParentContext.applicationId)
                 .containsExactlyContextAttributes(expectedAttributes)
                 .hasStartReason(fakeParentContext.sessionStartReason)


### PR DESCRIPTION
### What does this PR do?

Fixes a bug that uses view scope creation timestamp instead of `vital` event's timestamp

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

