### PR TITLE
feat: Support sending anonymous user ids in logs.

### DIFF
--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/user/DatadogUserInfoProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/user/DatadogUserInfoProviderTest.kt
@@ -55,6 +55,7 @@ internal class DatadogUserInfoProviderTest {
         val validUserInfo = userInfo.copy(id = nonNullUserId)
 
         // When
+        testedProvider.setAnonymousId(userInfo.anonymousId)
         testedProvider.setUserInfo(nonNullUserId, userInfo.name, userInfo.email, userInfo.additionalProperties)
         val result = testedProvider.getUserInfo()
 

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/UserInfoForgeryFactory.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/UserInfoForgeryFactory.kt
@@ -14,6 +14,7 @@ class UserInfoForgeryFactory : ForgeryFactory<UserInfo> {
 
     override fun getForgery(forge: Forge): UserInfo {
         return UserInfo(
+            anonymousId = forge.aNullable() { anHexadecimalString() },
             id = forge.aNullable { anHexadecimalString() },
             name = forge.aNullable { forge.aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
             email = forge.aNullable { forge.aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },

--- a/features/dd-sdk-android-logs/api/apiSurface
+++ b/features/dd-sdk-android-logs/api/apiSurface
@@ -65,7 +65,7 @@ data class com.datadog.android.log.model.LogEvent
       fun fromJson(kotlin.String): Dd
       fun fromJsonObject(com.google.gson.JsonObject): Dd
   data class Usr
-    constructor(kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
+    constructor(kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Usr

--- a/features/dd-sdk-android-logs/api/dd-sdk-android-logs.api
+++ b/features/dd-sdk-android-logs/api/dd-sdk-android-logs.api
@@ -475,18 +475,20 @@ public final class com/datadog/android/log/model/LogEvent$Type$Companion {
 public final class com/datadog/android/log/model/LogEvent$Usr {
 	public static final field Companion Lcom/datadog/android/log/model/LogEvent$Usr$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/util/Map;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/datadog/android/log/model/LogEvent$Usr;
-	public static synthetic fun copy$default (Lcom/datadog/android/log/model/LogEvent$Usr;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/datadog/android/log/model/LogEvent$Usr;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/datadog/android/log/model/LogEvent$Usr;
+	public static synthetic fun copy$default (Lcom/datadog/android/log/model/LogEvent$Usr;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/datadog/android/log/model/LogEvent$Usr;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/log/model/LogEvent$Usr;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/log/model/LogEvent$Usr;
 	public final fun getAdditionalProperties ()Ljava/util/Map;
+	public final fun getAnonymousId ()Ljava/lang/String;
 	public final fun getEmail ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;

--- a/features/dd-sdk-android-logs/src/main/json/log/log-schema.json
+++ b/features/dd-sdk-android-logs/src/main/json/log/log-schema.json
@@ -95,6 +95,11 @@
       "type": "object",
       "description": "User properties",
       "properties": {
+        "anonymous_id": {
+          "type": "string",
+          "description": "An anonymous identifier of the user across sessions",
+          "readOnly": true
+        },
         "id": {
           "type": "string",
           "description": "Identifier of the user",

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/domain/DatadogLogGenerator.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/domain/DatadogLogGenerator.kt
@@ -280,6 +280,7 @@ internal class DatadogLogGenerator(
     private fun resolveUserInfo(datadogContext: DatadogContext, userInfo: UserInfo?): LogEvent.Usr {
         return with(userInfo ?: datadogContext.userInfo) {
             LogEvent.Usr(
+                anonymousId = anonymousId,
                 name = name,
                 email = email,
                 id = id,

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/assertj/LogEventAssert.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/assertj/LogEventAssert.kt
@@ -197,6 +197,13 @@ internal class LogEventAssert(actual: LogEvent) :
     }
 
     fun hasUserInfo(userInfo: UserInfo): LogEventAssert {
+        assertThat(actual.usr?.anonymousId)
+            .overridingErrorMessage(
+                "Expected LogEvent to have anonymousId: " +
+                    "${userInfo.anonymousId} but " +
+                    "instead was: ${actual.usr?.anonymousId}"
+            )
+            .isEqualTo(userInfo.anonymousId)
         assertThat(actual.usr?.name)
             .overridingErrorMessage(
                 "Expected LogEvent to have user name: " +

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/domain/event/LogEventSerializerTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/domain/event/LogEventSerializerTest.kt
@@ -349,6 +349,12 @@ internal class LogEventSerializerTest {
         val userName = userInfo.name
         val userEmail = userInfo.email
         val userId = userInfo.id
+        val anonymousId = userInfo.anonymousId
+        if (anonymousId != null) {
+            hasField(KEY_USR_ANONYMOUS_ID, anonymousId)
+        } else {
+            doesNotHaveField(KEY_USR_ANONYMOUS_ID)
+        }
         if (userId != null) {
             hasField(KEY_USR_ID, userId)
         } else {
@@ -542,6 +548,7 @@ internal class LogEventSerializerTest {
         private const val KEY_CLIENT = "client"
         private const val KEY_USR_NAME = "name"
         private const val KEY_USR_EMAIL = "email"
+        private const val KEY_USR_ANONYMOUS_ID = "anonymous_id"
         private const val KEY_USR_ID = "id"
         private const val KEY_ACCOUNT_NAME = "name"
         private const val KEY_ACCOUNT_ID = "id"

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/utils/forge/LogEventForgeryFactory.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/utils/forge/LogEventForgeryFactory.kt
@@ -60,6 +60,7 @@ internal class LogEventForgeryFactory : ForgeryFactory<LogEvent> {
             ddtags = forge.exhaustiveTags().joinToString(separator = ","),
             usr = forge.aNullable {
                 LogEvent.Usr(
+                    anonymousId = userInfo?.anonymousId,
                     id = userInfo?.id,
                     name = userInfo?.name,
                     email = userInfo?.email,


### PR DESCRIPTION
### What does this PR do?

RUM supports tracking users anonymously through an anonymous user id. Other platforms add this id to the `usr` attribute in logs, but Android currently does not, so this adds support for it.

### Motivation

When implementing the new User and Account information APIs, Flutter integration tests that were checking for the anonymous user id in logs noticed it was missing.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

