### PR TITLE
RUM-13514: Pass original resource id to stopResource in DatadogInterceptor

### DIFF
--- a/integrations/dd-sdk-android-okhttp/api/apiSurface
+++ b/integrations/dd-sdk-android-okhttp/api/apiSurface
@@ -17,7 +17,7 @@ class com.datadog.android.okhttp.DatadogEventListener : okhttp3.EventListener
     override fun create(okhttp3.Call): okhttp3.EventListener
 open class com.datadog.android.okhttp.DatadogInterceptor : com.datadog.android.okhttp.trace.TracingInterceptor
   override fun intercept(okhttp3.Interceptor.Chain): okhttp3.Response
-  override fun onRequestIntercepted(com.datadog.android.api.feature.FeatureSdkCore, okhttp3.Request, com.datadog.android.trace.api.span.DatadogSpan?, okhttp3.Response?, Throwable?)
+  override fun onRequestIntercepted(com.datadog.android.api.feature.FeatureSdkCore, okhttp3.Request, com.datadog.android.trace.api.span.DatadogSpan?, okhttp3.Response?, Throwable?, com.datadog.android.rum.resource.ResourceId?)
   override fun canSendSpan(): Boolean
   override fun onSdkInstanceReady(com.datadog.android.core.InternalSdkCore)
   class Builder : BaseBuilder<DatadogInterceptor, Builder>
@@ -39,7 +39,9 @@ interface com.datadog.android.okhttp.trace.TracedRequestListener
   fun onRequestIntercepted(okhttp3.Request, com.datadog.android.trace.api.span.DatadogSpan, okhttp3.Response?, Throwable?)
 open class com.datadog.android.okhttp.trace.TracingInterceptor : okhttp3.Interceptor
   override fun intercept(okhttp3.Interceptor.Chain): okhttp3.Response
-  protected open fun onRequestIntercepted(com.datadog.android.api.feature.FeatureSdkCore, okhttp3.Request, com.datadog.android.trace.api.span.DatadogSpan?, okhttp3.Response?, Throwable?)
+  protected fun doIntercept(okhttp3.Interceptor.Chain, com.datadog.android.rum.resource.ResourceId?): okhttp3.Response
+  protected open fun onRequestIntercepted(com.datadog.android.api.feature.FeatureSdkCore, okhttp3.Request, com.datadog.android.trace.api.span.DatadogSpan?, okhttp3.Response?, Throwable?, com.datadog.android.rum.resource.ResourceId?)
+  DEPRECATED protected open fun onRequestIntercepted(com.datadog.android.api.feature.FeatureSdkCore, okhttp3.Request, com.datadog.android.trace.api.span.DatadogSpan?, okhttp3.Response?, Throwable?)
   class Builder : BaseBuilder<TracingInterceptor, Builder>
     constructor(Map<String, Set<com.datadog.android.trace.TracingHeaderType>>)
     constructor(List<String>)

--- a/integrations/dd-sdk-android-okhttp/api/dd-sdk-android-okhttp.api
+++ b/integrations/dd-sdk-android-okhttp/api/dd-sdk-android-okhttp.api
@@ -23,7 +23,7 @@ public final class com/datadog/android/okhttp/DatadogEventListener$Factory : okh
 
 public class com/datadog/android/okhttp/DatadogInterceptor : com/datadog/android/okhttp/trace/TracingInterceptor {
 	public fun intercept (Lokhttp3/Interceptor$Chain;)Lokhttp3/Response;
-	protected fun onRequestIntercepted (Lcom/datadog/android/api/feature/FeatureSdkCore;Lokhttp3/Request;Lcom/datadog/android/trace/api/span/DatadogSpan;Lokhttp3/Response;Ljava/lang/Throwable;)V
+	protected fun onRequestIntercepted (Lcom/datadog/android/api/feature/FeatureSdkCore;Lokhttp3/Request;Lcom/datadog/android/trace/api/span/DatadogSpan;Lokhttp3/Response;Ljava/lang/Throwable;Lcom/datadog/android/rum/resource/ResourceId;)V
 }
 
 public final class com/datadog/android/okhttp/DatadogInterceptor$Builder : com/datadog/android/okhttp/trace/TracingInterceptor$BaseBuilder {
@@ -72,8 +72,10 @@ public abstract interface class com/datadog/android/okhttp/trace/TracedRequestLi
 }
 
 public class com/datadog/android/okhttp/trace/TracingInterceptor : okhttp3/Interceptor {
+	protected final fun doIntercept (Lokhttp3/Interceptor$Chain;Lcom/datadog/android/rum/resource/ResourceId;)Lokhttp3/Response;
 	public fun intercept (Lokhttp3/Interceptor$Chain;)Lokhttp3/Response;
 	protected fun onRequestIntercepted (Lcom/datadog/android/api/feature/FeatureSdkCore;Lokhttp3/Request;Lcom/datadog/android/trace/api/span/DatadogSpan;Lokhttp3/Response;Ljava/lang/Throwable;)V
+	protected fun onRequestIntercepted (Lcom/datadog/android/api/feature/FeatureSdkCore;Lokhttp3/Request;Lcom/datadog/android/trace/api/span/DatadogSpan;Lokhttp3/Response;Ljava/lang/Throwable;Lcom/datadog/android/rum/resource/ResourceId;)V
 }
 
 public abstract class com/datadog/android/okhttp/trace/TracingInterceptor$BaseBuilder {

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -223,6 +223,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                     eq(expectedStopAttrs)
                 )
                 assertThat(firstValue).isEqualTo(secondValue)
