### PR TITLE
feat: allow blank targeting keys

### DIFF
--- a/features/dd-sdk-android-flags/README.md
+++ b/features/dd-sdk-android-flags/README.md
@@ -128,6 +128,14 @@ client.setEvaluationContext(context)
 - All attribute values must be strings - convert numbers, booleans, and other types to strings before passing them
 - Common targeting keys include user ID, device ID, or session ID
 
+**Targeting Key Best Practices:**
+
+For anonymous or unauthenticated users, use a **persistent UUID** as the targeting key:
+- **Proper traffic splitting**: A unique identifier ensures users are distributed correctly across flag variations
+- **Consistent experience**: Persistence means the same user always sees the same flag values (consistent bucketing)
+- Generate the UUID once and persist it locally (e.g., in SharedPreferences)
+- Transition to a user ID when the user authenticates
+
 ### Evaluate Feature Flags
 
 The `FlagsClient` provides two ways to resolve flag values:

--- a/features/dd-sdk-android-flags/README.md
+++ b/features/dd-sdk-android-flags/README.md
@@ -125,7 +125,6 @@ client.setEvaluationContext(context)
 
 **Important Notes:**
 - The `targetingKey` must be consistent for the same user/entity to ensure consistent flag evaluation across requests
-- The `targetingKey` cannot be blank or whitespace-only
 - All attribute values must be strings - convert numbers, booleans, and other types to strings before passing them
 - Common targeting keys include user ID, device ID, or session ID
 

--- a/features/dd-sdk-android-flags/README.md
+++ b/features/dd-sdk-android-flags/README.md
@@ -133,7 +133,7 @@ client.setEvaluationContext(context)
 For anonymous or unauthenticated users, use a **persistent UUID** as the targeting key:
 - **Proper traffic splitting**: A unique identifier ensures users are distributed correctly across flag variations
 - **Consistent experience**: Persistence means the same user always sees the same flag values (consistent bucketing)
-- Generate the UUID once and persist it locally (e.g., in SharedPreferences)
+- Generate the UUID once and persist it locally (e.g., in `SharedPreferences`)
 - Transition to a user ID when the user authenticates
 
 ### Evaluate Feature Flags

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/DatadogFlagsClient.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/DatadogFlagsClient.kt
@@ -63,15 +63,6 @@ internal class DatadogFlagsClient(
      * Must contain a valid targeting key; invalid contexts are logged and ignored.
      */
     override fun setEvaluationContext(context: EvaluationContext) {
-        if (context.targetingKey.isBlank()) {
-            featureSdkCore.internalLogger.log(
-                InternalLogger.Level.WARN,
-                InternalLogger.Target.USER,
-                { "Invalid evaluation context: targeting key cannot be blank or whitespace-only" }
-            )
-            return
-        }
-
         evaluationsManager.updateEvaluationsForContext(context)
     }
 

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/model/EvaluationContext.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/model/EvaluationContext.kt
@@ -18,7 +18,6 @@ package com.datadog.android.flags.model
  *   bucketing for that user. Common examples include user ID (consistent treatment per user),
  *   company ID (consistent treatment for entire company), or device ID (consistent treatment
  *   per device). The targeting key may also be used in targeting rules for flag evaluation.
- *   Must not be blank or whitespace-only.
  * @param attributes Additional attributes used for targeting flag evaluation. All values must be
  *   strings - you are responsible for converting numbers, booleans, and other types to their
  *   string representation before passing them to the context. Examples:
@@ -31,7 +30,6 @@ data class EvaluationContext(
      * The unique identifier used for targeting and bucketing flag evaluation.
      *
      * Must be consistent for the same entity to ensure consistent flag behavior across requests.
-     * Must not be blank or whitespace-only.
      * Examples: user ID, company ID, device ID.
      */
     val targetingKey: String,


### PR DESCRIPTION
### What does this PR do?
Remove restriction on blank/whitespace-only targeting keys

### Motivation

A blank targeting key is valid and supported.

### Additional Notes

While a blank targeting key is discouraged, it does not present technical problems. Customers are coached on proper use of targeting key

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

