### PR TITLE
Set initialized flag to false when stop RumFeature

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -334,6 +334,7 @@ internal class RumFeature(
         cleanupInfoProviders()
 
         GlobalRumMonitor.unregister(sdkCore)
+        initialized.set(false)
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -1533,6 +1533,33 @@ internal class RumFeatureTest {
         assertThat(testedFeature.displayInfoProvider).isInstanceOf(InfoProvider::class.java)
     }
 
+    @Test
+    fun `M set initialized to true W onInitialize`() {
+        // Before
+        assertThat(testedFeature.initialized).isFalse()
+
+        // When
+        testedFeature.onInitialize(appContext.mockInstance)
+
+        // Then
+        assertThat(testedFeature.initialized).isTrue()
+    }
+
+    @Test
+    fun `M set initialized to false W onStop`() {
+        // When
+        testedFeature.onInitialize(appContext.mockInstance)
+
+        // Then
+        assertThat(testedFeature.initialized).isTrue()
+
+        // When
+        testedFeature.onStop()
+
+        // Then
+        assertThat(testedFeature.initialized).isFalse()
+    }
+
     // endregion
 
     private fun verifyFrameStateAggregatorInitialized(


### PR DESCRIPTION
### What does this PR do?

Set initialized flag to false when stop RumFeature


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