+                assertThat(firstValue.uuid).isEqualTo(secondValue.uuid)
             }
         }
     }
@@ -266,6 +267,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                     eq(expectedStopAttrs)
                 )
                 assertThat(firstValue).isEqualTo(secondValue)
+                assertThat(firstValue.uuid).isEqualTo(secondValue.uuid)
             }
         }
     }
@@ -307,6 +309,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                     eq(expectedStopAttrs)
                 )
                 assertThat(firstValue).isEqualTo(secondValue)
+                assertThat(firstValue.uuid).isEqualTo(secondValue.uuid)
             }
         }
     }
@@ -352,6 +355,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                     eq(expectedStopAttrs)
                 )
                 assertThat(firstValue).isEqualTo(secondValue)
+                assertThat(firstValue.uuid).isEqualTo(secondValue.uuid)
             }
         }
     }
@@ -444,6 +448,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                 }
 
                 assertThat(firstValue).isEqualTo(secondValue)
+                assertThat(firstValue.uuid).isEqualTo(secondValue.uuid)
             }
         }
     }
@@ -496,6 +501,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                     eq(expectedStopAttrs)
                 )
                 assertThat(firstValue).isEqualTo(secondValue)
+                assertThat(firstValue.uuid).isEqualTo(secondValue.uuid)
             }
         }
 
@@ -542,6 +548,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                     eq(expectedStopAttrs)
                 )
                 assertThat(firstValue).isEqualTo(secondValue)
+                assertThat(firstValue.uuid).isEqualTo(secondValue.uuid)
             }
         }
     }
@@ -592,6 +599,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                     eq(expectedStopAttrs)
                 )
                 assertThat(firstValue).isEqualTo(secondValue)
+                assertThat(firstValue.uuid).isEqualTo(secondValue.uuid)
             }
         }
     }
@@ -641,6 +649,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                     eq(expectedStopAttrs)
                 )
                 assertThat(firstValue).isEqualTo(secondValue)
+                assertThat(firstValue.uuid).isEqualTo(secondValue.uuid)
             }
         }
     }
@@ -689,6 +698,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                     eq(expectedStopAttrs)
                 )
                 assertThat(firstValue).isEqualTo(secondValue)
+                assertThat(firstValue.uuid).isEqualTo(secondValue.uuid)
             }
         }
     }
@@ -736,6 +746,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                     eq(expectedStopAttrs)
                 )
                 assertThat(firstValue).isEqualTo(secondValue)
+                assertThat(firstValue.uuid).isEqualTo(secondValue.uuid)
             }
         }
     }
@@ -798,6 +809,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                     eq(expectedStopAttrs)
                 )
                 assertThat(firstValue).isEqualTo(secondValue)
+                assertThat(firstValue.uuid).isEqualTo(secondValue.uuid)
             }
         }
     }
@@ -858,6 +870,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                     eq(expectedStopAttrs)
                 )
                 assertThat(firstValue).isEqualTo(secondValue)
+                assertThat(firstValue.uuid).isEqualTo(secondValue.uuid)
             }
         }
     }
@@ -900,6 +913,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                     eq(expectedStopAttrs)
                 )
                 assertThat(firstValue).isEqualTo(secondValue)
+                assertThat(firstValue.uuid).isEqualTo(secondValue.uuid)
             }
         }
     }
@@ -940,6 +954,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                     eq(expectedStopAttrs)
                 )
                 assertThat(firstValue).isEqualTo(secondValue)
+                assertThat(firstValue.uuid).isEqualTo(secondValue.uuid)
             }
         }
     }
@@ -976,6 +991,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                     eq(fakeAttributes)
                 )
                 assertThat(firstValue).isEqualTo(secondValue)
+                assertThat(firstValue.uuid).isEqualTo(secondValue.uuid)
             }
         }
     }


### PR DESCRIPTION
### What does this PR do?

See description of the bug in the ticket (RUM-13514).

The fix is about passing the RUM resource id generated for `startResource` call to the `stopResource` call through different places in `DatadogInterceptor` and `TracingInterceptor`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

