### PR TITLE
docs: Clarify NotReady state semantics for OpenFeature

### DIFF
--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/NoOpFlagsClient.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/NoOpFlagsClient.kt
@@ -36,7 +36,7 @@ internal class NoOpFlagsClient(
 ) : FlagsClient {
 
     override val state: StateObservable = object : StateObservable {
-        override fun getCurrentState(): FlagsClientState = FlagsClientState.Error(null)
+        override fun getCurrentState(): FlagsClientState = FlagsClientState.NotReady
         override fun addListener(listener: FlagsStateListener) = Unit
         override fun removeListener(listener: FlagsStateListener) = Unit
     }

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/model/FlagsClientState.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/model/FlagsClientState.kt
@@ -11,8 +11,15 @@ package com.datadog.android.flags.model
  */
 sealed class FlagsClientState {
     /**
-     * The client has been created but no evaluation context has been set.
+     * The client is not ready to evaluate flags.
+     *
+     * This state occurs:
+     * - Before the first setEvaluationContext() call (initialization)
+     * - After client shutdown
+     * - When the provider is not initialized or unavailable
+     *
      * No flags are available for evaluation in this state.
+     * Maps to OpenFeature's NOT_READY state.
      */
     object NotReady : FlagsClientState()
 

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/NoOpFlagsClientTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/NoOpFlagsClientTest.kt
@@ -432,12 +432,12 @@ internal class NoOpFlagsClientTest {
     // region State Management
 
     @Test
-    fun `M return error state W state_getCurrentState()`() {
+    fun `M return not ready state W state_getCurrentState()`() {
         // When
         val state = testedClient.state.getCurrentState()
 
         // Then
-        assertThat(state).isInstanceOf(FlagsClientState.Error::class.java)
+        assertThat(state).isEqualTo(FlagsClientState.NotReady)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Clarifies the semantics of `FlagsClientState.NotReady` to support OpenFeature integration.

## Changes

**FlagsClientState.kt:**
- Enhanced NotReady documentation explaining when this state occurs
- Documented mapping to OpenFeature's NOT_READY state
- Clarified pre-initialization vs post-shutdown usage

**NoOpFlagsClient.kt:**
- Changed state from `Error(null)` to `NotReady`
- Rationale: No-op client is not in error state, it's simply not ready/unavailable

**NoOpFlagsClientTest.kt:**
- Updated test expectations to match new NotReady state

## Motivation

The OpenFeature spec defines NOT_READY as a valid pre-initialization and post-shutdown state,
not an error condition. These clarifications ensure FlagsClient state semantics align with
OpenFeature expectations.

## Dependencies

This PR builds on PR #3042 (State management) and is required for PR #2998 (OpenFeature provider).

🤖 Generated with [Claude Code](https://claude.com/claude-code)