### PR TITLE
Update Kotlin AST parser dependency version

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -38,7 +38,6 @@ dependencies {
 
     // check api surface
     implementation(libs.kotlinGrammarParser)
-    implementation(libs.kotlinAntlrRuntime)
 
     // JsonSchema 2 Poko
     implementation(libs.gson)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,11 +71,7 @@ nexusPublishGradlePlugin = "2.0.0"
 datadogPlugin = "1.21.0"
 
 kotlinPoet = "1.14.2"
-kotlinGrammarParser = "0.1.0"
-# version d4384e4d90 of com.github.drieks.antlr-kotlin:antlr-kotlin-runtime
-# referenced by com.github.kotlinx.ast:grammar-kotlin-parser-antlr-kotlin-jvm cannot be found
-# so explicitly overriding with the version which can be found
-kotlinAntlrRuntime = "v0.1.0"
+kotlinGrammarParser = "41b00c0"
 jsonSchemaValidator = "1.12.1"
 binaryCompatibility = "0.17.0"
 dependencyLicense = "0.4.0"
@@ -230,7 +226,6 @@ kotlinPoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinPoet" }
 kotlinPoetKsp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinPoet" }
 kotlinSP = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "kotlinSP" }
 kotlinGrammarParser = { module = "com.github.kotlinx.ast:grammar-kotlin-parser-antlr-kotlin-jvm", version.ref = "kotlinGrammarParser" }
-kotlinAntlrRuntime = { module = "com.github.drieks.antlr-kotlin:antlr-kotlin-runtime", version.ref = "kotlinAntlrRuntime" }
 jsonSchemaValidator = { module = "com.github.everit-org.json-schema:org.everit.json.schema", version.ref = "jsonSchemaValidator" }
 kotlinXmlBuilder = {module="org.redundent:kotlin-xml-builder", version.ref="kotlinXmlBuilder"}
 


### PR DESCRIPTION
### What does this PR do?

This PR updates the version of [Kotlin AST parser](https://github.com/kotlinx/ast/commits/master/) used. It seems the transitive libs used by the previous one were either leaking memory or using too much memory causing OOM sometimes with 4GB heap limit (e.g. I found 1GB+ of related classes for a simple API surface generation task when OOM happened).

With the newer version I can run builds with 1GB heap (sometimes).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

