### PR TITLE
RUM-8198 - Support custom view instrumentation types for cross-platform SDKs 

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -10,12 +10,20 @@ interface com.datadog.android.internal.attributes.LocalAttribute
 fun MutableMap<String, Any?>.enrichWithConstantAttribute(LocalAttribute.Constant)
 fun MutableMap<String, Any?>.enrichWithNonNullAttribute(LocalAttribute.Key, Any?)
 fun MutableMap<String, Any?>.enrichWithLocalAttribute(LocalAttribute.Key, Any?)
-enum com.datadog.android.internal.attributes.ViewScopeInstrumentationType : LocalAttribute.Constant
-  - MANUAL
-  - COMPOSE
-  - ACTIVITY
-  - FRAGMENT
-  override val key: LocalAttribute.Key
+sealed interface com.datadog.android.internal.attributes.ViewScopeInstrumentationType : LocalAttribute.Constant
+  val value: String
+  enum Native : ViewScopeInstrumentationType
+    constructor(String)
+    - MANUAL
+    - COMPOSE
+    - ACTIVITY
+    - FRAGMENT
+    override val key: LocalAttribute.Key
+  class Custom : ViewScopeInstrumentationType
+    override val value: String
+    override val key: LocalAttribute.Key
+    companion object 
+      fun create(String): Custom
 class com.datadog.android.internal.collections.EvictingQueue<T> : java.util.Queue<T>
   constructor(Int = Int.MAX_VALUE)
   override val size: Int

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -20,14 +20,29 @@ public final class com/datadog/android/internal/attributes/LocalAttributeKt {
 	public static final fun enrichWithNonNullAttribute (Ljava/util/Map;Lcom/datadog/android/internal/attributes/LocalAttribute$Key;Ljava/lang/Object;)Ljava/util/Map;
 }
 
