### PR TITLE
Initialize Profiler only once for multiple start calls

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingStorage.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingStorage.kt
@@ -13,7 +13,7 @@ private const val KEY_PROFILING_ENABLED = "dd_profiling_enabled"
 
 internal object ProfilingStorage {
 
-    private var sharedPreferencesStorage: SharedPreferencesStorage? = null
+    internal var sharedPreferencesStorage: SharedPreferencesStorage? = null
 
     @JvmStatic
     internal fun addProfilingFlag(appContext: Context, sdkInstanceName: String) {

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling
+
+import android.content.Context
+import android.os.ProfilingManager
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.internal.data.SharedPreferencesStorage
+import com.datadog.android.profiling.forge.Configurator
+import com.datadog.android.profiling.internal.NoOpProfiler
+import com.datadog.android.profiling.internal.ProfilingFeature
+import com.datadog.android.profiling.internal.ProfilingStorage
+import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import java.util.concurrent.ExecutorService
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+class ProfilingTest {
+
+    @Mock
+    private lateinit var mockSdkCore: InternalSdkCore
+
+    @Mock
+    private lateinit var mockInternalLogger: InternalLogger
+
+    @Mock
+    private lateinit var mockContext: Context
+
+    @Mock
+    private lateinit var mockProfilingExecutor: ExecutorService
+
+    @Mock
+    private lateinit var mockProfilingManager: ProfilingManager
+
+    @Mock
+    private lateinit var mockSharedPreferencesStorage: SharedPreferencesStorage
+
+    @Forgery
+    private lateinit var fakeConfiguration: ProfilingConfiguration
+
+    @StringForgery
+    private lateinit var fakeInstanceName: String
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
+        whenever(mockSdkCore.name) doReturn fakeInstanceName
+        whenever(mockSdkCore.createSingleThreadExecutorService(any())) doReturn mockProfilingExecutor
+        whenever(mockContext.getSystemService(ProfilingManager::class.java)) doReturn mockProfilingManager
+        ProfilingStorage.sharedPreferencesStorage = mockSharedPreferencesStorage
+    }
+
+    @AfterEach
+    fun `tear down`() {
+        resetProfilerField()
+        ProfilingStorage.sharedPreferencesStorage = null
+    }
+
+    @Test
+    fun `M use PerfettoProfiler W enable called before start`() {
+        // Given
+        val sdkInstanceNames = setOf(fakeInstanceName)
+
+        // When
+        Profiling.enable(fakeConfiguration, mockSdkCore)
+        Profiling.start(mockContext, sdkInstanceNames)
+
+        // Then
+        verify(mockSdkCore).registerFeature(any<ProfilingFeature>())
+
+        assertThat(Profiling.profiler).isNotInstanceOf(NoOpProfiler::class.java)
+        assertThat(Profiling.profiler).isInstanceOf(PerfettoProfiler::class.java)
+    }
+
+    @Test
+    fun `M use PerfettoProfiler W enable called but start not called`() {
+        // When
+        Profiling.enable(fakeConfiguration, mockSdkCore)
+
+        // Then
+        verify(mockSdkCore).registerFeature(any<ProfilingFeature>())
+
+        assertThat(Profiling.profiler).isNotInstanceOf(NoOpProfiler::class.java)
+        assertThat(Profiling.profiler).isInstanceOf(PerfettoProfiler::class.java)
+    }
+
+    @Test
+    fun `M use PerfettoProfiler W start called before enable`() {
+        // Given
+        val sdkInstanceNames = setOf(fakeInstanceName)
+
+        // When
+        Profiling.start(mockContext, sdkInstanceNames)
+        Profiling.enable(fakeConfiguration, mockSdkCore)
+
+        // Then
+        verify(mockSdkCore).registerFeature(any<ProfilingFeature>())
+
+        assertThat(Profiling.profiler).isNotInstanceOf(NoOpProfiler::class.java)
+        assertThat(Profiling.profiler).isInstanceOf(PerfettoProfiler::class.java)
+    }
+
+    @Test
+    fun `M keep same profiler instance W start called multiple times`() {
+        // Given
+        val sdkInstanceNames = setOf(fakeInstanceName)
+
+        // When
+        Profiling.start(mockContext, sdkInstanceNames)
+
+        val firstProfiler = Profiling.profiler
+
+        Profiling.start(mockContext, sdkInstanceNames)
+
+        val secondProfiler = Profiling.profiler
+
+        // Then
+        assertThat(firstProfiler).isNotInstanceOf(NoOpProfiler::class.java)
+        assertThat(secondProfiler).isNotInstanceOf(NoOpProfiler::class.java)
+        assertThat(firstProfiler).isSameAs(secondProfiler)
+    }
+
+    private fun resetProfilerField() {
+        Profiling.profiler = NoOpProfiler()
+        Profiling.isProfilerInitialized.set(false)
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This PR takes one step further to support custom profiling.

The current implementation of `Profiling.kt` is based on application launch profiling, which presumes the `Profiling.start` is called only once and always called before `Profiling.enable`. 

Which brings following consequences for custom profiling:
* If `Profiling.enable` is called before `Profiling.start`, then `ProfilingFeature` will be initialized with `NoOpProfiler`
* If `Profiling.start` is called several times, the profiler will be recreated each times, which will be different from the instance held inside `ProfilingFeature`


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

