### PR TITLE
Set profiling sampling rate to 15%, improve profiling logic

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -104,6 +104,11 @@ object com.datadog.android.internal.profiler.GlobalBenchmark
   fun getProfiler(): BenchmarkProfiler
   fun getBenchmarkSdkUploads(): BenchmarkSdkUploads
   fun createExecutionTimer(String, com.datadog.android.internal.time.TimeProvider): ExecutionTimer
+sealed class com.datadog.android.internal.profiling.ProfilerStopEvent
+  data class TTID : ProfilerStopEvent
+    constructor(TTIDRumContext? = null)
+data class com.datadog.android.internal.profiling.TTIDRumContext
+  constructor(String, String, String, String?, String?)
 interface com.datadog.android.internal.system.BuildSdkVersionProvider
   val version: Int
   val isAtLeastN: Boolean
@@ -206,7 +211,5 @@ class com.datadog.android.rum.DdRumContentProvider : android.content.ContentProv
   companion object 
     var processImportance: Int
     var createTimeNs: Long
-data class com.datadog.android.rum.TTIDEvent
-  constructor(Long, String, String, String, String?, String?)
 annotation com.datadog.tools.annotation.NoOpImplementation
   constructor(Boolean = false)

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -202,6 +202,41 @@ public final class com/datadog/android/internal/profiler/GlobalBenchmark {
 	public final fun register (Lcom/datadog/android/internal/profiler/BenchmarkSdkUploads;)V
 }
 
