### PR TITLE
Handle RumVitalAppLaunchEvent by default

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapper.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapper.kt
@@ -13,6 +13,7 @@ import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
+import com.datadog.android.rum.model.RumVitalAppLaunchEvent
 import com.datadog.android.rum.model.RumVitalOperationStepEvent
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.telemetry.model.TelemetryConfigurationEvent
@@ -64,6 +65,8 @@ internal data class RumEventMapper(
             is LongTaskEvent -> longTaskEventMapper.map(event)
             is RumVitalOperationStepEvent -> vitalOperationStepEventMapper.map(event)
             is TelemetryConfigurationEvent -> telemetryConfigurationMapper.map(event)
+            // TODO RUM-13103: add vitalAppLaunchEventMapper.
+            is RumVitalAppLaunchEvent,
             is TelemetryDebugEvent,
             is TelemetryUsageEvent,
             is TelemetryErrorEvent -> event


### PR DESCRIPTION
### What does this PR do?

Handle RumVitalAppLaunchEvent by default to stop throwing warning

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

