### PR TITLE
RUM-12923: Attach RUM information on profiling event

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -158,6 +158,6 @@ class com.datadog.android.rum.DdRumContentProvider : android.content.ContentProv
     var processImportance: Int
     val createTimeNs: Long
 data class com.datadog.android.rum.TTIDEvent
-  constructor(Long)
+  constructor(Long, String, String, String, String?, String?)
 annotation com.datadog.tools.annotation.NoOpImplementation
   constructor(Boolean = false)

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -382,12 +382,22 @@ public final class com/datadog/android/rum/DdRumContentProvider$Companion {
 }
 
 public final class com/datadog/android/rum/TTIDEvent {
-	public fun <init> (J)V
+	public fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()J
-	public final fun copy (J)Lcom/datadog/android/rum/TTIDEvent;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/TTIDEvent;JILjava/lang/Object;)Lcom/datadog/android/rum/TTIDEvent;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/rum/TTIDEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/TTIDEvent;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/TTIDEvent;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getValue ()J
+	public final fun getApplicationId ()Ljava/lang/String;
+	public final fun getDurationNs ()J
+	public final fun getSessionId ()Ljava/lang/String;
+	public final fun getViewId ()Ljava/lang/String;
+	public final fun getViewName ()Ljava/lang/String;
+	public final fun getVitalId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/rum/TTIDEvent.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/rum/TTIDEvent.kt
@@ -9,6 +9,18 @@ package com.datadog.android.rum
 /**
  * Internal event to pass the Time To Initial Display (TTID) value in nanoseconds.
  *
- * @param value The TTID value in nanoseconds.
+ * @param durationNs The TTID value in nanoseconds.
+ * @param applicationId The Id of the application of RUM.
+ * @param sessionId The Id of the RUM session where TTID is captured
+ * @param vitalId The Id of the TTID vital event
+ * @param viewId The Id of the view where TTID is captured
+ * @param viewName The name of the view where TTID is captured
  */
-data class TTIDEvent(val value: Long)
+data class TTIDEvent(
+    val durationNs: Long,
+    val applicationId: String,
+    val sessionId: String,
+    val vitalId: String,
+    val viewId: String?,
+    val viewName: String?
+)

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/forge/Configurator.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/forge/Configurator.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.internal.forge
 
 import com.datadog.android.internal.tests.elmyr.InternalTelemetryErrorLogForgeryFactory
+import com.datadog.android.internal.tests.elmyr.TTIDEventFactory
 import com.datadog.tools.unit.forge.BaseConfigurator
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.jvm.useJvmFactories
@@ -17,5 +18,6 @@ internal class Configurator :
         super.configure(forge)
         forge.useJvmFactories()
         forge.addFactory(InternalTelemetryErrorLogForgeryFactory())
+        forge.addFactory(TTIDEventFactory())
     }
 }

--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/TTIDEventFactory.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/TTIDEventFactory.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.tests.elmyr
+
+import com.datadog.android.rum.TTIDEvent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+class TTIDEventFactory : ForgeryFactory<TTIDEvent> {
+    override fun getForgery(forge: Forge): TTIDEvent {
+        return TTIDEvent(
+            durationNs = forge.aLong(),
+            applicationId = forge.anAlphabeticalString(),
+            sessionId = forge.anAlphabeticalString(),
+            vitalId = forge.anAlphabeticalString(),
+            viewId = forge.aNullable { anAlphabeticalString() },
+            viewName = forge.aNullable { anAlphabeticalString() }
+        )
+    }
+}

--- a/features/dd-sdk-android-profiling/build.gradle.kts
+++ b/features/dd-sdk-android-profiling/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     }
 
     testImplementation(testFixtures(project(":dd-sdk-android-core")))
