### PR TITLE
Remove consumer ProGuard rules definition from buildscript of `dd-sdk-android-trace-internal`

### DIFF
--- a/features/dd-sdk-android-trace-internal/build.gradle.kts
+++ b/features/dd-sdk-android-trace-internal/build.gradle.kts
@@ -40,9 +40,6 @@ plugins {
 }
 
 android {
-    defaultConfig {
-        consumerProguardFiles("consumer-rules.pro")
-    }
     namespace = "com.datadog.android.trace.internal"
 }
 


### PR DESCRIPTION
### What does this PR do?

There is no such file in the module root.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

