### PR TITLE
Move DdRumContentProvider to core and use its creation time as app launch time

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -743,8 +743,5 @@ internal class DatadogCore(
             "SDK core already has \"%s\" listener registered."
 
         internal val CONFIGURATION_TELEMETRY_DELAY_MS = TimeUnit.SECONDS.toMillis(5)
-
-        // fallback for APIs below Android N, see [DefaultAppStartTimeProvider].
-        internal val startupTimeNs: Long = System.nanoTime()
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/time/DefaultAppStartTimeProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/time/DefaultAppStartTimeProvider.kt
@@ -10,8 +10,8 @@ import android.annotation.SuppressLint
 import android.os.Build
 import android.os.Process
 import android.os.SystemClock
-import com.datadog.android.core.internal.DatadogCore
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
+import com.datadog.android.rum.DdRumContentProvider
 import java.util.concurrent.TimeUnit
 
 internal class DefaultAppStartTimeProvider(
@@ -25,7 +25,7 @@ internal class DefaultAppStartTimeProvider(
                 val diffMs = SystemClock.elapsedRealtime() - Process.getStartElapsedRealtime()
                 System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(diffMs)
             }
-            else -> DatadogCore.startupTimeNs
+            else -> DdRumContentProvider.createTimeNs
         }
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/time/DefaultAppStartTimeProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/time/DefaultAppStartTimeProviderTest.kt
@@ -9,8 +9,8 @@ package com.datadog.android.core.internal.time
 import android.os.Build
 import android.os.Process
 import android.os.SystemClock
-import com.datadog.android.core.internal.DatadogCore
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
+import com.datadog.android.rum.DdRumContentProvider
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -47,13 +47,13 @@ class DefaultAppStartTimeProviderTest {
     }
 
     @Test
-    fun `M return rum load time W appStartTime { Legacy }`(
+    fun `M return content provider load time W appStartTime { Legacy }`(
         @IntForgery(min = Build.VERSION_CODES.M, max = Build.VERSION_CODES.N) apiVersion: Int
     ) {
         // GIVEN
         val mockBuildSdkVersionProvider: BuildSdkVersionProvider = mock()
         whenever(mockBuildSdkVersionProvider.version) doReturn apiVersion
-        val startTimeNs = DatadogCore.startupTimeNs
+        val startTimeNs = DdRumContentProvider.createTimeNs
 
         // WHEN
         val timeProvider = DefaultAppStartTimeProvider(mockBuildSdkVersionProvider)

--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -113,5 +113,15 @@ fun Thread.safeGetThreadId(): Long
 fun Thread.State.asString(): String
 fun Array<StackTraceElement>.loggableStackTrace(): String
 fun Throwable.loggableStackTrace(): String
+class com.datadog.android.rum.DdRumContentProvider : android.content.ContentProvider
+  override fun onCreate(): Boolean
+  override fun query(android.net.Uri, Array<String>?, String?, Array<String>?, String?): android.database.Cursor?
+  override fun getType(android.net.Uri): String?
+  override fun insert(android.net.Uri, android.content.ContentValues?): android.net.Uri?
+  override fun delete(android.net.Uri, String?, Array<String>?): Int
+  override fun update(android.net.Uri, android.content.ContentValues?, String?, Array<String>?): Int
+  companion object 
+    var processImportance: Int
+    val createTimeNs: Long
 annotation com.datadog.tools.annotation.NoOpImplementation
   constructor(Boolean = false)

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -300,6 +300,23 @@ public final class com/datadog/android/internal/utils/ThrowableExtKt {
 	public static final fun loggableStackTrace (Ljava/lang/Throwable;)Ljava/lang/String;
 }
 
+public final class com/datadog/android/rum/DdRumContentProvider : android/content/ContentProvider {
+	public static final field Companion Lcom/datadog/android/rum/DdRumContentProvider$Companion;
+	public fun <init> ()V
+	public fun delete (Landroid/net/Uri;Ljava/lang/String;[Ljava/lang/String;)I
+	public fun getType (Landroid/net/Uri;)Ljava/lang/String;
+	public fun insert (Landroid/net/Uri;Landroid/content/ContentValues;)Landroid/net/Uri;
+	public fun onCreate ()Z
+	public fun query (Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Landroid/database/Cursor;
+	public fun update (Landroid/net/Uri;Landroid/content/ContentValues;Ljava/lang/String;[Ljava/lang/String;)I
+}
+
+public final class com/datadog/android/rum/DdRumContentProvider$Companion {
+	public final fun getCreateTimeNs ()J
+	public final fun getProcessImportance ()I
+	public final fun setProcessImportance (I)V
+}
+
 public abstract interface annotation class com/datadog/tools/annotation/NoOpImplementation : java/lang/annotation/Annotation {
 	public abstract fun publicNoOpImplementation ()Z
 }

--- a/dd-sdk-android-internal/build.gradle.kts
+++ b/dd-sdk-android-internal/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
     id("com.github.ben-manes.versions")
 
     // Tests
+    id("de.mobilej.unmock")
     id("org.jetbrains.kotlinx.kover")
 
     // Internal Generation
@@ -69,6 +70,7 @@ dependencies {
             )
         }
     }
+    unmock(libs.robolectric)
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
@@ -80,3 +82,24 @@ publishingConfig(
     "Internal library to be used by the Datadog SDK modules."
 )
 detektCustomConfig()
+
+unMock {
+    keep("android.os.BaseBundle")
+    keep("android.os.Bundle")
+    keep("android.os.Parcel")
+    keepStartingWith("com.android.internal.util.")
+    keepStartingWith("android.util.")
+    keep("android.content.ComponentName")
+    keep("android.content.ContentProvider")
+    keep("android.content.IContentProvider")
+    keep("android.content.ContentProviderNative")
+    keep("android.net.Uri")
+    keep("android.os.Handler")
+    keep("android.os.IMessenger")
+    keep("android.os.Looper")
+    keep("android.os.Message")
+    keep("android.os.MessageQueue")
+    keep("android.os.SystemProperties")
+    keep("android.view.DisplayEventReceiver")
+    keepStartingWith("org.json")
+}

--- a/dd-sdk-android-internal/src/main/AndroidManifest.xml
+++ b/dd-sdk-android-internal/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
     <application>
 
         <provider
-            android:name=".DdRumContentProvider"
+            android:name="com.datadog.android.rum.DdRumContentProvider"
             android:authorities="${applicationId}.provider.datadog.rum"
             android:exported="false" />
 

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/rum/DdRumContentProvider.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/rum/DdRumContentProvider.kt
@@ -64,19 +64,19 @@ class DdRumContentProvider : ContentProvider() {
         return 0
     }
 
-    internal companion object {
+    companion object {
         internal const val DEFAULT_IMPORTANCE: Int =
             ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
-        internal var processImportance = 0
 
-        @Suppress("unused") // Used for instrumented tests
-        @JvmStatic
-        private fun overrideProcessImportance(importance: Int) {
-            Log.w(
-                "DdRumContentProvider",
-                "override processImportance: $processImportance -> $importance"
-            )
-            processImportance = importance
-        }
+        /**
+         * Process importance at the moment of creating [DdRumContentProvider]
+         * Should be set from the outside only in tests.
+         */
+        var processImportance: Int = 0
+
+        /**
+         * fallback for APIs below Android N, see [DefaultAppStartTimeProvider].
+         */
+        val createTimeNs: Long = System.nanoTime()
     }
 }

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/forge/Configurator.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/forge/Configurator.kt
@@ -9,11 +9,13 @@ package com.datadog.android.internal.forge
 import com.datadog.android.internal.tests.elmyr.InternalTelemetryErrorLogForgeryFactory
 import com.datadog.tools.unit.forge.BaseConfigurator
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.jvm.useJvmFactories
 
 internal class Configurator :
     BaseConfigurator() {
     override fun configure(forge: Forge) {
         super.configure(forge)
+        forge.useJvmFactories()
         forge.addFactory(InternalTelemetryErrorLogForgeryFactory())
     }
 }

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/rum/DdRumContentProviderTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/rum/DdRumContentProviderTest.kt
@@ -12,7 +12,7 @@ import android.content.ContentValues
 import android.content.Context
 import android.net.Uri
 import android.os.Process
-import com.datadog.android.rum.utils.forge.Configurator
+import com.datadog.android.internal.forge.Configurator
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.setFieldValue
 import fr.xgouchet.elmyr.Forge

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -1,11 +1,4 @@
 fun <T: java.io.Closeable, R> T.useMonitored(com.datadog.android.api.SdkCore = Datadog.getInstance(), (T) -> R): R
-class com.datadog.android.rum.DdRumContentProvider : android.content.ContentProvider
-  override fun onCreate(): Boolean
-  override fun query(android.net.Uri, Array<String>?, String?, Array<String>?, String?): android.database.Cursor?
-  override fun getType(android.net.Uri): String?
-  override fun insert(android.net.Uri, android.content.ContentValues?): android.net.Uri?
-  override fun delete(android.net.Uri, String?, Array<String>?): Int
-  override fun update(android.net.Uri, android.content.ContentValues?, String?, Array<String>?): Int
 annotation com.datadog.android.rum.ExperimentalRumApi
 object com.datadog.android.rum.GlobalRumMonitor
   fun isRegistered(com.datadog.android.api.SdkCore = Datadog.getInstance()): Boolean

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -3,16 +3,6 @@ public final class com/datadog/android/rum/CloseableExtKt {
 	public static synthetic fun useMonitored$default (Ljava/io/Closeable;Lcom/datadog/android/api/SdkCore;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
-public final class com/datadog/android/rum/DdRumContentProvider : android/content/ContentProvider {
-	public fun <init> ()V
-	public fun delete (Landroid/net/Uri;Ljava/lang/String;[Ljava/lang/String;)I
-	public fun getType (Landroid/net/Uri;)Ljava/lang/String;
-	public fun insert (Landroid/net/Uri;Landroid/content/ContentValues;)Landroid/net/Uri;
-	public fun onCreate ()Z
-	public fun query (Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Landroid/database/Cursor;
-	public fun update (Landroid/net/Uri;Landroid/content/ContentValues;Ljava/lang/String;[Ljava/lang/String;)I
-}
-
 public abstract interface annotation class com/datadog/android/rum/ExperimentalRumApi : java/lang/annotation/Annotation {
 }
 

--- a/instrumented/integration/build.gradle.kts
+++ b/instrumented/integration/build.gradle.kts
@@ -95,6 +95,7 @@ dependencies {
     implementation(project(":features:dd-sdk-android-logs"))
     implementation(project(":features:dd-sdk-android-trace"))
     implementation(project(":features:dd-sdk-android-rum"))
+    implementation(project(":dd-sdk-android-internal"))
     implementation(project(":integrations:dd-sdk-android-okhttp"))
 
     implementation(libs.gson)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/GesturesTrackingActivityTestRule.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/GesturesTrackingActivityTestRule.kt
@@ -41,11 +41,6 @@ internal class GesturesTrackingActivityTestRule<T : Activity>(
             .useViewTrackingStrategy(ActivityViewTrackingStrategy(false))
             .build()
         Rum.enable(rumConfig, sdkCore)
-        DdRumContentProvider::class.java.declaredMethods.firstOrNull() {
-            it.name == "overrideProcessImportance"
-        }?.apply {
-            isAccessible = true
-            invoke(null, ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND)
-        }
+        DdRumContentProvider.processImportance = ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
     }
 }

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/KioskTrackingActivityTestRule.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/KioskTrackingActivityTestRule.kt
@@ -19,11 +19,6 @@ internal class KioskTrackingActivityTestRule<T : Activity>(
 
     override fun beforeActivityLaunched() {
         super.beforeActivityLaunched()
-        DdRumContentProvider::class.java.declaredMethods.firstOrNull() {
-            it.name == "overrideProcessImportance"
-        }?.apply {
-            isAccessible = true
-            invoke(null, ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND)
-        }
+        DdRumContentProvider.processImportance = ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
     }
 }

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingPlaygroundActivity.kt
@@ -33,12 +33,7 @@ internal class ActivityTrackingPlaygroundActivity : AppCompatActivity() {
         val sdkCore = Datadog.initialize(this, config, trackingConsent)
         checkNotNull(sdkCore)
 
-        DdRumContentProvider::class.java.declaredMethods.firstOrNull() {
-            it.name == "overrideProcessImportance"
-        }?.apply {
-            isAccessible = true
-            invoke(null, ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND)
-        }
+        DdRumContentProvider.processImportance = ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
 
         val rumConfig = RuntimeConfig.rumConfigBuilder()
             .trackUserInteractions()

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/ProcessImportanceExt.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/ProcessImportanceExt.kt
@@ -17,10 +17,5 @@ import com.datadog.android.rum.DdRumContentProvider
  * is in the foreground.
  */
 fun overrideProcessImportance() {
-    DdRumContentProvider::class.java.declaredMethods.firstOrNull() {
-        it.name == "overrideProcessImportance"
-    }?.apply {
-        isAccessible = true
-        invoke(null, ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND)
-    }
+    DdRumContentProvider.processImportance = ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
 }

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/utils/ProcessImportanceExt.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/utils/ProcessImportanceExt.kt
@@ -17,10 +17,5 @@ import com.datadog.android.rum.DdRumContentProvider
  * is in the foreground.
  */
 fun overrideProcessImportance() {
-    DdRumContentProvider::class.java.declaredMethods.firstOrNull {
-        it.name == "overrideProcessImportance"
-    }?.apply {
-        isAccessible = true
-        invoke(null, ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND)
-    }
+    DdRumContentProvider.processImportance = ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
 }


### PR DESCRIPTION
### What does this PR do?

Currently we use [DatadogCore.startupTimeNs](https://github.com/DataDog/dd-sdk-android/blob/6f16289fa5f3e0fd7ed5ce41c774cf03fff6e732/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/time/DefaultAppStartTimeProvider.kt#L28C21-L28C46) as app launch timestamp for API < 24 (now it is only 23).

Fields of the companion object get initialized during the first usage of the class in code (in our case `DatadogCore`) which happens somewhere inside `Application.onCreate`. Using `DdRumContentProvider.createTimeNs` (proposed in this pr) is better, because content providers are initialized earlier than `Application.onCreate` and thus we include more user code inside our application launch metrics.

Stacktrace to illustrate the point:
```
lambda 'run' in 'Companion':746, DatadogCore (com.datadog.android.core.internal)
<clinit>:745, DatadogCore (com.datadog.android.core.internal)
lambda 'synchronized' in 'initialize':91, Datadog (com.datadog.android)
initialize:87, Datadog (com.datadog.android)
initialize:125, Datadog (com.datadog.android)
initializeDatadog:145, SampleApplication (com.datadog.android.sample)
onCreate:108, SampleApplication (com.datadog.android.sample)
```

This change requires `DdRumContentProvider` to be used from `DefaultAppStartTimeProvider`, which is in `dd-sdk-android-core`. So I moved `DdRumContentProvider` to `dd-sdk-android-internal` and renamed it.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