+    testImplementation(testFixtures(project(":dd-sdk-android-internal")))
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     unmock(libs.robolectric)

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -29,6 +29,8 @@ internal class ProfilingFeature(
 
     private var dataWriter: ProfilingWriter = NoOpProfilingWriter()
 
+    private var ttidEvent: TTIDEvent? = null
+
     override val requestFactory: RequestFactory = ProfilingRequestFactory(
         configuration.customEndpointUrl,
         sdkCore.internalLogger
@@ -44,7 +46,10 @@ internal class ProfilingFeature(
         profiler.apply {
             this.internalLogger = sdkCore.internalLogger
             this.onProfilingSuccess = { result ->
-                dataWriter.write(profilingResult = result)
+                dataWriter.write(
+                    profilingResult = result,
+                    ttidEvent = ttidEvent
+                )
             }
         }
         // Set the profiling flag in SharedPreferences to profile for the next app launch
@@ -67,11 +72,12 @@ internal class ProfilingFeature(
             )
             return
         }
+        this.ttidEvent = event
         profiler.stop()
         sdkCore.internalLogger.log(
             InternalLogger.Level.INFO,
             InternalLogger.Target.USER,
-            { "Profiling stopped with TTID=${event.value}" }
+            { "Profiling stopped with TTID=${event.durationNs}" }
         )
     }
 

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingWriter.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingWriter.kt
@@ -7,12 +7,14 @@
 package com.datadog.android.profiling.internal
 
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
+import com.datadog.android.rum.TTIDEvent
 import com.datadog.tools.annotation.NoOpImplementation
 
 @NoOpImplementation
 internal interface ProfilingWriter {
 
     fun write(
-        profilingResult: PerfettoResult
+        profilingResult: PerfettoResult,
+        ttidEvent: TTIDEvent?
     )
 }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -17,7 +17,6 @@ import com.datadog.android.profiling.internal.ProfilingFeature
 import com.datadog.android.profiling.internal.ProfilingRequestFactory
 import com.datadog.android.rum.TTIDEvent
 import fr.xgouchet.elmyr.annotation.Forgery
-import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -110,9 +109,11 @@ class ProfilingFeatureTest {
     }
 
     @Test
-    fun `M stop Profiling W receive TTID event`(@LongForgery fakeTtid: Long) {
+    fun `M stop Profiling W receive TTID event`(
+        @Forgery fakeTTIDEvent: TTIDEvent
+    ) {
         // When
-        testedFeature.onReceive(TTIDEvent(fakeTtid))
+        testedFeature.onReceive(fakeTTIDEvent)
 
         // Then
         verify(mockProfiler).stop()

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/Configurator.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/Configurator.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.profiling.forge
 
+import com.datadog.android.internal.tests.elmyr.TTIDEventFactory
 import com.datadog.android.tests.elmyr.useCoreFactories
 import com.datadog.tools.unit.forge.BaseConfigurator
 import fr.xgouchet.elmyr.Forge
@@ -17,5 +18,6 @@ class Configurator : BaseConfigurator() {
         forge.useCoreFactories()
         forge.addFactory(ProfilingConfigurationForgeryFactory())
         forge.addFactory(PerfettoResultFactory())
+        forge.addFactory(TTIDEventFactory())
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -40,7 +40,6 @@ import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.RumSessionType
-import com.datadog.android.rum.TTIDEvent
 import com.datadog.android.rum.configuration.SlowFramesConfiguration
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
 import com.datadog.android.rum.internal.anr.ANRDetectorRunnable
@@ -706,10 +705,6 @@ internal class RumFeature(
                             )
 
                             rumMonitor.sendTTIDEvent(info)
-
-                            // Send TTID event to Profiling feature
-                            sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)
-                                ?.sendEvent(TTIDEvent(durationNs))
                         }
                     }
 
@@ -814,8 +809,6 @@ internal class RumFeature(
         internal const val EVENT_THROWABLE_PROPERTY = "throwable"
         internal const val EVENT_ATTRIBUTES_PROPERTY = "attributes"
         internal const val EVENT_STACKTRACE_PROPERTY = "stacktrace"
-
-        internal const val RUM_TTID_BUS_MESSAGE_KEY = "rum_ttid"
 
         internal const val UNSUPPORTED_EVENT_TYPE =
             "RUM feature receive an event of unsupported type=%s."


### PR DESCRIPTION
### What does this PR do?

This PR attaches following RUM context information in Profiling event so that it can be shown as tags in profiling page:
* session id
* vital id
* view name
* view id
Also it changes the timing of RUM feature send TTID event to Profiling feature in order to stop the recording, so that the profiling event can attach the real first view event instead of artificial "AppLaunch" view event.

### Motivation

RUM-12923

### Demo

<img width="699" height="471" alt="image" src="https://github.com/user-attachments/assets/e96c2aec-5518-4010-9652-169522c5078d" />


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

