### PR TITLE
Fix missing feature flags in crash and ANR error events

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
@@ -279,6 +279,9 @@ internal class DatadogLateCrashReporter(
                 timeSinceAppStart = timeSinceAppStartMs
             ),
             version = viewEvent.version,
+            featureFlags = viewEvent.featureFlags?.let {
+                ErrorEvent.Context(additionalProperties = it.additionalProperties)
+            },
             ddtags = buildDDTagsString(datadogContext)
         )
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
@@ -581,6 +581,16 @@ internal class ErrorEventAssert(actual: ErrorEvent) :
         return this
     }
 
+    fun hasFeatureFlags(expected: ErrorEvent.Context?): ErrorEventAssert {
+        assertThat(actual.featureFlags?.additionalProperties)
+            .overridingErrorMessage(
+                "Expected RUM ErrorEvent to have featureFlags: $expected" +
+                    " but instead was: ${actual.featureFlags}"
+            )
+            .isEqualTo(expected?.additionalProperties)
+        return this
+    }
+
     fun hasSampleRate(sampleRate: Float?): ErrorEventAssert {
         assertThat(actual.dd.configuration?.sessionSampleRate ?: 0)
             .overridingErrorMessage(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
@@ -236,6 +236,65 @@ internal class DatadogLateCrashReporterTest {
     }
 
     @Test
+    fun `M propagate feature flags to error event W handleNdkCrashEvent()`(
+        @StringForgery crashMessage: String,
+        @LongForgery(min = 1) fakeTimestamp: Long,
+        @LongForgery(min = 1) fakeTimeSinceAppStartMs: Long,
+        @StringForgery fakeSignalName: String,
+        @StringForgery fakeStacktrace: String,
+        @Forgery viewEvent: ViewEvent,
+        forge: Forge
+    ) {
+        // Given
+        val fakeServerOffset =
+            forge.aLong(min = -fakeTimestamp, max = Long.MAX_VALUE - fakeTimestamp)
+        fakeDatadogContext = fakeDatadogContext.copy(
+            time = fakeDatadogContext.time.copy(
+                serverTimeOffsetMs = fakeServerOffset
+            )
+        )
+
+        val fakeFeatureFlags = ViewEvent.Context(
+            additionalProperties = forge.aMap { aString() to aString() }.toMutableMap()
+        )
+        val fakeViewEvent = viewEvent.copy(
+            date = fakeCurrentTimeMs - forge.aLong(
+                min = 0L,
+                max = DatadogLateCrashReporter.VIEW_EVENT_AVAILABILITY_TIME_THRESHOLD - 1000
+            ),
+            featureFlags = fakeFeatureFlags
+        )
+        val fakeViewEventJson = fakeViewEvent.toJson().asJsonObject
+
+        whenever(mockRumEventDeserializer.deserialize(fakeViewEventJson))
+            .doReturn(fakeViewEvent)
+
+        val fakeEvent = mapOf(
+            "timestamp" to fakeTimestamp,
+            "timeSinceAppStartMs" to fakeTimeSinceAppStartMs,
+            "signalName" to fakeSignalName,
+            "stacktrace" to fakeStacktrace,
+            "message" to crashMessage,
+            "lastViewEvent" to fakeViewEventJson
+        )
+
+        // When
+        testedHandler.handleNdkCrashEvent(fakeEvent, mockRumWriter)
+
+        // Then
+        argumentCaptor<Any> {
+            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
+
+            val errorEvent = firstValue as ErrorEvent
+            val expectedFeatureFlags = ErrorEvent.Context(
+                additionalProperties = fakeFeatureFlags.additionalProperties.toMutableMap()
+            )
+            ErrorEventAssert.assertThat(errorEvent)
+                .hasFeatureFlags(expectedFeatureFlags)
+        }
+    }
+
+    @Test
     fun `M send RUM view+error W handleNdkCrashEvent() {source_type set}`(
         @StringForgery crashMessage: String,
         @LongForgery(min = 1) fakeTimestamp: Long,
@@ -791,6 +850,58 @@ internal class DatadogLateCrashReporterTest {
                 .hasVersion(fakeViewEvent.dd.documentVersion + 1)
                 .hasCrashCount((fakeViewEvent.view.crash?.count ?: 0) + 1)
                 .isActive(false)
+        }
+    }
+
+    @Test
+    fun `M propagate feature flags to error event W handleAnrCrash()`(
+        @Forgery viewEvent: ViewEvent,
+        forge: Forge
+    ) {
+        // Given
+        val fakeFeatureFlags = ViewEvent.Context(
+            additionalProperties = forge.aMap { aString() to aString() }.toMutableMap()
+        )
+        val fakeViewEvent = viewEvent.copy(
+            date = fakeCurrentTimeMs - forge.aLong(
+                min = 0L,
+                max = DatadogLateCrashReporter.VIEW_EVENT_AVAILABILITY_TIME_THRESHOLD - 1000
+            ),
+            featureFlags = fakeFeatureFlags
+        )
+        val fakeTimestamp = fakeViewEvent.date + forge.aLong(min = 1L, max = 1000000L)
+        val fakeServerOffset =
+            forge.aLong(min = -fakeTimestamp, max = Long.MAX_VALUE - fakeTimestamp)
+        fakeDatadogContext = fakeDatadogContext.copy(
+            time = fakeDatadogContext.time.copy(
+                serverTimeOffsetMs = fakeServerOffset
+            )
+        )
+
+        val fakeViewEventJson = fakeViewEvent.toJson().asJsonObject
+
+        whenever(mockRumEventDeserializer.deserialize(fakeViewEventJson)) doReturn fakeViewEvent
+
+        val fakeThreadsDump = forge.anrCrashThreadDump()
+        whenever(mockAndroidTraceParser.parse(any())) doReturn fakeThreadsDump
+        val mockAnrExitInfo = mock<ApplicationExitInfo>().apply {
+            whenever(traceInputStream) doReturn mock()
+            whenever(timestamp) doReturn fakeTimestamp
+        }
+
+        // When
+        testedHandler.handleAnrCrash(mockAnrExitInfo, fakeViewEventJson, mockRumWriter)
+
+        // Then
+        argumentCaptor<Any> {
+            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
+
+            val errorEvent = firstValue as ErrorEvent
+            val expectedFeatureFlags = ErrorEvent.Context(
+                additionalProperties = fakeFeatureFlags.additionalProperties.toMutableMap()
+            )
+            ErrorEventAssert.assertThat(errorEvent)
+                .hasFeatureFlags(expectedFeatureFlags)
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

Feature flags from the last RUM view event were not propagated to the `ErrorEvent` constructed by `DatadogLateCrashReporter` when handling NDK crashes and ANR fatal errors. This caused feature flag context to be lost in crash error events sent to Datadog.

The fix adds `featureFlags` field mapping (with `ViewEvent.Context` to `ErrorEvent.Context` conversion) in `resolveErrorEventFromViewEvent()`.

This is the Android counterpart of https://github.com/DataDog/dd-sdk-ios/pull/2688 which fixed the same issue in the iOS SDK.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)