### PR TITLE
[flags] FFL-1237: Add telemetry for critical paths

### DIFF
--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/featureflags/internal/DatadogFlagsClient.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/featureflags/internal/DatadogFlagsClient.kt
@@ -173,10 +173,8 @@ internal class DatadogFlagsClient(
                 level = InternalLogger.Level.ERROR,
                 messageBuilder = { ERROR_NO_EVALUATION_CONTEXT }
             )
-        } else {
-            if (flagsConfiguration.trackExposures) {
-                writeExposureEvent(flagKey, precomputedFlag, evaluationContext)
-            }
+        } else if (flagsConfiguration.trackExposures) {
+            writeExposureEvent(flagKey, precomputedFlag, evaluationContext)
         }
 
         if (flagsConfiguration.rumIntegrationEnabled) {

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/featureflags/internal/persistence/FlagsStateDeserializer.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/featureflags/internal/persistence/FlagsStateDeserializer.kt
@@ -44,6 +44,15 @@ internal class FlagsStateDeserializer(private val internalLogger: InternalLogger
             { "Failed to deserialize FlagsStateEntry from JSON" },
             e
         )
+
+        internalLogger.log(
+            level = InternalLogger.Level.ERROR,
+            target = InternalLogger.Target.TELEMETRY,
+            messageBuilder = { "Failed to parse persisted flag state" },
+            throwable = e,
+            onlyOnce = true
+        )
+
         null
     }
 

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/featureflags/internal/repository/net/PrecomputeMapper.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/featureflags/internal/repository/net/PrecomputeMapper.kt
@@ -59,6 +59,14 @@ internal class PrecomputeMapper(private val internalLogger: InternalLogger) {
             throwable = e
         )
 
+        internalLogger.log(
+            level = InternalLogger.Level.WARN,
+            target = InternalLogger.Target.TELEMETRY,
+            messageBuilder = { ERROR_FAILED_TO_PARSE_RESPONSE },
+            throwable = e,
+            onlyOnce = true
+        )
+
         emptyMap()
     }
 

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/net/ExposuresRequestFactory.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/net/ExposuresRequestFactory.kt
@@ -35,7 +35,7 @@ internal class ExposuresRequestFactory(
             url = url,
             headers = buildHeaders(
                 requestId,
-                context.clientToken, // replace when testing
+                context.clientToken,
                 context.source,
                 context.sdkVersion
             ),

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsDownloader.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsDownloader.kt
@@ -37,22 +37,6 @@ internal class PrecomputedAssignmentsDownloader(
     private fun executeDownloadRequest(request: Request): String? = try {
         val response = callFactory.newCall(request).execute()
         handleResponse(response)
-    } catch (e: IllegalStateException) {
-        internalLogger.log(
-            InternalLogger.Level.ERROR,
-            InternalLogger.Target.MAINTAINER,
-            { "Invalid state while downloading flags" },
-            e
-        )
-        null
-    } catch (e: IllegalArgumentException) {
-        internalLogger.log(
-            InternalLogger.Level.ERROR,
-            InternalLogger.Target.MAINTAINER,
-            { "Invalid argument while downloading flags" },
-            e
-        )
-        null
     } catch (e: Throwable) {
         internalLogger.log(
             InternalLogger.Level.ERROR,
@@ -70,6 +54,13 @@ internal class PrecomputedAssignmentsDownloader(
             InternalLogger.Level.ERROR,
             InternalLogger.Target.MAINTAINER,
             { "Failed to download flags: ${response.code}" }
+        )
+
+        internalLogger.log(
+            level = InternalLogger.Level.ERROR,
+            target = InternalLogger.Target.TELEMETRY,
+            messageBuilder = { "Flag assignment server returned error (${response.code})" },
+            onlyOnce = true
         )
 
         null

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsRequestFactory.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsRequestFactory.kt
@@ -40,7 +40,7 @@ internal class PrecomputedAssignmentsRequestFactory(private val internalLogger: 
     fun create(context: EvaluationContext, flagsContext: FlagsContext): Request? {
         val url = flagsContext.flagEndpoint ?: return null
 
-        val headers = buildHeaders(flagsContext)
+        val headers = buildHeaders(flagsContext) ?: return null
 
         val body = buildRequestBody(context, flagsContext) ?: return null
 
@@ -51,7 +51,7 @@ internal class PrecomputedAssignmentsRequestFactory(private val internalLogger: 
             .build()
     }
 
-    private fun buildHeaders(flagsContext: FlagsContext): Headers {
+    private fun buildHeaders(flagsContext: FlagsContext): Headers? {
         val headersBuilder = Headers.Builder()
 
         try {
@@ -69,6 +69,7 @@ internal class PrecomputedAssignmentsRequestFactory(private val internalLogger: 
                 { "Failed to build HTTP headers: invalid header values" },
                 e
             )
+            return null
         }
 
         return headersBuilder.build()

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsDownloaderTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsDownloaderTest.kt
@@ -327,6 +327,18 @@ internal class PrecomputedAssignmentsDownloaderTest {
         )
         assertThat(messageCaptor.firstValue.invoke())
             .isEqualTo("Failed to download flags: 404")
+
+        val telemetryMessageCaptor = argumentCaptor<() -> String>()
+        verify(mockInternalLogger).log(
+            eq(InternalLogger.Level.ERROR),
+            eq(InternalLogger.Target.TELEMETRY),
+            telemetryMessageCaptor.capture(),
+            eq(null),
+            eq(true),
+            eq(null)
+        )
+        assertThat(telemetryMessageCaptor.firstValue.invoke())
+            .isEqualTo("Flag assignment server returned error (404)")
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
Add telemetry for errors when downloading precomputed flags and parsing them, and for errors reading precomputed flag data from the datastore.

### Motivation
Cover critical paths with telemetry.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

