### PR TITLE
RUM-13518: Fix Compose checkbox not sending RUM action

### DIFF
--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeUtils.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeUtils.kt
@@ -59,7 +59,8 @@ internal class LayoutNodeUtils {
                             isClickable = true
                         }
 
-                        CLASS_NAME_TOGGLEABLE_ELEMENT -> {
+                        CLASS_NAME_TOGGLEABLE_ELEMENT,
+                        CLASS_NAME_TRI_STATE_TOGGLEABLE_ELEMENT -> {
                             isClickable = true
                         }
 
@@ -133,6 +134,8 @@ internal class LayoutNodeUtils {
             "androidx.compose.foundation.CombinedClickableElement"
         private const val CLASS_NAME_TOGGLEABLE_ELEMENT =
             "androidx.compose.foundation.selection.ToggleableElement"
+        private const val CLASS_NAME_TRI_STATE_TOGGLEABLE_ELEMENT =
+            "androidx.compose.foundation.selection.TriStateToggleableElement"
         private const val CLASS_NAME_SCROLLING_LAYOUT_ELEMENT =
             "androidx.compose.foundation.ScrollingLayoutElement"
         private const val CLASS_NAME_SCROLLABLE_ELEMENT =

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/androidx/compose/foundation/ClickableElement.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/androidx/compose/foundation/ClickableElement.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package androidx.compose.foundation
+
+import androidx.compose.ui.Modifier
+
+/**
+ * Test stub class for [LayoutNodeUtilsTest].
+ *
+ * The production code [LayoutNodeUtils.resolveLayoutNode] identifies clickable/scrollable elements
+ * by checking `modifier::class.qualifiedName` against known Compose class names. Since `::class`
+ * is a Kotlin language intrinsic that cannot be mocked, we create real stub classes with the exact
+ * package and class names that the production code expects. When instantiated, these stubs return
+ * the correct qualified name (e.g., "androidx.compose.foundation.ClickableElement"),
+ * allowing us to unit test the class name matching logic.
+ */
+internal class ClickableElement : Modifier.Element

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/androidx/compose/foundation/CombinedClickableElement.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/androidx/compose/foundation/CombinedClickableElement.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package androidx.compose.foundation
+
+import androidx.compose.ui.Modifier
+
+/**
+ * Test stub class for [LayoutNodeUtilsTest].
+ *
+ * The production code [LayoutNodeUtils.resolveLayoutNode] identifies clickable/scrollable elements
+ * by checking `modifier::class.qualifiedName` against known Compose class names. Since `::class`
+ * is a Kotlin language intrinsic that cannot be mocked, we create real stub classes with the exact
+ * package and class names that the production code expects. When instantiated, these stubs return
+ * the correct qualified name (e.g., "androidx.compose.foundation.CombinedClickableElement"),
+ * allowing us to unit test the class name matching logic.
+ */
+internal class CombinedClickableElement : Modifier.Element

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/androidx/compose/foundation/ScrollingLayoutElement.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/androidx/compose/foundation/ScrollingLayoutElement.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package androidx.compose.foundation
+
+import androidx.compose.ui.Modifier
+
+/**
+ * Test stub class for [LayoutNodeUtilsTest].
+ *
+ * The production code [LayoutNodeUtils.resolveLayoutNode] identifies clickable/scrollable elements
+ * by checking `modifier::class.qualifiedName` against known Compose class names. Since `::class`
+ * is a Kotlin language intrinsic that cannot be mocked, we create real stub classes with the exact
+ * package and class names that the production code expects. When instantiated, these stubs return
+ * the correct qualified name (e.g., "androidx.compose.foundation.ScrollingLayoutElement"),
+ * allowing us to unit test the class name matching logic.
+ */
+internal class ScrollingLayoutElement : Modifier.Element

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/androidx/compose/foundation/gestures/ScrollableElement.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/androidx/compose/foundation/gestures/ScrollableElement.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package androidx.compose.foundation.gestures
+
+import androidx.compose.ui.Modifier
+
+/**
+ * Test stub class for [LayoutNodeUtilsTest].
+ *
+ * The production code [LayoutNodeUtils.resolveLayoutNode] identifies clickable/scrollable elements
+ * by checking `modifier::class.qualifiedName` against known Compose class names. Since `::class`
+ * is a Kotlin language intrinsic that cannot be mocked, we create real stub classes with the exact
+ * package and class names that the production code expects. When instantiated, these stubs return
+ * the correct qualified name (e.g., "androidx.compose.foundation.gestures.ScrollableElement"),
+ * allowing us to unit test the class name matching logic.
+ */
+internal class ScrollableElement : Modifier.Element

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/androidx/compose/foundation/selection/SelectableElement.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/androidx/compose/foundation/selection/SelectableElement.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package androidx.compose.foundation.selection
+
+import androidx.compose.ui.Modifier
+
+/**
+ * Test stub class for [LayoutNodeUtilsTest].
+ *
+ * The production code [LayoutNodeUtils.resolveLayoutNode] identifies clickable/scrollable elements
+ * by checking `modifier::class.qualifiedName` against known Compose class names. Since `::class`
+ * is a Kotlin language intrinsic that cannot be mocked, we create real stub classes with the exact
+ * package and class names that the production code expects. When instantiated, these stubs return
+ * the correct qualified name (e.g., "androidx.compose.foundation.selection.SelectableElement"),
+ * allowing us to unit test the class name matching logic.
+ */
+internal class SelectableElement : Modifier.Element

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/androidx/compose/foundation/selection/ToggleableElement.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/androidx/compose/foundation/selection/ToggleableElement.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package androidx.compose.foundation.selection
+
+import androidx.compose.ui.Modifier
+
+/**
+ * Test stub class for [LayoutNodeUtilsTest].
+ *
+ * The production code [LayoutNodeUtils.resolveLayoutNode] identifies clickable/scrollable elements
+ * by checking `modifier::class.qualifiedName` against known Compose class names. Since `::class`
+ * is a Kotlin language intrinsic that cannot be mocked, we create real stub classes with the exact
+ * package and class names that the production code expects. When instantiated, these stubs return
+ * the correct qualified name (e.g., "androidx.compose.foundation.selection.ToggleableElement"),
+ * allowing us to unit test the class name matching logic.
+ */
+internal class ToggleableElement : Modifier.Element

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/androidx/compose/foundation/selection/TriStateToggleableElement.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/androidx/compose/foundation/selection/TriStateToggleableElement.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package androidx.compose.foundation.selection
+
+import androidx.compose.ui.Modifier
+
+/**
+ * Test stub class for [LayoutNodeUtilsTest].
+ *
+ * The production code [LayoutNodeUtils.resolveLayoutNode] identifies clickable/scrollable elements
+ * by checking `modifier::class.qualifiedName` against known Compose class names. Since `::class`
+ * is a Kotlin language intrinsic that cannot be mocked, we create real stub classes with the exact
+ * package and class names that the production code expects. When instantiated, these stubs return
+ * the correct qualified name (e.g., "androidx.compose.foundation.selection.TriStateToggleableElement"),
+ * allowing us to unit test the class name matching logic.
+ */
+internal class TriStateToggleableElement : Modifier.Element

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeUtilsTest.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeUtilsTest.kt
@@ -7,6 +7,14 @@
 
 package com.datadog.android.compose.internal.utils
 
+import androidx.compose.foundation.ClickableElement
+import androidx.compose.foundation.CombinedClickableElement
+import androidx.compose.foundation.ScrollingLayoutElement
+import androidx.compose.foundation.gestures.ScrollableElement
+import androidx.compose.foundation.selection.SelectableElement
+import androidx.compose.foundation.selection.ToggleableElement
+import androidx.compose.foundation.selection.TriStateToggleableElement
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.ModifierInfo
 import androidx.compose.ui.node.LayoutNode
@@ -17,18 +25,22 @@ import androidx.compose.ui.semantics.getOrNull
 import com.datadog.android.compose.DatadogSemanticsPropertyKey
 import com.datadog.tools.unit.forge.BaseConfigurator
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.stream.Stream
 
 @Extensions(
     ExtendWith(
@@ -42,10 +54,13 @@ class LayoutNodeUtilsTest {
 
     private val testedLayoutNodeUtils = LayoutNodeUtils()
 
+    // region Legacy Compose (SemanticsModifier)
+
     @Test
     fun `M return correct target node W call resolveLayoutNode {legacy compose}`(
         forge: Forge
     ) {
+        // Given
         val fakeTagName = forge.aString()
         val isClickable = forge.aBool()
         val isScrollable = forge.aBool()
@@ -54,8 +69,11 @@ class LayoutNodeUtilsTest {
             isClickable,
             isScrollable
         )
+
+        // When
         val result = testedLayoutNodeUtils.resolveLayoutNode(mockNode)
 
+        // Then
         assertThat(result).isEqualTo(
             LayoutNodeUtils.TargetNode(
                 tag = fakeTagName,
@@ -63,6 +81,81 @@ class LayoutNodeUtilsTest {
                 isClickable = isClickable
             )
         )
+    }
+
+    // endregion
+
+    // region Clickable Modifier Elements
+
+    @ParameterizedTest
+    @MethodSource("clickableModifierElements")
+    fun `M return clickable target node W resolveLayoutNode {clickable modifier element}`(
+        testCase: ModifierTestCase,
+        @StringForgery fakeTagName: String
+    ) {
+        // Given
+        val mockNode = mockLayoutNodeWithModifiers(fakeTagName, testCase.modifier)
+
+        // When
+        val result = testedLayoutNodeUtils.resolveLayoutNode(mockNode)
+
+        // Then
+        checkNotNull(result)
+        assertThat(result.tag).isEqualTo(fakeTagName)
+        assertThat(result.isClickable).isTrue()
+        assertThat(result.isScrollable).isFalse()
+    }
+
+    // endregion
+
+    // region Scrollable Modifier Elements
+
+    @ParameterizedTest
+    @MethodSource("scrollableModifierElements")
+    fun `M return scrollable target node W resolveLayoutNode {scrollable modifier element}`(
+        testCase: ModifierTestCase,
+        @StringForgery fakeTagName: String
+    ) {
+        // Given
+        val mockNode = mockLayoutNodeWithModifiers(fakeTagName, testCase.modifier)
+
+        // When
+        val result = testedLayoutNodeUtils.resolveLayoutNode(mockNode)
+
+        // Then
+        checkNotNull(result)
+        assertThat(result.tag).isEqualTo(fakeTagName)
+        assertThat(result.isClickable).isFalse()
+        assertThat(result.isScrollable).isTrue()
+    }
+
+    // endregion
+
+    // region Private
+
+    private fun mockLayoutNodeWithModifiers(
+        tagName: String,
+        vararg modifiers: Modifier.Element
+    ): LayoutNode {
+        val mockLayoutCoordinates = mock<LayoutCoordinates>()
+        val mockSemanticsConfiguration = mock<SemanticsConfiguration> {
+            whenever(it.getOrNull(DatadogSemanticsPropertyKey)).thenReturn(tagName)
+        }
+
+        val mockSemanticsModifier = mock<SemanticsModifier> {
+            whenever(it.semanticsConfiguration).thenReturn(mockSemanticsConfiguration)
+        }
+
+        val modifierInfoList = mutableListOf(
+            ModifierInfo(mockSemanticsModifier, mockLayoutCoordinates)
+        )
+        modifiers.forEach { modifier ->
+            modifierInfoList.add(ModifierInfo(modifier, mockLayoutCoordinates))
+        }
+
+        return mock<LayoutNode> {
+            whenever(it.getModifierInfo()) doReturn modifierInfoList
+        }
     }
 
     private fun mockLegacyLayoutNode(
@@ -87,5 +180,31 @@ class LayoutNodeUtilsTest {
             )
         }
         return node
+    }
+
+    // endregion
+
+    data class ModifierTestCase(
+        val name: String,
+        val modifier: Modifier.Element
+    ) {
+        override fun toString(): String = name
+    }
+
+    companion object {
+        @JvmStatic
+        fun clickableModifierElements(): Stream<ModifierTestCase> = Stream.of(
+            ModifierTestCase("TriStateToggleableElement", TriStateToggleableElement()),
+            ModifierTestCase("ToggleableElement", ToggleableElement()),
+            ModifierTestCase("ClickableElement", ClickableElement()),
+            ModifierTestCase("CombinedClickableElement", CombinedClickableElement()),
+            ModifierTestCase("SelectableElement", SelectableElement())
+        )
+
+        @JvmStatic
+        fun scrollableModifierElements(): Stream<ModifierTestCase> = Stream.of(
+            ModifierTestCase("ScrollingLayoutElement", ScrollingLayoutElement()),
+            ModifierTestCase("ScrollableElement", ScrollableElement())
+        )
     }
 }


### PR DESCRIPTION
### What does this PR do?

• Modifies `LayoutNodeUtils` to identify Compose checkboxes as clickable
• Add stub classes for Compose elements to make tests more comprehensive

### Motivation

Checkbox taps were not being sent as RUM actions. 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

