### PR TITLE
RUM-11737: Add documentation to the public API members where missing

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/InternalLogger.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/InternalLogger.kt
@@ -47,10 +47,29 @@ interface InternalLogger {
      * The severity level of a logged message.
      */
     enum class Level {
+        /**
+         * Verbose level.
+         */
         VERBOSE,
+
+        /**
+         * Debug level.
+         */
         DEBUG,
+
+        /**
+         * Info level.
+         */
         INFO,
+
+        /**
+         * Warning level.
+         */
         WARN,
+
+        /**
+         * Error level.
+         */
         ERROR
     }
 
@@ -58,8 +77,19 @@ interface InternalLogger {
      * The target handler for a log message.
      */
     enum class Target {
+        /**
+         * Log message will be sent to Logcat.
+         */
         USER,
+
+        /**
+         * Log message will be sent to Logcat, but only in debug SDK builds.
+         */
         MAINTAINER,
+
+        /**
+         * Log message will be sent to telemetry.
+         */
         TELEMETRY
     }
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/context/DeviceType.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/context/DeviceType.kt
@@ -10,11 +10,38 @@ package com.datadog.android.api.context
  * Device type.
  */
 enum class DeviceType {
+    /**
+     * Mobile device type.
+     */
     MOBILE,
+
+    /**
+     * Tablet device type.
+     */
     TABLET,
+
+    /**
+     * TV device type.
+     */
     TV,
+
+    /**
+     * Desktop device type.
+     */
     DESKTOP,
+
+    /**
+     * Gaming console device type.
+     */
     GAMING_CONSOLE,
+
+    /**
+     * Bot type.
+     */
     BOT,
+
+    /**
+     * Other device type.
+     */
     OTHER
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/context/NetworkInfo.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/context/NetworkInfo.kt
@@ -127,17 +127,64 @@ data class NetworkInfo(
     enum class Connectivity(
         private val jsonValue: String
     ) {
+        /**
+         * The network is not connected.
+         */
         NETWORK_NOT_CONNECTED("network_not_connected"),
+
+        /**
+         * The network is connected using a Ethernet connection.
+         */
         NETWORK_ETHERNET("network_ethernet"),
+
+        /**
+         * The network is connected using a WiFi connection.
+         */
         NETWORK_WIFI("network_wifi"),
+
+        /**
+         * The network is connected using a WiMax connection.
+         */
         NETWORK_WIMAX("network_wimax"),
+
+        /**
+         * The network is connected using a Bluetooth connection.
+         */
         NETWORK_BLUETOOTH("network_bluetooth"),
+
+        /**
+         * The network is connected using a 2G connection.
+         */
         NETWORK_2G("network_2G"),
+
+        /**
+         * The network is connected using a 3G connection.
+         */
         NETWORK_3G("network_3G"),
+
+        /**
+         * The network is connected using a 4G connection.
+         */
         NETWORK_4G("network_4G"),
+
+        /**
+         * The network is connected using a 5G connection.
+         */
         NETWORK_5G("network_5G"),
+
+        /**
+         * The network is connected using a cellular connection with a unknown technology.
+         */
         NETWORK_MOBILE_OTHER("network_mobile_other"),
+
+        /**
+         * The network is connected using a cellular connection.
+         */
         NETWORK_CELLULAR("network_cellular"),
+
+        /**
+         * The network is connected using an other connection type.
+         */
         NETWORK_OTHER("network_other")
         ;
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/metrics/MethodCallSamplingRate.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/metrics/MethodCallSamplingRate.kt
@@ -11,10 +11,33 @@ package com.datadog.android.core.metrics
  * @param rate the rate to sample at (between 0 and 100).
  */
 enum class MethodCallSamplingRate(val rate: Float) {
+    /**
+     * Sample all.
+     */
     ALL(rate = 100.0f),
+
+    /**
+     * Sample 10% of the time.
+     */
     HIGH(rate = 10.0f),
+
+    /**
+     * Sample 1% of the time.
+     */
     MEDIUM(rate = 1.0f),
+
+    /**
+     * Sample 0.1% of the time.
+     */
     LOW(rate = 0.1f),
+
+    /**
+     * Sample 0.01% of the time.
+     */
     REDUCED(rate = 0.01f),
+
+    /**
+     * Sample 0.001% of the time.
+     */
     RARE(rate = 0.001f)
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/metrics/TelemetryMetricType.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/metrics/TelemetryMetricType.kt
@@ -10,5 +10,8 @@ package com.datadog.android.core.metrics
  * Types of performance metrics.
  */
 enum class TelemetryMetricType {
+    /**
+     * "method called" performance metric.
+     */
     MethodCalled
 }

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/attributes/LocalAttribute.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/attributes/LocalAttribute.kt
@@ -20,7 +20,7 @@ interface LocalAttribute {
     enum class Key(
         private val string: String
     ) {
-        /*
+        /**
          * Some of the metrics such as [PerformanceMetric] are sampled at the point of
          * metric creation and then reported with 100% probability.
          * In such cases we need to use *creationSampleRate* to correctly calculate effectiveSampleRate.
@@ -29,14 +29,14 @@ interface LocalAttribute {
          */
         CREATION_SAMPLING_RATE("_dd.local.head_sampling_rate_key"),
 
-        /*
+        /**
          * Sampling rate that is used to decide to send or not to send the metric.
          * Each metric should have reporting(tail) sampling rate.
          * It's possible that metric has only reporting(tail) sampling rate.
          */
         REPORTING_SAMPLING_RATE("_dd.local.tail_sampling_rate_key"),
 
-        /*
+        /**
          * Indicates which instrumentation was used to track the view scope.
          * See [ViewScopeInstrumentationType] for possible values.
          */

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/telemetry/TracingHeaderType.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/telemetry/TracingHeaderType.kt
@@ -8,8 +8,23 @@ package com.datadog.android.internal.telemetry
 
 @Suppress("UndocumentedPublicClass")
 enum class TracingHeaderType {
+    /**
+     * Datadog's [`x-datadog-*` header](https://docs.datadoghq.com/real_user_monitoring/connect_rum_and_traces/?tab=browserrum#how-are-rum-resources-linked-to-traces).
+     */
     DATADOG,
+
+    /**
+     * Open Telemetry B3 [Single header](https://github.com/openzipkin/b3-propagation#single-header).
+     */
     B3,
+
+    /**
+     * Open Telemetry B3 [Multiple headers](https://github.com/openzipkin/b3-propagation#multiple-headers).
+     */
     B3MULTI,
+
+    /**
+     * W3C [Trace Context header](https://www.w3.org/TR/trace-context/#tracestate-header).
+     */
     TRACECONTEXT
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumResourceKind.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumResourceKind.kt
@@ -14,19 +14,67 @@ import java.util.Locale
  */
 enum class RumResourceKind(internal val value: String) {
     // Specific kind of JS resources loading
+
+    /**
+     * Beacon type resource.
+     */
     BEACON("beacon"),
+
+    /**
+     * Fetch type resource.
+     */
     FETCH("fetch"),
+
+    /**
+     * XHR type resource.
+     */
     XHR("xhr"),
+
+    /**
+     * Document type resource.
+     */
     DOCUMENT("document"),
 
     // Common kinds
+
+    /**
+     * Native type resource.
+     */
     NATIVE("native"),
+
+    /**
+     * Unknown type resource.
+     */
     UNKNOWN("unknown"),
+
+    /**
+     * Image type resource.
+     */
     IMAGE("image"),
+
+    /**
+     * JS type resource.
+     */
     JS("js"),
+
+    /**
+     * Font type resource.
+     */
     FONT("font"),
+
+    /**
+     * CSS type resource.
+     */
     CSS("css"),
+
+    /**
+     * Media type resource.
+     */
     MEDIA("media"),
+
+    /**
+     * Other type resource.
+     */
     OTHER("other");
 
     companion object {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumSessionType.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumSessionType.kt
@@ -13,6 +13,13 @@ import com.datadog.android.lint.InternalApi
  */
 @InternalApi
 enum class RumSessionType {
+    /**
+     * Synthetic session type.
+     */
     SYNTHETICS,
+
+    /**
+     * User session type.
+     */
     USER
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/featureoperations/FailureReason.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/featureoperations/FailureReason.kt
@@ -7,13 +7,20 @@ package com.datadog.android.rum.featureoperations
 
 /**
  * Represents the possible reasons for a failed feature operation.
- *
- * [ERROR]: Represents a failure caused by an error during execution.
- * [ABANDONED]: Represents a failure caused by user or process abandonment.
- * [OTHER]: Represents a failure due to other unspecified reasons.
  */
 enum class FailureReason {
+    /**
+     * Represents a failure caused by an error during execution.
+     */
     ERROR,
+
+    /**
+     * Represents a failure caused by user or process abandonment.
+     */
     ABANDONED,
+
+    /**
+     * Represents a failure due to other unspecified reasons.
+     */
     OTHER
 }


### PR DESCRIPTION
### What does this PR do?

With Detekt version change from `1.23.4` (the one we are using on CI) to `1.23.8` we have new reports for the Public API check and we need to address them. Mostly it is missing documentation for the enum members.

Note: there are also reports about missing docs for `companion object` classes, but this should either be ignored or it is a but in the Detekt rule.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

