### PR TITLE
RUM-11784: Update RUM Schema to include app launch vitals

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReader.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReader.kt
@@ -172,7 +172,6 @@ class JsonSchemaReader(
                     TypeProperty(
                         name = "",
                         type = typeDef,
-                        optional = true,
                         readOnly = readOnly ?: false,
                         defaultValue = null
                     )
@@ -185,7 +184,6 @@ class JsonSchemaReader(
                     TypeProperty(
                         name = "",
                         type = typeDef,
-                        optional = true,
                         readOnly = false,
                         defaultValue = null
                     )
@@ -358,7 +356,11 @@ class JsonSchemaReader(
         allOf: List<JsonDefinition>,
         fromFile: File
     ): TypeDefinition {
-        var mergedType: TypeDefinition = TypeDefinition.Class(typeName, emptyList())
+        var mergedType: TypeDefinition = TypeDefinition.Class(
+            name = typeName,
+            properties = emptyList(),
+            required = emptySet()
+        )
 
         allOf.forEach {
             val type = transform(it, typeName, fromFile)
@@ -374,7 +376,6 @@ class JsonSchemaReader(
     ): TypeDefinition {
         val properties = mutableListOf<TypeProperty>()
         definition.properties?.forEach { (name, property) ->
-            val required = (definition.required != null) && (name in definition.required)
             val readOnly = (property.readOnly == null) || (property.readOnly)
             val propertyType = transform(
                 property,
@@ -385,7 +386,6 @@ class JsonSchemaReader(
                 TypeProperty(
                     name,
                     propertyType,
-                    !required,
                     readOnly,
                     property.default
                 )
@@ -397,7 +397,8 @@ class JsonSchemaReader(
             name = typeName,
             description = definition.description.orEmpty(),
             properties = properties,
-            additionalProperties = additional
+            additionalProperties = additional,
+            required = definition.required.orEmpty().toSet()
         )
     }
 

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/TypeDefinition.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/TypeDefinition.kt
@@ -101,6 +101,7 @@ sealed class TypeDefinition {
     data class Class(
         val name: String,
         val properties: List<TypeProperty>,
+        val required: Set<String>,
         override val description: String = "",
         val additionalProperties: TypeProperty? = null,
         val parentType: OneOfClass? = null
@@ -135,18 +136,22 @@ sealed class TypeDefinition {
                     additionalProperties.mergedWith(other.additionalProperties)
                 }
 
+            val mergedRequired = this.required + other.required
+
             return Class(
-                name,
-                mergedFields,
-                "$description\n${other.description}".trim(),
-                mergedAdditionalProperties
+                name = name,
+                properties = mergedFields,
+                required = mergedRequired,
+                description = "$description\n${other.description}".trim(),
+                additionalProperties = mergedAdditionalProperties
             )
         }
 
         override fun matches(other: TypeDefinition): Boolean {
             return (other is Class) &&
                 (other.properties == properties) &&
-                (other.additionalProperties == additionalProperties)
+                (other.additionalProperties == additionalProperties) &&
+                (other.required == required)
         }
 
         fun isConstantClass(): Boolean {

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/TypeProperty.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/TypeProperty.kt
@@ -9,7 +9,6 @@ package com.datadog.gradle.plugin.jsonschema
 data class TypeProperty(
     val name: String,
     val type: TypeDefinition,
-    val optional: Boolean,
     val readOnly: Boolean = true,
     val defaultValue: Any? = null
 ) {
@@ -18,9 +17,8 @@ data class TypeProperty(
             this
         } else {
             TypeProperty(
-                name,
-                type.mergedWith(other.type),
-                optional && other.optional
+                name = name,
+                type = type.mergedWith(other.type)
             )
         }
     }

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/generator/ClassJsonElementDeserializerGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/generator/ClassJsonElementDeserializerGenerator.kt
@@ -66,7 +66,7 @@ class ClassJsonElementDeserializerGenerator(
                 propertyType = p.type,
                 assignee = "val ${p.name.variableName()}",
                 getter = "${Identifier.PARAM_JSON_OBJ}.get(\"${p.name}\")",
-                nullable = p.optional,
+                nullable = !definition.required.contains(p.name),
                 rootTypeName = rootTypeName
             )
         }
@@ -80,7 +80,7 @@ class ClassJsonElementDeserializerGenerator(
 
         definition.properties
             .filter { it.type is TypeDefinition.Constant }
-            .forEach { appendConstantPropertyCheck(it) }
+            .forEach { appendConstantPropertyCheck(property = it, isRequired = definition.required.contains(it.name)) }
 
         val nonConstantProperties = definition.properties
             .filter { it.type !is TypeDefinition.Constant }
@@ -91,11 +91,11 @@ class ClassJsonElementDeserializerGenerator(
         addStatement("return %L($constructorArguments)", definition.name)
     }
 
-    private fun FunSpec.Builder.appendConstantPropertyCheck(property: TypeProperty) {
+    private fun FunSpec.Builder.appendConstantPropertyCheck(property: TypeProperty, isRequired: Boolean) {
         val constant = property.type as TypeDefinition.Constant
         val variableName = property.name.variableName()
 
-        if (property.optional) {
+        if (!isRequired) {
             beginControlFlow("if (%L != null)", variableName)
         }
 
@@ -113,7 +113,7 @@ class ClassJsonElementDeserializerGenerator(
             JsonType.ARRAY -> TODO()
             null -> TODO()
         }
-        if (property.optional) {
+        if (!isRequired) {
             endControlFlow()
         }
     }

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReaderTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReaderTest.kt
@@ -86,7 +86,8 @@ class JsonSchemaReaderTest(
                 arrayOf("all_of_merged", UserMerged),
                 arrayOf("constant_number", Version),
                 arrayOf("sets", Video),
-                arrayOf("one_of_nested", WeirdCombo)
+                arrayOf("one_of_nested", WeirdCombo),
+                arrayOf("required_for_other_all_of", RequiredForOtherAllOf)
             )
         }
     }

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/TestDefinitions.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/TestDefinitions.kt
@@ -8,21 +8,19 @@ package com.datadog.gradle.plugin.jsonschema
 
 val Address = TypeDefinition.Class(
     name = "Address",
+    required = setOf("street_address", "city", "state"),
     properties = listOf(
         TypeProperty(
             name = "street_address",
-            type = TypeDefinition.Primitive(JsonPrimitiveType.STRING),
-            optional = false
+            type = TypeDefinition.Primitive(JsonPrimitiveType.STRING)
         ),
         TypeProperty(
             name = "city",
-            type = TypeDefinition.Primitive(JsonPrimitiveType.STRING),
-            optional = false
+            type = TypeDefinition.Primitive(JsonPrimitiveType.STRING)
         ),
         TypeProperty(
             name = "state",
-            type = TypeDefinition.Primitive(JsonPrimitiveType.STRING),
-            optional = false
+            type = TypeDefinition.Primitive(JsonPrimitiveType.STRING)
         )
     )
 )
@@ -32,21 +30,21 @@ val Animal = TypeDefinition.OneOfClass(
     options = listOf(
         TypeDefinition.Class(
             name = "Fish",
+            required = setOf("water"),
             properties = listOf(
                 TypeProperty(
                     name = "water",
-                    type = TypeDefinition.Enum("Water", JsonType.STRING, listOf("salt", "fresh")),
-                    optional = false
+                    type = TypeDefinition.Enum("Water", JsonType.STRING, listOf("salt", "fresh"))
                 ),
                 TypeProperty(
                     name = "size",
-                    type = TypeDefinition.Primitive(JsonPrimitiveType.INTEGER),
-                    optional = true
+                    type = TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)
                 )
             )
         ),
         TypeDefinition.Class(
             name = "Bird",
+            required = setOf("food", "can_fly"),
             properties = listOf(
                 TypeProperty(
                     name = "food",
@@ -62,10 +60,12 @@ val Animal = TypeDefinition.OneOfClass(
                             "seeds",
                             "pollen"
                         )
-                    ),
-                    optional = false
+                    )
                 ),
-                TypeProperty("can_fly", TypeDefinition.Primitive(JsonPrimitiveType.BOOLEAN), false)
+                TypeProperty(
+                    name = "can_fly",
+                    type = TypeDefinition.Primitive(JsonPrimitiveType.BOOLEAN)
+                )
             )
         )
     ),
@@ -74,234 +74,225 @@ val Animal = TypeDefinition.OneOfClass(
 
 val Article = TypeDefinition.Class(
     name = "Article",
+    required = setOf("title", "authors"),
     properties = listOf(
-        TypeProperty("title", TypeDefinition.Primitive(JsonPrimitiveType.STRING), false),
+        TypeProperty(name = "title", type = TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
         TypeProperty(
-            "tags",
-            TypeDefinition.Array(TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
-            true
+            name = "tags",
+            type = TypeDefinition.Array(TypeDefinition.Primitive(JsonPrimitiveType.STRING))
         ),
         TypeProperty(
-            "authors",
-            TypeDefinition.Array(TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
-            false
+            name = "authors",
+            type = TypeDefinition.Array(TypeDefinition.Primitive(JsonPrimitiveType.STRING))
         )
     )
 )
 
 val Book = TypeDefinition.Class(
     name = "Book",
+    required = setOf("bookId", "title", "price", "author"),
     properties = listOf(
-        TypeProperty("bookId", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER), false),
-        TypeProperty("title", TypeDefinition.Primitive(JsonPrimitiveType.STRING), false),
-        TypeProperty("price", TypeDefinition.Primitive(JsonPrimitiveType.NUMBER), false),
+        TypeProperty("bookId", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)),
+        TypeProperty("title", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("price", TypeDefinition.Primitive(JsonPrimitiveType.NUMBER)),
         TypeProperty(
             "author",
             TypeDefinition.Class(
                 name = "Author",
+                required = setOf("firstName", "lastName", "contact"),
                 properties = listOf(
                     TypeProperty(
                         "firstName",
-                        TypeDefinition.Primitive(JsonPrimitiveType.STRING),
-                        false
+                        TypeDefinition.Primitive(JsonPrimitiveType.STRING)
                     ),
                     TypeProperty(
                         "lastName",
-                        TypeDefinition.Primitive(JsonPrimitiveType.STRING),
-                        false
+                        TypeDefinition.Primitive(JsonPrimitiveType.STRING)
                     ),
                     TypeProperty(
                         "contact",
                         TypeDefinition.Class(
                             name = "Contact",
+                            required = emptySet(),
                             properties = listOf(
                                 TypeProperty(
                                     "phone",
-                                    TypeDefinition.Primitive(JsonPrimitiveType.STRING),
-                                    true
+                                    TypeDefinition.Primitive(JsonPrimitiveType.STRING)
                                 ),
                                 TypeProperty(
                                     "email",
-                                    TypeDefinition.Primitive(JsonPrimitiveType.STRING),
-                                    true
+                                    TypeDefinition.Primitive(JsonPrimitiveType.STRING)
                                 )
                             )
-                        ),
-                        false
+                        )
                     )
                 )
-            ),
-            false
+            )
         )
     )
 )
 
 val Customer = TypeDefinition.Class(
     name = "Customer",
+    required = emptySet(),
     properties = listOf(
-        TypeProperty("name", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-        TypeProperty("billing_address", Address, true),
-        TypeProperty("shipping_address", Address, true)
+        TypeProperty("name", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("billing_address", Address),
+        TypeProperty("shipping_address", Address)
     )
 )
 
 val Comment = TypeDefinition.Class(
     name = "Comment",
+    required = emptySet(),
     properties = listOf(
-        TypeProperty("message", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
+        TypeProperty("message", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
         TypeProperty(
             "ratings",
             TypeDefinition.Class(
                 name = "Ratings",
+                required = setOf("global"),
                 properties = listOf(
                     TypeProperty(
                         "global",
-                        TypeDefinition.Primitive(JsonPrimitiveType.INTEGER),
-                        false
+                        TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)
                     )
                 ),
                 additionalProperties = TypeProperty(
                     name = "",
                     type = TypeDefinition.Primitive(JsonPrimitiveType.INTEGER),
-                    optional = true,
                     readOnly = true
                 )
-            ),
-            true
+            )
         ),
         TypeProperty(
             "flags",
             TypeDefinition.Class(
                 name = "Flags",
+                required = emptySet(),
                 properties = listOf(),
                 additionalProperties = TypeProperty(
                     name = "",
                     type = TypeDefinition.Primitive(JsonPrimitiveType.BOOLEAN),
-                    optional = true,
                     readOnly = false
                 )
-            ),
-            true
+            )
         ),
         TypeProperty(
             "tags",
             TypeDefinition.Class(
                 name = "Tags",
+                required = emptySet(),
                 properties = listOf(),
                 additionalProperties = TypeProperty(
                     name = "",
                     type = TypeDefinition.Primitive(JsonPrimitiveType.STRING),
-                    optional = true,
                     readOnly = false
                 )
-            ),
-            true
+            )
         )
     )
 )
 
 val Company = TypeDefinition.Class(
     name = "Company",
+    required = emptySet(),
     properties = listOf(
-        TypeProperty("name", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
+        TypeProperty("name", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
         TypeProperty(
             "ratings",
             TypeDefinition.Class(
                 name = "Ratings",
+                required = setOf("global"),
                 properties = listOf(
                     TypeProperty(
                         "global",
-                        TypeDefinition.Primitive(JsonPrimitiveType.INTEGER),
-                        false
+                        TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)
                     )
                 ),
                 additionalProperties = TypeProperty(
                     name = "",
                     type = TypeDefinition.Primitive(JsonPrimitiveType.INTEGER),
-                    optional = true,
                     readOnly = false
                 )
-            ),
-            true
+            )
         ),
         TypeProperty(
             "information",
             TypeDefinition.Class(
                 name = "Information",
+                required = emptySet(),
                 properties = listOf(
                     TypeProperty(
                         "date",
-                        TypeDefinition.Primitive(JsonPrimitiveType.INTEGER),
-                        true
+                        TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)
                     ),
                     TypeProperty(
                         "priority",
-                        TypeDefinition.Primitive(JsonPrimitiveType.INTEGER),
-                        true
+                        TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)
                     )
                 ),
                 additionalProperties = TypeProperty(
                     name = "",
-                    type = TypeDefinition.Class("?", emptyList()),
-                    optional = true,
+                    type = TypeDefinition.Class("?", emptyList(), emptySet()),
                     readOnly = false
                 )
-            ),
-            true
+            )
         )
     ),
     additionalProperties = TypeProperty(
         name = "",
-        type = TypeDefinition.Class("?", emptyList()),
-        optional = true,
+        type = TypeDefinition.Class("?", emptyList(), emptySet()),
         readOnly = false
     )
 )
 
 val Conflict = TypeDefinition.Class(
     name = "Conflict",
+    required = emptySet(),
     properties = listOf(
         TypeProperty(
             "type",
             TypeDefinition.Class(
                 name = "ConflictType",
+                required = emptySet(),
                 properties = listOf(
-                    TypeProperty("id", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true)
+                    TypeProperty("id", TypeDefinition.Primitive(JsonPrimitiveType.STRING))
                 )
-            ),
-            true
+            )
         ),
         TypeProperty(
             "user",
             TypeDefinition.Class(
                 name = "User",
+                required = emptySet(),
                 properties = listOf(
-                    TypeProperty("name", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
+                    TypeProperty("name", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
                     TypeProperty(
                         "type",
                         TypeDefinition.Enum(
                             name = "UserType",
                             type = JsonType.STRING,
                             values = listOf("unknown", "customer", "partner")
-                        ),
-                        true
+                        )
                     )
                 )
-            ),
-            true
+            )
         )
     )
 )
 
 val DateTime = TypeDefinition.Class(
     name = "DateTime",
+    required = emptySet(),
     properties = listOf(
         TypeProperty(
             "date",
             TypeDefinition.Class(
                 name = "Date",
+                required = emptySet(),
                 properties = listOf(
-                    TypeProperty("year", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER), true),
+                    TypeProperty("year", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)),
                     TypeProperty(
                         "month",
                         TypeDefinition.Enum(
@@ -311,153 +302,147 @@ val DateTime = TypeDefinition.Class(
                                 "jan", "feb", "mar", "apr", "may", "jun",
                                 "jul", "aug", "sep", "oct", "nov", "dec"
                             )
-                        ),
-                        true
+                        )
                     ),
-                    TypeProperty("day", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER), true)
+                    TypeProperty("day", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER))
                 )
-            ),
-            true
+            )
         ),
         TypeProperty(
             "time",
             TypeDefinition.Class(
                 name = "Time",
+                required = emptySet(),
                 properties = listOf(
-                    TypeProperty("hour", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER), true),
+                    TypeProperty("hour", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)),
                     TypeProperty(
                         "minute",
-                        TypeDefinition.Primitive(JsonPrimitiveType.INTEGER),
-                        true
+                        TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)
                     ),
                     TypeProperty(
                         "seconds",
-                        TypeDefinition.Primitive(JsonPrimitiveType.INTEGER),
-                        true
+                        TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)
                     )
                 )
