### PR TITLE
PANA-4799: Send text truncation mode

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapper.kt
@@ -82,7 +82,8 @@ internal abstract class AbstractSemanticsNodeMapper(
             },
             size = textLayoutInfo.fontSize,
             color = convertColor(textLayoutInfo.color.toLong()) ?: parentContext.parentContentColor
-                ?: DEFAULT_TEXT_COLOR
+                ?: DEFAULT_TEXT_COLOR,
+            truncationMode = textLayoutInfo.textOverflow
         )
     }
 

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextLayoutInfo.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextLayoutInfo.kt
@@ -8,11 +8,13 @@ package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
+import com.datadog.android.sessionreplay.model.MobileSegment
 
 internal data class TextLayoutInfo(
     val text: String,
     val color: ULong,
     val fontSize: Long,
     val fontFamily: FontFamily?,
-    val textAlign: TextAlign? = TextAlign.Start
+    val textAlign: TextAlign? = TextAlign.Start,
+    val textOverflow: MobileSegment.TruncationMode? = null
 )

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
@@ -43,6 +43,7 @@ internal object ComposeReflection {
 
     val TextStringSimpleElement = getClassSafe("androidx.compose.foundation.text.modifiers.TextStringSimpleElement")
     val ColorProducerField = TextStringSimpleElement?.getDeclaredFieldSafe("color")
+    val TextStringSimpleElementOverflowField = TextStringSimpleElement?.getDeclaredFieldSafe("overflow")
 
     val BackgroundElementClass = getClassSafe("androidx.compose.foundation.BackgroundElement")
     val ColorField = BackgroundElementClass?.getDeclaredFieldSafe("color")

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/ReflectionUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/ReflectionUtils.kt
@@ -99,6 +99,10 @@ internal class ReflectionUtils {
         return (ComposeReflection.ColorProducerField?.getSafe(modifier) as? ColorProducer)?.invoke()
     }
 
+    fun getTextStringSimpleElementOverflow(modifier: Modifier): Any? {
+        return ComposeReflection.TextStringSimpleElementOverflowField?.getSafe(modifier)
+    }
+
     fun getPlaceable(semanticsNode: SemanticsNode): Placeable? {
         val layoutNode = LayoutNodeField?.getSafe(semanticsNode)
         val innerLayerCoordinator = layoutNode?.let { GetInnerLayerCoordinatorMethod?.invoke(it) }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
@@ -346,17 +346,104 @@ internal class SemanticsUtils(
             .firstOrNull { reflectionUtils.isTextStringSimpleElement(it.modifier) }
             ?.modifier ?: return null
 
-        return reflectionUtils.getTextStringSimpleElementOverflow(modifier)?.let { overflow ->
-            resolveTextOverflow(overflow)
+        val overflowValue = reflectionUtils.getTextStringSimpleElementOverflow(modifier)
+        return overflowValue?.let { overflow ->
+            when (overflow) {
+                is Int -> resolveTextOverflow(overflow)
+                else -> {
+                    // TextOverflow value class may be boxed when accessed via reflection
+                    val overflowInt = extractTextOverflowValue(overflow)
+                    if (overflowInt != null) {
+                        resolveTextOverflow(overflowInt)
+                    } else {
+                        logUnknownOverflowType(overflow)
+                        null
+                    }
+                }
+            }
         }
     }
 
-    private fun resolveTextOverflow(overflowMode: Any): MobileSegment.TruncationMode? {
+    private fun resolveTextOverflow(overflowMode: Int): MobileSegment.TruncationMode? {
         return when (overflowMode) {
             TEXT_OVERFLOW_CLIP -> MobileSegment.TruncationMode.CLIP
             TEXT_OVERFLOW_ELLIPSE -> MobileSegment.TruncationMode.TAIL
-            else -> null
+            else -> {
+                logUnknownOverflowOrdinal(overflowMode)
+                null
+            }
         }
+    }
+
+    private fun extractTextOverflowValue(overflowValue: Any): Int? {
+        return try {
+            // Suppressed: All exceptions (NoSuchFieldException, SecurityException, NullPointerException)
+            // are handled by the catch blocks below
+            @Suppress("UnsafeThirdPartyFunctionCall")
+            val valueField = overflowValue.javaClass.getDeclaredField("value")
+            valueField.isAccessible = true
+            // Suppressed: All exceptions (IllegalAccessException, IllegalArgumentException, NullPointerException,
+            // ExceptionInInitializerError) are handled by the catch blocks below
+            @Suppress("UnsafeThirdPartyFunctionCall")
+            valueField.get(overflowValue) as? Int
+        } catch (e: ReflectiveOperationException) {
+            logReflectionExtractionFailure(overflowValue, e)
+            null
+        } catch (@Suppress("TooGenericExceptionCaught") e: RuntimeException) {
+            logReflectionExtractionFailure(overflowValue, e)
+            null
+        }
+    }
+
+    private fun logReflectionExtractionFailure(overflowValue: Any, e: Throwable) {
+        (Datadog.getInstance() as? FeatureSdkCore)?.internalLogger?.log(
+            level = InternalLogger.Level.WARN,
+            targets = listOf(InternalLogger.Target.MAINTAINER),
+            messageBuilder = {
+                "Failed to extract Int value from TextOverflow instance via reflection: ${e.message}. " +
+                    "Type: ${overflowValue.javaClass.name}"
+            },
+            throwable = e,
+            onlyOnce = true,
+            additionalProperties = mapOf(
+                OVERFLOW_TYPE_KEY to (overflowValue::class.simpleName?.toString() ?: UNKNOWN_VALUE),
+                ERROR_TYPE_KEY to (e::class.simpleName?.toString() ?: UNKNOWN_VALUE),
+                COMPONENT_KEY to COMPONENT_NAME
+            )
+        )
+    }
+
+    private fun logUnknownOverflowOrdinal(ordinal: Int) {
+        (Datadog.getInstance() as? FeatureSdkCore)?.internalLogger?.log(
+            level = InternalLogger.Level.WARN,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            messageBuilder = {
+                "Unknown TextOverflow Int value: $ordinal. " +
+                    "This may indicate a new Compose TextOverflow value class instance that needs to be mapped."
+            },
+            onlyOnce = true,
+            additionalProperties = mapOf(
+                "overflow.value" to ordinal.toString(),
+                COMPONENT_KEY to COMPONENT_NAME
+            )
+        )
+    }
+
+    private fun logUnknownOverflowType(overflowValue: Any) {
+        (Datadog.getInstance() as? FeatureSdkCore)?.internalLogger?.log(
+            level = InternalLogger.Level.WARN,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            messageBuilder = {
+                "Unexpected type for TextOverflow value: ${overflowValue::class.simpleName}. " +
+                    "Expected Int or TextOverflow value class instance, got ${overflowValue.javaClass.name}. " +
+                    "This may indicate a Compose API change."
+            },
+            onlyOnce = true,
+            additionalProperties = mapOf(
+                OVERFLOW_TYPE_KEY to (overflowValue::class.simpleName?.toString() ?: UNKNOWN_VALUE),
+                COMPONENT_KEY to COMPONENT_NAME
+            )
+        )
     }
 
     private fun convertTextLayoutInfo(
@@ -450,7 +537,13 @@ internal class SemanticsUtils(
         internal const val DEFAULT_COLOR_WHITE = "#FFFFFFFF"
         private const val BITMAP_TELEMETRY_SAMPLE_RATE = 1f
 
-        private const val TEXT_OVERFLOW_CLIP = 1
-        private const val TEXT_OVERFLOW_ELLIPSE = 2
+        private const val COMPONENT_NAME = "SemanticsUtils"
+        private const val COMPONENT_KEY = "component"
+        private const val UNKNOWN_VALUE = "unknown"
+        private const val OVERFLOW_TYPE_KEY = "overflow.type"
+        private const val ERROR_TYPE_KEY = "error.type"
+
+        internal const val TEXT_OVERFLOW_CLIP = 1
+        internal const val TEXT_OVERFLOW_ELLIPSE = 2
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
@@ -368,6 +368,9 @@ internal class SemanticsUtils(
         return when (overflowMode) {
             TEXT_OVERFLOW_CLIP -> MobileSegment.TruncationMode.CLIP
             TEXT_OVERFLOW_ELLIPSE -> MobileSegment.TruncationMode.TAIL
+            TEXT_OVERFLOW_VISIBLE -> null
+            TEXT_OVERFLOW_ELLIPSIS_START -> MobileSegment.TruncationMode.HEAD
+            TEXT_OVERFLOW_ELLIPSIS_MIDDLE -> MobileSegment.TruncationMode.MIDDLE
             else -> {
                 logUnknownOverflowOrdinal(overflowMode)
                 null
@@ -406,8 +409,8 @@ internal class SemanticsUtils(
             throwable = e,
             onlyOnce = true,
             additionalProperties = mapOf(
-                OVERFLOW_TYPE_KEY to (overflowValue::class.simpleName?.toString() ?: UNKNOWN_VALUE),
-                ERROR_TYPE_KEY to (e::class.simpleName?.toString() ?: UNKNOWN_VALUE),
+                OVERFLOW_TYPE_KEY to (overflowValue::class.simpleName ?: UNKNOWN_VALUE),
+                ERROR_TYPE_KEY to (e::class.simpleName ?: UNKNOWN_VALUE),
                 COMPONENT_KEY to COMPONENT_NAME
             )
         )
@@ -440,7 +443,7 @@ internal class SemanticsUtils(
             },
             onlyOnce = true,
             additionalProperties = mapOf(
-                OVERFLOW_TYPE_KEY to (overflowValue::class.simpleName?.toString() ?: UNKNOWN_VALUE),
+                OVERFLOW_TYPE_KEY to (overflowValue::class.simpleName ?: UNKNOWN_VALUE),
                 COMPONENT_KEY to COMPONENT_NAME
             )
         )
@@ -545,5 +548,8 @@ internal class SemanticsUtils(
 
         internal const val TEXT_OVERFLOW_CLIP = 1
         internal const val TEXT_OVERFLOW_ELLIPSE = 2
+        internal const val TEXT_OVERFLOW_VISIBLE = 3
+        internal const val TEXT_OVERFLOW_ELLIPSIS_START = 4
+        internal const val TEXT_OVERFLOW_ELLIPSIS_MIDDLE = 5
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapperTest.kt
@@ -129,7 +129,8 @@ internal open class AbstractSemanticsNodeMapperTest {
                 else -> DEFAULT_FONT_FAMILY
             },
             size = fakeTextLayoutInfo.fontSize,
-            color = fakeColorHexString
+            color = fakeColorHexString,
+            truncationMode = fakeTextLayoutInfo.textOverflow
         )
         mockColorStringFormatter(fakeTextLayoutInfo.color.toLong(), fakeColorHexString)
 
@@ -138,6 +139,75 @@ internal open class AbstractSemanticsNodeMapperTest {
 
         // Then
         assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `M return CLIP truncation mode W TextLayoutInfo has CLIP overflow`(
+        @Forgery fakeUiContext: UiContext,
+        @StringForgery fakeColorHexString: String
+    ) {
+        // Given
+        val fakeTextLayoutInfo = TextLayoutInfo(
+            text = "test",
+            color = 0UL,
+            fontSize = 12,
+            fontFamily = null,
+            textAlign = TextAlign.Start,
+            textOverflow = MobileSegment.TruncationMode.CLIP
+        )
+        mockColorStringFormatter(fakeTextLayoutInfo.color.toLong(), fakeColorHexString)
+
+        // When
+        val result = testedMapper.stubTextLayoutInfoToTextStyle(fakeUiContext, fakeTextLayoutInfo)
+
+        // Then
+        assertThat(result.truncationMode).isEqualTo(MobileSegment.TruncationMode.CLIP)
+    }
+
+    @Test
+    fun `M return TAIL truncation mode W TextLayoutInfo has TAIL overflow`(
+        @Forgery fakeUiContext: UiContext,
+        @StringForgery fakeColorHexString: String
+    ) {
+        // Given
+        val fakeTextLayoutInfo = TextLayoutInfo(
+            text = "test",
+            color = 0UL,
+            fontSize = 12,
+            fontFamily = null,
+            textAlign = TextAlign.Start,
+            textOverflow = MobileSegment.TruncationMode.TAIL
+        )
+        mockColorStringFormatter(fakeTextLayoutInfo.color.toLong(), fakeColorHexString)
+
+        // When
+        val result = testedMapper.stubTextLayoutInfoToTextStyle(fakeUiContext, fakeTextLayoutInfo)
+
+        // Then
+        assertThat(result.truncationMode).isEqualTo(MobileSegment.TruncationMode.TAIL)
+    }
+
+    @Test
+    fun `M return null truncation mode W TextLayoutInfo has null overflow`(
+        @Forgery fakeUiContext: UiContext,
+        @StringForgery fakeColorHexString: String
+    ) {
+        // Given
+        val fakeTextLayoutInfo = TextLayoutInfo(
+            text = "test",
+            color = 0UL,
+            fontSize = 12,
+            fontFamily = null,
+            textAlign = TextAlign.Start,
+            textOverflow = null
+        )
+        mockColorStringFormatter(fakeTextLayoutInfo.color.toLong(), fakeColorHexString)
+
+        // When
+        val result = testedMapper.stubTextLayoutInfoToTextStyle(fakeUiContext, fakeTextLayoutInfo)
+
+        // Then
+        assertThat(result.truncationMode).isNull()
     }
 
     @Test

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapperTest.kt
@@ -158,7 +158,8 @@ internal class TextFieldSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTes
                 family = (fakeTextLayoutInfo.fontFamily as? GenericFontFamily)?.name
                     ?: DEFAULT_FONT_FAMILY,
                 size = fakeTextLayoutInfo.fontSize,
-                color = fakeTextColorHexString
+                color = fakeTextColorHexString,
+                truncationMode = fakeTextLayoutInfo.textOverflow
             ),
             textPosition = MobileSegment.TextPosition(
                 padding = MobileSegment.Padding(

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtilsTest.kt
@@ -568,12 +568,29 @@ class SemanticsUtilsTest {
          */
         private class MockTextOverflowValueClass(val value: Int)
 
+        /**
+         * Mock object without a "value" field to simulate reflection extraction failure.
+         * Used to test error handling when reflection fails to extract the Int value.
+         */
+        private class MockOverflowWithoutValueField {
+            override fun toString() = "MockOverflowWithoutValueField"
+        }
+
         @JvmStatic
         fun truncationModeMappings(): Stream<Arguments> {
             return Stream.of(
                 // Int values (unboxed value class)
                 Arguments.of(SemanticsUtils.TEXT_OVERFLOW_CLIP, MobileSegment.TruncationMode.CLIP),
                 Arguments.of(SemanticsUtils.TEXT_OVERFLOW_ELLIPSE, MobileSegment.TruncationMode.TAIL),
+                Arguments.of(SemanticsUtils.TEXT_OVERFLOW_VISIBLE, null),
+                Arguments.of(
+                    SemanticsUtils.TEXT_OVERFLOW_ELLIPSIS_START,
+                    MobileSegment.TruncationMode.HEAD
+                ),
+                Arguments.of(
+                    SemanticsUtils.TEXT_OVERFLOW_ELLIPSIS_MIDDLE,
+                    MobileSegment.TruncationMode.MIDDLE
+                ),
                 // Value class instances (boxed) - simulates TextOverflow value class
                 Arguments.of(
                     MockTextOverflowValueClass(SemanticsUtils.TEXT_OVERFLOW_CLIP),
@@ -583,8 +600,25 @@ class SemanticsUtilsTest {
                     MockTextOverflowValueClass(SemanticsUtils.TEXT_OVERFLOW_ELLIPSE),
                     MobileSegment.TruncationMode.TAIL
                 ),
+                Arguments.of(
+                    MockTextOverflowValueClass(SemanticsUtils.TEXT_OVERFLOW_VISIBLE),
+                    null
+                ),
+                Arguments.of(
+                    MockTextOverflowValueClass(SemanticsUtils.TEXT_OVERFLOW_ELLIPSIS_START),
+                    MobileSegment.TruncationMode.HEAD
+                ),
+                Arguments.of(
+                    MockTextOverflowValueClass(SemanticsUtils.TEXT_OVERFLOW_ELLIPSIS_MIDDLE),
+                    MobileSegment.TruncationMode.MIDDLE
+                ),
                 // Edge cases
                 Arguments.of(UNKNOWN_TEXT_OVERFLOW_ORDINAL, null), // Unknown/unsupported overflow mode
+                Arguments.of("unexpected_type", null), // Unexpected overflow type (triggers logUnknownOverflowType)
+                Arguments.of(
+                    MockOverflowWithoutValueField(),
+                    null
+                ), // Reflection extraction failure (triggers logReflectionExtractionFailure)
                 Arguments.of(null, null) // No overflow modifier
             )
         }

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtilsTest.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.dp
 import com.datadog.android.sessionreplay.compose.internal.data.BitmapInfo
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.TextLayoutInfo
 import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
+import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.GlobalBounds
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.FloatForgery
@@ -566,6 +567,180 @@ class SemanticsUtilsTest {
 
         // Then
         assertThat(result).isEqualTo(BitmapInfo(mockBitmap, true))
+    }
+
+    @Test
+    fun `M return CLIP truncation mode W resolveTextLayoutInfo with overflow ordinal 1`(forge: Forge) {
+        // Given
+        val fakeText = AnnotatedString(forge.aString())
+        val fakeColorValue = forge.aLong().toULong()
+        val fakeFontSize = forge.aFloat()
+        val fakeFontFamily = forge.anElementFrom(
+            FontFamily.Serif,
+            FontFamily.SansSerif,
+            FontFamily.Cursive,
+            FontFamily.Monospace,
+            FontFamily.Default
+        )
+        val fakeTextAlign = forge.anElementFrom(TextAlign.values())
+        val mockResult = mock<AccessibilityAction<(MutableList<TextLayoutResult>) -> Boolean>>()
+        val mockAction = mock<(MutableList<TextLayoutResult>) -> Boolean>()
+        val textLayoutResult: TextLayoutResult = mock()
+        val textLayoutResults = mutableListOf<TextLayoutResult>()
+        val mockTextLayoutInput = mock<TextLayoutInput>()
+        val mockTextStyle = mock<TextStyle>()
+        whenever(mockConfig.getOrNull(SemanticsActions.GetTextLayoutResult)) doReturn mockResult
+        whenever(mockResult.action) doReturn mockAction
+        whenever(textLayoutResult.layoutInput) doReturn mockTextLayoutInput
+        doAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            (invocation.arguments[0] as MutableList<TextLayoutResult>).add(textLayoutResult)
+            true
+        }.whenever(mockAction).invoke(textLayoutResults)
+        whenever(mockTextLayoutInput.style) doReturn mockTextStyle
+        whenever(mockTextLayoutInput.text) doReturn fakeText
+        whenever(mockTextStyle.color) doReturn Color(fakeColorValue)
+        whenever(mockTextStyle.textAlign) doReturn fakeTextAlign
+        whenever(mockTextStyle.fontSize) doReturn TextUnit(fakeFontSize, TextUnitType.Sp)
+        whenever(mockTextStyle.fontFamily) doReturn fakeFontFamily
+        whenever(mockReflectionUtils.isTextStringSimpleElement(mockModifier)) doReturn true
+        whenever(mockReflectionUtils.getTextStringSimpleElementOverflow(mockModifier)) doReturn 1
+
+        // When
+        val result = testedSemanticsUtils.resolveTextLayoutInfo(mockSemanticsNode)
+
+        // Then
+        assertThat(result?.textOverflow).isEqualTo(MobileSegment.TruncationMode.CLIP)
+    }
+
+    @Test
+    fun `M return TAIL truncation mode W resolveTextLayoutInfo with overflow ordinal 2`(forge: Forge) {
+        // Given
+        val fakeText = AnnotatedString(forge.aString())
+        val fakeColorValue = forge.aLong().toULong()
+        val fakeFontSize = forge.aFloat()
+        val fakeFontFamily = forge.anElementFrom(
+            FontFamily.Serif,
+            FontFamily.SansSerif,
+            FontFamily.Cursive,
+            FontFamily.Monospace,
+            FontFamily.Default
+        )
+        val fakeTextAlign = forge.anElementFrom(TextAlign.values())
+        val mockResult = mock<AccessibilityAction<(MutableList<TextLayoutResult>) -> Boolean>>()
+        val mockAction = mock<(MutableList<TextLayoutResult>) -> Boolean>()
+        val textLayoutResult: TextLayoutResult = mock()
+        val textLayoutResults = mutableListOf<TextLayoutResult>()
+        val mockTextLayoutInput = mock<TextLayoutInput>()
+        val mockTextStyle = mock<TextStyle>()
+        whenever(mockConfig.getOrNull(SemanticsActions.GetTextLayoutResult)) doReturn mockResult
+        whenever(mockResult.action) doReturn mockAction
+        whenever(textLayoutResult.layoutInput) doReturn mockTextLayoutInput
+        doAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            (invocation.arguments[0] as MutableList<TextLayoutResult>).add(textLayoutResult)
+            true
+        }.whenever(mockAction).invoke(textLayoutResults)
+        whenever(mockTextLayoutInput.style) doReturn mockTextStyle
+        whenever(mockTextLayoutInput.text) doReturn fakeText
+        whenever(mockTextStyle.color) doReturn Color(fakeColorValue)
+        whenever(mockTextStyle.textAlign) doReturn fakeTextAlign
+        whenever(mockTextStyle.fontSize) doReturn TextUnit(fakeFontSize, TextUnitType.Sp)
+        whenever(mockTextStyle.fontFamily) doReturn fakeFontFamily
+        whenever(mockReflectionUtils.isTextStringSimpleElement(mockModifier)) doReturn true
+        whenever(mockReflectionUtils.getTextStringSimpleElementOverflow(mockModifier)) doReturn 2
+
+        // When
+        val result = testedSemanticsUtils.resolveTextLayoutInfo(mockSemanticsNode)
+
+        // Then
+        assertThat(result?.textOverflow).isEqualTo(MobileSegment.TruncationMode.TAIL)
+    }
+
+    @Test
+    fun `M return null truncation mode W resolveTextLayoutInfo with overflow ordinal 3`(forge: Forge) {
+        // Given
+        val fakeText = AnnotatedString(forge.aString())
+        val fakeColorValue = forge.aLong().toULong()
+        val fakeFontSize = forge.aFloat()
+        val fakeFontFamily = forge.anElementFrom(
+            FontFamily.Serif,
+            FontFamily.SansSerif,
+            FontFamily.Cursive,
+            FontFamily.Monospace,
+            FontFamily.Default
+        )
+        val fakeTextAlign = forge.anElementFrom(TextAlign.values())
+        val mockResult = mock<AccessibilityAction<(MutableList<TextLayoutResult>) -> Boolean>>()
+        val mockAction = mock<(MutableList<TextLayoutResult>) -> Boolean>()
+        val textLayoutResult: TextLayoutResult = mock()
+        val textLayoutResults = mutableListOf<TextLayoutResult>()
+        val mockTextLayoutInput = mock<TextLayoutInput>()
+        val mockTextStyle = mock<TextStyle>()
+        whenever(mockConfig.getOrNull(SemanticsActions.GetTextLayoutResult)) doReturn mockResult
+        whenever(mockResult.action) doReturn mockAction
+        whenever(textLayoutResult.layoutInput) doReturn mockTextLayoutInput
+        doAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            (invocation.arguments[0] as MutableList<TextLayoutResult>).add(textLayoutResult)
+            true
+        }.whenever(mockAction).invoke(textLayoutResults)
+        whenever(mockTextLayoutInput.style) doReturn mockTextStyle
+        whenever(mockTextLayoutInput.text) doReturn fakeText
+        whenever(mockTextStyle.color) doReturn Color(fakeColorValue)
+        whenever(mockTextStyle.textAlign) doReturn fakeTextAlign
+        whenever(mockTextStyle.fontSize) doReturn TextUnit(fakeFontSize, TextUnitType.Sp)
+        whenever(mockTextStyle.fontFamily) doReturn fakeFontFamily
+        whenever(mockReflectionUtils.isTextStringSimpleElement(mockModifier)) doReturn true
+        whenever(mockReflectionUtils.getTextStringSimpleElementOverflow(mockModifier)) doReturn 3
+
+        // When
+        val result = testedSemanticsUtils.resolveTextLayoutInfo(mockSemanticsNode)
+
+        // Then
+        assertThat(result?.textOverflow).isNull()
+    }
+
+    @Test
+    fun `M return null truncation mode W resolveTextLayoutInfo with no overflow modifier`(forge: Forge) {
+        // Given
+        val fakeText = AnnotatedString(forge.aString())
+        val fakeColorValue = forge.aLong().toULong()
+        val fakeFontSize = forge.aFloat()
+        val fakeFontFamily = forge.anElementFrom(
+            FontFamily.Serif,
+            FontFamily.SansSerif,
+            FontFamily.Cursive,
+            FontFamily.Monospace,
+            FontFamily.Default
+        )
+        val fakeTextAlign = forge.anElementFrom(TextAlign.values())
+        val mockResult = mock<AccessibilityAction<(MutableList<TextLayoutResult>) -> Boolean>>()
+        val mockAction = mock<(MutableList<TextLayoutResult>) -> Boolean>()
+        val textLayoutResult: TextLayoutResult = mock()
+        val textLayoutResults = mutableListOf<TextLayoutResult>()
+        val mockTextLayoutInput = mock<TextLayoutInput>()
+        val mockTextStyle = mock<TextStyle>()
+        whenever(mockConfig.getOrNull(SemanticsActions.GetTextLayoutResult)) doReturn mockResult
+        whenever(mockResult.action) doReturn mockAction
+        whenever(textLayoutResult.layoutInput) doReturn mockTextLayoutInput
+        doAnswer { invocation ->
+            @Suppress("UNCHECKED_CAST")
+            (invocation.arguments[0] as MutableList<TextLayoutResult>).add(textLayoutResult)
+            true
+        }.whenever(mockAction).invoke(textLayoutResults)
+        whenever(mockTextLayoutInput.style) doReturn mockTextStyle
+        whenever(mockTextLayoutInput.text) doReturn fakeText
+        whenever(mockTextStyle.color) doReturn Color(fakeColorValue)
+        whenever(mockTextStyle.textAlign) doReturn fakeTextAlign
+        whenever(mockTextStyle.fontSize) doReturn TextUnit(fakeFontSize, TextUnitType.Sp)
+        whenever(mockTextStyle.fontFamily) doReturn fakeFontFamily
+
+        // When
+        val result = testedSemanticsUtils.resolveTextLayoutInfo(mockSemanticsNode)
+
+        // Then
+        assertThat(result?.textOverflow).isNull()
     }
 
     private fun rectToBounds(rect: Rect, density: Float): GlobalBounds {

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/TextLayoutInfoForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/TextLayoutInfoForgeryFactory.kt
@@ -29,13 +29,7 @@ internal class TextLayoutInfoForgeryFactory : ForgeryFactory<TextLayoutInfo> {
                 )
             ),
             textAlign = forge.anElementFrom(TextAlign.values()),
-            textOverflow = forge.anElementFrom(
-                listOf(
-                    MobileSegment.TruncationMode.CLIP,
-                    MobileSegment.TruncationMode.TAIL,
-                    null
-                )
-            )
+            textOverflow = forge.aNullable { aValueFrom(MobileSegment.TruncationMode::class.java) }
         )
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/TextLayoutInfoForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/TextLayoutInfoForgeryFactory.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.compose.test.elmyr
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.TextLayoutInfo
+import com.datadog.android.sessionreplay.model.MobileSegment
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
@@ -27,7 +28,14 @@ internal class TextLayoutInfoForgeryFactory : ForgeryFactory<TextLayoutInfo> {
                     FontFamily.Default
                 )
             ),
-            textAlign = forge.anElementFrom(TextAlign.values())
+            textAlign = forge.anElementFrom(TextAlign.values()),
+            textOverflow = forge.anElementFrom(
+                listOf(
+                    MobileSegment.TruncationMode.CLIP,
+                    MobileSegment.TruncationMode.TAIL,
+                    null
+                )
+            )
         )
     }
 }

--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -232,7 +232,7 @@ data class com.datadog.android.sessionreplay.model.MobileSegment
   sealed class MobileIncrementalData
     abstract fun toJson(): com.google.gson.JsonElement
     data class MobileMutationData : MobileIncrementalData
-      constructor(kotlin.collections.List<Add>? = null, kotlin.collections.List<Remove>? = null, kotlin.collections.List<WireframeUpdateMutation>? = null)
+      constructor(kotlin.collections.List<Add>, kotlin.collections.List<Remove>, kotlin.collections.List<WireframeUpdateMutation>)
       val source: kotlin.Long
       override fun toJson(): com.google.gson.JsonElement
       companion object 
@@ -397,7 +397,7 @@ data class com.datadog.android.sessionreplay.model.MobileSegment
       fun fromJson(kotlin.String): ShapeBorder
       fun fromJsonObject(com.google.gson.JsonObject): ShapeBorder
   data class TextStyle
-    constructor(kotlin.String, kotlin.Long, kotlin.String)
+    constructor(kotlin.String, kotlin.Long, kotlin.String, TruncationMode? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): TextStyle
@@ -446,6 +446,15 @@ data class com.datadog.android.sessionreplay.model.MobileSegment
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): PointerType
+  enum TruncationMode
+    constructor(kotlin.String)
+    - CLIP
+    - HEAD
+    - TAIL
+    - MIDDLE
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TruncationMode
   enum Horizontal
     constructor(kotlin.String)
     - LEFT

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -377,9 +377,7 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$MobileI
 
 public final class com/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData$MobileMutationData : com/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData {
 	public static final field Companion Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData$MobileMutationData$Companion;
-	public fun <init> ()V
 	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/util/List;
@@ -852,18 +850,21 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$TextPos
 
 public final class com/datadog/android/sessionreplay/model/MobileSegment$TextStyle {
 	public static final field Companion Lcom/datadog/android/sessionreplay/model/MobileSegment$TextStyle$Companion;
-	public fun <init> (Ljava/lang/String;JLjava/lang/String;)V
+	public fun <init> (Ljava/lang/String;JLjava/lang/String;Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;)V
+	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()J
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;JLjava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$TextStyle;
-	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/model/MobileSegment$TextStyle;Ljava/lang/String;JLjava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$TextStyle;
+	public final fun component4 ()Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;
+	public final fun copy (Ljava/lang/String;JLjava/lang/String;Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;)Lcom/datadog/android/sessionreplay/model/MobileSegment$TextStyle;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/model/MobileSegment$TextStyle;Ljava/lang/String;JLjava/lang/String;Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$TextStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$TextStyle;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/sessionreplay/model/MobileSegment$TextStyle;
 	public final fun getColor ()Ljava/lang/String;
 	public final fun getFamily ()Ljava/lang/String;
 	public final fun getSize ()J
+	public final fun getTruncationMode ()Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
@@ -872,6 +873,22 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$TextSty
 public final class com/datadog/android/sessionreplay/model/MobileSegment$TextStyle$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$TextStyle;
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/sessionreplay/model/MobileSegment$TextStyle;
+}
+
+public final class com/datadog/android/sessionreplay/model/MobileSegment$TruncationMode : java/lang/Enum {
+	public static final field CLIP Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;
+	public static final field Companion Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode$Companion;
+	public static final field HEAD Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;
+	public static final field MIDDLE Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;
+	public static final field TAIL Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;
+	public static fun values ()[Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;
+}
+
+public final class com/datadog/android/sessionreplay/model/MobileSegment$TruncationMode$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;
 }
 
 public final class com/datadog/android/sessionreplay/model/MobileSegment$Vertical : java/lang/Enum {

--- a/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/mutation-payload-schema.json
+++ b/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/mutation-payload-schema.json
@@ -5,51 +5,47 @@
   "type": "object",
   "description": "Mobile-specific. Schema of a MutationPayload.",
   "required": ["adds", "removes", "updates"],
-  "allOf": [
-    {
-      "properties": {
-        "adds": {
-          "type": "array",
-          "readOnly": true,
-          "items": {
-            "type": "object",
-            "required": ["wireframe"],
-            "properties": {
-              "previousId": {
-                "type": "integer",
-                "description": "The previous wireframe id next or after which this new wireframe is drawn or attached to, respectively."
-              },
-              "wireframe": {
-                "$ref": "wireframe-schema.json"
-              }
-            }
+  "properties": {
+    "adds": {
+      "type": "array",
+      "readOnly": true,
+      "items": {
+        "type": "object",
+        "required": ["wireframe"],
+        "properties": {
+          "previousId": {
+            "type": "integer",
+            "description": "The previous wireframe id next or after which this new wireframe is drawn or attached to, respectively."
           },
-          "description": "Contains the newly added wireframes."
-        },
-        "removes": {
-          "type": "array",
-          "readOnly": true,
-          "items": {
-            "type": "object",
-            "required": ["id"],
-            "properties": {
-              "id": {
-                "type": "integer",
-                "description": "The id of the wireframe that needs to be removed."
-              }
-            }
-          },
-          "description": "Contains the removed wireframes as an array of ids."
-        },
-        "updates": {
-          "type": "array",
-          "readOnly": true,
-          "items": {
-            "$ref": "wireframe-update-mutation-schema.json"
-          },
-          "description": "Contains the updated wireframes mutations."
+          "wireframe": {
+            "$ref": "wireframe-schema.json"
+          }
         }
-      }
+      },
+      "description": "Contains the newly added wireframes."
+    },
+    "removes": {
+      "type": "array",
+      "readOnly": true,
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The id of the wireframe that needs to be removed."
+          }
+        }
+      },
+      "description": "Contains the removed wireframes as an array of ids."
+    },
+    "updates": {
+      "type": "array",
+      "readOnly": true,
+      "items": {
+        "$ref": "wireframe-update-mutation-schema.json"
+      },
+      "description": "Contains the updated wireframes mutations."
     }
-  ]
+  }
 }

--- a/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/text-style-schema.json
+++ b/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/text-style-schema.json
@@ -23,6 +23,12 @@
           "pattern": "^#[A-Fa-f0-9]{6}([A-Fa-f0-9]{2})?$",
           "description": "The font color as a string hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.",
           "readOnly": true
+        },
+        "truncationMode": {
+          "type": "string",
+          "description": "Defines how text should be truncated when it exceeds the wireframe bounds. If omitted, text wraps naturally.",
+          "enum": ["clip", "head", "tail", "middle"],
+          "readOnly": true
         }
       },
       "readOnly": true

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.recorder.mapper
 
 import android.graphics.Typeface
+import android.text.TextUtils
 import android.view.Gravity
 import android.widget.TextView
 import androidx.annotation.UiThread
@@ -148,9 +149,10 @@ open class TextViewMapper<in T : TextView>(
 
     private fun resolveTextStyle(textView: T, pixelsDensity: Float): MobileSegment.TextStyle {
         return MobileSegment.TextStyle(
-            resolveFontFamily(textView.typeface),
-            textView.textSize.toLong().densityNormalized(pixelsDensity),
-            resolveTextColor(textView)
+            family = resolveFontFamily(textView.typeface),
+            size = textView.textSize.toLong().densityNormalized(pixelsDensity),
+            color = resolveTextColor(textView),
+            truncationMode = resolveTruncationMode(textView)
         )
     }
 
@@ -185,6 +187,17 @@ open class TextViewMapper<in T : TextView>(
             resolvePadding(textView, pixelsDensity),
             resolveAlignment(textView)
         )
+    }
+
+    private fun resolveTruncationMode(textView: T): MobileSegment.TruncationMode? {
+        return textView.ellipsize?.let { truncationMode ->
+            when (truncationMode) {
+                TextUtils.TruncateAt.START -> MobileSegment.TruncationMode.HEAD
+                TextUtils.TruncateAt.END -> MobileSegment.TruncationMode.TAIL
+                TextUtils.TruncateAt.MIDDLE -> MobileSegment.TruncationMode.MIDDLE
+                TextUtils.TruncateAt.MARQUEE -> MobileSegment.TruncationMode.CLIP
+            }
+        }
     }
 
     private fun resolvePadding(textView: TextView, pixelsDensity: Float): MobileSegment.Padding {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/MutationDataForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/MutationDataForgeryFactory.kt
@@ -15,12 +15,12 @@ internal class MutationDataForgeryFactory :
     override fun getForgery(forge: Forge): MobileSegment.MobileIncrementalData.MobileMutationData {
         return MobileSegment.MobileIncrementalData.MobileMutationData(
             adds =
-                forge.aList {
-                    MobileSegment.Add(
-                        previousId = forge.aNullable { forge.aLong() },
-                        forge.getForgery(MobileSegment.Wireframe::class.java)
-                    )
-                },
+            forge.aList {
+                MobileSegment.Add(
+                    previousId = forge.aNullable { forge.aLong() },
+                    forge.getForgery(MobileSegment.Wireframe::class.java)
+                )
+            },
             removes = forge.aList { MobileSegment.Remove(forge.aLong()) },
             updates = forge.aList { forge.getForgery() }
         )

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/MutationDataForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/MutationDataForgeryFactory.kt
@@ -14,16 +14,15 @@ internal class MutationDataForgeryFactory :
     ForgeryFactory<MobileSegment.MobileIncrementalData.MobileMutationData> {
     override fun getForgery(forge: Forge): MobileSegment.MobileIncrementalData.MobileMutationData {
         return MobileSegment.MobileIncrementalData.MobileMutationData(
-            adds = forge.aNullable {
+            adds =
                 forge.aList {
                     MobileSegment.Add(
                         previousId = forge.aNullable { forge.aLong() },
                         forge.getForgery(MobileSegment.Wireframe::class.java)
                     )
-                }
-            },
-            removes = forge.aNullable { forge.aList { MobileSegment.Remove(forge.aLong()) } },
-            updates = forge.aNullable { forge.aList { forge.getForgery() } }
+                },
+            removes = forge.aList { MobileSegment.Remove(forge.aLong()) },
+            updates = forge.aList { forge.getForgery() }
         )
     }
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/TypographySample.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/TypographySample.kt
@@ -11,7 +11,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -24,7 +27,11 @@ import androidx.compose.ui.unit.dp
 @Suppress("LongMethod")
 @Composable
 internal fun TypographySample() {
-    Column {
+    Column(
+        modifier = Modifier
+            .verticalScroll(rememberScrollState())
+            .navigationBarsPadding()
+    ) {
         Text(
             text = "Material H3 - onBackground",
             style = MaterialTheme.typography.h3,
@@ -63,6 +70,11 @@ internal fun TypographySample() {
             modifier = Modifier.padding(16.dp)
         )
         Text(
+            text = "TextOverflow.Ellipsis - Ellipsis at end (TAIL)",
+            style = MaterialTheme.typography.caption,
+            modifier = Modifier.padding(start = 16.dp, top = 8.dp)
+        )
+        Text(
             text = FAKE_LONG_TEXT,
             style = MaterialTheme.typography.caption.copy(
                 color = Color.Black
@@ -74,6 +86,22 @@ internal fun TypographySample() {
                 .background(color = Color.Yellow)
                 .padding(16.dp)
         )
+        Row {
+            Text(
+                text = "TextOverflow.Ellipsis (TAIL)",
+                style = MaterialTheme.typography.caption,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 16.dp, top = 8.dp)
+            )
+            Text(
+                text = "TextOverflow.Clip (CLIP)",
+                style = MaterialTheme.typography.caption,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 16.dp, top = 8.dp)
+            )
+        }
         Row {
             Text(
                 text = FAKE_LONG_TEXT,
@@ -100,6 +128,58 @@ internal fun TypographySample() {
                 maxLines = 1
             )
         }
+        Text(
+            text = "TextOverflow.Visible - Shows all text even if it overflows (null)",
+            style = MaterialTheme.typography.caption,
+            modifier = Modifier.padding(start = 16.dp, top = 8.dp)
+        )
+        Text(
+            text = FAKE_LONG_TEXT,
+            style = MaterialTheme.typography.caption.copy(
+                color = Color.Black
+            ),
+            overflow = TextOverflow.Visible,
+            modifier = Modifier
+                .height(60.dp)
+                .fillMaxWidth()
+                .background(color = Color.Cyan)
+                .padding(16.dp),
+            maxLines = 2
+        )
+        Text(
+            text = "TextOverflow.StartEllipsis - Ellipsis at start (HEAD)",
+            style = MaterialTheme.typography.caption,
+            modifier = Modifier.padding(start = 16.dp, top = 8.dp)
+        )
+        Text(
+            text = FAKE_LONG_TEXT,
+            style = MaterialTheme.typography.caption.copy(
+                color = Color.Black
+            ),
+            overflow = TextOverflow.StartEllipsis,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = Color.Magenta)
+                .padding(16.dp),
+            maxLines = 1
+        )
+        Text(
+            text = "TextOverflow.MiddleEllipsis - Ellipsis in middle (MIDDLE)",
+            style = MaterialTheme.typography.caption,
+            modifier = Modifier.padding(start = 16.dp, top = 8.dp)
+        )
+        Text(
+            text = FAKE_LONG_TEXT,
+            style = MaterialTheme.typography.caption.copy(
+                color = Color.Black
+            ),
+            overflow = TextOverflow.MiddleEllipsis,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = Color.LightGray)
+                .padding(16.dp),
+            maxLines = 1
+        )
     }
 }
 

--- a/sample/kotlin/src/main/res/layout/activity_nav.xml
+++ b/sample/kotlin/src/main/res/layout/activity_nav.xml
@@ -11,6 +11,7 @@
              android:id="@+id/frame_container"
              android:layout_width="match_parent"
              android:layout_height="match_parent"
+             android:fitsSystemWindows="true"
              tools:context=".NavActivity">
 
     <TextView

--- a/sample/kotlin/src/main/res/layout/fragment_tabs.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_tabs.xml
@@ -7,7 +7,8 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/main_nav_tab_layout"

--- a/sample/kotlin/src/main/res/layout/fragment_text_view_components.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_text_view_components.xml
@@ -4,11 +4,17 @@
   ~ Copyright 2016-Present Datadog, Inc.
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="@dimen/default_padding"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:fitsSystemWindows="true"
+    android:fillViewport="true">
+
+<androidx.constraintlayout.widget.ConstraintLayout
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/default_padding">
 
     <TextView
         app:layout_constraintTop_toTopOf="parent"
@@ -22,16 +28,96 @@
     <TextView
         app:layout_constraintTop_toBottomOf="@+id/text_view"
         app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginTop="@dimen/default_padding"
+        android:id="@+id/ellipsize_start_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="ellipsize=&quot;start&quot; - Ellipsis at start (HEAD)"
+        android:textStyle="bold"
+        android:textColor="@android:color/black" />
+
+    <TextView
+        app:layout_constraintTop_toBottomOf="@+id/ellipsize_start_label"
+        app:layout_constraintStart_toStartOf="parent"
         android:ellipsize="start"
-        android:id="@+id/ellipsize_text_view"
+        android:id="@+id/ellipsize_start_text_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:singleLine="true"
         android:textColor="@color/datadog_violet"
         android:text="@string/ellipsize_text_view" />
 
+    <TextView
+        app:layout_constraintTop_toBottomOf="@+id/ellipsize_start_text_view"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginTop="@dimen/default_padding"
+        android:id="@+id/ellipsize_end_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="ellipsize=&quot;end&quot; - Ellipsis at end (TAIL)"
+        android:textStyle="bold"
+        android:textColor="@android:color/black" />
+
+    <TextView
+        app:layout_constraintTop_toBottomOf="@+id/ellipsize_end_label"
+        app:layout_constraintStart_toStartOf="parent"
+        android:ellipsize="end"
+        android:id="@+id/ellipsize_end_text_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:singleLine="true"
+        android:textColor="@color/datadog_violet"
+        android:text="@string/ellipsize_text_view" />
+
+    <TextView
+        app:layout_constraintTop_toBottomOf="@+id/ellipsize_end_text_view"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginTop="@dimen/default_padding"
+        android:id="@+id/ellipsize_middle_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="ellipsize=&quot;middle&quot; - Ellipsis in middle (MIDDLE)"
+        android:textStyle="bold"
+        android:textColor="@android:color/black" />
+
+    <TextView
+        app:layout_constraintTop_toBottomOf="@+id/ellipsize_middle_label"
+        app:layout_constraintStart_toStartOf="parent"
+        android:ellipsize="middle"
+        android:id="@+id/ellipsize_middle_text_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:singleLine="true"
+        android:textColor="@color/datadog_violet"
+        android:text="@string/ellipsize_text_view" />
+
+    <TextView
+        app:layout_constraintTop_toBottomOf="@+id/ellipsize_middle_text_view"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginTop="@dimen/default_padding"
+        android:id="@+id/ellipsize_marquee_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="ellipsize=&quot;marquee&quot; - Scrolling marquee (CLIP)"
+        android:textStyle="bold"
+        android:textColor="@android:color/black" />
+
+    <TextView
+        app:layout_constraintTop_toBottomOf="@+id/ellipsize_marquee_label"
+        app:layout_constraintStart_toStartOf="parent"
+        android:ellipsize="marquee"
+        android:id="@+id/ellipsize_marquee_text_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:singleLine="true"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:marqueeRepeatLimit="marquee_forever"
+        android:textColor="@color/datadog_violet"
+        android:text="@string/ellipsize_text_view" />
+
     <com.google.android.material.textview.MaterialTextView
-        app:layout_constraintTop_toBottomOf="@+id/ellipsize_text_view"
+        app:layout_constraintTop_toBottomOf="@+id/ellipsize_marquee_text_view"
         app:layout_constraintStart_toStartOf="parent"
         android:layout_marginTop="@dimen/default_padding"
         android:id="@+id/material_text_view"
@@ -167,5 +253,6 @@
         app:layout_constraintStart_toEndOf="@+id/chip_1"
         app:layout_constraintTop_toBottomOf="@+id/app_compat_checked_text_view" />
 
-
 </androidx.constraintlayout.widget.ConstraintLayout>
+
+</ScrollView>


### PR DESCRIPTION
### What does this PR do?
The wireframe schema has been updated to allow sending text truncation mode. Possible modes are:

`head`
`middle`
`tail`
`clip`

This pr:
• Updates the session replay schema
• Captures and sends truncation mode for native
• Captures and sends truncation mode for compose
• Fixes a small issue with the sample application where it wasn't respecting system windows bounds

Depends on https://github.com/DataDog/rum-events-format/pull/318
Related to https://github.com/DataDog/dd-sdk-ios/pull/2550

### Motivation
• Align with iOS on sending text truncation 
• More accurate presentation of text when it overflows the bounds of the container.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

