### PR TITLE
[Flags] fix: add STATIC resolution reason

### DIFF
--- a/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/internal/adapters/ConvertersTest.kt
+++ b/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/internal/adapters/ConvertersTest.kt
@@ -92,6 +92,30 @@ internal class ConvertersTest {
     }
 
     @Test
+    fun `M convert STATIC reason W toProviderEvaluation() {resolution with STATIC reason}`(
+        @StringForgery variant: String,
+        forge: Forge
+    ) {
+        // Given
+        val value = forge.aBool()
+        val resolution = ResolutionDetails(
+            value = value,
+            variant = variant,
+            reason = ResolutionReason.STATIC
+        )
+
+        // When
+        val result = resolution.toProviderEvaluation()
+
+        // Then
+        assertThat(result.value).isEqualTo(value)
+        assertThat(result.variant).isEqualTo(variant)
+        assertThat(result.reason).isEqualTo("STATIC")
+        assertThat(result.errorCode).isNull()
+        assertThat(result.errorMessage).isNull()
+    }
+
+    @Test
     fun `M convert error resolution W toProviderEvaluation() {with error code}`(@StringForgery errorMessage: String) {
         // Given
         val resolution = ResolutionDetails(

--- a/features/dd-sdk-android-flags/api/apiSurface
+++ b/features/dd-sdk-android-flags/api/apiSurface
@@ -56,6 +56,7 @@ sealed class com.datadog.android.flags.model.FlagsClientState
 data class com.datadog.android.flags.model.ResolutionDetails<T: Any>
   constructor(T, String? = null, ResolutionReason? = null, ErrorCode? = null, String? = null, Map<String, Any> = emptyMap())
 enum com.datadog.android.flags.model.ResolutionReason
+  - STATIC
   - DEFAULT
   - TARGETING_MATCH
   - RULE_MATCH

--- a/features/dd-sdk-android-flags/api/dd-sdk-android-flags.api
+++ b/features/dd-sdk-android-flags/api/dd-sdk-android-flags.api
@@ -261,6 +261,7 @@ public final class com/datadog/android/flags/model/ResolutionReason : java/lang/
 	public static final field ERROR Lcom/datadog/android/flags/model/ResolutionReason;
 	public static final field PREREQUISITE_FAILED Lcom/datadog/android/flags/model/ResolutionReason;
 	public static final field RULE_MATCH Lcom/datadog/android/flags/model/ResolutionReason;
+	public static final field STATIC Lcom/datadog/android/flags/model/ResolutionReason;
 	public static final field TARGETING_MATCH Lcom/datadog/android/flags/model/ResolutionReason;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/flags/model/ResolutionReason;
 	public static fun values ()[Lcom/datadog/android/flags/model/ResolutionReason;

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/model/ResolutionReason.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/model/ResolutionReason.kt
@@ -14,12 +14,14 @@ package com.datadog.android.flags.model
  */
 enum class ResolutionReason {
     /**
-     * The resolved value is a static value configured for the flag.
+     * No targeting rules matched; the fallthrough/default allocation was used.
+     * This is the value configured in the flag's default variation when no rules apply.
      */
     STATIC,
 
     /**
-     * The resolved value is the default value for the flag.
+     * The resolved value is the default value provided in code.
+     * Used when the flag is not found or the provider is not ready.
      */
     DEFAULT,
 

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/model/ResolutionReason.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/model/ResolutionReason.kt
@@ -14,6 +14,11 @@ package com.datadog.android.flags.model
  */
 enum class ResolutionReason {
     /**
+     * The resolved value is a static value configured for the flag.
+     */
+    STATIC,
+
+    /**
      * The resolved value is the default value for the flag.
      */
     DEFAULT,


### PR DESCRIPTION
### What does this PR do?

This PR adds the STATIC resolution reason to the `flags` and `flags-openfeature` modules

### Motivation

This resolution reason is returned from the flagging service when a flag's value is determined by the platform default rather than any targeting rules


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

