### PR TITLE
RUM-12046: Pass synthetic ids to RUM earlier in benchmark app

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -167,6 +167,7 @@ class com.datadog.android.rum._RumInternalProxy
   fun setInternalViewAttribute(String, Any?)
   fun setSyntheticsAttribute(String?, String?)
   fun enableJankStatsTracking(android.app.Activity)
+  fun setSyntheticsAttributeFromIntent(android.content.Intent)
   companion object 
     fun setTelemetryConfigurationEventMapper(com.datadog.android.rum.RumConfiguration.Builder, com.datadog.android.event.EventMapper<com.datadog.android.telemetry.model.TelemetryConfigurationEvent>): com.datadog.android.rum.RumConfiguration.Builder
     fun setAdditionalConfiguration(com.datadog.android.rum.RumConfiguration.Builder, Map<String, Any>): com.datadog.android.rum.RumConfiguration.Builder

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -251,6 +251,7 @@ public final class com/datadog/android/rum/_RumInternalProxy {
 	public final fun enableJankStatsTracking (Landroid/app/Activity;)V
 	public final fun setInternalViewAttribute (Ljava/lang/String;Ljava/lang/Object;)V
 	public final fun setSyntheticsAttribute (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun setSyntheticsAttributeFromIntent (Landroid/content/Intent;)V
 	public final fun updateExternalRefreshRate (D)V
 	public final fun updatePerformanceMetric (Lcom/datadog/android/rum/RumPerformanceMetric;D)V
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
@@ -76,7 +76,7 @@ class _RumInternalProxy internal constructor(private val rumMonitor: AdvancedRum
         rumMonitor.enableJankStatsTracking(activity)
     }
 
-    internal fun setSyntheticsAttributeFromIntent(intent: Intent) {
+    fun setSyntheticsAttributeFromIntent(intent: Intent) {
         @Suppress("TooGenericExceptionCaught")
         val extras = try { intent.extras } catch (_: Exception) { null }
         val testId = extras?.getString("_dd.synthetics.test_id")

--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/activities/LaunchActivity.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/activities/LaunchActivity.kt
@@ -49,7 +49,7 @@ internal class LaunchActivity : AppCompatActivity() {
          * have [SyntheticsRun.Instrumented] or [SyntheticsRun.Baseline] only in [LaunchActivity.onCreate].
          * It is derived from intent extras.
          */
-        benchmarkFeaturesInitializer.initialize(config)
+        benchmarkFeaturesInitializer.initialize(config = config, intent = intent)
 
         initializeCoil()
 


### PR DESCRIPTION
### What does this PR do?

Right now RUM sessions that correspond to synthetic test runs of the benchmark app don't contain the information about the synthetic test.

The reason is that [this](https://github.com/DataDog/dd-sdk-android/blob/2e519123ee44ba3a1136fd77b17e8c0b68044327/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityLifecycleTrackingStrategy.kt#L97) code is called on the `Activity` whose `intent` doesn't have the necessary ids.

This in turn happens because in the benchmark app we first open [LaunchActivity](https://github.com/DataDog/dd-sdk-android/blob/d493283ae7d3596a02ced6a6898eb0c3fca763f9/sample/benchmark/src/main/java/com/datadog/benchmark/sample/activities/LaunchActivity.kt#L28) to determine what features of the SDK we want to enable and what test scenario to run. And only after that we launch a scenario-specific `Activity`. Thus `intent` for `LaunchActivity` contains these ids.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

