### PR TITLE
Add missing Profile event tags

### DIFF
--- a/features/dd-sdk-android-profiling/api/apiSurface
+++ b/features/dd-sdk-android-profiling/api/apiSurface
@@ -14,7 +14,7 @@ data class com.datadog.android.profiling.ProfilingConfiguration
   companion object 
     val DEFAULT: ProfilingConfiguration
 data class com.datadog.android.profiling.model.ProfileEvent
-  constructor(kotlin.collections.List<kotlin.String>, kotlin.String, kotlin.String, kotlin.String, kotlin.String, kotlin.String)
+  constructor(kotlin.collections.List<kotlin.String>, kotlin.String, kotlin.String, kotlin.String, kotlin.String, kotlin.String, kotlin.String)
   fun toJson(): com.google.gson.JsonElement
   companion object 
     fun fromJson(kotlin.String): ProfileEvent

--- a/features/dd-sdk-android-profiling/api/dd-sdk-android-profiling.api
+++ b/features/dd-sdk-android-profiling/api/dd-sdk-android-profiling.api
@@ -37,27 +37,27 @@ public final class com/datadog/android/profiling/ProfilingConfiguration$Companio
 
 public final class com/datadog/android/profiling/model/ProfileEvent {
 	public static final field Companion Lcom/datadog/android/profiling/model/ProfileEvent$Companion;
-	public fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/profiling/model/ProfileEvent;
-	public static synthetic fun copy$default (Lcom/datadog/android/profiling/model/ProfileEvent;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/profiling/model/ProfileEvent;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/profiling/model/ProfileEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/profiling/model/ProfileEvent;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/profiling/model/ProfileEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/profiling/model/ProfileEvent;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/profiling/model/ProfileEvent;
 	public final fun getAttachments ()Ljava/util/List;
 	public final fun getEnd ()Ljava/lang/String;
 	public final fun getFamily ()Ljava/lang/String;
+	public final fun getRuntime ()Ljava/lang/String;
 	public final fun getStart ()Ljava/lang/String;
 	public final fun getTagsProfiler ()Ljava/lang/String;
 	public final fun getVersion ()Ljava/lang/String;
 	public fun hashCode ()I
-	public final fun setAttachments (Ljava/util/List;)V
-	public final fun setTagsProfiler (Ljava/lang/String;)V
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
@@ -66,6 +66,7 @@ internal class ProfilingDataWriter(
             end = formatIsoUtc(profilingResult.end),
             attachments = listOf(PERFETTO_ATTACHMENT_NAME),
             family = ANDROID_FAMILY_NAME,
+            runtime = ANDROID_RUNTIME_NAME,
             version = VERSION_NUMBER,
             tagsProfiler = buildTags(context)
         )
@@ -74,7 +75,11 @@ internal class ProfilingDataWriter(
     private fun buildTags(context: DatadogContext): String = buildString {
         append("$TAG_KEY_SERVICE:${context.service}")
         append(",")
+        append("$TAG_KEY_ENV:${context.env}")
+        append(",")
         append("$TAG_KEY_VERSION:${context.version}")
+        append(",")
+        append("$TAG_KEY_SDK_VERSION:${context.sdkVersion}")
     }
 
     private fun readProfilingData(profilingPath: String): ByteArray? {
@@ -86,8 +91,11 @@ internal class ProfilingDataWriter(
     companion object {
         private const val TAG_KEY_SERVICE = "service"
         private const val TAG_KEY_VERSION = "version"
+        private const val TAG_KEY_SDK_VERSION = "sdk_version"
+        private const val TAG_KEY_ENV = "env"
         private const val PERFETTO_ATTACHMENT_NAME = "perfetto.proto"
         private const val ANDROID_FAMILY_NAME = "android"
+        private const val ANDROID_RUNTIME_NAME = "android"
 
         // Only `4` is supported by profiling Backend
         private const val VERSION_NUMBER = "4"

--- a/features/dd-sdk-android-profiling/src/main/json/profiling/profiling-schema.json
+++ b/features/dd-sdk-android-profiling/src/main/json/profiling/profiling-schema.json
@@ -13,7 +13,7 @@
         "description": "Profile file name",
         "readOnly": true
       },
-      "readOnly": false
+      "readOnly": true
     },
     "start": {
       "type": "string",
@@ -30,6 +30,11 @@
       "description": "Profile family used by the backend to identify the profile type. For Perfetto, use \"android\".",
       "readOnly": true
     },
+    "runtime": {
+      "type": "string",
+      "description": "Profile runtime. Use \"android\".",
+      "readOnly": true
+    },
     "version": {
       "type": "string",
       "description": "Schema version of the event, only `4` is supported",
@@ -38,7 +43,7 @@
     "tags_profiler": {
       "type": "string",
       "description": "The list of tags joined into a String and divided by ',' ",
-      "readOnly": false
+      "readOnly": true
     }
   },
   "required": [
@@ -46,6 +51,7 @@
     "start",
     "end",
     "family",
+    "runtime",
     "version",
     "tags_profiler"
   ]

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingDataWriterTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingDataWriterTest.kt
@@ -113,8 +113,10 @@ internal class ProfilingDataWriterTest {
             end = formatIsoUtc(fakeResult.end),
             attachments = listOf("perfetto.proto"),
             family = "android",
+            runtime = "android",
             version = "4",
-            tagsProfiler = "service:${fakeDatadogContext.service},version:${fakeDatadogContext.version}"
+            tagsProfiler = "service:${fakeDatadogContext.service},env:${fakeDatadogContext.env}," +
+                "version:${fakeDatadogContext.version},sdk_version:${fakeDatadogContext.sdkVersion}"
         )
         val argumentCaptor = argumentCaptor<RawBatchEvent>()
         verify(mockEventBatchWriter).write(


### PR DESCRIPTION
### What does this PR do?

This PR adds missing tags to the `ProfileEvent`: `env`, `runtime`, `sdk_version` so that core facets are now correctly filled.

<img width="263" height="477" alt="image" src="https://github.com/user-attachments/assets/e8895fe7-0431-448d-ad3f-cdee2423ed4a" />

This brings us closer to the set of tags iOS is sending https://github.com/DataDog/dd-sdk-ios/blob/c5c677957cc03d939232674b1689597915fb02e1/DatadogProfiling/Sources/AppLaunchProfiler.swift#L50-L66.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

