### PR TITLE
Support non-ascii GraphQL headers

### DIFF
--- a/detekt_custom_unsafe_calls.yml
+++ b/detekt_custom_unsafe_calls.yml
@@ -25,6 +25,7 @@ datadog:
       - "android.net.ConnectivityManager.registerDefaultNetworkCallback(android.net.ConnectivityManager.NetworkCallback):java.lang.IllegalArgumentException,java.lang.SecurityException"
       - "android.net.ConnectivityManager.unregisterNetworkCallback(android.net.ConnectivityManager.NetworkCallback):java.lang.SecurityException"
       - "android.provider.Settings.System.getInt(android.content.ContentResolver?, kotlin.String?):android.provider.Settings.SettingNotFoundException"
+      - "android.util.Base64.decode(kotlin.String?, kotlin.Int):java.lang.IllegalArgumentException"
       - "android.util.Base64.encodeToString(kotlin.ByteArray?, kotlin.Int):java.lang.AssertionError"
       - "android.view.Choreographer.getInstance():java.lang.IllegalStateException"
       - "android.view.Choreographer.postFrameCallback():java.lang.IllegalArgumentException"

--- a/integrations/dd-sdk-android-apollo/build.gradle.kts
+++ b/integrations/dd-sdk-android-apollo/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     id("com.github.ben-manes.versions")
 
     // Tests
+    id("de.mobilej.unmock")
     id("org.jetbrains.kotlinx.kover")
 
     // Internal Generation
@@ -48,6 +49,11 @@ dependencies {
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     testImplementation(libs.okHttpMock)
+    unmock(libs.robolectric)
+}
+
+unMock {
+    keepStartingWith("android.util.")
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)

--- a/integrations/dd-sdk-android-apollo/src/test/java/com/datadog/android/apollo/DatadogApolloInterceptorTest.kt
+++ b/integrations/dd-sdk-android-apollo/src/test/java/com/datadog/android/apollo/DatadogApolloInterceptorTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.apollo
 
+import android.util.Base64
 import com.apollographql.apollo.api.ApolloRequest
 import com.apollographql.apollo.api.CustomScalarAdapters
 import com.apollographql.apollo.api.ExecutionContext
@@ -391,6 +392,8 @@ internal class DatadogApolloInterceptorTest {
 
     // endregion
 
+    // endregion
+
     // region helper methods
 
     private fun setupBasicMocks(
@@ -421,10 +424,16 @@ internal class DatadogApolloInterceptorTest {
         expectedHeaderValue: String? = null
     ) {
         if (expectedHeaderValue != null) {
-            verify(requestBuilder).addHttpHeader(eq(headerName), eq(expectedHeaderValue))
+            val expectedBase64Value = expectedHeaderValue.toBase64()
+            verify(requestBuilder).addHttpHeader(eq(headerName), eq(expectedBase64Value))
         } else {
             verify(requestBuilder).addHttpHeader(eq(headerName), any<String>())
         }
+    }
+
+    private fun String.toBase64(): String {
+        val bytes = this.toByteArray(Charsets.UTF_8)
+        return Base64.encodeToString(bytes, Base64.NO_WRAP)
     }
 
     private fun checkHeaderWasNotAdded(

--- a/integrations/dd-sdk-android-apollo/src/test/java/com/datadog/android/apollo/DatadogApolloInterceptorTest.kt
+++ b/integrations/dd-sdk-android-apollo/src/test/java/com/datadog/android/apollo/DatadogApolloInterceptorTest.kt
@@ -392,8 +392,6 @@ internal class DatadogApolloInterceptorTest {
 
     // endregion
 
-    // endregion
-
     // region helper methods
 
     private fun setupBasicMocks(
@@ -461,4 +459,6 @@ internal class DatadogApolloInterceptorTest {
             variablesExtractor = mockVariablesExtractor
         )
     }
+
+    // endregion
 }

--- a/integrations/dd-sdk-android-okhttp/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp/build.gradle.kts
@@ -74,6 +74,7 @@ dependencies {
 
 unMock {
     keepStartingWith("org.json")
+    keepStartingWith("android.util.")
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.okhttp
 
+import android.util.Base64
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
@@ -193,16 +194,16 @@ open class DatadogInterceptor internal constructor(
                 put(RumAttributes.RULE_PSR, (traceSampler.getSampleRate() ?: ZERO_SAMPLE_RATE) / ALL_IN_SAMPLE_RATE)
 
                 request.headers[GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue]?.let {
-                    put(RumAttributes.GRAPHQL_OPERATION_NAME, it)
+                    put(RumAttributes.GRAPHQL_OPERATION_NAME, it.fromBase64())
                 }
                 request.headers[GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER.headerValue]?.let {
-                    put(RumAttributes.GRAPHQL_OPERATION_TYPE, it)
+                    put(RumAttributes.GRAPHQL_OPERATION_TYPE, it.fromBase64())
                 }
                 request.headers[GraphQLHeaders.DD_GRAPHQL_VARIABLES_HEADER.headerValue]?.let {
-                    put(RumAttributes.GRAPHQL_VARIABLES, it)
+                    put(RumAttributes.GRAPHQL_VARIABLES, it.fromBase64())
                 }
                 request.headers[GraphQLHeaders.DD_GRAPHQL_PAYLOAD_HEADER.headerValue]?.let {
-                    put(RumAttributes.GRAPHQL_PAYLOAD, it)
+                    put(RumAttributes.GRAPHQL_PAYLOAD, it.fromBase64())
                 }
             }
         }
@@ -348,6 +349,15 @@ open class DatadogInterceptor internal constructor(
     private fun ResponseBody.contentLengthOrNull(): Long? {
         return contentLength().let {
             if (it < 0L) null else it
+        }
+    }
+
+    private fun String.fromBase64(): String? {
+        return try {
+            val decodedBytes = Base64.decode(this, Base64.NO_WRAP)
+            decodedBytes?.toString(Charsets.UTF_8)
+        } catch (_: IllegalArgumentException) {
+            null
         }
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.okhttp
 
+import android.util.Base64
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
@@ -366,10 +367,10 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         // Given
         fakeRequest = forgeRequest(forge) { builder ->
             builder.addHeader("User-Agent", fakeUserAgent)
-            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeGraphQLName)
-            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER.headerValue, fakeGraphQLType)
-            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_VARIABLES_HEADER.headerValue, fakeGraphQLVariables)
-            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_PAYLOAD_HEADER.headerValue, fakeGraphQLPayload)
+            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeGraphQLName.toBase64())
+            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER.headerValue, fakeGraphQLType.toBase64())
+            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_VARIABLES_HEADER.headerValue, fakeGraphQLVariables.toBase64())
+            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_PAYLOAD_HEADER.headerValue, fakeGraphQLPayload.toBase64())
         }
         stubChain(mockChain, 200)
 
