### PR TITLE
Add IDs to errors and long tasks

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
@@ -29,6 +29,7 @@ import com.datadog.android.rum.internal.utils.buildDDTagsString
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.ViewEvent
 import com.google.gson.JsonObject
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 internal class DatadogLateCrashReporter(
@@ -256,6 +257,7 @@ internal class DatadogLateCrashReporter(
             ),
             context = ErrorEvent.Context(additionalProperties = additionalProperties),
             error = ErrorEvent.Error(
+                id = UUID.randomUUID().toString(),
                 message = errorLogMessage,
                 source = ErrorEvent.ErrorSource.SOURCE,
                 stack = stacktrace,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -437,6 +437,7 @@ internal class RumResourceScope(
                 buildId = datadogContext.appBuildId,
                 date = eventTimestamp,
                 error = ErrorEvent.Error(
+                    id = UUID.randomUUID().toString(),
                     message = message,
                     source = source.toSchemaSource(),
                     stack = stackTrace,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -713,6 +713,7 @@ internal open class RumViewScope(
                 date = event.eventTime.timestamp + serverTimeOffsetInMs,
                 featureFlags = ErrorEvent.Context(eventFeatureFlags),
                 error = ErrorEvent.Error(
+                    id = UUID.randomUUID().toString(),
                     message = message,
                     source = event.source.toSchemaSource(),
                     stack = event.stacktrace ?: event.throwable?.loggableStackTrace(),
@@ -1449,6 +1450,7 @@ internal open class RumViewScope(
             LongTaskEvent(
                 date = timestamp - TimeUnit.NANOSECONDS.toMillis(event.durationNs),
                 longTask = LongTaskEvent.LongTask(
+                    id = UUID.randomUUID().toString(),
                     duration = event.durationNs,
                     isFrozenFrame = isFrozenFrame
                 ),

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
@@ -649,6 +649,17 @@ internal class ErrorEventAssert(actual: ErrorEvent) :
         return this
     }
 
+    fun hasErrorId(): ErrorEventAssert {
+        assertThat(actual.error.id)
+            .overridingErrorMessage(
+                "Expected RUM event to have error.id" +
+                    " but instead it was ${if (actual.error.id == null) "null" else "blank"}"
+            )
+            .isNotNull
+            .isNotBlank
+        return this
+    }
+
     companion object {
         internal const val TIMESTAMP_THRESHOLD_MS = 50L
         internal fun assertThat(actual: ErrorEvent): ErrorEventAssert =

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/LongTaskEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/LongTaskEventAssert.kt
@@ -401,6 +401,17 @@ internal class LongTaskEventAssert(actual: LongTaskEvent) :
         return this
     }
 
+    fun hasLongTaskId(): LongTaskEventAssert {
+        assertThat(actual.longTask.id)
+            .overridingErrorMessage(
+                "Expected RUM event to have long_task.id" +
+                    " but instead it was ${if (actual.longTask.id == null) "null" else "blank"}"
+            )
+            .isNotNull
+            .isNotBlank
+        return this
+    }
+
     companion object {
         internal const val TIMESTAMP_THRESHOLD_MS = 50L
         internal fun assertThat(actual: LongTaskEvent): LongTaskEventAssert =

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
@@ -174,6 +174,7 @@ internal class DatadogLateCrashReporterTest {
             verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
+                .hasErrorId()
                 .hasApplicationId(fakeViewEvent.application.id)
                 .hasSessionId(fakeViewEvent.session.id)
                 .hasView(
@@ -276,6 +277,7 @@ internal class DatadogLateCrashReporterTest {
             verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
+                .hasErrorId()
                 .hasApplicationId(fakeViewEvent.application.id)
                 .hasSessionId(fakeViewEvent.session.id)
                 .hasView(
@@ -378,6 +380,7 @@ internal class DatadogLateCrashReporterTest {
             verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
+                .hasErrorId()
                 .hasErrorSourceType(ErrorEvent.SourceType.NDK)
         }
     }
@@ -429,6 +432,7 @@ internal class DatadogLateCrashReporterTest {
             verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
+                .hasErrorId()
                 .hasApplicationId(fakeViewEvent.application.id)
                 .hasSessionId(fakeViewEvent.session.id)
                 .hasView(
@@ -525,6 +529,7 @@ internal class DatadogLateCrashReporterTest {
             verify(mockRumWriter, times(1)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
+                .hasErrorId()
                 .hasApplicationId(fakeViewEvent.application.id)
                 .hasSessionId(fakeViewEvent.session.id)
                 .hasBuildId(fakeDatadogContext.appBuildId)
@@ -724,6 +729,7 @@ internal class DatadogLateCrashReporterTest {
             verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
+                .hasErrorId()
                 .hasApplicationId(fakeViewEvent.application.id)
                 .hasSessionId(fakeViewEvent.session.id)
                 .hasView(
@@ -815,6 +821,7 @@ internal class DatadogLateCrashReporterTest {
             verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
+                .hasErrorId()
                 .hasApplicationId(fakeViewEvent.application.id)
                 .hasSessionId(fakeViewEvent.session.id)
                 .hasView(
@@ -904,6 +911,7 @@ internal class DatadogLateCrashReporterTest {
             verify(mockRumWriter, times(1)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
+                .hasErrorId()
                 .hasApplicationId(fakeViewEvent.application.id)
                 .hasSessionId(fakeViewEvent.session.id)
                 .hasView(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -1244,6 +1244,7 @@ internal class RumResourceScopeTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
+                    hasErrorId()
                     hasMessage(message)
                     hasErrorSource(source)
                     hasStackTrace(throwable.loggableStackTrace())
@@ -1327,6 +1328,7 @@ internal class RumResourceScopeTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
+                    hasErrorId()
                     hasMessage(message)
                     hasErrorSource(source)
                     hasStackTrace(throwable.loggableStackTrace())
@@ -1405,6 +1407,7 @@ internal class RumResourceScopeTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
+                    hasErrorId()
                     hasMessage(message)
                     hasErrorSource(source)
                     hasStackTrace(stackTrace)
@@ -1503,6 +1506,7 @@ internal class RumResourceScopeTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
+                    hasErrorId()
                     hasMessage(message)
                     hasErrorSource(source)
                     hasStackTrace(throwable.loggableStackTrace())
@@ -1604,6 +1608,7 @@ internal class RumResourceScopeTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
+                    hasErrorId()
                     hasMessage(message)
                     hasErrorSource(source)
                     hasStackTrace(stackTrace)
@@ -1698,6 +1703,7 @@ internal class RumResourceScopeTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
+                    hasErrorId()
                     hasMessage(message)
                     hasErrorSource(source)
                     hasStackTrace(throwable.loggableStackTrace())
@@ -1797,6 +1803,7 @@ internal class RumResourceScopeTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
+                    hasErrorId()
                     hasMessage(message)
                     hasErrorSource(source)
                     hasStackTrace(stackTrace)
@@ -1878,6 +1885,7 @@ internal class RumResourceScopeTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
+                    hasErrorId()
                     hasMessage(message)
                     hasErrorSource(source)
                     hasStackTrace(throwable.loggableStackTrace())
@@ -1961,6 +1969,7 @@ internal class RumResourceScopeTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
+                    hasErrorId()
                     hasMessage(message)
                     hasErrorSource(source)
                     hasStackTrace(stackTrace)
@@ -2042,6 +2051,7 @@ internal class RumResourceScopeTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
+                    hasErrorId()
                     hasMessage(message)
                     hasErrorSource(source)
                     hasStackTrace(throwable.loggableStackTrace())
@@ -2125,6 +2135,7 @@ internal class RumResourceScopeTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
+                    hasErrorId()
                     hasMessage(message)
                     hasErrorSource(source)
                     hasStackTrace(stackTrace)
@@ -2210,6 +2221,7 @@ internal class RumResourceScopeTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
+                    hasErrorId()
                     hasMessage(message)
                     hasErrorSource(source)
                     hasStackTrace(throwable.loggableStackTrace())
@@ -2298,6 +2310,7 @@ internal class RumResourceScopeTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
+                    hasErrorId()
                     hasMessage(message)
                     hasErrorSource(source)
                     hasStackTrace(stackTrace)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -3458,6 +3458,7 @@ internal class RumViewScopeTest {
 
             assertThat(firstValue)
                 .apply {
+                    hasErrorId()
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
                     hasMessage(expectedMessage)
                     hasErrorSource(source)
@@ -3540,6 +3541,7 @@ internal class RumViewScopeTest {
 
             assertThat(firstValue)
                 .apply {
+                    hasErrorId()
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
                     hasMessage(expectedMessage)
                     hasErrorSource(source)
@@ -3614,6 +3616,7 @@ internal class RumViewScopeTest {
 
             assertThat(firstValue)
                 .apply {
+                    hasErrorId()
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
                     hasMessage(message)
                     hasErrorSource(source)
@@ -3688,6 +3691,7 @@ internal class RumViewScopeTest {
 
             assertThat(firstValue)
                 .apply {
+                    hasErrorId()
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
                     hasMessage(message)
                     hasErrorSource(source)
@@ -3764,6 +3768,7 @@ internal class RumViewScopeTest {
 
             assertThat(firstValue)
                 .apply {
+                    hasErrorId()
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
                     hasMessage(message)
                     hasErrorSource(source)
@@ -3842,6 +3847,7 @@ internal class RumViewScopeTest {
 
             assertThat(firstValue)
                 .apply {
+                    hasErrorId()
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
                     hasMessage(throwableMessage)
                     hasErrorSource(source)
@@ -3916,6 +3922,7 @@ internal class RumViewScopeTest {
 
             assertThat(firstValue)
                 .apply {
+                    hasErrorId()
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
                     hasMessage(message)
                     hasErrorSource(source)
@@ -3975,6 +3982,7 @@ internal class RumViewScopeTest {
 
             assertThat(firstValue)
                 .apply {
+                    hasErrorId()
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
                     hasMessage(expectedMessage)
                     hasErrorSource(source)
@@ -4054,6 +4062,7 @@ internal class RumViewScopeTest {
 
             assertThat(firstValue)
                 .apply {
+                    hasErrorId()
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
                     hasMessage(message)
                     hasErrorSource(source)
@@ -4135,6 +4144,7 @@ internal class RumViewScopeTest {
             verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
             assertThat(firstValue as ErrorEvent)
                 .apply {
+                    hasErrorId()
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
                     hasMessage(message)
                     hasErrorSource(source)
@@ -4275,6 +4285,7 @@ internal class RumViewScopeTest {
 
             assertThat(firstValue)
                 .apply {
+                    hasErrorId()
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
                     hasMessage(throwableMessage)
                     hasErrorSource(source)
@@ -4352,6 +4363,7 @@ internal class RumViewScopeTest {
             verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
             assertThat(firstValue as ErrorEvent)
                 .apply {
+                    hasErrorId()
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
                     hasMessage(expectedMessage)
                     hasErrorSource(source)
@@ -4504,6 +4516,7 @@ internal class RumViewScopeTest {
             verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
             assertThat(firstValue as ErrorEvent)
                 .apply {
+                    hasErrorId()
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
                     hasMessage(expectedMessage)
                     hasErrorSource(source)
@@ -4639,6 +4652,7 @@ internal class RumViewScopeTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue as ErrorEvent)
                 .apply {
+                    hasErrorId()
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
                     hasMessage(expectedMessage)
                     hasErrorSource(source)
@@ -4721,6 +4735,7 @@ internal class RumViewScopeTest {
 
             assertThat(firstValue)
                 .apply {
+                    hasErrorId()
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
                     hasMessage(expectedMessage)
                     hasErrorSource(source)
@@ -4961,6 +4976,7 @@ internal class RumViewScopeTest {
 
             assertThat(firstValue)
                 .apply {
+                    hasLongTaskId()
                     hasTimestamp(
                         resolveExpectedTimestamp(fakeEvent.eventTime.timestamp) - durationMs
                     )
@@ -5018,6 +5034,7 @@ internal class RumViewScopeTest {
 
             assertThat(firstValue)
                 .apply {
+                    hasLongTaskId()
                     hasTimestamp(
                         resolveExpectedTimestamp(fakeEvent.eventTime.timestamp) - durationMs
                     )
@@ -5084,6 +5101,7 @@ internal class RumViewScopeTest {
 
             assertThat(firstValue)
                 .apply {
+                    hasLongTaskId()
                     hasTimestamp(
                         resolveExpectedTimestamp(fakeEvent.eventTime.timestamp) - durationMs
                     )
@@ -5152,6 +5170,7 @@ internal class RumViewScopeTest {
 
             assertThat(firstValue)
                 .apply {
+                    hasLongTaskId()
                     hasTimestamp(
                         resolveExpectedTimestamp(fakeEvent.eventTime.timestamp) - durationMs
                     )
@@ -7574,7 +7593,9 @@ internal class RumViewScopeTest {
         // THEN
         argumentCaptor<Any> {
             verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
-            assertThat(lastValue as ErrorEvent).hasFeatureFlag(flagName, flagValue)
+            assertThat(lastValue as ErrorEvent)
+                .hasErrorId()
+                .hasFeatureFlag(flagName, flagValue)
         }
     }
 
@@ -7747,9 +7768,11 @@ internal class RumViewScopeTest {
         // THEN
         argumentCaptor<Any> {
             verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
-            assertThat(lastValue as ErrorEvent).hasFeatureFlag(flagName1, flagValue1)
-            assertThat(lastValue as ErrorEvent).hasFeatureFlag(flagName2, flagValue2)
-            assertThat(lastValue as ErrorEvent).hasFeatureFlag(flagName3, flagValue3)
+            assertThat(lastValue as ErrorEvent)
+                .hasErrorId()
+                .hasFeatureFlag(flagName1, flagValue1)
+                .hasFeatureFlag(flagName2, flagValue2)
+                .hasFeatureFlag(flagName3, flagValue3)
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

IDs for errors and long tasks were added long time ago in https://github.com/DataDog/rum-events-format/pull/34, but we never implemented this property.

This PR fixes that.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

