### PR TITLE
Include sdk name/version for flag config requests

### DIFF
--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/model/FlagsContext.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/model/FlagsContext.kt
@@ -20,6 +20,7 @@ import com.datadog.android.flags.FlagsConfiguration
  * @param clientToken The client token for authenticating requests to Datadog
  * @param site The Datadog site (e.g., US1, EU1) for routing requests
  * @param env The environment name (e.g., prod, staging) for context
+ * @param sdkVersion The version of the SDK making the request
  * @param customExposureEndpoint Custom endpoint URL for uploading exposure events. If null, the default endpoint will be used.
  * @param customFlagEndpoint Custom endpoint URL for fetching flag assignments. If null, the endpoint will be derived from the site.
  */
@@ -28,6 +29,7 @@ internal data class FlagsContext(
     val clientToken: String,
     val site: DatadogSite,
     val env: String,
+    val sdkVersion: String,
     val customExposureEndpoint: String? = null,
     val customFlagEndpoint: String? = null
 ) {
@@ -50,6 +52,7 @@ internal data class FlagsContext(
             clientToken = datadogContext.clientToken,
             site = datadogContext.site,
             env = datadogContext.env,
+            sdkVersion = datadogContext.sdkVersion,
             customExposureEndpoint = flagsConfiguration.customExposureEndpoint,
             customFlagEndpoint = flagsConfiguration.customFlagEndpoint
         )

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsRequestFactory.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsRequestFactory.kt
@@ -86,8 +86,10 @@ internal class PrecomputedAssignmentsRequestFactory(private val internalLogger: 
             .put("targeting_key", context.targetingKey)
             .put("targeting_attributes", attributeObj)
         val env = buildEnvPayload(flagsContext)
+        val source = buildSourcePayload(flagsContext)
         val attributes = JSONObject()
             .put("env", env)
+            .put("source", source)
             .put("subject", subject)
         val data = JSONObject()
             .put("type", "precompute-assignments-request")
@@ -123,11 +125,18 @@ internal class PrecomputedAssignmentsRequestFactory(private val internalLogger: 
         JSONObject()
             .put("dd_env", flagsContext.env)
 
+    @Suppress("UnsafeThirdPartyFunctionCall") // call wrapped in try/catch
+    private fun buildSourcePayload(flagsContext: FlagsContext): JSONObject =
+        JSONObject()
+            .put("sdk_name", SDK_NAME)
+            .put("sdk_version", flagsContext.sdkVersion)
+
     companion object {
         private const val HEADER_APPLICATION_ID = "dd-application-id"
         private const val HEADER_CLIENT_TOKEN = "dd-client-token"
         private const val HEADER_CONTENT_TYPE = "Content-Type"
         private const val CONTENT_TYPE_VND_JSON = "application/vnd.api+json"
         private const val PREVIEW_CUSTOMER_DOMAIN = "preview"
+        private const val SDK_NAME = "dd-sdk-android"
     }
 }

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/model/FlagsContextTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/model/FlagsContextTest.kt
@@ -47,6 +47,9 @@ internal class FlagsContextTest {
     @StringForgery
     lateinit var fakeEnv: String
 
+    @StringForgery
+    lateinit var fakeSdkVersion: String
+
     @Test
     fun `M create FlagsContext with all parameters W create() { complete configuration }`(
         @StringForgery(regex = "https://[a-z]+\\.com(/[a-z]+)+") fakeExposureEndpoint: String,
@@ -57,6 +60,7 @@ internal class FlagsContextTest {
         whenever(mockDatadogContext.site) doReturn mockDatadogSite
         whenever(mockDatadogSite.name) doReturn fakeSiteName
         whenever(mockDatadogContext.env) doReturn fakeEnv
+        whenever(mockDatadogContext.sdkVersion) doReturn fakeSdkVersion
 
         val flagsConfiguration = FlagsConfiguration.Builder()
             .useCustomExposureEndpoint(fakeExposureEndpoint)
@@ -71,6 +75,7 @@ internal class FlagsContextTest {
         assertThat(flagsContext.clientToken).isEqualTo(fakeClientToken)
         assertThat(flagsContext.site).isEqualTo(mockDatadogSite)
         assertThat(flagsContext.env).isEqualTo(fakeEnv)
+        assertThat(flagsContext.sdkVersion).isEqualTo(fakeSdkVersion)
         assertThat(flagsContext.customExposureEndpoint).isEqualTo(fakeExposureEndpoint)
         assertThat(flagsContext.customFlagEndpoint).isEqualTo(fakeFlagEndpoint)
     }
@@ -82,6 +87,7 @@ internal class FlagsContextTest {
         whenever(mockDatadogContext.site) doReturn mockDatadogSite
         whenever(mockDatadogSite.name) doReturn fakeSiteName
         whenever(mockDatadogContext.env) doReturn fakeEnv
+        whenever(mockDatadogContext.sdkVersion) doReturn fakeSdkVersion
 
         val flagsConfiguration = FlagsConfiguration.Builder().build()
 
@@ -93,6 +99,7 @@ internal class FlagsContextTest {
         assertThat(flagsContext.clientToken).isEqualTo(fakeClientToken)
         assertThat(flagsContext.site).isEqualTo(mockDatadogSite)
         assertThat(flagsContext.env).isEqualTo(fakeEnv)
+        assertThat(flagsContext.sdkVersion).isEqualTo(fakeSdkVersion)
         assertThat(flagsContext.customExposureEndpoint).isNull()
         assertThat(flagsContext.customFlagEndpoint).isNull()
     }
@@ -104,6 +111,7 @@ internal class FlagsContextTest {
         whenever(mockDatadogContext.site) doReturn mockDatadogSite
         whenever(mockDatadogContext.site.name) doReturn fakeSiteName
         whenever(mockDatadogContext.env) doReturn fakeEnv
+        whenever(mockDatadogContext.sdkVersion) doReturn fakeSdkVersion
 
         val flagsConfiguration = FlagsConfiguration.Builder().build()
 
@@ -115,5 +123,6 @@ internal class FlagsContextTest {
         assertThat(flagsContext.clientToken).isEqualTo(fakeClientToken)
         assertThat(flagsContext.site).isEqualTo(mockDatadogSite)
         assertThat(flagsContext.env).isEqualTo(fakeEnv)
+        assertThat(flagsContext.sdkVersion).isEqualTo(fakeSdkVersion)
     }
 }

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsDownloaderTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsDownloaderTest.kt
@@ -70,7 +70,8 @@ internal class PrecomputedAssignmentsDownloaderTest {
             clientToken = forge.anAlphabeticalString(),
             applicationId = forge.anAlphabeticalString(),
             site = DatadogSite.US1,
-            env = "test"
+            env = "test",
+            sdkVersion = forge.anAlphabeticalString()
         )
 
         fakeEvaluationContext = EvaluationContext(

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsRequestFactoryTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsRequestFactoryTest.kt
@@ -45,6 +45,7 @@ internal class PrecomputedAssignmentsRequestFactoryTest {
         @StringForgery fakeApplicationId: String,
         @StringForgery fakeClientToken: String,
         @StringForgery fakeEnv: String,
+        @StringForgery fakeSdkVersion: String,
         @StringForgery fakeTargetingKey: String
     ) {
         // Given
@@ -56,7 +57,8 @@ internal class PrecomputedAssignmentsRequestFactoryTest {
             applicationId = fakeApplicationId,
             clientToken = fakeClientToken,
             site = DatadogSite.US1,
-            env = fakeEnv
+            env = fakeEnv,
+            sdkVersion = fakeSdkVersion
         )
 
         // When
@@ -75,6 +77,7 @@ internal class PrecomputedAssignmentsRequestFactoryTest {
     fun `M create valid request W create() { no application id }`(
         @StringForgery fakeClientToken: String,
         @StringForgery fakeEnv: String,
+        @StringForgery fakeSdkVersion: String,
         @StringForgery fakeTargetingKey: String
     ) {
         // Given
@@ -86,7 +89,8 @@ internal class PrecomputedAssignmentsRequestFactoryTest {
             applicationId = null,
             clientToken = fakeClientToken,
             site = DatadogSite.US1,
-            env = fakeEnv
+            env = fakeEnv,
+            sdkVersion = fakeSdkVersion
         )
 
         // When
@@ -104,6 +108,7 @@ internal class PrecomputedAssignmentsRequestFactoryTest {
         @StringForgery fakeApplicationId: String,
         @StringForgery fakeClientToken: String,
         @StringForgery fakeEnv: String,
+        @StringForgery fakeSdkVersion: String,
         @StringForgery fakeTargetingKey: String
     ) {
         // Given
@@ -117,6 +122,7 @@ internal class PrecomputedAssignmentsRequestFactoryTest {
             clientToken = fakeClientToken,
             site = DatadogSite.US1,
             env = fakeEnv,
+            sdkVersion = fakeSdkVersion,
             customFlagEndpoint = fakeCustomEndpoint
         )
 
@@ -136,6 +142,7 @@ internal class PrecomputedAssignmentsRequestFactoryTest {
         @StringForgery fakeApplicationId: String,
         @StringForgery fakeClientToken: String,
         @StringForgery fakeEnv: String,
+        @StringForgery fakeSdkVersion: String,
         @StringForgery fakeTargetingKey: String
     ) {
         // Given
@@ -151,7 +158,8 @@ internal class PrecomputedAssignmentsRequestFactoryTest {
             applicationId = fakeApplicationId,
             clientToken = fakeClientToken,
             site = DatadogSite.US1,
-            env = fakeEnv
+            env = fakeEnv,
+            sdkVersion = fakeSdkVersion
         )
 
         // When
@@ -170,6 +178,7 @@ internal class PrecomputedAssignmentsRequestFactoryTest {
         // Validate attributes structure
         val attributes = data.getJSONObject("attributes")
         assertThat(attributes.has("env")).isTrue()
+        assertThat(attributes.has("source")).isTrue()
         assertThat(attributes.has("subject")).isTrue()
 
         // Validate subject
@@ -186,6 +195,11 @@ internal class PrecomputedAssignmentsRequestFactoryTest {
         // Validate env
         val env = attributes.getJSONObject("env")
         assertThat(env.getString("dd_env")).isEqualTo(fakeEnv)
+
+        // Validate source
+        val source = attributes.getJSONObject("source")
+        assertThat(source.getString("sdk_name")).isEqualTo("dd-sdk-android")
+        assertThat(source.getString("sdk_version")).isEqualTo(fakeSdkVersion)
     }
 
     @Test
@@ -193,6 +207,7 @@ internal class PrecomputedAssignmentsRequestFactoryTest {
         @StringForgery fakeApplicationId: String,
         @StringForgery fakeClientToken: String,
         @StringForgery fakeEnv: String,
+        @StringForgery fakeSdkVersion: String,
         @StringForgery fakeTargetingKey: String
     ) {
         // Given
@@ -204,7 +219,8 @@ internal class PrecomputedAssignmentsRequestFactoryTest {
             applicationId = fakeApplicationId,
             clientToken = fakeClientToken,
             site = DatadogSite.US1,
-            env = fakeEnv
+            env = fakeEnv,
+            sdkVersion = fakeSdkVersion
         )
 
         // When
@@ -229,6 +245,7 @@ internal class PrecomputedAssignmentsRequestFactoryTest {
         @StringForgery fakeApplicationId: String,
         @StringForgery fakeClientToken: String,
         @StringForgery fakeEnv: String,
+        @StringForgery fakeSdkVersion: String,
         @StringForgery fakeTargetingKey: String
     ) {
         // Given
@@ -245,7 +262,8 @@ internal class PrecomputedAssignmentsRequestFactoryTest {
             applicationId = fakeApplicationId,
             clientToken = fakeClientToken,
             site = DatadogSite.US1,
-            env = fakeEnv
+            env = fakeEnv,
+            sdkVersion = fakeSdkVersion
         )
 
         // When
@@ -277,6 +295,7 @@ internal class PrecomputedAssignmentsRequestFactoryTest {
         @StringForgery fakeApplicationId: String,
         @StringForgery fakeClientToken: String,
         @StringForgery fakeEnv: String,
+        @StringForgery fakeSdkVersion: String,
         @StringForgery fakeTargetingKey: String
     ) {
         // Given
@@ -288,7 +307,8 @@ internal class PrecomputedAssignmentsRequestFactoryTest {
             applicationId = fakeApplicationId,
             clientToken = fakeClientToken,
             site = DatadogSite.US1_FED,
-            env = fakeEnv
+            env = fakeEnv,
+            sdkVersion = fakeSdkVersion
         )
 
         // When


### PR DESCRIPTION
### What does this PR do?

Adds a new `source` field to the `/precompute-assignments` endpoint request payload containing SDK identification information (`sdk_name` and `sdk_version`). This allows the backend to track which SDK and version is making feature flag configuration requests.

The resulting payload structure:
```json
{
  "data": {
    "type": "precompute-assignments-request",
    "attributes": {
      "env": {
        "dd_env": "production"
      },
      "source": {
        "sdk_name": "dd-sdk-android",
        "sdk_version": "3.7.0"
      },
      "subject": {
        "targeting_key": "user123",
        "targeting_attributes": {...}
      }
    }
  }
}
```

### Motivation

This change aligns with the iOS SDK implementation (DataDog/dd-sdk-ios#2656) to provide consistent SDK metadata across platforms. The `source` information will be used for logging feature flagging configuration requests to calculate usage metrics and track which SDK versions are being used.

### Additional Notes

**Changes made:**
- Added `sdkVersion` property to `FlagsContext` data class
- Updated `FlagsContext.create()` to pass `sdkVersion` from `DatadogContext`
- Added `buildSourcePayload()` method in `PrecomputedAssignmentsRequestFactory`
- Added `SDK_NAME = "dd-sdk-android"` constant
- Updated all relevant unit tests to include `sdkVersion` and validate the `source` field

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

