### PR TITLE
Update Profiling App launch telemetry

### DIFF
--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -960,6 +960,7 @@ datadog:
       - "kotlin.collections.MutableMap?.forEach(kotlin.Function1)"
       - "kotlin.collections.MutableSet.add(com.datadog.android.api.feature.FeatureContextUpdateReceiver)"
       - "kotlin.collections.MutableSet.add(com.datadog.android.core.internal.persistence.ConsentAwareStorage.Batch)"
+      - "kotlin.collections.MutableSet.add(com.datadog.android.profiling.internal.perfetto.PerfettoProfiler.TelemetryData)"
       - "kotlin.collections.MutableSet.add(com.datadog.android.sessionreplay.ExtensionSupport)"
       - "kotlin.collections.MutableSet.add(com.datadog.android.telemetry.internal.TelemetryEventId)"
       - "kotlin.collections.MutableSet.add(java.io.File)"


### PR DESCRIPTION
### What does this PR do?

* Update the telemetry message and properties to align with IOS
* Fix the issue when profiler callback is called before `internalLogger` is set, the telemetry was not sent.
* Update the sampling frequency from 100hz to 101hz to avoid lockstep sampling.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

