### PR TITLE
RUM-11785: Do not create a new session for TTID

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -218,14 +218,13 @@ internal class RumSessionScope(
         val isBackgroundEvent = event.javaClass in RumViewManagerScope.validBackgroundEventTypes
         val isSdkInitInForeground = event is RumRawEvent.SdkInit && event.isAppInForeground
         val isSdkInitInBackground = event is RumRawEvent.SdkInit && !event.isAppInForeground
-        val isAppStartEvent = event is RumRawEvent.AppStartTTIDEvent
 
         // When the session is expired, time-out or stopSession API is called, session ended metric should be sent
         if (isExpired || isTimedOut || isActive.not()) {
             sessionEndedMetricDispatcher.endMetric(sessionId, sdkCore.time.serverTimeOffsetMs)
         }
 
-        if (isInteraction || isSdkInitInForeground || isAppStartEvent) {
+        if (isInteraction || isSdkInitInForeground) {
             if (isNewSession || isExpired || isTimedOut) {
                 val reason = if (isNewSession) {
                     StartReason.USER_APP_LAUNCH

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -1424,7 +1424,7 @@ internal class RumSessionScopeTest {
 
     @ParameterizedTest
     @MethodSource("testScenarios")
-    fun `M call reportTTID and create new session W handleEvent { AppLaunchTTIDEvent }`(
+    fun `M call reportTTID W handleEvent { AppLaunchTTIDEvent }`(
         scenario: RumStartupScenario,
         forge: Forge
     ) {
@@ -1436,6 +1436,13 @@ internal class RumSessionScopeTest {
 
         val event = RumRawEvent.AppStartTTIDEvent(
             info = info
+        )
+
+        testedScope.handleEvent(
+            event = fakeInitialViewEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter
         )
 
         // When
@@ -1482,6 +1489,13 @@ internal class RumSessionScopeTest {
 
         val event2 = RumRawEvent.AppStartTTIDEvent(
             info = info2
+        )
+
+        testedScope.handleEvent(
+            event = fakeInitialViewEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter
         )
 
         // When


### PR DESCRIPTION
### What does this PR do?

This PR is related to [this](https://github.com/DataDog/dd-sdk-android/pull/2910#discussion_r2398963265) discussion. I thought about it a bit more and think that TTID event shouldn't trigger session recreation.

Reasons:
1. We have session sampling, the decision is made [here](https://github.com/DataDog/dd-sdk-android/blob/ad12432ed6b0d9c11aae3eb4b01c0dfbb128c01c/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt#L255). Suppose sampleRate < 100% and for example for the `StartView` action (considered [interaction](https://github.com/DataDog/dd-sdk-android/blob/ad12432ed6b0d9c11aae3eb4b01c0dfbb128c01c/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt#L217)) the session wasn't started. The TTID event that happens a bit later gives another chance to start the session. By giving more chances to start the session we effectively increase the sampling rate.
2. The code will be simpler, we actually don't need this. I did this at first because it seemed logical to consider TTID as some kind of interaction, but I think the point above is much more important.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

