### PR TITLE
Add detekt-cli jar to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,6 @@ config/*
 gh_token
 sdk_classpath
 detekt_classpath
+detekt-cli-*-all.jar
 **/verification-metadata.xml
 !gradle/verification-metadata.xml


### PR DESCRIPTION
### What does this PR do?

Adds a wildcard pattern (`detekt-cli-*-all.jar`) to `.gitignore` so that the detekt CLI jar required by the `customDetektRules` Gradle task is not committed to the repository.

### Motivation

The `customDetektRules` task needs `detekt-cli-*-all.jar` in the root folder to run, but this is a large binary that should not be tracked in version control. Previously it was not ignored, risking accidental commits.

### Additional Notes

The pattern uses a wildcard to cover all versions (e.g., `detekt-cli-1.23.4-all.jar`, `detekt-cli-2.0.0-all.jar`, etc.).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)