### PR TITLE
Fix `stopResourceWithError` overloads to use `getEventTime(attributes)`

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -287,6 +287,7 @@ internal class DatadogRumMonitor(
         errorType: String?,
         attributes: Map<String, Any?>
     ) {
+        val eventTime = getEventTime(attributes)
         handleEvent(
             RumRawEvent.StopResourceWithStackTrace(
                 key,
@@ -295,7 +296,8 @@ internal class DatadogRumMonitor(
                 source,
                 stackTrace,
                 errorType,
-                attributes.toMap()
+                attributes.toMap(),
+                eventTime
             )
         )
     }
@@ -340,6 +342,7 @@ internal class DatadogRumMonitor(
         throwable: Throwable,
         attributes: Map<String, Any?>
     ) {
+        val eventTime = getEventTime(attributes)
         handleEvent(
             RumRawEvent.StopResourceWithError(
                 key,
@@ -347,7 +350,8 @@ internal class DatadogRumMonitor(
                 message,
                 source,
                 throwable,
-                attributes.toMap()
+                attributes.toMap(),
+                eventTime
             )
         )
     }
@@ -361,6 +365,7 @@ internal class DatadogRumMonitor(
         errorType: String?,
         attributes: Map<String, Any?>
     ) {
+        val eventTime = getEventTime(attributes)
         handleEvent(
             RumRawEvent.StopResourceWithStackTrace(
                 key,
@@ -369,7 +374,8 @@ internal class DatadogRumMonitor(
                 source,
                 stackTrace,
                 errorType,
-                attributes.toMap()
+                attributes.toMap(),
+                eventTime
             )
         )
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -219,8 +219,12 @@ internal class DatadogRumMonitorTest {
 
     private var fakeRumSessionType: RumSessionType? = null
 
+    private var eventTimeMs: Long = 0L
+
     @BeforeEach
     fun `set up`(forge: Forge) {
+        eventTimeMs = forge.aLong(min = 0L)
+
         whenever(mockExecutorService.execute(any<Runnable>())) doAnswer {
             it.getArgument<Runnable>(0).run()
         }
@@ -231,6 +235,7 @@ internal class DatadogRumMonitorTest {
 
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockSdkCore.timeProvider) doReturn mock()
+        whenever(mockSdkCore.timeProvider.getDeviceTimestampMillis()) doReturn eventTimeMs
         whenever(mockSdkCore.time) doReturn fakeTimeInfo
         whenever(mockSlowFramesListener.resolveReport(any(), any(), any())) doReturn fakeViewUIPerformanceReport
         whenever(mockAccessibilitySnapshotManager.getIfChanged()) doReturn mock()
@@ -346,6 +351,7 @@ internal class DatadogRumMonitorTest {
             val event = firstValue as RumRawEvent.StartView
             assertThat(event.key).isEqualTo(RumScopeKey.from(key, name))
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -463,6 +469,7 @@ internal class DatadogRumMonitorTest {
             val event = firstValue as RumRawEvent.StopView
             assertThat(event.key).isEqualTo(RumScopeKey.from(key))
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -489,6 +496,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.name).isEqualTo(name)
             assertThat(event.waitForStop).isFalse
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -515,6 +523,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.name).isEqualTo(name)
             assertThat(event.waitForStop).isTrue
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -540,6 +549,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.type).isEqualTo(type)
             assertThat(event.name).isEqualTo(name)
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -567,6 +577,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.method).isEqualTo(method)
             assertThat(event.url).isEqualTo(url)
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -596,6 +607,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.kind).isEqualTo(kind)
             assertThat(event.size).isEqualTo(size)
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -623,6 +635,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.kind).isEqualTo(kind)
             assertThat(event.size).isNull()
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -661,6 +674,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.source).isEqualTo(source)
             assertThat(event.throwable).isEqualTo(throwable)
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -702,6 +716,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.stackTrace).isEqualTo(stackTrace)
             assertThat(event.errorType).isEqualTo(errorType)
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -732,6 +747,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.source).isEqualTo(source)
             assertThat(event.throwable).isEqualTo(throwable)
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -759,6 +775,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.method).isEqualTo(method)
             assertThat(event.url).isEqualTo(url)
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -788,6 +805,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.kind).isEqualTo(kind)
             assertThat(event.size).isEqualTo(size)
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -815,6 +833,8 @@ internal class DatadogRumMonitorTest {
             assertThat(event.kind).isEqualTo(kind)
             assertThat(event.size).isNull()
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -853,6 +873,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.source).isEqualTo(source)
             assertThat(event.throwable).isEqualTo(throwable)
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -894,6 +915,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.stackTrace).isEqualTo(stackTrace)
             assertThat(event.errorType).isEqualTo(errorType)
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -924,6 +946,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.source).isEqualTo(source)
             assertThat(event.throwable).isEqualTo(throwable)
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -955,6 +978,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.sourceType).isEqualTo(RumErrorSourceType.ANDROID)
             assertThat(event.timeSinceAppStartNs).isNull()
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -986,6 +1010,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.sourceType).isEqualTo(RumErrorSourceType.ANDROID)
             assertThat(event.timeSinceAppStartNs).isNull()
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -1160,6 +1185,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.sourceType).isEqualTo(RumErrorSourceType.ANDROID)
             assertThat(event.timeSinceAppStartNs).isEqualTo(event.eventTime.nanoTime - appStartTimeNs)
             assertThat(event.attributes).isEmpty()
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -1486,6 +1512,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.threads).isEqualTo(allThreads)
             assertThat(event.timeSinceAppStartNs).isNull()
             assertThat(event.attributes).containsExactlyEntriesOf(fakeAttributes)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -1583,6 +1610,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.sourceType).isEqualTo(RumErrorSourceType.ANDROID)
             assertThat(event.timeSinceAppStartNs).isNull()
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributesWithErrorType)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -1621,6 +1649,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.type).isEqualTo(errorType)
             assertThat(event.timeSinceAppStartNs).isNull()
             assertThat(event.sourceType).isEqualTo(RumErrorSourceType.ANDROID)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -1672,6 +1701,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.sourceType).isEqualTo(sourceTypeExpectations[sourceType])
             assertThat(event.timeSinceAppStartNs).isNull()
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributesWithErrorSourceType)
+            assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
         }
         verifyNoMoreInteractions(mockWriter)
     }


### PR DESCRIPTION
### What does this PR do?

This PR fixes what was mentioned in this comment https://github.com/DataDog/dd-sdk-android/pull/3154#discussion_r2730528703. 

For all overloads of the method `stopResourceWithError` we need to extract the eventTime from the attributes when possible so we should call the method `getEventTime(attributes)` similar to what is done in other events. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

