### PR TITLE
Fix evaluations feature startup deadlock

### DIFF
--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -769,6 +769,7 @@ datadog:
       - "kotlin.collections.Collection.forEach(kotlin.Function1)"
       - "kotlin.collections.Collection.isNotEmpty()"
       - "kotlin.collections.Collection.sumOf(kotlin.Function1)"
+      - "kotlin.collections.Collection.toList()"
       - "kotlin.collections.Collection.withIndex()"
       - "kotlin.collections.HashMap()"
       - "kotlin.collections.HashSet()"

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventWriter.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventWriter.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.flags.internal
 
-import com.datadog.android.flags.model.FlagEvaluation
+import com.datadog.android.flags.internal.aggregation.EvaluationAggregationStats
 import com.datadog.tools.annotation.NoOpImplementation
 
 /**
@@ -32,5 +32,5 @@ internal interface EvaluationEventWriter {
      *
      * @param events the evaluation events to write to storage
      */
-    fun writeAll(events: List<FlagEvaluation>)
+    fun writeAll(events: List<EvaluationAggregationStats>)
 }

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
@@ -7,9 +7,9 @@
 package com.datadog.android.flags.internal
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.flags.internal.aggregation.EvaluationAggregationStats
 import com.datadog.android.flags.internal.aggregation.EvaluationAggregator
 import com.datadog.android.flags.model.EvaluationContext
