### PR TITLE
RUM-14609: Fix npe in TracingInterceptor tests

### DIFF
--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorContextInjectionSampledTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorContextInjectionSampledTest.kt
@@ -1327,6 +1327,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
         // need this setup, otherwise #intercept actually throws NPE, which pollutes the log
         val localSpanBuilder: DatadogSpanBuilder = mock()
         val localSpan: DatadogSpan = mock()
+        whenever(localSpanBuilder.withOrigin(anyOrNull())) doReturn localSpanBuilder
         whenever(localSpanBuilder.withParentContext(null)) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
         whenever(localSpan.context()) doReturn mockSpanContext

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
@@ -1230,6 +1230,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         // need this setup, otherwise #intercept actually throws NPE, which pollutes the log
         val localSpanBuilder: DatadogSpanBuilder = mock()
         val localSpan: DatadogSpan = mock()
+        whenever(localSpanBuilder.withOrigin(anyOrNull())) doReturn localSpanBuilder
         whenever(localSpanBuilder.withParentContext(null)) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
         whenever(localSpan.context()) doReturn mockSpanContext

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
@@ -1338,6 +1338,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         // need this setup, otherwise #intercept actually throws NPE, which pollutes the log
         val localSpanBuilder: DatadogSpanBuilder = mock()
         val localSpan: DatadogSpan = mock()
