### PR TITLE
[RUM-11854]: Account id  and User id propagated in baggage header

### DIFF
--- a/features/dd-sdk-android-trace-internal/api/dd-sdk-android-trace-internal.api
+++ b/features/dd-sdk-android-trace-internal/api/dd-sdk-android-trace-internal.api
@@ -3135,7 +3135,8 @@ public class com/datadog/trace/core/propagation/ExtractedContext : com/datadog/t
 }
 
 public class com/datadog/trace/core/propagation/HttpCodec {
-	public static final field RUM_SESSION_ID_KEY Ljava/lang/String;
+	public static final field RUM_KEY_ACCOUNT_ID Ljava/lang/String;
+	public static final field RUM_KEY_USER_ID Ljava/lang/String;
 	public fun <init> ()V
 	public static fun allInjectorsFor (Lcom/datadog/trace/api/Config;Ljava/util/Map;)Ljava/util/Map;
 	public static fun createExtractor (Lcom/datadog/trace/api/Config;Lcom/datadog/android/trace/internal/compat/function/Supplier;)Lcom/datadog/trace/core/propagation/HttpCodec$Extractor;

--- a/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/core/propagation/HttpCodec.java
+++ b/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/core/propagation/HttpCodec.java
@@ -50,9 +50,14 @@ public class HttpCodec {
   static final String FASTLY_CLIENT_IP_KEY = "fastly-client-ip";
   static final String CF_CONNECTING_IP_KEY = "cf-connecting-ip";
   static final String CF_CONNECTING_IP_V6_KEY = "cf-connecting-ipv6";
-  static final String RUM_SESSION_ID_BAGGAGE_KEY = "session.id";
 
-  public static final String RUM_SESSION_ID_KEY = "session_id";
+  static final String BAGGAGE_SESSION_ID = "session.id";
+  static final String BAGGAGE_USER_ID = "user.id";
+  static final String BAGGAGE_ACCOUNT_ID = "account.id";
+
+  static final String RUM_KEY_SESSION_ID = "session_id";
+  public static final String RUM_KEY_USER_ID = "user_id";
+  public static final String RUM_KEY_ACCOUNT_ID = "account_id";
 
   public interface Injector {
     <C> void inject(
@@ -192,7 +197,7 @@ public class HttpCodec {
         final DDSpanContext context, final C carrier, final AgentPropagation.Setter<C> setter) {
       log.debug("Inject context {}", context);
       // Update session ide before injecting propagation tags
-      final String sessionId = (String) context.getTags().get(RUM_SESSION_ID_KEY);
+      final String sessionId = (String) context.getTags().get(RUM_KEY_SESSION_ID);
       if (sessionId != null) {
         context.getPropagationTags().updateRumSessionId(sessionId);
       }
@@ -369,10 +374,20 @@ public class HttpCodec {
   @NonNull
   static Baggage composeBaggage(@NonNull DDSpanContext context) {
     Baggage baggage = new Baggage();
-    final String sessionId = (String) context.getTags().get(RUM_SESSION_ID_KEY);
 
+    final String sessionId = (String) context.getTags().get(RUM_KEY_SESSION_ID);
     if (sessionId != null) {
-      baggage.put(RUM_SESSION_ID_BAGGAGE_KEY, sessionId);
+      baggage.put(BAGGAGE_SESSION_ID, sessionId);
+    }
+
+    final String userId = (String) context.getTags().get(RUM_KEY_USER_ID);
+    if (userId != null) {
+      baggage.put(BAGGAGE_USER_ID, userId);
+    }
+
+    final String accountId = (String) context.getTags().get(RUM_KEY_ACCOUNT_ID);
+    if (accountId != null) {
+      baggage.put(BAGGAGE_ACCOUNT_ID, accountId);
     }
 
     return baggage;

--- a/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/propagation/DatadogHttpCodecTest.kt
+++ b/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/propagation/DatadogHttpCodecTest.kt
@@ -11,7 +11,6 @@ import com.datadog.trace.bootstrap.instrumentation.api.AgentPropagation
 import com.datadog.trace.core.DDSpanContext
 import com.datadog.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
-import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -19,12 +18,16 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -46,22 +49,33 @@ internal class DatadogHttpCodecTest {
     @Mock
     lateinit var mockSetter: AgentPropagation.Setter<Any>
 
+    private val testedInjector = DatadogHttpCodec.newInjector(emptyMap<String, String>())
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         whenever(mockContext.traceId).thenReturn(DDTraceId.from(forge.aLong(min = 0L)))
         whenever(mockContext.propagationTags).thenReturn(mock())
     }
 
-    @Test
-    fun `M add baggage W inject { sessionId is in context }`(
-        @StringForgery fakeSessionId: String
+    @ParameterizedTest
+    @MethodSource("rumContext")
+    fun `M add baggage W inject { rum context present }`(
+        userId: String?,
+        accountId: String?,
+        sessionId: String?,
+        expected: String
     ) {
         // Given
-        val injector = DatadogHttpCodec.newInjector(emptyMap<String, String>())
-        whenever(mockContext.tags).thenReturn(mapOf(HttpCodec.RUM_SESSION_ID_KEY to fakeSessionId))
+        whenever(mockContext.tags).thenReturn(
+            mapOf(
+                HttpCodec.RUM_KEY_USER_ID to userId,
+                HttpCodec.RUM_KEY_ACCOUNT_ID to accountId,
+                HttpCodec.RUM_KEY_SESSION_ID to sessionId
+            )
+        )
 
         // When
-        injector.inject(mockContext, mockCarrier, mockSetter)
+        testedInjector.inject(mockContext, mockCarrier, mockSetter)
 
         // Then
         argumentCaptor<String> {
@@ -71,7 +85,56 @@ internal class DatadogHttpCodecTest {
                 capture()
             )
 
-            assertThat(firstValue).isEqualTo("session.id=$fakeSessionId")
+            assertThat(firstValue).isEqualTo(expected)
         }
+    }
+
+    @Test
+    fun `M not add  baggage W inject { no rum context }`() {
+        // Given
+        whenever(mockContext.tags).thenReturn(emptyMap())
+
+        // When
+        testedInjector.inject(mockContext, mockCarrier, mockSetter)
+
+        // Then
+        argumentCaptor<String> {
+            verify(mockSetter, never()).set(
+                eq(mockCarrier),
+                eq(W3CHttpCodec.BAGGAGE_KEY),
+                capture()
+            )
+        }
+    }
+
+    companion object {
+        @Suppress("unused")
+        @JvmStatic
+        fun rumContext() = listOf(
+            Arguments.of(
+                "userId",
+                "accountId",
+                "sessionId",
+                "account.id=accountId,user.id=userId,session.id=sessionId"
+            ),
+            Arguments.of(
+                null,
+                "accountId",
+                "sessionId",
+                "account.id=accountId,session.id=sessionId"
+            ),
+            Arguments.of(
+                "userId",
+                null,
+                "sessionId",
+                "user.id=userId,session.id=sessionId"
+            ),
+            Arguments.of(
+                "userId",
+                "accountId",
+                null,
+                "user.id=userId,account.id=accountId"
+            )
+        )
     }
 }

--- a/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/propagation/HttpCodecTest.kt
+++ b/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/propagation/HttpCodecTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.trace.core.propagation
+
+import com.datadog.trace.core.DDSpanContext
+import com.datadog.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class HttpCodecTest {
+
+    @Mock
+    private lateinit var mockContext: DDSpanContext
+
+    @Test
+    fun `M return correct baggage header W composeBaggage`(
+        @StringForgery fakeUserId: String,
+        @StringForgery fakeSessionId: String,
+        @StringForgery fakeAccountId: String
+    ) {
+        // Given
+        val expected = Baggage().apply {
+            put(HttpCodec.BAGGAGE_USER_ID, fakeUserId)
+            put(HttpCodec.BAGGAGE_ACCOUNT_ID, fakeAccountId)
+            put(HttpCodec.BAGGAGE_SESSION_ID, fakeSessionId)
+        }.toString()
+
+        whenever(mockContext.tags).thenReturn(
+            mapOf<String, Any>(
+                HttpCodec.RUM_KEY_SESSION_ID to fakeSessionId,
+                HttpCodec.RUM_KEY_USER_ID to fakeUserId,
+                HttpCodec.RUM_KEY_ACCOUNT_ID to fakeAccountId
+            )
+        )
+
+        // When
+        val actual = HttpCodec.composeBaggage(mockContext).toString()
+
+        // Then
+        assertThat(actual).isEqualTo(expected)
+    }
+}

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/RumContextPropagator.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/RumContextPropagator.kt
@@ -15,6 +15,7 @@ import com.datadog.android.log.LogAttributes
 import com.datadog.android.trace.api.span.DatadogSpan
 import com.datadog.android.trace.api.span.DatadogSpanBuilder
 import com.datadog.trace.core.DDSpan
+import com.datadog.trace.core.propagation.HttpCodec
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -61,6 +62,8 @@ class RumContextPropagator(private val sdkCoreProvider: () -> FeatureSdkCore?) {
                 instance.setTag(LogAttributes.RUM_SESSION_ID, rumContext["session_id"])
                 instance.setTag(LogAttributes.RUM_VIEW_ID, rumContext["view_id"])
                 instance.setTag(LogAttributes.RUM_ACTION_ID, rumContext["action_id"])
+                instance.setTag(HttpCodec.RUM_KEY_USER_ID, datadogContext.userInfo.id)
+                instance.setTag(HttpCodec.RUM_KEY_ACCOUNT_ID, datadogContext.accountInfo?.id)
             }
             instance.setTag(DATADOG_INITIAL_CONTEXT, null)
         }

--- a/features/dd-sdk-android-trace/src/testFixtures/kotlin/com/datadog/android/trace/api/DatadogTracingTestExt.kt
+++ b/features/dd-sdk-android-trace/src/testFixtures/kotlin/com/datadog/android/trace/api/DatadogTracingTestExt.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.trace.api
 
 import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.trace.GlobalDatadogTracer
 import com.datadog.android.trace.api.span.DatadogSpan
 import com.datadog.android.trace.api.span.DatadogSpanContext
 import com.datadog.android.trace.api.trace.DatadogTraceId
@@ -85,6 +86,13 @@ fun DatadogTracingToolkit.withMockPropagationHelper(
 
 fun DatadogTracerBuilder.setTestIdGenerationStrategy(strategy: TestIdGenerationStrategy) = apply {
     (this as? DatadogTracerBuilderAdapter)?.setCustomIdGenerationStrategy(strategy)
+}
+
+fun GlobalDatadogTracer.replace(
+    builder: DatadogTracerBuilder
+): Boolean {
+    clear()
+    return registerIfAbsent(builder.build())
 }
 
 private val DatadogSpanContext.ddSpanContext: DDSpanContext?

--- a/features/dd-sdk-android-trace/src/testFixtures/kotlin/com/datadog/android/trace/utils/RumContextTestsUtils.kt
+++ b/features/dd-sdk-android-trace/src/testFixtures/kotlin/com/datadog/android/trace/utils/RumContextTestsUtils.kt
@@ -6,7 +6,9 @@
 
 package com.datadog.android.trace.utils
 
+import com.datadog.android.api.context.AccountInfo
 import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.context.UserInfo
 import com.datadog.android.api.feature.Feature
 import fr.xgouchet.elmyr.Forge
 import java.util.UUID
@@ -17,15 +19,29 @@ object RumContextTestsUtils {
     const val RUM_CONTEXT_SESSION_ID = "session_id"
     const val RUM_CONTEXT_APPLICATION_ID = "application_id"
 
-    fun Forge.aRumContext() = mapOf(
-        RUM_CONTEXT_VIEW_ID to getForgery<UUID>().toString(),
-        RUM_CONTEXT_ACTION_ID to getForgery<UUID>().toString(),
-        RUM_CONTEXT_SESSION_ID to getForgery<UUID>().toString(),
-        RUM_CONTEXT_APPLICATION_ID to getForgery<UUID>().toString()
-    )
+    private const val HEX = 16
 
-    fun Forge.aDatadogContextWithRumContext(rumContext: Map<String, Any?>): DatadogContext =
-        getForgery<DatadogContext>().let {
-            it.copy(featuresContext = it.featuresContext + mapOf(Feature.Companion.RUM_FEATURE_NAME to rumContext))
+    fun Forge.aRumContext(sessionId: Long? = null) = buildMap {
+        put(RUM_CONTEXT_VIEW_ID, getForgery<UUID>().toString())
+        put(RUM_CONTEXT_ACTION_ID, getForgery<UUID>().toString())
+        put(RUM_CONTEXT_APPLICATION_ID, getForgery<UUID>().toString())
+        sessionId?.let {
+            put(
+                RUM_CONTEXT_SESSION_ID,
+                "aaaaaaaa-bbbb-Mccc-Nddd-${(sessionId).toULong().toString(HEX)}"
+            )
         }
+    }
+
+    fun Forge.aDatadogContextWithRumContext(
+        rumContext: Map<String, Any?>,
+        accountInfo: AccountInfo? = null,
+        userInfo: UserInfo = UserInfo()
+    ): DatadogContext = getForgery<DatadogContext>().let {
+        it.copy(
+            featuresContext = it.featuresContext + mapOf(Feature.Companion.RUM_FEATURE_NAME to rumContext),
+            accountInfo = accountInfo,
+            userInfo = userInfo
+        )
+    }
 }

--- a/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/SpanExtIntegrationTest.kt
+++ b/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/SpanExtIntegrationTest.kt
@@ -16,6 +16,7 @@ import com.datadog.android.trace.DatadogTracing
 import com.datadog.android.trace.GlobalDatadogTracer
 import com.datadog.android.trace.Trace
 import com.datadog.android.trace.TraceConfiguration
+import com.datadog.android.trace.api.replace
 import com.datadog.android.trace.api.span.DatadogSpan
 import com.datadog.android.trace.internal.DatadogTracingToolkit
 import com.datadog.android.trace.withinSpan
@@ -67,14 +68,12 @@ class SpanExtIntegrationTest {
         sampleRate: Double? = null,
         partialFlushMinSpans: Int? = null
     ): Boolean {
-        GlobalDatadogTracer.clear()
-        return GlobalDatadogTracer.registerIfAbsent(
+        return GlobalDatadogTracer.replace(
             DatadogTracing.newTracerBuilder(stubSdkCore)
                 .also {
                     if (sampleRate != null) it.withSampleRate(sampleRate)
                     if (partialFlushMinSpans != null) it.withPartialFlushMinSpans(partialFlushMinSpans)
                 }
-                .build()
         )
     }
 


### PR DESCRIPTION
### What does this PR do?

Adds support for `accountId` and `userId` propagation through `baggage` header.
Add and refactor tests that is related to rum context propagation

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

