### PR TITLE
RUM-8949: Enabling UI slow frames by default

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
@@ -349,9 +349,10 @@ data class RumConfiguration internal constructor(
          * Assigning a null value to this property will disable the [SlowFramesListener] and stop the computation of the
          * associated rates.
          *
+         * [SlowFramesConfiguration.DEFAULT] is going to be used by default.
+         *
          * @param slowFramesConfiguration The configuration to be applied to the [SlowFramesListener].
          */
-        @ExperimentalRumApi
         fun setSlowFramesConfiguration(
             slowFramesConfiguration: SlowFramesConfiguration?
         ): Builder {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -803,7 +803,7 @@ internal class RumFeature(
             composeActionTrackingStrategy = NoOpActionTrackingStrategy(),
             additionalConfig = emptyMap(),
             trackAnonymousUser = true,
-            slowFramesConfiguration = null,
+            slowFramesConfiguration = SlowFramesConfiguration.DEFAULT,
             rumSessionTypeOverride = null,
             collectAccessibility = false,
             disableJankStats = false

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
@@ -119,7 +119,7 @@ internal class RumConfigurationBuilderTest {
             assertThat(lastInteractionIdentifier).isEqualTo(TimeBasedInteractionIdentifier())
             assertThat(composeActionTrackingStrategy)
                 .isInstanceOf(NoOpActionTrackingStrategy::class.java)
-            assertThat(slowFramesConfiguration).isNull()
+            assertThat(slowFramesConfiguration).isEqualTo(SlowFramesConfiguration.DEFAULT)
         }
     }
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -33,7 +33,6 @@ import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.Rum
 import com.datadog.android.rum.RumConfiguration
 import com.datadog.android.rum.RumErrorSource
-import com.datadog.android.rum.configuration.SlowFramesConfiguration
 import com.datadog.android.rum.tracking.NavigationViewTrackingStrategy
 import com.datadog.android.sample.account.AccountFragment
 import com.datadog.android.sample.data.db.LocalDataSource
@@ -306,7 +305,6 @@ class SampleApplication : Application() {
             .trackUserInteractions()
             .trackLongTasks(250L)
             .trackNonFatalAnrs(true)
-            .setSlowFramesConfiguration(SlowFramesConfiguration.DEFAULT)
             .setViewEventMapper { event ->
                 event.context?.additionalProperties?.put(ATTR_IS_MAPPED, true)
                 event


### PR DESCRIPTION
### What does this PR do?
* Enables `UI Slowness` feature by default. 
* Removes `@ExperimentalRumApi` annotation.

### Motivation

Back-end (and web frontend) teams has supported required parts for the slowness feature and ask to start rolling out this feature from mobile SDK side.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

