### PR TITLE
RUM-12066: Add light theme colors to the RUM Debug Widget

### DIFF
--- a/features/dd-sdk-android-rum-debug-widget/src/main/res/layout/layout_dd_insights_widget.xml
+++ b/features/dd-sdk-android-rum-debug-widget/src/main/res/layout/layout_dd_insights_widget.xml
@@ -32,7 +32,7 @@
         android:ellipsize="start"
         android:singleLine="true"
         android:includeFontPadding="false"
-        android:textColor="@android:color/white"
+        android:textColor="@color/widget_text"
         android:textSize="14sp" />
 
     <!--
@@ -150,7 +150,7 @@
         android:layout_marginTop="200dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textColor="@android:color/white"
+        android:textColor="@color/widget_text"
         android:gravity="center_horizontal"
         android:textSize="11sp"
 

--- a/features/dd-sdk-android-rum-debug-widget/src/main/res/values-night/colors.xml
+++ b/features/dd-sdk-android-rum-debug-widget/src/main/res/values-night/colors.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+  ~ This product includes software developed at Datadog (https://www.datadoghq.com/).
+  ~ Copyright 2016-Present Datadog, Inc.
+  -->
+
+<resources>
+    <color name="widget_text">#FFFFFF</color>
+    <color name="vital_bg">#373737</color>
+    <color name="vital_chart">#AAFF0000</color>
+    <color name="widget_bg">#292929</color>
+    <color name="timeline_action">#FFC0CB</color>
+    <color name="timeline_slow_frame">#FFFF00</color>
+    <color name="timeline_freeze_frame">#FF0000</color>
+    <color name="timeline_resource">#00FF00</color>
+</resources>

--- a/features/dd-sdk-android-rum-debug-widget/src/main/res/values/colors.xml
+++ b/features/dd-sdk-android-rum-debug-widget/src/main/res/values/colors.xml
@@ -5,13 +5,13 @@
   -->
 
 <resources>
-<!--    <color name="vital_bg">#B5B5B5</color>-->
-    <color name="widget_text">#FFFFFF</color>
-    <color name="vital_bg">#373737</color>
+    <!-- Light theme colors -->
+    <color name="widget_text">#1A1A1A</color>
+    <color name="vital_bg">#E0E0E0</color>
     <color name="vital_chart">#AAFF0000</color>
-    <color name="widget_bg">#292929</color>
-    <color name="timeline_action">#FFC0CB</color>
-    <color name="timeline_slow_frame">#FFFF00</color>
-    <color name="timeline_freeze_frame">#FF0000</color>
-    <color name="timeline_resource">#00FF00</color>
+    <color name="widget_bg">#F5F5F5</color>
+    <color name="timeline_action">#C71585</color>
+    <color name="timeline_slow_frame">#B8860B</color>
+    <color name="timeline_freeze_frame">#CC0000</color>
+    <color name="timeline_resource">#228B22</color>
 </resources>


### PR DESCRIPTION
### What does this PR do?

Adds light theme support. The widget now automatically adapts to the device's current theme.

### Motivation

The widget previously only supported dark mode.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

