### PR TITLE
RUM-13441: Moving HttpSpec, RequestInfo/ResponseInfo into `internal` module

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -30,6 +30,29 @@ enum com.datadog.android.internal.network.GraphQLHeaders
   - DD_GRAPHQL_VARIABLES_HEADER
   - DD_GRAPHQL_TYPE_HEADER
   - DD_GRAPHQL_PAYLOAD_HEADER
+object com.datadog.android.internal.network.HttpSpec
+  object Method
+    const val GET: String
+    const val POST: String
+    const val PATCH: String
+    const val PUT: String
+    const val HEAD: String
+    const val DELETE: String
+    const val TRACE: String
+    const val OPTIONS: String
+    const val CONNECT: String
+    fun values()
+  object Headers
+    const val CONTENT_TYPE: String
+    const val CONTENT_LENGTH: String
+    const val WEBSOCKET_ACCEPT_HEADER: String
+  object ContentType
+    const val TEXT_PLAIN: String
+    const val TEXT_EVENT_STREAM: String
+    const val APPLICATION_GRPC: String
+    const val APPLICATION_GRPC_PROTO: String
+    const val APPLICATION_GRPC_JSON: String
+    fun isStream(String?): Boolean
 interface com.datadog.android.internal.profiler.BenchmarkCounter
   fun add(Long, Map<String, String>)
 interface com.datadog.android.internal.profiler.BenchmarkMeter

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -77,6 +77,41 @@ public final class com/datadog/android/internal/network/GraphQLHeaders : java/la
 	public static fun values ()[Lcom/datadog/android/internal/network/GraphQLHeaders;
 }
 
+public final class com/datadog/android/internal/network/HttpSpec {
+	public static final field INSTANCE Lcom/datadog/android/internal/network/HttpSpec;
+}
+
+public final class com/datadog/android/internal/network/HttpSpec$ContentType {
+	public static final field APPLICATION_GRPC Ljava/lang/String;
+	public static final field APPLICATION_GRPC_JSON Ljava/lang/String;
+	public static final field APPLICATION_GRPC_PROTO Ljava/lang/String;
+	public static final field INSTANCE Lcom/datadog/android/internal/network/HttpSpec$ContentType;
+	public static final field TEXT_EVENT_STREAM Ljava/lang/String;
+	public static final field TEXT_PLAIN Ljava/lang/String;
+	public final fun isStream (Ljava/lang/String;)Z
+}
+
+public final class com/datadog/android/internal/network/HttpSpec$Headers {
+	public static final field CONTENT_LENGTH Ljava/lang/String;
+	public static final field CONTENT_TYPE Ljava/lang/String;
+	public static final field INSTANCE Lcom/datadog/android/internal/network/HttpSpec$Headers;
+	public static final field WEBSOCKET_ACCEPT_HEADER Ljava/lang/String;
+}
+
+public final class com/datadog/android/internal/network/HttpSpec$Method {
+	public static final field CONNECT Ljava/lang/String;
+	public static final field DELETE Ljava/lang/String;
+	public static final field GET Ljava/lang/String;
+	public static final field HEAD Ljava/lang/String;
+	public static final field INSTANCE Lcom/datadog/android/internal/network/HttpSpec$Method;
+	public static final field OPTIONS Ljava/lang/String;
+	public static final field PATCH Ljava/lang/String;
+	public static final field POST Ljava/lang/String;
+	public static final field PUT Ljava/lang/String;
+	public static final field TRACE Ljava/lang/String;
+	public final fun values ()Ljava/util/List;
+}
+
 public abstract interface class com/datadog/android/internal/profiler/BenchmarkCounter {
 	public abstract fun add (JLjava/util/Map;)V
 }

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/network/GraphQLHeaders.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/network/GraphQLHeaders.kt
@@ -10,6 +10,7 @@ package com.datadog.android.internal.network
  * Headers used internally for intercepting GraphQL requests.
  * @param headerValue name of the header.
  */
+// TODO RUM-13454 - move these headers to [HttpSpec]
 enum class GraphQLHeaders(val headerValue: String) {
     DD_GRAPHQL_NAME_HEADER("_dd-custom-header-graph-ql-operation-name"),
     DD_GRAPHQL_VARIABLES_HEADER("_dd-custom-header-graph-ql-variables"),

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/network/HttpSpec.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/network/HttpSpec.kt
@@ -1,0 +1,100 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.android.internal.network
+
+/**
+ * HTTP specification constants and utilities.
+ */
+object HttpSpec {
+
+    /**
+     * Standard HTTP request methods.
+     */
+    object Method {
+        /** HTTP GET method. */
+        const val GET: String = "GET"
+
+        /** HTTP POST method. */
+        const val POST: String = "POST"
+
+        /** HTTP PATCH method. */
+        const val PATCH: String = "PATCH"
+
+        /** HTTP PUT method. */
+        const val PUT: String = "PUT"
+
+        /** HTTP HEAD method. */
+        const val HEAD: String = "HEAD"
+
+        /** HTTP DELETE method. */
+        const val DELETE: String = "DELETE"
+
+        /** HTTP TRACE method. */
+        const val TRACE: String = "TRACE"
+
+        /** HTTP OPTIONS method. */
+        const val OPTIONS: String = "OPTIONS"
+
+        /** HTTP CONNECT method. */
+        const val CONNECT: String = "CONNECT"
+
+        /**
+         * Returns a list of all HTTP methods.
+         */
+        fun values() = listOf(GET, POST, PATCH, PUT, HEAD, DELETE, TRACE, OPTIONS, CONNECT)
+    }
+
+    /**
+     * Standard HTTP header names.
+     */
+    object Headers {
+        /** Content-Type header name. */
+        const val CONTENT_TYPE: String = "Content-Type"
+
+        /** Content-Length header name. */
+        const val CONTENT_LENGTH: String = "Content-Length"
+
+        /** Sec-WebSocket-Accept header name. */
+        const val WEBSOCKET_ACCEPT_HEADER: String = "Sec-WebSocket-Accept"
+    }
+
+    /**
+     * HTTP content type values and utilities.
+     */
+    object ContentType {
+
+        /** Plain text content type. */
+        const val TEXT_PLAIN: String = "text/plain"
+
+        /** Server-Sent Events content type. */
+        const val TEXT_EVENT_STREAM: String = "text/event-stream"
+
+        /** gRPC content type. */
+        const val APPLICATION_GRPC: String = "application/grpc"
+
+        /** gRPC with Protocol Buffers content type. */
+        const val APPLICATION_GRPC_PROTO: String = "application/grpc+proto"
+
+        /** gRPC with JSON content type. */
+        const val APPLICATION_GRPC_JSON: String = "application/grpc+json"
+
+        /**
+         * Checks if the given content type represents a streaming protocol.
+         * @param contentType the content type to check
+         * @return true if the content type is a stream type, false otherwise
+         */
+        fun isStream(contentType: String?): Boolean {
+            return contentType != null && contentType in STREAM_CONTENT_TYPES
+        }
+
+        private val STREAM_CONTENT_TYPES = setOf(
+            TEXT_EVENT_STREAM,
+            APPLICATION_GRPC,
+            APPLICATION_GRPC_PROTO,
+            APPLICATION_GRPC_JSON
+        )
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Moves common classes from `core` to `internal` module

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

