### PR TITLE
Add `operation:launch` tag for profiling

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
@@ -108,7 +108,9 @@ internal class ProfilingDataWriter(
         append(",")
         append("$TAG_KEY_PROFILER_VERSION:${context.sdkVersion}")
         append(",")
-        append("$TAG_RUNTIME_VERSION:${context.deviceInfo.osVersion}")
+        append("$TAG_KEY_RUNTIME_VERSION:${context.deviceInfo.osVersion}")
+        append(",")
+        append("$TAG_KEY_OPERATION:$OPERATION_TYPE_LAUNCH")
         context.appBuildId?.let { buildId ->
             append(",")
             append("$TAG_KEY_BUILD_ID:$buildId")
@@ -127,11 +129,13 @@ internal class ProfilingDataWriter(
         private const val TAG_KEY_BUILD_ID = "build_id"
         private const val TAG_KEY_SDK_VERSION = "sdk_version"
         private const val TAG_KEY_PROFILER_VERSION = "profiler_version"
-        private const val TAG_RUNTIME_VERSION = "runtime_version"
+        private const val TAG_KEY_RUNTIME_VERSION = "runtime_version"
         private const val TAG_KEY_ENV = "env"
+        private const val TAG_KEY_OPERATION = "operation"
         private const val PERFETTO_ATTACHMENT_NAME = "perfetto.proto"
         private const val ANDROID_FAMILY_NAME = "android"
         private const val ANDROID_RUNTIME_NAME = "android"
+        private const val OPERATION_TYPE_LAUNCH = "launch"
 
         // Only `4` is supported by profiling Backend
         private const val VERSION_NUMBER = "4"

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingDataWriterTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingDataWriterTest.kt
@@ -127,7 +127,8 @@ internal class ProfilingDataWriterTest {
             "version:${fakeDatadogContext.version}",
             "sdk_version:${fakeDatadogContext.sdkVersion}",
             "profiler_version:${fakeDatadogContext.sdkVersion}",
-            "runtime_version:${fakeDatadogContext.deviceInfo.osVersion}"
+            "runtime_version:${fakeDatadogContext.deviceInfo.osVersion}",
+            "operation:launch"
         )
         fakeDatadogContext.appBuildId?.let {
             expectedTagList.add("build_id:${fakeDatadogContext.appBuildId}")


### PR DESCRIPTION
### What does this PR do?

Adding `operation:launch` tag to align with iOS SDK and allow filtering in the future once another profile types are added.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