+public abstract class com/datadog/android/internal/profiling/ProfilerStopEvent {
+}
+
+public final class com/datadog/android/internal/profiling/ProfilerStopEvent$TTID : com/datadog/android/internal/profiling/ProfilerStopEvent {
+	public fun <init> ()V
+	public fun <init> (Lcom/datadog/android/internal/profiling/TTIDRumContext;)V
+	public synthetic fun <init> (Lcom/datadog/android/internal/profiling/TTIDRumContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/internal/profiling/TTIDRumContext;
+	public final fun copy (Lcom/datadog/android/internal/profiling/TTIDRumContext;)Lcom/datadog/android/internal/profiling/ProfilerStopEvent$TTID;
+	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/ProfilerStopEvent$TTID;Lcom/datadog/android/internal/profiling/TTIDRumContext;ILjava/lang/Object;)Lcom/datadog/android/internal/profiling/ProfilerStopEvent$TTID;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRumContext ()Lcom/datadog/android/internal/profiling/TTIDRumContext;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/internal/profiling/TTIDRumContext {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/internal/profiling/TTIDRumContext;
+	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/TTIDRumContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/internal/profiling/TTIDRumContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApplicationId ()Ljava/lang/String;
+	public final fun getSessionId ()Ljava/lang/String;
+	public final fun getViewId ()Ljava/lang/String;
+	public final fun getViewName ()Ljava/lang/String;
+	public final fun getVitalId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/datadog/android/internal/system/BuildSdkVersionProvider {
 	public static final field Companion Lcom/datadog/android/internal/system/BuildSdkVersionProvider$Companion;
 	public abstract fun getVersion ()I
@@ -455,27 +490,6 @@ public final class com/datadog/android/rum/DdRumContentProvider$Companion {
 	public final fun getProcessImportance ()I
 	public final fun setCreateTimeNs (J)V
 	public final fun setProcessImportance (I)V
-}
-
-public final class com/datadog/android/rum/TTIDEvent {
-	public fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()J
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/rum/TTIDEvent;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/TTIDEvent;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/TTIDEvent;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getApplicationId ()Ljava/lang/String;
-	public final fun getDurationNs ()J
-	public final fun getSessionId ()Ljava/lang/String;
-	public final fun getViewId ()Ljava/lang/String;
-	public final fun getViewName ()Ljava/lang/String;
-	public final fun getVitalId ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface annotation class com/datadog/tools/annotation/NoOpImplementation : java/lang/annotation/Annotation {

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilerStopEvent.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilerStopEvent.kt
@@ -4,20 +4,32 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.rum
+package com.datadog.android.internal.profiling
 
 /**
- * Internal event to pass the Time To Initial Display (TTID) value in nanoseconds.
+ * Profiler stop event.
+ */
+sealed class ProfilerStopEvent {
+    /**
+     * Internal event to stop profiler at Time To Initial Display (TTID) point.
+     *
+     * @param rumContext RUM context at TTID point. Will be null if RUM session is not sampled.
+     */
+    data class TTID(
+        val rumContext: TTIDRumContext? = null
+    ) : ProfilerStopEvent()
+}
+
+/**
+ * RUM context at TTID mark.
  *
- * @param durationNs The TTID value in nanoseconds.
  * @param applicationId The Id of the application of RUM.
  * @param sessionId The Id of the RUM session where TTID is captured
  * @param vitalId The Id of the TTID vital event
  * @param viewId The Id of the view where TTID is captured
  * @param viewName The name of the view where TTID is captured
  */
-data class TTIDEvent(
-    val durationNs: Long,
+data class TTIDRumContext(
     val applicationId: String,
     val sessionId: String,
     val vitalId: String,

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/forge/Configurator.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/forge/Configurator.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.internal.forge
 
 import com.datadog.android.internal.tests.elmyr.InternalTelemetryErrorLogForgeryFactory
-import com.datadog.android.internal.tests.elmyr.TTIDEventFactory
 import com.datadog.tools.unit.forge.BaseConfigurator
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.jvm.useJvmFactories
@@ -18,6 +17,5 @@ internal class Configurator :
         super.configure(forge)
         forge.useJvmFactories()
         forge.addFactory(InternalTelemetryErrorLogForgeryFactory())
-        forge.addFactory(TTIDEventFactory())
     }
 }

--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilerStopEventTTIDFactory.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilerStopEventTTIDFactory.kt
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.tests.elmyr
+
+import com.datadog.android.internal.profiling.ProfilerStopEvent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+class ProfilerStopEventTTIDFactory : ForgeryFactory<ProfilerStopEvent.TTID> {
+    override fun getForgery(forge: Forge): ProfilerStopEvent.TTID {
+        return ProfilerStopEvent.TTID(
+            rumContext = forge.getForgery()
+        )
+    }
+}

--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/TTIDRumContextFactory.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/TTIDRumContextFactory.kt
@@ -6,14 +6,13 @@
 
 package com.datadog.android.internal.tests.elmyr
 
-import com.datadog.android.rum.TTIDEvent
+import com.datadog.android.internal.profiling.TTIDRumContext
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
-class TTIDEventFactory : ForgeryFactory<TTIDEvent> {
-    override fun getForgery(forge: Forge): TTIDEvent {
-        return TTIDEvent(
-            durationNs = forge.aLong(),
+class TTIDRumContextFactory : ForgeryFactory<TTIDRumContext> {
+    override fun getForgery(forge: Forge): TTIDRumContext {
+        return TTIDRumContext(
             applicationId = forge.anAlphabeticalString(),
             sessionId = forge.anAlphabeticalString(),
             vitalId = forge.anAlphabeticalString(),

--- a/features/dd-sdk-android-profiling/api/apiSurface
+++ b/features/dd-sdk-android-profiling/api/apiSurface
@@ -11,7 +11,7 @@ object com.datadog.android.profiling.Profiling
   fun stop(com.datadog.android.api.SdkCore = Datadog.getInstance())
 data class com.datadog.android.profiling.ProfilingConfiguration
   class Builder
-    fun setSampleRate(Float): Builder
+    fun setApplicationLaunchSampleRate(Float): Builder
     fun useCustomEndpoint(String): Builder
     fun build(): ProfilingConfiguration
   companion object 

--- a/features/dd-sdk-android-profiling/api/dd-sdk-android-profiling.api
+++ b/features/dd-sdk-android-profiling/api/dd-sdk-android-profiling.api
@@ -32,7 +32,7 @@ public final class com/datadog/android/profiling/ProfilingConfiguration {
 public final class com/datadog/android/profiling/ProfilingConfiguration$Builder {
 	public fun <init> ()V
 	public final fun build ()Lcom/datadog/android/profiling/ProfilingConfiguration;
-	public final fun setSampleRate (F)Lcom/datadog/android/profiling/ProfilingConfiguration$Builder;
+	public final fun setApplicationLaunchSampleRate (F)Lcom/datadog/android/profiling/ProfilingConfiguration$Builder;
 	public final fun useCustomEndpoint (Ljava/lang/String;)Lcom/datadog/android/profiling/ProfilingConfiguration$Builder;
 }
 

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/Profiling.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/Profiling.kt
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  */
 object Profiling {
 
+    @Volatile
     internal var profiler: Profiler = NoOpProfiler()
     internal val isProfilerInitialized = AtomicBoolean(false)
 

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/ProfilingConfiguration.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/ProfilingConfiguration.kt
@@ -22,17 +22,19 @@ data class ProfilingConfiguration internal constructor(
     class Builder {
 
         private var customEndpointUrl: String? = null
-        private var sampleRate: Float = DEFAULT_SAMPLE_RATE
+        private var applicationLaunchSampleRate: Float = DEFAULT_APPLICATION_LAUNCH_SAMPLE_RATE
 
         /**
-         * Sets the sampling rate for profiling.
+         * Sets the sampling rate for Application Launch profiling. It will be applied on the next application launch.
          *
-         * @param sampleRate The sampling rate, expressed as a percentage between 0 and 100 (inclusive).
-         * A value of 0 disables profiling entirely. A value of 100 enables profiling for all eligible
-         * requests, subject to rate limiting enforced by [android.os.ProfilingManager].
+         * @param sampleRate The sample rate, expressed as a percentage between 0 and 100 (inclusive).
+         * A value of 0 disables Application Launch profiling entirely. A value of 100 enables Application Launch
+         * profiling for all eligible requests, subject to rate limiting enforced by [android.os.ProfilingManager],
+         * see [profiling limitations doc](https://developer.android.com/topic/performance/tracing/profiling-manager/will-my-profile-always-be-collected).
+         * Default value is 15%. Effective rate for the ingested profiles is also a subject to RUM session sample rate.
          */
-        fun setSampleRate(@FloatRange(from = 0.0, to = 100.0) sampleRate: Float): Builder {
-            this.sampleRate = sampleRate
+        fun setApplicationLaunchSampleRate(@FloatRange(from = 0.0, to = 100.0) sampleRate: Float): Builder {
+            this.applicationLaunchSampleRate = sampleRate
             return this
         }
 
@@ -51,14 +53,14 @@ data class ProfilingConfiguration internal constructor(
         fun build(): ProfilingConfiguration {
             return ProfilingConfiguration(
                 customEndpointUrl = customEndpointUrl,
-                sampleRate = sampleRate
+                sampleRate = applicationLaunchSampleRate
             )
         }
     }
 
     companion object {
 
-        private const val DEFAULT_SAMPLE_RATE = 100f
+        private const val DEFAULT_APPLICATION_LAUNCH_SAMPLE_RATE = 15f
 
         /**
          * A default configuration for the Profiling feature.

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingWriter.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingWriter.kt
@@ -6,8 +6,8 @@
 
 package com.datadog.android.profiling.internal
 
+import com.datadog.android.internal.profiling.TTIDRumContext
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
-import com.datadog.android.rum.TTIDEvent
 import com.datadog.tools.annotation.NoOpImplementation
 
 @NoOpImplementation
@@ -15,6 +15,6 @@ internal interface ProfilingWriter {
 
     fun write(
         profilingResult: PerfettoResult,
-        ttidEvent: TTIDEvent
+        ttidRumContext: TTIDRumContext
     )
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
@@ -54,7 +54,6 @@ internal class PerfettoProfiler(
     private val callbackMap: MutableMap<String, ProfilerCallback> = ConcurrentHashMap()
 
     init {
-
         resultCallback = Consumer<ProfilingResult> { result ->
             val endTime = timeProvider.getDeviceTimestampMillis()
             val duration = endTime - profilingStartTime
@@ -65,6 +64,7 @@ internal class PerfettoProfiler(
                         PerfettoResult(
                             start = profilingStartTime,
                             end = endTime,
+                            tag = result.tag.orEmpty(),
                             resultFilePath = it
                         )
                     )
@@ -180,7 +180,7 @@ internal class PerfettoProfiler(
 
         // Duration is based on the current P99 TTID metric.
         private val PROFILING_MAX_DURATION_MS = TimeUnit.SECONDS.toMillis(10).toInt()
-        private const val PROFILING_TAG_APPLICATION_LAUNCH = "ApplicationLaunch"
+        internal const val PROFILING_TAG_APPLICATION_LAUNCH = "ApplicationLaunch"
 
         // Currently we give an estimated maximum size of profiling result to 5MB, it can be
         // increased or configurable if needed.

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoResult.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoResult.kt
@@ -11,10 +11,12 @@ package com.datadog.android.profiling.internal.perfetto
  *
  * @param start the start time of the profiling in milliseconds since epoch.
  * @param end the end time of the profiling in milliseconds since epoch.
+ * @param tag the tag used to start profiler
  * @param resultFilePath the path to the file containing the profiling result.
  */
 internal data class PerfettoResult(
     val start: Long,
     val end: Long,
+    val tag: String,
     val resultFilePath: String
 )

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -12,12 +12,12 @@ import android.os.ProfilingManager
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.internal.data.SharedPreferencesStorage
+import com.datadog.android.internal.profiling.ProfilerStopEvent
 import com.datadog.android.profiling.forge.Configurator
 import com.datadog.android.profiling.internal.Profiler
 import com.datadog.android.profiling.internal.ProfilingFeature
 import com.datadog.android.profiling.internal.ProfilingRequestFactory
 import com.datadog.android.profiling.internal.ProfilingStorage
-import com.datadog.android.rum.TTIDEvent
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -180,7 +180,7 @@ class ProfilingFeatureTest {
 
     @Test
     fun `M stop Profiling W receive TTID event`(
-        @Forgery fakeTTIDEvent: TTIDEvent
+        @Forgery fakeTTIDEvent: ProfilerStopEvent.TTID
     ) {
         // When
         testedFeature.onReceive(fakeTTIDEvent)

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/Configurator.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/Configurator.kt
@@ -6,7 +6,8 @@
 
 package com.datadog.android.profiling.forge
 
-import com.datadog.android.internal.tests.elmyr.TTIDEventFactory
+import com.datadog.android.internal.tests.elmyr.ProfilerStopEventTTIDFactory
+import com.datadog.android.internal.tests.elmyr.TTIDRumContextFactory
 import com.datadog.android.tests.elmyr.useCoreFactories
 import com.datadog.tools.unit.forge.BaseConfigurator
 import fr.xgouchet.elmyr.Forge
@@ -18,6 +19,7 @@ class Configurator : BaseConfigurator() {
         forge.useCoreFactories()
         forge.addFactory(ProfilingConfigurationForgeryFactory())
         forge.addFactory(PerfettoResultFactory())
-        forge.addFactory(TTIDEventFactory())
+        forge.addFactory(ProfilerStopEventTTIDFactory())
+        forge.addFactory(TTIDRumContextFactory())
     }
 }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/PerfettoResultFactory.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/PerfettoResultFactory.kt
@@ -15,6 +15,7 @@ internal class PerfettoResultFactory : ForgeryFactory<PerfettoResult> {
         return PerfettoResult(
             start = forge.aLong(),
             end = forge.aLong(),
+            tag = forge.aString(),
             resultFilePath = forge.anAlphabeticalString()
         )
     }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/ProfilingConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/ProfilingConfigurationForgeryFactory.kt
@@ -13,12 +13,11 @@ import fr.xgouchet.elmyr.ForgeryFactory
 class ProfilingConfigurationForgeryFactory :
     ForgeryFactory<ProfilingConfiguration> {
     override fun getForgery(forge: Forge): ProfilingConfiguration {
-        return ProfilingConfiguration.Builder()
-            .setSampleRate(
-                sampleRate = forge.aFloat(min = 1f, max = 100f)
-            )
-            .useCustomEndpoint(
-                endpoint = forge.aStringMatching("http(s?)://[a-z]+\\.com/\\w+")
-            ).build()
+        return ProfilingConfiguration(
+            sampleRate = forge.aFloat(min = 0f, max = 100f),
+            customEndpointUrl = forge.aNullable {
+                aStringMatching("http(s?)://[a-z]+\\.com/\\w+")
+            }
+        )
     }
 }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingConfigurationTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingConfigurationTest.kt
@@ -27,7 +27,7 @@ internal class ProfilingConfigurationTest {
 
         // Then
         assertThat(config.customEndpointUrl).isNull()
-        assertThat(config.sampleRate).isEqualTo(100f)
+        assertThat(config.sampleRate).isEqualTo(15f)
     }
 
     @Test
@@ -49,7 +49,7 @@ internal class ProfilingConfigurationTest {
     ) {
         // When
         val config = ProfilingConfiguration.Builder()
-            .setSampleRate(sampleRate)
+            .setApplicationLaunchSampleRate(sampleRate)
             .build()
 
         // Then
@@ -72,7 +72,7 @@ internal class ProfilingConfigurationTest {
 
         // Then
         assertThat(original.customEndpointUrl).isNull()
-        assertThat(original.sampleRate).isEqualTo(100f)
+        assertThat(original.sampleRate).isEqualTo(15f)
         assertThat(modified.customEndpointUrl).isEqualTo(endpoint)
         assertThat(modified.sampleRate).isEqualTo(sampleRate)
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -14,6 +14,7 @@ import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.NoOpDataWriter
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
+import com.datadog.android.internal.profiling.ProfilerStopEvent
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.domain.InfoProvider
@@ -168,6 +169,11 @@ internal class RumSessionScope(
                         writer = actualWriter,
                         rumContext = rumContext,
                         customAttributes = getCustomAttributes()
+                    )
+                } else {
+                    // can refactor in the future by moving session state check into RumSessionScopeStartupManager
+                    sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.sendEvent(
+                        ProfilerStopEvent.TTID()
                     )
                 }
             }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManager.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManager.kt
@@ -12,7 +12,8 @@ import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.core.InternalSdkCore
-import com.datadog.android.rum.TTIDEvent
+import com.datadog.android.internal.profiling.ProfilerStopEvent
+import com.datadog.android.internal.profiling.TTIDRumContext
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.scope.RumRawEvent
 import com.datadog.android.rum.internal.domain.scope.RumVitalAppLaunchEventHelper
@@ -117,13 +118,14 @@ internal class RumSessionScopeStartupManagerImpl(
         )
 
         sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.sendEvent(
-            TTIDEvent(
-                durationNs = event.info.durationNs,
-                applicationId = rumContext.applicationId,
-                sessionId = rumContext.sessionId,
-                viewId = rumContext.viewId,
-                viewName = rumContext.viewName,
-                vitalId = ttidEvent.vital.id
+            ProfilerStopEvent.TTID(
+                rumContext = TTIDRumContext(
+                    applicationId = rumContext.applicationId,
+                    sessionId = rumContext.sessionId,
+                    viewId = rumContext.viewId,
+                    viewName = rumContext.viewName,
+                    vitalId = ttidEvent.vital.id
+                )
             )
         )
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -30,6 +30,7 @@ import com.datadog.android.okhttp.DatadogEventListener
 import com.datadog.android.okhttp.DatadogInterceptor
 import com.datadog.android.okhttp.trace.TracingInterceptor
 import com.datadog.android.profiling.Profiling
+import com.datadog.android.profiling.ProfilingConfiguration
 import com.datadog.android.rum.ExperimentalRumApi
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.Rum
@@ -169,7 +170,11 @@ class SampleApplication : Application() {
         GlobalRumMonitor.get().debug = true
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-            Profiling.enable()
+            Profiling.enable(
+                ProfilingConfiguration.Builder()
+                    .setApplicationLaunchSampleRate(100f)
+                    .build()
+            )
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

This change set default profiling sampling rate to 15% and also does a bit of refactoring.

Additionally it stops profiler even if it RUM session is not sampled, to avoid having profiler running for nothing.

Also `profiler_version` and `runtime_version` tags are added to have more visibility in profiling backend metrics.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