@@ -381,13 +382,11 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         verify(mockChain).proceed(requestCaptor.capture())
         val cleanedRequest = requestCaptor.firstValue
 
-        // Verify GraphQL headers are removed
         assertThat(cleanedRequest.headers[GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue]).isNull()
         assertThat(cleanedRequest.headers[GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER.headerValue]).isNull()
         assertThat(cleanedRequest.headers[GraphQLHeaders.DD_GRAPHQL_VARIABLES_HEADER.headerValue]).isNull()
         assertThat(cleanedRequest.headers[GraphQLHeaders.DD_GRAPHQL_PAYLOAD_HEADER.headerValue]).isNull()
 
-        // Verify other headers are preserved
         assertThat(cleanedRequest.headers["User-Agent"]).isEqualTo(fakeUserAgent)
         assertThat(cleanedRequest.url.toString()).isEqualTo(fakeRequest.url.toString())
     }
@@ -403,10 +402,10 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
     ) {
         // Given
         fakeRequest = forgeRequest(forge) { builder ->
-            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeGraphQLName)
-            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER.headerValue, fakeGraphQLType)
-            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_VARIABLES_HEADER.headerValue, fakeGraphQLVariables)
-            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_PAYLOAD_HEADER.headerValue, fakeGraphQLPayload)
+            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeGraphQLName.toBase64())
+            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER.headerValue, fakeGraphQLType.toBase64())
+            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_VARIABLES_HEADER.headerValue, fakeGraphQLVariables.toBase64())
+            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_PAYLOAD_HEADER.headerValue, fakeGraphQLPayload.toBase64())
         }
         stubChain(mockChain, statusCode)
 
@@ -423,7 +422,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                     eq(emptyMap())
                 )
 
-                // Capture the actual attributes passed to stopResource
                 val stopAttrsCaptor = argumentCaptor<Map<String, Any?>>()
                 verify(rumMonitor.mockInstance).stopResource(
                     capture(),
@@ -435,13 +433,11 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
                 val actualStopAttrs = stopAttrsCaptor.firstValue
 
-                // Verify GraphQL attributes are present
                 assertThat(actualStopAttrs[RumAttributes.GRAPHQL_OPERATION_NAME]).isEqualTo(fakeGraphQLName)
                 assertThat(actualStopAttrs[RumAttributes.GRAPHQL_OPERATION_TYPE]).isEqualTo(fakeGraphQLType)
                 assertThat(actualStopAttrs[RumAttributes.GRAPHQL_VARIABLES]).isEqualTo(fakeGraphQLVariables)
                 assertThat(actualStopAttrs[RumAttributes.GRAPHQL_PAYLOAD]).isEqualTo(fakeGraphQLPayload)
 
-                // Verify fakeAttributes are included
                 fakeAttributes.forEach { (key, value) ->
                     assertThat(actualStopAttrs[key]).isEqualTo(value)
                 }
@@ -449,6 +445,11 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                 assertThat(firstValue).isEqualTo(secondValue)
             }
         }
+    }
+
+    private fun String.toBase64(): String {
+        val bytes = this.toByteArray(Charsets.UTF_8)
+        return Base64.encodeToString(bytes, Base64.NO_WRAP)
     }
 
     @Test
@@ -1015,7 +1016,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         // Given
         fakeRequest = forgeRequest(forge) { builder ->
             builder.addHeader("User-Agent", fakeUserAgent)
-            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeGraphQLName)
+            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeGraphQLName.toBase64())
         }
         stubChain(mockChain, 200)
 
@@ -1043,8 +1044,8 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         // Given
         fakeRequest = forgeRequest(forge) { builder ->
             builder.addHeader("User-Agent", fakeUserAgent)
-            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, "")
-            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER.headerValue, "")
+            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, "".toBase64())
+            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER.headerValue, "".toBase64())
         }
         stubChain(mockChain, 200)
 

--- a/reliability/single-fit/okhttp/build.gradle.kts
+++ b/reliability/single-fit/okhttp/build.gradle.kts
@@ -77,6 +77,7 @@ unMock {
     keep("dalvik.system.BlockGuard")
     keep("dalvik.system.CloseGuard")
     keepStartingWith("android.os")
+    keepStartingWith("android.util.")
     keepStartingWith("org.json")
 }
 


### PR DESCRIPTION
### What does this PR do?
Support GraphQL headers that are non-ascii by encoding payloads to base64 in the DatadogApolloInterceptor and decoding them in the DatadogInterceptor.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

