### PR TITLE
RUM-11790: Supporting synthetics attribute for vital event

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -344,6 +344,7 @@ internal open class RumViewScope(
                 id = rumContext.applicationId,
                 currentLocale = datadogContext.deviceInfo.localeInfo.currentLocale
             ),
+            synthetics = syntheticsAttribute,
             session = VitalEvent.VitalEventSession(
                 id = rumContext.sessionId,
                 type = sessionType,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/VitalEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/VitalEventAssert.kt
@@ -158,6 +158,28 @@ internal class VitalEventAssert(actual: VitalEvent) : AbstractObjectAssert<Vital
             .isEqualTo(expected)
     }
 
+    fun hasNoSyntheticsTest() = apply {
+        assertThat(actual.synthetics?.testId)
+            .overridingErrorMessage(
+                "Expected event to have no synthetics.testId but was ${actual.synthetics?.testId}"
+            ).isNull()
+        assertThat(actual.synthetics?.resultId)
+            .overridingErrorMessage(
+                "Expected event to have no synthetics.resultId but was ${actual.synthetics?.resultId}"
+            ).isNull()
+    }
+
+    fun hasSyntheticsTest(testId: String, resultId: String) = apply {
+        assertThat(actual.synthetics?.testId)
+            .overridingErrorMessage(
+                "Expected event to have synthetics.testId $testId but was ${actual.synthetics?.testId}"
+            ).isEqualTo(testId)
+        assertThat(actual.synthetics?.resultId)
+            .overridingErrorMessage(
+                "Expected event to have synthetics.resultId $resultId but was ${actual.synthetics?.resultId}"
+            ).isEqualTo(resultId)
+    }
+
     companion object {
         internal fun assertThat(actual: VitalEvent): VitalEventAssert = VitalEventAssert(actual)
     }


### PR DESCRIPTION
### What does this PR do?

Adds missing `synthetic` attribute for FO vital event

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

