### PR TITLE
Bump dd-trace-java version to 1.54.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  CURRENT_CI_IMAGE: "20"
+  CURRENT_CI_IMAGE: "21"
   CI_IMAGE_DOCKER: registry.ddbuild.io/ci/dd-sdk-android:$CURRENT_CI_IMAGE
   GIT_DEPTH: 5
 

--- a/ci/Dockerfile.gitlab
+++ b/ci/Dockerfile.gitlab
@@ -32,7 +32,7 @@ ENV ANDROID_BUILD_TOOLS 36.0.0
 ENV ANDROID_SDK_TOOLS 11076708
 ENV NDK_VERSION 28.0.13004108
 ENV CMAKE_VERSION 3.22.1
-ENV DD_TRACER_VERSION 1.53.0
+ENV DD_TRACER_VERSION 1.54.0
 # requires build with BuildKit to be available https://docs.docker.com/build/building/variables/#multi-platform-build-arguments
 ARG TARGETARCH
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-${TARGETARCH}


### PR DESCRIPTION
### What does this PR do?

Bumps the version of [dd-trace-java](https://github.com/DataDog/dd-trace-java) used in CI to the latest one ([v1.54.0](https://github.com/DataDog/dd-trace-java/releases/tag/v1.54.0)).

### Motivation

The latest release contains a fix for the code coverage report upload functionality.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

