### PR TITLE
RUM-11887: Send TTID event to Profiling feature to stop profiling

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -136,5 +136,7 @@ class com.datadog.android.rum.DdRumContentProvider : android.content.ContentProv
   companion object 
     var processImportance: Int
     val createTimeNs: Long
+data class com.datadog.android.rum.TTIDEvent
+  constructor(Long)
 annotation com.datadog.tools.annotation.NoOpImplementation
   constructor(Boolean = false)

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -339,6 +339,17 @@ public final class com/datadog/android/rum/DdRumContentProvider$Companion {
 	public final fun setProcessImportance (I)V
 }
 
+public final class com/datadog/android/rum/TTIDEvent {
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lcom/datadog/android/rum/TTIDEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/TTIDEvent;JILjava/lang/Object;)Lcom/datadog/android/rum/TTIDEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface annotation class com/datadog/tools/annotation/NoOpImplementation : java/lang/annotation/Annotation {
 	public abstract fun publicNoOpImplementation ()Z
 }

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/rum/TTIDEvent.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/rum/TTIDEvent.kt
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum
+
+/**
+ * Internal event to pass the Time To Initial Display (TTID) value in nanoseconds.
+ *
+ * @param value The TTID value in nanoseconds.
+ */
+data class TTIDEvent(val value: Long)

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/Profiling.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/Profiling.kt
@@ -12,6 +12,7 @@ import com.datadog.android.Datadog
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.profiling.internal.ProfilingFeature
+import com.datadog.android.profiling.internal.perfetto.PerfettoProfilerProvider
 
 /**
  * An entry point to Datadog Profiling feature.
@@ -36,7 +37,8 @@ object Profiling {
         val featureSdkCore = sdkCore as FeatureSdkCore
         val profilingFeature = ProfilingFeature(
             sdkCore = featureSdkCore,
-            configuration = configuration
+            configuration = configuration,
+            profilerProvider = PerfettoProfilerProvider()
         )
         featureSdkCore.registerFeature(profilingFeature)
     }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilerProvider.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilerProvider.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling.internal
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.profiling.internal.perfetto.PerfettoResult
+import java.util.concurrent.ExecutorService
+
+internal interface ProfilerProvider {
+    fun provide(
+        internalLogger: InternalLogger,
+        timeProvider: TimeProvider,
+        profilingExecutor: ExecutorService,
+        onProfilingSuccess: (PerfettoResult) -> Unit
+    ): Profiler
+}

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
@@ -13,6 +13,7 @@ import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.internal.persistence.file.readBytesSafe
 import com.datadog.android.internal.utils.formatIsoUtc
+import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 import com.datadog.android.profiling.model.ProfilingEvent
 import java.io.File
 

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingWriter.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingWriter.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.profiling.internal
 
+import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 import com.datadog.tools.annotation.NoOpImplementation
 
 @NoOpImplementation

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.profiling.internal
+package com.datadog.android.profiling.internal.perfetto
 
 import android.content.Context
 import android.os.Build
@@ -15,6 +15,7 @@ import androidx.core.os.StackSamplingRequestBuilder
 import androidx.core.os.requestProfiling
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.profiling.internal.Profiler
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -22,7 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Consumer
 
 /**
- * Profiler based on Android's [androidx.core.os.requestProfiling] API to record callstack samples during application launch.
+ * Profiler based on Android's [requestProfiling] API to record callstack samples during application launch.
  *
  * @param internalLogger the logger instance to use for logging.
  * @param timeProvider The time provider to use to get the current time.

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfilerProvider.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfilerProvider.kt
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling.internal.perfetto
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.profiling.internal.Profiler
+import com.datadog.android.profiling.internal.ProfilerProvider
+import java.util.concurrent.ExecutorService
+
+@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+internal class PerfettoProfilerProvider : ProfilerProvider {
+    override fun provide(
+        internalLogger: InternalLogger,
+        timeProvider: TimeProvider,
+        profilingExecutor: ExecutorService,
+        onProfilingSuccess: (PerfettoResult) -> Unit
+    ): Profiler = PerfettoProfiler(
+        internalLogger = internalLogger,
+        timeProvider = timeProvider,
+        profilingExecutor = profilingExecutor,
+        onProfilingSuccess = onProfilingSuccess
+    )
+}

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoResult.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoResult.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.profiling.internal
+package com.datadog.android.profiling.internal.perfetto
 
 /**
  * Result of a profiling request made through [androidx.core.os.requestProfiling].

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/PerfettoResultFactory.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/PerfettoResultFactory.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.profiling.forge
 
-import com.datadog.android.profiling.internal.PerfettoResult
+import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -13,6 +13,8 @@ import android.os.ProfilingManager
 import android.os.ProfilingResult
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
+import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingDataWriterTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingDataWriterTest.kt
@@ -17,6 +17,7 @@ import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.internal.utils.formatIsoUtc
 import com.datadog.android.profiling.forge.Configurator
+import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 import com.datadog.android.profiling.model.ProfilingEvent
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -39,6 +39,7 @@ import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.RumSessionType
+import com.datadog.android.rum.TTIDEvent
 import com.datadog.android.rum.configuration.SlowFramesConfiguration
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
 import com.datadog.android.rum.internal.anr.ANRDetectorRunnable
@@ -685,12 +686,16 @@ internal class RumFeature(
 
                     val callback = object : RumFirstDrawTimeReporter.Callback {
                         override fun onFirstFrameDrawn(timestampNs: Long) {
+                            val ttid = timestampNs - scenario.initialTimeNs
                             val info = RumTTIDInfo(
                                 scenario = scenario,
                                 durationNs = timestampNs - scenario.initialTimeNs
                             )
                             (GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor)
                                 ?.sendTTIDEvent(info)
+                            // Send TTID event to Profiling feature
+                            sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)
+                                ?.sendEvent(TTIDEvent(ttid))
                         }
                     }
 
@@ -793,6 +798,8 @@ internal class RumFeature(
         internal const val EVENT_THROWABLE_PROPERTY = "throwable"
         internal const val EVENT_ATTRIBUTES_PROPERTY = "attributes"
         internal const val EVENT_STACKTRACE_PROPERTY = "stacktrace"
+
+        internal const val RUM_TTID_BUS_MESSAGE_KEY = "rum_ttid"
 
         internal const val UNSUPPORTED_EVENT_TYPE =
             "RUM feature receive an event of unsupported type=%s."

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -158,6 +158,7 @@ dependencies {
     implementation(project(":features:dd-sdk-android-session-replay"))
     implementation(project(":features:dd-sdk-android-session-replay-material"))
     implementation(project(":features:dd-sdk-android-session-replay-compose"))
+    implementation(project(":features:dd-sdk-android-profiling"))
     implementation(project(":integrations:dd-sdk-android-trace-coroutines"))
     implementation(project(":integrations:dd-sdk-android-rum-coroutines"))
     implementation(project(":integrations:dd-sdk-android-rx"))

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -26,6 +26,7 @@ import com.datadog.android.ndk.NdkCrashReports
 import com.datadog.android.okhttp.DatadogEventListener
 import com.datadog.android.okhttp.DatadogInterceptor
 import com.datadog.android.okhttp.trace.TracingInterceptor
+import com.datadog.android.profiling.Profiling
 import com.datadog.android.rum.ExperimentalRumApi
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.Rum
@@ -160,6 +161,10 @@ class SampleApplication : Application() {
         Rum.enable(createRumConfiguration())
 
         GlobalRumMonitor.get().debug = true
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            Profiling.enable()
+        }
     }
 
     private fun initializeUserInfo(preferences: Preferences.DefaultPreferences) {


### PR DESCRIPTION
### What does this PR do?

* Send TTID event from RUM feature when TTID is detected.
* Receive TTID event and stop perfetto profiling.
* Some internal moves of files between the packages.
* Enable profiling feature in Sample app

### Motivation

RUM-11887


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

