### PR TITLE
RUM-12046: Fix synthetic ids logging in RumViewScope

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
+import android.util.Log
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
@@ -1702,11 +1703,11 @@ internal open class RumViewScope(
     }
 
     private fun logSynthetics(key: String, value: String) {
-        sdkCore.internalLogger.log(
-            level = InternalLogger.Level.INFO,
-            target = InternalLogger.Target.USER,
-            messageBuilder = { "$key=$value" }
-        )
+        /**
+         * We use [android.util.Log] here instead of [InternalLogger] because we want to log regardless of the
+         * verbosity level set using [com.datadog.android.Datadog.setVerbosity].
+         */
+        Log.i("DatadogSynthetics", "$key=$value")
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

I'm returning `Log.i` that was changed [here](https://github.com/DataDog/dd-sdk-android/pull/2699/files#diff-ab30afe3da5a0243ae755135af0e1296b0137b5794ad63b8ec03d9731a5d75d2) to `InternalLogger` usage.

See the detailed explanation of the bug and its cause in the ticket: https://datadoghq.atlassian.net/browse/RUM-12046

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