+        whenever(localSpanBuilder.withOrigin(anyOrNull())) doReturn localSpanBuilder
         whenever(localSpanBuilder.withParentContext(null as DatadogSpanContext?)) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
         whenever(localSpan.context()) doReturn mockSpanContext

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
@@ -1524,6 +1524,7 @@ internal open class TracingInterceptorTest {
         // need this setup, otherwise #intercept actually throws NPE, which pollutes the log
         val localSpanBuilder: DatadogSpanBuilder = mock()
         val localSpan: DatadogSpan = mock()
+        whenever(localSpanBuilder.withOrigin(anyOrNull())) doReturn localSpanBuilder
         whenever(localSpanBuilder.withParentContext(null as DatadogSpanContext?)) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
         whenever(localSpan.context()) doReturn mockSpanContext


### PR DESCRIPTION
### What does this PR do?

This PR fixes test setup in order to remove NPE like following:

```
DatadogInterceptorWithoutRumTest > M create only one local tracer W intercept() called from multiple threads(int) STANDARD_ERROR
    Exception in thread "Thread-7" java.lang.NullPointerException: Cannot invoke "com.datadog.android.trace.api.span.DatadogSpanBuilder.withParentContext(com.datadog.android.trace.api.span.DatadogSpanContext)" because the return value of "com.datadog.android.trace.api.span.DatadogSpanBuilder.withOrigin(String)" is null
        at com.datadog.android.okhttp.trace.TracingInterceptor.buildSpan(TracingInterceptor.kt:340)
        at com.datadog.android.okhttp.trace.TracingInterceptor.interceptAndTrace(TracingInterceptor.kt:238)
        at com.datadog.android.okhttp.trace.TracingInterceptor.doIntercept(TracingInterceptor.kt:157)
        at com.datadog.android.okhttp.DatadogInterceptor.intercept(DatadogInterceptor.kt:148)
        at com.datadog.android.okhttp.trace.TracingInterceptorTest.M_create_only_one_local_tracer_W_intercept___called_from_multiple_threads$lambda$32(TracingInterceptorTest.kt:1537)
        at java.base/java.lang.Thread.run(Thread.java:840)
    Exception in thread "Thread-8" java.lang.NullPointerException: Cannot invoke "com.datadog.android.trace.api.span.DatadogSpanBuilder.withParentContext(com.datadog.android.trace.api.span.DatadogSpanContext)" because the return value of "com.datadog.android.trace.api.span.DatadogSpanBuilder.withOrigin(String)" is null
        at com.datadog.android.okhttp.trace.TracingInterceptor.buildSpan(TracingInterceptor.kt:340)
        at com.datadog.android.okhttp.trace.TracingInterceptor.interceptAndTrace(TracingInterceptor.kt:238)
        at com.datadog.android.okhttp.trace.TracingInterceptor.doIntercept(TracingInterceptor.kt:157)
        at com.datadog.android.okhttp.DatadogInterceptor.intercept(DatadogInterceptor.kt:148)
        at com.datadog.android.okhttp.trace.TracingInterceptorTest.M_create_only_one_local_tracer_W_intercept___called_from_multiple_threads$lambda$33(TracingInterceptorTest.kt:1541)
        at java.base/java.lang.Thread.run(Thread.java:840)

TracingInterceptorContextInjectionSampledTest > M create only one local tracer W intercept() called from multiple threads(int) STANDARD_ERROR
    Exception in thread "Thread-9" java.lang.NullPointerException: Cannot invoke "com.datadog.android.trace.api.span.DatadogSpanBuilder.withParentContext(com.datadog.android.trace.api.span.DatadogSpanContext)" because the return value of "com.datadog.android.trace.api.span.DatadogSpanBuilder.withOrigin(String)" is null
        at com.datadog.android.okhttp.trace.TracingInterceptor.buildSpan(TracingInterceptor.kt:340)
        at com.datadog.android.okhttp.trace.TracingInterceptor.interceptAndTrace(TracingInterceptor.kt:238)
        at com.datadog.android.okhttp.trace.TracingInterceptor.doIntercept(TracingInterceptor.kt:157)
        at com.datadog.android.okhttp.trace.TracingInterceptor.intercept(TracingInterceptor.kt:122)
        at com.datadog.android.okhttp.trace.TracingInterceptorContextInjectionSampledTest.M_create_only_one_local_tracer_W_intercept___called_from_multiple_threads$lambda$27(TracingInterceptorContextInjectionSampledTest.kt:1340)
        at java.base/java.lang.Thread.run(Thread.java:840)
    Exception in thread "Thread-10" java.lang.NullPointerException: Cannot invoke "com.datadog.android.trace.api.span.DatadogSpanBuilder.withParentContext(com.datadog.android.trace.api.span.DatadogSpanContext)" because the return value of "com.datadog.android.trace.api.span.DatadogSpanBuilder.withOrigin(String)" is null
        at com.datadog.android.okhttp.trace.TracingInterceptor.buildSpan(TracingInterceptor.kt:340)
        at com.datadog.android.okhttp.trace.TracingInterceptor.interceptAndTrace(TracingInterceptor.kt:238)
        at com.datadog.android.okhttp.trace.TracingInterceptor.doIntercept(TracingInterceptor.kt:157)
        at com.datadog.android.okhttp.trace.TracingInterceptor.intercept(TracingInterceptor.kt:122)
        at com.datadog.android.okhttp.trace.TracingInterceptorContextInjectionSampledTest.M_create_only_one_local_tracer_W_intercept___called_from_multiple_threads$lambda$28(TracingInterceptorContextInjectionSampledTest.kt:1344)
        at java.base/java.lang.Thread.run(Thread.java:840)

TracingInterceptorNonDdTracerNotSendingSpanTest > M create only one local tracer W intercept() called from multiple threads(int) STANDARD_ERROR
    Exception in thread "Thread-11" java.lang.NullPointerException: Cannot invoke "com.datadog.android.trace.api.span.DatadogSpanBuilder.withParentContext(com.datadog.android.trace.api.span.DatadogSpanContext)" because the return value of "com.datadog.android.trace.api.span.DatadogSpanBuilder.withOrigin(String)" is null
        at com.datadog.android.okhttp.trace.TracingInterceptor.buildSpan(TracingInterceptor.kt:340)
        at com.datadog.android.okhttp.trace.TracingInterceptor.interceptAndTrace(TracingInterceptor.kt:238)
        at com.datadog.android.okhttp.trace.TracingInterceptor.doIntercept(TracingInterceptor.kt:157)
        at com.datadog.android.okhttp.trace.TracingInterceptor.intercept(TracingInterceptor.kt:122)
        at com.datadog.android.okhttp.trace.TracingInterceptorNonDdTracerNotSendingSpanTest.M_create_only_one_local_tracer_W_intercept___called_from_multiple_threads$lambda$23(TracingInterceptorNonDdTracerNotSendingSpanTest.kt:1243)
        at java.base/java.lang.Thread.run(Thread.java:840)
    Exception in thread "Thread-12" java.lang.NullPointerException: Cannot invoke "com.datadog.android.trace.api.span.DatadogSpanBuilder.withParentContext(com.datadog.android.trace.api.span.DatadogSpanContext)" because the return value of "com.datadog.android.trace.api.span.DatadogSpanBuilder.withOrigin(String)" is null
        at com.datadog.android.okhttp.trace.TracingInterceptor.buildSpan(TracingInterceptor.kt:340)
        at com.datadog.android.okhttp.trace.TracingInterceptor.interceptAndTrace(TracingInterceptor.kt:238)
        at com.datadog.android.okhttp.trace.TracingInterceptor.doIntercept(TracingInterceptor.kt:157)
        at com.datadog.android.okhttp.trace.TracingInterceptor.intercept(TracingInterceptor.kt:122)
        at com.datadog.android.okhttp.trace.TracingInterceptorNonDdTracerNotSendingSpanTest.M_create_only_one_local_tracer_W_intercept___called_from_multiple_threads$lambda$24(TracingInterceptorNonDdTracerNotSendingSpanTest.kt:1247)
        at java.base/java.lang.Thread.run(Thread.java:840)

TracingInterceptorNonDdTracerTest > M create only one local tracer W intercept() called from multiple threads(int) STANDARD_ERROR
    Exception in thread "Thread-13" java.lang.NullPointerException: Cannot invoke "com.datadog.android.trace.api.span.DatadogSpanBuilder.withParentContext(com.datadog.android.trace.api.span.DatadogSpanContext)" because the return value of "com.datadog.android.trace.api.span.DatadogSpanBuilder.withOrigin(String)" is null
        at com.datadog.android.okhttp.trace.TracingInterceptor.buildSpan(TracingInterceptor.kt:340)
        at com.datadog.android.okhttp.trace.TracingInterceptor.interceptAndTrace(TracingInterceptor.kt:238)
        at com.datadog.android.okhttp.trace.TracingInterceptor.doIntercept(TracingInterceptor.kt:157)
        at com.datadog.android.okhttp.trace.TracingInterceptor.intercept(TracingInterceptor.kt:122)
        at com.datadog.android.okhttp.trace.TracingInterceptorNonDdTracerTest.M_create_only_one_local_tracer_W_intercept___called_from_multiple_threads$lambda$25(TracingInterceptorNonDdTracerTest.kt:1351)
        at java.base/java.lang.Thread.run(Thread.java:840)
    Exception in thread "Thread-14" java.lang.NullPointerException: Cannot invoke "com.datadog.android.trace.api.span.DatadogSpanBuilder.withParentContext(com.datadog.android.trace.api.span.DatadogSpanContext)" because the return value of "com.datadog.android.trace.api.span.DatadogSpanBuilder.withOrigin(String)" is null
        at com.datadog.android.okhttp.trace.TracingInterceptor.buildSpan(TracingInterceptor.kt:340)
        at com.datadog.android.okhttp.trace.TracingInterceptor.interceptAndTrace(TracingInterceptor.kt:238)
        at com.datadog.android.okhttp.trace.TracingInterceptor.doIntercept(TracingInterceptor.kt:157)
        at com.datadog.android.okhttp.trace.TracingInterceptor.intercept(TracingInterceptor.kt:122)
        at com.datadog.android.okhttp.trace.TracingInterceptorNonDdTracerTest.M_create_only_one_local_tracer_W_intercept___called_from_multiple_threads$lambda$26(TracingInterceptorNonDdTracerTest.kt:1355)
        at java.base/java.lang.Thread.run(Thread.java:840)

TracingInterceptorTest > M create only one local tracer W intercept() called from multiple threads(int) STANDARD_ERROR
    Exception in thread "Thread-17" java.lang.NullPointerException: Cannot invoke "com.datadog.android.trace.api.span.DatadogSpanBuilder.withParentContext(com.datadog.android.trace.api.span.DatadogSpanContext)" because the return value of "com.datadog.android.trace.api.span.DatadogSpanBuilder.withOrigin(String)" is null
        at com.datadog.android.okhttp.trace.TracingInterceptor.buildSpan(TracingInterceptor.kt:340)
        at com.datadog.android.okhttp.trace.TracingInterceptor.interceptAndTrace(TracingInterceptor.kt:238)
        at com.datadog.android.okhttp.trace.TracingInterceptor.doIntercept(TracingInterceptor.kt:157)
        at com.datadog.android.okhttp.trace.TracingInterceptor.intercept(TracingInterceptor.kt:122)
        at com.datadog.android.okhttp.trace.TracingInterceptorTest.M_create_only_one_local_tracer_W_intercept___called_from_multiple_threads$lambda$32(TracingInterceptorTest.kt:1537)
        at java.base/java.lang.Thread.run(Thread.java:840)
    Exception in thread "Thread-18" java.lang.NullPointerException: Cannot invoke "com.datadog.android.trace.api.span.DatadogSpanBuilder.withParentContext(com.datadog.android.trace.api.span.DatadogSpanContext)" because the return value of "com.datadog.android.trace.api.span.DatadogSpanBuilder.withOrigin(String)" is null
        at com.datadog.android.okhttp.trace.TracingInterceptor.buildSpan(TracingInterceptor.kt:340)
        at com.datadog.android.okhttp.trace.TracingInterceptor.interceptAndTrace(TracingInterceptor.kt:238)
        at com.datadog.android.okhttp.trace.TracingInterceptor.doIntercept(TracingInterceptor.kt:157)
        at com.datadog.android.okhttp.trace.TracingInterceptor.intercept(TracingInterceptor.kt:122)
        at com.datadog.android.okhttp.trace.TracingInterceptorTest.M_create_only_one_local_tracer_W_intercept___called_from_multiple_threads$lambda$33(TracingInterceptorTest.kt:1541)
        at java.base/java.lang.Thread.run(Thread.java:840)
```

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

