### PR TITLE
Skip profiling schema files in session replay module

### DIFF
--- a/features/dd-sdk-android-session-replay/clone_session_replay_schema.gradle.kts
+++ b/features/dd-sdk-android-session-replay/clone_session_replay_schema.gradle.kts
@@ -12,6 +12,7 @@ createRumSchemaCloneTask("cloneSessionReplayRootSchemas") {
         subFolder = "schemas/",
         destinationFolder = "src/main/json/schemas",
         excludedPrefixes = listOf(
+            "profiling",
             "session-replay/",
             "rum",
             "mobile",


### PR DESCRIPTION
### What does this PR do?

Addressing [this](https://github.com/DataDog/rum-events-format/pull/325#issuecomment-3723825515) issue. We don't need schema files related to profiling in the session replay module.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

