### PR TITLE
Add `anonymousId` to the empty `UserInfo` object check

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
@@ -192,7 +192,7 @@ internal class DatadogLateCrashReporter(
         val additionalProperties = viewEvent.context?.additionalProperties ?: mutableMapOf()
         val additionalUserProperties = viewEvent.usr?.additionalProperties ?: mutableMapOf()
         val user = viewEvent.usr
-        val hasUserInfo = user?.id != null || user?.name != null ||
+        val hasUserInfo = user?.id != null || user?.anonymousId != null || user?.name != null ||
             user?.email != null || additionalUserProperties.isNotEmpty()
         val account = viewEvent.account
         val deviceInfo = datadogContext.deviceInfo

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/utils/RuntimeUtils.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/utils/RuntimeUtils.kt
@@ -9,6 +9,6 @@ package com.datadog.android.rum.internal.utils
 import com.datadog.android.api.context.UserInfo
 
 internal fun UserInfo.hasUserData(): Boolean {
-    return id != null || name != null ||
+    return id != null || anonymousId != null || name != null ||
         email != null || additionalProperties.isNotEmpty()
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
@@ -205,6 +205,12 @@ internal class ActionEventAssert(actual: ActionEvent) :
                     "but was ${actual.usr?.id}"
             )
             .isEqualTo(expected?.id)
+        assertThat(actual.usr?.anonymousId)
+            .overridingErrorMessage(
+                "Expected RUM event to have usr.anonymousId ${expected?.anonymousId} " +
+                    "but was ${actual.usr?.anonymousId}"
+            )
+            .isEqualTo(expected?.anonymousId)
         assertThat(actual.usr?.name)
             .overridingErrorMessage(
                 "Expected RUM event to have usr.name ${expected?.name} " +

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
@@ -132,6 +132,12 @@ internal class ErrorEventAssert(actual: ErrorEvent) :
                     "but was ${actual.usr?.id}"
             )
             .isEqualTo(expected?.id)
+        assertThat(actual.usr?.anonymousId)
+            .overridingErrorMessage(
+                "Expected RUM event to have usr.anonymousId ${expected?.anonymousId} " +
+                    "but was ${actual.usr?.anonymousId}"
+            )
+            .isEqualTo(expected?.anonymousId)
         assertThat(actual.usr?.name)
             .overridingErrorMessage(
                 "Expected RUM event to have usr.name ${expected?.name} " +

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/LongTaskEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/LongTaskEventAssert.kt
@@ -62,6 +62,12 @@ internal class LongTaskEventAssert(actual: LongTaskEvent) :
                     "but was ${actual.usr?.id}"
             )
             .isEqualTo(expected?.id)
+        assertThat(actual.usr?.anonymousId)
+            .overridingErrorMessage(
+                "Expected RUM event to have usr.anonymousId ${expected?.anonymousId} " +
+                    "but was ${actual.usr?.anonymousId}"
+            )
+            .isEqualTo(expected?.anonymousId)
         assertThat(actual.usr?.name)
             .overridingErrorMessage(
                 "Expected RUM event to have usr.name ${expected?.name} " +

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
@@ -261,6 +261,12 @@ internal class ResourceEventAssert(actual: ResourceEvent) :
                     "but was ${actual.usr?.id}"
             )
             .isEqualTo(expected?.id)
+        assertThat(actual.usr?.anonymousId)
+            .overridingErrorMessage(
+                "Expected RUM event to have usr.anonymousId ${expected?.anonymousId} " +
+                    "but was ${actual.usr?.anonymousId}"
+            )
+            .isEqualTo(expected?.anonymousId)
         assertThat(actual.usr?.name)
             .overridingErrorMessage(
                 "Expected event to have usr.name ${expected?.name} " +

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
@@ -333,6 +333,12 @@ internal class ViewEventAssert(actual: ViewEvent) :
                     "but was ${actual.usr?.id}"
             )
             .isEqualTo(expected?.id)
+        assertThat(actual.usr?.anonymousId)
+            .overridingErrorMessage(
+                "Expected event to have usr.anonymousId ${expected?.anonymousId} " +
+                    "but was ${actual.usr?.anonymousId}"
+            )
+            .isEqualTo(expected?.anonymousId)
         assertThat(actual.usr?.name)
             .overridingErrorMessage(
                 "Expected event to have usr.name ${expected?.name} " +
@@ -385,6 +391,12 @@ internal class ViewEventAssert(actual: ViewEvent) :
                     "but was ${actual.usr?.id}"
             )
             .isEqualTo(expected?.id)
+        assertThat(actual.usr?.anonymousId)
+            .overridingErrorMessage(
+                "Expected event to have usr.anonymousId ${expected?.anonymousId} " +
+                    "but was ${actual.usr?.anonymousId}"
+            )
+            .isEqualTo(expected?.anonymousId)
         assertThat(actual.usr?.name)
             .overridingErrorMessage(
                 "Expected event to have usr.name ${expected?.name} " +

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/VitalEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/VitalEventAssert.kt
@@ -177,6 +177,12 @@ internal class VitalEventAssert(
                     "but was ${actual.usr?.id}"
             )
             .isEqualTo(expected?.id)
+        assertThat(actual.usr?.anonymousId)
+            .overridingErrorMessage(
+                "Expected RUM event to have usr.anonymousId ${expected?.anonymousId} " +
+                    "but was ${actual.usr?.anonymousId}"
+            )
+            .isEqualTo(expected?.anonymousId)
         assertThat(actual.usr?.name)
             .overridingErrorMessage(
                 "Expected event to have usr.name ${expected?.name} " +


### PR DESCRIPTION
### What does this PR do?

We were missing `anonymousId` property in the `UserInfo` object check for data, this could lead to `anonymousId` not being sent if there is not other user data set.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

