### PR TITLE
Fix null build id in profile event tags

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
@@ -105,8 +105,10 @@ internal class ProfilingDataWriter(
         append("$TAG_KEY_VERSION:${context.version}")
         append(",")
         append("$TAG_KEY_SDK_VERSION:${context.sdkVersion}")
-        append(",")
-        append("$TAG_KEY_BUILD_ID:${context.appBuildId}")
+        context.appBuildId?.let { buildId ->
+            append(",")
+            append("$TAG_KEY_BUILD_ID:$buildId")
+        }
     }
 
     private fun readProfilingData(profilingPath: String): ByteArray? {

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingDataWriterTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingDataWriterTest.kt
@@ -121,6 +121,16 @@ internal class ProfilingDataWriterTest {
             eventType = eq(EventType.DEFAULT)
         )
         val actualEvent = ProfileEvent.fromJson(String(argumentCaptor.firstValue.data))
+        val expectedTagList = arrayListOf(
+            "service:${fakeDatadogContext.service}",
+            "env:${fakeDatadogContext.env}",
+            "version:${fakeDatadogContext.version}",
+            "sdk_version:${fakeDatadogContext.sdkVersion}"
+        )
+        fakeDatadogContext.appBuildId?.let {
+            expectedTagList.add("build_id:${fakeDatadogContext.appBuildId}")
+        }
+
         assertThat(actualEvent)
             .hasStart(formatIsoUtc(fakeResult.start))
             .hasEnd(formatIsoUtc(fakeResult.end))
@@ -128,15 +138,7 @@ internal class ProfilingDataWriterTest {
             .hasFamily("android")
             .hasRuntime("android")
             .hasVersion("4")
-            .hasTags(
-                listOf(
-                    "service:${fakeDatadogContext.service}",
-                    "env:${fakeDatadogContext.env}",
-                    "version:${fakeDatadogContext.version}",
-                    "sdk_version:${fakeDatadogContext.sdkVersion}",
-                    "build_id:${fakeDatadogContext.appBuildId}"
-                )
-            )
+            .hasTags(expectedTagList)
             .hasApplicationId(fakeTTIDEvent.applicationId)
             .hasSessionId(fakeTTIDEvent.sessionId)
             .hasVitalId(fakeTTIDEvent.vitalId)


### PR DESCRIPTION
### What does this PR do?

Fix the issue that we still add build id in the tag when the build id is null, (finally it showed like `build_id:null` in the frontend)

Unit test already covers it with a nullable forgery string.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

