### PR TITLE
RUM-11716: Check for result of `activity.intent`

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityLifecycleTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityLifecycleTrackingStrategy.kt
@@ -91,10 +91,13 @@ abstract class ActivityLifecycleTrackingStrategy :
     @MainThread
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
         if (::sdkCore.isInitialized) {
-            GlobalRumMonitor
-                .get(sdkCore)
-                ._getInternal()
-                ?.setSyntheticsAttributeFromIntent(activity.intent)
+            val intent = activity.intent
+            if (intent != null) {
+                GlobalRumMonitor
+                    .get(sdkCore)
+                    ._getInternal()
+                    ?.setSyntheticsAttributeFromIntent(intent)
+            }
         }
     }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityViewTrackingStrategy.kt
@@ -53,7 +53,12 @@ constructor(
         componentPredicate.runIfValid(activity, internalLogger) {
             val viewName = componentPredicate.resolveViewName(activity)
             val attributes = if (trackExtras) {
-                convertToRumAttributes(it.intent)
+                val intent = it.intent
+                if (intent != null) {
+                    convertToRumAttributes(intent)
+                } else {
+                    emptyMap()
+                }
             } else {
                 emptyMap()
             }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityLifecycleTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityLifecycleTrackingStrategyTest.kt
@@ -171,6 +171,21 @@ internal abstract class ActivityLifecycleTrackingStrategyTest<T> : ObjectTest<T>
     }
 
     @Test
+    fun `M do nothing W onActivityCreated() { intent is null }`() {
+        // Given
+        testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
+        val mockActivity = mock<Activity>()
+        whenever(mockActivity.intent) doReturn null
+
+        // When
+        testedStrategy.onActivityCreated(mockActivity, null)
+
+        // verify
+        val mockRumMonitor = rumMonitor.mockInstance as AdvancedRumMonitor
+        verify(mockRumMonitor, never()).setSyntheticsAttribute(any(), any())
+    }
+
+    @Test
     fun `M do nothing W onActivityCreated() { no synthetics extra }`() {
         // Given
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityViewTrackingStrategyTest.kt
@@ -98,7 +98,6 @@ internal class ActivityViewTrackingStrategyTest :
         // Given
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
         whenever(mockPredicate.accept(mockActivity)) doReturn true
-        testedStrategy.register(rumMonitor.mockSdkCore, mockActivity)
 
         // When
         testedStrategy.onActivityResumed(mockActivity)
@@ -134,7 +133,6 @@ internal class ActivityViewTrackingStrategyTest :
             .enrichWithConstantAttribute(ViewScopeInstrumentationType.ACTIVITY)
         expectedAttributes["view.intent.action"] = action
         expectedAttributes["view.intent.uri"] = uri
-        testedStrategy.register(rumMonitor.mockSdkCore, mockActivity)
 
         // When
         testedStrategy.onActivityResumed(mockActivity)
@@ -166,8 +164,6 @@ internal class ActivityViewTrackingStrategyTest :
             ViewScopeInstrumentationType.ACTIVITY.key.toString() to ViewScopeInstrumentationType.ACTIVITY
         )
 
-        testedStrategy.register(rumMonitor.mockSdkCore, mockActivity)
-
         // When
         testedStrategy.onActivityResumed(mockActivity)
 
@@ -176,6 +172,24 @@ internal class ActivityViewTrackingStrategyTest :
             mockActivity,
             mockActivity.resolveViewName(),
             expectedAttributes
+        )
+    }
+
+    @Test
+    fun `M start a RUM View event W onActivityResumed() { intent is null }`() {
+        // Given
+        testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
+        whenever(mockActivity.intent) doReturn null
+        whenever(mockPredicate.accept(mockActivity)) doReturn true
+
+        // When
+        testedStrategy.onActivityResumed(mockActivity)
+
+        // Then
+        verify(rumMonitor.mockInstance).startView(
+            mockActivity,
+            mockActivity.resolveViewName(),
+            emptyMap()
         )
     }
 
@@ -194,7 +208,6 @@ internal class ActivityViewTrackingStrategyTest :
         whenever(mockIntent.extras).thenReturn(arguments)
         whenever(mockActivity.intent).thenReturn(mockIntent)
         whenever(mockPredicate.accept(mockActivity)) doReturn true
-        testedStrategy.register(rumMonitor.mockSdkCore, mockActivity)
 
         // When
         testedStrategy.onActivityResumed(mockActivity)
@@ -214,7 +227,6 @@ internal class ActivityViewTrackingStrategyTest :
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
         whenever(mockPredicate.accept(mockActivity)) doReturn true
         whenever(mockPredicate.getViewName(mockActivity)) doReturn fakeName
-        testedStrategy.register(rumMonitor.mockSdkCore, mockActivity)
 
         // When
         testedStrategy.onActivityResumed(mockActivity)
@@ -235,7 +247,6 @@ internal class ActivityViewTrackingStrategyTest :
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
         whenever(mockPredicate.accept(mockActivity)) doReturn true
         whenever(mockPredicate.getViewName(mockActivity)) doReturn fakeName
-        testedStrategy.register(rumMonitor.mockSdkCore, mockActivity)
 
         // When
         testedStrategy.onActivityResumed(mockActivity)
@@ -253,7 +264,6 @@ internal class ActivityViewTrackingStrategyTest :
         // Given
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
         whenever(mockPredicate.accept(mockActivity)) doReturn true
-        testedStrategy.register(rumMonitor.mockSdkCore, mockActivity)
 
         // When
         testedStrategy.onActivityPaused(mockActivity)
@@ -268,7 +278,6 @@ internal class ActivityViewTrackingStrategyTest :
         // Given
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
         whenever(mockPredicate.accept(mockActivity)) doReturn true
-        testedStrategy.register(rumMonitor.mockSdkCore, mockActivity)
 
         // When
         testedStrategy.onActivityPaused(mockActivity)
@@ -283,7 +292,6 @@ internal class ActivityViewTrackingStrategyTest :
         // Given
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
         whenever(mockPredicate.accept(mockActivity)) doReturn true
-        testedStrategy.register(rumMonitor.mockSdkCore, mockActivity)
 
         // When
         testedStrategy.onActivityStopped(mockActivity)
@@ -298,7 +306,6 @@ internal class ActivityViewTrackingStrategyTest :
         // Given
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
         whenever(mockPredicate.accept(mockActivity)) doReturn true
-        testedStrategy.register(rumMonitor.mockSdkCore, mockActivity)
 
         // When
         testedStrategy.onActivityStopped(mockActivity)


### PR DESCRIPTION
### What does this PR do?

There is the following SDK crash reported:

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{....}: java.lang.NullPointerException: activity.intent must not be null
	at com.datadog.android.rum.tracking.ActivityLifecycleTrackingStrategy.onActivityCreated(ActivityLifecycleTrackingStrategy.kt:97)
	at android.app.Application.dispatchActivityCreated(Application.java:373)
	at android.app.Activity.dispatchActivityCreated(Activity.java:1316)
	at android.app.Activity.onCreate_aroundBody0(Activity.java:1589)
	at android.app.Activity$AjcClosure1.run(Activity.java:1)
	at <redacted>(unknown:2)
	at android.app.Activity.onCreate(Activity.java:1565)
	at <redacted>(unknown:5)
	at android.app.Activity.performCreate(Activity.java:7994)
	at android.app.Activity.performCreate(Activity.java:7978)
	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1548)
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3406)
```

It is not a fault of SDK per se, and probably it is some very rare/weird situation, but we can add a guard by checking the result of `Activity.getIntent()`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

