### PR TITLE
fix: Add internal disableJankStats config option

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -174,6 +174,7 @@ class com.datadog.android.rum._RumInternalProxy
     fun setAdditionalConfiguration(com.datadog.android.rum.RumConfiguration.Builder, Map<String, Any>): com.datadog.android.rum.RumConfiguration.Builder
     fun setComposeActionTrackingStrategy(com.datadog.android.rum.RumConfiguration.Builder, com.datadog.android.rum.tracking.ActionTrackingStrategy): com.datadog.android.rum.RumConfiguration.Builder
     fun setRumSessionTypeOverride(com.datadog.android.rum.RumConfiguration.Builder, RumSessionType): com.datadog.android.rum.RumConfiguration.Builder
+    fun setDisableJankStats(com.datadog.android.rum.RumConfiguration.Builder, Boolean): com.datadog.android.rum.RumConfiguration.Builder
 data class com.datadog.android.rum.configuration.SlowFramesConfiguration
   constructor(Int = DEFAULT_SLOW_FRAME_RECORDS_MAX_AMOUNT, Long = DEFAULT_FROZEN_FRAME_THRESHOLD_NS, Long = DEFAULT_CONTINUOUS_SLOW_FRAME_THRESHOLD_NS, Long = DEFAULT_FREEZE_DURATION_NS, Long = DEFAULT_VIEW_LIFETIME_THRESHOLD_NS)
   companion object 

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -260,6 +260,7 @@ public final class com/datadog/android/rum/_RumInternalProxy {
 public final class com/datadog/android/rum/_RumInternalProxy$Companion {
 	public final fun setAdditionalConfiguration (Lcom/datadog/android/rum/RumConfiguration$Builder;Ljava/util/Map;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setComposeActionTrackingStrategy (Lcom/datadog/android/rum/RumConfiguration$Builder;Lcom/datadog/android/rum/tracking/ActionTrackingStrategy;)Lcom/datadog/android/rum/RumConfiguration$Builder;
+	public final fun setDisableJankStats (Lcom/datadog/android/rum/RumConfiguration$Builder;Z)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setRumSessionTypeOverride (Lcom/datadog/android/rum/RumConfiguration$Builder;Lcom/datadog/android/rum/RumSessionType;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setTelemetryConfigurationEventMapper (Lcom/datadog/android/rum/RumConfiguration$Builder;Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
@@ -423,5 +423,14 @@ data class RumConfiguration internal constructor(
             rumConfig = rumConfig.copy(rumSessionTypeOverride = rumSessionTypeOverride)
             return this
         }
+
+        /**
+         * Disables JankStats tracking. This flag may be enabled by cross-platform SDKs where
+         * native frame metrics are not meaningful.
+         */
+        internal fun setDisableJankStats(disable: Boolean): Builder {
+            rumConfig = rumConfig.copy(disableJankStats = disable)
+            return this
+        }
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
@@ -115,5 +115,12 @@ class _RumInternalProxy internal constructor(private val rumMonitor: AdvancedRum
         ): Builder {
             return builder.setRumSessionTypeOverride(rumSessionTypeOverride)
         }
+
+        fun setDisableJankStats(
+            builder: Builder,
+            disable: Boolean
+        ): Builder {
+            return builder.setDisableJankStats(disable)
+        }
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -239,13 +239,20 @@ internal class RumFeature(
             initializeVitalExecutorService(frequency)
             initializeCpuVitalMonitor(frequency)
             initializeMemoryVitalMonitor(frequency)
-            initializeFrameStatesAggregator(
-                application = appContext as? Application,
-                listeners = listOfNotNull(
-                    initializeSlowFrameListener(slowFrameListenerConfiguration),
-                    initializeFPSVitalMonitor(frequency)
+
+            // If "_dd.rum.disable_jank_stats" is explicitly set to true, refrain from registering
+            // any frame state listeners; if false or not set, proceed normally
+            val disableJankStats = configuration.additionalConfig[DD_RUM_DISABLE_JANK_STATS_TAG]
+            val allowJankStats = disableJankStats as? Boolean != true
+            if (allowJankStats) {
+                initializeFrameStatesAggregator(
+                    application = appContext as? Application,
+                    listeners = listOfNotNull(
+                        initializeSlowFrameListener(slowFrameListenerConfiguration),
+                        initializeFPSVitalMonitor(frequency)
+                    )
                 )
-            )
+            }
         }
 
         if (configuration.trackNonFatalAnrs) {
@@ -762,6 +769,7 @@ internal class RumFeature(
         internal const val DEFAULT_LONG_TASK_THRESHOLD_MS = 100L
         internal const val DD_TELEMETRY_CONFIG_SAMPLE_RATE_TAG =
             "_dd.telemetry.configuration_sample_rate"
+        internal const val DD_RUM_DISABLE_JANK_STATS_TAG = "_dd.rum.disable_jank_stats"
 
         internal val DEFAULT_RUM_CONFIG = Configuration(
             customEndpointUrl = null,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -239,12 +239,7 @@ internal class RumFeature(
             initializeVitalExecutorService(frequency)
             initializeCpuVitalMonitor(frequency)
             initializeMemoryVitalMonitor(frequency)
-
-            // If "_dd.rum.disable_jank_stats" is explicitly set to true, refrain from registering
-            // any frame state listeners; if false or not set, proceed normally
-            val disableJankStats = configuration.additionalConfig[DD_RUM_DISABLE_JANK_STATS_TAG]
-            val allowJankStats = disableJankStats as? Boolean != true
-            if (allowJankStats) {
+            if (!configuration.disableJankStats) {
                 initializeFrameStatesAggregator(
                     application = appContext as? Application,
                     listeners = listOfNotNull(
@@ -749,7 +744,8 @@ internal class RumFeature(
         val additionalConfig: Map<String, Any>,
         val trackAnonymousUser: Boolean,
         val rumSessionTypeOverride: RumSessionType?,
-        val collectAccessibility: Boolean
+        val collectAccessibility: Boolean,
+        val disableJankStats: Boolean
     )
 
     internal companion object {
@@ -769,7 +765,6 @@ internal class RumFeature(
         internal const val DEFAULT_LONG_TASK_THRESHOLD_MS = 100L
         internal const val DD_TELEMETRY_CONFIG_SAMPLE_RATE_TAG =
             "_dd.telemetry.configuration_sample_rate"
-        internal const val DD_RUM_DISABLE_JANK_STATS_TAG = "_dd.rum.disable_jank_stats"
 
         internal val DEFAULT_RUM_CONFIG = Configuration(
             customEndpointUrl = null,
@@ -802,7 +797,8 @@ internal class RumFeature(
             trackAnonymousUser = true,
             slowFramesConfiguration = null,
             rumSessionTypeOverride = null,
-            collectAccessibility = false
+            collectAccessibility = false,
+            disableJankStats = false
         )
 
         internal const val EVENT_MESSAGE_PROPERTY = "message"

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -347,13 +347,11 @@ internal class RumFeatureTest {
     }
 
     @Test
-    fun `M frameStatesAggregator == null W initialize { frequency = AVERAGE, additionalConfig disables JankStats }`() {
+    fun `M frameStatesAggregator == null W initialize { frequency = AVERAGE, disableJankStats = true }`() {
         // Given
         fakeConfiguration = fakeConfiguration.copy(
             vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.AVERAGE,
-            additionalConfig = mapOf(
-                RumFeature.DD_RUM_DISABLE_JANK_STATS_TAG to true
-            )
+            disableJankStats = true
         )
         testedFeature = RumFeature(
             mockSdkCore,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -327,6 +327,49 @@ internal class RumFeatureTest {
     }
 
     @Test
+    fun `M frameStatesAggregator != null W initialize { frequency = AVERAGE }`() {
+        // Given
+        fakeConfiguration = fakeConfiguration.copy(
+            vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.AVERAGE
+        )
+        testedFeature = RumFeature(
+            mockSdkCore,
+            fakeApplicationId.toString(),
+            fakeConfiguration,
+            lateCrashReporterFactory = { mockLateCrashReporter }
+        )
+
+        // When
+        testedFeature.onInitialize(appContext.mockInstance)
+
+        // Then
+        assertThat(testedFeature.frameStatesAggregator).isNotNull()
+    }
+
+    @Test
+    fun `M frameStatesAggregator == null W initialize { frequency = AVERAGE, additionalConfig disables JankStats }`() {
+        // Given
+        fakeConfiguration = fakeConfiguration.copy(
+            vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.AVERAGE,
+            additionalConfig = mapOf(
+                RumFeature.DD_RUM_DISABLE_JANK_STATS_TAG to true
+            )
+        )
+        testedFeature = RumFeature(
+            mockSdkCore,
+            fakeApplicationId.toString(),
+            fakeConfiguration,
+            lateCrashReporterFactory = { mockLateCrashReporter }
+        )
+
+        // When
+        testedFeature.onInitialize(appContext.mockInstance)
+
+        // Then
+        assertThat(testedFeature.frameStatesAggregator).isNull()
+    }
+
+    @Test
     fun `M set sample rate to 100 W initialize() {developer mode enabled}`() {
         // Given
         whenever(mockSdkCore.isDeveloperModeEnabled) doReturn true

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
@@ -70,7 +70,8 @@ internal class ConfigurationRumForgeryFactory :
             composeActionTrackingStrategy = mock(),
             slowFramesConfiguration = forge.getForgery(),
             rumSessionTypeOverride = forge.aNullable { aValueFrom(RumSessionType::class.java) },
-            collectAccessibility = forge.aBool()
+            collectAccessibility = forge.aBool(),
+            disableJankStats = false
         )
     }
 }


### PR DESCRIPTION
refs: RUM-12763

### What does this PR do?

This PR adds a check to RUM feature initialization: if the new internal option `_dd.rum.disable_jank_stats` is explicitly set to true, then we refrain from calling `initializeFrameStatesAggregator()`. Otherwise, we call that function as normal.

### Motivation

This change allows the Unity SDK to configure the Android SDK in such a way that it will never call `JankStats.createAndTrack()`, which is necessary to avoid crashes caused by the older versions of `androidx.metrics` that the `dd-sdk-unity` is forced to use in older versions of Unity.

### Additional Notes

I notice that the generated `apiSurface` files are not up to date at latest in develop, so I expect that CI will fail. When I test locally with `./local-ci.sh --test`, everything passes. I can rebase once the unrelated API surface issue is fixed in develop.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

