### PR TITLE
RUM-7562: Provide SDK commit SHA1 to the Shopist App

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
@@ -18,6 +18,12 @@ object MavenConfig {
     const val PUBLICATION = "release"
 }
 
+private fun Project.getGitCommitSha1(): String {
+    return providers.exec {
+        commandLine("git", "rev-parse", "HEAD")
+    }.standardOutput.asText.get().trim()
+}
+
 fun Project.publishingConfig(
     projectDescription: String,
     customArtifactId: String = name
@@ -85,6 +91,12 @@ fun Project.publishingConfig(
                         connection.set("scm:git:git@github.com:Datadog/dd-sdk-android.git")
                         developerConnection.set("scm:git:git@github.com:Datadog/dd-sdk-android.git")
                     }
+
+                    properties.set(
+                        mapOf(
+                            "dd-sdk-android.commit.sha1" to getGitCommitSha1()
+                        )
+                    )
                 }
             }
         }

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
@@ -18,12 +18,6 @@ object MavenConfig {
     const val PUBLICATION = "release"
 }
 
-private fun Project.getGitCommitSha1(): String {
-    return providers.exec {
-        commandLine("git", "rev-parse", "HEAD")
-    }.standardOutput.asText.get().trim()
-}
-
 fun Project.publishingConfig(
     projectDescription: String,
     customArtifactId: String = name
@@ -91,12 +85,6 @@ fun Project.publishingConfig(
                         connection.set("scm:git:git@github.com:Datadog/dd-sdk-android.git")
                         developerConnection.set("scm:git:git@github.com:Datadog/dd-sdk-android.git")
                     }
-
-                    properties.set(
-                        mapOf(
-                            "dd-sdk-android.commit.sha1" to getGitCommitSha1()
-                        )
-                    )
                 }
             }
         }

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -3,6 +3,7 @@ public final class com/datadog/android/BuildConfig {
 	public static final field DEBUG Z
 	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
 	public static final field LOGCAT_ENABLED Ljava/lang/Boolean;
+	public static final field SDK_COMMIT_SHA1 Ljava/lang/String;
 	public static final field SDK_VERSION_CODE I
 	public static final field SDK_VERSION_NAME Ljava/lang/String;
 	public fun <init> ()V

--- a/dd-sdk-android-core/build.gradle.kts
+++ b/dd-sdk-android-core/build.gradle.kts
@@ -65,6 +65,13 @@ android {
             "SDK_VERSION_NAME",
             "\"${AndroidConfig.VERSION.name}\""
         )
+        buildConfigField(
+            "String",
+            "SDK_COMMIT_SHA1",
+            "\"${providers.exec {
+                commandLine("git", "rev-parse", "HEAD")
+            }.standardOutput.asText.get().trim()}\""
+        )
     }
 
     namespace = "com.datadog.android"


### PR DESCRIPTION
### What does this PR do?

Adds the latest Git commit SHA1 to the `dd-sdk-android-core` `build.gradle` file as a `BuildConfig` constant, so the Shopist app can send it as a global RUM attribute.

### Motivation

The Shopist app uses SNAPSHOT versions of the SDK. When multiple snapshot builds are published to the repository, it becomes difficult to determine which exact commit was used in a particular release.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

