### PR TITLE
Fix GraphQL operation type header

### DIFF
--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/network/GraphQLHeaders.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/network/GraphQLHeaders.kt
@@ -13,6 +13,6 @@ package com.datadog.android.internal.network
 enum class GraphQLHeaders(val headerValue: String) {
     DD_GRAPHQL_NAME_HEADER("_dd-custom-header-graph-ql-operation-name"),
     DD_GRAPHQL_VARIABLES_HEADER("_dd-custom-header-graph-ql-variables"),
-    DD_GRAPHQL_TYPE_HEADER("_dd-custom-header-graph-ql-operation_type"),
+    DD_GRAPHQL_TYPE_HEADER("_dd-custom-header-graph-ql-operation-type"),
     DD_GRAPHQL_PAYLOAD_HEADER("_dd-custom-header-graph-ql-payload")
 }


### PR DESCRIPTION
### What does this PR do?
The header had an underscore instead of a hyphen. It's internal and shared between `DatadogApolloInterceptor` and `DatadogInterceptor`, so there should be no impact in fixing this (other than code correctness).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

