### PR TITLE
Add Profiling.profileNextAppStartup API

### DIFF
--- a/features/dd-sdk-android-profiling/api/apiSurface
+++ b/features/dd-sdk-android-profiling/api/apiSurface
@@ -7,6 +7,7 @@ class com.datadog.android.profiling.DdProfilingContentProvider : android.content
   override fun update(android.net.Uri, android.content.ContentValues?, String?, Array<String>?): Int
 object com.datadog.android.profiling.Profiling
   fun enable(ProfilingConfiguration = ProfilingConfiguration.DEFAULT, com.datadog.android.api.SdkCore = Datadog.getInstance())
+  fun profileNextAppStartup(com.datadog.android.api.SdkCore = Datadog.getInstance(), Boolean)
 data class com.datadog.android.profiling.ProfilingConfiguration
   class Builder
     fun useCustomEndpoint(String): Builder

--- a/features/dd-sdk-android-profiling/api/dd-sdk-android-profiling.api
+++ b/features/dd-sdk-android-profiling/api/dd-sdk-android-profiling.api
@@ -14,6 +14,9 @@ public final class com/datadog/android/profiling/Profiling {
 	public static final fun enable (Lcom/datadog/android/profiling/ProfilingConfiguration;)V
 	public static final fun enable (Lcom/datadog/android/profiling/ProfilingConfiguration;Lcom/datadog/android/api/SdkCore;)V
 	public static synthetic fun enable$default (Lcom/datadog/android/profiling/ProfilingConfiguration;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
+	public static final fun profileNextAppStartup (Lcom/datadog/android/api/SdkCore;Z)V
+	public static final fun profileNextAppStartup (Z)V
+	public static synthetic fun profileNextAppStartup$default (Lcom/datadog/android/api/SdkCore;ZILjava/lang/Object;)V
 }
 
 public final class com/datadog/android/profiling/ProfilingConfiguration {

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/Profiling.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/Profiling.kt
@@ -10,7 +10,9 @@ import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.datadog.android.Datadog
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
+import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.profiling.internal.NoOpProfiler
@@ -28,8 +30,7 @@ object Profiling {
     private var profiler: Profiler = NoOpProfiler()
 
     /**
-     * Enables the Perfetto based profiler to start recording callstack samples during application
-     * launch.
+     * Enables the profiling feature.
      *
      * @param configuration Configuration to use for the feature.
      * @param sdkCore SDK instance to register feature in. If not provided, default SDK instance
@@ -49,6 +50,33 @@ object Profiling {
             profiler = profiler
         )
         featureSdkCore.registerFeature(profilingFeature)
+    }
+
+    /**
+     * Decides if the next app launch should be profiled.
+     *
+     * @param sdkCore SDK instance to register feature in.
+     * @param enable enables the profiling for next app launch, otherwise disables it.
+     */
+    @JvmStatic
+    @JvmOverloads
+    @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+    fun profileNextAppStartup(
+        sdkCore: SdkCore = Datadog.getInstance(),
+        enable: Boolean
+    ) {
+        val featureSdkCore = sdkCore as FeatureSdkCore
+        val profilingFeature = featureSdkCore
+            .getFeature(Feature.PROFILING_FEATURE_NAME)?.let {
+                it.unwrap() as? ProfilingFeature
+            }
+        profilingFeature?.profileNextAppStartup(enable) ?: run {
+            featureSdkCore.internalLogger.log(
+                level = InternalLogger.Level.WARN,
+                target = InternalLogger.Target.USER,
+                messageBuilder = { "Profiling feature needs to be enabled before calling this method." }
+            )
+        }
     }
 
     @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingStorage.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingStorage.kt
@@ -15,6 +15,7 @@ internal object ProfilingStorage {
 
     private var sharedPreferencesStorage: SharedPreferencesStorage? = null
 
+    @JvmStatic
     internal fun addProfilingFlag(appContext: Context, sdkInstanceName: String) {
         getStorage(appContext).apply {
             val oldValue = getStringSet(KEY_PROFILING_ENABLED, emptySet())
@@ -23,10 +24,12 @@ internal object ProfilingStorage {
         }
     }
 
+    @JvmStatic
     internal fun getProfilingEnabledInstanceNames(appContext: Context): Set<String> {
         return getStorage(appContext).getStringSet(KEY_PROFILING_ENABLED)
     }
 
+    @JvmStatic
     internal fun removeProfilingFlag(appContext: Context, sdkInstanceNames: Set<String>) {
         getStorage(appContext).apply {
             val value = getStringSet(KEY_PROFILING_ENABLED).toMutableSet()

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.profiling.forge.Configurator
 import com.datadog.android.profiling.internal.Profiler
 import com.datadog.android.profiling.internal.ProfilingFeature
 import com.datadog.android.profiling.internal.ProfilingRequestFactory
+import com.datadog.android.profiling.internal.ProfilingStorage
 import com.datadog.android.rum.TTIDEvent
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
@@ -142,5 +144,33 @@ class ProfilingFeatureTest {
         assertThat(argumentCaptor.firstValue.invoke())
             .isEqualTo("Profiling feature receive an event of unsupported type=${String::class.java.canonicalName}.")
         verify(mockProfiler, never()).stop(fakeInstanceName)
+    }
+
+    @Test
+    fun `M add profiling flag W profileNextAppStartup {enable = true}`() {
+        Mockito.mockStatic(ProfilingStorage::class.java).use { mockedStatic ->
+
+            // When
+            testedFeature.profileNextAppStartup(true)
+
+            // Then
+            mockedStatic.verify {
+                ProfilingStorage.addProfilingFlag(mockContext, fakeInstanceName)
+            }
+        }
+    }
+
+    @Test
+    fun `M remove profiling flag W profileNextAppStartup {enable = false}`() {
+        Mockito.mockStatic(ProfilingStorage::class.java).use { mockedStatic ->
+
+            // When
+            testedFeature.profileNextAppStartup(false)
+
+            // Then
+            mockedStatic.verify {
+                ProfilingStorage.removeProfilingFlag(mockContext, setOf(fakeInstanceName))
+            }
+        }
     }
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -168,6 +168,7 @@ class SampleApplication : Application() {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
             Profiling.enable()
+            Profiling.profileNextAppStartup(enable = true)
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

`Profiling.enable` needs to be called ASAP during the app startup, but the decision of profiling next app launch can usually be determined later with user's feature flags for example, so we need to add a dedicated API to control this.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

