### PR TITLE
RUM-13564: Add GraphQL errors support to RUM resource events

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -31,6 +31,7 @@ object com.datadog.android.rum.RumAttributes
   const val GRAPHQL_OPERATION_NAME: String
   const val GRAPHQL_PAYLOAD: String
   const val GRAPHQL_VARIABLES: String
+  const val GRAPHQL_ERRORS: String
   const val ERROR_RESOURCE_METHOD: String
   const val ERROR_RESOURCE_STATUS_CODE: String
   const val ERROR_RESOURCE_URL: String

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -62,6 +62,7 @@ public final class com/datadog/android/rum/RumAttributes {
 	public static final field ERROR_RESOURCE_STATUS_CODE Ljava/lang/String;
 	public static final field ERROR_RESOURCE_URL Ljava/lang/String;
 	public static final field FLUTTER_FIRST_BUILD_COMPLETE Ljava/lang/String;
+	public static final field GRAPHQL_ERRORS Ljava/lang/String;
 	public static final field GRAPHQL_OPERATION_NAME Ljava/lang/String;
 	public static final field GRAPHQL_OPERATION_TYPE Ljava/lang/String;
 	public static final field GRAPHQL_PAYLOAD Ljava/lang/String;

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
@@ -126,6 +126,11 @@ object RumAttributes {
      */
     const val GRAPHQL_VARIABLES: String = "_dd.graphql.variables"
 
+    /**
+     * JSON representation of GraphQL errors (String).
+     */
+    const val GRAPHQL_ERRORS: String = "_dd.graphql.errors"
+
     // endregion
 
     // region Error


### PR DESCRIPTION
### What does this PR do?

Adds GraphQL errors support to RUM resource events. Extracts and parses GraphQL errors from the `_dd.graphql.errors` attribute, and populates `resource.graphql.errors` and `resource.graphql.error_count` fields in RUM event data.

### Motivation

Achieve cross-platform parity with iOS SDK. React Native SDK sends GraphQL errors from JS, but Android wasn't parsing them, resulting in missing error data.

### Additional Notes

This supports both wrapped errors format (e.g., `_dd.graphql.errors: {"errors": [...]}`) and direct array format (e.g., `_dd.graphql.errors: [...]` ) for flexibility. iOS only accepts the wrapped format, which was surprising given the the shape of the data, so here both work. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

