### PR TITLE
RUM-13567: Avoid querying battery during initialization

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/battery/DefaultBatteryInfoProviderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/battery/DefaultBatteryInfoProviderTest.kt
@@ -165,19 +165,16 @@ internal class DefaultBatteryInfoProviderTest {
 
     @Test
     fun `M update battery level W getState() { after polling interval }`() {
-        // When
+        // Given
         whenever(mockBatteryManager.getIntProperty(BATTERY_PROPERTY_CAPACITY)) doReturn 75
+        assertThat(testedProvider.getState().batteryLevel).isEqualTo(0.75f)
 
-        // nothing changes because we are within polling interval
-        assertThat(testedProvider.getState().batteryLevel).isEqualTo(0.5f)
-        whenever(mockTimeProvider.getDeviceElapsedRealtimeMillis()) doReturn fakeStartTimeMs + shortPollingInterval / 2
-        assertThat(testedProvider.getState().batteryLevel).isEqualTo(0.5f)
+        // When
+        whenever(mockBatteryManager.getIntProperty(BATTERY_PROPERTY_CAPACITY)) doReturn 50
+        whenever(mockTimeProvider.getDeviceElapsedRealtimeMillis()) doReturn fakeStartTimeMs + shortPollingInterval
 
         // Then
-        // after polling interval level should change
-        whenever(mockTimeProvider.getDeviceElapsedRealtimeMillis()) doReturn fakeStartTimeMs + shortPollingInterval
-        val batteryInfo = testedProvider.getState()
-        assertThat(batteryInfo.batteryLevel).isEqualTo(0.75f)
+        assertThat(testedProvider.getState().batteryLevel).isEqualTo(0.5f)
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?
Instead of populating the initial battery level when the battery provider starts up, here we instead rely on lazy querying whenever getState is called. 

### Motivation
Move battery level querying entirely off the main thread.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

