### PR TITLE
RUM-12069: Add service name to `ddtags` of `LogEvent`

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -378,6 +378,7 @@ object com.datadog.android.log.LogAttributes
   const val APPLICATION_PACKAGE: String
   const val APPLICATION_VERSION: String
   const val ENV: String
+  const val SERVICE: String
   const val DATE: String
   const val DB_INSTANCE: String
   const val DB_OPERATION: String

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -1021,6 +1021,7 @@ public final class com/datadog/android/log/LogAttributes {
 	public static final field RUM_APPLICATION_ID Ljava/lang/String;
 	public static final field RUM_SESSION_ID Ljava/lang/String;
 	public static final field RUM_VIEW_ID Ljava/lang/String;
+	public static final field SERVICE Ljava/lang/String;
 	public static final field SERVICE_NAME Ljava/lang/String;
 	public static final field SOURCE Ljava/lang/String;
 	public static final field SOURCE_TYPE Ljava/lang/String;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/log/LogAttributes.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/log/LogAttributes.kt
@@ -37,10 +37,16 @@ object LogAttributes {
     const val APPLICATION_VERSION: String = "version"
 
     /**
-     * The custom environment name. (Number)
+     * The custom environment name. (String)
      * This value is filled automatically by the [Logger].
      */
     const val ENV: String = "env"
+
+    /**
+     * The service name. (String)
+     * This value is filled automatically by the [Logger].
+     */
+    const val SERVICE: String = "service"
 
     /**
      * The date when the log is fired as an ISO-8601 String. (String)

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/domain/DatadogLogGenerator.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/domain/DatadogLogGenerator.kt
@@ -260,6 +260,15 @@ internal class DatadogLogGenerator(
         }
     }
 
+    private fun serviceTag(datadogContext: DatadogContext): String? {
+        val service = datadogContext.service
+        return if (service.isNotEmpty()) {
+            "${LogAttributes.SERVICE}:$service"
+        } else {
+            null
+        }
+    }
+
     private fun resolveNetworkInfo(
         datadogContext: DatadogContext,
         networkInfo: NetworkInfo?
@@ -314,6 +323,9 @@ internal class DatadogLogGenerator(
             combinedTags.add(it)
         }
         variantTag(datadogContext)?.let {
+            combinedTags.add(it)
+        }
+        serviceTag(datadogContext)?.let {
             combinedTags.add(it)
         }
 

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
@@ -460,7 +460,8 @@ internal class LogsFeatureTest {
                     setOf(
                         "${LogAttributes.ENV}:${fakeDatadogContext.env}",
                         "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
-                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
+                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}",
+                        "${LogAttributes.SERVICE}:${fakeDatadogContext.service}"
                     )
                 )
         }

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/domain/DatadogLogGeneratorTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/domain/DatadogLogGeneratorTest.kt
@@ -25,7 +25,6 @@ import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -737,7 +736,7 @@ internal class DatadogLogGeneratorTest {
 
         // THEN
         val deserializedTags = log.ddtags.split(",")
-        Assertions.assertThat(deserializedTags)
+        assertThat(deserializedTags)
             .contains("${LogAttributes.ENV}:${fakeDatadogContext.env}")
     }
 
@@ -765,7 +764,8 @@ internal class DatadogLogGeneratorTest {
         // THEN
         val expectedTags = fakeTags +
             "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}" +
-            "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
+            "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}" +
+            "${LogAttributes.SERVICE}:${fakeDatadogContext.service}"
         assertThat(log).hasExactlyTags(expectedTags)
     }
 
@@ -787,7 +787,7 @@ internal class DatadogLogGeneratorTest {
 
         // THEN
         val deserializedTags = log.ddtags.split(",")
-        Assertions.assertThat(deserializedTags)
+        assertThat(deserializedTags)
             .contains("${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}")
     }
 
@@ -815,7 +815,8 @@ internal class DatadogLogGeneratorTest {
         // THEN
         val expectedTags = fakeTags +
             "${LogAttributes.ENV}:${fakeDatadogContext.env}" +
-            "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
+            "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}" +
+            "${LogAttributes.SERVICE}:${fakeDatadogContext.service}"
         assertThat(log).hasExactlyTags(expectedTags)
     }
 
@@ -837,7 +838,7 @@ internal class DatadogLogGeneratorTest {
 
         // THEN
         val deserializedTags = log.ddtags.split(",")
-        Assertions.assertThat(deserializedTags)
+        assertThat(deserializedTags)
             .contains("${LogAttributes.VARIANT}:${fakeDatadogContext.variant}")
     }
 
@@ -865,7 +866,59 @@ internal class DatadogLogGeneratorTest {
         // THEN
         val expectedTags = fakeTags +
             "${LogAttributes.ENV}:${fakeDatadogContext.env}" +
-            "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}"
+            "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}" +
+            "${LogAttributes.SERVICE}:${fakeDatadogContext.service}"
+        assertThat(log).hasExactlyTags(expectedTags)
+    }
+
+    @Test
+    fun `M add the serviceTag W not empty`() {
+        // When
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp,
+            fakeThreadName,
+            fakeDatadogContext,
+            attachNetworkInfo = true,
+            fakeLoggerName
+        )
+
+        // Then
+        val deserializedTags = log.ddtags.split(",")
+        assertThat(deserializedTags)
+            .contains("${LogAttributes.SERVICE}:${fakeDatadogContext.service}")
+    }
+
+    @Test
+    fun `M not add the serviceTag W empty`() {
+        // Given
+        fakeDatadogContext = fakeDatadogContext.copy(
+            service = ""
+        )
+
+        // When
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp,
+            fakeThreadName,
+            fakeDatadogContext,
+            attachNetworkInfo = true,
+            fakeLoggerName
+        )
+
+        // Then
+        val expectedTags = fakeTags +
+            "${LogAttributes.ENV}:${fakeDatadogContext.env}" +
+            "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}" +
+            "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
         assertThat(log).hasExactlyTags(expectedTags)
     }
 
@@ -906,7 +959,7 @@ internal class DatadogLogGeneratorTest {
         )
 
         // THEN
-        Assertions.assertThat(log.additionalProperties).containsAllEntriesOf(
+        assertThat(log.additionalProperties).containsAllEntriesOf(
             mapOf(
                 LogAttributes.DD_TRACE_ID to fakeTraceId,
                 LogAttributes.DD_SPAN_ID to fakeSpanId
@@ -1036,7 +1089,7 @@ internal class DatadogLogGeneratorTest {
         )
 
         // THEN
-        Assertions.assertThat(log.additionalProperties).containsAllEntriesOf(
+        assertThat(log.additionalProperties).containsAllEntriesOf(
             mapOf(
                 LogAttributes.RUM_APPLICATION_ID to fakeRumApplicationId,
                 LogAttributes.RUM_SESSION_ID to fakeRumSessionId,

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -121,6 +121,7 @@ internal class DatadogLogHandlerTest {
         fakeAttributes = forge.aMap { anAlphabeticalString() to anInt() }
         fakeTags = forge.aList { anAlphabeticalString() }.toSet()
         fakeDatadogContext = fakeDatadogContext.copy(
+            service = fakeServiceName,
             time = fakeDatadogContext.time.copy(
                 serverTimeOffsetMs = 0L
             ),
@@ -209,7 +210,8 @@ internal class DatadogLogHandlerTest {
                     fakeTags + setOf(
                         "${LogAttributes.ENV}:${fakeDatadogContext.env}",
                         "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
-                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
+                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}",
+                        "${LogAttributes.SERVICE}:$fakeServiceName"
                     )
                 )
                 .doesNotHaveError()
@@ -290,7 +292,8 @@ internal class DatadogLogHandlerTest {
                     fakeTags + setOf(
                         "${LogAttributes.ENV}:${fakeDatadogContext.env}",
                         "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
-                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
+                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}",
+                        "${LogAttributes.SERVICE}:$fakeServiceName"
                     )
                 )
                 .hasError(
@@ -355,7 +358,8 @@ internal class DatadogLogHandlerTest {
                     fakeTags + setOf(
                         "${LogAttributes.ENV}:${fakeDatadogContext.env}",
                         "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
-                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
+                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}",
+                        "${LogAttributes.SERVICE}:$fakeServiceName"
                     )
                 )
                 .hasError(
@@ -614,7 +618,8 @@ internal class DatadogLogHandlerTest {
                     fakeTags + setOf(
                         "${LogAttributes.ENV}:${fakeDatadogContext.env}",
                         "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
-                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
+                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}",
+                        "${LogAttributes.SERVICE}:$fakeServiceName"
                     )
                 )
         }
@@ -676,7 +681,8 @@ internal class DatadogLogHandlerTest {
                     fakeTags + setOf(
                         "${LogAttributes.ENV}:${fakeDatadogContext.env}",
                         "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
-                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
+                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}",
+                        "${LogAttributes.SERVICE}:$fakeServiceName"
                     )
                 )
         }
@@ -736,7 +742,8 @@ internal class DatadogLogHandlerTest {
                     fakeTags + setOf(
                         "${LogAttributes.ENV}:${fakeDatadogContext.env}",
                         "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
-                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
+                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}",
+                        "${LogAttributes.SERVICE}:$fakeServiceName"
                     )
                 )
         }
@@ -794,7 +801,8 @@ internal class DatadogLogHandlerTest {
                     setOf(
                         "${LogAttributes.ENV}:${fakeDatadogContext.env}",
                         "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
-                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
+                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}",
+                        "${LogAttributes.SERVICE}:$fakeServiceName"
                     )
                 )
                 .doesNotHaveError()
@@ -1104,7 +1112,8 @@ internal class DatadogLogHandlerTest {
                     fakeTags + setOf(
                         "${LogAttributes.ENV}:${fakeDatadogContext.env}",
                         "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
-                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
+                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}",
+                        "${LogAttributes.SERVICE}:$fakeServiceName"
                     )
                 )
         }


### PR DESCRIPTION
### What does this PR do?

This PR adds service name to the `ddtags` property of `LogEvent` to align with what Browser SDK is doing.

iOS SDK counterpart is here https://github.com/DataDog/dd-sdk-ios/pull/2575.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

