### PR TITLE
RUMS-5535:  Fix global attributes not copied when view stops

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -559,7 +559,9 @@ internal open class RumViewScope(
         writeScope: EventWriteScope,
         writer: DataWriter<Any>
     ) {
-        stopScope(event, datadogContext, writeScope, writer)
+        stopScope(event, datadogContext, writeScope, writer) {
+            memoizedParentAttributes = parentScope.getCustomAttributes().toMap()
+        }
     }
 
     @WorkerThread

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeAttributePropagationTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeAttributePropagationTest.kt
@@ -572,6 +572,67 @@ internal class RumViewScopeAttributePropagationTest {
 
     // endregion
 
+    @Test
+    fun `M copy parent custom attributes to memoizedParentAttributes W handleEvent(StopView)`(
+        forge: Forge
+    ) {
+        // Given
+        val parentAttributes = forge.exhaustiveAttributes(excludedKeys = fakeViewAttributes.keys)
+        val newParentAttributes = forge.exhaustiveAttributes(excludedKeys = parentAttributes.keys)
+        whenever(mockParentScope.getCustomAttributes()) doReturn parentAttributes.toMutableMap()
+        testedScope = newRumViewScope()
+
+        // When
+        testedScope.handleEvent(
+            RumRawEvent.StopView(fakeKey, emptyMap()),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then - change parent attributes after stopping
+        whenever(mockParentScope.getCustomAttributes()) doReturn newParentAttributes.toMutableMap()
+        val customAttributes = testedScope.getCustomAttributes()
+        val expectedAttributes = mutableMapOf<String, Any?>()
+        expectedAttributes.putAll(parentAttributes)
+        expectedAttributes.putAll(fakeViewAttributes)
+
+        // Verify that memoized parent attributes are used (original parent attributes, not new ones)
+        assertThat(customAttributes)
+            .containsExactlyInAnyOrderEntriesOf(expectedAttributes)
+    }
+
+    @Test
+    fun `M copy parent custom attributes to memoizedParentAttributes W handleEvent(StartView)`(
+        forge: Forge
+    ) {
+        // Given
+        val parentAttributes = forge.exhaustiveAttributes(excludedKeys = fakeViewAttributes.keys)
+        val newParentAttributes = forge.exhaustiveAttributes(excludedKeys = parentAttributes.keys)
+        val newViewKey: RumScopeKey = forge.getForgery()
+        whenever(mockParentScope.getCustomAttributes()) doReturn parentAttributes.toMutableMap()
+        testedScope = newRumViewScope()
+
+        // When
+        testedScope.handleEvent(
+            RumRawEvent.StartView(newViewKey, emptyMap()),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then - change parent attributes after stopping
+        whenever(mockParentScope.getCustomAttributes()) doReturn newParentAttributes.toMutableMap()
+        val customAttributes = testedScope.getCustomAttributes()
+        val expectedAttributes = mutableMapOf<String, Any?>()
+        expectedAttributes.putAll(parentAttributes)
+        expectedAttributes.putAll(fakeViewAttributes)
+
+        // Verify that memoized parent attributes are used (original parent attributes, not new ones)
+        assertThat(customAttributes)
+            .containsExactlyInAnyOrderEntriesOf(expectedAttributes)
+    }
+
     // region Helper
 
     private fun newRumViewScope(


### PR DESCRIPTION
### Current Issue

When customers call `GlobalRumMonitor.get().addAttribute(attribute.key, attribute.value)`,  they expect to see the custom attributes in all the following views, actions, resources and errors. There is an issue reported by a customer that the global attributes are missing in most of the views in the sessions, while they are available in all the actions, resources or errors.

### Cause

When a view is stopped, it is expected to copy the snapshot of custom attributes of the parent scope at the moment it stops, which is the case when customer calls stop view manually, but not the case if stop view is triggered by `StartView` of the new view. Thus, when `sendViewUpdate` is triggered by stopView like this, it is updated without the global attributes.


### Fix
apply the same snapshot copy logic into stop view when it's triggered by a new start view.



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