-import com.datadog.android.flags.model.FlagEvaluation
 import com.datadog.android.internal.time.TimeProvider
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ScheduledExecutorService
@@ -49,7 +49,6 @@ internal class EvaluationEventsProcessor(
     fun processEvaluation(
         flagKey: String,
         context: EvaluationContext,
-        service: String?,
         rumApplicationId: String?,
         rumViewName: String?,
         variantKey: String?,
@@ -61,7 +60,6 @@ internal class EvaluationEventsProcessor(
             timestamp = timeProvider.getDeviceTimestampMillis(),
             flagKey = flagKey,
             context = context,
-            service = service,
             rumApplicationId = rumApplicationId,
             rumViewName = rumViewName,
             variantKey = variantKey,
@@ -81,7 +79,7 @@ internal class EvaluationEventsProcessor(
             return
         }
 
-        val events: List<FlagEvaluation>
+        val events: List<EvaluationAggregationStats>
         try {
             events = aggregator.drain()
             reschedulePeriodicFlush()

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationsFeature.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationsFeature.kt
@@ -13,7 +13,6 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.feature.StorageBackedFeature
 import com.datadog.android.api.net.RequestFactory
 import com.datadog.android.api.storage.FeatureStorageConfiguration
-import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.flags.FlagsConfiguration
 import com.datadog.android.flags.internal.aggregation.EvaluationAggregator
 import com.datadog.android.flags.internal.net.EvaluationsRequestFactory
@@ -37,7 +36,7 @@ internal class EvaluationsFeature(
     /**
      * Cached Datadog context information for evaluation events.
      */
-    private data class DDContext(val service: String?, val rumApplicationId: String?, val rumViewName: String?)
+    private data class RumContext(val rumApplicationId: String?, val rumViewName: String?)
 
     internal val initialized = AtomicBoolean(false)
 
@@ -55,7 +54,7 @@ internal class EvaluationsFeature(
      * Updated when RUM context changes via [onContextUpdate].
      */
     @Volatile
-    private var ddContext: DDContext? = null
+    private var rumContext: RumContext? = null
 
     // region Feature
 
@@ -104,7 +103,7 @@ internal class EvaluationsFeature(
         scheduledExecutor?.shutdown()
         scheduledExecutor = null
 
-        ddContext = null
+        rumContext = null
         initialized.set(false)
     }
 
@@ -114,12 +113,7 @@ internal class EvaluationsFeature(
 
     override fun onContextUpdate(featureName: String, context: Map<String, Any?>) {
         if (featureName == Feature.RUM_FEATURE_NAME) {
-            val currentContext = ddContext
-            val service = currentContext?.service
-                ?: (sdkCore as? InternalSdkCore)?.getDatadogContext()?.service
-
-            ddContext = DDContext(
-                service = service,
+            rumContext = RumContext(
                 rumApplicationId = context[RUM_APPLICATION_ID] as? String,
                 rumViewName = context[RUM_VIEW_NAME] as? String
             )
@@ -142,12 +136,11 @@ internal class EvaluationsFeature(
         errorMessage: String?
     ) {
         val processor = evaluationProcessor ?: return
-        val currentDdContext = ddContext
+        val currentDdContext = rumContext
 
         processor.processEvaluation(
             flagKey = flagKey,
             context = context,
-            service = currentDdContext?.service,
             rumApplicationId = currentDdContext?.rumApplicationId,
             rumViewName = currentDdContext?.rumViewName,
             variantKey = variantKey,

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/aggregation/EvaluationAggregationKey.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/aggregation/EvaluationAggregationKey.kt
@@ -22,7 +22,7 @@ package com.datadog.android.flags.internal.aggregation
  *
  * Context aggregation is reserved for future use and not implemented.
  */
-internal data class AggregationKey(
+internal data class EvaluationAggregationKey(
     val flagKey: String,
     val variantKey: String?,
     val allocationKey: String?,

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/aggregation/EvaluationAggregationStats.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/aggregation/EvaluationAggregationStats.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.flags.internal.aggregation
 
+import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.flags.model.EvaluationContext
 import com.datadog.android.flags.model.FlagEvaluation
 
@@ -17,29 +18,27 @@ import com.datadog.android.flags.model.FlagEvaluation
  * @param firstEvaluation timestamp of the earliest evaluation
  * @param lastEvaluation timestamp of the latest evaluation
  * @param context the evaluation context
- * @param service the service name from DatadogContext
  * @param rumApplicationId the RUM application ID (null if RUM not active)
  * @param errorMessage the most recent error message (null if no error)
  */
-internal data class AggregationStats(
-    private val aggregationKey: AggregationKey,
+internal data class EvaluationAggregationStats(
+    internal val aggregationKey: EvaluationAggregationKey,
     internal val count: Int,
     internal val firstEvaluation: Long,
     internal val lastEvaluation: Long,
     private val context: EvaluationContext,
-    private val service: String?,
     private val rumApplicationId: String?,
     internal val errorMessage: String?
 ) {
     /**
      * Converts the aggregated statistics to a [FlagEvaluation].
      */
-    fun toEvaluationEvent(): FlagEvaluation {
+    fun toEvaluationEvent(datadogContext: DatadogContext): FlagEvaluation {
         // Build context with Datadog-specific information
         val eventContext = FlagEvaluation.Context(
             evaluation = null, // Evaluation context reserved for future use
             dd = FlagEvaluation.Dd(
-                service = service,
+                service = datadogContext.service,
                 rum = rumApplicationId?.let { appId ->
                     FlagEvaluation.Rum(
                         application = FlagEvaluation.Application(id = appId),

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/aggregation/EvaluationAggregator.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/aggregation/EvaluationAggregator.kt
@@ -18,7 +18,7 @@ import kotlin.concurrent.withLock
  * ensuring exclusive access during [drain].
  */
 internal class EvaluationAggregator(private val maxAggregations: Int) {
-    private var aggregationMap = mutableMapOf<AggregationKey, AggregationStats>()
+    private var aggregationMap = mutableMapOf<EvaluationAggregationKey, EvaluationAggregationStats>()
 
     private val mapLock = ReentrantLock()
 
@@ -32,15 +32,14 @@ internal class EvaluationAggregator(private val maxAggregations: Int) {
         timestamp: Long,
         flagKey: String,
         context: EvaluationContext,
-        service: String?,
         rumApplicationId: String?,
         rumViewName: String?,
         variantKey: String?,
         allocationKey: String?,
         errorCode: String?,
         errorMessage: String?
-    ): List<FlagEvaluation> {
-        val key = AggregationKey(
+    ): List<EvaluationAggregationStats> {
+        val key = EvaluationAggregationKey(
             flagKey = flagKey,
             variantKey = variantKey,
             allocationKey = allocationKey,
@@ -51,13 +50,12 @@ internal class EvaluationAggregator(private val maxAggregations: Int) {
 
         val drained = mapLock.withLock {
             @Suppress("UnsafeThirdPartyFunctionCall") // Only throws if null is passed
-            val existing = aggregationMap.get(key) ?: AggregationStats(
+            val existing = aggregationMap.get(key) ?: EvaluationAggregationStats(
                 aggregationKey = key,
                 count = 0,
                 firstEvaluation = timestamp,
                 lastEvaluation = timestamp,
                 context = context,
-                service = service,
                 rumApplicationId = rumApplicationId,
                 errorMessage = errorMessage
             )
@@ -75,7 +73,7 @@ internal class EvaluationAggregator(private val maxAggregations: Int) {
             if (aggregationMap.size < maxAggregations) emptyMap() else drainAggregationStats()
         }
 
-        return drained.map { it.value.toEvaluationEvent() }
+        return drained.values.toList()
     }
 
     /**
@@ -84,9 +82,9 @@ internal class EvaluationAggregator(private val maxAggregations: Int) {
      *
      * @return list of aggregated events, or empty list if none
      */
-    fun drain(): List<FlagEvaluation> {
+    fun drain(): List<EvaluationAggregationStats> {
         val drained = mapLock.withLock { drainAggregationStats() }
-        return drained.map { it.value.toEvaluationEvent() }
+        return drained.values.toList()
     }
 
     /**
@@ -95,7 +93,7 @@ internal class EvaluationAggregator(private val maxAggregations: Int) {
      *
      * @return the old map, or null if empty
      */
-    private fun drainAggregationStats(): Map<AggregationKey, AggregationStats> = mapLock.withLock {
+    private fun drainAggregationStats(): Map<EvaluationAggregationKey, EvaluationAggregationStats> = mapLock.withLock {
         val toDrain = aggregationMap
         aggregationMap = mutableMapOf()
         toDrain

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/storage/EvaluationEventRecordWriter.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/storage/EvaluationEventRecordWriter.kt
@@ -11,7 +11,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.flags.internal.EvaluationEventWriter
-import com.datadog.android.flags.model.FlagEvaluation
+import com.datadog.android.flags.internal.aggregation.EvaluationAggregationStats
 
 /**
  * Persists serialized flag evaluation events to SDK Core storage.
@@ -20,14 +20,17 @@ import com.datadog.android.flags.model.FlagEvaluation
  * to the EVP intake endpoint by the SDK Core's upload mechanism.
  */
 internal class EvaluationEventRecordWriter(private val sdkCore: FeatureSdkCore) : EvaluationEventWriter {
-    override fun writeAll(events: List<FlagEvaluation>) {
+    override fun writeAll(events: List<EvaluationAggregationStats>) {
         if (events.isEmpty()) return
 
         sdkCore.getFeature(Feature.FLAGS_EVALUATIONS_FEATURE_NAME)
-            ?.withWriteContext { _, writeScope ->
+            ?.withWriteContext { datadogContext, writeScope ->
                 writeScope { batchWriter ->
                     for (event in events) {
-                        val serializedRecord = event.toJson().toString().toByteArray(Charsets.UTF_8)
+                        val serializedRecord = event.toEvaluationEvent(datadogContext)
+                            .toJson()
+                            .toString()
+                            .toByteArray(Charsets.UTF_8)
                         val rawBatchEvent = RawBatchEvent(data = serializedRecord)
                         batchWriter.write(
                             event = rawBatchEvent,

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessorTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessorTest.kt
@@ -7,9 +7,9 @@
 package com.datadog.android.flags.internal
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.flags.internal.aggregation.EvaluationAggregationStats
 import com.datadog.android.flags.internal.aggregation.EvaluationAggregator
 import com.datadog.android.flags.model.EvaluationContext
-import com.datadog.android.flags.model.FlagEvaluation
 import com.datadog.android.flags.utils.forge.ForgeConfigurator
 import com.datadog.android.internal.time.TimeProvider
 import fr.xgouchet.elmyr.Forge
@@ -85,13 +85,11 @@ internal class EvaluationEventsProcessorTest {
     private lateinit var testedProcessor: EvaluationEventsProcessor
     private lateinit var testedAggregator: EvaluationAggregator
     private lateinit var fakeContext: EvaluationContext
-    private lateinit var fakeService: String
     private lateinit var fakeApplicationId: String
     private lateinit var fakeViewName: String
 
     @BeforeEach
     fun `set up`(forge: Forge) {
-        fakeService = forge.anAlphabeticalString()
         fakeApplicationId = forge.anAlphabeticalString()
         fakeViewName = forge.anAlphabeticalString()
         fakeContext = EvaluationContext(targetingKey = fakeTargetingKey)
@@ -119,7 +117,7 @@ internal class EvaluationEventsProcessorTest {
 
         val events = captureWrittenEvents()
         assertThat(events).hasSize(1)
-        assertThat(events.first().flag.key).isEqualTo(fakeFlagKey)
+        assertThat(events.first().aggregationKey.flagKey).isEqualTo(fakeFlagKey)
     }
 
     @Test
@@ -139,9 +137,12 @@ internal class EvaluationEventsProcessorTest {
             processor.processEvaluation(
                 fakeFlagKey,
                 EvaluationContext(targetingKey = "user-$index"),
-                fakeService, fakeApplicationId, fakeViewName,
-                fakeVariantKey, fakeAllocationKey,
-                null, null
+                fakeApplicationId,
+                fakeViewName,
+                fakeVariantKey,
+                fakeAllocationKey,
+                null,
+                null
             )
         }
 
@@ -168,7 +169,7 @@ internal class EvaluationEventsProcessorTest {
         processEval()
         testedProcessor.flush()
 
-        val captor = argumentCaptor<List<FlagEvaluation>>()
+        val captor = argumentCaptor<List<EvaluationAggregationStats>>()
         verify(mockWriter, times(2)).writeAll(captor.capture())
         assertThat(captor.allValues.flatten()).hasSize(2)
     }
@@ -179,8 +180,14 @@ internal class EvaluationEventsProcessorTest {
         val processor = createSchedulingEnabledProcessor()
 
         processor.processEvaluation(
-            fakeFlagKey, fakeContext, fakeService, fakeApplicationId, fakeViewName,
-            fakeVariantKey, fakeAllocationKey, null, null
+            fakeFlagKey,
+            fakeContext,
+            fakeApplicationId,
+            fakeViewName,
+            fakeVariantKey,
+            fakeAllocationKey,
+            null,
+            null
         )
         processor.flush()
 
@@ -199,8 +206,14 @@ internal class EvaluationEventsProcessorTest {
         val initialCount = scheduleCount
 
         processor.processEvaluation(
-            fakeFlagKey, fakeContext, fakeService, fakeApplicationId, fakeViewName,
-            fakeVariantKey, fakeAllocationKey, null, null
+            fakeFlagKey,
+            fakeContext,
+            fakeApplicationId,
+            fakeViewName,
+            fakeVariantKey,
+            fakeAllocationKey,
+            null,
+            null
         )
         processor.flush()
 
@@ -324,7 +337,7 @@ internal class EvaluationEventsProcessorTest {
 
         verify(mockScheduledExecutor).shutdown()
         val events = captureWrittenEvents()
-        assertThat(events.first().flag.key).isEqualTo(fakeFlagKey)
+        assertThat(events.first().aggregationKey.flagKey).isEqualTo(fakeFlagKey)
     }
 
     @Test
@@ -412,7 +425,7 @@ internal class EvaluationEventsProcessorTest {
 
         val events = captureWrittenEvents()
         assertThat(events).hasSize(1)
-        assertThat(events.first().evaluationCount).isEqualTo((threadCount * executionsPerThread).toLong())
+        assertThat(events.first().count).isEqualTo((threadCount * executionsPerThread).toLong())
     }
 
     @Test
@@ -425,9 +438,12 @@ internal class EvaluationEventsProcessorTest {
                 testedProcessor.processEvaluation(
                     fakeFlagKey,
                     EvaluationContext(targetingKey = "thread-$threadIndex-exec-$execIndex"),
-                    fakeService, fakeApplicationId, fakeViewName,
-                    fakeVariantKey, fakeAllocationKey,
-                    null, null
+                    fakeApplicationId,
+                    fakeViewName,
+                    fakeVariantKey,
+                    fakeAllocationKey,
+                    null,
+                    null
                 )
             }
         }
@@ -454,9 +470,12 @@ internal class EvaluationEventsProcessorTest {
                     testedProcessor.processEvaluation(
                         fakeFlagKey,
                         EvaluationContext(targetingKey = "user-$threadIndex-$execIndex"),
-                        fakeService, fakeApplicationId, fakeViewName,
-                        fakeVariantKey, fakeAllocationKey,
-                        null, null
+                        fakeApplicationId,
+                        fakeViewName,
+                        fakeVariantKey,
+                        fakeAllocationKey,
+                        null,
+                        null
                     )
                 }
                 finishLatch.countDown()
@@ -479,7 +498,7 @@ internal class EvaluationEventsProcessorTest {
         finishLatch.await()
         testedProcessor.flush()
 
-        val captor = argumentCaptor<List<FlagEvaluation>>()
+        val captor = argumentCaptor<List<EvaluationAggregationStats>>()
         verify(mockWriter, atLeast(1)).writeAll(captor.capture())
         assertThat(captor.allValues.sumOf { it.size }).isEqualTo(processingThreads * executionsPerThread)
     }
@@ -491,7 +510,7 @@ internal class EvaluationEventsProcessorTest {
         var writeCount = 0
 
         val slowWriter = object : EvaluationEventWriter {
-            override fun writeAll(events: List<FlagEvaluation>) {
+            override fun writeAll(events: List<EvaluationAggregationStats>) {
                 writeCount++
                 writeStarted.countDown()
                 blockWrite.await()
@@ -508,8 +527,14 @@ internal class EvaluationEventsProcessorTest {
         )
 
         processor.processEvaluation(
-            fakeFlagKey, fakeContext, fakeService, fakeApplicationId, fakeViewName,
-            fakeVariantKey, fakeAllocationKey, null, null
+            fakeFlagKey,
+            fakeContext,
+            fakeApplicationId,
+            fakeViewName,
+            fakeVariantKey,
+            fakeAllocationKey,
+            null,
+            null
         )
 
         val flushThread = Thread { processor.flush() }
@@ -530,10 +555,10 @@ internal class EvaluationEventsProcessorTest {
     fun `M not lose events W stop() { flush in progress }`() {
         val writeStarted = CountDownLatch(1)
         val continueWrite = CountDownLatch(1)
-        val writtenEvents = CopyOnWriteArrayList<FlagEvaluation>()
+        val writtenEvents = CopyOnWriteArrayList<EvaluationAggregationStats>()
 
         val slowWriter = object : EvaluationEventWriter {
-            override fun writeAll(events: List<FlagEvaluation>) {
+            override fun writeAll(events: List<EvaluationAggregationStats>) {
                 if (writtenEvents.isEmpty()) {
                     writeStarted.countDown()
                     continueWrite.await()
@@ -555,9 +580,14 @@ internal class EvaluationEventsProcessorTest {
 
         repeat(10) { index ->
             processor.processEvaluation(
-                fakeFlagKey, EvaluationContext(targetingKey = "initial-$index"),
-                fakeService, fakeApplicationId, fakeViewName,
-                fakeVariantKey, fakeAllocationKey, null, null
+                fakeFlagKey,
+                EvaluationContext(targetingKey = "initial-$index"),
+                fakeApplicationId,
+                fakeViewName,
+                fakeVariantKey,
+                fakeAllocationKey,
+                null,
+                null
             )
         }
 
@@ -567,9 +597,14 @@ internal class EvaluationEventsProcessorTest {
 
         repeat(5) { index ->
             processor.processEvaluation(
-                fakeFlagKey, EvaluationContext(targetingKey = "during-flush-$index"),
-                fakeService, fakeApplicationId, fakeViewName,
-                fakeVariantKey, fakeAllocationKey, null, null
+                fakeFlagKey,
+                EvaluationContext(targetingKey = "during-flush-$index"),
+                fakeApplicationId,
+                fakeViewName,
+                fakeVariantKey,
+                fakeAllocationKey,
+                null,
+                null
             )
         }
 
@@ -589,8 +624,8 @@ internal class EvaluationEventsProcessorTest {
         val totalWritten = AtomicInteger(0)
 
         val trackingWriter = object : EvaluationEventWriter {
-            override fun writeAll(events: List<FlagEvaluation>) {
-                totalWritten.addAndGet(events.sumOf { it.evaluationCount.toInt() })
+            override fun writeAll(events: List<EvaluationAggregationStats>) {
+                totalWritten.addAndGet(events.sumOf { it.count })
             }
         }
 
@@ -617,8 +652,14 @@ internal class EvaluationEventsProcessorTest {
                 startLatch.await()
                 repeat(evaluationsPerThread) {
                     processor.processEvaluation(
-                        fakeFlagKey, fakeContext, fakeService, fakeApplicationId, fakeViewName,
-                        fakeVariantKey, fakeAllocationKey, null, null
+                        fakeFlagKey,
+                        fakeContext,
+                        fakeApplicationId,
+                        fakeViewName,
+                        fakeVariantKey,
+                        fakeAllocationKey,
+                        null,
+                        null
                     )
                 }
                 finishLatch.countDown()
@@ -653,7 +694,7 @@ internal class EvaluationEventsProcessorTest {
         val firstCall = AtomicBoolean(true)
 
         val slowWriter = object : EvaluationEventWriter {
-            override fun writeAll(events: List<FlagEvaluation>) {
+            override fun writeAll(events: List<EvaluationAggregationStats>) {
                 val isFirst = firstCall.compareAndSet(true, false)
                 writeCount.addAndGet(events.size)
                 if (isFirst) {
@@ -674,9 +715,14 @@ internal class EvaluationEventsProcessorTest {
 
         repeat(50) { index ->
             processor.processEvaluation(
-                fakeFlagKey, EvaluationContext(targetingKey = "initial-$index"),
-                fakeService, fakeApplicationId, fakeViewName,
-                fakeVariantKey, fakeAllocationKey, null, null
+                fakeFlagKey,
+                EvaluationContext(targetingKey = "initial-$index"),
+                fakeApplicationId,
+                fakeViewName,
+                fakeVariantKey,
+                fakeAllocationKey,
+                null,
+                null
             )
         }
 
@@ -690,9 +736,14 @@ internal class EvaluationEventsProcessorTest {
 
         repeat(25) { index ->
             processor.processEvaluation(
-                fakeFlagKey, EvaluationContext(targetingKey = "during-flush-$index"),
-                fakeService, fakeApplicationId, fakeViewName,
-                fakeVariantKey, fakeAllocationKey, null, null
+                fakeFlagKey,
+                EvaluationContext(targetingKey = "during-flush-$index"),
+                fakeApplicationId,
+                fakeViewName,
+                fakeVariantKey,
+                fakeAllocationKey,
+                null,
+                null
             )
         }
 
@@ -729,15 +780,21 @@ internal class EvaluationEventsProcessorTest {
         errorMessage: String? = null
     ) {
         testedProcessor.processEvaluation(
-            flagKey, context, fakeService, fakeApplicationId, fakeViewName,
-            variantKey, allocationKey, errorCode, errorMessage
+            flagKey,
+            context,
+            fakeApplicationId,
+            fakeViewName,
+            variantKey,
+            allocationKey,
+            errorCode,
+            errorMessage
         )
     }
 
-    private fun captureWrittenEvents(): List<FlagEvaluation> {
-        val captor = argumentCaptor<List<FlagEvaluation>>()
+    private fun captureWrittenEvents(): List<EvaluationAggregationStats> {
+        val captor = argumentCaptor<List<EvaluationAggregationStats>>()
         verify(mockWriter).writeAll(captor.capture())
-        return captor.firstValue
+        return captor.allValues.flatten()
     }
 
     private fun runConcurrently(threadCount: Int, action: (Int) -> Unit) {

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/aggregation/EvaluationAggregationStatsTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/aggregation/EvaluationAggregationStatsTest.kt
@@ -6,9 +6,11 @@
 
 package com.datadog.android.flags.internal.aggregation
 
+import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.flags.model.EvaluationContext
 import com.datadog.android.flags.utils.forge.ForgeConfigurator
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -21,7 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(ForgeExtension::class)
 @ForgeConfiguration(ForgeConfigurator::class)
-internal class AggregationStatsTest {
+internal class EvaluationAggregationStatsTest {
 
     @LongForgery(min = 1000000L)
     var fakeFirstTimestamp = 0L
@@ -45,21 +47,21 @@ internal class AggregationStatsTest {
     lateinit var fakeFlagName: String
 
     @StringForgery
-    lateinit var fakeService: String
-
-    @StringForgery
     lateinit var fakeApplicationId: String
 
     @StringForgery
     lateinit var fakeViewName: String
 
+    @Forgery
+    lateinit var fakeDatadogContext: DatadogContext
+
     private lateinit var fakeContext: EvaluationContext
-    private lateinit var fakeAggregationKey: AggregationKey
+    private lateinit var fakeEvaluationAggregationKey: EvaluationAggregationKey
 
     @BeforeEach
     fun `set up`() {
         fakeContext = EvaluationContext(targetingKey = fakeTargetingKey)
-        fakeAggregationKey = AggregationKey(
+        fakeEvaluationAggregationKey = EvaluationAggregationKey(
             flagKey = fakeFlagName,
             variantKey = fakeVariantKey,
             allocationKey = fakeAllocationKey,
@@ -81,7 +83,7 @@ internal class AggregationStatsTest {
         val stats = createStats()
 
         // When
-        val event = stats.toEvaluationEvent()
+        val event = stats.toEvaluationEvent(fakeDatadogContext)
 
         // Then
         assertThat(event.timestamp).isEqualTo(fakeFirstTimestamp)
@@ -96,7 +98,7 @@ internal class AggregationStatsTest {
         assertThat(event.error).isNull()
         assertThat(event.targetingRule).isNull()
         assertThat(event.context).isNotNull()
-        assertThat(event.context?.dd?.service).isEqualTo(fakeService)
+        assertThat(event.context?.dd?.service).isEqualTo(fakeDatadogContext.service)
         assertThat(event.context?.dd?.rum?.application?.id).isEqualTo(fakeApplicationId)
         assertThat(event.context?.dd?.rum?.view?.url).isEqualTo(fakeViewName)
     }
@@ -104,11 +106,11 @@ internal class AggregationStatsTest {
     @Test
     fun `M set runtime default true W toEvaluationEvent() { null variantKey }`() {
         // Given - null variantKey indicates runtime default was used
-        val keyWithoutVariant = fakeAggregationKey.copy(variantKey = null, allocationKey = null)
-        val stats = createStats(aggregationKey = keyWithoutVariant)
+        val keyWithoutVariant = fakeEvaluationAggregationKey.copy(variantKey = null, allocationKey = null)
+        val stats = createStats(evaluationAggregationKey = keyWithoutVariant)
 
         // When
-        val event = stats.toEvaluationEvent()
+        val event = stats.toEvaluationEvent(fakeDatadogContext)
 
         // Then
         assertThat(event.runtimeDefaultUsed).isTrue()
@@ -120,18 +122,18 @@ internal class AggregationStatsTest {
     fun `M set runtime default true W toEvaluationEvent() { ERROR reason }`(forge: Forge) {
         // Given - ERROR reason (reason = null, no flag data)
         val errorMessage = forge.anAlphabeticalString()
-        val keyWithError = fakeAggregationKey.copy(
+        val keyWithError = fakeEvaluationAggregationKey.copy(
             variantKey = null,
             allocationKey = null,
             errorCode = "FLAG_NOT_FOUND"
         )
         val stats = createStats(
-            aggregationKey = keyWithError,
+            evaluationAggregationKey = keyWithError,
             errorMessage = errorMessage
         )
 
         // When
-        val event = stats.toEvaluationEvent()
+        val event = stats.toEvaluationEvent(fakeDatadogContext)
 
         // Then
         assertThat(event.runtimeDefaultUsed).isTrue()
@@ -144,7 +146,7 @@ internal class AggregationStatsTest {
         val stats = createStats()
 
         // When
-        val event = stats.toEvaluationEvent()
+        val event = stats.toEvaluationEvent(fakeDatadogContext)
 
         // Then
         assertThat(event.runtimeDefaultUsed).isFalse()
@@ -156,7 +158,7 @@ internal class AggregationStatsTest {
         val stats = createStats() // fakeAggregationKey has non-null variantKey
 
         // When
-        val event = stats.toEvaluationEvent()
+        val event = stats.toEvaluationEvent(fakeDatadogContext)
 
         // Then
         assertThat(event.runtimeDefaultUsed).isFalse()
@@ -169,7 +171,7 @@ internal class AggregationStatsTest {
         val stats = createStats(errorMessage = errorMessage)
 
         // When
-        val event = stats.toEvaluationEvent()
+        val event = stats.toEvaluationEvent(fakeDatadogContext)
 
         // Then
         assertThat(event.error?.message).isEqualTo(errorMessage)
@@ -181,7 +183,7 @@ internal class AggregationStatsTest {
         val stats = createStats(errorMessage = null)
 
         // When
-        val event = stats.toEvaluationEvent()
+        val event = stats.toEvaluationEvent(fakeDatadogContext)
 
         // Then
         assertThat(event.error).isNull()
@@ -193,22 +195,22 @@ internal class AggregationStatsTest {
         val stats = createStats()
 
         // When
-        val event = stats.toEvaluationEvent()
+        val event = stats.toEvaluationEvent(fakeDatadogContext)
 
         // Then
-        assertThat(event.variant?.key).isEqualTo(fakeAggregationKey.variantKey)
-        assertThat(event.allocation?.key).isEqualTo(fakeAggregationKey.allocationKey)
-        assertThat(event.targetingKey).isEqualTo(fakeAggregationKey.targetingKey)
+        assertThat(event.variant?.key).isEqualTo(fakeEvaluationAggregationKey.variantKey)
+        assertThat(event.allocation?.key).isEqualTo(fakeEvaluationAggregationKey.allocationKey)
+        assertThat(event.targetingKey).isEqualTo(fakeEvaluationAggregationKey.targetingKey)
     }
 
     @Test
     fun `M handle null variant W toEvaluationEvent() { key has null variant }`() {
         // Given
-        val keyWithNullVariant = fakeAggregationKey.copy(variantKey = null)
-        val stats = createStats(aggregationKey = keyWithNullVariant)
+        val keyWithNullVariant = fakeEvaluationAggregationKey.copy(variantKey = null)
+        val stats = createStats(evaluationAggregationKey = keyWithNullVariant)
 
         // When
-        val event = stats.toEvaluationEvent()
+        val event = stats.toEvaluationEvent(fakeDatadogContext)
 
         // Then
         assertThat(event.variant).isNull()
@@ -217,11 +219,11 @@ internal class AggregationStatsTest {
     @Test
     fun `M handle null allocation W toEvaluationEvent() { key has null allocation }`() {
         // Given
-        val keyWithNullAllocation = fakeAggregationKey.copy(allocationKey = null)
-        val stats = createStats(aggregationKey = keyWithNullAllocation)
+        val keyWithNullAllocation = fakeEvaluationAggregationKey.copy(allocationKey = null)
+        val stats = createStats(evaluationAggregationKey = keyWithNullAllocation)
 
         // When
-        val event = stats.toEvaluationEvent()
+        val event = stats.toEvaluationEvent(fakeDatadogContext)
 
         // Then
         assertThat(event.allocation).isNull()
@@ -233,7 +235,7 @@ internal class AggregationStatsTest {
         val stats = createStats()
 
         // When
-        val event = stats.toEvaluationEvent()
+        val event = stats.toEvaluationEvent(fakeDatadogContext)
 
         // Then
         assertThat(event.timestamp).isEqualTo(fakeFirstTimestamp)
@@ -246,7 +248,7 @@ internal class AggregationStatsTest {
         val stats = createStats(count = 42)
 
         // When
-        val event = stats.toEvaluationEvent()
+        val event = stats.toEvaluationEvent(fakeDatadogContext)
 
         // Then
         assertThat(event.evaluationCount).isEqualTo(42L)
@@ -258,7 +260,7 @@ internal class AggregationStatsTest {
         val stats = createStats(rumApplicationId = null)
 
         // When
-        val event = stats.toEvaluationEvent()
+        val event = stats.toEvaluationEvent(fakeDatadogContext)
 
         // Then
         assertThat(event.context?.dd?.rum).isNull()
@@ -267,11 +269,11 @@ internal class AggregationStatsTest {
     @Test
     fun `M handle null view name W toEvaluationEvent() { RUM app ID present }`() {
         // Given
-        val keyWithoutView = fakeAggregationKey.copy(viewName = null)
-        val stats = createStats(aggregationKey = keyWithoutView)
+        val keyWithoutView = fakeEvaluationAggregationKey.copy(viewName = null)
+        val stats = createStats(evaluationAggregationKey = keyWithoutView)
 
         // When
-        val event = stats.toEvaluationEvent()
+        val event = stats.toEvaluationEvent(fakeDatadogContext)
 
         // Then
         assertThat(event.context?.dd?.rum?.application?.id).isEqualTo(fakeApplicationId)
@@ -326,21 +328,19 @@ internal class AggregationStatsTest {
     // region Helpers
 
     private fun createStats(
-        aggregationKey: AggregationKey = fakeAggregationKey,
+        evaluationAggregationKey: EvaluationAggregationKey = fakeEvaluationAggregationKey,
         count: Int = fakeCount,
         firstEvaluation: Long = fakeFirstTimestamp,
         lastEvaluation: Long = fakeLastTimestamp,
         context: EvaluationContext = fakeContext,
-        service: String? = fakeService,
         rumApplicationId: String? = fakeApplicationId,
         errorMessage: String? = null
-    ): AggregationStats = AggregationStats(
-        aggregationKey = aggregationKey,
+    ): EvaluationAggregationStats = EvaluationAggregationStats(
+        aggregationKey = evaluationAggregationKey,
         count = count,
         firstEvaluation = firstEvaluation,
         lastEvaluation = lastEvaluation,
         context = context,
-        service = service,
         rumApplicationId = rumApplicationId,
         errorMessage = errorMessage
     )

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/aggregation/EvaluationAggregatorTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/aggregation/EvaluationAggregatorTest.kt
@@ -8,7 +8,6 @@ package com.datadog.android.flags.internal.aggregation
 
 import com.datadog.android.flags.model.ErrorCode
 import com.datadog.android.flags.model.EvaluationContext
-import com.datadog.android.flags.model.FlagEvaluation
 import com.datadog.android.flags.utils.forge.ForgeConfigurator
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -58,14 +57,13 @@ internal class EvaluationAggregatorTest {
     @Test
     fun `M return drained events W record() { at threshold }`() {
         val aggregator = EvaluationAggregator(maxAggregations = 5)
-        var lastResult: List<FlagEvaluation> = emptyList()
+        var lastResult: List<EvaluationAggregationStats> = emptyList()
 
         repeat(5) { index ->
             lastResult = aggregator.record(
                 timestamp = fakeTimestamp,
                 flagKey = "flag-$index",
                 context = fakeContext,
-                service = null,
                 rumApplicationId = null,
                 rumViewName = null,
                 variantKey = fakeVariantKey,
@@ -77,7 +75,7 @@ internal class EvaluationAggregatorTest {
 
         assertThat(lastResult).isNotEmpty()
         assertThat(lastResult).hasSize(5)
-        assertThat(lastResult.map { it.flag.key }).containsExactlyInAnyOrder(
+        assertThat(lastResult.map { it.aggregationKey.flagKey }).containsExactlyInAnyOrder(
             "flag-0",
             "flag-1",
             "flag-2",
@@ -96,7 +94,6 @@ internal class EvaluationAggregatorTest {
                 timestamp = fakeTimestamp,
                 flagKey = "flag-$index",
                 context = fakeContext,
-                service = null,
                 rumApplicationId = null,
                 rumViewName = null,
                 variantKey = fakeVariantKey,
@@ -111,7 +108,6 @@ internal class EvaluationAggregatorTest {
             timestamp = fakeTimestamp,
             flagKey = "new-flag",
             context = fakeContext,
-            service = null,
             rumApplicationId = null,
             rumViewName = null,
             variantKey = fakeVariantKey,
@@ -135,7 +131,7 @@ internal class EvaluationAggregatorTest {
 
         val events = testedAggregator.drain()
         assertThat(events).hasSize(1)
-        assertThat(events.first().evaluationCount).isEqualTo(10L)
+        assertThat(events.first().count).isEqualTo(10)
     }
 
     @Test
@@ -190,8 +186,8 @@ internal class EvaluationAggregatorTest {
 
         val events = testedAggregator.drain()
         assertThat(events).hasSize(1)
-        assertThat(events.first().evaluationCount).isEqualTo(3L)
-        assertThat(events.first().error?.message).isEqualTo("msg3")
+        assertThat(events.first().count).isEqualTo(3)
+        assertThat(events.first().errorMessage).isEqualTo("msg3")
     }
 
     @Test
@@ -252,7 +248,7 @@ internal class EvaluationAggregatorTest {
         val events = testedAggregator.drain()
 
         assertThat(events).hasSize(10)
-        assertThat(events.map { it.flag.key }).containsExactlyInAnyOrder(
+        assertThat(events.map { it.aggregationKey.flagKey }).containsExactlyInAnyOrder(
             "flag-0", "flag-1", "flag-2", "flag-3", "flag-4",
             "flag-5", "flag-6", "flag-7", "flag-8", "flag-9"
         )
@@ -275,7 +271,7 @@ internal class EvaluationAggregatorTest {
 
         val events = testedAggregator.drain()
         assertThat(events).hasSize(1)
-        assertThat(events.first().evaluationCount).isEqualTo((threadCount * recordsPerThread).toLong())
+        assertThat(events.first().count).isEqualTo(threadCount * recordsPerThread)
     }
 
     @Test
@@ -283,7 +279,7 @@ internal class EvaluationAggregatorTest {
         val threadCount = 10
         val keysPerThread = 50
         val expectedTotal = threadCount * keysPerThread
-        val allDrained = CopyOnWriteArrayList<FlagEvaluation>()
+        val allDrained = CopyOnWriteArrayList<EvaluationAggregationStats>()
 
         runConcurrently(threadCount) { threadId ->
             repeat(keysPerThread) { index ->
@@ -309,7 +305,7 @@ internal class EvaluationAggregatorTest {
 
         val startLatch = CountDownLatch(1)
         val finishLatch = CountDownLatch(recordThreads + 1)
-        val allDrained = CopyOnWriteArrayList<Long>()
+        val allDrained = CopyOnWriteArrayList<Int>()
 
         val recorders = (1..recordThreads).map { threadId ->
             Thread {
@@ -317,7 +313,7 @@ internal class EvaluationAggregatorTest {
                 repeat(recordsPerThread) { index ->
                     val drained = record(flagKey = "thread-$threadId-flag-$index")
                     if (drained.isNotEmpty()) {
-                        allDrained.addAll(drained.map { it.evaluationCount })
+                        allDrained.addAll(drained.map { it.count })
                     }
                 }
                 finishLatch.countDown()
@@ -328,7 +324,7 @@ internal class EvaluationAggregatorTest {
             startLatch.await()
             repeat(drainCount) {
                 Thread.sleep(1)
-                allDrained.addAll(testedAggregator.drain().map { it.evaluationCount })
+                allDrained.addAll(testedAggregator.drain().map { it.count })
             }
             finishLatch.countDown()
         }
@@ -338,7 +334,7 @@ internal class EvaluationAggregatorTest {
         startLatch.countDown()
         finishLatch.await()
 
-        allDrained.addAll(testedAggregator.drain().map { it.evaluationCount })
+        allDrained.addAll(testedAggregator.drain().map { it.count })
 
         assertThat(allDrained.sum()).isEqualTo(expectedTotal.toLong())
     }
@@ -354,11 +350,10 @@ internal class EvaluationAggregatorTest {
         variantKey: String? = fakeVariantKey,
         errorCode: String? = null,
         errorMessage: String? = null
-    ): List<FlagEvaluation> = testedAggregator.record(
+    ): List<EvaluationAggregationStats> = testedAggregator.record(
         timestamp = timestamp,
         flagKey = flagKey,
         context = context,
-        service = null,
         rumApplicationId = null,
         rumViewName = null,
         variantKey = variantKey,

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/storage/EvaluationEventRecordWriterTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/storage/EvaluationEventRecordWriterTest.kt
@@ -14,7 +14,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
-import com.datadog.android.flags.model.FlagEvaluation
+import com.datadog.android.flags.internal.aggregation.EvaluationAggregationStats
 import com.datadog.android.flags.utils.forge.ForgeConfigurator
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -29,7 +29,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -48,6 +47,9 @@ internal class EvaluationEventRecordWriterTest {
     @Mock
     lateinit var mockEventBatchWriter: EventBatchWriter
 
+    @Forgery
+    lateinit var fakeDatadogContext: DatadogContext
+
     private lateinit var testedWriter: EvaluationEventRecordWriter
 
     @BeforeEach
@@ -59,19 +61,14 @@ internal class EvaluationEventRecordWriterTest {
 
     @Test
     fun `M write all events to storage W writeAll() { multiple events }`(
-        @Forgery event1: FlagEvaluation,
-        @Forgery event2: FlagEvaluation,
-        @Forgery event3: FlagEvaluation
+        @Forgery events: List<EvaluationAggregationStats>
     ) {
         // Given
-        val events = listOf(event1, event2, event3)
-
         whenever(mockSdkCore.getFeature(Feature.FLAGS_EVALUATIONS_FEATURE_NAME)).thenReturn(mockFeature)
         whenever(mockFeature.withWriteContext(any(), any()))
             .thenAnswer { invocation ->
                 val callback = invocation.getArgument<(DatadogContext, EventWriteScope) -> Unit>(1)
-                val mockContext = mock<DatadogContext>()
-                callback.invoke(mockContext) { writerScope ->
+                callback.invoke(fakeDatadogContext) { writerScope ->
                     writerScope.invoke(mockEventBatchWriter)
                 }
             }
@@ -79,25 +76,21 @@ internal class EvaluationEventRecordWriterTest {
         // When
         testedWriter.writeAll(events)
 
-        // Then - all 3 events should be written
+        // Then
         val eventCaptor = argumentCaptor<RawBatchEvent>()
-        verify(mockEventBatchWriter, times(3)).write(
+        verify(mockEventBatchWriter, times(events.size)).write(
             event = eventCaptor.capture(),
             batchMetadata = isNull(),
             eventType = eq(EventType.DEFAULT)
         )
 
-        // Verify each event was serialized correctly
         val capturedEvents = eventCaptor.allValues
-        assertThat(capturedEvents).hasSize(3)
+        assertThat(capturedEvents).hasSize(events.size)
 
-        val expectedJson1 = event1.toJson().toString()
-        val expectedJson2 = event2.toJson().toString()
-        val expectedJson3 = event3.toJson().toString()
-
-        assertThat(String(capturedEvents[0].data, Charsets.UTF_8)).isEqualTo(expectedJson1)
-        assertThat(String(capturedEvents[1].data, Charsets.UTF_8)).isEqualTo(expectedJson2)
-        assertThat(String(capturedEvents[2].data, Charsets.UTF_8)).isEqualTo(expectedJson3)
+        events.withIndex().forEach {
+            val expectedJson = events[it.index].toEvaluationEvent(fakeDatadogContext).toJson().toString()
+            assertThat(String(capturedEvents[it.index].data, Charsets.UTF_8)).isEqualTo(expectedJson)
+        }
     }
 
     @Test
@@ -105,24 +98,22 @@ internal class EvaluationEventRecordWriterTest {
         // When
         testedWriter.writeAll(emptyList())
 
-        // Then - should not interact with SDK Core at all
+        // Then
         verifyNoInteractions(mockSdkCore)
         verifyNoInteractions(mockEventBatchWriter)
     }
 
     @Test
     fun `M do nothing W writeAll() { feature not available }`(
-        @Forgery event1: FlagEvaluation,
-        @Forgery event2: FlagEvaluation
+        @Forgery events: List<EvaluationAggregationStats>
     ) {
         // Given
-        val events = listOf(event1, event2)
         whenever(mockSdkCore.getFeature(Feature.FLAGS_EVALUATIONS_FEATURE_NAME)).thenReturn(null)
 
         // When
         testedWriter.writeAll(events)
 
-        // Then - should not write anything
+        // Then
         verify(mockSdkCore).getFeature(Feature.FLAGS_EVALUATIONS_FEATURE_NAME)
         verifyNoInteractions(mockEventBatchWriter)
     }

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/utils/forge/EvaluationAggregationStatsForgeryFactory.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/utils/forge/EvaluationAggregationStatsForgeryFactory.kt
@@ -1,0 +1,41 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.flags.utils.forge
+
+import com.datadog.android.flags.internal.aggregation.EvaluationAggregationKey
+import com.datadog.android.flags.internal.aggregation.EvaluationAggregationStats
+import com.datadog.android.flags.model.ResolutionReason
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.util.UUID
+
+internal class EvaluationAggregationStatsForgeryFactory : ForgeryFactory<EvaluationAggregationStats> {
+    override fun getForgery(forge: Forge): EvaluationAggregationStats {
+        val reason = forge.aValueFrom(ResolutionReason::class.java)
+        val isDefaultOrError = reason == ResolutionReason.DEFAULT || reason == ResolutionReason.ERROR
+        val hasError = forge.aBool() && (reason == ResolutionReason.ERROR || forge.aBool())
+        val firstEvalTimestamp = forge.aPositiveLong()
+        val lastEvalTimestamp = firstEvalTimestamp + forge.aLong(min = 0, max = 10_000)
+
+        return EvaluationAggregationStats(
+            context = forge.getForgery(),
+            aggregationKey = EvaluationAggregationKey(
+                flagKey = forge.anAlphabeticalString(),
+                variantKey = if (!isDefaultOrError) forge.anAlphabeticalString() else null,
+                allocationKey = if (!isDefaultOrError) forge.anAlphabeticalString() else null,
+                targetingKey = forge.aNullable { anAlphabeticalString() },
+                viewName = forge.aNullable { anAlphabeticalString() },
+                errorCode = if (hasError) forge.anAlphabeticalString() else null
+            ),
+            errorMessage = if (hasError) forge.anAlphabeticalString() else null,
+            count = forge.anInt(min = 1, max = 10_000),
+            firstEvaluation = firstEvalTimestamp,
+            lastEvaluation = lastEvalTimestamp,
+            rumApplicationId = forge.aNullable { getForgery<UUID>().toString() }
+        )
+    }
+}

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/utils/forge/ForgeConfigurator.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/utils/forge/ForgeConfigurator.kt
@@ -22,5 +22,6 @@ internal class ForgeConfigurator : BaseConfigurator() {
         forge.addFactory(PrecomputedFlagForgeryFactory())
         forge.addFactory(FlagEvaluationForgeryFactory())
         forge.addFactory(EvaluationContextForgeryFactory())
+        forge.addFactory(EvaluationAggregationStatsForgeryFactory())
     }
 }


### PR DESCRIPTION
### What does this PR do?

The following code causes a deadlock (we are reading context while it is updated) preventing sample app to start https://github.com/DataDog/dd-sdk-android/blob/b79d67578e5db296828af581546bebb913cde1dc/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationsFeature.kt#L118-L119

This PR fixes it by moving core context read to the event write stage.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

