### PR TITLE
RUM-12891: Fix RUM resource duration breakdown

### DIFF
--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogEventListener.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogEventListener.kt
@@ -9,7 +9,6 @@ package com.datadog.android.okhttp
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.core.SdkReference
-import com.datadog.android.okhttp.DatadogEventListener.Factory
 import com.datadog.android.okhttp.internal.rum.buildResourceId
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
@@ -244,7 +243,7 @@ internal constructor(
 
         /** @inheritdoc */
         override fun create(call: Call): EventListener {
-            val resourceId = call.request().buildResourceId(generateUuid = true)
+            val resourceId = call.request().buildResourceId(generateUuid = false)
             val sdkCore = sdkCoreReference.get()
             return if (sdkCore != null) {
                 DatadogEventListener(sdkCore, resourceId)

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogEventListenerFactoryTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogEventListenerFactoryTest.kt
@@ -81,6 +81,16 @@ internal class DatadogEventListenerFactoryTest {
         assertThat(result).isSameAs(DatadogEventListener.Factory.NO_OP_EVENT_LISTENER)
     }
 
+    @Test
+    fun `M not generate UUID in the resource key W create()`() {
+        // When
+        val result = testedFactory.create(mockCall)
+
+        // Then
+        check(result is DatadogEventListener)
+        assertThat(result.key.uuid).isEqualTo(null)
+    }
+
     companion object {
         val datadogCore = DatadogSingletonTestConfiguration()
 


### PR DESCRIPTION
### What does this PR do?

This PRs fixes the resource duration breakdown feature which is broken since the version 2.12.0, more precisely from this [commit](https://github.com/DataDog/dd-sdk-android/pull/2126).

#### The main cause of issue:

We have `DatadogInteceptor` generating the RUM event `startResource` with the `ResourceId(requestUrl, randomUUID)` as the key of the resource when intercepting a request, also we have `DatadogEventListener` to add `waitForResourceTiming` event and `addResourceTiming` to report the resource timing for this duration breakdown.

The issue is that, both `DatadogInteceptor` and `DatadogEventListener` are generating their own UUID for the same request, so in our event processing they won’t be able to match.

The fix is to remove the generation of UUID in `DatadogEventListener` since its key is only used for enhancing the current resource.

### Motivation

RUM-12891

### Demo

| Before | <img width="1059" height="292" alt="image" src="https://github.com/user-attachments/assets/5b44aaaf-e3cd-45b2-ab31-868b2993d3f4" />  |
| --- | --- |
|After| <img width="1056" height="362" alt="image" src="https://github.com/user-attachments/assets/c8e64c16-a5b8-4da2-946e-090632a3af66" />|

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