-            ),
-            true
+            )
         )
     )
 )
 val Demo = TypeDefinition.Class(
     name = "Demo",
+    required = setOf("s", "i", "n", "b", "l"),
     properties = listOf(
-        TypeProperty("s", TypeDefinition.Primitive(JsonPrimitiveType.STRING), false),
-        TypeProperty("i", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER), false),
-        TypeProperty("n", TypeDefinition.Primitive(JsonPrimitiveType.NUMBER), false),
-        TypeProperty("b", TypeDefinition.Primitive(JsonPrimitiveType.BOOLEAN), false),
-        TypeProperty("l", TypeDefinition.Null(), false),
-        TypeProperty("ns", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-        TypeProperty("ni", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER), true),
-        TypeProperty("nn", TypeDefinition.Primitive(JsonPrimitiveType.NUMBER), true),
-        TypeProperty("nb", TypeDefinition.Primitive(JsonPrimitiveType.BOOLEAN), true),
-        TypeProperty("nl", TypeDefinition.Null(), true)
+        TypeProperty("s", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("i", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)),
+        TypeProperty("n", TypeDefinition.Primitive(JsonPrimitiveType.NUMBER)),
+        TypeProperty("b", TypeDefinition.Primitive(JsonPrimitiveType.BOOLEAN)),
+        TypeProperty("l", TypeDefinition.Null()),
+        TypeProperty("ns", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("ni", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)),
+        TypeProperty("nn", TypeDefinition.Primitive(JsonPrimitiveType.NUMBER)),
+        TypeProperty("nb", TypeDefinition.Primitive(JsonPrimitiveType.BOOLEAN)),
+        TypeProperty("nl", TypeDefinition.Null())
 
     )
 )
 
 val Delivery = TypeDefinition.Class(
     name = "Delivery",
+    required = setOf("item", "customer"),
     properties = listOf(
-        TypeProperty("item", TypeDefinition.Primitive(JsonPrimitiveType.STRING), false),
+        TypeProperty("item", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
         TypeProperty(
             "customer",
             TypeDefinition.Class(
                 name = "Customer",
+                required = emptySet(),
                 properties = listOf(
-                    TypeProperty("name", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-                    TypeProperty("billing_address", Address, true),
-                    TypeProperty("shipping_address", Address, true)
+                    TypeProperty("name", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+                    TypeProperty("billing_address", Address),
+                    TypeProperty("shipping_address", Address)
                 )
-            ),
-            false
+            )
         )
     )
 )
 
 val Employee = TypeDefinition.Class(
     name = "Employee",
+    required = emptySet(),
     properties = listOf(
-        TypeProperty("name", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
+        TypeProperty("name", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
         TypeProperty(
             name = "contact",
             type = TypeDefinition.Class(
                 name = "Contact",
+                required = setOf("phone", "address"),
                 properties = listOf(
                     TypeProperty(
                         "phone",
-                        TypeDefinition.Primitive(JsonPrimitiveType.STRING),
-                        false
+                        TypeDefinition.Primitive(JsonPrimitiveType.STRING)
                     ),
-                    TypeProperty("address", Address, false)
+                    TypeProperty("address", Address)
                 )
-            ),
-            optional = true
+            )
         )
     )
 )
 
 val Foo = TypeDefinition.Class(
     name = "Foo",
+    required = emptySet(),
     properties = listOf(
-        TypeProperty("bar", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-        TypeProperty("baz", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER), true)
+        TypeProperty("bar", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("baz", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER))
     )
 )
 
 val Location = TypeDefinition.Class(
     name = "Location",
+    required = setOf("planet", "solar_system"),
     properties = listOf(
-        TypeProperty("planet", TypeDefinition.Constant(JsonType.STRING, "earth"), false),
-        TypeProperty("solar_system", TypeDefinition.Constant(JsonType.STRING, "sol"), false)
+        TypeProperty("planet", TypeDefinition.Constant(JsonType.STRING, "earth")),
+        TypeProperty("solar_system", TypeDefinition.Constant(JsonType.STRING, "sol"))
     )
 )
 
 val Message = TypeDefinition.Class(
     name = "Message",
+    required = setOf("destination", "origin"),
     properties = listOf(
         TypeProperty(
             "destination",
             TypeDefinition.Array(TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
-            optional = false,
             readOnly = true
         ),
         TypeProperty(
             "origin",
             TypeDefinition.Primitive(JsonPrimitiveType.STRING),
-            optional = false,
             readOnly = true
         ),
         TypeProperty(
             "subject",
             TypeDefinition.Primitive(JsonPrimitiveType.STRING),
-            optional = true,
             readOnly = true
         ),
         TypeProperty(
             "message",
             TypeDefinition.Primitive(JsonPrimitiveType.STRING),
-            optional = true,
             readOnly = true
         ),
         TypeProperty(
             "labels",
             TypeDefinition.Array(TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
-            optional = true,
             readOnly = false
         ),
         TypeProperty(
             "read",
             TypeDefinition.Primitive(JsonPrimitiveType.BOOLEAN),
-            optional = true,
             readOnly = false
         ),
         TypeProperty(
             "important",
             TypeDefinition.Primitive(JsonPrimitiveType.BOOLEAN),
-            optional = true,
             readOnly = false
         )
     )
@@ -466,16 +451,15 @@ val Message = TypeDefinition.Class(
 val Opus = TypeDefinition.Class(
     name = "Opus",
     description = "A musical opus.",
+    required = emptySet(),
     properties = listOf(
         TypeProperty(
             "title",
-            TypeDefinition.Primitive(JsonPrimitiveType.STRING, "The opus's title."),
-            true
+            TypeDefinition.Primitive(JsonPrimitiveType.STRING, "The opus's title.")
         ),
         TypeProperty(
             "composer",
-            TypeDefinition.Primitive(JsonPrimitiveType.STRING, "The opus's composer."),
-            true
+            TypeDefinition.Primitive(JsonPrimitiveType.STRING, "The opus's composer.")
         ),
         TypeProperty(
             "artists",
@@ -483,14 +467,14 @@ val Opus = TypeDefinition.Class(
                 TypeDefinition.Class(
                     name = "Artist",
                     description = "An artist and their role in an opus.",
+                    required = emptySet(),
                     properties = listOf(
                         TypeProperty(
                             "name",
                             TypeDefinition.Primitive(
                                 JsonPrimitiveType.STRING,
                                 "The artist's name."
-                            ),
-                            true
+                            )
                         ),
                         TypeProperty(
                             "role",
@@ -502,77 +486,74 @@ val Opus = TypeDefinition.Class(
                                     "violinist", "dj", "vocals", "other"
                                 ),
                                 "The artist's role."
-                            ),
-                            true
+                            )
                         )
                     )
                 ),
                 description = "The opus's artists."
-            ),
-            true
+            )
         ),
         TypeProperty(
             "duration",
-            TypeDefinition.Primitive(JsonPrimitiveType.INTEGER, "The opus's duration in seconds"),
-            true
+            TypeDefinition.Primitive(JsonPrimitiveType.INTEGER, "The opus's duration in seconds")
         )
     )
 )
 
 val Person = TypeDefinition.Class(
     name = "Person",
+    required = emptySet(),
     properties = listOf(
-        TypeProperty("firstName", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-        TypeProperty("lastName", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-        TypeProperty("age", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER), true)
+        TypeProperty("firstName", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("lastName", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("age", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER))
     )
 )
 
 val Product = TypeDefinition.Class(
     name = "Product",
+    required = setOf("productId", "productName", "price"),
     properties = listOf(
-        TypeProperty("productId", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER), false),
-        TypeProperty("productName", TypeDefinition.Primitive(JsonPrimitiveType.STRING), false),
-        TypeProperty("price", TypeDefinition.Primitive(JsonPrimitiveType.NUMBER), false)
+        TypeProperty("productId", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)),
+        TypeProperty("productName", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("price", TypeDefinition.Primitive(JsonPrimitiveType.NUMBER))
     )
 )
 
 val Paper = TypeDefinition.Class(
     name = "Paper",
+    required = setOf("title", "author"),
     properties = listOf(
-        TypeProperty("title", TypeDefinition.Primitive(JsonPrimitiveType.STRING), false),
+        TypeProperty("title", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
         TypeProperty(
             "author",
             TypeDefinition.Array(TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
-            false
+            readOnly = true
         )
     )
 )
 
 val Bike = TypeDefinition.Class(
     name = "Bike",
+    required = setOf("productId", "productName", "price", "inStock", "color"),
     properties = listOf(
         TypeProperty(
             "productId",
             TypeDefinition.Primitive(JsonPrimitiveType.INTEGER),
-            false,
             defaultValue = 1.0
         ),
         TypeProperty(
             "productName",
-            TypeDefinition.Primitive(JsonPrimitiveType.STRING),
-            false
+            TypeDefinition.Primitive(JsonPrimitiveType.STRING)
         ),
         TypeProperty(
             "type",
             TypeDefinition.Primitive(JsonPrimitiveType.STRING),
-            true,
             defaultValue = "road"
         ),
         TypeProperty(
             "price",
             TypeDefinition.Primitive(JsonPrimitiveType.NUMBER),
-            false,
             defaultValue = 55.5
         ),
         TypeProperty(
@@ -586,13 +567,11 @@ val Bike = TypeDefinition.Class(
                     "iron"
                 )
             ),
-            true,
             defaultValue = "light_aluminium"
         ),
         TypeProperty(
             "inStock",
             TypeDefinition.Primitive(JsonPrimitiveType.BOOLEAN),
-            false,
             defaultValue = true
         ),
         TypeProperty(
@@ -609,7 +588,6 @@ val Bike = TypeDefinition.Class(
                     "sunburst-yellow"
                 )
             ),
-            false,
             defaultValue = "lime green"
         )
     )
@@ -617,14 +595,16 @@ val Bike = TypeDefinition.Class(
 
 val Shipping = TypeDefinition.Class(
     name = "Shipping",
+    required = setOf("item", "destination"),
     properties = listOf(
-        TypeProperty("item", TypeDefinition.Primitive(JsonPrimitiveType.STRING), false),
-        TypeProperty("destination", Address, false)
+        TypeProperty("item", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("destination", Address)
     )
 )
 
 val Style = TypeDefinition.Class(
     name = "Style",
+    required = setOf("color"),
     properties = listOf(
         TypeProperty(
             name = "color",
@@ -640,14 +620,14 @@ val Style = TypeDefinition.Class(
                     "sunburst-yellow",
                     null
                 )
-            ),
-            optional = false
+            )
         )
     )
 )
 
 val Household = TypeDefinition.Class(
     name = "Household",
+    required = emptySet(),
     properties = listOf(
         TypeProperty(
             name = "pets",
@@ -657,6 +637,7 @@ val Household = TypeDefinition.Class(
                     options = listOf(
                         TypeDefinition.Class(
                             name = "Fish",
+                            required = setOf("water"),
                             properties = listOf(
                                 TypeProperty(
                                     name = "water",
@@ -664,18 +645,17 @@ val Household = TypeDefinition.Class(
                                         "Water",
                                         JsonType.STRING,
                                         listOf("salt", "fresh")
-                                    ),
-                                    optional = false
+                                    )
                                 ),
                                 TypeProperty(
                                     name = "size",
-                                    type = TypeDefinition.Primitive(JsonPrimitiveType.INTEGER),
-                                    optional = true
+                                    type = TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)
                                 )
                             )
                         ),
                         TypeDefinition.Class(
                             name = "Bird",
+                            required = setOf("food", "can_fly"),
                             properties = listOf(
                                 TypeProperty(
                                     name = "food",
@@ -691,21 +671,15 @@ val Household = TypeDefinition.Class(
                                             "seeds",
                                             "pollen"
                                         )
-                                    ),
-                                    optional = false
+                                    )
                                 ),
-                                TypeProperty(
-                                    "can_fly",
-                                    TypeDefinition.Primitive(JsonPrimitiveType.BOOLEAN),
-                                    false
-                                )
+                                TypeProperty("can_fly", TypeDefinition.Primitive(JsonPrimitiveType.BOOLEAN))
                             )
                         )
                     ),
                     description = "A representation of the animal kingdom"
                 )
-            ),
-            optional = true
+            )
         ),
         TypeProperty(
             name = "situation",
@@ -714,37 +688,37 @@ val Household = TypeDefinition.Class(
                 options = listOf(
                     TypeDefinition.Class(
                         name = "Marriage",
+                        required = setOf("spouses"),
                         properties = listOf(
                             TypeProperty(
                                 name = "spouses",
                                 type = TypeDefinition.Array(
                                     items = TypeDefinition.Primitive(JsonPrimitiveType.STRING)
-                                ),
-                                optional = false
+                                )
                             )
                         )
                     ),
                     TypeDefinition.Class(
                         name = "Cotenancy",
+                        required = setOf("roommates"),
                         properties = listOf(
                             TypeProperty(
                                 name = "roommates",
                                 type = TypeDefinition.Array(
                                     items = TypeDefinition.Primitive(JsonPrimitiveType.STRING)
-                                ),
-                                optional = false
+                                )
                             )
                         )
                     )
                 )
-            ),
-            optional = true
+            )
         )
     )
 )
 
 val Jacket = TypeDefinition.Class(
     name = "Jacket",
+    required = setOf("size"),
     properties = listOf(
         TypeProperty(
             "size",
@@ -754,13 +728,14 @@ val Jacket = TypeDefinition.Class(
                 listOf("1", "2", "3", "4")
             ),
             defaultValue = 1.0,
-            optional = false
+            readOnly = true
         )
     )
 )
 
 val Order = TypeDefinition.Class(
     name = "Order",
+    required = setOf("sizes"),
     properties = listOf(
         TypeProperty(
             "sizes",
@@ -771,183 +746,182 @@ val Order = TypeDefinition.Class(
                     listOf("x small", "small", "medium", "large", "x large")
                 ),
                 uniqueItems = true
-            ),
-            false
+            )
         )
     )
 )
 
 val User = TypeDefinition.Class(
     name = "User",
+    required = setOf("username", "host", "lastname", "contact_type"),
     properties = listOf(
-        TypeProperty("username", TypeDefinition.Primitive(JsonPrimitiveType.STRING), false),
-        TypeProperty("host", TypeDefinition.Primitive(JsonPrimitiveType.STRING), false),
-        TypeProperty("firstname", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-        TypeProperty("lastname", TypeDefinition.Primitive(JsonPrimitiveType.STRING), false),
+        TypeProperty("username", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("host", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("firstname", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("lastname", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
         TypeProperty(
             "contact_type",
             TypeDefinition.Enum(
                 name = "ContactType",
                 type = null,
                 values = listOf("personal", "professional")
-            ),
-            false
+            )
         )
     )
 )
 
 val Country = TypeDefinition.Class(
     name = "Country",
+    required = emptySet(),
     properties = listOf(
-        TypeProperty("name", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-        TypeProperty("continent", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-        TypeProperty("population", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER), true)
+        TypeProperty("name", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("continent", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("population", TypeDefinition.Primitive(JsonPrimitiveType.INTEGER))
     )
 )
 
 // both items have additionalProperties explicitly defined
 val AdditionalPropsMerged = TypeDefinition.Class(
     name = "AdditionalPropsMerged",
+    required = setOf("lastname"),
     properties = listOf(
-        TypeProperty("email", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-        TypeProperty("phone", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
+        TypeProperty("email", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("phone", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
         TypeProperty(
             "info",
             TypeDefinition.Class(
                 name = "Info",
+                required = emptySet(),
                 properties = listOf(
-                    TypeProperty("notes", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-                    TypeProperty("source", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true)
+                    TypeProperty("notes", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+                    TypeProperty("source", TypeDefinition.Primitive(JsonPrimitiveType.STRING))
                 ),
                 additionalProperties = TypeProperty(
                     name = "",
-                    type = TypeDefinition.Class("?", emptyList()),
-                    optional = true,
+                    type = TypeDefinition.Class("?", emptyList(), emptySet()),
                     readOnly = false
                 )
-            ),
-            true
+            )
         ),
-        TypeProperty("firstname", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-        TypeProperty("lastname", TypeDefinition.Primitive(JsonPrimitiveType.STRING), false)
+        TypeProperty("firstname", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("lastname", TypeDefinition.Primitive(JsonPrimitiveType.STRING))
     )
 )
 
 // only one item has additionalProperties explicitly defined
 val AdditionalPropsSingleMerge = TypeDefinition.Class(
     name = "AdditionalPropsSingleMerge",
+    required = setOf("lastname"),
     properties = listOf(
-        TypeProperty("email", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-        TypeProperty("phone", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
+        TypeProperty("email", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("phone", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
         TypeProperty(
             "info",
             TypeDefinition.Class(
                 name = "Info",
+                required = emptySet(),
                 properties = listOf(
-                    TypeProperty("notes", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-                    TypeProperty("source", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true)
+                    TypeProperty("notes", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+                    TypeProperty("source", TypeDefinition.Primitive(JsonPrimitiveType.STRING))
                 ),
                 additionalProperties = TypeProperty(
                     name = "",
-                    type = TypeDefinition.Class("?", emptyList()),
-                    optional = true,
+                    type = TypeDefinition.Class("?", emptyList(), emptySet()),
                     readOnly = false
                 )
-            ),
-            true
+            )
         ),
-        TypeProperty("firstname", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-        TypeProperty("lastname", TypeDefinition.Primitive(JsonPrimitiveType.STRING), false)
+        TypeProperty("firstname", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("lastname", TypeDefinition.Primitive(JsonPrimitiveType.STRING))
     )
 )
 
 val UserMerged = TypeDefinition.Class(
     name = "UserMerged",
+    required = setOf("lastname"),
     properties = listOf(
-        TypeProperty("email", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-        TypeProperty("phone", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
+        TypeProperty("email", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("phone", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
         TypeProperty(
             "info",
             TypeDefinition.Class(
                 name = "Info",
+                required = emptySet(),
                 properties = listOf(
-                    TypeProperty("notes", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-                    TypeProperty("source", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true)
+                    TypeProperty("notes", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+                    TypeProperty("source", TypeDefinition.Primitive(JsonPrimitiveType.STRING))
                 )
-            ),
-            true
+            )
         ),
-        TypeProperty("firstname", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
-        TypeProperty("lastname", TypeDefinition.Primitive(JsonPrimitiveType.STRING), false)
+        TypeProperty("firstname", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty("lastname", TypeDefinition.Primitive(JsonPrimitiveType.STRING))
     )
 )
 
 val Version = TypeDefinition.Class(
     name = "Version",
+    required = setOf("major", "id"),
     properties = listOf(
-        TypeProperty("major", TypeDefinition.Constant(JsonType.INTEGER, 42.0), false),
-        TypeProperty("delta", TypeDefinition.Constant(JsonType.NUMBER, 3.1415), true),
+        TypeProperty("major", TypeDefinition.Constant(JsonType.INTEGER, 42.0)),
+        TypeProperty("delta", TypeDefinition.Constant(JsonType.NUMBER, 3.1415)),
         TypeProperty(
             "id",
             TypeDefinition.Class(
                 name = "Id",
+                required = emptySet(),
                 properties = listOf(
                     TypeProperty(
                         "serialNumber",
-                        TypeDefinition.Constant(JsonType.NUMBER, 12112.0),
-                        true
+                        TypeDefinition.Constant(JsonType.NUMBER, 12112.0)
                     )
                 )
-            ),
-            false
+            )
         ),
         TypeProperty(
             "date",
             TypeDefinition.Class(
                 name = "Date",
+                required = emptySet(),
                 properties = listOf(
                     TypeProperty(
                         "year",
-                        TypeDefinition.Constant(JsonType.INTEGER, 2021.0),
-                        true
+                        TypeDefinition.Constant(JsonType.INTEGER, 2021.0)
                     ),
                     TypeProperty(
                         "month",
-                        TypeDefinition.Constant(JsonType.INTEGER, 3.0),
-                        true
+                        TypeDefinition.Constant(JsonType.INTEGER, 3.0)
                     )
                 )
-            ),
-            true
+            )
         )
     )
 )
 
 val Video = TypeDefinition.Class(
     name = "Video",
+    required = setOf("title"),
     properties = listOf(
-        TypeProperty("title", TypeDefinition.Primitive(JsonPrimitiveType.STRING), false),
+        TypeProperty("title", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
         TypeProperty(
             "tags",
             TypeDefinition.Array(
                 TypeDefinition.Primitive(JsonPrimitiveType.STRING),
                 uniqueItems = true
-            ),
-            true
+            )
         ),
         TypeProperty(
             "links",
             TypeDefinition.Array(
                 TypeDefinition.Primitive(JsonPrimitiveType.STRING),
                 uniqueItems = true
-            ),
-            true
+            )
         )
     )
 )
 
 val WeirdCombo = TypeDefinition.Class(
     name = "WeirdCombo",
+    required = emptySet(),
     properties = listOf(
         TypeProperty(
             name = "anything",
@@ -956,21 +930,22 @@ val WeirdCombo = TypeDefinition.Class(
                 options = listOf(
                     TypeDefinition.Class(
                         name = "Fish",
+                        required = setOf("water"),
                         properties = listOf(
                             TypeProperty(
                                 name = "water",
                                 type = TypeDefinition.Enum("Water", JsonType.STRING, listOf("salt", "fresh")),
-                                optional = false
+                                readOnly = true
                             ),
                             TypeProperty(
                                 name = "size",
-                                type = TypeDefinition.Primitive(JsonPrimitiveType.INTEGER),
-                                optional = true
+                                type = TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)
                             )
                         )
                     ),
                     TypeDefinition.Class(
                         name = "Bird",
+                        required = setOf("food", "can_fly"),
                         properties = listOf(
                             TypeProperty(
                                 name = "food",
@@ -986,26 +961,33 @@ val WeirdCombo = TypeDefinition.Class(
                                         "seeds",
                                         "pollen"
                                     )
-                                ),
-                                optional = false
+                                )
                             ),
-                            TypeProperty("can_fly", TypeDefinition.Primitive(JsonPrimitiveType.BOOLEAN), false)
+                            TypeProperty("can_fly", TypeDefinition.Primitive(JsonPrimitiveType.BOOLEAN))
                         )
                     ),
                     TypeDefinition.Class(
                         name = "Paper",
+                        required = setOf("title", "author"),
                         properties = listOf(
-                            TypeProperty("title", TypeDefinition.Primitive(JsonPrimitiveType.STRING), false),
+                            TypeProperty("title", TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
                             TypeProperty(
                                 "author",
-                                TypeDefinition.Array(TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
-                                false
+                                TypeDefinition.Array(TypeDefinition.Primitive(JsonPrimitiveType.STRING))
                             )
                         )
                     )
                 )
-            ),
-            optional = true
+            )
         )
+    )
+)
+
+val RequiredForOtherAllOf = TypeDefinition.Class(
+    name = "RequiredForOtherAllOf",
+    required = setOf("key_1", "key_2"),
+    properties = listOf(
+        TypeProperty(name = "key_1", type = TypeDefinition.Primitive(JsonPrimitiveType.STRING)),
+        TypeProperty(name = "key_2", type = TypeDefinition.Primitive(JsonPrimitiveType.STRING))
     )
 )

--- a/buildSrc/src/test/resources/input/external_description_complex_path.json
+++ b/buildSrc/src/test/resources/input/external_description_complex_path.json
@@ -9,9 +9,5 @@
     "contact": {
       "$ref": "subfolder/external_description_proxy.json#/definitions/contact"
     }
-  },
-  "required": [
-    "item",
-    "destination"
-  ]
+  }
 }

--- a/buildSrc/src/test/resources/input/required_for_other_all_of.json
+++ b/buildSrc/src/test/resources/input/required_for_other_all_of.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RequiredForOtherAllOf",
+  "type": "object",
+  "allOf": [
+    {
+      "type": "object",
+      "properties": {
+        "key_1": { "type": "string" }
+      }
+    },
+    {
+      "type": "object",
+      "required": ["key_1", "key_2"],
+      "properties": {
+        "key_2": { "type": "string" }
+      }
+    }
+  ]
+}

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -616,6 +616,34 @@ data class com.datadog.android.rum.model.ActionEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Type
+data class com.datadog.android.rum.model.AppLaunchProperties
+  constructor(kotlin.String, kotlin.String? = null, kotlin.String? = null, AppLaunchMetric, kotlin.Number, StartupType? = null, kotlin.Boolean? = null, kotlin.Boolean? = null)
+  val type: kotlin.String
+  fun toJson(): com.google.gson.JsonElement
+  companion object 
+    fun fromJson(kotlin.String): AppLaunchProperties
+    fun fromJsonObject(com.google.gson.JsonObject): AppLaunchProperties
+  enum AppLaunchMetric
+    constructor(kotlin.String)
+    - TTID
+    - TTFD
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): AppLaunchMetric
+  enum StartupType
+    constructor(kotlin.String)
+    - COLD_START
+    - WARM_START
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): StartupType
+data class com.datadog.android.rum.model.DurationProperties
+  constructor(kotlin.String, kotlin.String? = null, kotlin.String? = null, kotlin.Number)
+  val type: kotlin.String
+  fun toJson(): com.google.gson.JsonElement
+  companion object 
+    fun fromJson(kotlin.String): DurationProperties
+    fun fromJsonObject(com.google.gson.JsonObject): DurationProperties
 data class com.datadog.android.rum.model.ErrorEvent
   constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ErrorEventSession, ErrorEventSource? = null, ErrorEventView, Usr? = null, Account? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Action? = null, Container? = null, Error, Freeze? = null, Context? = null)
   val type: kotlin.String
@@ -966,6 +994,30 @@ data class com.datadog.android.rum.model.ErrorEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): ProviderType
+data class com.datadog.android.rum.model.FeatureOperationProperties
+  constructor(kotlin.String, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, StepType? = null, FailureReason? = null)
+  val type: kotlin.String
+  fun toJson(): com.google.gson.JsonElement
+  companion object 
+    fun fromJson(kotlin.String): FeatureOperationProperties
+    fun fromJsonObject(com.google.gson.JsonObject): FeatureOperationProperties
+  enum StepType
+    constructor(kotlin.String)
+    - START
+    - UPDATE
+    - RETRY
+    - END
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): StepType
+  enum FailureReason
+    constructor(kotlin.String)
+    - ERROR
+    - ABANDONED
+    - OTHER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): FailureReason
 data class com.datadog.android.rum.model.LongTaskEvent
   constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, LongTaskEventSession, LongTaskEventSource? = null, LongTaskEventView, Usr? = null, Account? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Action? = null, Container? = null, LongTask)
   val type: kotlin.String
@@ -1985,7 +2037,7 @@ data class com.datadog.android.rum.model.ViewEvent
     companion object 
       fun fromJson(kotlin.String): ErrorReason
 data class com.datadog.android.rum.model.VitalEvent
-  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, VitalEventSession, VitalEventSource? = null, VitalEventView, Usr? = null, Account? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Container? = null, VitalEventVital)
+  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, VitalEventSession, VitalEventSource? = null, VitalEventView? = null, Usr? = null, Account? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Container? = null, Vital)
   val type: kotlin.String
   fun toJson(): com.google.gson.JsonElement
   companion object 
@@ -2022,7 +2074,7 @@ data class com.datadog.android.rum.model.VitalEvent
       fun fromJson(kotlin.String): Account
       fun fromJsonObject(com.google.gson.JsonObject): Account
   data class Connectivity
-    constructor(Status, kotlin.collections.List<Interface>? = null, EffectiveType? = null, Cellular? = null)
+    constructor(ConnectivityStatus, kotlin.collections.List<Interface>? = null, EffectiveType? = null, Cellular? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Connectivity
@@ -2058,7 +2110,7 @@ data class com.datadog.android.rum.model.VitalEvent
       fun fromJson(kotlin.String): Device
       fun fromJsonObject(com.google.gson.JsonObject): Device
   data class Dd
-    constructor(DdSession? = null, Configuration? = null, kotlin.String? = null, kotlin.String? = null, DdVital? = null)
+    constructor(DdSession? = null, Configuration? = null, kotlin.String? = null, kotlin.String? = null, Vital1? = null, Profiling? = null)
     val formatVersion: kotlin.Long
     fun toJson(): com.google.gson.JsonElement
     companion object 
@@ -2076,12 +2128,32 @@ data class com.datadog.android.rum.model.VitalEvent
     companion object 
       fun fromJson(kotlin.String): Container
       fun fromJsonObject(com.google.gson.JsonObject): Container
-  data class VitalEventVital
-    constructor(VitalEventVitalType, kotlin.String, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Number? = null, StepType? = null, FailureReason? = null)
-    fun toJson(): com.google.gson.JsonElement
+  sealed class Vital
+    abstract fun toJson(): com.google.gson.JsonElement
+    data class DurationProperties : Vital
+      constructor(kotlin.String, kotlin.String? = null, kotlin.String? = null, kotlin.Number)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): DurationProperties
+        fun fromJsonObject(com.google.gson.JsonObject): DurationProperties
+    data class AppLaunchProperties : Vital
+      constructor(kotlin.String, kotlin.String? = null, kotlin.String? = null, AppLaunchMetric, kotlin.Number, StartupType? = null, kotlin.Boolean? = null, kotlin.Boolean? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): AppLaunchProperties
+        fun fromJsonObject(com.google.gson.JsonObject): AppLaunchProperties
+    data class FeatureOperationProperties : Vital
+      constructor(kotlin.String, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, StepType? = null, FailureReason? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): FeatureOperationProperties
+        fun fromJsonObject(com.google.gson.JsonObject): FeatureOperationProperties
     companion object 
-      fun fromJson(kotlin.String): VitalEventVital
-      fun fromJsonObject(com.google.gson.JsonObject): VitalEventVital
+      fun fromJson(kotlin.String): Vital
+      fun fromJsonObject(com.google.gson.JsonObject): Vital
   data class Cellular
     constructor(kotlin.String? = null, kotlin.String? = null)
     fun toJson(): com.google.gson.JsonElement
@@ -2106,12 +2178,18 @@ data class com.datadog.android.rum.model.VitalEvent
     companion object 
       fun fromJson(kotlin.String): Configuration
       fun fromJsonObject(com.google.gson.JsonObject): Configuration
-  data class DdVital
+  data class Vital1
     constructor(kotlin.Boolean? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
-      fun fromJson(kotlin.String): DdVital
-      fun fromJsonObject(com.google.gson.JsonObject): DdVital
+      fun fromJson(kotlin.String): Vital1
+      fun fromJsonObject(com.google.gson.JsonObject): Vital1
+  data class Profiling
+    constructor(ProfilingStatus? = null, ErrorReason? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Profiling
+      fun fromJsonObject(com.google.gson.JsonObject): Profiling
   data class ContainerView
     constructor(kotlin.String)
     fun toJson(): com.google.gson.JsonElement
@@ -2139,14 +2217,14 @@ data class com.datadog.android.rum.model.VitalEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): VitalEventSessionType
-  enum Status
+  enum ConnectivityStatus
     constructor(kotlin.String)
     - CONNECTED
     - NOT_CONNECTED
     - MAYBE
     fun toJson(): com.google.gson.JsonElement
     companion object 
-      fun fromJson(kotlin.String): Status
+      fun fromJson(kotlin.String): ConnectivityStatus
   enum Interface
     constructor(kotlin.String)
     - BLUETOOTH
@@ -2182,13 +2260,20 @@ data class com.datadog.android.rum.model.VitalEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): DeviceType
-  enum VitalEventVitalType
+  enum AppLaunchMetric
     constructor(kotlin.String)
-    - DURATION
-    - OPERATION_STEP
+    - TTID
+    - TTFD
     fun toJson(): com.google.gson.JsonElement
     companion object 
-      fun fromJson(kotlin.String): VitalEventVitalType
+      fun fromJson(kotlin.String): AppLaunchMetric
+  enum StartupType
+    constructor(kotlin.String)
+    - COLD_START
+    - WARM_START
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): StartupType
   enum StepType
     constructor(kotlin.String)
     - START
@@ -2225,6 +2310,24 @@ data class com.datadog.android.rum.model.VitalEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): SessionPrecondition
+  enum ProfilingStatus
+    constructor(kotlin.String)
+    - STARTING
+    - RUNNING
+    - STOPPED
+    - ERROR
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ProfilingStatus
+  enum ErrorReason
+    constructor(kotlin.String)
+    - NOT_SUPPORTED_BY_BROWSER
+    - FAILED_TO_LAZY_LOAD
+    - MISSING_DOCUMENT_POLICY_HEADER
+    - UNEXPECTED_EXCEPTION
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ErrorReason
 data class com.datadog.android.telemetry.model.TelemetryConfigurationEvent
   constructor(Dd, kotlin.Long, kotlin.String, Source, kotlin.String, Application? = null, Session? = null, View? = null, Action? = null, kotlin.Number? = null, kotlin.collections.List<kotlin.String>? = null, Telemetry)
   val type: kotlin.String

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -1424,6 +1424,98 @@ public final class com/datadog/android/rum/model/ActionEvent$Viewport$Companion 
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ActionEvent$Viewport;
 }
 
+public final class com/datadog/android/rum/model/AppLaunchProperties {
+	public static final field Companion Lcom/datadog/android/rum/model/AppLaunchProperties$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/AppLaunchProperties$AppLaunchMetric;Ljava/lang/Number;Lcom/datadog/android/rum/model/AppLaunchProperties$StartupType;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/AppLaunchProperties$AppLaunchMetric;Ljava/lang/Number;Lcom/datadog/android/rum/model/AppLaunchProperties$StartupType;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/datadog/android/rum/model/AppLaunchProperties$AppLaunchMetric;
+	public final fun component5 ()Ljava/lang/Number;
+	public final fun component6 ()Lcom/datadog/android/rum/model/AppLaunchProperties$StartupType;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/AppLaunchProperties$AppLaunchMetric;Ljava/lang/Number;Lcom/datadog/android/rum/model/AppLaunchProperties$StartupType;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lcom/datadog/android/rum/model/AppLaunchProperties;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/AppLaunchProperties;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/AppLaunchProperties$AppLaunchMetric;Ljava/lang/Number;Lcom/datadog/android/rum/model/AppLaunchProperties$StartupType;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/rum/model/AppLaunchProperties;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/AppLaunchProperties;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/AppLaunchProperties;
+	public final fun getAppLaunchMetric ()Lcom/datadog/android/rum/model/AppLaunchProperties$AppLaunchMetric;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getDuration ()Ljava/lang/Number;
+	public final fun getHasSavedInstanceStateBundle ()Ljava/lang/Boolean;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getStartupType ()Lcom/datadog/android/rum/model/AppLaunchProperties$StartupType;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isPrewarmed ()Ljava/lang/Boolean;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/AppLaunchProperties$AppLaunchMetric : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/rum/model/AppLaunchProperties$AppLaunchMetric$Companion;
+	public static final field TTFD Lcom/datadog/android/rum/model/AppLaunchProperties$AppLaunchMetric;
+	public static final field TTID Lcom/datadog/android/rum/model/AppLaunchProperties$AppLaunchMetric;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/AppLaunchProperties$AppLaunchMetric;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/AppLaunchProperties$AppLaunchMetric;
+	public static fun values ()[Lcom/datadog/android/rum/model/AppLaunchProperties$AppLaunchMetric;
+}
+
+public final class com/datadog/android/rum/model/AppLaunchProperties$AppLaunchMetric$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/AppLaunchProperties$AppLaunchMetric;
+}
+
+public final class com/datadog/android/rum/model/AppLaunchProperties$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/AppLaunchProperties;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/AppLaunchProperties;
+}
+
+public final class com/datadog/android/rum/model/AppLaunchProperties$StartupType : java/lang/Enum {
+	public static final field COLD_START Lcom/datadog/android/rum/model/AppLaunchProperties$StartupType;
+	public static final field Companion Lcom/datadog/android/rum/model/AppLaunchProperties$StartupType$Companion;
+	public static final field WARM_START Lcom/datadog/android/rum/model/AppLaunchProperties$StartupType;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/AppLaunchProperties$StartupType;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/AppLaunchProperties$StartupType;
+	public static fun values ()[Lcom/datadog/android/rum/model/AppLaunchProperties$StartupType;
+}
+
+public final class com/datadog/android/rum/model/AppLaunchProperties$StartupType$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/AppLaunchProperties$StartupType;
+}
+
+public final class com/datadog/android/rum/model/DurationProperties {
+	public static final field Companion Lcom/datadog/android/rum/model/DurationProperties$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;)Lcom/datadog/android/rum/model/DurationProperties;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/DurationProperties;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/DurationProperties;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/DurationProperties;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/DurationProperties;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getDuration ()Ljava/lang/Number;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/DurationProperties$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/DurationProperties;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/DurationProperties;
+}
+
 public final class com/datadog/android/rum/model/ErrorEvent {
 	public static final field Companion Lcom/datadog/android/rum/model/ErrorEvent$Companion;
 	public fun <init> (JLcom/datadog/android/rum/model/ErrorEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSession;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSource;Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventView;Lcom/datadog/android/rum/model/ErrorEvent$Usr;Lcom/datadog/android/rum/model/ErrorEvent$Account;Lcom/datadog/android/rum/model/ErrorEvent$Connectivity;Lcom/datadog/android/rum/model/ErrorEvent$Display;Lcom/datadog/android/rum/model/ErrorEvent$Synthetics;Lcom/datadog/android/rum/model/ErrorEvent$CiTest;Lcom/datadog/android/rum/model/ErrorEvent$Os;Lcom/datadog/android/rum/model/ErrorEvent$Device;Lcom/datadog/android/rum/model/ErrorEvent$Dd;Lcom/datadog/android/rum/model/ErrorEvent$Context;Lcom/datadog/android/rum/model/ErrorEvent$Action;Lcom/datadog/android/rum/model/ErrorEvent$Container;Lcom/datadog/android/rum/model/ErrorEvent$Error;Lcom/datadog/android/rum/model/ErrorEvent$Freeze;Lcom/datadog/android/rum/model/ErrorEvent$Context;)V
@@ -2549,6 +2641,69 @@ public final class com/datadog/android/rum/model/ErrorEvent$Viewport {
 public final class com/datadog/android/rum/model/ErrorEvent$Viewport$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Viewport;
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ErrorEvent$Viewport;
+}
+
+public final class com/datadog/android/rum/model/FeatureOperationProperties {
+	public static final field Companion Lcom/datadog/android/rum/model/FeatureOperationProperties$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/FeatureOperationProperties$StepType;Lcom/datadog/android/rum/model/FeatureOperationProperties$FailureReason;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/FeatureOperationProperties$StepType;Lcom/datadog/android/rum/model/FeatureOperationProperties$FailureReason;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lcom/datadog/android/rum/model/FeatureOperationProperties$StepType;
+	public final fun component6 ()Lcom/datadog/android/rum/model/FeatureOperationProperties$FailureReason;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/FeatureOperationProperties$StepType;Lcom/datadog/android/rum/model/FeatureOperationProperties$FailureReason;)Lcom/datadog/android/rum/model/FeatureOperationProperties;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/FeatureOperationProperties;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/FeatureOperationProperties$StepType;Lcom/datadog/android/rum/model/FeatureOperationProperties$FailureReason;ILjava/lang/Object;)Lcom/datadog/android/rum/model/FeatureOperationProperties;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/FeatureOperationProperties;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/FeatureOperationProperties;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getFailureReason ()Lcom/datadog/android/rum/model/FeatureOperationProperties$FailureReason;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOperationKey ()Ljava/lang/String;
+	public final fun getStepType ()Lcom/datadog/android/rum/model/FeatureOperationProperties$StepType;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/FeatureOperationProperties$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/FeatureOperationProperties;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/FeatureOperationProperties;
+}
+
+public final class com/datadog/android/rum/model/FeatureOperationProperties$FailureReason : java/lang/Enum {
+	public static final field ABANDONED Lcom/datadog/android/rum/model/FeatureOperationProperties$FailureReason;
+	public static final field Companion Lcom/datadog/android/rum/model/FeatureOperationProperties$FailureReason$Companion;
+	public static final field ERROR Lcom/datadog/android/rum/model/FeatureOperationProperties$FailureReason;
+	public static final field OTHER Lcom/datadog/android/rum/model/FeatureOperationProperties$FailureReason;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/FeatureOperationProperties$FailureReason;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/FeatureOperationProperties$FailureReason;
+	public static fun values ()[Lcom/datadog/android/rum/model/FeatureOperationProperties$FailureReason;
+}
+
+public final class com/datadog/android/rum/model/FeatureOperationProperties$FailureReason$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/FeatureOperationProperties$FailureReason;
+}
+
+public final class com/datadog/android/rum/model/FeatureOperationProperties$StepType : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/rum/model/FeatureOperationProperties$StepType$Companion;
+	public static final field END Lcom/datadog/android/rum/model/FeatureOperationProperties$StepType;
+	public static final field RETRY Lcom/datadog/android/rum/model/FeatureOperationProperties$StepType;
+	public static final field START Lcom/datadog/android/rum/model/FeatureOperationProperties$StepType;
+	public static final field UPDATE Lcom/datadog/android/rum/model/FeatureOperationProperties$StepType;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/FeatureOperationProperties$StepType;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/FeatureOperationProperties$StepType;
+	public static fun values ()[Lcom/datadog/android/rum/model/FeatureOperationProperties$StepType;
+}
+
+public final class com/datadog/android/rum/model/FeatureOperationProperties$StepType$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/FeatureOperationProperties$StepType;
 }
 
 public final class com/datadog/android/rum/model/LongTaskEvent {
@@ -6065,8 +6220,8 @@ public final class com/datadog/android/rum/model/ViewEvent$Viewport$Companion {
 
 public final class com/datadog/android/rum/model/VitalEvent {
 	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$Companion;
-	public fun <init> (JLcom/datadog/android/rum/model/VitalEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$VitalEventSession;Lcom/datadog/android/rum/model/VitalEvent$VitalEventSource;Lcom/datadog/android/rum/model/VitalEvent$VitalEventView;Lcom/datadog/android/rum/model/VitalEvent$Usr;Lcom/datadog/android/rum/model/VitalEvent$Account;Lcom/datadog/android/rum/model/VitalEvent$Connectivity;Lcom/datadog/android/rum/model/VitalEvent$Display;Lcom/datadog/android/rum/model/VitalEvent$Synthetics;Lcom/datadog/android/rum/model/VitalEvent$CiTest;Lcom/datadog/android/rum/model/VitalEvent$Os;Lcom/datadog/android/rum/model/VitalEvent$Device;Lcom/datadog/android/rum/model/VitalEvent$Dd;Lcom/datadog/android/rum/model/VitalEvent$Context;Lcom/datadog/android/rum/model/VitalEvent$Container;Lcom/datadog/android/rum/model/VitalEvent$VitalEventVital;)V
-	public synthetic fun <init> (JLcom/datadog/android/rum/model/VitalEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$VitalEventSession;Lcom/datadog/android/rum/model/VitalEvent$VitalEventSource;Lcom/datadog/android/rum/model/VitalEvent$VitalEventView;Lcom/datadog/android/rum/model/VitalEvent$Usr;Lcom/datadog/android/rum/model/VitalEvent$Account;Lcom/datadog/android/rum/model/VitalEvent$Connectivity;Lcom/datadog/android/rum/model/VitalEvent$Display;Lcom/datadog/android/rum/model/VitalEvent$Synthetics;Lcom/datadog/android/rum/model/VitalEvent$CiTest;Lcom/datadog/android/rum/model/VitalEvent$Os;Lcom/datadog/android/rum/model/VitalEvent$Device;Lcom/datadog/android/rum/model/VitalEvent$Dd;Lcom/datadog/android/rum/model/VitalEvent$Context;Lcom/datadog/android/rum/model/VitalEvent$Container;Lcom/datadog/android/rum/model/VitalEvent$VitalEventVital;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (JLcom/datadog/android/rum/model/VitalEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$VitalEventSession;Lcom/datadog/android/rum/model/VitalEvent$VitalEventSource;Lcom/datadog/android/rum/model/VitalEvent$VitalEventView;Lcom/datadog/android/rum/model/VitalEvent$Usr;Lcom/datadog/android/rum/model/VitalEvent$Account;Lcom/datadog/android/rum/model/VitalEvent$Connectivity;Lcom/datadog/android/rum/model/VitalEvent$Display;Lcom/datadog/android/rum/model/VitalEvent$Synthetics;Lcom/datadog/android/rum/model/VitalEvent$CiTest;Lcom/datadog/android/rum/model/VitalEvent$Os;Lcom/datadog/android/rum/model/VitalEvent$Device;Lcom/datadog/android/rum/model/VitalEvent$Dd;Lcom/datadog/android/rum/model/VitalEvent$Context;Lcom/datadog/android/rum/model/VitalEvent$Container;Lcom/datadog/android/rum/model/VitalEvent$Vital;)V
+	public synthetic fun <init> (JLcom/datadog/android/rum/model/VitalEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$VitalEventSession;Lcom/datadog/android/rum/model/VitalEvent$VitalEventSource;Lcom/datadog/android/rum/model/VitalEvent$VitalEventView;Lcom/datadog/android/rum/model/VitalEvent$Usr;Lcom/datadog/android/rum/model/VitalEvent$Account;Lcom/datadog/android/rum/model/VitalEvent$Connectivity;Lcom/datadog/android/rum/model/VitalEvent$Display;Lcom/datadog/android/rum/model/VitalEvent$Synthetics;Lcom/datadog/android/rum/model/VitalEvent$CiTest;Lcom/datadog/android/rum/model/VitalEvent$Os;Lcom/datadog/android/rum/model/VitalEvent$Device;Lcom/datadog/android/rum/model/VitalEvent$Dd;Lcom/datadog/android/rum/model/VitalEvent$Context;Lcom/datadog/android/rum/model/VitalEvent$Container;Lcom/datadog/android/rum/model/VitalEvent$Vital;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
 	public final fun component10 ()Lcom/datadog/android/rum/model/VitalEvent$VitalEventView;
 	public final fun component11 ()Lcom/datadog/android/rum/model/VitalEvent$Usr;
@@ -6081,7 +6236,7 @@ public final class com/datadog/android/rum/model/VitalEvent {
 	public final fun component2 ()Lcom/datadog/android/rum/model/VitalEvent$Application;
 	public final fun component20 ()Lcom/datadog/android/rum/model/VitalEvent$Context;
 	public final fun component21 ()Lcom/datadog/android/rum/model/VitalEvent$Container;
-	public final fun component22 ()Lcom/datadog/android/rum/model/VitalEvent$VitalEventVital;
+	public final fun component22 ()Lcom/datadog/android/rum/model/VitalEvent$Vital;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
@@ -6089,8 +6244,8 @@ public final class com/datadog/android/rum/model/VitalEvent {
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Lcom/datadog/android/rum/model/VitalEvent$VitalEventSession;
 	public final fun component9 ()Lcom/datadog/android/rum/model/VitalEvent$VitalEventSource;
-	public final fun copy (JLcom/datadog/android/rum/model/VitalEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$VitalEventSession;Lcom/datadog/android/rum/model/VitalEvent$VitalEventSource;Lcom/datadog/android/rum/model/VitalEvent$VitalEventView;Lcom/datadog/android/rum/model/VitalEvent$Usr;Lcom/datadog/android/rum/model/VitalEvent$Account;Lcom/datadog/android/rum/model/VitalEvent$Connectivity;Lcom/datadog/android/rum/model/VitalEvent$Display;Lcom/datadog/android/rum/model/VitalEvent$Synthetics;Lcom/datadog/android/rum/model/VitalEvent$CiTest;Lcom/datadog/android/rum/model/VitalEvent$Os;Lcom/datadog/android/rum/model/VitalEvent$Device;Lcom/datadog/android/rum/model/VitalEvent$Dd;Lcom/datadog/android/rum/model/VitalEvent$Context;Lcom/datadog/android/rum/model/VitalEvent$Container;Lcom/datadog/android/rum/model/VitalEvent$VitalEventVital;)Lcom/datadog/android/rum/model/VitalEvent;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalEvent;JLcom/datadog/android/rum/model/VitalEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$VitalEventSession;Lcom/datadog/android/rum/model/VitalEvent$VitalEventSource;Lcom/datadog/android/rum/model/VitalEvent$VitalEventView;Lcom/datadog/android/rum/model/VitalEvent$Usr;Lcom/datadog/android/rum/model/VitalEvent$Account;Lcom/datadog/android/rum/model/VitalEvent$Connectivity;Lcom/datadog/android/rum/model/VitalEvent$Display;Lcom/datadog/android/rum/model/VitalEvent$Synthetics;Lcom/datadog/android/rum/model/VitalEvent$CiTest;Lcom/datadog/android/rum/model/VitalEvent$Os;Lcom/datadog/android/rum/model/VitalEvent$Device;Lcom/datadog/android/rum/model/VitalEvent$Dd;Lcom/datadog/android/rum/model/VitalEvent$Context;Lcom/datadog/android/rum/model/VitalEvent$Container;Lcom/datadog/android/rum/model/VitalEvent$VitalEventVital;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalEvent;
+	public final fun copy (JLcom/datadog/android/rum/model/VitalEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$VitalEventSession;Lcom/datadog/android/rum/model/VitalEvent$VitalEventSource;Lcom/datadog/android/rum/model/VitalEvent$VitalEventView;Lcom/datadog/android/rum/model/VitalEvent$Usr;Lcom/datadog/android/rum/model/VitalEvent$Account;Lcom/datadog/android/rum/model/VitalEvent$Connectivity;Lcom/datadog/android/rum/model/VitalEvent$Display;Lcom/datadog/android/rum/model/VitalEvent$Synthetics;Lcom/datadog/android/rum/model/VitalEvent$CiTest;Lcom/datadog/android/rum/model/VitalEvent$Os;Lcom/datadog/android/rum/model/VitalEvent$Device;Lcom/datadog/android/rum/model/VitalEvent$Dd;Lcom/datadog/android/rum/model/VitalEvent$Context;Lcom/datadog/android/rum/model/VitalEvent$Container;Lcom/datadog/android/rum/model/VitalEvent$Vital;)Lcom/datadog/android/rum/model/VitalEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalEvent;JLcom/datadog/android/rum/model/VitalEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$VitalEventSession;Lcom/datadog/android/rum/model/VitalEvent$VitalEventSource;Lcom/datadog/android/rum/model/VitalEvent$VitalEventView;Lcom/datadog/android/rum/model/VitalEvent$Usr;Lcom/datadog/android/rum/model/VitalEvent$Account;Lcom/datadog/android/rum/model/VitalEvent$Connectivity;Lcom/datadog/android/rum/model/VitalEvent$Display;Lcom/datadog/android/rum/model/VitalEvent$Synthetics;Lcom/datadog/android/rum/model/VitalEvent$CiTest;Lcom/datadog/android/rum/model/VitalEvent$Os;Lcom/datadog/android/rum/model/VitalEvent$Device;Lcom/datadog/android/rum/model/VitalEvent$Dd;Lcom/datadog/android/rum/model/VitalEvent$Context;Lcom/datadog/android/rum/model/VitalEvent$Container;Lcom/datadog/android/rum/model/VitalEvent$Vital;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent;
@@ -6116,7 +6271,7 @@ public final class com/datadog/android/rum/model/VitalEvent {
 	public final fun getUsr ()Lcom/datadog/android/rum/model/VitalEvent$Usr;
 	public final fun getVersion ()Ljava/lang/String;
 	public final fun getView ()Lcom/datadog/android/rum/model/VitalEvent$VitalEventView;
-	public final fun getVital ()Lcom/datadog/android/rum/model/VitalEvent$VitalEventVital;
+	public final fun getVital ()Lcom/datadog/android/rum/model/VitalEvent$Vital;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
@@ -6145,6 +6300,20 @@ public final class com/datadog/android/rum/model/VitalEvent$Account {
 public final class com/datadog/android/rum/model/VitalEvent$Account$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Account;
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$Account;
+}
+
+public final class com/datadog/android/rum/model/VitalEvent$AppLaunchMetric : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$AppLaunchMetric$Companion;
+	public static final field TTFD Lcom/datadog/android/rum/model/VitalEvent$AppLaunchMetric;
+	public static final field TTID Lcom/datadog/android/rum/model/VitalEvent$AppLaunchMetric;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$AppLaunchMetric;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$AppLaunchMetric;
+	public static fun values ()[Lcom/datadog/android/rum/model/VitalEvent$AppLaunchMetric;
+}
+
+public final class com/datadog/android/rum/model/VitalEvent$AppLaunchMetric$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$AppLaunchMetric;
 }
 
 public final class com/datadog/android/rum/model/VitalEvent$Application {
@@ -6246,21 +6415,21 @@ public final class com/datadog/android/rum/model/VitalEvent$Configuration$Compan
 
 public final class com/datadog/android/rum/model/VitalEvent$Connectivity {
 	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$Connectivity$Companion;
-	public fun <init> (Lcom/datadog/android/rum/model/VitalEvent$Status;Ljava/util/List;Lcom/datadog/android/rum/model/VitalEvent$EffectiveType;Lcom/datadog/android/rum/model/VitalEvent$Cellular;)V
-	public synthetic fun <init> (Lcom/datadog/android/rum/model/VitalEvent$Status;Ljava/util/List;Lcom/datadog/android/rum/model/VitalEvent$EffectiveType;Lcom/datadog/android/rum/model/VitalEvent$Cellular;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/datadog/android/rum/model/VitalEvent$Status;
+	public fun <init> (Lcom/datadog/android/rum/model/VitalEvent$ConnectivityStatus;Ljava/util/List;Lcom/datadog/android/rum/model/VitalEvent$EffectiveType;Lcom/datadog/android/rum/model/VitalEvent$Cellular;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/VitalEvent$ConnectivityStatus;Ljava/util/List;Lcom/datadog/android/rum/model/VitalEvent$EffectiveType;Lcom/datadog/android/rum/model/VitalEvent$Cellular;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/rum/model/VitalEvent$ConnectivityStatus;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Lcom/datadog/android/rum/model/VitalEvent$EffectiveType;
 	public final fun component4 ()Lcom/datadog/android/rum/model/VitalEvent$Cellular;
-	public final fun copy (Lcom/datadog/android/rum/model/VitalEvent$Status;Ljava/util/List;Lcom/datadog/android/rum/model/VitalEvent$EffectiveType;Lcom/datadog/android/rum/model/VitalEvent$Cellular;)Lcom/datadog/android/rum/model/VitalEvent$Connectivity;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalEvent$Connectivity;Lcom/datadog/android/rum/model/VitalEvent$Status;Ljava/util/List;Lcom/datadog/android/rum/model/VitalEvent$EffectiveType;Lcom/datadog/android/rum/model/VitalEvent$Cellular;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalEvent$Connectivity;
+	public final fun copy (Lcom/datadog/android/rum/model/VitalEvent$ConnectivityStatus;Ljava/util/List;Lcom/datadog/android/rum/model/VitalEvent$EffectiveType;Lcom/datadog/android/rum/model/VitalEvent$Cellular;)Lcom/datadog/android/rum/model/VitalEvent$Connectivity;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalEvent$Connectivity;Lcom/datadog/android/rum/model/VitalEvent$ConnectivityStatus;Ljava/util/List;Lcom/datadog/android/rum/model/VitalEvent$EffectiveType;Lcom/datadog/android/rum/model/VitalEvent$Cellular;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalEvent$Connectivity;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Connectivity;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$Connectivity;
 	public final fun getCellular ()Lcom/datadog/android/rum/model/VitalEvent$Cellular;
 	public final fun getEffectiveType ()Lcom/datadog/android/rum/model/VitalEvent$EffectiveType;
 	public final fun getInterfaces ()Ljava/util/List;
-	public final fun getStatus ()Lcom/datadog/android/rum/model/VitalEvent$Status;
+	public final fun getStatus ()Lcom/datadog/android/rum/model/VitalEvent$ConnectivityStatus;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
@@ -6269,6 +6438,21 @@ public final class com/datadog/android/rum/model/VitalEvent$Connectivity {
 public final class com/datadog/android/rum/model/VitalEvent$Connectivity$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Connectivity;
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$Connectivity;
+}
+
+public final class com/datadog/android/rum/model/VitalEvent$ConnectivityStatus : java/lang/Enum {
+	public static final field CONNECTED Lcom/datadog/android/rum/model/VitalEvent$ConnectivityStatus;
+	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$ConnectivityStatus$Companion;
+	public static final field MAYBE Lcom/datadog/android/rum/model/VitalEvent$ConnectivityStatus;
+	public static final field NOT_CONNECTED Lcom/datadog/android/rum/model/VitalEvent$ConnectivityStatus;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$ConnectivityStatus;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$ConnectivityStatus;
+	public static fun values ()[Lcom/datadog/android/rum/model/VitalEvent$ConnectivityStatus;
+}
+
+public final class com/datadog/android/rum/model/VitalEvent$ConnectivityStatus$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$ConnectivityStatus;
 }
 
 public final class com/datadog/android/rum/model/VitalEvent$Container {
@@ -6338,24 +6522,26 @@ public final class com/datadog/android/rum/model/VitalEvent$Context$Companion {
 public final class com/datadog/android/rum/model/VitalEvent$Dd {
 	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$Dd$Companion;
 	public fun <init> ()V
-	public fun <init> (Lcom/datadog/android/rum/model/VitalEvent$DdSession;Lcom/datadog/android/rum/model/VitalEvent$Configuration;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$DdVital;)V
-	public synthetic fun <init> (Lcom/datadog/android/rum/model/VitalEvent$DdSession;Lcom/datadog/android/rum/model/VitalEvent$Configuration;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$DdVital;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/datadog/android/rum/model/VitalEvent$DdSession;Lcom/datadog/android/rum/model/VitalEvent$Configuration;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$Vital1;Lcom/datadog/android/rum/model/VitalEvent$Profiling;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/VitalEvent$DdSession;Lcom/datadog/android/rum/model/VitalEvent$Configuration;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$Vital1;Lcom/datadog/android/rum/model/VitalEvent$Profiling;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/datadog/android/rum/model/VitalEvent$DdSession;
 	public final fun component2 ()Lcom/datadog/android/rum/model/VitalEvent$Configuration;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Lcom/datadog/android/rum/model/VitalEvent$DdVital;
-	public final fun copy (Lcom/datadog/android/rum/model/VitalEvent$DdSession;Lcom/datadog/android/rum/model/VitalEvent$Configuration;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$DdVital;)Lcom/datadog/android/rum/model/VitalEvent$Dd;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalEvent$Dd;Lcom/datadog/android/rum/model/VitalEvent$DdSession;Lcom/datadog/android/rum/model/VitalEvent$Configuration;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$DdVital;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalEvent$Dd;
+	public final fun component5 ()Lcom/datadog/android/rum/model/VitalEvent$Vital1;
+	public final fun component6 ()Lcom/datadog/android/rum/model/VitalEvent$Profiling;
+	public final fun copy (Lcom/datadog/android/rum/model/VitalEvent$DdSession;Lcom/datadog/android/rum/model/VitalEvent$Configuration;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$Vital1;Lcom/datadog/android/rum/model/VitalEvent$Profiling;)Lcom/datadog/android/rum/model/VitalEvent$Dd;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalEvent$Dd;Lcom/datadog/android/rum/model/VitalEvent$DdSession;Lcom/datadog/android/rum/model/VitalEvent$Configuration;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$Vital1;Lcom/datadog/android/rum/model/VitalEvent$Profiling;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalEvent$Dd;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Dd;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$Dd;
 	public final fun getBrowserSdkVersion ()Ljava/lang/String;
 	public final fun getConfiguration ()Lcom/datadog/android/rum/model/VitalEvent$Configuration;
 	public final fun getFormatVersion ()J
+	public final fun getProfiling ()Lcom/datadog/android/rum/model/VitalEvent$Profiling;
 	public final fun getSdkName ()Ljava/lang/String;
 	public final fun getSession ()Lcom/datadog/android/rum/model/VitalEvent$DdSession;
-	public final fun getVital ()Lcom/datadog/android/rum/model/VitalEvent$DdVital;
+	public final fun getVital ()Lcom/datadog/android/rum/model/VitalEvent$Vital1;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
@@ -6388,28 +6574,6 @@ public final class com/datadog/android/rum/model/VitalEvent$DdSession {
 public final class com/datadog/android/rum/model/VitalEvent$DdSession$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$DdSession;
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$DdSession;
-}
-
-public final class com/datadog/android/rum/model/VitalEvent$DdVital {
-	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$DdVital$Companion;
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/Boolean;
-	public final fun copy (Ljava/lang/Boolean;)Lcom/datadog/android/rum/model/VitalEvent$DdVital;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalEvent$DdVital;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalEvent$DdVital;
-	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$DdVital;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$DdVital;
-	public final fun getComputedValue ()Ljava/lang/Boolean;
-	public fun hashCode ()I
-	public final fun toJson ()Lcom/google/gson/JsonElement;
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/datadog/android/rum/model/VitalEvent$DdVital$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$DdVital;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$DdVital;
 }
 
 public final class com/datadog/android/rum/model/VitalEvent$Device {
@@ -6511,6 +6675,22 @@ public final class com/datadog/android/rum/model/VitalEvent$EffectiveType$Compan
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$EffectiveType;
 }
 
+public final class com/datadog/android/rum/model/VitalEvent$ErrorReason : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$ErrorReason$Companion;
+	public static final field FAILED_TO_LAZY_LOAD Lcom/datadog/android/rum/model/VitalEvent$ErrorReason;
+	public static final field MISSING_DOCUMENT_POLICY_HEADER Lcom/datadog/android/rum/model/VitalEvent$ErrorReason;
+	public static final field NOT_SUPPORTED_BY_BROWSER Lcom/datadog/android/rum/model/VitalEvent$ErrorReason;
+	public static final field UNEXPECTED_EXCEPTION Lcom/datadog/android/rum/model/VitalEvent$ErrorReason;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$ErrorReason;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$ErrorReason;
+	public static fun values ()[Lcom/datadog/android/rum/model/VitalEvent$ErrorReason;
+}
+
+public final class com/datadog/android/rum/model/VitalEvent$ErrorReason$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$ErrorReason;
+}
+
 public final class com/datadog/android/rum/model/VitalEvent$FailureReason : java/lang/Enum {
 	public static final field ABANDONED Lcom/datadog/android/rum/model/VitalEvent$FailureReason;
 	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$FailureReason$Companion;
@@ -6588,6 +6768,46 @@ public final class com/datadog/android/rum/model/VitalEvent$Plan$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Plan;
 }
 
+public final class com/datadog/android/rum/model/VitalEvent$Profiling {
+	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$Profiling$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/datadog/android/rum/model/VitalEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalEvent$ErrorReason;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/VitalEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalEvent$ErrorReason;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/rum/model/VitalEvent$ProfilingStatus;
+	public final fun component2 ()Lcom/datadog/android/rum/model/VitalEvent$ErrorReason;
+	public final fun copy (Lcom/datadog/android/rum/model/VitalEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalEvent$ErrorReason;)Lcom/datadog/android/rum/model/VitalEvent$Profiling;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalEvent$Profiling;Lcom/datadog/android/rum/model/VitalEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalEvent$ErrorReason;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalEvent$Profiling;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Profiling;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$Profiling;
+	public final fun getErrorReason ()Lcom/datadog/android/rum/model/VitalEvent$ErrorReason;
+	public final fun getStatus ()Lcom/datadog/android/rum/model/VitalEvent$ProfilingStatus;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/VitalEvent$Profiling$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Profiling;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$Profiling;
+}
+
+public final class com/datadog/android/rum/model/VitalEvent$ProfilingStatus : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$ProfilingStatus$Companion;
+	public static final field ERROR Lcom/datadog/android/rum/model/VitalEvent$ProfilingStatus;
+	public static final field RUNNING Lcom/datadog/android/rum/model/VitalEvent$ProfilingStatus;
+	public static final field STARTING Lcom/datadog/android/rum/model/VitalEvent$ProfilingStatus;
+	public static final field STOPPED Lcom/datadog/android/rum/model/VitalEvent$ProfilingStatus;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$ProfilingStatus;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$ProfilingStatus;
+	public static fun values ()[Lcom/datadog/android/rum/model/VitalEvent$ProfilingStatus;
+}
+
+public final class com/datadog/android/rum/model/VitalEvent$ProfilingStatus$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$ProfilingStatus;
+}
+
 public final class com/datadog/android/rum/model/VitalEvent$SessionPrecondition : java/lang/Enum {
 	public static final field BACKGROUND_LAUNCH Lcom/datadog/android/rum/model/VitalEvent$SessionPrecondition;
 	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$SessionPrecondition$Companion;
@@ -6607,19 +6827,18 @@ public final class com/datadog/android/rum/model/VitalEvent$SessionPrecondition$
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$SessionPrecondition;
 }
 
-public final class com/datadog/android/rum/model/VitalEvent$Status : java/lang/Enum {
-	public static final field CONNECTED Lcom/datadog/android/rum/model/VitalEvent$Status;
-	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$Status$Companion;
-	public static final field MAYBE Lcom/datadog/android/rum/model/VitalEvent$Status;
-	public static final field NOT_CONNECTED Lcom/datadog/android/rum/model/VitalEvent$Status;
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Status;
+public final class com/datadog/android/rum/model/VitalEvent$StartupType : java/lang/Enum {
+	public static final field COLD_START Lcom/datadog/android/rum/model/VitalEvent$StartupType;
+	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$StartupType$Companion;
+	public static final field WARM_START Lcom/datadog/android/rum/model/VitalEvent$StartupType;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$StartupType;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
-	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Status;
-	public static fun values ()[Lcom/datadog/android/rum/model/VitalEvent$Status;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$StartupType;
+	public static fun values ()[Lcom/datadog/android/rum/model/VitalEvent$StartupType;
 }
 
-public final class com/datadog/android/rum/model/VitalEvent$Status$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Status;
+public final class com/datadog/android/rum/model/VitalEvent$StartupType$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$StartupType;
 }
 
 public final class com/datadog/android/rum/model/VitalEvent$StepType : java/lang/Enum {
@@ -6715,6 +6934,136 @@ public final class com/datadog/android/rum/model/VitalEvent$Viewport$Companion {
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$Viewport;
 }
 
+public abstract class com/datadog/android/rum/model/VitalEvent$Vital {
+	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$Vital$Companion;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Vital;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$Vital;
+	public abstract fun toJson ()Lcom/google/gson/JsonElement;
+}
+
+public final class com/datadog/android/rum/model/VitalEvent$Vital$AppLaunchProperties : com/datadog/android/rum/model/VitalEvent$Vital {
+	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$Vital$AppLaunchProperties$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$AppLaunchMetric;Ljava/lang/Number;Lcom/datadog/android/rum/model/VitalEvent$StartupType;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$AppLaunchMetric;Ljava/lang/Number;Lcom/datadog/android/rum/model/VitalEvent$StartupType;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lcom/datadog/android/rum/model/VitalEvent$AppLaunchMetric;
+	public final fun component5 ()Ljava/lang/Number;
+	public final fun component6 ()Lcom/datadog/android/rum/model/VitalEvent$StartupType;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$AppLaunchMetric;Ljava/lang/Number;Lcom/datadog/android/rum/model/VitalEvent$StartupType;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lcom/datadog/android/rum/model/VitalEvent$Vital$AppLaunchProperties;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalEvent$Vital$AppLaunchProperties;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$AppLaunchMetric;Ljava/lang/Number;Lcom/datadog/android/rum/model/VitalEvent$StartupType;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalEvent$Vital$AppLaunchProperties;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Vital$AppLaunchProperties;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$Vital$AppLaunchProperties;
+	public final fun getAppLaunchMetric ()Lcom/datadog/android/rum/model/VitalEvent$AppLaunchMetric;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getDuration ()Ljava/lang/Number;
+	public final fun getHasSavedInstanceStateBundle ()Ljava/lang/Boolean;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getStartupType ()Lcom/datadog/android/rum/model/VitalEvent$StartupType;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isPrewarmed ()Ljava/lang/Boolean;
+	public fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/VitalEvent$Vital$AppLaunchProperties$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Vital$AppLaunchProperties;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$Vital$AppLaunchProperties;
+}
+
+public final class com/datadog/android/rum/model/VitalEvent$Vital$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Vital;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$Vital;
+}
+
+public final class com/datadog/android/rum/model/VitalEvent$Vital$DurationProperties : com/datadog/android/rum/model/VitalEvent$Vital {
+	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$Vital$DurationProperties$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;)Lcom/datadog/android/rum/model/VitalEvent$Vital$DurationProperties;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalEvent$Vital$DurationProperties;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalEvent$Vital$DurationProperties;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Vital$DurationProperties;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$Vital$DurationProperties;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getDuration ()Ljava/lang/Number;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/VitalEvent$Vital$DurationProperties$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Vital$DurationProperties;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$Vital$DurationProperties;
+}
+
+public final class com/datadog/android/rum/model/VitalEvent$Vital$FeatureOperationProperties : com/datadog/android/rum/model/VitalEvent$Vital {
+	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$Vital$FeatureOperationProperties$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$StepType;Lcom/datadog/android/rum/model/VitalEvent$FailureReason;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$StepType;Lcom/datadog/android/rum/model/VitalEvent$FailureReason;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lcom/datadog/android/rum/model/VitalEvent$StepType;
+	public final fun component6 ()Lcom/datadog/android/rum/model/VitalEvent$FailureReason;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$StepType;Lcom/datadog/android/rum/model/VitalEvent$FailureReason;)Lcom/datadog/android/rum/model/VitalEvent$Vital$FeatureOperationProperties;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalEvent$Vital$FeatureOperationProperties;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$StepType;Lcom/datadog/android/rum/model/VitalEvent$FailureReason;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalEvent$Vital$FeatureOperationProperties;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Vital$FeatureOperationProperties;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$Vital$FeatureOperationProperties;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getFailureReason ()Lcom/datadog/android/rum/model/VitalEvent$FailureReason;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOperationKey ()Ljava/lang/String;
+	public final fun getStepType ()Lcom/datadog/android/rum/model/VitalEvent$StepType;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/VitalEvent$Vital$FeatureOperationProperties$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Vital$FeatureOperationProperties;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$Vital$FeatureOperationProperties;
+}
+
+public final class com/datadog/android/rum/model/VitalEvent$Vital1 {
+	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$Vital1$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/Boolean;)Lcom/datadog/android/rum/model/VitalEvent$Vital1;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalEvent$Vital1;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalEvent$Vital1;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Vital1;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$Vital1;
+	public final fun getComputedValue ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/VitalEvent$Vital1$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$Vital1;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$Vital1;
+}
+
 public final class com/datadog/android/rum/model/VitalEvent$VitalEventSession {
 	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$VitalEventSession$Companion;
 	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/VitalEvent$VitalEventSessionType;Ljava/lang/Boolean;)V
@@ -6803,55 +7152,6 @@ public final class com/datadog/android/rum/model/VitalEvent$VitalEventView {
 public final class com/datadog/android/rum/model/VitalEvent$VitalEventView$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$VitalEventView;
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$VitalEventView;
-}
-
-public final class com/datadog/android/rum/model/VitalEvent$VitalEventVital {
-	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$VitalEventVital$Companion;
-	public fun <init> (Lcom/datadog/android/rum/model/VitalEvent$VitalEventVitalType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/VitalEvent$StepType;Lcom/datadog/android/rum/model/VitalEvent$FailureReason;)V
-	public synthetic fun <init> (Lcom/datadog/android/rum/model/VitalEvent$VitalEventVitalType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/VitalEvent$StepType;Lcom/datadog/android/rum/model/VitalEvent$FailureReason;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/datadog/android/rum/model/VitalEvent$VitalEventVitalType;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/Number;
-	public final fun component7 ()Lcom/datadog/android/rum/model/VitalEvent$StepType;
-	public final fun component8 ()Lcom/datadog/android/rum/model/VitalEvent$FailureReason;
-	public final fun copy (Lcom/datadog/android/rum/model/VitalEvent$VitalEventVitalType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/VitalEvent$StepType;Lcom/datadog/android/rum/model/VitalEvent$FailureReason;)Lcom/datadog/android/rum/model/VitalEvent$VitalEventVital;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalEvent$VitalEventVital;Lcom/datadog/android/rum/model/VitalEvent$VitalEventVitalType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Lcom/datadog/android/rum/model/VitalEvent$StepType;Lcom/datadog/android/rum/model/VitalEvent$FailureReason;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalEvent$VitalEventVital;
-	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$VitalEventVital;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$VitalEventVital;
-	public final fun getDescription ()Ljava/lang/String;
-	public final fun getDuration ()Ljava/lang/Number;
-	public final fun getFailureReason ()Lcom/datadog/android/rum/model/VitalEvent$FailureReason;
-	public final fun getId ()Ljava/lang/String;
-	public final fun getName ()Ljava/lang/String;
-	public final fun getOperationKey ()Ljava/lang/String;
-	public final fun getStepType ()Lcom/datadog/android/rum/model/VitalEvent$StepType;
-	public final fun getType ()Lcom/datadog/android/rum/model/VitalEvent$VitalEventVitalType;
-	public fun hashCode ()I
-	public final fun toJson ()Lcom/google/gson/JsonElement;
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/datadog/android/rum/model/VitalEvent$VitalEventVital$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$VitalEventVital;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalEvent$VitalEventVital;
-}
-
-public final class com/datadog/android/rum/model/VitalEvent$VitalEventVitalType : java/lang/Enum {
-	public static final field Companion Lcom/datadog/android/rum/model/VitalEvent$VitalEventVitalType$Companion;
-	public static final field DURATION Lcom/datadog/android/rum/model/VitalEvent$VitalEventVitalType;
-	public static final field OPERATION_STEP Lcom/datadog/android/rum/model/VitalEvent$VitalEventVitalType;
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$VitalEventVitalType;
-	public final fun toJson ()Lcom/google/gson/JsonElement;
-	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$VitalEventVitalType;
-	public static fun values ()[Lcom/datadog/android/rum/model/VitalEvent$VitalEventVitalType;
-}
-
-public final class com/datadog/android/rum/model/VitalEvent$VitalEventVitalType$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalEvent$VitalEventVitalType;
 }
 
 public final class com/datadog/android/rum/resource/ContextExtKt {

--- a/features/dd-sdk-android-rum/generate_rum_models.gradle.kts
+++ b/features/dd-sdk-android-rum/generate_rum_models.gradle.kts
@@ -23,7 +23,8 @@ tasks.register(
         "_rect-schema.json",
         "_view-container-schema.json",
         "_view-accessibility-schema.json",
-        "_view-performance-schema.json"
+        "_view-performance-schema.json",
+        "_vital-common-schema.json"
     )
     inputNameMapping = mapOf(
         "action-schema.json" to "ActionEvent",

--- a/features/dd-sdk-android-rum/src/main/json/rum/_common-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/_common-schema.json
@@ -4,7 +4,7 @@
   "title": "CommonProperties",
   "type": "object",
   "description": "Schema of common properties of RUM events",
-  "required": ["date", "application", "session", "view", "_dd"],
+  "required": ["date", "application", "session", "_dd"],
   "properties": {
     "date": {
       "type": "integer",

--- a/features/dd-sdk-android-rum/src/main/json/rum/_vital-common-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/_vital-common-schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/_vital-common-schema.json",
+  "title": "VitalCommonProperties",
+  "type": "object",
+  "description": "Schema of common properties for a Vital event",
+  "allOf": [
+    {
+      "description": "Vital properties",
+      "required": ["id", "type"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "UUID of the vital",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the vital, as it is also used as facet path for its value, it must contain only letters, digits, or the characters - _ . @ $",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the vital. It can be used as a secondary identifier (URL, React component name...)",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    }
+  ]
+}

--- a/features/dd-sdk-android-rum/src/main/json/rum/action-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/action-schema.json
@@ -12,7 +12,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "action"],
+      "required": ["type", "view", "action"],
       "properties": {
         "type": {
           "type": "string",

--- a/features/dd-sdk-android-rum/src/main/json/rum/error-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/error-schema.json
@@ -15,7 +15,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "error"],
+      "required": ["type", "view", "error"],
       "properties": {
         "type": {
           "type": "string",

--- a/features/dd-sdk-android-rum/src/main/json/rum/long_task-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/long_task-schema.json
@@ -16,7 +16,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "long_task"],
+      "required": ["type", "view", "long_task"],
       "properties": {
         "type": {
           "type": "string",
@@ -61,19 +61,19 @@
             },
             "render_start": {
               "type": "number",
-              "description": "Start time of the rendering cycle, which includes requestAnimationFrame callbacks, style and layout calculation, resize observer and intersection observer callbacks",
+              "description": "Time difference (in ns) between the timeOrigin and the start time of the rendering cycle, which includes requestAnimationFrame callbacks, style and layout calculation, resize observer and intersection observer callbacks",
               "minimum": 0,
               "readOnly": true
             },
             "style_and_layout_start": {
               "type": "number",
-              "description": "Start time of the time period spent in style and layout calculations",
+              "description": "Time difference (in ns) between the timeOrigin and the start time of the time period spent in style and layout calculations",
               "minimum": 0,
               "readOnly": true
             },
             "first_ui_event_timestamp": {
               "type": "number",
-              "description": "Start time of of the first UI event (mouse/keyboard and so on) to be handled during the course of this frame",
+              "description": "Time difference (in ns) between the timeOrigin and the start time of of the first UI event (mouse/keyboard and so on) to be handled during the course of this frame",
               "minimum": 0,
               "readOnly": true
             },

--- a/features/dd-sdk-android-rum/src/main/json/rum/resource-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/resource-schema.json
@@ -15,7 +15,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "resource"],
+      "required": ["type", "view", "resource"],
       "properties": {
         "type": {
           "type": "string",

--- a/features/dd-sdk-android-rum/src/main/json/rum/vital-app-launch-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/vital-app-launch-schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/vital-app-launch-schema.json",
+  "title": "AppLaunchProperties",
+  "type": "object",
+  "description": "Schema for app launch metrics.",
+  "allOf": [
+    {
+      "$ref": "_vital-common-schema.json"
+    },
+    {
+      "required": ["type", "app_launch_metric", "duration"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type of the vital.",
+          "const": "app_launch",
+          "readOnly": true
+        },
+        "app_launch_metric": {
+          "type": "string",
+          "description": "The metric of the app launch.",
+          "enum": ["ttid", "ttfd"],
+          "readOnly": true
+        },
+        "duration": {
+          "type": "number",
+          "description": "Duration of the vital in nanoseconds.",
+          "readOnly": true
+        },
+        "startup_type": {
+          "type": "string",
+          "description": "The type of the app launch.",
+          "enum": ["cold_start", "warm_start"],
+          "readOnly": true
+        },
+        "is_prewarmed": {
+          "type": "boolean",
+          "description": "Whether the app launch was prewarmed.",
+          "readOnly": true
+        },
+        "has_saved_instance_state_bundle": {
+          "type": "boolean",
+          "description": "If the app launch had a saved instance state bundle.",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    }
+  ]
+}

--- a/features/dd-sdk-android-rum/src/main/json/rum/vital-duration-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/vital-duration-schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/vital-duration-schema.json",
+  "title": "DurationProperties",
+  "type": "object",
+  "description": "Duration properties of a Vital event",
+  "allOf": [
+    {
+      "$ref": "_vital-common-schema.json"
+    },
+    {
+      "required": ["type", "duration"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type of the vital.",
+          "const": "duration",
+          "readOnly": true
+        },
+        "duration": {
+          "type": "number",
+          "description": "Duration of the vital in nanoseconds.",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    }
+  ]
+}

--- a/features/dd-sdk-android-rum/src/main/json/rum/vital-feature-operation-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/vital-feature-operation-schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/vital-feature-operation-schema.json",
+  "title": "FeatureOperationProperties",
+  "type": "object",
+  "description": "Schema for a feature operation.",
+  "allOf": [
+    {
+      "$ref": "_vital-common-schema.json"
+    },
+    {
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type of the vital.",
+          "const": "operation_step",
+          "readOnly": true
+        },
+        "operation_key": {
+          "type": "string",
+          "description": "Optional key to distinguish between multiple operations of the same name running in parallel (e.g., 'photo_upload' with keys 'profile_pic' vs 'cover')",
+          "readOnly": true
+        },
+        "step_type": {
+          "type": "string",
+          "description": "Type of the step that triggered the vital, if applicable",
+          "enum": ["start", "update", "retry", "end"],
+          "readOnly": true
+        },
+        "failure_reason": {
+          "type": "string",
+          "description": "Reason for the failure of the step, if applicable",
+          "enum": ["error", "abandoned", "other"],
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    }
+  ]
+}

--- a/features/dd-sdk-android-rum/src/main/json/rum/vital-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/vital-schema.json
@@ -21,56 +21,17 @@
           "readOnly": true
         },
         "vital": {
-          "type": "object",
-          "description": "Vital properties",
-          "required": ["id", "type"],
-          "properties": {
-            "type": {
-              "type": "string",
-              "description": "Type of the vital",
-              "enum": ["duration", "operation_step"],
-              "readOnly": true
+          "oneOf": [
+            {
+              "$ref": "vital-duration-schema.json"
             },
-            "id": {
-              "type": "string",
-              "description": "UUID of the vital",
-              "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
-              "readOnly": true
+            {
+              "$ref": "vital-app-launch-schema.json"
             },
-            "operation_key": {
-              "type": "string",
-              "description": "UUID for distinguishing the active operations in parallel, if applicable",
-              "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
-              "readOnly": true
-            },
-            "name": {
-              "type": "string",
-              "description": "Name of the vital, as it is also used as facet path for its value, it must contain only letters, digits, or the characters - _ . @ $",
-              "readOnly": true
-            },
-            "description": {
-              "type": "string",
-              "description": "Description of the vital. It can be used as a secondary identifier (URL, React component name...)",
-              "readOnly": true
-            },
-            "duration": {
-              "type": "number",
-              "description": "Duration of the vital in nanoseconds",
-              "readOnly": true
-            },
-            "step_type": {
-              "type": "string",
-              "description": "Type of the step that triggered the vital, if applicable",
-              "enum": ["start", "update", "retry", "end"],
-              "readOnly": true
-            },
-            "failure_reason": {
-              "type": "string",
-              "description": "Reason for the failure of the step, if applicable",
-              "enum": ["error", "abandoned", "other"],
-              "readOnly": true
+            {
+              "$ref": "vital-feature-operation-schema.json"
             }
-          },
+          ],
           "readOnly": true
         },
         "_dd": {
@@ -88,6 +49,11 @@
                 }
               },
               "readOnly": true
+            },
+            "profiling": {
+              "type": "object",
+              "description": "Profiling context",
+              "allOf": [{ "$ref": "./_profiling-internal-context-schema.json" }]
             }
           },
           "readOnly": true

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
@@ -352,9 +352,9 @@ internal fun NetworkInfo.toActionConnectivity(): ActionEvent.Connectivity {
 
 internal fun NetworkInfo.toVitalConnectivity(): VitalEvent.Connectivity {
     val status = if (isConnected()) {
-        VitalEvent.Status.CONNECTED
+        VitalEvent.ConnectivityStatus.CONNECTED
     } else {
-        VitalEvent.Status.NOT_CONNECTED
+        VitalEvent.ConnectivityStatus.NOT_CONNECTED
     }
     val interfaces = when (connectivity) {
         NetworkInfo.Connectivity.NETWORK_ETHERNET -> listOf(VitalEvent.Interface.ETHERNET)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -401,13 +401,12 @@ internal open class RumViewScope(
             version = datadogContext.version,
             service = datadogContext.service,
             ddtags = buildDDTagsString(datadogContext),
-            vital = VitalEvent.VitalEventVital(
+            vital = VitalEvent.Vital.FeatureOperationProperties(
                 id = UUID.randomUUID().toString(),
                 name = name,
                 operationKey = operationKey,
                 stepType = stepType,
-                failureReason = failureReason,
-                type = VitalEvent.VitalEventVitalType.OPERATION_STEP
+                failureReason = failureReason
             )
         )
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/VitalEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/VitalEventAssert.kt
@@ -8,10 +8,8 @@ package com.datadog.android.rum.assertj
 import com.datadog.android.api.context.AccountInfo
 import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.api.context.UserInfo
-import com.datadog.android.rum.featureoperations.FailureReason
 import com.datadog.android.rum.internal.domain.scope.RumSessionScope
 import com.datadog.android.rum.internal.domain.scope.isConnected
-import com.datadog.android.rum.internal.domain.scope.toSchemaFailureReason
 import com.datadog.android.rum.internal.domain.scope.toVitalSessionPrecondition
 import com.datadog.android.rum.model.VitalEvent
 import com.datadog.android.rum.model.VitalEvent.VitalEventSessionType
@@ -91,73 +89,25 @@ internal class VitalEventAssert(actual: VitalEvent) : AbstractObjectAssert<Vital
     }
 
     fun hasViewId(expectedId: String) = apply {
-        assertThat(actual.view.id)
+        assertThat(actual.view?.id)
             .overridingErrorMessage(
-                "Expected event data to have view.id $expectedId but was ${actual.view.id}"
+                "Expected event data to have view.id $expectedId but was ${actual.view?.id}"
             )
             .isEqualTo(expectedId)
     }
 
     fun hasName(expected: String) = apply {
-        assertThat(actual.view.name)
+        assertThat(actual.view?.name)
             .overridingErrorMessage(
-                "Expected event data to have view.name $expected but was ${actual.view.name}"
+                "Expected event data to have view.name $expected but was ${actual.view?.name}"
             )
             .isEqualTo(expected)
     }
 
     fun hasUrl(expected: String) = apply {
-        assertThat(actual.view.url)
+        assertThat(actual.view?.url)
             .overridingErrorMessage(
-                "Expected event data to have view.url $expected but was ${actual.view.url}"
-            )
-            .isEqualTo(expected)
-    }
-
-    fun hasVitalName(expected: String) = apply {
-        assertThat(actual.vital.name)
-            .overridingErrorMessage(
-                "Expected event data to have vital.name $expected but was ${actual.vital.name}"
-            )
-            .isEqualTo(expected)
-    }
-
-    fun hasVitalOperationalKey(expected: String?) = apply {
-        assertThat(actual.vital.operationKey)
-            .overridingErrorMessage(
-                "Expected event data to have vital.operationKey $expected but was ${actual.vital.operationKey}"
-            )
-            .isEqualTo(expected)
-    }
-
-    fun hasVitalStepType(expected: VitalEvent.StepType) = apply {
-        assertThat(actual.vital.stepType)
-            .overridingErrorMessage(
-                "Expected event data to have vital.operationKey $expected but was ${actual.vital.stepType}"
-            )
-            .isEqualTo(expected)
-    }
-
-    fun hasVitalFailureReason(expected: FailureReason) = apply {
-        assertThat(actual.vital.failureReason)
-            .overridingErrorMessage(
-                "Expected event data to have vital.failureReason $expected but was ${actual.vital.failureReason}"
-            )
-            .isEqualTo(expected.toSchemaFailureReason())
-    }
-
-    fun hasNoVitalFailureReason() = apply {
-        assertThat(actual.vital.failureReason)
-            .overridingErrorMessage(
-                "Expected event data to have vital.failureReason to be null but was ${actual.vital.failureReason}"
-            )
-            .isNull()
-    }
-
-    fun hasVitalType(expected: VitalEvent.VitalEventVitalType) = apply {
-        assertThat(actual.vital.type)
-            .overridingErrorMessage(
-                "Expected event data to have vital.type $expected but was ${actual.vital.type}"
+                "Expected event data to have view.url $expected but was ${actual.view?.url}"
             )
             .isEqualTo(expected)
     }
@@ -306,9 +256,9 @@ internal class VitalEventAssert(actual: VitalEvent) : AbstractObjectAssert<Vital
 
     fun hasConnectivityInfo(expected: NetworkInfo?) = apply {
         val expectedStatus = if (expected?.isConnected() == true) {
-            VitalEvent.Status.CONNECTED
+            VitalEvent.ConnectivityStatus.CONNECTED
         } else {
-            VitalEvent.Status.NOT_CONNECTED
+            VitalEvent.ConnectivityStatus.NOT_CONNECTED
         }
         val expectedInterfaces = when (expected?.connectivity) {
             NetworkInfo.Connectivity.NETWORK_ETHERNET -> listOf(VitalEvent.Interface.ETHERNET)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/VitalFeatureOperationPropertiesAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/VitalFeatureOperationPropertiesAssert.kt
@@ -1,0 +1,67 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.assertj
+
+import com.datadog.android.rum.featureoperations.FailureReason
+import com.datadog.android.rum.internal.domain.scope.toSchemaFailureReason
+import com.datadog.android.rum.model.VitalEvent
+import org.assertj.core.api.AbstractObjectAssert
+import org.assertj.core.api.Assertions.assertThat
+
+internal class VitalFeatureOperationPropertiesAssert(actual: VitalEvent.Vital.FeatureOperationProperties) :
+    AbstractObjectAssert<VitalFeatureOperationPropertiesAssert, VitalEvent.Vital.FeatureOperationProperties>(
+        actual,
+        VitalFeatureOperationPropertiesAssert::class.java
+    ) {
+
+    fun hasVitalName(expected: String) = apply {
+        assertThat(actual.name)
+            .overridingErrorMessage(
+                "Expected event data to have vital.name $expected but was ${actual.name}"
+            )
+            .isEqualTo(expected)
+    }
+
+    fun hasVitalOperationalKey(expected: String?) = apply {
+        assertThat(actual.operationKey)
+            .overridingErrorMessage(
+                "Expected event data to have vital.operationKey $expected but was ${actual.operationKey}"
+            )
+            .isEqualTo(expected)
+    }
+
+    fun hasVitalStepType(expected: VitalEvent.StepType) = apply {
+        assertThat(actual.stepType)
+            .overridingErrorMessage(
+                "Expected event data to have vital.operationKey $expected but was ${actual.stepType}"
+            )
+            .isEqualTo(expected)
+    }
+
+    fun hasVitalFailureReason(expected: FailureReason) = apply {
+        assertThat(actual.failureReason)
+            .overridingErrorMessage(
+                "Expected event data to have vital.failureReason $expected but was ${actual.failureReason}"
+            )
+            .isEqualTo(expected.toSchemaFailureReason())
+    }
+
+    fun hasNoVitalFailureReason() = apply {
+        assertThat(actual.failureReason)
+            .overridingErrorMessage(
+                "Expected event data to have vital.failureReason to be null but was ${actual.failureReason}"
+            )
+            .isNull()
+    }
+
+    companion object {
+        internal fun assertThat(
+            actual: VitalEvent.Vital.FeatureOperationProperties
+        ): VitalFeatureOperationPropertiesAssert =
+            VitalFeatureOperationPropertiesAssert(actual)
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
@@ -566,13 +566,18 @@ internal class RumEventSerializerTest {
             .hasField("type", "vital")
             .hasField("date", event.date)
             .hasField("vital") {
-                hasField("type", event.vital.type.toJson())
-                event.vital.name?.let { hasField("name", it) }
-                event.vital.operationKey?.let { hasField("operation_key", it) }
-                event.vital.description?.let { hasField("description", it) }
-                event.vital.duration?.let { hasField("duration", it) }
-                event.vital.stepType?.let { hasField("step_type", it.toJson()) }
-                event.vital.failureReason?.let { hasField("failure_reason", it.toJson()) }
+                when (val vital = event.vital) {
+                    is VitalEvent.Vital.FeatureOperationProperties -> {
+                        hasField("type", vital.type)
+                        vital.name?.let { hasField("name", it) }
+                        vital.operationKey?.let { hasField("operation_key", it) }
+                        vital.description?.let { hasField("description", it) }
+                        vital.stepType?.let { hasField("step_type", it.toJson()) }
+                        vital.failureReason?.let { hasField("failure_reason", it.toJson()) }
+                    }
+                    is VitalEvent.Vital.DurationProperties,
+                    is VitalEvent.Vital.AppLaunchProperties -> TODO("SDK doesn't support this vital type yet")
+                }
             }
             .hasField("application") {
                 hasField("id", event.application.id)
@@ -583,10 +588,11 @@ internal class RumEventSerializerTest {
                 event.session.hasReplay?.let { hasField("has_replay", it) }
             }
             .hasField("view") {
-                hasField("id", event.view.id)
-                hasField("url", event.view.url)
-                event.view.referrer?.let { hasField("referrer", it) }
-                event.view.name?.let { hasField("name", it) }
+                val view = checkNotNull(event.view)
+                hasField("id", view.id)
+                hasField("url", view.url)
+                view.referrer?.let { hasField("referrer", it) }
+                view.name?.let { hasField("name", it) }
             }
             .hasField("_dd") {
                 event.dd.browserSdkVersion?.let { hasField("browser_sdk_version", it) }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -31,6 +31,7 @@ import com.datadog.android.rum.assertj.ErrorEventAssert.Companion.assertThat
 import com.datadog.android.rum.assertj.LongTaskEventAssert.Companion.assertThat
 import com.datadog.android.rum.assertj.ViewEventAssert.Companion.assertThat
 import com.datadog.android.rum.assertj.VitalEventAssert
+import com.datadog.android.rum.assertj.VitalFeatureOperationPropertiesAssert
 import com.datadog.android.rum.featureoperations.FailureReason
 import com.datadog.android.rum.internal.FeaturesContextResolver
 import com.datadog.android.rum.internal.RumErrorSourceType
@@ -8702,12 +8703,7 @@ internal class RumViewScopeTest {
                 .hasViewId(testedScope.viewId)
                 .hasName(fakeKey.name)
                 .hasUrl(fakeUrl)
-                .hasVitalName(fakeName)
-                .hasVitalOperationalKey(fakeOperationKey)
                 .hasNoSyntheticsTest()
-                .hasVitalStepType(VitalEvent.StepType.START)
-                .hasNoVitalFailureReason()
-                .hasVitalType(VitalEvent.VitalEventVitalType.OPERATION_STEP)
                 .hasSource(fakeVitalSourceEvent)
                 .hasAccountInfo(fakeDatadogContext.accountInfo)
                 .hasUserInfo(fakeDatadogContext.userInfo)
@@ -8727,6 +8723,16 @@ internal class RumViewScopeTest {
                 .hasVersion(fakeDatadogContext.version)
                 .hasServiceName(fakeDatadogContext.service)
                 .hasDDTags(buildDDTagsString(fakeDatadogContext))
+
+            val featureOperationsProps = lastValue.vital
+
+            check(featureOperationsProps is VitalEvent.Vital.FeatureOperationProperties)
+
+            VitalFeatureOperationPropertiesAssert.assertThat(featureOperationsProps)
+                .hasVitalName(fakeName)
+                .hasVitalOperationalKey(fakeOperationKey)
+                .hasVitalStepType(VitalEvent.StepType.START)
+                .hasNoVitalFailureReason()
         }
     }
 
@@ -8769,12 +8775,7 @@ internal class RumViewScopeTest {
                 .hasViewId(testedScope.viewId)
                 .hasName(fakeKey.name)
                 .hasUrl(fakeUrl)
-                .hasVitalName(fakeName)
-                .hasVitalOperationalKey(fakeOperationKey)
                 .hasSyntheticsTest(fakeTestId, fakeResultId)
-                .hasVitalStepType(VitalEvent.StepType.START)
-                .hasNoVitalFailureReason()
-                .hasVitalType(VitalEvent.VitalEventVitalType.OPERATION_STEP)
                 .hasSource(fakeVitalSourceEvent)
                 .hasAccountInfo(fakeDatadogContext.accountInfo)
                 .hasUserInfo(fakeDatadogContext.userInfo)
@@ -8794,6 +8795,16 @@ internal class RumViewScopeTest {
                 .hasVersion(fakeDatadogContext.version)
                 .hasServiceName(fakeDatadogContext.service)
                 .hasDDTags(buildDDTagsString(fakeDatadogContext))
+
+            val featureOperationsProps = lastValue.vital
+
+            check(featureOperationsProps is VitalEvent.Vital.FeatureOperationProperties)
+
+            VitalFeatureOperationPropertiesAssert.assertThat(featureOperationsProps)
+                .hasVitalName(fakeName)
+                .hasVitalOperationalKey(fakeOperationKey)
+                .hasVitalStepType(VitalEvent.StepType.START)
+                .hasNoVitalFailureReason()
         }
     }
 
@@ -8834,11 +8845,6 @@ internal class RumViewScopeTest {
                 .hasViewId(testedScope.viewId)
                 .hasName(fakeKey.name)
                 .hasUrl(fakeUrl)
-                .hasVitalName(fakeName)
-                .hasVitalOperationalKey(fakeOperationKey)
-                .hasVitalStepType(VitalEvent.StepType.END)
-                .hasNoVitalFailureReason()
-                .hasVitalType(VitalEvent.VitalEventVitalType.OPERATION_STEP)
                 .hasSource(fakeVitalSourceEvent)
                 .hasAccountInfo(fakeDatadogContext.accountInfo)
                 .hasUserInfo(fakeDatadogContext.userInfo)
@@ -8858,6 +8864,16 @@ internal class RumViewScopeTest {
                 .hasVersion(fakeDatadogContext.version)
                 .hasServiceName(fakeDatadogContext.service)
                 .hasDDTags(buildDDTagsString(fakeDatadogContext))
+
+            val featureOperationsProps = lastValue.vital
+
+            check(featureOperationsProps is VitalEvent.Vital.FeatureOperationProperties)
+
+            VitalFeatureOperationPropertiesAssert.assertThat(featureOperationsProps)
+                .hasVitalName(fakeName)
+                .hasVitalOperationalKey(fakeOperationKey)
+                .hasVitalStepType(VitalEvent.StepType.END)
+                .hasNoVitalFailureReason()
         }
     }
 
@@ -8901,11 +8917,6 @@ internal class RumViewScopeTest {
                 .hasName(fakeKey.name)
                 .hasSyntheticsTest(fakeTestId, fakeResultId)
                 .hasUrl(fakeUrl)
-                .hasVitalName(fakeName)
-                .hasVitalOperationalKey(fakeOperationKey)
-                .hasVitalStepType(VitalEvent.StepType.END)
-                .hasNoVitalFailureReason()
-                .hasVitalType(VitalEvent.VitalEventVitalType.OPERATION_STEP)
                 .hasSource(fakeVitalSourceEvent)
                 .hasAccountInfo(fakeDatadogContext.accountInfo)
                 .hasUserInfo(fakeDatadogContext.userInfo)
@@ -8925,6 +8936,16 @@ internal class RumViewScopeTest {
                 .hasVersion(fakeDatadogContext.version)
                 .hasServiceName(fakeDatadogContext.service)
                 .hasDDTags(buildDDTagsString(fakeDatadogContext))
+
+            val featureOperationsProps = lastValue.vital
+
+            check(featureOperationsProps is VitalEvent.Vital.FeatureOperationProperties)
+
+            VitalFeatureOperationPropertiesAssert.assertThat(featureOperationsProps)
+                .hasVitalName(fakeName)
+                .hasVitalOperationalKey(fakeOperationKey)
+                .hasVitalStepType(VitalEvent.StepType.END)
+                .hasNoVitalFailureReason()
         }
     }
 
@@ -8966,11 +8987,6 @@ internal class RumViewScopeTest {
                 .hasNoSyntheticsTest()
                 .hasName(fakeKey.name)
                 .hasUrl(fakeUrl)
-                .hasVitalName(fakeName)
-                .hasVitalOperationalKey(fakeOperationKey)
-                .hasVitalStepType(VitalEvent.StepType.END)
-                .hasVitalFailureReason(failureReason)
-                .hasVitalType(VitalEvent.VitalEventVitalType.OPERATION_STEP)
                 .hasSource(fakeVitalSourceEvent)
                 .hasAccountInfo(fakeDatadogContext.accountInfo)
                 .hasUserInfo(fakeDatadogContext.userInfo)
@@ -8990,6 +9006,16 @@ internal class RumViewScopeTest {
                 .hasVersion(fakeDatadogContext.version)
                 .hasServiceName(fakeDatadogContext.service)
                 .hasDDTags(buildDDTagsString(fakeDatadogContext))
+
+            val featureOperationsProps = lastValue.vital
+
+            check(featureOperationsProps is VitalEvent.Vital.FeatureOperationProperties)
+
+            VitalFeatureOperationPropertiesAssert.assertThat(featureOperationsProps)
+                .hasVitalName(fakeName)
+                .hasVitalOperationalKey(fakeOperationKey)
+                .hasVitalStepType(VitalEvent.StepType.END)
+                .hasVitalFailureReason(failureReason)
         }
     }
 
@@ -9035,11 +9061,6 @@ internal class RumViewScopeTest {
                 .hasViewId(testedScope.viewId)
                 .hasName(fakeKey.name)
                 .hasUrl(fakeUrl)
-                .hasVitalName(fakeName)
-                .hasVitalOperationalKey(fakeOperationKey)
-                .hasVitalStepType(VitalEvent.StepType.END)
-                .hasVitalFailureReason(failureReason)
-                .hasVitalType(VitalEvent.VitalEventVitalType.OPERATION_STEP)
                 .hasSource(fakeVitalSourceEvent)
                 .hasAccountInfo(fakeDatadogContext.accountInfo)
                 .hasUserInfo(fakeDatadogContext.userInfo)
@@ -9059,6 +9080,16 @@ internal class RumViewScopeTest {
                 .hasVersion(fakeDatadogContext.version)
                 .hasServiceName(fakeDatadogContext.service)
                 .hasDDTags(buildDDTagsString(fakeDatadogContext))
+
+            val featureOperationsProps = lastValue.vital
+
+            check(featureOperationsProps is VitalEvent.Vital.FeatureOperationProperties)
+
+            VitalFeatureOperationPropertiesAssert.assertThat(featureOperationsProps)
+                .hasVitalName(fakeName)
+                .hasVitalOperationalKey(fakeOperationKey)
+                .hasVitalStepType(VitalEvent.StepType.END)
+                .hasVitalFailureReason(failureReason)
         }
     }
     // endregion

--- a/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/VitalEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/VitalEventForgeryFactory.kt
@@ -64,9 +64,8 @@ class VitalEventForgeryFactory : ForgeryFactory<VitalEvent> {
                 url = forge.aStringMatching("https://[a-z]+.[a-z]{3}/[a-z0-9_/]+"),
                 name = forge.aNullable { anAlphabeticalString() }
             ),
-            vital = VitalEvent.VitalEventVital(
+            vital = VitalEvent.Vital.FeatureOperationProperties(
                 id = forge.aString(),
-                type = forge.aValueFrom(VitalEvent.VitalEventVitalType::class.java),
                 operationKey = forge.aNullable { aString() },
                 name = forge.anAlphabeticalString(),
                 stepType = forge.aValueFrom(StepType::class.java),


### PR DESCRIPTION
### What does this PR do?

This PR pulls the most recent RUM events schema and updates the code to use it.

The goal is to use the new application launch vital introduced [here](https://github.com/DataDog/rum-events-format/pull/302). But it will be done in future PRs. I plan to merge this PR to develop.

The current PR:
1. Fixes the build errors and adapts code related to feature operations to the schema changes.
2. Fixes the json parser generator so that the following schema works correctly:
```
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "title": "RequiredForOtherAllOf",
  "type": "object",
  "allOf": [
    {
      "type": "object",
      "properties": {
        "key_1": { "type": "string" }
      }
    },
    {
      "type": "object",
      "required": ["key_1", "key_2"],
      "properties": {
        "key_2": { "type": "string" }
      }
    }
  ]
}
```
`key_1` should be non-null in the resulting `data class`. See other comments in the PR for further explanation. This change is needed to properly support [this](https://github.com/DataDog/rum-events-format/pull/306) change. Otherwise `view` becomes optional for example in `ErrorEvent` which is not what we intended to do.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