-public final class com/datadog/android/internal/attributes/ViewScopeInstrumentationType : java/lang/Enum, com/datadog/android/internal/attributes/LocalAttribute$Constant {
-	public static final field ACTIVITY Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType;
-	public static final field COMPOSE Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType;
-	public static final field FRAGMENT Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType;
-	public static final field MANUAL Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType;
+public abstract interface class com/datadog/android/internal/attributes/ViewScopeInstrumentationType : com/datadog/android/internal/attributes/LocalAttribute$Constant {
+	public abstract fun getValue ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/internal/attributes/ViewScopeInstrumentationType$Custom : com/datadog/android/internal/attributes/ViewScopeInstrumentationType {
+	public static final field Companion Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType$Custom$Companion;
 	public fun getKey ()Lcom/datadog/android/internal/attributes/LocalAttribute$Key;
-	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType;
-	public static fun values ()[Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType;
+	public fun getValue ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/internal/attributes/ViewScopeInstrumentationType$Custom$Companion {
+	public final fun create (Ljava/lang/String;)Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType$Custom;
+}
+
+public final class com/datadog/android/internal/attributes/ViewScopeInstrumentationType$Native : java/lang/Enum, com/datadog/android/internal/attributes/ViewScopeInstrumentationType {
+	public static final field ACTIVITY Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType$Native;
+	public static final field COMPOSE Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType$Native;
+	public static final field FRAGMENT Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType$Native;
+	public static final field MANUAL Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType$Native;
+	public fun getKey ()Lcom/datadog/android/internal/attributes/LocalAttribute$Key;
+	public fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType$Native;
+	public static fun values ()[Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType$Native;
 }
 
 public final class com/datadog/android/internal/collections/EvictingQueue : java/util/Queue {

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/attributes/ViewScopeInstrumentationType.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/attributes/ViewScopeInstrumentationType.kt
@@ -6,21 +6,58 @@
 package com.datadog.android.internal.attributes
 
 /**
- * A set of constants describing the instrumentation that were used to define the view scope.
+ * Describes the instrumentation used to define a RUM view scope.
+ *
+ * Supports both native Android instrumentation types (Activity, Fragment, Compose, Manual)
+ * and custom types from cross-platform SDKs (Flutter, React Native, Unity, etc.).
  */
-enum class ViewScopeInstrumentationType : LocalAttribute.Constant {
-    /** Tracked manually through the RUMMonitor API. */
-    MANUAL,
+sealed interface ViewScopeInstrumentationType : LocalAttribute.Constant {
 
-    /** Tracked through ComposeNavigationObserver instrumentation. */
-    COMPOSE,
+    /**
+     * The string value sent in telemetry for this instrumentation type.
+     */
+    val value: String
 
-    /** Tracked through ActivityViewTrackingStrategy instrumentation. */
-    ACTIVITY,
+    /**
+     * Native Android instrumentation types tracked by the SDK.
+     */
+    enum class Native(override val value: String) : ViewScopeInstrumentationType {
+        /** Tracked manually through the RumMonitor API. */
+        MANUAL("manual"),
 
-    /** Tracked through FragmentViewTrackingStrategy instrumentation. */
-    FRAGMENT;
+        /** Tracked through ComposeNavigationObserver instrumentation. */
+        COMPOSE("compose"),
 
-    /** @inheritdoc */
-    override val key: LocalAttribute.Key = LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE
+        /** Tracked through ActivityViewTrackingStrategy instrumentation. */
+        ACTIVITY("activity"),
+
+        /** Tracked through FragmentViewTrackingStrategy instrumentation. */
+        FRAGMENT("fragment");
+
+        override val key: LocalAttribute.Key = LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE
+    }
+
+    /**
+     * Custom instrumentation type for cross-platform SDKs.
+     *
+     * Used when cross-platform frameworks (Flutter, React Native, Unity, etc.)
+     * need to report their specific navigation/instrumentation patterns.
+     */
+    class Custom internal constructor(private val customValue: String) : ViewScopeInstrumentationType {
+
+        override val value: String get() = customValue
+
+        override val key: LocalAttribute.Key get() = LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE
+
+        companion object {
+            /**
+             * Creates a custom instrumentation type.
+             *
+             * @param type The custom type identifier
+             */
+            fun create(type: String): Custom {
+                return Custom(type.trim())
+            }
+        }
+    }
 }

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -23,6 +23,7 @@ object com.datadog.android.rum.RumAttributes
   const val INTERNAL_TIMESTAMP: String
   const val INTERNAL_ERROR_SOURCE_TYPE: String
   const val INTERNAL_ERROR_IS_CRASH: String
+  const val INTERNAL_INSTRUMENTATION_TYPE: String
   const val TRACE_ID: String
   const val SPAN_ID: String
   const val RULE_PSR: String

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -70,6 +70,7 @@ public final class com/datadog/android/rum/RumAttributes {
 	public static final field INTERNAL_ERROR_IS_CRASH Ljava/lang/String;
 	public static final field INTERNAL_ERROR_SOURCE_TYPE Ljava/lang/String;
 	public static final field INTERNAL_ERROR_TYPE Ljava/lang/String;
+	public static final field INTERNAL_INSTRUMENTATION_TYPE Ljava/lang/String;
 	public static final field INTERNAL_TIMESTAMP Ljava/lang/String;
 	public static final field LONG_TASK_TARGET Ljava/lang/String;
 	public static final field NETWORK_BYTES_READ Ljava/lang/String;

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
@@ -79,6 +79,27 @@ object RumAttributes {
      */
     internal const val INTERNAL_ALL_THREADS: String = "_dd.error.threads"
 
+    /**
+     * Overrides the default view instrumentation type with a custom one.
+     * Used by cross-platform SDKs (Flutter, React Native, Unity, etc.) to report
+     * their specific navigation patterns in telemetry.
+     *
+     * Accepts any non-empty string value. If not provided or empty, defaults to "manual".
+     * Takes precedence over native instrumentation types (Activity, Fragment, Compose).
+     *
+     * Example:
+     * ```kotlin
+     * rumMonitor.startView(
+     *     key = "HomeScreen",
+     *     name = "Home",
+     *     attributes = mapOf(
+     *         RumAttributes.INTERNAL_INSTRUMENTATION_TYPE to "cross_platform_navigator"
+     *     )
+     * )
+     * ```
+     */
+    const val INTERNAL_INSTRUMENTATION_TYPE: String = "_dd.instrumentation_type"
+
     // endregion
 
     // region Resource

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -1703,8 +1703,17 @@ internal open class RumViewScope(
             )
         }
 
-        private fun RumRawEvent.StartView.tryResolveInstrumentationType() =
-            attributes[LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.toString()] as? ViewScopeInstrumentationType
+        private fun RumRawEvent.StartView.tryResolveInstrumentationType(): ViewScopeInstrumentationType? {
+            // First check for cross-platform string attribute (highest priority)
+            val crossPlatformType = attributes[RumAttributes.INTERNAL_INSTRUMENTATION_TYPE] as? String
+            if (!crossPlatformType.isNullOrBlank()) {
+                return ViewScopeInstrumentationType.Custom.create(crossPlatformType)
+            }
+
+            // Fall back to native enum-based instrumentation type
+            return attributes[LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.toString()]
+                as? ViewScopeInstrumentationType
+        }
 
         @Suppress("CommentOverPrivateFunction")
         /**

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/ViewEndedMetricDispatcher.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/ViewEndedMetricDispatcher.kt
@@ -14,9 +14,12 @@ import com.datadog.android.rum.internal.domain.scope.RumViewType
 internal class ViewEndedMetricDispatcher(
     private val viewType: RumViewType,
     private val internalLogger: InternalLogger,
-    private val instrumentationType: ViewScopeInstrumentationType? = null,
+    instrumentationType: ViewScopeInstrumentationType? = null,
     private val samplingRate: Float = DEFAULT_SAMPLE_RATE
 ) : ViewMetricDispatcher {
+
+    private val instrumentationType: ViewScopeInstrumentationType =
+        instrumentationType ?: ViewScopeInstrumentationType.Native.MANUAL
 
     private var duration: Long? = null
 
@@ -87,7 +90,7 @@ internal class ViewEndedMetricDispatcher(
                 }
             }
         )
-        putNonNull(KEY_INSTRUMENTATION_TYPE, toAttributeValue(instrumentationType))
+        put(KEY_INSTRUMENTATION_TYPE, instrumentationType.value)
     }
 
     companion object {
@@ -126,10 +129,6 @@ internal class ViewEndedMetricDispatcher(
         private const val VALUE_DISABLED = "disabled"
 
         internal const val KEY_INSTRUMENTATION_TYPE = "instrumentation_type"
-        private const val VALUE_INSTRUMENTATION_TYPE_COMPOSE = "compose"
-        private const val VALUE_INSTRUMENTATION_TYPE_MANUAL = "manual"
-        private const val VALUE_INSTRUMENTATION_TYPE_ACTIVITY = "activity"
-        private const val VALUE_INSTRUMENTATION_TYPE_FRAGMENT = "fragment"
 
         private fun <K, V> MutableMap<K, V>.putNonNull(key: K, value: V?) {
             if (value != null) put(key, value)
@@ -150,17 +149,6 @@ internal class ViewEndedMetricDispatcher(
             ViewInitializationMetricsConfig.CUSTOM -> VALUE_CUSTOM
             ViewInitializationMetricsConfig.TIME_BASED_DEFAULT -> VALUE_TIME_BASED_DEFAULT
             ViewInitializationMetricsConfig.TIME_BASED_CUSTOM -> VALUE_TIME_BASED_CUSTOM
-        }
-
-        @VisibleForTesting
-        private fun toAttributeValue(
-            instrumentationType: ViewScopeInstrumentationType?
-        ): String = when (instrumentationType) {
-            ViewScopeInstrumentationType.COMPOSE -> VALUE_INSTRUMENTATION_TYPE_COMPOSE
-            ViewScopeInstrumentationType.MANUAL -> VALUE_INSTRUMENTATION_TYPE_MANUAL
-            ViewScopeInstrumentationType.ACTIVITY -> VALUE_INSTRUMENTATION_TYPE_ACTIVITY
-            ViewScopeInstrumentationType.FRAGMENT -> VALUE_INSTRUMENTATION_TYPE_FRAGMENT
-            null -> VALUE_INSTRUMENTATION_TYPE_MANUAL
         }
 
         @VisibleForTesting

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityViewTrackingStrategy.kt
@@ -128,7 +128,7 @@ constructor(
         }
 
         attributes.putAll(intent.safeExtras.convertToRumViewAttributes())
-        attributes.enrichWithConstantAttribute(ViewScopeInstrumentationType.ACTIVITY)
+        attributes.enrichWithConstantAttribute(ViewScopeInstrumentationType.Native.ACTIVITY)
 
         return attributes
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategy.kt
@@ -76,7 +76,7 @@ internal constructor(
                             it.arguments.convertToRumViewAttributes().toMutableMap()
                         } else {
                             mutableMapOf()
-                        }.enrichWithConstantAttribute(ViewScopeInstrumentationType.FRAGMENT)
+                        }.enrichWithConstantAttribute(ViewScopeInstrumentationType.Native.FRAGMENT)
                     },
                     componentPredicate = supportFragmentComponentPredicate,
                     rumMonitor = rumMonitor,
@@ -103,7 +103,7 @@ internal constructor(
                             it.arguments.convertToRumViewAttributes().toMutableMap()
                         } else {
                             mutableMapOf()
-                        }.enrichWithConstantAttribute(ViewScopeInstrumentationType.FRAGMENT)
+                        }.enrichWithConstantAttribute(ViewScopeInstrumentationType.Native.FRAGMENT)
                     },
                     componentPredicate = defaultFragmentComponentPredicate,
                     rumMonitor = rumMonitor,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
@@ -102,7 +102,7 @@ class NavigationViewTrackingStrategy(
                 mutableMapOf()
             }
 
-            attributes.enrichWithConstantAttribute(ViewScopeInstrumentationType.FRAGMENT)
+            attributes.enrichWithConstantAttribute(ViewScopeInstrumentationType.Native.FRAGMENT)
 
             val viewName = componentPredicate.resolveViewName(destination)
             rumMonitor?.startView(destination, viewName, attributes)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityViewTrackingStrategyTest.kt
@@ -106,7 +106,10 @@ internal class ActivityViewTrackingStrategyTest :
         verify(rumMonitor.mockInstance).startView(
             mockActivity,
             mockActivity.resolveViewName(),
-            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.toString() to ViewScopeInstrumentationType.ACTIVITY)
+            mapOf(
+                ViewScopeInstrumentationType.Native.ACTIVITY.key.toString()
+                    to ViewScopeInstrumentationType.Native.ACTIVITY
+            )
         )
     }
 
@@ -130,7 +133,7 @@ internal class ActivityViewTrackingStrategyTest :
         whenever(mockPredicate.accept(mockActivity)) doReturn true
         val expectedAttributes = extras.map { (k, v) -> "view.arguments.$k" to v }
             .toMutableMap<String, Any?>()
-            .enrichWithConstantAttribute(ViewScopeInstrumentationType.ACTIVITY)
+            .enrichWithConstantAttribute(ViewScopeInstrumentationType.Native.ACTIVITY)
         expectedAttributes["view.intent.action"] = action
         expectedAttributes["view.intent.uri"] = uri
 
@@ -161,7 +164,7 @@ internal class ActivityViewTrackingStrategyTest :
         val expectedAttributes = mapOf<String, Any?>(
             "view.intent.action" to action,
             "view.intent.uri" to uri,
-            ViewScopeInstrumentationType.ACTIVITY.key.toString() to ViewScopeInstrumentationType.ACTIVITY
+            ViewScopeInstrumentationType.Native.ACTIVITY.key.toString() to ViewScopeInstrumentationType.Native.ACTIVITY
         )
 
         // When
@@ -235,7 +238,10 @@ internal class ActivityViewTrackingStrategyTest :
         verify(rumMonitor.mockInstance).startView(
             mockActivity,
             fakeName,
-            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.toString() to ViewScopeInstrumentationType.ACTIVITY)
+            mapOf(
+                ViewScopeInstrumentationType.Native.ACTIVITY.key.toString()
+                    to ViewScopeInstrumentationType.Native.ACTIVITY
+            )
         )
     }
 
@@ -255,7 +261,10 @@ internal class ActivityViewTrackingStrategyTest :
         verify(rumMonitor.mockInstance).startView(
             mockActivity,
             mockActivity.resolveViewName(),
-            mapOf(ViewScopeInstrumentationType.ACTIVITY.key.toString() to ViewScopeInstrumentationType.ACTIVITY)
+            mapOf(
+                ViewScopeInstrumentationType.Native.ACTIVITY.key.toString()
+                    to ViewScopeInstrumentationType.Native.ACTIVITY
+            )
         )
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/metric/ViewEndedMetricDispatcherTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/metric/ViewEndedMetricDispatcherTest.kt
@@ -70,7 +70,7 @@ internal class ViewEndedMetricDispatcherTest {
     private lateinit var fakeViewType: RumViewType
     private lateinit var fakeInvState: ViewInitializationMetricsState
     private lateinit var fakeTnsState: ViewInitializationMetricsState
-    private var fakeInstrumentationType: String? = null
+    private var fakeInstrumentationType: ViewScopeInstrumentationType? = null
 
     private lateinit var dispatcherUnderTest: ViewEndedMetricDispatcher
 
@@ -79,22 +79,20 @@ internal class ViewEndedMetricDispatcherTest {
         fakeViewType = forge.aValueFrom(RumViewType::class.java)
         fakeTnsState = forge.aViewInitializationMetricsState(NoValueReason.TimeToNetworkSettle::class.java)
         fakeInvState = forge.aViewInitializationMetricsState(NoValueReason.InteractionToNextView::class.java)
-        val instrumentationType = forge.aNullable {
+        fakeInstrumentationType = forge.aNullable {
             anElementFrom(
-                ViewScopeInstrumentationType.COMPOSE,
-                ViewScopeInstrumentationType.MANUAL,
-                ViewScopeInstrumentationType.ACTIVITY,
-                ViewScopeInstrumentationType.FRAGMENT
+                ViewScopeInstrumentationType.Native.COMPOSE,
+                ViewScopeInstrumentationType.Native.MANUAL,
+                ViewScopeInstrumentationType.Native.ACTIVITY,
+                ViewScopeInstrumentationType.Native.FRAGMENT
             )
         }
-
-        fakeInstrumentationType = instrumentationType?.name?.lowercase()
 
         dispatcherUnderTest = ViewEndedMetricDispatcher(
             viewType = fakeViewType,
             internalLogger = mockInternalLogger,
             samplingRate = fakeSampleRate,
-            instrumentationType = instrumentationType
+            instrumentationType = fakeInstrumentationType
         )
     }
 
@@ -231,13 +229,62 @@ internal class ViewEndedMetricDispatcherTest {
         }
     }
 
+    @Test
+    fun `M send custom instrumentation type W sendViewEnded() { cross-platform type }`() {
+        // Given
+        val customInstrumentationType = ViewScopeInstrumentationType.Custom.create("cross_platform_navigator")
+        val dispatcher = ViewEndedMetricDispatcher(
+            viewType = fakeViewType,
+            internalLogger = mockInternalLogger,
+            instrumentationType = customInstrumentationType,
+            samplingRate = fakeSampleRate
+        )
+        dispatcher.onDurationResolved(fakeDuration)
+        dispatcher.onViewLoadingTimeResolved(fakeLoadingTime)
+
+        // When
+        dispatcher.sendViewEnded(fakeInvState, fakeTnsState)
+
+        // Then
+        verify(mockInternalLogger).logMetric(
+            messageBuilder = argThat { invoke() == VIEW_ENDED_MESSAGE },
+            additionalProperties = eq(expectedAttributes(instrumentationType = "cross_platform_navigator")),
+            samplingRate = eq(fakeSampleRate),
+            creationSampleRate = eq(null)
+        )
+    }
+
+    @Test
+    fun `M default to manual W sendViewEnded() { null instrumentation type }`() {
+        // Given
+        val dispatcher = ViewEndedMetricDispatcher(
+            viewType = fakeViewType,
+            internalLogger = mockInternalLogger,
+            instrumentationType = null,
+            samplingRate = fakeSampleRate
+        )
+        dispatcher.onDurationResolved(fakeDuration)
+        dispatcher.onViewLoadingTimeResolved(fakeLoadingTime)
+
+        // When
+        dispatcher.sendViewEnded(fakeInvState, fakeTnsState)
+
+        // Then
+        verify(mockInternalLogger).logMetric(
+            messageBuilder = argThat { invoke() == VIEW_ENDED_MESSAGE },
+            additionalProperties = eq(expectedAttributes(instrumentationType = "manual")),
+            samplingRate = eq(fakeSampleRate),
+            creationSampleRate = eq(null)
+        )
+    }
+
     private fun expectedAttributes(
         duration: Long? = fakeDuration,
         loadingTime: Long? = fakeLoadingTime,
         viewType: RumViewType = fakeViewType,
         invState: ViewInitializationMetricsState = fakeInvState,
         tnsState: ViewInitializationMetricsState = fakeTnsState,
-        instrumentationType: String? = fakeInstrumentationType
+        instrumentationType: String? = fakeInstrumentationType?.value
     ) = buildAttributesMap(
         duration = duration,
         loadingTime = loadingTime,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategyTest.kt
@@ -176,7 +176,7 @@ internal class FragmentViewTrackingStrategyTest : ObjectTest<FragmentViewTrackin
         val mockFragment: Fragment = mockFragmentWithArguments(forge)
         val expectedAttrs = mockFragment.arguments!!
             .toRumAttributes()
-            .enrichWithConstantAttribute(ViewScopeInstrumentationType.FRAGMENT)
+            .enrichWithConstantAttribute(ViewScopeInstrumentationType.Native.FRAGMENT)
         val argumentCaptor = argumentCaptor<FragmentManager.FragmentLifecycleCallbacks>()
 
         // When
@@ -258,7 +258,7 @@ internal class FragmentViewTrackingStrategyTest : ObjectTest<FragmentViewTrackin
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
         val mockFragment: Fragment = mockFragmentWithArguments(forge)
         val expectedAttrs = mapOf(
-            ViewScopeInstrumentationType.FRAGMENT.key.toString() to ViewScopeInstrumentationType.FRAGMENT
+            ViewScopeInstrumentationType.Native.FRAGMENT.key.toString() to ViewScopeInstrumentationType.Native.FRAGMENT
         )
         val argumentCaptor = argumentCaptor<FragmentManager.FragmentLifecycleCallbacks>()
 
@@ -376,7 +376,7 @@ internal class FragmentViewTrackingStrategyTest : ObjectTest<FragmentViewTrackin
         val mockFragment: android.app.Fragment = mockDeprecatedFragmentWithArguments(forge)
         val expectedAttrs = mockFragment.arguments
             .toRumAttributes()
-            .enrichWithConstantAttribute(ViewScopeInstrumentationType.FRAGMENT)
+            .enrichWithConstantAttribute(ViewScopeInstrumentationType.Native.FRAGMENT)
         val argumentCaptor =
             argumentCaptor<android.app.FragmentManager.FragmentLifecycleCallbacks>()
 
@@ -468,7 +468,7 @@ internal class FragmentViewTrackingStrategyTest : ObjectTest<FragmentViewTrackin
         )
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
         val expectedAttrs = mapOf(
-            ViewScopeInstrumentationType.FRAGMENT.key.toString() to ViewScopeInstrumentationType.FRAGMENT
+            ViewScopeInstrumentationType.Native.FRAGMENT.key.toString() to ViewScopeInstrumentationType.Native.FRAGMENT
         )
         val mockFragment: android.app.Fragment = mockDeprecatedFragmentWithArguments(forge)
         val argumentCaptor =

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
@@ -314,7 +314,10 @@ internal class NavigationViewTrackingStrategyTest {
         verify(rumMonitor.mockInstance).startView(
             mockNavDestination,
             fakeDestinationName,
-            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.toString() to ViewScopeInstrumentationType.FRAGMENT)
+            mapOf(
+                ViewScopeInstrumentationType.Native.FRAGMENT.key.toString()
+                    to ViewScopeInstrumentationType.Native.FRAGMENT
+            )
         )
     }
 
@@ -341,7 +344,10 @@ internal class NavigationViewTrackingStrategyTest {
         verify(rumMonitor.mockInstance).startView(
             mockNavDestination,
             customName,
-            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.toString() to ViewScopeInstrumentationType.FRAGMENT)
+            mapOf(
+                ViewScopeInstrumentationType.Native.FRAGMENT.key.toString()
+                    to ViewScopeInstrumentationType.Native.FRAGMENT
+            )
         )
     }
 
@@ -352,7 +358,8 @@ internal class NavigationViewTrackingStrategyTest {
         whenever(mockPredicate.accept(mockNavDestination)) doReturn true
         val arguments = Bundle()
         val expectedAttrs = mutableMapOf<String, Any?>(
-            ViewScopeInstrumentationType.FRAGMENT.key.toString() to ViewScopeInstrumentationType.FRAGMENT
+            ViewScopeInstrumentationType.Native.FRAGMENT.key.toString()
+                to ViewScopeInstrumentationType.Native.FRAGMENT
         )
         repeat(10) {
             val key = forge.anAlphabeticalString()
@@ -391,7 +398,10 @@ internal class NavigationViewTrackingStrategyTest {
         verify(rumMonitor.mockInstance).startView(
             mockNavDestination,
             fakeDestinationName,
-            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.toString() to ViewScopeInstrumentationType.FRAGMENT)
+            mapOf(
+                ViewScopeInstrumentationType.Native.FRAGMENT.key.toString()
+                    to ViewScopeInstrumentationType.Native.FRAGMENT
+            )
         )
     }
 
@@ -413,12 +423,18 @@ internal class NavigationViewTrackingStrategyTest {
             verify(rumMonitor.mockInstance).startView(
                 mockNavDestination,
                 fakeDestinationName,
-                mapOf(ViewScopeInstrumentationType.FRAGMENT.key.toString() to ViewScopeInstrumentationType.FRAGMENT)
+                mapOf(
+                    ViewScopeInstrumentationType.Native.FRAGMENT.key.toString()
+                        to ViewScopeInstrumentationType.Native.FRAGMENT
+                )
             )
             verify(rumMonitor.mockInstance).startView(
                 newDestination,
                 newDestinationName,
-                mapOf(ViewScopeInstrumentationType.FRAGMENT.key.toString() to ViewScopeInstrumentationType.FRAGMENT)
+                mapOf(
+                    ViewScopeInstrumentationType.Native.FRAGMENT.key.toString()
+                        to ViewScopeInstrumentationType.Native.FRAGMENT
+                )
             )
         }
     }

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/Navigation3.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/Navigation3.kt
@@ -134,7 +134,7 @@ internal fun <T : Any> trackBackStack(
             if (keyPredicate.accept(topKey)) {
                 val attributes =
                     attributesResolver?.resolveAttributes(topKey)?.toMutableMap()
-                        ?.enrichWithConstantAttribute(ViewScopeInstrumentationType.COMPOSE)
+                        ?.enrichWithConstantAttribute(ViewScopeInstrumentationType.Native.COMPOSE)
                         ?: emptyMap()
 
                 rumMonitor.startView(

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/ComposeNavigationObserver.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/ComposeNavigationObserver.kt
@@ -67,7 +67,7 @@ internal class ComposeNavigationObserver(
             arguments.convertToRumViewAttributes().toMutableMap()
         } else {
             mutableMapOf()
-        }.enrichWithConstantAttribute(ViewScopeInstrumentationType.COMPOSE)
+        }.enrichWithConstantAttribute(ViewScopeInstrumentationType.Native.COMPOSE)
 
         rumMonitor.startView(key = route, name = viewName, attributes = attributes)
     }

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/Navigation3Test.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/Navigation3Test.kt
@@ -87,7 +87,7 @@ class Navigation3Test {
             fakeStableKey,
             fakeViewName,
             expectedAttributes.toMutableMap()
-                .enrichWithConstantAttribute(ViewScopeInstrumentationType.COMPOSE)
+                .enrichWithConstantAttribute(ViewScopeInstrumentationType.Native.COMPOSE)
         )
         verify(mockRumMonitor, never()).stopView(any(), any())
     }

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/internal/ComposeNavigationObserverTest.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/internal/ComposeNavigationObserverTest.kt
@@ -79,7 +79,7 @@ internal class ComposeNavigationObserverTest {
         // Given
         val arguments = Bundle()
         val expectedAttrs = mutableMapOf<String, Any?>(
-            LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.toString() to ViewScopeInstrumentationType.COMPOSE
+            LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.toString() to ViewScopeInstrumentationType.Native.COMPOSE
         )
         repeat(10) {
             val key = forge.anAlphabeticalString()
@@ -113,7 +113,7 @@ internal class ComposeNavigationObserverTest {
 
         val arguments = Bundle()
         val expectedAttrs = mutableMapOf<String, Any?>(
-            LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.toString() to ViewScopeInstrumentationType.COMPOSE
+            LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.toString() to ViewScopeInstrumentationType.Native.COMPOSE
         )
         repeat(10) {
             val key = forge.anAlphabeticalString()
@@ -164,7 +164,10 @@ internal class ComposeNavigationObserverTest {
         verify(mockRumMonitor).startView(
             mockNavDestination.route!!,
             mockNavDestination.route!!,
-            mapOf(LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.toString() to ViewScopeInstrumentationType.COMPOSE)
+            mapOf(
+                LocalAttribute.Key.VIEW_SCOPE_INSTRUMENTATION_TYPE.toString()
+                    to ViewScopeInstrumentationType.Native.COMPOSE
+            )
         )
         verifyNoMoreInteractions(mockRumMonitor)
     }


### PR DESCRIPTION
### What does this PR do?

Enables cross-platform SDKs (Flutter, React Native, Unity, etc.) to report custom view instrumentation types via the `_dd.instrumentation_type` attribute. Refactors internal `ViewScopeInstrumentationType` from enum to sealed interface for type safety while maintaining backward compatibility. 

### Motivation

Cross-platform SDKs need to report their specific navigation patterns in RUM telemetry to accurately track how views are instrumented. The previous enum-only approach couldn't accommodate arbitrary framework types like "flutter_navigator" or "react_native_navigator" without losing type safety.          

### Additional Notes

Sample app includes test fragment demonstrating cross-platform instrumentation types, those types are only for testing. Those are not real values.

**Note**: When testing this, remember that the sampling rate may drop some events. You can modify the specific [ViewEnded sample rate](https://github.com/DataDog/dd-sdk-android/blob/cd6029be95755b3d342808bcaa63021beb73e6ee/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/ViewEndedMetricDispatcher.kt#L18)￼ and increase the [Telemetry sample rate](https://github.com/DataDog/dd-sdk-android/blob/cd6029be95755b3d342808bcaa63021beb73e6ee/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt#L83C13-L83C35)￼ if necessary. In the sample app, it is already set to 100%.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

