### PR TITLE
[RUM-11495]: Supporting baggage header updates

### DIFF
--- a/features/dd-sdk-android-trace-internal/api/dd-sdk-android-trace-internal.api
+++ b/features/dd-sdk-android-trace-internal/api/dd-sdk-android-trace-internal.api
@@ -3070,6 +3070,16 @@ public class com/datadog/trace/core/propagation/B3TraceId : com/datadog/trace/ap
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/datadog/trace/core/propagation/Baggage {
+	public fun <init> ()V
+	public fun asMap ()Ljava/util/Map;
+	public static fun from (Ljava/lang/String;)Lcom/datadog/trace/core/propagation/Baggage;
+	public fun isEmpty ()Z
+	public fun mergeWith (Lcom/datadog/trace/core/propagation/Baggage;)Lcom/datadog/trace/core/propagation/Baggage;
+	public fun put (Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/trace/core/propagation/Baggage;
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract class com/datadog/trace/core/propagation/ContextInterpreter : com/datadog/trace/bootstrap/instrumentation/api/AgentPropagation$KeyClassifier {
 	protected static final field LOG_EXTRACT_HEADER_NAMES Z
 	protected field baggage Ljava/util/Map;
@@ -3537,6 +3547,22 @@ public final class com/datadog/trace/util/CollectionUtils {
 	public static fun tryMakeImmutableList (Ljava/util/Collection;)Ljava/util/List;
 	public static fun tryMakeImmutableMap (Ljava/util/Map;)Ljava/util/Map;
 	public static fun tryMakeImmutableSet (Ljava/util/Collection;)Ljava/util/Set;
+}
+
+public final class com/datadog/trace/util/PercentEscaper {
+	public fun <init> ()V
+	public static fun create ()Lcom/datadog/trace/util/PercentEscaper;
+	public fun escape (Ljava/lang/String;[Z)Lcom/datadog/trace/util/PercentEscaper$Escaped;
+	public fun escapeKey (Ljava/lang/String;)Lcom/datadog/trace/util/PercentEscaper$Escaped;
+	public fun escapeValue (Ljava/lang/String;)Lcom/datadog/trace/util/PercentEscaper$Escaped;
+	public fun keyNeedsEncoding (Ljava/lang/String;)Z
+	public fun valNeedsEncoding (Ljava/lang/String;)Z
+}
+
+public class com/datadog/trace/util/PercentEscaper$Escaped {
+	public field data Ljava/lang/String;
+	public field size I
+	public fun <init> (Ljava/lang/String;I)V
 }
 
 public final class com/datadog/trace/util/PidHelper {

--- a/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/core/propagation/Baggage.java
+++ b/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/core/propagation/Baggage.java
@@ -1,0 +1,112 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.trace.core.propagation;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.datadog.trace.util.PercentEscaper;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.HashMap;
+import java.util.Map;
+
+// Source: https://github.com/DataDog/dd-trace-java/blob/master/dd-trace-core/src/main/java/datadog/trace/core/baggage/BaggagePropagator.java
+public final class Baggage {
+    private static final char PAIR_SEPARATOR = ',';
+    private static final char KEY_VALUE_SEPARATOR = '=';
+    private static final PercentEscaper UTF_ESCAPER = PercentEscaper.create();
+
+    private final HashMap<String, String> values;
+
+    public Baggage() {
+        this.values = new HashMap<>();
+    }
+
+    public boolean isEmpty() {
+        return values.isEmpty();
+    }
+
+    public Baggage put(@NonNull String key, @NonNull String value) {
+        values.put(key, value);
+        return this;
+    }
+
+    @NonNull
+    public Baggage mergeWith(@Nullable Baggage other) {
+        if (other != null) {
+            values.putAll(other.asMap());
+        }
+        return this;
+    }
+
+    @NonNull
+    public String toString() {
+        int processedItems = 0;
+        StringBuilder baggageText = new StringBuilder();
+        for (final Map.Entry<String, String> entry : asMap().entrySet()) {
+            if (processedItems > 0) baggageText.append(',');
+
+            PercentEscaper.Escaped escapedKey = UTF_ESCAPER.escapeKey(entry.getKey());
+            PercentEscaper.Escaped escapedVal = UTF_ESCAPER.escapeValue(entry.getValue());
+
+            baggageText.append(escapedKey.data);
+            baggageText.append('=');
+            baggageText.append(escapedVal.data);
+
+            processedItems++;
+        }
+
+        return baggageText.toString();
+    }
+
+    @NonNull
+    public Map<String, String> asMap() {
+        return new HashMap<>(values);
+    }
+
+    @NonNull
+    public static Baggage from(@Nullable String input) {
+        if (input == null) return new Baggage();
+        int start = 0;
+        int pairSeparatorInd = input.indexOf(PAIR_SEPARATOR);
+        pairSeparatorInd = pairSeparatorInd == -1 ? input.length() : pairSeparatorInd;
+        int kvSeparatorInd = input.indexOf(KEY_VALUE_SEPARATOR);
+        Baggage baggage = new Baggage();
+        while (kvSeparatorInd != -1) {
+            int end = pairSeparatorInd;
+            if (kvSeparatorInd > end) {
+                return new Baggage();
+            }
+            String key = decode(input.substring(start, kvSeparatorInd).trim());
+            String value = decode(input.substring(kvSeparatorInd + 1, end).trim());
+            if (key.isEmpty() || value.isEmpty()) {
+                return new Baggage();
+            }
+            baggage.put(key, value);
+
+            kvSeparatorInd = input.indexOf(KEY_VALUE_SEPARATOR, pairSeparatorInd + 1);
+            pairSeparatorInd = input.indexOf(PAIR_SEPARATOR, pairSeparatorInd + 1);
+            pairSeparatorInd = pairSeparatorInd == -1 ? input.length() : pairSeparatorInd;
+            start = end + 1;
+        }
+
+        return baggage;
+    }
+
+    private static String decode(final String value) {
+        String decoded = value;
+        try {
+            // Suppressing decode(String s, Charset charset) because it requires minSdk = 33.
+            // noinspection CharsetObjectCanBeUsed
+            decoded = URLDecoder.decode(value, "UTF-8");
+        } catch (final UnsupportedEncodingException | IllegalArgumentException ignored) {
+        }
+        return decoded;
+    }
+}

--- a/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/core/propagation/Baggage.java
+++ b/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/core/propagation/Baggage.java
@@ -22,10 +22,9 @@ public final class Baggage {
     private static final char KEY_VALUE_SEPARATOR = '=';
     private static final PercentEscaper UTF_ESCAPER = PercentEscaper.create();
 
-    private final HashMap<String, String> values;
+    private final HashMap<String, String> values = new HashMap<>();
 
     public Baggage() {
-        this.values = new HashMap<>();
     }
 
     public boolean isEmpty() {
@@ -83,8 +82,8 @@ public final class Baggage {
             if (kvSeparatorInd > end) {
                 return new Baggage();
             }
-            String key = decode(input.substring(start, kvSeparatorInd).trim());
-            String value = decode(input.substring(kvSeparatorInd + 1, end).trim());
+            String key = urlDecode(input.substring(start, kvSeparatorInd).trim());
+            String value = urlDecode(input.substring(kvSeparatorInd + 1, end).trim());
             if (key.isEmpty() || value.isEmpty()) {
                 return new Baggage();
             }
@@ -99,7 +98,7 @@ public final class Baggage {
         return baggage;
     }
 
-    private static String decode(final String value) {
+    private static String urlDecode(final String value) {
         String decoded = value;
         try {
             // Suppressing decode(String s, Charset charset) because it requires minSdk = 33.

--- a/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/core/propagation/DatadogHttpCodec.java
+++ b/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/core/propagation/DatadogHttpCodec.java
@@ -2,12 +2,12 @@ package com.datadog.trace.core.propagation;
 
 import static com.datadog.trace.api.TracePropagationStyle.DATADOG;
 import static com.datadog.trace.core.propagation.HttpCodec.firstHeaderValue;
-import static com.datadog.trace.core.propagation.W3CHttpCodec.RUM_SESSION_ID_BAGGAGE_KEY;
 import static com.datadog.trace.core.propagation.XRayHttpCodec.XRayContextInterpreter.handleXRayTraceHeader;
 import static com.datadog.trace.core.propagation.XRayHttpCodec.X_AMZN_TRACE_ID;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
+import com.datadog.android.trace.internal.compat.function.Supplier;
 import com.datadog.trace.api.Config;
 import com.datadog.trace.api.DD128bTraceId;
 import com.datadog.trace.api.DDSpanId;
@@ -24,7 +24,6 @@ import com.datadog.trace.logger.LoggerFactory;
 
 import java.util.Map;
 import java.util.TreeMap;
-import com.datadog.android.trace.internal.compat.function.Supplier;
 
 /** A codec designed for HTTP transport via headers using Datadog headers */
 class DatadogHttpCodec {
@@ -85,10 +84,10 @@ class DatadogHttpCodec {
         setter.set(carrier, DATADOG_TAGS_KEY, datadogTags);
       }
 
-      // inject session id
-      final String sessionId = (String) context.getTags().get(HttpCodec.RUM_SESSION_ID_KEY);
-      if(sessionId != null) {
-        setter.set(carrier, W3CHttpCodec.BAGGAGE_KEY, RUM_SESSION_ID_BAGGAGE_KEY + '='+sessionId);
+      // inject baggage
+      Baggage baggage = HttpCodec.composeBaggage(context);
+      if (!baggage.isEmpty()) {
+        setter.set(carrier, W3CHttpCodec.BAGGAGE_KEY, baggage.toString());
       }
     }
   }

--- a/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/core/propagation/HttpCodec.java
+++ b/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/core/propagation/HttpCodec.java
@@ -2,6 +2,7 @@ package com.datadog.trace.core.propagation;
 
 import static com.datadog.trace.api.TracePropagationStyle.TRACECONTEXT;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.datadog.android.trace.internal.compat.function.Supplier;
@@ -49,6 +50,7 @@ public class HttpCodec {
   static final String FASTLY_CLIENT_IP_KEY = "fastly-client-ip";
   static final String CF_CONNECTING_IP_KEY = "cf-connecting-ip";
   static final String CF_CONNECTING_IP_V6_KEY = "cf-connecting-ipv6";
+  static final String RUM_SESSION_ID_BAGGAGE_KEY = "session.id";
 
   public static final String RUM_SESSION_ID_KEY = "session_id";
 
@@ -362,5 +364,17 @@ public class HttpCodec {
 
     int firstComma = value.indexOf(',');
     return firstComma == -1 ? value : value.substring(0, firstComma).trim();
+  }
+
+  @NonNull
+  static Baggage composeBaggage(@NonNull DDSpanContext context) {
+    Baggage baggage = new Baggage();
+    final String sessionId = (String) context.getTags().get(RUM_SESSION_ID_KEY);
+
+    if (sessionId != null) {
+      baggage.put(RUM_SESSION_ID_BAGGAGE_KEY, sessionId);
+    }
+
+    return baggage;
   }
 }

--- a/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/util/PercentEscaper.java
+++ b/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/util/PercentEscaper.java
@@ -1,0 +1,429 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+// Includes work from:
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (C) 2008 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.datadog.trace.util;
+
+import androidx.annotation.Nullable;
+
+/**
+ * Note: This class is based on code from guava. It is comprised of code from three classes:
+ *
+ * <ul>
+ *   <li><a
+ *       href="https://github.com/google/guava/blob/46093e2517b4f49c019ecff6dbe90cc22e8003b5/guava/src/com/google/common/escape/Escaper.java">com.google.common.escape.Escaper</a>
+ *   <li><a
+ *       href="https://github.com/google/guava/blob/46093e2517b4f49c019ecff6dbe90cc22e8003b5/guava/src/com/google/common/escape/UnicodeEscaper.java">com.google.common.escape.UnicodeEscaper</a>
+ *   <li><a
+ *       href="https://github.com/google/guava/blob/46093e2517b4f49c019ecff6dbe90cc22e8003b5/guava/src/com/google/common/net/PercentEscaper.java">com.google.common.net.PercentEscaper</a>
+ * </ul>
+ *
+ * <p>Escapes some set of Java characters using a UTF-8 based percent encoding scheme. The set of
+ * safe characters (those which remain unescaped) can be specified on construction.
+ *
+ * <p>This class is primarily used for creating URI escapers in {@code UrlEscapers} but can be used
+ * directly if required. While URI escapers impose specific semantics on which characters are
+ * considered 'safe', this class has a minimal set of restrictions.
+ *
+ * <p>When escaping a String, the following rules apply:
+ *
+ * <ul>
+ *   <li>All specified safe characters remain unchanged.
+ *   <li>If {@code plusForSpace} was specified, the space character " " is converted into a plus
+ *       sign {@code "+"}.
+ *   <li>All other characters are converted into one or more bytes using UTF-8 encoding and each
+ *       byte is then represented by the 3-character string "%XX", where "XX" is the two-digit,
+ *       uppercase, hexadecimal representation of the byte value.
+ * </ul>
+ *
+ * <p>For performance reasons the only currently supported character encoding of this class is
+ * UTF-8.
+ *
+ * <p><b>Note:</b> This escaper produces <a
+ * href="https://url.spec.whatwg.org/#percent-encode">uppercase</a> hexadecimal sequences.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ *
+ * @author David Beaumont
+ * @since 15.0
+ */
+public final class PercentEscaper {
+
+    /** The amount of padding (chars) to use when growing the escape buffer. */
+    private static final int DEST_PAD = 32;
+
+    private static final String UNSAFE_CHARACTERS_KEY = "\",;\\()/:<=>?@[]{} ";
+    private static final String UNSAFE_CHARACTERS_VALUE = "\",;\\ ";
+
+    // Percent escapers output upper case hex digits (uri escapers require this).
+    private static final char[] UPPER_HEX_DIGITS = "0123456789ABCDEF".toCharArray();
+
+    /**
+     * Arrays of flags where for any {@code char c} if {@code safeOctets[c]} is true then {@code c}
+     * should remain unmodified in the output. If {@code c >= safeOctets.length} then it should be
+     * escaped.
+     */
+    private static final boolean[] unsafeKeyOctets = createUnsafeOctets(UNSAFE_CHARACTERS_KEY);
+
+    private static final boolean[] unsafeValOctets = createUnsafeOctets(UNSAFE_CHARACTERS_VALUE);
+
+    /** The default {@link PercentEscaper} which will *not* replace spaces with plus signs. */
+    public static PercentEscaper create() {
+        return new PercentEscaper();
+    }
+
+    /**
+     * Creates a boolean array with entries corresponding to the character values specified in
+     * safeChars set to true. The array is as small as is required to hold the given character
+     * information.
+     */
+    private static boolean[] createUnsafeOctets(String safeChars) {
+        int maxChar = -1;
+        char[] safeCharArray = safeChars.toCharArray();
+        for (char c : safeCharArray) {
+            maxChar = Math.max(c, maxChar);
+        }
+        boolean[] octets = new boolean[maxChar + 1];
+        for (char c : safeCharArray) {
+            octets[c] = true;
+        }
+        return octets;
+    }
+
+    public Escaped escapeKey(String s) {
+        return escape(s, unsafeKeyOctets);
+    }
+
+    public Escaped escapeValue(String s) {
+        return escape(s, unsafeValOctets);
+    }
+
+    private boolean needsEncoding(char c, boolean[] unsafeOctets) {
+        if (c > '~' || c <= ' ' || c < unsafeOctets.length && unsafeOctets[c]) {
+            return true;
+        }
+        return false;
+    }
+
+    private boolean needsEncoding(String key, boolean[] unsafeOctets) {
+        int slen = key.length();
+        for (int index = 0; index < slen; index++) {
+            char c = key.charAt(index);
+            if (needsEncoding(c, unsafeOctets)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean keyNeedsEncoding(String key) {
+        return needsEncoding(key, unsafeKeyOctets);
+    }
+
+    public boolean valNeedsEncoding(String val) {
+        return needsEncoding(val, unsafeValOctets);
+    }
+
+    /** Escape the provided String, using percent-style URL Encoding. */
+    public Escaped escape(String s, boolean[] unsafeOctets) {
+        int slen = s.length();
+        for (int index = 0; index < slen; index++) {
+            char c = s.charAt(index);
+            if (needsEncoding(c, unsafeOctets)) {
+                return escapeSlow(s, index, unsafeOctets);
+            }
+        }
+        return new Escaped(s, slen);
+    }
+
+    /*
+     * Overridden for performance. For unescaped strings this improved the performance of the uri
+     * escaper from ~760ns to ~400ns as measured by {@link CharEscapersBenchmark}.
+     */
+    /**
+     * Returns the escaped form of a given literal string, starting at the given index. This method is
+     * called by the {@link #escape(String, boolean[])} method when it discovers that escaping is
+     * required. It is protected to allow subclasses to override the fastpath escaping function to
+     * inline their escaping test.
+     *
+     * <p>This method is not reentrant and may only be invoked by the top level {@link #escape(String,
+     * boolean[])} method.
+     *
+     * @param s the literal string to be escaped
+     * @param index the index to start escaping from
+     * @return the escaped form of {@code string}
+     * @throws NullPointerException if {@code string} is null
+     * @throws IllegalArgumentException if invalid surrogate characters are encountered
+     */
+    private static Escaped escapeSlow(String s, int index, boolean[] unsafeOctets) {
+        int end = s.length();
+
+        // Get a destination buffer and setup some loop variables.
+        char[] dest = new char[1024]; // 1024 from the original guava source
+        int destIndex = 0;
+        int unescapedChunkStart = 0;
+        Escaped result = new Escaped("", index);
+
+        while (index < end) {
+            int cp = codePointAt(s, index, end);
+            if (cp < 0) {
+                throw new IllegalArgumentException("Trailing high surrogate at end of input");
+            }
+            // It is possible for this to return null because nextEscapeIndex() may
+            // (for performance reasons) yield some false positives but it must never
+            // give false negatives.
+            char[] escaped = escape(cp, result, unsafeOctets);
+            int nextIndex = index + (Character.isSupplementaryCodePoint(cp) ? 2 : 1);
+            if (escaped != null) {
+                int charsSkipped = index - unescapedChunkStart;
+
+                // This is the size needed to add the replacement, not the full
+                // size needed by the string. We only regrow when we absolutely must.
+                int sizeNeeded = destIndex + charsSkipped + escaped.length;
+                if (dest.length < sizeNeeded) {
+                    int destLength = sizeNeeded + (end - index) + DEST_PAD;
+                    dest = growBuffer(dest, destIndex, destLength);
+                }
+                // If we have skipped any characters, we need to copy them now.
+                if (charsSkipped > 0) {
+                    s.getChars(unescapedChunkStart, index, dest, destIndex);
+                    destIndex += charsSkipped;
+                }
+                if (escaped.length > 0) {
+                    System.arraycopy(escaped, 0, dest, destIndex, escaped.length);
+                    destIndex += escaped.length;
+                }
+                // If we dealt with an escaped character, reset the unescaped range.
+                unescapedChunkStart = nextIndex;
+            }
+            index = nextEscapeIndex(s, nextIndex, end, unsafeOctets);
+        }
+
+        // Process trailing unescaped characters - no need to account for escaped
+        // length or padding the allocation.
+        int charsSkipped = end - unescapedChunkStart;
+        if (charsSkipped > 0) {
+            int endIndex = destIndex + charsSkipped;
+            if (dest.length < endIndex) {
+                dest = growBuffer(dest, destIndex, endIndex);
+            }
+            s.getChars(unescapedChunkStart, end, dest, destIndex);
+            destIndex = endIndex;
+        }
+        // Adding characters in-between characters that want to be encoded
+        result.size += charsSkipped;
+
+        result.data = new String(dest, 0, destIndex);
+        return result;
+    }
+
+    private static int nextEscapeIndex(CharSequence csq, int index, int end, boolean[] unsafeOctets) {
+        for (; index < end; index++) {
+            char c = csq.charAt(index);
+            if (c < unsafeOctets.length && unsafeOctets[c]) {
+                break;
+            }
+        }
+        return index;
+    }
+
+    /** Escapes the given Unicode code point in UTF-8. */
+    @Nullable
+    @SuppressWarnings("UngroupedOverloads")
+    private static char[] escape(int cp, Escaped escaped, boolean[] unsafeOctets) {
+        // We should never get negative values here but if we do it will throw an
+        // IndexOutOfBoundsException, so at least it will get spotted.
+        if (cp < unsafeOctets.length && !unsafeOctets[cp]) {
+            return null;
+        } else if (cp <= 0x7F) {
+            // Single byte UTF-8 characters
+            // Start with "%--" and fill in the blanks
+            char[] dest = new char[3];
+            dest[0] = '%';
+            dest[2] = UPPER_HEX_DIGITS[cp & 0xF];
+            dest[1] = UPPER_HEX_DIGITS[cp >>> 4];
+            escaped.size++;
+            return dest;
+        } else if (cp <= 0x7ff) {
+            // Two byte UTF-8 characters [cp >= 0x80 && cp <= 0x7ff]
+            // Start with "%--%--" and fill in the blanks
+            char[] dest = new char[6];
+            dest[0] = '%';
+            dest[3] = '%';
+            dest[5] = UPPER_HEX_DIGITS[cp & 0xF];
+            cp >>>= 4;
+            dest[4] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+            cp >>>= 2;
+            dest[2] = UPPER_HEX_DIGITS[cp & 0xF];
+            cp >>>= 4;
+            dest[1] = UPPER_HEX_DIGITS[0xC | cp];
+            escaped.size += 2;
+            return dest;
+        } else if (cp <= 0xffff) {
+            // Three byte UTF-8 characters [cp >= 0x800 && cp <= 0xffff]
+            // Start with "%E-%--%--" and fill in the blanks
+            char[] dest = new char[9];
+            dest[0] = '%';
+            dest[1] = 'E';
+            dest[3] = '%';
+            dest[6] = '%';
+            dest[8] = UPPER_HEX_DIGITS[cp & 0xF];
+            cp >>>= 4;
+            dest[7] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+            cp >>>= 2;
+            dest[5] = UPPER_HEX_DIGITS[cp & 0xF];
+            cp >>>= 4;
+            dest[4] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+            cp >>>= 2;
+            dest[2] = UPPER_HEX_DIGITS[cp];
+            escaped.size += 3;
+            return dest;
+        } else if (cp <= 0x10ffff) {
+            char[] dest = new char[12];
+            // Four byte UTF-8 characters [cp >= 0xffff && cp <= 0x10ffff]
+            // Start with "%F-%--%--%--" and fill in the blanks
+            dest[0] = '%';
+            dest[1] = 'F';
+            dest[3] = '%';
+            dest[6] = '%';
+            dest[9] = '%';
+            dest[11] = UPPER_HEX_DIGITS[cp & 0xF];
+            cp >>>= 4;
+            dest[10] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+            cp >>>= 2;
+            dest[8] = UPPER_HEX_DIGITS[cp & 0xF];
+            cp >>>= 4;
+            dest[7] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+            cp >>>= 2;
+            dest[5] = UPPER_HEX_DIGITS[cp & 0xF];
+            cp >>>= 4;
+            dest[4] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+            cp >>>= 2;
+            dest[2] = UPPER_HEX_DIGITS[cp & 0x7];
+            escaped.size += 4;
+            return dest;
+        } else {
+            // If this ever happens it is due to bug in UnicodeEscaper, not bad input.
+            throw new IllegalArgumentException("Invalid unicode character value " + cp);
+        }
+    }
+
+    /**
+     * Returns the Unicode code point of the character at the given index.
+     *
+     * <p>Unlike {@link Character#codePointAt(CharSequence, int)} or {@link String#codePointAt(int)}
+     * this method will never fail silently when encountering an invalid surrogate pair.
+     *
+     * <p>The behaviour of this method is as follows:
+     *
+     * <ol>
+     *   <li>If {@code index >= end}, {@link IndexOutOfBoundsException} is thrown.
+     *   <li><b>If the character at the specified index is not a surrogate, it is returned.</b>
+     *   <li>If the first character was a high surrogate value, then an attempt is made to read the
+     *       next character.
+     *       <ol>
+     *         <li><b>If the end of the sequence was reached, the negated value of the trailing high
+     *             surrogate is returned.</b>
+     *         <li><b>If the next character was a valid low surrogate, the code point value of the
+     *             high/low surrogate pair is returned.</b>
+     *         <li>If the next character was not a low surrogate value, then {@link
+     *             IllegalArgumentException} is thrown.
+     *       </ol>
+     *   <li>If the first character was a low surrogate value, {@link IllegalArgumentException} is
+     *       thrown.
+     * </ol>
+     *
+     * @param seq the sequence of characters from which to decode the code point
+     * @param index the index of the first character to decode
+     * @param end the index beyond the last valid character to decode
+     * @return the Unicode code point for the given index or the negated value of the trailing high
+     *     surrogate character at the end of the sequence
+     */
+    private static int codePointAt(CharSequence seq, int index, int end) {
+        if (index < end) {
+            char c1 = seq.charAt(index++);
+            if (c1 < Character.MIN_HIGH_SURROGATE || c1 > Character.MAX_LOW_SURROGATE) {
+                // Fast path (first test is probably all we need to do)
+                return c1;
+            } else if (c1 <= Character.MAX_HIGH_SURROGATE) {
+                // If the high surrogate was the last character, return its inverse
+                if (index == end) {
+                    return -c1;
+                }
+                // Otherwise look for the low surrogate following it
+                char c2 = seq.charAt(index);
+                if (Character.isLowSurrogate(c2)) {
+                    return Character.toCodePoint(c1, c2);
+                }
+                throw new IllegalArgumentException(
+                        "Expected low surrogate but got char '"
+                                + c2
+                                + "' with value "
+                                + (int) c2
+                                + " at index "
+                                + index
+                                + " in '"
+                                + seq
+                                + "'");
+            } else {
+                throw new IllegalArgumentException(
+                        "Unexpected low surrogate character '"
+                                + c1
+                                + "' with value "
+                                + (int) c1
+                                + " at index "
+                                + (index - 1)
+                                + " in '"
+                                + seq
+                                + "'");
+            }
+        }
+        throw new IndexOutOfBoundsException("Index exceeds specified range");
+    }
+
+    /**
+     * Helper method to grow the character buffer as needed, this only happens once in a while so it's
+     * ok if it's in a method call. If the index passed in is 0 then no copying will be done.
+     */
+    private static char[] growBuffer(char[] dest, int index, int size) {
+        if (size < 0) { // overflow - should be OutOfMemoryError but GWT/j2cl don't support it
+            throw new AssertionError("Cannot increase internal buffer any further");
+        }
+        char[] copy = new char[size];
+        if (index > 0) {
+            System.arraycopy(dest, 0, copy, 0, index);
+        }
+        return copy;
+    }
+
+    public static class Escaped {
+        public String data;
+        public int size;
+
+        public Escaped(String data, int size) {
+            this.data = data;
+            this.size = size;
+        }
+    }
+}

--- a/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/propagation/BaggageTest.kt
+++ b/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/propagation/BaggageTest.kt
@@ -17,7 +17,7 @@ internal class BaggageTest {
     fun `M return empty W from { invalid header value }`(
         headerValue: String?
     ) {
-        assertThat(Baggage.from(headerValue).asMap()).isEqualTo(emptyMap<String, String>())
+        assertThat(Baggage.from(headerValue).asMap()).isEmpty()
     }
 
     @ParameterizedTest

--- a/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/propagation/BaggageTest.kt
+++ b/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/propagation/BaggageTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.trace.core.propagation
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class BaggageTest {
+
+    @ParameterizedTest
+    @MethodSource("invalidBaggageHeaderSamples")
+    fun `M return empty W from { invalid header value }`(
+        headerValue: String?
+    ) {
+        assertThat(Baggage.from(headerValue).asMap()).isEqualTo(emptyMap<String, String>())
+    }
+
+    @ParameterizedTest
+    @MethodSource("validBaggageHeaderSamples")
+    fun `M return expected W from`(
+        headerValue: String?,
+        expectedMap: Map<String, String>
+    ) {
+        assertThat(Baggage.from(headerValue).asMap()).isEqualTo(expectedMap)
+    }
+
+    @ParameterizedTest
+    @MethodSource("validBaggageHeaderSamples")
+    fun `M return expected W toString`(
+        expectedString: String?,
+        entries: Map<String, String>
+    ) {
+        val baggage = Baggage()
+        entries.forEach { (key, value) -> baggage.put(key, value) }
+        assertThat(baggage.toString()).isEqualTo(expectedString)
+    }
+
+    private companion object {
+        @JvmStatic
+        fun invalidBaggageHeaderSamples() = listOf(
+            Arguments.of(null),
+            Arguments.of("no-equal-sign"),
+            Arguments.of("foo=gets-dropped-because-subsequent-pair-is-malformed,="),
+            Arguments.of("=no-key"),
+            Arguments.of("no-value="),
+            Arguments.of(",,"),
+            Arguments.of("=")
+        )
+
+        @JvmStatic
+        fun validBaggageHeaderSamples() = listOf(
+            Arguments.of("", emptyMap<String, String>()),
+
+            Arguments.of("key=value", mapOf("key" to "value")),
+            Arguments.of("key1=val1,key2=val2", mapOf("key1" to "val1", "key2" to "val2")),
+            Arguments.of("serverNode=DF%2028", mapOf("serverNode" to "DF 28")),
+            Arguments.of("abcdefg=hijklmnopq%E2%99%A5", mapOf("abcdefg" to "hijklmnopq♥")),
+            Arguments.of("userId=Am%C3%A9lie", mapOf("userId" to "Amélie")),
+            Arguments.of("userId=Am%C3%A9lie", mapOf("userId" to "Amélie")),
+            Arguments.of(
+                "%22%2C%3B%5C%28%29%2F%3A%3C%3D%3E%3F%40%5B%5D%7B%7D=%22%2C%3B%5C",
+                mapOf(
+                    "\",;\\()/:<=>?@[]{}" to "\",;\\"
+                )
+            ),
+            Arguments.of(
+                "key1=value1%3Bproperty1%3Bproperty2,key2=value2,key3=value3%3B%20propertyKey=propertyValue",
+                mapOf(
+                    "key1" to "value1;property1;property2",
+                    "key2" to "value2",
+                    "key3" to "value3; propertyKey=propertyValue"
+                )
+            )
+        )
+    }
+}

--- a/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/propagation/DatadogHttpCodecTest.kt
+++ b/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/propagation/DatadogHttpCodecTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.trace.core.propagation
+
+import com.datadog.trace.api.DDTraceId
+import com.datadog.trace.bootstrap.instrumentation.api.AgentPropagation
+import com.datadog.trace.core.DDSpanContext
+import com.datadog.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class DatadogHttpCodecTest {
+
+    @Mock
+    lateinit var mockContext: DDSpanContext
+
+    @Mock
+    lateinit var mockCarrier: Any
+
+    @Mock
+    lateinit var mockSetter: AgentPropagation.Setter<Any>
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        whenever(mockContext.traceId).thenReturn(DDTraceId.from(forge.aLong(min = 0L)))
+        whenever(mockContext.propagationTags).thenReturn(mock())
+    }
+
+    @Test
+    fun `M add baggage W inject { sessionId is in context }`(
+        @StringForgery fakeSessionId: String
+    ) {
+        // Given
+        val injector = DatadogHttpCodec.newInjector(emptyMap<String, String>())
+        whenever(mockContext.tags).thenReturn(mapOf(HttpCodec.RUM_SESSION_ID_KEY to fakeSessionId))
+
+        // When
+        injector.inject(mockContext, mockCarrier, mockSetter)
+
+        // Then
+        argumentCaptor<String> {
+            verify(mockSetter).set(
+                eq(mockCarrier),
+                eq(W3CHttpCodec.BAGGAGE_KEY),
+                capture()
+            )
+
+            assertThat(firstValue).isEqualTo("session.id=$fakeSessionId")
+        }
+    }
+}

--- a/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/propagation/W3CHttpCodecTest.kt
+++ b/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/propagation/W3CHttpCodecTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.trace.core.propagation
+
+import com.datadog.trace.api.DDTraceId
+import com.datadog.trace.bootstrap.instrumentation.api.AgentPropagation
+import com.datadog.trace.core.DDSpanContext
+import com.datadog.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class W3CHttpCodecTest {
+
+    @Mock
+    lateinit var mockContext: DDSpanContext
+
+    @Mock
+    lateinit var mockCarrier: Any
+
+    @Mock
+    lateinit var mockSetter: AgentPropagation.Setter<Any>
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        whenever(mockContext.traceId).thenReturn(DDTraceId.from(forge.aLong(min = 0L)))
+        whenever(mockContext.propagationTags).thenReturn(mock())
+    }
+
+    @Test
+    fun `M add baggage W inject { sessionId is in context }`(
+        @StringForgery fakeSessionId: String
+    ) {
+        // Given
+        val injector = W3CHttpCodec.newInjector(emptyMap<String, String>())
+        whenever(mockContext.tags).thenReturn(mapOf(HttpCodec.RUM_SESSION_ID_KEY to fakeSessionId))
+
+        // When
+        injector.inject(mockContext, mockCarrier, mockSetter)
+
+        // Then
+        argumentCaptor<String> {
+            verify(mockSetter).set(
+                eq(mockCarrier),
+                eq(W3CHttpCodec.BAGGAGE_KEY),
+                capture()
+            )
+
+            assertThat(firstValue).isEqualTo("session.id=$fakeSessionId")
+        }
+    }
+}

--- a/features/dd-sdk-android-trace/api/apiSurface
+++ b/features/dd-sdk-android-trace/api/apiSurface
@@ -33,6 +33,7 @@ object com.datadog.android.trace.internal.DatadogTracingToolkit
   fun setSdkV2Compatible(com.datadog.android.trace.api.tracer.DatadogTracerBuilder): com.datadog.android.trace.api.tracer.DatadogTracerBuilder
   fun addThrowable(com.datadog.android.trace.api.span.DatadogSpan, Throwable, Byte)
   fun activateSpan(com.datadog.android.trace.api.tracer.DatadogTracer, com.datadog.android.trace.api.span.DatadogSpan, Boolean): com.datadog.android.trace.api.scope.DatadogScope?
+  fun mergeBaggage(String?, String): String
 object com.datadog.android.trace.internal.SpanAttributes
   const val DATADOG_INITIAL_CONTEXT: String
 fun <T> android.database.sqlite.SQLiteDatabase.transactionTraced(String, Boolean = true, com.datadog.android.trace.api.span.DatadogSpan.(android.database.sqlite.SQLiteDatabase) -> T): T

--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -68,6 +68,7 @@ public final class com/datadog/android/trace/internal/DatadogTracingToolkit {
 	public static final fun activateSpan (Lcom/datadog/android/trace/api/tracer/DatadogTracer;Lcom/datadog/android/trace/api/span/DatadogSpan;Z)Lcom/datadog/android/trace/api/scope/DatadogScope;
 	public static final fun addThrowable (Lcom/datadog/android/trace/api/span/DatadogSpan;Ljava/lang/Throwable;B)V
 	public final fun getPropagationHelper ()Lcom/datadog/android/trace/internal/DatadogPropagationHelper;
+	public final fun mergeBaggage (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public final fun setSdkV2Compatible (Lcom/datadog/android/trace/api/tracer/DatadogTracerBuilder;)Lcom/datadog/android/trace/api/tracer/DatadogTracerBuilder;
 	public final fun setTraceId128BitGenerationEnabled (Lcom/datadog/android/trace/api/tracer/DatadogTracerBuilder;)Lcom/datadog/android/trace/api/tracer/DatadogTracerBuilder;
 	public final fun setTracingSamplingPriorityIfNecessary (Lcom/datadog/android/trace/api/span/DatadogSpanContext;)V

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/DatadogTracingToolkit.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/DatadogTracingToolkit.kt
@@ -11,6 +11,7 @@ import com.datadog.android.trace.api.span.DatadogSpan
 import com.datadog.android.trace.api.span.DatadogSpanContext
 import com.datadog.android.trace.api.tracer.DatadogTracer
 import com.datadog.android.trace.api.tracer.DatadogTracerBuilder
+import com.datadog.trace.core.propagation.Baggage
 
 /**
  * For library usage only.
@@ -87,5 +88,20 @@ object DatadogTracingToolkit {
     @JvmStatic // this method is called from OTel code, written in java
     fun activateSpan(tracer: DatadogTracer, span: DatadogSpan, asyncPropagating: Boolean): DatadogScope? {
         return (tracer as? DatadogTracerAdapter)?.activateSpan(span, asyncPropagating)
+    }
+
+    /**
+     * Merges two baggage headers into a single string representation. The [oldHeader] represents the
+     * previously existing baggage header, and the [newHeader] represents the new baggage information
+     * to be merged with the old one.
+     *
+     * @param oldHeader The existing baggage header, which may be null.
+     * @param newHeader The new baggage header to be merged, must not be null.
+     * @return A string representation of the merged baggage.
+     */
+    fun mergeBaggage(oldHeader: String?, newHeader: String): String {
+        return Baggage.from(oldHeader)
+            .mergeWith(Baggage.from(newHeader))
+            .toString()
     }
 }


### PR DESCRIPTION
### What does this PR do?

Adds a logic to properly support W3C's [baggage header.](https://www.w3.org/TR/baggage/). Existing logic just re-write the `baggage` header value every time new item was added.  This PR changes this logic and allows to update header value. SDK will replace item only if item keys are equal.

Note that Baggage implementation is taken from `dd-trace-java` and modified a bit. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

