### PR TITLE
Address concurrency and app start detection issues in Profiling

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/DdProfilingContentProvider.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/DdProfilingContentProvider.kt
@@ -38,9 +38,8 @@ class DdProfilingContentProvider : ContentProvider() {
     @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
     private fun isProcessFromLauncher(): Boolean {
         val manager = context?.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
-        return manager?.getHistoricalProcessStartReasons(0)?.any { info ->
-            info.reason == ApplicationStartInfo.START_REASON_LAUNCHER
-        } ?: false
+        return manager?.getHistoricalProcessStartReasons(1)
+            ?.firstOrNull()?.reason == ApplicationStartInfo.START_REASON_LAUNCHER
     }
 
     override fun query(

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingRequestFactory.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingRequestFactory.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.profiling.internal
 
-import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.net.Request
 import com.datadog.android.api.net.RequestExecutionContext
@@ -17,13 +16,14 @@ import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okio.Buffer
+import java.io.IOException
 import java.util.UUID
 
 internal class ProfilingRequestFactory(
-    internal val customEndpointUrl: String?,
-    private val internalLogger: InternalLogger
+    internal val customEndpointUrl: String?
 ) : RequestFactory {
 
+    @Throws(IOException::class)
     override fun create(
         context: DatadogContext,
         executionContext: RequestExecutionContext,
@@ -78,21 +78,11 @@ internal class ProfilingRequestFactory(
         return multipartBodyBuilder.build()
     }
 
+    @Suppress("UnsafeThirdPartyFunctionCall") // Caught in the caller
     private fun extractByteArrayFromBody(body: RequestBody): ByteArray {
-        try {
-            val buffer = Buffer()
-            body.writeTo(buffer)
-            return buffer.readByteArray()
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            // we want to catch all the possible exceptions to avoid crashing the app
-            internalLogger.log(
-                InternalLogger.Level.ERROR,
-                InternalLogger.Target.TELEMETRY,
-                { "Failed to read the request body" },
-                e
-            )
-            return ByteArray(0)
-        }
+        val buffer = Buffer()
+        body.writeTo(buffer)
+        return buffer.readByteArray()
     }
 
     companion object {

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingStorage.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingStorage.kt
@@ -9,33 +9,42 @@ package com.datadog.android.profiling.internal
 import android.content.Context
 import com.datadog.android.internal.data.SharedPreferencesStorage
 
-private const val KEY_PROFILING_ENABLED = "dd_profiling_enabled"
-
 internal object ProfilingStorage {
 
+    internal const val KEY_PROFILING_ENABLED = "dd_profiling_enabled"
+
+    @Volatile
     internal var sharedPreferencesStorage: SharedPreferencesStorage? = null
 
     @JvmStatic
     internal fun addProfilingFlag(appContext: Context, sdkInstanceName: String) {
         getStorage(appContext).apply {
-            val oldValue = getStringSet(KEY_PROFILING_ENABLED, emptySet())
-            val newSet = oldValue + sdkInstanceName
-            putStringSet(KEY_PROFILING_ENABLED, newSet)
+            synchronized(this) {
+                val oldValue = getStringSet(KEY_PROFILING_ENABLED, emptySet())
+                val newSet = oldValue + sdkInstanceName
+                putStringSet(KEY_PROFILING_ENABLED, newSet)
+            }
         }
     }
 
     @JvmStatic
     internal fun getProfilingEnabledInstanceNames(appContext: Context): Set<String> {
-        return getStorage(appContext).getStringSet(KEY_PROFILING_ENABLED)
+        return getStorage(appContext).let {
+            synchronized(it) {
+                it.getStringSet(KEY_PROFILING_ENABLED)
+            }
+        }
     }
 
     @JvmStatic
     internal fun removeProfilingFlag(appContext: Context, sdkInstanceNames: Set<String>) {
         getStorage(appContext).apply {
-            val value = getStringSet(KEY_PROFILING_ENABLED).toMutableSet()
-            val removed = value.removeAll(sdkInstanceNames)
-            if (removed) {
-                putStringSet(KEY_PROFILING_ENABLED, value)
+            synchronized(this) {
+                val value = getStringSet(KEY_PROFILING_ENABLED).toMutableSet()
+                val removed = value.removeAll(sdkInstanceNames)
+                if (removed) {
+                    putStringSet(KEY_PROFILING_ENABLED, value)
+                }
             }
         }
     }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingRequestFactoryTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingRequestFactoryTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.profiling.internal
 
-import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.net.RequestExecutionContext
 import com.datadog.android.api.net.RequestFactory
@@ -22,7 +21,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
-import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
@@ -38,9 +36,6 @@ class ProfilingRequestFactoryTest {
     @StringForgery
     private lateinit var fakeEndpoint: String
 
-    @Mock
-    private lateinit var mockInternalLogger: InternalLogger
-
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
@@ -49,8 +44,7 @@ class ProfilingRequestFactoryTest {
     @BeforeEach
     fun `set up`() {
         testedFactory = ProfilingRequestFactory(
-            customEndpointUrl = null,
-            internalLogger = mockInternalLogger
+            customEndpointUrl = null
         )
     }
 
@@ -96,8 +90,7 @@ class ProfilingRequestFactoryTest {
     ) {
         // Given
         testedFactory = ProfilingRequestFactory(
-            customEndpointUrl = fakeEndpoint,
-            internalLogger = mockInternalLogger
+            customEndpointUrl = fakeEndpoint
         )
         val batchMetadata = forge.aNullable { forge.aString().toByteArray() }
 


### PR DESCRIPTION
### What does this PR do?

This PR does the following:

* Fixes some threading/concurrency issues due to the properties accessed from different threads: profiler callback thread vs SDK thread
* Fixes app start detection logic: we were checking if any historical reason is from the launcher, we need to check only the current (most recent one).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

