### PR TITLE
Fix JSON model generation task caching

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/GenerateJsonSchemaTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/GenerateJsonSchemaTask.kt
@@ -15,7 +15,9 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -56,6 +58,13 @@ abstract class GenerateJsonSchemaTask : DefaultTask() {
             }
             .toList()
     }
+
+    // this is kind of hack: sometimes json can reference other json outside of the module,
+    // so we need just to watch such external dir for changes, otherwise task is cached when external changes not seen
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:Optional
+    @get:InputDirectory
+    abstract val extraInputWatchDir: DirectoryProperty
 
     /**
      * The directory from which to read the files json schema files.

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/utils/JsonSchemaGenerationTasks.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/utils/JsonSchemaGenerationTasks.kt
@@ -61,6 +61,7 @@ fun Project.createJsonModelsGenerationTask(
         ignoredFiles.convention(emptyList())
         inputDirPath.convention("")
         targetPackageName.convention("")
+        extraInputWatchDir.convention(null)
 
         action()
 

--- a/features/dd-sdk-android-logs/generate_log_models.gradle.kts
+++ b/features/dd-sdk-android-logs/generate_log_models.gradle.kts
@@ -5,6 +5,7 @@
  */
 
 import com.datadog.gradle.utils.createJsonModelsGenerationTask
+import java.nio.file.Paths
 
 createJsonModelsGenerationTask("generateLogModelsFromJson") {
     inputDirPath = "src/main/json/log"
@@ -12,4 +13,7 @@ createJsonModelsGenerationTask("generateLogModelsFromJson") {
         "_common-schema.json"
     )
     targetPackageName = "com.datadog.android.log.model"
+    extraInputWatchDir = project.layout.projectDirectory.dir(
+        Paths.get("../dd-sdk-android-rum/src/main/json/rum").toString()
+    )
 }

--- a/features/dd-sdk-android-trace/generate_trace_models.gradle.kts
+++ b/features/dd-sdk-android-trace/generate_trace_models.gradle.kts
@@ -5,6 +5,7 @@
  */
 
 import com.datadog.gradle.utils.createJsonModelsGenerationTask
+import java.nio.file.Paths
 
 createJsonModelsGenerationTask("generateTraceModelsFromJson") {
     inputDirPath = "src/main/json/trace"
@@ -12,4 +13,7 @@ createJsonModelsGenerationTask("generateTraceModelsFromJson") {
         "_common-schema.json"
     )
     targetPackageName = "com.datadog.android.trace.model"
+    extraInputWatchDir = project.layout.projectDirectory.dir(
+        Paths.get("../dd-sdk-android-rum/src/main/json/rum").toString()
+    )
 }


### PR DESCRIPTION
### What does this PR do?

JSON model can reference external file, outside of the `inputDirPath` property, leading to build caching missing changes in such files.

This PR adds extra property to add external folder to watch.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

