### PR TITLE
[RUM-9129] Make ViewLoadingTimeMetrics tests deterministic and faster with controlled time 

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -517,7 +517,7 @@ internal class DatadogRumMonitor(
         throwable: Throwable,
         threads: List<ThreadDump>
     ) {
-        val now = Time()
+        val now = getCurrentTime()
         val timeSinceAppStartNs = now.nanoTime - sdkCore.appStartTimeNs
         handleEvent(
             RumRawEvent.AddError(
@@ -910,8 +910,11 @@ internal class DatadogRumMonitor(
     }
 
     private fun getEventTime(attributes: Map<String, Any?>): Time {
-        return (attributes[RumAttributes.INTERNAL_TIMESTAMP] as? Long)?.asTime() ?: Time()
+        return (attributes[RumAttributes.INTERNAL_TIMESTAMP] as? Long)?.asTime() ?: getCurrentTime()
     }
+
+    private fun getCurrentTime() =
+        Time(sdkCore.timeProvider.getDeviceTimestampMillis(), sdkCore.timeProvider.getDeviceElapsedTimeNanos())
 
     private fun getErrorType(attributes: Map<String, Any?>): String? {
         return attributes[RumAttributes.INTERNAL_ERROR_TYPE] as? String

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -264,6 +264,7 @@ internal class DatadogRumMonitor(
         throwable: Throwable,
         attributes: Map<String, Any?>
     ) {
+        val eventTime = getEventTime(attributes)
         handleEvent(
             RumRawEvent.StopResourceWithError(
                 key,
@@ -271,7 +272,8 @@ internal class DatadogRumMonitor(
                 message,
                 source,
                 throwable,
-                attributes.toMap()
+                attributes.toMap(),
+                eventTime
             )
         )
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -544,7 +544,7 @@ internal class DatadogRumMonitor(
 
     @ExperimentalRumApi
     override fun addViewLoadingTime(overwrite: Boolean) {
-        handleEvent(RumRawEvent.AddViewLoadingTime(overwrite = overwrite))
+        handleEvent(RumRawEvent.AddViewLoadingTime(overwrite = overwrite, getCurrentTime()))
     }
 
     override fun addViewAttributes(attributes: Map<String, Any?>) {

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingRumTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingRumTest.kt
@@ -208,7 +208,7 @@ class ManualTrackingRumTest {
         // When
         rumMonitor.startView(viewKey, viewName)
         rumMonitor.addAction(RumActionType.CUSTOM, actionName)
-        Thread.sleep(100)
+        stubSdkCore.advanceTimeBy(100)
         // Used to trigger the action event
         rumMonitor.stopView(viewKey)
 
@@ -347,7 +347,7 @@ class ManualTrackingRumTest {
         // When
         rumMonitor.startView(key, name)
         rumMonitor.startResource(resourceKey, RumResourceMethod.GET, resourceUrl.toString())
-        Thread.sleep(100)
+        stubSdkCore.advanceTimeBy(100)
         rumMonitor.stopResource(resourceKey, resourceStatus, resourceSize, RumResourceKind.NATIVE)
         rumMonitor.stopView(key)
 
@@ -418,7 +418,7 @@ class ManualTrackingRumTest {
         // When
         rumMonitor.startView(key, name)
         rumMonitor.startResource(resourceId, RumResourceMethod.GET, resourceUrl.toString())
-        Thread.sleep(100)
+        stubSdkCore.advanceTimeBy(100)
         rumMonitor.stopResource(resourceId, resourceStatus, resourceSize, RumResourceKind.NATIVE)
         rumMonitor.stopView(key)
 
@@ -485,12 +485,11 @@ class ManualTrackingRumTest {
     ) {
         // Given
         val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
-        val startTime = System.nanoTime()
         rumMonitor.startView(key, name)
 
         // When
-        val endTime = System.nanoTime()
-        val expectedViewLoadingTime = endTime - startTime
+        stubSdkCore.advanceTimeBy(100)
+        val expectedViewLoadingTime = TimeUnit.MILLISECONDS.toNanos(100)
         rumMonitor.addViewLoadingTime(overwrite)
 
         // Then
@@ -578,19 +577,17 @@ class ManualTrackingRumTest {
     ) {
         // Given
         val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
-        val startTime = System.nanoTime()
         rumMonitor.startView(key, name)
-        val intermediateTime = System.nanoTime()
+        stubSdkCore.advanceTimeBy(50)
         rumMonitor.addViewLoadingTime(overwrite)
 
         // When
-        Thread.sleep(100)
-        val endTime = System.nanoTime()
+        stubSdkCore.advanceTimeBy(50)
         rumMonitor.addViewLoadingTime(true)
 
         // Then
-        val expectedFirstViewLoadingTime = intermediateTime - startTime
-        val expectedSecondViewLoadingTime = endTime - startTime
+        val expectedFirstViewLoadingTime = TimeUnit.MILLISECONDS.toNanos(50)
+        val expectedSecondViewLoadingTime = TimeUnit.MILLISECONDS.toNanos(100)
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
             .hasSize(3)
@@ -645,17 +642,16 @@ class ManualTrackingRumTest {
     ) {
         // Given
         val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
-        val startTime = System.nanoTime()
         rumMonitor.startView(key, name)
-        val intermediateTime = System.nanoTime()
+        stubSdkCore.advanceTimeBy(50)
         rumMonitor.addViewLoadingTime(overwrite)
 
         // When
-        Thread.sleep(100)
+        stubSdkCore.advanceTimeBy(50)
         rumMonitor.addViewLoadingTime(false)
 
         // Then
-        val expectedViewLoadingTime = intermediateTime - startTime
+        val expectedViewLoadingTime = TimeUnit.MILLISECONDS.toNanos(50)
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
             .hasSize(2)

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ViewLoadingTimeMetricsTests.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ViewLoadingTimeMetricsTests.kt
@@ -111,14 +111,12 @@ class ViewLoadingTimeMetricsTests {
         val monitor = GlobalRumMonitor.get(stubSdkCore)
 
         // When
-        val startViewTime = System.nanoTime()
         monitor.startView(viewKey, viewName)
         monitor.startResource(resourceKey, rumResourceMethod, resourceUrl)
-        Thread.sleep(100)
-        val stopResourceTime = System.nanoTime()
+        stubSdkCore.advanceTimeBy(100)
         monitor.stopResource(resourceKey, resourceStatus, resourceSize, rumResourceKind)
         monitor.stopView(viewKey)
-        val appExpectedTtnsTime = (stopResourceTime - startViewTime)
+        val appExpectedTtnsTime = TimeUnit.MILLISECONDS.toNanos(100)
 
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
@@ -184,17 +182,15 @@ class ViewLoadingTimeMetricsTests {
         val monitor = GlobalRumMonitor.get(stubSdkCore)
 
         // When
-        val startViewTime = System.nanoTime()
         monitor.startView(viewKey, viewName)
         monitor.startResource(resourceKey, rumResourceMethod, resourceUrl)
-        Thread.sleep(100)
-        val stopResourceTime = System.nanoTime()
+        stubSdkCore.advanceTimeBy(100)
         monitor.stopResource(resourceKey, resourceStatus, resourceSize, rumResourceKind)
         monitor.addTiming(forge.anAlphabeticalString())
-        Thread.sleep(100)
+        stubSdkCore.advanceTimeBy(100)
         monitor.addTiming(forge.anAlphabeticalString())
         monitor.stopView(viewKey)
-        val appExpectedTtnsTime = (stopResourceTime - startViewTime)
+        val appExpectedTtnsTime = TimeUnit.MILLISECONDS.toNanos(100)
 
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
@@ -286,14 +282,12 @@ class ViewLoadingTimeMetricsTests {
         val monitor = GlobalRumMonitor.get(stubSdkCore)
 
         // When
-        val startViewTime = System.nanoTime()
         monitor.startView(viewKey, viewName)
         monitor.startResource(resourceKey, rumResourceMethod, resourceUrl)
-        Thread.sleep(100)
-        val stopResourceTime = System.nanoTime()
+        stubSdkCore.advanceTimeBy(100)
         monitor.stopResourceWithError(resourceKey, resourceStatus, errorMessage, errorSource, throwable)
         monitor.stopView(viewKey)
-        val appExpectedTtnsTime = (stopResourceTime - startViewTime)
+        val appExpectedTtnsTime = TimeUnit.MILLISECONDS.toNanos(100)
 
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
@@ -365,7 +359,7 @@ class ViewLoadingTimeMetricsTests {
         // When
         monitor.startView(viewKey, viewName)
         monitor.startResource(resourceKey, rumResourceMethod, resourceUrl)
-        Thread.sleep(100)
+        stubSdkCore.advanceTimeBy(100)
         monitor.stopResourceWithError(resourceKey, resourceStatus, errorMessage, errorSource, throwable)
         monitor.stopView(viewKey)
 
@@ -412,7 +406,7 @@ class ViewLoadingTimeMetricsTests {
         // When
         monitor.startView(viewKey, viewName)
         monitor.startResource(resourceKey, rumResourceMethod, resourceUrl)
-        Thread.sleep(100)
+        stubSdkCore.advanceTimeBy(100)
         monitor.stopResource(resourceKey, resourceStatus, resourceSize, rumResourceKind)
         monitor.stopView(viewKey)
 
@@ -458,9 +452,9 @@ class ViewLoadingTimeMetricsTests {
         // When
         monitor.startView(viewKey, viewName)
         // wait for more than the default threshold in the default identifier (100ms)
-        Thread.sleep(100 + 10)
+        stubSdkCore.advanceTimeBy(110)
         monitor.startResource(resourceKey, rumResourceMethod, resourceUrl)
-        Thread.sleep(100)
+        stubSdkCore.advanceTimeBy(100)
         monitor.stopResource(resourceKey, resourceStatus, resourceSize, rumResourceKind)
         monitor.stopView(viewKey)
 
@@ -531,9 +525,9 @@ class ViewLoadingTimeMetricsTests {
         // When
         monitor.startView(viewKey, viewName)
         // wait for more than the custom threshold
-        Thread.sleep(resourceIdentifierThresholdMs + 10)
+        stubSdkCore.advanceTimeBy(resourceIdentifierThresholdMs + 10)
         monitor.startResource(resourceKey, rumResourceMethod, resourceUrl)
-        Thread.sleep(100)
+        stubSdkCore.advanceTimeBy(100)
         monitor.stopResource(resourceKey, resourceStatus, resourceSize, rumResourceKind)
         monitor.stopView(viewKey)
 
@@ -606,7 +600,7 @@ class ViewLoadingTimeMetricsTests {
         // When
         monitor.startView(viewKey, viewName)
         monitor.startResource(resourceKey, rumResourceMethod, resourceUrl)
-        Thread.sleep(100)
+        stubSdkCore.advanceTimeBy(100)
         monitor.stopResource(resourceKey, resourceStatus, resourceSize, rumResourceKind)
         monitor.stopView(viewKey)
 
@@ -1196,13 +1190,13 @@ class ViewLoadingTimeMetricsTests {
         // When
         monitor.startView(previousViewKey, previousViewName)
         monitor.startAction(validActionType, lastInteractionName)
-        Thread.sleep(100)
+        stubSdkCore.advanceTimeBy(100)
         monitor.stopAction(validActionType, lastInteractionName)
         monitor.stopView(previousViewKey)
         // Wait for more than the default threshold in the default identifier (3000ms)
-        Thread.sleep(3000 + 10)
+        stubSdkCore.advanceTimeBy(3010)
         monitor.startView(viewKey, viewName)
-        Thread.sleep(100)
+        stubSdkCore.advanceTimeBy(100)
         monitor.stopView(viewKey)
 
         // Then
@@ -1295,13 +1289,13 @@ class ViewLoadingTimeMetricsTests {
         // When
         monitor.startView(previousViewKey, previousViewName)
         monitor.startAction(validActionType, lastInteractionName)
-        Thread.sleep(100)
+        stubSdkCore.advanceTimeBy(100)
         monitor.stopAction(validActionType, lastInteractionName)
         monitor.stopView(previousViewKey)
         // Wait for more than the custom threshold
-        Thread.sleep(customThreshold + 10)
+        stubSdkCore.advanceTimeBy(customThreshold + 10)
         monitor.startView(viewKey, viewName)
-        Thread.sleep(100)
+        stubSdkCore.advanceTimeBy(100)
         monitor.stopView(viewKey)
 
         // Then
@@ -1389,25 +1383,24 @@ class ViewLoadingTimeMetricsTests {
     private fun runSuccessfulItnvTestScenario(monitor: RumMonitor, rumActionType: RumActionType): Long {
         monitor.startView(previousViewKey, previousViewName)
         monitor.startAction(rumActionType, lastInteractionName)
-        Thread.sleep(100)
-        val stopActionTime = System.nanoTime()
+        stubSdkCore.advanceTimeBy(100)
         monitor.stopAction(rumActionType, lastInteractionName)
         monitor.stopView(previousViewKey)
-        val startViewTime = System.nanoTime()
+        stubSdkCore.advanceTimeBy(100)
         monitor.startView(viewKey, viewName)
-        Thread.sleep(100)
+        stubSdkCore.advanceTimeBy(100)
         monitor.stopView(viewKey)
-        return (startViewTime - stopActionTime)
+        return TimeUnit.MILLISECONDS.toNanos(100)
     }
 
     private fun runUnsuccessfulItnvTestScenario(monitor: RumMonitor, rumActionType: RumActionType) {
         monitor.startView(previousViewKey, previousViewName)
         monitor.startAction(rumActionType, lastInteractionName)
-        Thread.sleep(100)
+        stubSdkCore.advanceTimeBy(100)
         monitor.stopAction(rumActionType, lastInteractionName)
         monitor.stopView(previousViewKey)
         monitor.startView(viewKey, viewName)
-        Thread.sleep(100)
+        stubSdkCore.advanceTimeBy(100)
         monitor.stopView(viewKey)
     }
 

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
@@ -28,6 +28,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.whenever
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import org.mockito.kotlin.mock as kmock
 
 /**
@@ -45,6 +46,9 @@ class StubSDKCore(
 ) : InternalSdkCore by mockSdkCore {
 
     private val featureScopes = mutableMapOf<String, FeatureScope>()
+
+    private var currentTimestampMillis: Long = 0L
+    private var currentNanoTime: Long = 0L
 
     init {
         val mockResources = mock<Resources>()
@@ -110,6 +114,15 @@ class StubSDKCore(
     }
 
     /**
+     * Advances the current time by the specified duration.
+     * @param durationMs the duration to advance in milliseconds
+     */
+    fun advanceTimeBy(durationMs: Long) {
+        currentTimestampMillis += durationMs
+        currentNanoTime += TimeUnit.MILLISECONDS.toNanos(durationMs)
+    }
+
+    /**
      * Stubs a feature with a mock.
      * This is useful when a feature under tests checks for the presence of another one,
      * or sends events to another feature for cross feature communication.
@@ -162,9 +175,9 @@ class StubSDKCore(
     override val internalLogger: InternalLogger = StubInternalLogger()
 
     override val timeProvider = object : TimeProvider {
-        override fun getDeviceTimestampMillis(): Long = System.currentTimeMillis()
+        override fun getDeviceTimestampMillis(): Long = currentTimestampMillis
         override fun getServerTimestampMillis(): Long = 0L
-        override fun getDeviceElapsedTimeNanos(): Long = System.nanoTime()
+        override fun getDeviceElapsedTimeNanos(): Long = currentNanoTime
         override fun getServerOffsetNanos(): Long = 0L
         override fun getServerOffsetMillis(): Long = 0L
         override fun getDeviceElapsedRealtimeMillis(): Long = SystemClock.elapsedRealtime()

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
@@ -10,6 +10,7 @@ import android.app.Application
 import android.content.ContentResolver
 import android.content.res.Configuration
 import android.content.res.Resources
+import android.os.SystemClock
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.AccountInfo
 import com.datadog.android.api.context.DatadogContext
@@ -161,12 +162,12 @@ class StubSDKCore(
     override val internalLogger: InternalLogger = StubInternalLogger()
 
     override val timeProvider = object : TimeProvider {
-        override fun getDeviceTimestampMillis(): Long = 0L
+        override fun getDeviceTimestampMillis(): Long = System.currentTimeMillis()
         override fun getServerTimestampMillis(): Long = 0L
-        override fun getDeviceElapsedTimeNanos(): Long = 0L
+        override fun getDeviceElapsedTimeNanos(): Long = System.nanoTime()
         override fun getServerOffsetNanos(): Long = 0L
         override fun getServerOffsetMillis(): Long = 0L
-        override fun getDeviceElapsedRealtimeMillis(): Long = 0L
+        override fun getDeviceElapsedRealtimeMillis(): Long = SystemClock.elapsedRealtime()
     }
 
     override fun registerFeature(feature: Feature) {


### PR DESCRIPTION
### What does this PR do?

This PR refactors `ViewLoadingTimeMetricsTests` to use a controllable time provider instead of `Thread.sleep()`. It adds an `advanceTimeBy()` method to `StubSDKCore` that allows tests to control time  advancement, making tests deterministic and significantly faster (~25 seconds saved per test run). All test methods are updated to use explicit time advancement, and `DatadogRumMonitor.stopResourceWithError()` now uses `getEventTime()` to respect the controllable time provider.        

| Before   |      After      |
|----------|-------------|
| <img width="842" height="53" alt="image" src="https://github.com/user-attachments/assets/0f18563b-a9a5-421c-a68d-8dff2806229f" />|  <img width="842" height="53" alt="image" src="https://github.com/user-attachments/assets/f9586eb7-7011-4c2e-a7c3-b40f2ca8631f" /> |
|<img width="842" height="53" alt="image" src="https://github.com/user-attachments/assets/e08bfb72-ff62-4edd-b650-fb0eb3f23658" />|<img width="842" height="53" alt="image" src="https://github.com/user-attachments/assets/1c3ef73b-d2f7-4a5b-8352-044edd9122bd" />|

### Motivation

`ViewLoadingTimeMetricsTests` contained the same flaky test multiple times, and I believe some of the flakiness was due to how we were managing time within `DatadogRumMonitor`. We were instantiating Time directly inside the monitor instead of using the values provided by a time provider. With that approach, tests were able to modify time values, which made them non-deterministic because they depended on real time.

With the proposed changes, we can fully control time values and switch to deterministic tests.

 ### Additional Notes

I plan to open a **separate PR** to remove the default value for eventTime in `RumRawEvent` so that we use the timeProvider values everywhere.

For example:
```kotlin
internal data class ActionDropped(
    val viewId: String,
    override val eventTime: Time
) : RumRawEvent()
```

Any reasons not do it?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

