### PR TITLE
Remove unused isConstantClass variable

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/generator/ClassStringDeserializerGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/generator/ClassStringDeserializerGenerator.kt
@@ -21,7 +21,6 @@ class ClassStringDeserializerGenerator(
     knownTypes
 ) {
     override fun generate(definition: TypeDefinition.Class, rootTypeName: String): FunSpec {
-        val isConstantClass = definition.isConstantClass()
         val returnType = ClassName.bestGuess(definition.name)
 
         val funBuilder = FunSpec.builder(Identifier.FUN_FROM_JSON)


### PR DESCRIPTION
### What does this PR do?

Just removing unused code that resulted in warnings during build:

```
> Task :buildSrc:compileKotlin
w: file:///Users/aleksandr.gringauz/projects/dd-sdk-android-2/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/generator/ClassStringDeserializerGenerator.kt:24:13 Variable 'isConstantClass' is never used
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

