### PR TITLE
Generate Kotlin metadata ABI and JVM bytecode versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -136,6 +136,8 @@ registerSubModuleAggregationTask("checkDependencyLicencesAll", "checkDependencyL
 
 registerSubModuleAggregationTask("checkApiSurfaceChangesAll", "checkApiSurfaceChanges")
 
+registerSubModuleAggregationTask("checkCompilerMetadataChangesAll", "checkCompilerMetadataChanges")
+
 registerSubModuleAggregationTask("checkTransitiveDependenciesListAll", "checkTransitiveDependenciesList")
 
 /**
@@ -144,6 +146,7 @@ registerSubModuleAggregationTask("checkTransitiveDependenciesListAll", "checkTra
 tasks.register("checkGeneratedFiles") {
     dependsOn("checkDependencyLicencesAll")
     dependsOn("checkApiSurfaceChangesAll")
+    dependsOn("checkCompilerMetadataChangesAll")
     dependsOn("checkTransitiveDependenciesListAll")
 }
 

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/ApiSurfacePlugin.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/ApiSurfacePlugin.kt
@@ -9,6 +9,8 @@ package com.datadog.gradle.plugin.apisurface
 import com.datadog.gradle.config.taskConfig
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.File
 import java.nio.file.Paths
@@ -24,15 +26,16 @@ class ApiSurfacePlugin : Plugin<Project> {
         val apiDir = File(target.projectDir, "api")
         val kotlinSurfaceFile = File(apiDir, FILE_NAME)
         val javaSurfaceFile = File(apiDir, "${target.name}.api")
+        val compilerMetaFile = File(apiDir, "compiler-meta.txt")
 
-        target.tasks
-            .register(TASK_GEN_KOTLIN_API_SURFACE, GenerateApiSurfaceTask::class.java) {
+        val generateApiSurfaceTask = target.tasks
+            .register<GenerateApiSurfaceTask>(TASK_GEN_KOTLIN_API_SURFACE) {
                 this.srcDirPath = srcDir.absolutePath
                 this.genDirPath = genDir.absolutePath
                 this.surfaceFile = kotlinSurfaceFile
             }
         target.tasks
-            .register(TASK_CHECK_API_SURFACE, CheckApiSurfaceTask::class.java) {
+            .register<CheckApiSurfaceTask>(TASK_CHECK_API_SURFACE) {
                 this.kotlinSurfaceFile = kotlinSurfaceFile
                 this.javaSurfaceFile = javaSurfaceFile
                 dependsOn(TASK_GEN_KOTLIN_API_SURFACE)
@@ -41,20 +44,41 @@ class ApiSurfacePlugin : Plugin<Project> {
                 }
             }
 
+        val generateCompilerMetaTask = target.tasks
+            .register<GenerateCompilerMetaTask>(TASK_GEN_COMPILER_METADATA) {
+                this.metadataInfoFile.set(compilerMetaFile)
+            }
+
+        target.tasks
+            .register<CheckCompilerMetaTask>(TASK_CHECK_COMPILER_METADATA) {
+                this.metadataInfoFile.set(compilerMetaFile)
+                dependsOn(TASK_GEN_COMPILER_METADATA)
+            }
+
+        // cannot use taskConfig below because of afterEvaluate usage under the hood
+        target.tasks.withType<KotlinCompile>() {
+            if (name == "compileDebugKotlin") {
+                generateCompilerMetaTask.configure { compiledClassesDirectory.set(destinationDirectory) }
+                finalizedBy(generateCompilerMetaTask)
+            }
+        }
+
         target.taskConfig<KotlinCompile> {
             // Java API generation task does a clean-up of all files in the output
             // folder, so let it run first
             if (target.plugins.hasPlugin(GEN_JAVA_API_LAYOUT_PLUGIN)) {
                 finalizedBy(TASK_GEN_JAVA_API_SURFACE)
             }
-            finalizedBy(TASK_GEN_KOTLIN_API_SURFACE)
+            finalizedBy(generateApiSurfaceTask)
         }
     }
 
     companion object {
         const val TASK_GEN_KOTLIN_API_SURFACE = "generateApiSurface"
+        const val TASK_GEN_COMPILER_METADATA = "generateCompilerMetadata"
         const val TASK_GEN_JAVA_API_SURFACE = "apiDump"
         const val TASK_CHECK_API_SURFACE = "checkApiSurfaceChanges"
+        const val TASK_CHECK_COMPILER_METADATA = "checkCompilerMetadataChanges"
         const val FILE_NAME = "apiSurface"
         const val GEN_JAVA_API_LAYOUT_PLUGIN = "binary-compatibility-validator"
     }

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/CheckCompilerMetaTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/CheckCompilerMetaTask.kt
@@ -1,0 +1,39 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.apisurface
+
+import com.datadog.gradle.plugin.CheckGeneratedFileTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
+
+abstract class CheckCompilerMetaTask @Inject constructor(
+    execOperations: ExecOperations
+) : CheckGeneratedFileTask(
+    genTaskName = ApiSurfacePlugin.TASK_GEN_COMPILER_METADATA,
+    execOperations
+) {
+
+    @get:InputFile
+    abstract val metadataInfoFile: RegularFileProperty
+
+    init {
+        group = "datadog"
+        description = "Check the compiler metadata of the library"
+    }
+
+    // region Task
+
+    @TaskAction
+    fun applyTask() {
+        verifyGeneratedFileExists(metadataInfoFile.get().asFile)
+    }
+
+    // endregion
+}

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/GenerateCompilerMetaTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/GenerateCompilerMetaTask.kt
@@ -1,0 +1,101 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.apisurface
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+import org.gradle.process.internal.ExecException
+import java.io.ByteArrayOutputStream
+import javax.inject.Inject
+
+abstract class GenerateCompilerMetaTask @Inject constructor(
+    private val execOperations: ExecOperations
+) : DefaultTask() {
+
+    @get:OutputFile
+    abstract val metadataInfoFile: RegularFileProperty
+
+    @get:InputDirectory
+    abstract val compiledClassesDirectory: DirectoryProperty
+
+    init {
+        group = "datadog"
+        description = "List compiler metadata properties"
+    }
+
+    @TaskAction
+    fun applyTask() {
+        val classesDir = compiledClassesDirectory.get().asFile
+
+        val classFile = classesDir
+            .walkTopDown()
+            .filter {
+                it.extension == "class" &&
+                    !it.name.contains("$") &&
+                    it.path.contains("datadog") &&
+                    !it.path.contains("test", ignoreCase = true)
+            }
+            .firstOrNull()
+
+        checkNotNull(classFile) {
+            "Couldn't find any class file to get compilation metadata, did a search in $classesDir"
+        }
+
+        // could try Class.forName, but some modules like Coil have only one class generated and loading it
+        // requires 3rd party classpath to be available
+        val result = execOperations.execShell("javap", "-v", classFile.absolutePath)
+            .lines()
+            .map { it.trim() }
+
+        val kotlinAbiVersion = result
+            .filter { it.startsWith("mv=[") }
+            .first()
+            .removePrefix("mv=[")
+            .removeSuffix("]")
+            .replace(",", ".")
+
+        val jvmBytecodeVersion = result
+            .filter { it.startsWith("major version: ") }
+            .first()
+            .removePrefix("major version: ")
+            .toInt()
+            .let {
+                // Java 25
+                require(it <= 69) { "Unsupported JVM major version value: $it" }
+                // at least between Java 25 and Java 5 this formula is true
+                it - 44
+            }
+
+        metadataInfoFile.get().asFile
+            .writeText(
+                "kotlin_abi_version=$kotlinAbiVersion\n" +
+                    "jvm_bytecode_version=$jvmBytecodeVersion\n"
+            )
+    }
+
+    private fun ExecOperations.execShell(vararg command: String): String {
+        val outputStream = ByteArrayOutputStream()
+        val errorStream = ByteArrayOutputStream()
+        try {
+            this.exec {
+                commandLine(*command)
+                standardOutput = outputStream
+                errorOutput = errorStream
+            }.assertNormalExitValue()
+        } catch (e: ExecException) {
+            logger.error(errorStream.toString(Charsets.UTF_8))
+            throw e
+        }
+
+        return outputStream.toString(Charsets.UTF_8)
+    }
+}

--- a/dd-sdk-android-core/api/compiler-meta.txt
+++ b/dd-sdk-android-core/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/dd-sdk-android-internal/api/compiler-meta.txt
+++ b/dd-sdk-android-internal/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/features/dd-sdk-android-flags/api/compiler-meta.txt
+++ b/features/dd-sdk-android-flags/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/features/dd-sdk-android-logs/api/compiler-meta.txt
+++ b/features/dd-sdk-android-logs/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/features/dd-sdk-android-ndk/api/compiler-meta.txt
+++ b/features/dd-sdk-android-ndk/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/features/dd-sdk-android-rum/api/compiler-meta.txt
+++ b/features/dd-sdk-android-rum/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/features/dd-sdk-android-session-replay-compose/api/compiler-meta.txt
+++ b/features/dd-sdk-android-session-replay-compose/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/features/dd-sdk-android-session-replay-material/api/compiler-meta.txt
+++ b/features/dd-sdk-android-session-replay-material/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/features/dd-sdk-android-session-replay/api/compiler-meta.txt
+++ b/features/dd-sdk-android-session-replay/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/features/dd-sdk-android-trace-api/api/compiler-meta.txt
+++ b/features/dd-sdk-android-trace-api/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/features/dd-sdk-android-trace-internal/api/compiler-meta.txt
+++ b/features/dd-sdk-android-trace-internal/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/features/dd-sdk-android-trace-otel/api/compiler-meta.txt
+++ b/features/dd-sdk-android-trace-otel/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/features/dd-sdk-android-trace/api/compiler-meta.txt
+++ b/features/dd-sdk-android-trace/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/features/dd-sdk-android-webview/api/compiler-meta.txt
+++ b/features/dd-sdk-android-webview/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-apollo/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-apollo/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-coil/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-coil/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-coil3/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-coil3/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-compose/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-compose/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-cronet/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-cronet/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-fresco/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-fresco/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-glide/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-glide/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-okhttp-otel/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-okhttp-otel/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-okhttp/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-okhttp/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-rum-coroutines/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-rum-coroutines/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-rx/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-rx/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-sqldelight/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-sqldelight/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-timber/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-timber/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-trace-coroutines/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-trace-coroutines/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-tv/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-tv/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11


### PR DESCRIPTION
### What does this PR do?

Kotlin adds metadata in a `Metadata` annotation of the generated Java class file and overall this metadata has version, making it incompatible for older compiler versions.

Read ABI changelog here https://github.com/JetBrains/kotlin/blob/master/compiler/util-klib/KotlinAbiVersionBumpHistory.md.

This PR adds a check to list ABI (metadata) version in the generated class files, so that we are aware about any breaking change -> this will force customers to use newer Kotlin version.

Plus JVM bytecode version is added as well.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

