### PR TITLE
[RUM-10753] Configure JUnit test tasks to log FAILED and STANDARD_ERROR events

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/JUnitConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/JUnitConfig.kt
@@ -8,6 +8,7 @@ package com.datadog.gradle.config
 
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.gradle.kotlin.dsl.withType
 
 fun Project.junitConfig() {
@@ -22,6 +23,9 @@ fun Project.junitConfig() {
         reports {
             junitXml.required.set(true)
             html.required.set(true)
+        }
+        testLogging {
+            events(TestLogEvent.FAILED, TestLogEvent.STANDARD_ERROR)
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR  configures JUnit test tasks to log FAILED events and STANDARD_ERROR output, enabling visibility of diagnostic information (like Forge seeds) when  tests fail in CI. 

You can see an example of how it will look like [here](https://gitlab.ddbuild.io/DataDog/dd-sdk-android/-/jobs/1383266108#L1077).

<img width="948" height="328" alt="image" src="https://github.com/user-attachments/assets/ac14238a-63f2-4411-aef9-d7d3552f0375" />


### Motivation

Before this PR, when a test failed in CI, we didn’t have access to the Forge seed, so it wasn’t possible to reproduce the same test. This is especially important when dealing with flaky tests.

### Additional Notes

This change will make the Gradle tasks more verbose, but in my opinion this is acceptable, since we’ll only look at the output when tests are failing, so it shouldn’t affect us much.

In addition, if you run `./local_ci.sh --test`, you will see a number of tests that write to `STANDARD_ERROR` or throw exceptions but still pass. It could be a good idea to take a look at them and verify that the tests are working as expected.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

