### PR TITLE
Expose Profiling start/stop as public API

### DIFF
--- a/features/dd-sdk-android-profiling/api/apiSurface
+++ b/features/dd-sdk-android-profiling/api/apiSurface
@@ -8,6 +8,8 @@ class com.datadog.android.profiling.DdProfilingContentProvider : android.content
 object com.datadog.android.profiling.Profiling
   fun enable(ProfilingConfiguration = ProfilingConfiguration.DEFAULT, com.datadog.android.api.SdkCore = Datadog.getInstance())
   fun profileNextAppStartup(com.datadog.android.api.SdkCore = Datadog.getInstance(), Boolean)
+  fun start(android.content.Context, com.datadog.android.api.SdkCore = Datadog.getInstance())
+  fun stop(com.datadog.android.api.SdkCore = Datadog.getInstance())
 data class com.datadog.android.profiling.ProfilingConfiguration
   class Builder
     fun useCustomEndpoint(String): Builder

--- a/features/dd-sdk-android-profiling/api/compiler-meta.txt
+++ b/features/dd-sdk-android-profiling/api/compiler-meta.txt
@@ -1,0 +1,2 @@
+kotlin_abi_version=1.8.0
+jvm_bytecode_version=11

--- a/features/dd-sdk-android-profiling/api/dd-sdk-android-profiling.api
+++ b/features/dd-sdk-android-profiling/api/dd-sdk-android-profiling.api
@@ -17,6 +17,10 @@ public final class com/datadog/android/profiling/Profiling {
 	public static final fun profileNextAppStartup (Lcom/datadog/android/api/SdkCore;Z)V
 	public static final fun profileNextAppStartup (Z)V
 	public static synthetic fun profileNextAppStartup$default (Lcom/datadog/android/api/SdkCore;ZILjava/lang/Object;)V
+	public final fun start (Landroid/content/Context;Lcom/datadog/android/api/SdkCore;)V
+	public static synthetic fun start$default (Lcom/datadog/android/profiling/Profiling;Landroid/content/Context;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
+	public final fun stop (Lcom/datadog/android/api/SdkCore;)V
+	public static synthetic fun stop$default (Lcom/datadog/android/profiling/Profiling;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
 }
 
 public final class com/datadog/android/profiling/ProfilingConfiguration {

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/Profiling.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/Profiling.kt
@@ -82,11 +82,37 @@ object Profiling {
         }
     }
 
+    /**
+     * Start profiling with given SDK instances names.
+     *
+     * @param context application context
+     * @param sdkInstanceNames the set of the SDK instances name
+     */
     @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
     internal fun start(context: Context, sdkInstanceNames: Set<String>) {
         initializeProfiler()
         profiler.start(context, sdkInstanceNames)
         ProfilingStorage.removeProfilingFlag(context, sdkInstanceNames)
+    }
+
+    /**
+     * Start profiling for a given SDK instance.
+     *
+     * @param context application context
+     * @param sdkCore SDK instance to start profiling with. If not provided, default SDK instance.
+     */
+    @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+    fun start(context: Context, sdkCore: SdkCore = Datadog.getInstance()) {
+        start(context, setOf(sdkCore.name))
+    }
+
+    /**
+     * Stop profiling for a given SDK instance.
+     *
+     * @param sdkCore SDK instance to stop profiling. If not provided, default SDK instance.
+     */
+    fun stop(sdkCore: SdkCore = Datadog.getInstance()) {
+        profiler.stop(sdkCore.name)
     }
 
     @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -45,7 +45,7 @@ internal class ProfilingFeature(
         get() = FeatureStorageConfiguration.Companion.DEFAULT
 
     override val name: String
-        get() = Feature.Companion.PROFILING_FEATURE_NAME
+        get() = Feature.PROFILING_FEATURE_NAME
 
     override fun onInitialize(appContext: Context) {
         this.appContext = appContext
@@ -58,7 +58,7 @@ internal class ProfilingFeature(
         }
         sdkCore.setEventReceiver(name, this)
         sdkCore.updateFeatureContext(Feature.PROFILING_FEATURE_NAME) { context ->
-            context.put(PROFILER_IS_RUNNING, profiler.isRunning(sdkCore.name))
+            context[PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
         }
         dataWriter = createDataWriter(sdkCore)
     }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.internal.data.SharedPreferencesStorage
 import com.datadog.android.profiling.forge.Configurator
 import com.datadog.android.profiling.internal.NoOpProfiler
+import com.datadog.android.profiling.internal.Profiler
 import com.datadog.android.profiling.internal.ProfilingFeature
 import com.datadog.android.profiling.internal.ProfilingStorage
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
+import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
@@ -145,6 +147,50 @@ class ProfilingTest {
         assertThat(firstProfiler).isNotInstanceOf(NoOpProfiler::class.java)
         assertThat(secondProfiler).isNotInstanceOf(NoOpProfiler::class.java)
         assertThat(firstProfiler).isSameAs(secondProfiler)
+    }
+
+    @Test
+    fun `M start profiler W call Profiling start(with instance names)`() {
+        // Given
+        val sdkInstanceNames = setOf(fakeInstanceName)
+        val mockProfiler = mock<Profiler>()
+        Profiling.profiler = mockProfiler
+        Profiling.isProfilerInitialized.set(true)
+
+        // When
+        Profiling.start(mockContext, sdkInstanceNames)
+
+        // Then
+        verify(mockProfiler).start(mockContext, sdkInstanceNames)
+    }
+
+    @Test
+    fun `M start profiler W call Profiling start(with sdk core)`() {
+        // Given
+        val mockProfiler = mock<Profiler>()
+        Profiling.profiler = mockProfiler
+        Profiling.isProfilerInitialized.set(true)
+
+        // When
+        Profiling.start(mockContext, mockSdkCore)
+
+        // Then
+        verify(mockProfiler).start(mockContext, setOf(fakeInstanceName))
+    }
+
+    @Test
+    fun `M stop profiler W call Profiling stop`() {
+        // Given
+        val mockProfiler = mock<Profiler>()
+        Profiling.profiler = mockProfiler
+        Profiling.isProfilerInitialized.set(true)
+
+        // When
+        Profiling.start(mockContext, mockSdkCore)
+        Profiling.stop(mockSdkCore)
+
+        // Then
+        verify(mockProfiler).stop(fakeInstanceName)
     }
 
     private fun resetProfilerField() {


### PR DESCRIPTION
### What does this PR do?

This PR exposes start/stop profiling as public API, make it possible to send some custom profiling from sample app.
Note: this is not the final form of custom profiling.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

