### PR TITLE
Remove unused `FileOrchestrator.getRootDirName` API

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileOrchestrator.kt
@@ -61,11 +61,6 @@ internal interface FileOrchestrator {
     fun getMetadataFile(file: File): File?
 
     /**
-     * @return the name of the root directory of this orchestrator or null if the root directory does not exist.
-     */
-    fun getRootDirName(): String?
-
-    /**
      * @return the number of pending files in the orchestrator, after decrementing by 1.
      */
     fun decrementAndGetPendingFilesCount(): Int

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
@@ -58,10 +58,6 @@ internal open class ConsentAwareFileOrchestrator(
         return null
     }
 
-    override fun getRootDirName(): String? {
-        return null
-    }
-
     @WorkerThread
     override fun getFlushableFiles(): List<File> {
         return grantedOrchestrator.getFlushableFiles()

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
@@ -112,10 +112,6 @@ internal class BatchFileOrchestrator(
         return rootDir
     }
 
-    override fun getRootDirName(): String {
-        return rootDir.nameWithoutExtension
-    }
-
     @WorkerThread
     override fun getMetadataFile(file: File): File? {
         if (file.parent != rootDir.path) {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleFileOrchestrator.kt
@@ -56,10 +56,6 @@ internal class SingleFileOrchestrator(
         return null
     }
 
-    override fun getRootDirName(): String? {
-        return file.parentFile?.nameWithoutExtension
-    }
-
     // single file orchestrator has a single file, so this is essentially a noop implementation
     override fun decrementAndGetPendingFilesCount(): Int {
         return 0

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
@@ -120,8 +120,6 @@ internal class ConsentAwareStorageTest {
     fun `set up`() {
         whenever(mockPendingOrchestrator.getRootDir()) doReturn File(mockPendingRootParentFile, fakeRootDirName)
         whenever(mockGrantedOrchestrator.getRootDir()) doReturn File(mockGrantedRootParentFile, fakeRootDirName)
-        whenever(mockPendingOrchestrator.getRootDirName()) doReturn fakeRootDirName
-        whenever(mockGrantedOrchestrator.getRootDirName()) doReturn fakeRootDirName
         whenever((mockGrantedOrchestrator).decrementAndGetPendingFilesCount())
             .thenReturn(fakePendingBatches - 1)
         whenever((mockPendingOrchestrator).decrementAndGetPendingFilesCount())

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestratorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestratorTest.kt
@@ -450,42 +450,6 @@ internal class ConsentAwareFileOrchestratorTest {
 
     // endregion
 
-    // region getRootDirName
-
-    @Test
-    fun `M return null W getRootDirName() {initial consent}`(
-        @Forgery consent: TrackingConsent
-    ) {
-        // Given
-        instantiateTestedOrchestrator(consent)
-
-        // When
-        val result = testedOrchestrator.getRootDirName()
-
-        // Then
-        assertThat(result).isNull()
-        verifyNoInteractions(mockPendingOrchestrator, mockGrantedOrchestrator)
-    }
-
-    @Test
-    fun `M return null W getRootDirName() {updated consent}`(
-        @Forgery initialConsent: TrackingConsent,
-        @Forgery updatedConsent: TrackingConsent
-    ) {
-        // Given
-        instantiateTestedOrchestrator(initialConsent)
-
-        // When
-        testedOrchestrator.onConsentUpdated(initialConsent, updatedConsent)
-        val result = testedOrchestrator.getRootDirName()
-
-        // Then
-        assertThat(result).isNull()
-        verifyNoInteractions(mockPendingOrchestrator, mockGrantedOrchestrator)
-    }
-
-    // endregion
-
     // region getMetadataFile
 
     @Test

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/SingleFileOrchestratorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/SingleFileOrchestratorTest.kt
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.io.TempDir
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
-import org.mockito.kotlin.mock
 import org.mockito.quality.Strictness
 import java.io.File
 
@@ -149,32 +148,6 @@ internal class SingleFileOrchestratorTest {
     fun `M return null W getRootDir()`() {
         // When
         val result = testedOrchestrator.getRootDir()
-
-        // Then
-        assertThat(result).isNull()
-    }
-
-    // endregion
-
-    // region getRootDirName
-
-    @Test
-    fun `M return file parent dirname W getRootDirName()`() {
-        // When
-        val result = testedOrchestrator.getRootDirName()
-
-        // Then
-        assertThat(result).isEqualTo(fakeParentDirName)
-    }
-
-    @Test
-    fun `M return null W getRootDirName() { parent dir is null }`() {
-        // Given
-        val fakeInvalidFile: File = mock()
-        testedOrchestrator = SingleFileOrchestrator(fakeInvalidFile, mockInternalLogger)
-
-        // When
-        val result = testedOrchestrator.getRootDirName()
 
         // Then
         assertThat(result).isNull()

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestratorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestratorTest.kt
@@ -1124,19 +1124,6 @@ internal class BatchFileOrchestratorTest {
 
     // endregion
 
-    // region getRootDirName
-
-    @Test
-    fun `M return rootDirName W getRootDirName()`() {
-        // When
-        val result = testedOrchestrator.getRootDirName()
-
-        // Then
-        assertThat(result).isEqualTo(fakeRootDir.nameWithoutExtension)
-    }
-
-    // endregion
-
     // region getMetadataFile
 
     @Test


### PR DESCRIPTION
### What does this PR do?

This API was added for a very specific use-case and not used anymore.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

