### PR TITLE
Fix missing error tracking in resolve() API

### DIFF
--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/DatadogFlagsClient.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/DatadogFlagsClient.kt
@@ -169,6 +169,7 @@ internal class DatadogFlagsClient(
                 createSuccessResolution(resolution.flag, resolution.value)
             }
             is InternalResolution.Error -> {
+                trackErrorResolution(resolution)
                 createErrorResolution(
                     flagKey = flagKey,
                     defaultValue = resolution.defaultValue,

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/DatadogFlagsClientTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/DatadogFlagsClientTest.kt
@@ -976,6 +976,100 @@ internal class DatadogFlagsClientTest {
     }
 
     @Test
+    fun `M track error evaluation W resolve() { flag not found and trackEvaluations enabled }`(forge: Forge) {
+        // Given
+        val fakeFlagKey = forge.anAlphabeticalString()
+        val fakeDefaultValue = forge.anInt()
+        val fakeContext = EvaluationContext(
+            targetingKey = forge.anAlphabeticalString(),
+            attributes = emptyMap()
+        )
+        val mockEvaluationsFeature = mock<EvaluationsFeature>()
+
+        whenever(mockFlagsRepository.getPrecomputedFlagWithContext(fakeFlagKey)) doReturn null
+        whenever(mockFlagsRepository.getEvaluationContext()) doReturn fakeContext
+
+        val clientWithEvaluationTracking = DatadogFlagsClient(
+            featureSdkCore = mockFeatureSdkCore,
+            evaluationsManager = mockEvaluationsManager,
+            flagsRepository = mockFlagsRepository,
+            flagsConfiguration = forge.getForgery<FlagsConfiguration>().copy(
+                trackEvaluations = true
+            ),
+            rumEvaluationLogger = mockRumEvaluationLogger,
+            exposureProcessor = mockProcessor,
+            evaluationsFeature = mockEvaluationsFeature,
+            flagStateManager = mockFlagsStateManager
+        )
+
+        // When
+        val result = clientWithEvaluationTracking.resolve(fakeFlagKey, fakeDefaultValue)
+
+        // Then
+        assertThat(result.value).isEqualTo(fakeDefaultValue)
+        assertThat(result.errorCode).isEqualTo(ErrorCode.FLAG_NOT_FOUND)
+
+        // Verify error evaluation was tracked
+        verify(mockEvaluationsFeature).processEvaluation(
+            flagKey = eq(fakeFlagKey),
+            context = eq(fakeContext),
+            variantKey = isNull(),
+            allocationKey = isNull(),
+            errorCode = eq(ErrorCode.FLAG_NOT_FOUND.name),
+            errorMessage = eq("Flag not found")
+        )
+    }
+
+    @Test
+    fun `M track error evaluation W resolve() { type mismatch and trackEvaluations enabled }`(forge: Forge) {
+        // Given
+        val fakeFlagKey = forge.anAlphabeticalString()
+        val fakeDefaultValue = forge.aBool()
+        val fakeFlag = forge.getForgery<PrecomputedFlag>().copy(
+            variationType = VariationType.STRING.value,
+            variationValue = "some-string"
+        )
+        val fakeContext = EvaluationContext(
+            targetingKey = forge.anAlphabeticalString(),
+            attributes = emptyMap()
+        )
+        val mockEvaluationsFeature = mock<EvaluationsFeature>()
+
+        whenever(mockFlagsRepository.getPrecomputedFlagWithContext(fakeFlagKey)) doReturn (fakeFlag to fakeContext)
+        whenever(mockFlagsRepository.getEvaluationContext()) doReturn fakeContext
+
+        val clientWithEvaluationTracking = DatadogFlagsClient(
+            featureSdkCore = mockFeatureSdkCore,
+            evaluationsManager = mockEvaluationsManager,
+            flagsRepository = mockFlagsRepository,
+            flagsConfiguration = forge.getForgery<FlagsConfiguration>().copy(
+                trackEvaluations = true
+            ),
+            rumEvaluationLogger = mockRumEvaluationLogger,
+            exposureProcessor = mockProcessor,
+            evaluationsFeature = mockEvaluationsFeature,
+            flagStateManager = mockFlagsStateManager
+        )
+
+        // When
+        val result = clientWithEvaluationTracking.resolve(fakeFlagKey, fakeDefaultValue)
+
+        // Then
+        assertThat(result.value).isEqualTo(fakeDefaultValue)
+        assertThat(result.errorCode).isEqualTo(ErrorCode.TYPE_MISMATCH)
+
+        // Verify error evaluation was tracked
+        verify(mockEvaluationsFeature).processEvaluation(
+            flagKey = eq(fakeFlagKey),
+            context = eq(fakeContext),
+            variantKey = isNull(),
+            allocationKey = isNull(),
+            errorCode = eq(ErrorCode.TYPE_MISMATCH.name),
+            errorMessage = eq("Flag has type 'string' but Boolean was requested")
+        )
+    }
+
+    @Test
     fun `M track exposure W resolve() { successful resolution and trackExposures enabled }`(forge: Forge) {
         // Given
         val fakeFlagKey = forge.anAlphabeticalString()

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/DatadogFlagsClientTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/DatadogFlagsClientTest.kt
@@ -1021,13 +1021,20 @@ internal class DatadogFlagsClientTest {
     }
 
     @Test
-    fun `M track error evaluation W resolve() { type mismatch and trackEvaluations enabled }`(forge: Forge) {
+    fun `M track success evaluation W resolve() { successful resolution and trackEvaluations enabled }`(forge: Forge) {
         // Given
         val fakeFlagKey = forge.anAlphabeticalString()
-        val fakeDefaultValue = forge.aBool()
+        val fakeDefaultValue = forge.anAlphabeticalString()
+        val fakeFlagValue = forge.anAlphabeticalString()
+        val fakeVariationKey = forge.anAlphabeticalString()
+        val fakeAllocationKey = forge.anAlphabeticalString()
         val fakeFlag = forge.getForgery<PrecomputedFlag>().copy(
             variationType = VariationType.STRING.value,
-            variationValue = "some-string"
+            variationValue = fakeFlagValue,
+            variationKey = fakeVariationKey,
+            allocationKey = fakeAllocationKey,
+            reason = "STATIC",
+            doLog = true
         )
         val fakeContext = EvaluationContext(
             targetingKey = forge.anAlphabeticalString(),
@@ -1036,7 +1043,6 @@ internal class DatadogFlagsClientTest {
         val mockEvaluationsFeature = mock<EvaluationsFeature>()
 
         whenever(mockFlagsRepository.getPrecomputedFlagWithContext(fakeFlagKey)) doReturn (fakeFlag to fakeContext)
-        whenever(mockFlagsRepository.getEvaluationContext()) doReturn fakeContext
 
         val clientWithEvaluationTracking = DatadogFlagsClient(
             featureSdkCore = mockFeatureSdkCore,
@@ -1055,17 +1061,17 @@ internal class DatadogFlagsClientTest {
         val result = clientWithEvaluationTracking.resolve(fakeFlagKey, fakeDefaultValue)
 
         // Then
-        assertThat(result.value).isEqualTo(fakeDefaultValue)
-        assertThat(result.errorCode).isEqualTo(ErrorCode.TYPE_MISMATCH)
+        assertThat(result.value).isEqualTo(fakeFlagValue)
+        assertThat(result.reason).isEqualTo(ResolutionReason.STATIC)
 
-        // Verify error evaluation was tracked
+        // Verify success evaluation was tracked
         verify(mockEvaluationsFeature).processEvaluation(
             flagKey = eq(fakeFlagKey),
             context = eq(fakeContext),
-            variantKey = isNull(),
-            allocationKey = isNull(),
-            errorCode = eq(ErrorCode.TYPE_MISMATCH.name),
-            errorMessage = eq("Flag has type 'string' but Boolean was requested")
+            variantKey = eq(fakeVariationKey),
+            allocationKey = eq(fakeAllocationKey),
+            errorCode = isNull(),
+            errorMessage = isNull()
         )
     }
 


### PR DESCRIPTION
### What does this PR do?

Adds missing `trackErrorResolution()` call in the `resolve(flagKey, defaultValue)` method's error branch, ensuring error evaluations are properly tracked in telemetry.

### Motivation

The `resolve()` method that returns `ResolutionDetails<T>` was not calling `trackErrorResolution()` for error cases (FLAG_NOT_FOUND, TYPE_MISMATCH, PARSE_ERROR, PROVIDER_NOT_READY). This caused:
- Missing/type-mismatched flags to be excluded from evaluation telemetry
- Underreported error rates
- Skewed aggregated evaluation metrics

The convenience methods (`resolveBooleanValue`, `resolveStringValue`, etc.) correctly track errors via `resolveTracked()`, but the detailed `resolve()` API took a different code path that bypassed error tracking.

### Additional Notes

This is a one-line fix that adds the `trackErrorResolution(resolution)` call to match the behavior of the convenience methods. All existing tests pass.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)