### PR TITLE
Mark fatal ANR as processed before RUM events are written

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
@@ -152,12 +152,14 @@ internal class DatadogLateCrashReporter(
                     lastViewEvent
                 )
                 writeScope {
+                    // mark it before creating RUM events, so that we don't handle it again if code crashed after
+                    // RUM events are written
+                    sdkCore.writeLastFatalAnrSent(anrExitInfo.timestamp)
                     rumWriter.write(it, toSendErrorEvent, EventType.CRASH)
                     if (lastViewEvent.isWithinSessionAvailability) {
                         val updatedViewEvent = updateViewEvent(lastViewEvent)
                         rumWriter.write(it, updatedViewEvent, EventType.CRASH)
                     }
-                    sdkCore.writeLastFatalAnrSent(anrExitInfo.timestamp)
                 }
             }
         }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
@@ -56,6 +56,7 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -739,7 +740,10 @@ internal class DatadogLateCrashReporterTest {
         // Then
         verify(mockRumFeatureScope).withWriteContext(eq(setOf(Feature.RUM_FEATURE_NAME)), any())
         argumentCaptor<Any> {
-            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
+            inOrder(mockSdkCore, mockRumWriter) {
+                verify(mockSdkCore).writeLastFatalAnrSent(fakeTimestamp)
+                verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
+            }
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
                 .hasErrorId()
@@ -788,8 +792,6 @@ internal class DatadogLateCrashReporterTest {
                 .hasCrashCount((fakeViewEvent.view.crash?.count ?: 0) + 1)
                 .isActive(false)
         }
-
-        verify(mockSdkCore).writeLastFatalAnrSent(fakeTimestamp)
     }
 
     @Test
@@ -831,7 +833,10 @@ internal class DatadogLateCrashReporterTest {
         // Then
         verify(mockRumFeatureScope).withWriteContext(eq(setOf(Feature.RUM_FEATURE_NAME)), any())
         argumentCaptor<Any> {
-            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
+            inOrder(mockSdkCore, mockRumWriter) {
+                verify(mockSdkCore).writeLastFatalAnrSent(fakeTimestamp)
+                verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
+            }
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
                 .hasErrorId()
@@ -872,8 +877,6 @@ internal class DatadogLateCrashReporterTest {
                 .hasCrashCount((fakeViewEvent.view.crash?.count ?: 0) + 1)
                 .isActive(false)
         }
-
-        verify(mockSdkCore).writeLastFatalAnrSent(fakeTimestamp)
     }
 
     @Test
@@ -922,7 +925,10 @@ internal class DatadogLateCrashReporterTest {
         // Then
         verify(mockRumFeatureScope).withWriteContext(eq(setOf(Feature.RUM_FEATURE_NAME)), any())
         argumentCaptor<Any> {
-            verify(mockRumWriter, times(1)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
+            inOrder(mockSdkCore, mockRumWriter) {
+                verify(mockSdkCore).writeLastFatalAnrSent(fakeTimestamp)
+                verify(mockRumWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
+            }
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
                 .hasErrorId()
@@ -966,8 +972,6 @@ internal class DatadogLateCrashReporterTest {
                 )
                 .hasThreads(fakeThreadsDump)
         }
-
-        verify(mockSdkCore).writeLastFatalAnrSent(fakeTimestamp)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

This is attempt to fix a case of double-sending fatal ANR. Probably it can happen if RUM events are written but there is an issue between RUM events write and marking ANR as processed preventing the latter.

Let's try to mark ANR as processed first.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

