### PR TITLE
Fix RumWindowCallbacksRegistry for multiple SDK instances

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/utils/window/RumWindowCallbacksRegistry.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/utils/window/RumWindowCallbacksRegistry.kt
@@ -44,26 +44,28 @@ internal class RumWindowCallbacksRegistryImpl : RumWindowCallbacksRegistry {
             }
         }
     }
-}
 
-private fun Window.wrapCallback(): RumWindowCallback {
-    val currentCallback = callback
-    val newCallback = RumWindowCallback(
-        wrapped = currentCallback
-    )
-    callback = newCallback
-    return newCallback
-}
+    private fun Window.wrapCallback(): RumWindowCallback {
+        val currentCallback = callback
+        val newCallback = RumWindowCallback(
+            wrapped = currentCallback,
+            registry = this@RumWindowCallbacksRegistryImpl
+        )
+        callback = newCallback
+        return newCallback
+    }
 
-private fun Window.tryToRemoveCallback() {
-    val currentCallback = callback
-    if (currentCallback is RumWindowCallback) {
-        callback = currentCallback.wrapped
+    private fun Window.tryToRemoveCallback() {
+        val currentCallback = callback
+        if (currentCallback is RumWindowCallback && currentCallback.registry === this@RumWindowCallbacksRegistryImpl) {
+            callback = currentCallback.wrapped
+        }
     }
 }
 
 private class RumWindowCallback(
-    val wrapped: Window.Callback
+    val wrapped: Window.Callback,
+    val registry: RumWindowCallbacksRegistry
 ) : FixedWindowCallback(wrapped) {
 
     val subscription = DDCoreSubscription.create<RumWindowCallbackListener>()

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/utils/window/RumWindowCallbacksRegistry.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/utils/window/RumWindowCallbacksRegistry.kt
@@ -48,8 +48,7 @@ internal class RumWindowCallbacksRegistryImpl : RumWindowCallbacksRegistry {
     private fun Window.wrapCallback(): RumWindowCallback {
         val currentCallback = callback
         val newCallback = RumWindowCallback(
-            wrapped = currentCallback,
-            registry = this@RumWindowCallbacksRegistryImpl
+            wrapped = currentCallback
         )
         callback = newCallback
         return newCallback
@@ -57,15 +56,14 @@ internal class RumWindowCallbacksRegistryImpl : RumWindowCallbacksRegistry {
 
     private fun Window.tryToRemoveCallback() {
         val currentCallback = callback
-        if (currentCallback is RumWindowCallback && currentCallback.registry === this@RumWindowCallbacksRegistryImpl) {
+        if (currentCallback is RumWindowCallback && currentCallback in callbacks.values) {
             callback = currentCallback.wrapped
         }
     }
 }
 
 private class RumWindowCallback(
-    val wrapped: Window.Callback,
-    val registry: RumWindowCallbacksRegistry
+    val wrapped: Window.Callback
 ) : FixedWindowCallback(wrapped) {
 
     val subscription = DDCoreSubscription.create<RumWindowCallbackListener>()

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/utils/RumWindowCallbacksRegistryTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/utils/RumWindowCallbacksRegistryTest.kt
@@ -130,6 +130,52 @@ class RumWindowCallbacksRegistryTest {
         // Then
         assertThat(callback).isEqualTo(anotherWrapper)
     }
+
+    @Test
+    fun `M not restore the callback W removeListener { if there is another RumWindowCallbacksRegistry }`() {
+        // Given
+        val anotherRegistry = RumWindowCallbacksRegistryImpl()
+        val anotherListener = mock<RumWindowCallbackListener>()
+
+        registry.addListener(activity, listener)
+        val callback1 = window.callback
+
+        anotherRegistry.addListener(activity, anotherListener)
+        val callback2 = window.callback
+
+        // When
+        registry.removeListener(activity, listener)
+
+        // Then
+        assertThat(callback1).isNotEqualTo(callback2)
+        assertThat(window.callback).isEqualTo(callback2)
+    }
+
+    @Test
+    fun `M call listeners from both RumWindowCallbacksRegistries W addListener { onContentChanged called }`() {
+        // Given
+        val anotherRegistry = RumWindowCallbacksRegistryImpl()
+        val anotherListener = mock<RumWindowCallbackListener>()
+
+        registry.addListener(activity, listener)
+        val callback1 = window.callback
+
+        anotherRegistry.addListener(activity, anotherListener)
+        val callback2 = window.callback
+
+        // When
+        callback.onContentChanged()
+
+        // Then
+        inOrder(listener, existingCallback, anotherListener) {
+            verify(existingCallback).onContentChanged()
+            verify(listener).onContentChanged()
+            verify(anotherListener).onContentChanged()
+            verifyNoMoreInteractions()
+        }
+        assertThat(callback1).isNotEqualTo(callback2)
+        assertThat(window.callback).isEqualTo(callback2)
+    }
 }
 
 private class TestWindowCallbackWrapper(wrapped: Window.Callback) : FixedWindowCallback(wrapped)


### PR DESCRIPTION
### What does this PR do?

Fixing `RumWindowCallbacksRegistry` for the case when there are multiple Datadog SDK instances in the app.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

