### PR TITLE
Remove JVM assert usage

### DIFF
--- a/buildSrc/src/test/kotlin/com/datadog/gradle/utils/VersionTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/utils/VersionTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.gradle.utils
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class VersionTest {
@@ -27,72 +28,99 @@ class VersionTest {
 
     @Test
     fun computesName() {
+        // When
         val name = Version(3, 12, 7).name
-        assert(name == "3.12.7")
+
+        // Then
+        assertThat(name).isEqualTo("3.12.7")
     }
 
     @Test
     fun computesCode() {
+        // When
         val code = Version(3, 12, 7).code
 
-        assert(code == 3127) { "expected code to be 3127 but was $code" }
+        // Then
+        assertThat(code).isEqualTo(3127)
     }
 
     @Test
     fun ensureCodeSequenceHotfix() {
+        // When
         val code = Version(3, 12, Version.MAX_HOTFIX - 1).code
         val next = Version(3, 13, 0).code
 
-        assert(code == next - 1) { "expected code to be next - 1 = ${next - 1} but was $code (@next:$next)" }
+        // Then
+        assertThat(code).isEqualTo(next - 1)
     }
 
     @Test
     fun ensureCodeSequenceMinor() {
+        // When
         val code = Version(3, Version.MAX_MINOR - 1, Version.MAX_HOTFIX - 1).code
         val next = Version(4, 0, 0).code
 
-        assert(code == next - 1) { "expected code to be next - 1 = ${next - 1} but was $code (@next:$next)" }
+        // Then
+        assertThat(code).isEqualTo(next - 1)
     }
 
     @Test
     fun addNoSuffixForRelease() {
+        // When
         val name = Version(3, 12, 7, Version.Type.Release).name
+
+        // Then
         val expected = "3.12.7"
-        assert(name == expected) { " expected name to be $expected but was $name" }
+        assertThat(name).isEqualTo(expected)
     }
 
     @Test
     fun addSuffixForRC() {
+        // When
         val name = Version(3, 12, 7, Version.Type.ReleaseCandidate(1)).name
+
+        // Then
         val expected = "3.12.7-rc1"
-        assert(name == expected) { " expected name to be $expected but was $name" }
+        assertThat(name).isEqualTo(expected)
     }
 
     @Test
     fun addSuffixForBeta() {
+        // When
         val name = Version(3, 12, 7, Version.Type.Beta(5)).name
+
+        // Then
         val expected = "3.12.7-beta5"
-        assert(name == expected) { " expected name to be $expected but was $name" }
+        assertThat(name).isEqualTo(expected)
     }
 
     @Test
     fun addSuffixForAlpha() {
+        // When
         val name = Version(3, 12, 7, Version.Type.Alpha(3)).name
+
+        // Then
         val expected = "3.12.7-alpha3"
-        assert(name == expected) { " expected name to be $expected but was $name" }
+        assertThat(name).isEqualTo(expected)
     }
 
     @Test
     fun addSuffixForDev() {
+        // When
         val name = Version(3, 12, 7, Version.Type.Dev).name
+
+        // Then
         val expected = "3.12.7-dev"
-        assert(name == expected) { " expected name to be $expected but was $name" }
+        assertThat(name).isEqualTo(expected)
     }
 
     @Test
     fun addSuffixForSnapshot() {
+        // When
         val name = Version(4, 11, 5, Version.Type.Snapshot).name
+
+        // Then
         val expected = "4.11.5-SNAPSHOT"
-        assert(name == expected) { " expected name to be $expected but was $name" }
+        assertThat(name).isEqualTo(expected)
     }
 }


### PR DESCRIPTION
### What does this PR do?

There is JVM `assert` usage in the code, which is no-op only unless JVM if started with `-ea` (enable assertions) flag.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

