### PR TITLE
[RUM-11711]: Extend resource handling to support multiple MIME types

### DIFF
--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -38,6 +38,10 @@ data class com.datadog.android.sessionreplay.SessionReplayConfiguration
     fun build(): SessionReplayConfiguration
 interface com.datadog.android.sessionreplay.SessionReplayInternalCallback
   fun getCurrentActivity(): android.app.Activity?
+  fun addResourceItem(String, ByteArray, String? = null)
+  fun setResourceQueue(SessionReplayInternalResourceQueue)
+interface com.datadog.android.sessionreplay.SessionReplayInternalResourceQueue
+  fun addResourceItem(String, ByteArray, String? = null)
 enum com.datadog.android.sessionreplay.SessionReplayPrivacy
   - ALLOW
   - MASK

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -70,7 +70,21 @@ public final class com/datadog/android/sessionreplay/SessionReplayConfiguration$
 }
 
 public abstract interface class com/datadog/android/sessionreplay/SessionReplayInternalCallback {
+	public abstract fun addResourceItem (Ljava/lang/String;[BLjava/lang/String;)V
 	public abstract fun getCurrentActivity ()Landroid/app/Activity;
+	public abstract fun setResourceQueue (Lcom/datadog/android/sessionreplay/SessionReplayInternalResourceQueue;)V
+}
+
+public final class com/datadog/android/sessionreplay/SessionReplayInternalCallback$DefaultImpls {
+	public static synthetic fun addResourceItem$default (Lcom/datadog/android/sessionreplay/SessionReplayInternalCallback;Ljava/lang/String;[BLjava/lang/String;ILjava/lang/Object;)V
+}
+
+public abstract interface class com/datadog/android/sessionreplay/SessionReplayInternalResourceQueue {
+	public abstract fun addResourceItem (Ljava/lang/String;[BLjava/lang/String;)V
+}
+
+public final class com/datadog/android/sessionreplay/SessionReplayInternalResourceQueue$DefaultImpls {
+	public static synthetic fun addResourceItem$default (Lcom/datadog/android/sessionreplay/SessionReplayInternalResourceQueue;Ljava/lang/String;[BLjava/lang/String;ILjava/lang/Object;)V
 }
 
 public final class com/datadog/android/sessionreplay/SessionReplayPrivacy : java/lang/Enum {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayInternalCallback.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayInternalCallback.kt
@@ -21,4 +21,22 @@ interface SessionReplayInternalCallback {
      * that were missed because the client was initialized after the `Application.onCreate` phase.
      */
     fun getCurrentActivity(): Activity?
+
+    /**
+     * Adds a resource item to the current resource queue.
+     *
+     * @param identifier A unique identifier for the resource.
+     * @param resourceData The raw content of the resource.
+     * @param mimeType Optional MIME type describing the resource data (e.g. `"image/png"` or `"image/svg+xml"`).
+     */
+    fun addResourceItem(identifier: String, resourceData: ByteArray, mimeType: String? = null)
+
+    /**
+     * Sets the resource queue used by this callback. This allows resource management to also be handled
+     * on a platform-specific level.
+     *
+     * @param resourceQueue The [SessionReplayInternalResourceQueue] instance that will
+     * collect and manage resource items submitted through [addResourceItem].
+     */
+    fun setResourceQueue(resourceQueue: SessionReplayInternalResourceQueue)
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayInternalResourceQueue.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayInternalResourceQueue.kt
@@ -1,0 +1,42 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay
+
+import com.datadog.android.lint.InternalApi
+
+/**
+ * Internal API for queuing custom resources in Session Replay.
+ *
+ * This interface provides access to the Session Replay resource queue, allowing clients
+ * to manually add custom resources (e.g., SVG images, custom assets) that will be
+ * uploaded alongside standard Session Replay data.
+ *
+ * Note: This is an internal API intended for advanced use cases where standard image
+ * capture mechanisms don't apply. For regular image resources, the SDK handles
+ * resource capture automatically.
+ */
+@InternalApi
+interface SessionReplayInternalResourceQueue {
+    /**
+     * Adds a custom resource item to the Session Replay upload queue.
+     *
+     * Resources are deduplicated based on their identifier. If a resource with the same
+     * identifier has already been queued or uploaded in this session, it will not be
+     * queued again.
+     *
+     * @param identifier A unique identifier for this resource. Typically an MD5 hash of
+     * the resource content to ensure deduplication across identical resources.
+     * @param resourceData The raw binary data of the resource to upload.
+     * @param mimeType Optional MIME type of the resource (e.g., "image/svg+xml").
+     * If null, the resource will be uploaded without a specific content type.
+     */
+    fun addResourceItem(
+        identifier: String,
+        resourceData: ByteArray,
+        mimeType: String? = null
+    )
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/DataQueueHandler.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/DataQueueHandler.kt
@@ -12,7 +12,8 @@ import com.datadog.android.sessionreplay.recorder.SystemInformation
 internal interface DataQueueHandler {
     fun addResourceItem(
         identifier: String,
-        resourceData: ByteArray
+        resourceData: ByteArray,
+        mimeType: String? = null
     ): ResourceRecordedDataQueueItem?
     fun addTouchEventItem(
         pointerInteractions: List<MobileSegment.MobileRecord>

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/NoopDataQueueHandler.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/NoopDataQueueHandler.kt
@@ -12,7 +12,8 @@ import com.datadog.android.sessionreplay.recorder.SystemInformation
 internal class NoopDataQueueHandler : DataQueueHandler {
     override fun addResourceItem(
         identifier: String,
-        resourceData: ByteArray
+        resourceData: ByteArray,
+        mimeType: String?
     ): ResourceRecordedDataQueueItem? = null
 
     override fun addTouchEventItem(

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandler.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandler.kt
@@ -44,7 +44,8 @@ internal class RecordedDataQueueHandler(
     @MainThread
     override fun addResourceItem(
         identifier: String,
-        resourceData: ByteArray
+        resourceData: ByteArray,
+        mimeType: String?
     ): ResourceRecordedDataQueueItem? {
         val rumContextData = rumContextDataHandler.createRumContextData()
             ?: return null
@@ -52,7 +53,8 @@ internal class RecordedDataQueueHandler(
         val item = ResourceRecordedDataQueueItem(
             recordedQueuedItemContext = rumContextData,
             identifier = identifier,
-            resourceData = resourceData
+            resourceData = resourceData,
+            mimeType
         )
 
         insertIntoRecordedDataQueue(item)

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/ResourceRecordedDataQueueItem.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/ResourceRecordedDataQueueItem.kt
@@ -11,7 +11,8 @@ import com.datadog.android.sessionreplay.internal.processor.RecordedQueuedItemCo
 internal class ResourceRecordedDataQueueItem(
     recordedQueuedItemContext: RecordedQueuedItemContext,
     val identifier: String,
-    val resourceData: ByteArray
+    val resourceData: ByteArray,
+    val mimeType: String? = null
 ) : RecordedDataQueueItem(recordedQueuedItemContext) {
 
     override fun isValid(): Boolean {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/net/ResourceEvent.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/net/ResourceEvent.kt
@@ -9,7 +9,8 @@ package com.datadog.android.sessionreplay.internal.net
 internal data class ResourceEvent(
     val applicationId: String,
     val identifier: String,
-    val resourceData: ByteArray
+    val resourceData: ByteArray,
+    val mimeType: String? = null
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/EnrichedResource.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/EnrichedResource.kt
@@ -10,7 +10,8 @@ import com.google.gson.JsonObject
 
 internal data class EnrichedResource(
     internal val resource: ByteArray,
-    internal val filename: String
+    internal val filename: String,
+    internal val mimeType: String? = null
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -33,6 +34,7 @@ internal data class EnrichedResource(
         internal const val APPLICATION_KEY = "application"
         internal const val ID_KEY = "id"
         internal const val FILENAME_KEY = "filename"
+        internal const val MIME_TYPE = "mimeType"
     }
 }
 
@@ -41,5 +43,8 @@ internal fun EnrichedResource.asBinaryMetadata(rumApplicationId: String): ByteAr
     val jsonObject = JsonObject()
     jsonObject.addProperty(EnrichedResource.APPLICATION_ID_KEY, rumApplicationId)
     jsonObject.addProperty(EnrichedResource.FILENAME_KEY, filename)
+    if (this.mimeType != null) {
+        jsonObject.addProperty(EnrichedResource.MIME_TYPE, this.mimeType)
+    }
     return jsonObject.toString().toByteArray(Charsets.UTF_8)
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/RecordedDataProcessor.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/RecordedDataProcessor.kt
@@ -50,7 +50,8 @@ internal class RecordedDataProcessor(
 
             val enrichedResource = EnrichedResource(
                 resource = item.resourceData,
-                filename = resourceHash
+                filename = resourceHash,
+                mimeType = item.mimeType
             )
 
             resourcesWriter.write(enrichedResource)

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/ResourceQueueImpl.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/ResourceQueueImpl.kt
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.processor
+
+import androidx.annotation.MainThread
+import com.datadog.android.sessionreplay.SessionReplayInternalResourceQueue
+import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
+
+internal class ResourceQueueImpl(
+    private val internalHandler: RecordedDataQueueHandler
+) : SessionReplayInternalResourceQueue {
+    @MainThread
+    override fun addResourceItem(identifier: String, resourceData: ByteArray, mimeType: String?) {
+        internalHandler.addResourceItem(identifier, resourceData, mimeType)
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
@@ -24,6 +24,7 @@ import com.datadog.android.sessionreplay.internal.TouchPrivacyManager
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.processor.MutationResolver
 import com.datadog.android.sessionreplay.internal.processor.RecordedDataProcessor
+import com.datadog.android.sessionreplay.internal.processor.ResourceQueueImpl
 import com.datadog.android.sessionreplay.internal.processor.RumContextDataHandler
 import com.datadog.android.sessionreplay.internal.recorder.callback.OnWindowRefreshedCallback
 import com.datadog.android.sessionreplay.internal.recorder.mapper.DecorViewMapper
@@ -212,6 +213,9 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
             sessionReplayLifecycleCallback.setCurrentWindow(it)
             sessionReplayLifecycleCallback.registerFragmentLifecycleCallbacks(it)
         }
+
+        // Expose this object so it can be used to dynamically add resources
+        internalCallback.setResourceQueue(ResourceQueueImpl(this.recordedDataQueueHandler))
 
         this.uiHandler = Handler(Looper.getMainLooper())
         this.internalLogger = internalLogger

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolverTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolverTest.kt
@@ -932,7 +932,8 @@ internal class ResourceResolverTest {
 
         verify(mockRecordedDataQueueHandler, times(1)).addResourceItem(
             identifier = eq(fakeResourceId),
-            resourceData = eq(fakeByteArray)
+            resourceData = eq(fakeByteArray),
+            mimeType = anyOrNull()
         )
 
         // second time
@@ -950,7 +951,8 @@ internal class ResourceResolverTest {
 
         verify(mockRecordedDataQueueHandler, times(1)).addResourceItem(
             identifier = eq(fakeResourceId),
-            resourceData = eq(fakeByteArray)
+            resourceData = eq(fakeByteArray),
+            mimeType = anyOrNull()
         )
     }
 


### PR DESCRIPTION
### What does this PR do?

Adds optional mimeType parameter to resource handling APIs to support more image formats like SVG. Maintains backward compatibility with default value for existing resources.

### Motivation

Allow React Native clients to handle SVG resources.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

