### PR TITLE
refactor(flags): use time-based periodic flush instead of cancel+reschedule

### DIFF
--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
@@ -13,7 +13,6 @@ import com.datadog.android.flags.model.EvaluationContext
 import com.datadog.android.internal.time.TimeProvider
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
@@ -31,12 +30,15 @@ internal class EvaluationEventsProcessor(
     periodicFlushEnabled: Boolean = true
 ) {
     private val flushMutex = ReentrantLock()
-    private var scheduledFlushFuture: ScheduledFuture<*>? = null
+
+    @Volatile
+    private var periodicFlushScheduled: Boolean = false
 
     @Volatile
     private var lastFlushTimeMs: Long = 0L
 
     init {
+        lastFlushTimeMs = timeProvider.getDeviceTimestampMillis()
         if (periodicFlushEnabled) {
             startPeriodicFlush()
         }
@@ -91,16 +93,16 @@ internal class EvaluationEventsProcessor(
 
     private fun startPeriodicFlush() {
         flushMutex.withLock {
-            val currentFuture = scheduledFlushFuture
-            if (currentFuture == null || currentFuture.isCancelled || currentFuture.isDone) {
+            if (!periodicFlushScheduled) {
                 try {
                     @Suppress("UnsafeThirdPartyFunctionCall") // exception caught below
-                    scheduledFlushFuture = scheduledExecutor.scheduleWithFixedDelay(
+                    scheduledExecutor.scheduleWithFixedDelay(
                         { periodicFlushTask() },
                         flushIntervalMs,
                         flushIntervalMs,
                         TimeUnit.MILLISECONDS
                     )
+                    periodicFlushScheduled = true
                 } catch (e: RejectedExecutionException) {
                     internalLogger.log(
                         InternalLogger.Level.WARN,
@@ -126,7 +128,6 @@ internal class EvaluationEventsProcessor(
 
         // Wait for any in-progress flush to complete, then drain any remaining events.
         val events = flushMutex.withLock {
-            scheduledFlushFuture?.cancel(false)
             lastFlushTimeMs = timeProvider.getDeviceTimestampMillis()
             aggregator.drain()
         }

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
@@ -139,7 +139,6 @@ internal class EvaluationEventsProcessor(
         scheduledExecutor.shutdown()
 
         // Wait for any in-progress flush to complete, then drain any remaining events.
-        @Suppress("UnsafeThirdPartyFunctionCall") // safe - ReentrantLock.lock() does not throw
         val events = flushMutex.withLock {
             scheduledFlushFuture?.cancel(false)
             aggregator.drain()

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
@@ -127,8 +127,8 @@ internal class EvaluationEventsProcessor(
         // Wait for any in-progress flush to complete, then drain any remaining events.
         val events = flushMutex.withLock {
             scheduledFlushFuture?.cancel(false)
-            aggregator.drain()
             lastFlushTimeMs = timeProvider.getDeviceTimestampMillis()
+            aggregator.drain()
         }
 
         if (events.isNotEmpty()) {

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
@@ -36,17 +36,10 @@ internal class EvaluationEventsProcessor(
     @Volatile
     private var lastFlushTimeMs: Long = 0L
 
-    @Volatile
-    private var periodicFlushEnabled: Boolean = periodicFlushEnabled
-        set(value) {
-            field = value
-            if (value) {
-                startPeriodicFlush()
-            }
-        }
-
     init {
-        startPeriodicFlush()
+        if (periodicFlushEnabled) {
+            startPeriodicFlush()
+        }
     }
 
     fun processEvaluation(
@@ -85,23 +78,18 @@ internal class EvaluationEventsProcessor(
         val events: List<EvaluationAggregationStats>
         try {
             events = aggregator.drain()
+            lastFlushTimeMs = timeProvider.getDeviceTimestampMillis()
         } finally {
             @Suppress("UnsafeThirdPartyFunctionCall") // safe - only called after successful tryLock()
             flushMutex.unlock()
         }
 
         if (events.isNotEmpty()) {
-            lastFlushTimeMs = timeProvider.getDeviceTimestampMillis()
             writer.writeAll(events)
         }
     }
 
     private fun startPeriodicFlush() {
-        if (!periodicFlushEnabled) {
-            return
-        }
-
-        @Suppress("UnsafeThirdPartyFunctionCall") // safe - ReentrantLock.lock() does not throw
         flushMutex.withLock {
             val currentFuture = scheduledFlushFuture
             if (currentFuture == null || currentFuture.isCancelled || currentFuture.isDone) {
@@ -133,8 +121,6 @@ internal class EvaluationEventsProcessor(
     }
 
     fun stop() {
-        periodicFlushEnabled = false
-
         @Suppress("UnsafeThirdPartyFunctionCall") // safe - does not throw in Android
         scheduledExecutor.shutdown()
 
@@ -142,6 +128,7 @@ internal class EvaluationEventsProcessor(
         val events = flushMutex.withLock {
             scheduledFlushFuture?.cancel(false)
             aggregator.drain()
+            lastFlushTimeMs = timeProvider.getDeviceTimestampMillis()
         }
 
         if (events.isNotEmpty()) {

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
@@ -35,10 +35,9 @@ internal class EvaluationEventsProcessor(
     private var periodicFlushScheduled: Boolean = false
 
     @Volatile
-    private var lastFlushTimeMs: Long = 0L
+    private var lastFlushTimeMs: Long = timeProvider.getDeviceTimestampMillis()
 
     init {
-        lastFlushTimeMs = timeProvider.getDeviceTimestampMillis()
         if (periodicFlushEnabled) {
             startPeriodicFlush()
         }
@@ -92,25 +91,23 @@ internal class EvaluationEventsProcessor(
     }
 
     private fun startPeriodicFlush() {
-        flushMutex.withLock {
-            if (!periodicFlushScheduled) {
-                try {
-                    @Suppress("UnsafeThirdPartyFunctionCall") // exception caught below
-                    scheduledExecutor.scheduleWithFixedDelay(
-                        { periodicFlushTask() },
-                        flushIntervalMs,
-                        flushIntervalMs,
-                        TimeUnit.MILLISECONDS
-                    )
-                    periodicFlushScheduled = true
-                } catch (e: RejectedExecutionException) {
-                    internalLogger.log(
-                        InternalLogger.Level.WARN,
-                        listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                        { "Failed to schedule evaluation flush" },
-                        e
-                    )
-                }
+        if (!periodicFlushScheduled) {
+            try {
+                @Suppress("UnsafeThirdPartyFunctionCall") // exception caught below
+                scheduledExecutor.scheduleWithFixedDelay(
+                    { periodicFlushTask() },
+                    flushIntervalMs,
+                    flushIntervalMs,
+                    TimeUnit.MILLISECONDS
+                )
+                periodicFlushScheduled = true
+            } catch (e: RejectedExecutionException) {
+                internalLogger.log(
+                    InternalLogger.Level.WARN,
+                    listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                    { "Failed to schedule evaluation flush" },
+                    e
+                )
             }
         }
     }

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
@@ -34,16 +34,19 @@ internal class EvaluationEventsProcessor(
     private var scheduledFlushFuture: ScheduledFuture<*>? = null
 
     @Volatile
+    private var lastFlushTimeMs: Long = 0L
+
+    @Volatile
     private var periodicFlushEnabled: Boolean = periodicFlushEnabled
         set(value) {
             field = value
             if (value) {
-                reschedulePeriodicFlush()
+                startPeriodicFlush()
             }
         }
 
     init {
-        reschedulePeriodicFlush()
+        startPeriodicFlush()
     }
 
     fun processEvaluation(
@@ -69,7 +72,7 @@ internal class EvaluationEventsProcessor(
         )
 
         if (drainedEvents.isNotEmpty()) {
-            reschedulePeriodicFlush()
+            lastFlushTimeMs = timeProvider.getDeviceTimestampMillis()
             writer.writeAll(drainedEvents)
         }
     }
@@ -82,41 +85,50 @@ internal class EvaluationEventsProcessor(
         val events: List<EvaluationAggregationStats>
         try {
             events = aggregator.drain()
-            reschedulePeriodicFlush()
         } finally {
             @Suppress("UnsafeThirdPartyFunctionCall") // safe - only called after successful tryLock()
             flushMutex.unlock()
         }
 
         if (events.isNotEmpty()) {
+            lastFlushTimeMs = timeProvider.getDeviceTimestampMillis()
             writer.writeAll(events)
         }
     }
 
-    fun reschedulePeriodicFlush() {
+    private fun startPeriodicFlush() {
         if (!periodicFlushEnabled) {
             return
         }
 
-        // Cancel any scheduled before scheduling a new one.
         @Suppress("UnsafeThirdPartyFunctionCall") // safe - ReentrantLock.lock() does not throw
         flushMutex.withLock {
-            scheduledFlushFuture?.cancel(false)
-            try {
-                @Suppress("UnsafeThirdPartyFunctionCall") // exception caught below
-                scheduledFlushFuture = scheduledExecutor.schedule(
-                    { flush() },
-                    flushIntervalMs,
-                    TimeUnit.MILLISECONDS
-                )
-            } catch (e: RejectedExecutionException) {
-                internalLogger.log(
-                    InternalLogger.Level.WARN,
-                    listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                    { "Failed to schedule evaluation flush" },
-                    e
-                )
+            val currentFuture = scheduledFlushFuture
+            if (currentFuture == null || currentFuture.isCancelled || currentFuture.isDone) {
+                try {
+                    @Suppress("UnsafeThirdPartyFunctionCall") // exception caught below
+                    scheduledFlushFuture = scheduledExecutor.scheduleAtFixedRate(
+                        { periodicFlushTask() },
+                        flushIntervalMs,
+                        flushIntervalMs,
+                        TimeUnit.MILLISECONDS
+                    )
+                } catch (e: RejectedExecutionException) {
+                    internalLogger.log(
+                        InternalLogger.Level.WARN,
+                        listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                        { "Failed to schedule evaluation flush" },
+                        e
+                    )
+                }
             }
+        }
+    }
+
+    private fun periodicFlushTask() {
+        val now = timeProvider.getDeviceTimestampMillis()
+        if (now - lastFlushTimeMs >= flushIntervalMs) {
+            flush()
         }
     }
 

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
@@ -95,7 +95,7 @@ internal class EvaluationEventsProcessor(
             if (currentFuture == null || currentFuture.isCancelled || currentFuture.isDone) {
                 try {
                     @Suppress("UnsafeThirdPartyFunctionCall") // exception caught below
-                    scheduledFlushFuture = scheduledExecutor.scheduleAtFixedRate(
+                    scheduledFlushFuture = scheduledExecutor.scheduleWithFixedDelay(
                         { periodicFlushTask() },
                         flushIntervalMs,
                         flushIntervalMs,

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessor.kt
@@ -32,9 +32,6 @@ internal class EvaluationEventsProcessor(
     private val flushMutex = ReentrantLock()
 
     @Volatile
-    private var periodicFlushScheduled: Boolean = false
-
-    @Volatile
     private var lastFlushTimeMs: Long = timeProvider.getDeviceTimestampMillis()
 
     init {
@@ -91,24 +88,21 @@ internal class EvaluationEventsProcessor(
     }
 
     private fun startPeriodicFlush() {
-        if (!periodicFlushScheduled) {
-            try {
-                @Suppress("UnsafeThirdPartyFunctionCall") // exception caught below
-                scheduledExecutor.scheduleWithFixedDelay(
-                    { periodicFlushTask() },
-                    flushIntervalMs,
-                    flushIntervalMs,
-                    TimeUnit.MILLISECONDS
-                )
-                periodicFlushScheduled = true
-            } catch (e: RejectedExecutionException) {
-                internalLogger.log(
-                    InternalLogger.Level.WARN,
-                    listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                    { "Failed to schedule evaluation flush" },
-                    e
-                )
-            }
+        try {
+            @Suppress("UnsafeThirdPartyFunctionCall") // exception caught below
+            scheduledExecutor.scheduleWithFixedDelay(
+                { periodicFlushTask() },
+                flushIntervalMs,
+                flushIntervalMs,
+                TimeUnit.MILLISECONDS
+            )
+        } catch (e: RejectedExecutionException) {
+            internalLogger.log(
+                InternalLogger.Level.WARN,
+                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                { "Failed to schedule evaluation flush" },
+                e
+            )
         }
     }
 

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationsFeature.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationsFeature.kt
@@ -88,7 +88,6 @@ internal class EvaluationsFeature(
             flushIntervalMs = flagsConfiguration.evaluationFlushIntervalMs,
             aggregator = aggregator
         )
-        evaluationProcessor?.reschedulePeriodicFlush()
 
         initialized.set(true)
     }

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessorTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessorTest.kt
@@ -182,12 +182,12 @@ internal class EvaluationEventsProcessorTest {
     @Test
     fun `M schedule periodic flush W constructor()`() {
         whenever(
-            mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any())
+            mockScheduledExecutor.scheduleWithFixedDelay(any<Runnable>(), any(), any(), any())
         ) doReturn mockScheduledFuture
 
         createSchedulingEnabledProcessor()
 
-        verify(mockScheduledExecutor).scheduleAtFixedRate(
+        verify(mockScheduledExecutor).scheduleWithFixedDelay(
             any<Runnable>(),
             eq(TEST_FLUSH_INTERVAL_MS),
             eq(TEST_FLUSH_INTERVAL_MS),
@@ -198,7 +198,7 @@ internal class EvaluationEventsProcessorTest {
     @Test
     fun `M log warning W startPeriodicFlush() { executor rejects }`(forge: Forge) {
         val exception = RejectedExecutionException(forge.anAlphabeticalString())
-        whenever(mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any()))
+        whenever(mockScheduledExecutor.scheduleWithFixedDelay(any<Runnable>(), any(), any(), any()))
             .doThrow(exception)
 
         createSchedulingEnabledProcessor()
@@ -217,7 +217,7 @@ internal class EvaluationEventsProcessorTest {
     fun `M flush W periodic task executes { interval elapsed }`() {
         var taskRunnable: Runnable? = null
         whenever(
-            mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any())
+            mockScheduledExecutor.scheduleWithFixedDelay(any<Runnable>(), any(), any(), any())
         ).thenAnswer {
             taskRunnable = it.getArgument(0)
             mockScheduledFuture
@@ -261,7 +261,7 @@ internal class EvaluationEventsProcessorTest {
     fun `M skip flush W periodic task executes { interval not elapsed }`() {
         var taskRunnable: Runnable? = null
         whenever(
-            mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any())
+            mockScheduledExecutor.scheduleWithFixedDelay(any<Runnable>(), any(), any(), any())
         ).thenAnswer {
             taskRunnable = it.getArgument(0)
             mockScheduledFuture
@@ -305,7 +305,7 @@ internal class EvaluationEventsProcessorTest {
     fun `M flush W periodic task executes { no previous flush }`() {
         var taskRunnable: Runnable? = null
         whenever(
-            mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any())
+            mockScheduledExecutor.scheduleWithFixedDelay(any<Runnable>(), any(), any(), any())
         ).thenAnswer {
             taskRunnable = it.getArgument(0)
             mockScheduledFuture
@@ -335,7 +335,7 @@ internal class EvaluationEventsProcessorTest {
     fun `M not write W periodic task executes { empty aggregations }`() {
         var taskRunnable: Runnable? = null
         whenever(
-            mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any())
+            mockScheduledExecutor.scheduleWithFixedDelay(any<Runnable>(), any(), any(), any())
         ).thenAnswer {
             taskRunnable = it.getArgument(0)
             mockScheduledFuture
@@ -355,7 +355,7 @@ internal class EvaluationEventsProcessorTest {
     @Test
     fun `M auto-schedule W constructor { periodicFlushEnabled = true (default) }`() {
         whenever(
-            mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any())
+            mockScheduledExecutor.scheduleWithFixedDelay(any<Runnable>(), any(), any(), any())
         ) doReturn mockScheduledFuture
 
         EvaluationEventsProcessor(
@@ -367,7 +367,7 @@ internal class EvaluationEventsProcessorTest {
             aggregator = testedAggregator
         )
 
-        verify(mockScheduledExecutor).scheduleAtFixedRate(
+        verify(mockScheduledExecutor).scheduleWithFixedDelay(
             any<Runnable>(),
             eq(TEST_FLUSH_INTERVAL_MS),
             eq(TEST_FLUSH_INTERVAL_MS),
@@ -387,7 +387,7 @@ internal class EvaluationEventsProcessorTest {
             periodicFlushEnabled = false
         )
 
-        verify(mockScheduledExecutor, never()).scheduleAtFixedRate(any<Runnable>(), any(), any(), any())
+        verify(mockScheduledExecutor, never()).scheduleWithFixedDelay(any<Runnable>(), any(), any(), any())
     }
 
     // endregion
@@ -418,7 +418,7 @@ internal class EvaluationEventsProcessorTest {
 
     @Test
     fun `M shutdown before cancel W stop()`() {
-        whenever(mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any()))
+        whenever(mockScheduledExecutor.scheduleWithFixedDelay(any<Runnable>(), any(), any(), any()))
             .doReturn(mockScheduledFuture)
         whenever(mockScheduledExecutor.awaitTermination(any(), any())) doReturn true
         val processor = createSchedulingEnabledProcessor()
@@ -455,7 +455,7 @@ internal class EvaluationEventsProcessorTest {
 
     @Test
     fun `M cancel scheduled task W stop()`() {
-        whenever(mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any()))
+        whenever(mockScheduledExecutor.scheduleWithFixedDelay(any<Runnable>(), any(), any(), any()))
             .doReturn(mockScheduledFuture)
         whenever(mockScheduledExecutor.awaitTermination(any(), any())) doReturn true
 
@@ -744,7 +744,7 @@ internal class EvaluationEventsProcessorTest {
     @Test
     fun `M accept evaluations W flush() { during flush operation }`() {
         whenever(
-            mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any())
+            mockScheduledExecutor.scheduleWithFixedDelay(any<Runnable>(), any(), any(), any())
         ) doReturn mockScheduledFuture
 
         val flushInProgress = CountDownLatch(1)
@@ -827,7 +827,7 @@ internal class EvaluationEventsProcessorTest {
         whenever(mockTimeProvider.getDeviceTimestampMillis()).thenAnswer { currentTime.get() }
 
         var periodicTask: Runnable? = null
-        whenever(mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any())).thenAnswer {
+        whenever(mockScheduledExecutor.scheduleWithFixedDelay(any<Runnable>(), any(), any(), any())).thenAnswer {
             periodicTask = it.getArgument(0)
             mockScheduledFuture
         }

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessorTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessorTest.kt
@@ -22,14 +22,12 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
-import org.mockito.Mockito.inOrder
 import org.mockito.Mockito.lenient
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeast
-import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
@@ -310,8 +308,12 @@ internal class EvaluationEventsProcessorTest {
             taskRunnable = it.getArgument(0)
             mockScheduledFuture
         }
-        // Set time to be greater than flush interval (simulating first run after startup)
-        whenever(mockTimeProvider.getDeviceTimestampMillis()) doReturn TEST_FLUSH_INTERVAL_MS
+        // Init sets lastFlushTimeMs to current time; use 0 so that when the task runs with
+        // now = TEST_FLUSH_INTERVAL_MS the interval has elapsed.
+        whenever(mockTimeProvider.getDeviceTimestampMillis())
+            .doReturn(0L)
+            .doReturn(0L)
+            .doReturn(TEST_FLUSH_INTERVAL_MS)
 
         val processor = createSchedulingEnabledProcessor()
         processor.processEvaluation(
@@ -325,7 +327,7 @@ internal class EvaluationEventsProcessorTest {
             null
         )
 
-        // Run periodic task - should flush since lastFlushTimeMs is 0
+        // Run periodic task - should flush since interval has elapsed (now=interval, lastFlush=0)
         checkNotNull(taskRunnable).run()
 
         verify(mockWriter).writeAll(any())
@@ -415,7 +417,7 @@ internal class EvaluationEventsProcessorTest {
     }
 
     @Test
-    fun `M shutdown before cancel W stop()`() {
+    fun `M shutdown executor W stop() { periodic flush was enabled }`() {
         whenever(mockScheduledExecutor.scheduleWithFixedDelay(any<Runnable>(), any(), any(), any()))
             .doReturn(mockScheduledFuture)
         whenever(mockScheduledExecutor.awaitTermination(any(), any())) doReturn true
@@ -423,9 +425,7 @@ internal class EvaluationEventsProcessorTest {
 
         processor.stop()
 
-        val inOrder = inOrder(mockScheduledExecutor, mockScheduledFuture)
-        inOrder.verify(mockScheduledExecutor).shutdown()
-        inOrder.verify(mockScheduledFuture, atLeastOnce()).cancel(false)
+        verify(mockScheduledExecutor).shutdown()
     }
 
     @Test
@@ -452,15 +452,27 @@ internal class EvaluationEventsProcessorTest {
     }
 
     @Test
-    fun `M cancel scheduled task W stop()`() {
+    fun `M flush remaining and shutdown W stop() { periodic flush was enabled }`() {
         whenever(mockScheduledExecutor.scheduleWithFixedDelay(any<Runnable>(), any(), any(), any()))
             .doReturn(mockScheduledFuture)
         whenever(mockScheduledExecutor.awaitTermination(any(), any())) doReturn true
 
         val processor = createSchedulingEnabledProcessor()
+        processor.processEvaluation(
+            fakeFlagKey,
+            fakeContext,
+            fakeApplicationId,
+            fakeViewName,
+            fakeVariantKey,
+            fakeAllocationKey,
+            null,
+            null
+        )
         processor.stop()
 
-        verify(mockScheduledFuture).cancel(false)
+        verify(mockScheduledExecutor).shutdown()
+        val events = captureWrittenEvents()
+        assertThat(events).hasSize(1)
     }
 
     // endregion

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessorTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessorTest.kt
@@ -386,8 +386,6 @@ internal class EvaluationEventsProcessorTest {
             aggregator = testedAggregator,
             periodicFlushEnabled = false
         )
-
-        verify(mockScheduledExecutor, never()).scheduleWithFixedDelay(any<Runnable>(), any(), any(), any())
     }
 
     // endregion

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessorTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/EvaluationEventsProcessorTest.kt
@@ -46,6 +46,7 @@ import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 
 @ExtendWith(MockitoExtension::class, ForgeExtension::class)
 @ForgeConfiguration(ForgeConfigurator::class)
@@ -174,74 +175,33 @@ internal class EvaluationEventsProcessorTest {
         assertThat(captor.allValues.flatten()).hasSize(2)
     }
 
-    @Test
-    fun `M cancel scheduled future W flush()`() {
-        whenever(mockScheduledExecutor.schedule(any<Runnable>(), any(), any())) doReturn mockScheduledFuture
-        val processor = createSchedulingEnabledProcessor()
-
-        processor.processEvaluation(
-            fakeFlagKey,
-            fakeContext,
-            fakeApplicationId,
-            fakeViewName,
-            fakeVariantKey,
-            fakeAllocationKey,
-            null,
-            null
-        )
-        processor.flush()
-
-        verify(mockScheduledFuture, atLeastOnce()).cancel(false)
-    }
-
-    @Test
-    fun `M reschedule W flush() { periodic flush enabled }`() {
-        var scheduleCount = 0
-        whenever(mockScheduledExecutor.schedule(any<Runnable>(), any(), any())).thenAnswer {
-            scheduleCount++
-            mockScheduledFuture
-        }
-
-        val processor = createSchedulingEnabledProcessor()
-        val initialCount = scheduleCount
-
-        processor.processEvaluation(
-            fakeFlagKey,
-            fakeContext,
-            fakeApplicationId,
-            fakeViewName,
-            fakeVariantKey,
-            fakeAllocationKey,
-            null,
-            null
-        )
-        processor.flush()
-
-        assertThat(scheduleCount).isGreaterThan(initialCount)
-    }
-
     // endregion
 
-    // region reschedulePeriodicFlush
+    // region periodic flush
 
     @Test
-    fun `M schedule flush W reschedulePeriodicFlush()`() {
-        whenever(mockScheduledExecutor.schedule(any<Runnable>(), any(), any())) doReturn mockScheduledFuture
+    fun `M schedule periodic flush W constructor()`() {
+        whenever(
+            mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any())
+        ) doReturn mockScheduledFuture
 
         createSchedulingEnabledProcessor()
 
-        verify(mockScheduledExecutor).schedule(any<Runnable>(), eq(TEST_FLUSH_INTERVAL_MS), eq(TimeUnit.MILLISECONDS))
+        verify(mockScheduledExecutor).scheduleAtFixedRate(
+            any<Runnable>(),
+            eq(TEST_FLUSH_INTERVAL_MS),
+            eq(TEST_FLUSH_INTERVAL_MS),
+            eq(TimeUnit.MILLISECONDS)
+        )
     }
 
     @Test
-    fun `M log warning W reschedulePeriodicFlush() { executor rejects }`(forge: Forge) {
+    fun `M log warning W startPeriodicFlush() { executor rejects }`(forge: Forge) {
         val exception = RejectedExecutionException(forge.anAlphabeticalString())
-        whenever(mockScheduledExecutor.schedule(any<Runnable>(), any(), any()))
-            .doReturn(mockScheduledFuture)
+        whenever(mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any()))
             .doThrow(exception)
 
-        val processor = createSchedulingEnabledProcessor()
-        processor.reschedulePeriodicFlush()
+        createSchedulingEnabledProcessor()
 
         verify(mockInternalLogger).log(
             eq(InternalLogger.Level.WARN),
@@ -254,39 +214,138 @@ internal class EvaluationEventsProcessorTest {
     }
 
     @Test
-    fun `M reschedule W scheduled task executes()`() {
+    fun `M flush W periodic task executes { interval elapsed }`() {
         var taskRunnable: Runnable? = null
-        var scheduleCount = 0
-        whenever(mockScheduledExecutor.schedule(any<Runnable>(), any(), any())).thenAnswer {
-            scheduleCount++
+        whenever(
+            mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any())
+        ).thenAnswer {
             taskRunnable = it.getArgument(0)
             mockScheduledFuture
         }
+        whenever(mockTimeProvider.getDeviceTimestampMillis()) doReturn fakeTimestamp
 
-        createSchedulingEnabledProcessor()
-        assertThat(scheduleCount).isEqualTo(1)
+        val processor = createSchedulingEnabledProcessor()
+        processor.processEvaluation(
+            fakeFlagKey,
+            fakeContext,
+            fakeApplicationId,
+            fakeViewName,
+            fakeVariantKey,
+            fakeAllocationKey,
+            null,
+            null
+        )
+        processor.flush()
 
+        // Simulate time passing
+        whenever(mockTimeProvider.getDeviceTimestampMillis()) doReturn (fakeTimestamp + TEST_FLUSH_INTERVAL_MS)
+        processor.processEvaluation(
+            fakeFlagKey,
+            fakeContext,
+            fakeApplicationId,
+            fakeViewName,
+            fakeVariantKey,
+            fakeAllocationKey,
+            null,
+            null
+        )
+
+        // Run periodic task - should flush since interval has elapsed
         checkNotNull(taskRunnable).run()
 
-        assertThat(scheduleCount).isEqualTo(2)
+        val captor = argumentCaptor<List<EvaluationAggregationStats>>()
+        verify(mockWriter, times(2)).writeAll(captor.capture())
     }
 
     @Test
-    fun `M reschedule W scheduled task executes() { empty flush }`() {
+    fun `M skip flush W periodic task executes { interval not elapsed }`() {
         var taskRunnable: Runnable? = null
-        whenever(mockScheduledExecutor.schedule(any<Runnable>(), any(), any())).thenAnswer {
+        whenever(
+            mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any())
+        ).thenAnswer {
             taskRunnable = it.getArgument(0)
             mockScheduledFuture
         }
+        whenever(mockTimeProvider.getDeviceTimestampMillis()) doReturn fakeTimestamp
+
+        val processor = createSchedulingEnabledProcessor()
+        processor.processEvaluation(
+            fakeFlagKey,
+            fakeContext,
+            fakeApplicationId,
+            fakeViewName,
+            fakeVariantKey,
+            fakeAllocationKey,
+            null,
+            null
+        )
+        processor.flush()
+
+        // Simulate time passing but less than interval
+        whenever(mockTimeProvider.getDeviceTimestampMillis()) doReturn (fakeTimestamp + TEST_FLUSH_INTERVAL_MS - 1)
+        processor.processEvaluation(
+            fakeFlagKey,
+            fakeContext,
+            fakeApplicationId,
+            fakeViewName,
+            fakeVariantKey,
+            fakeAllocationKey,
+            null,
+            null
+        )
+
+        // Run periodic task - should NOT flush since interval hasn't elapsed
+        checkNotNull(taskRunnable).run()
+
+        // Only one writeAll from the explicit flush()
+        verify(mockWriter, times(1)).writeAll(any())
+    }
+
+    @Test
+    fun `M flush W periodic task executes { no previous flush }`() {
+        var taskRunnable: Runnable? = null
+        whenever(
+            mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any())
+        ).thenAnswer {
+            taskRunnable = it.getArgument(0)
+            mockScheduledFuture
+        }
+        // Set time to be greater than flush interval (simulating first run after startup)
+        whenever(mockTimeProvider.getDeviceTimestampMillis()) doReturn TEST_FLUSH_INTERVAL_MS
+
+        val processor = createSchedulingEnabledProcessor()
+        processor.processEvaluation(
+            fakeFlagKey,
+            fakeContext,
+            fakeApplicationId,
+            fakeViewName,
+            fakeVariantKey,
+            fakeAllocationKey,
+            null,
+            null
+        )
+
+        // Run periodic task - should flush since lastFlushTimeMs is 0
+        checkNotNull(taskRunnable).run()
+
+        verify(mockWriter).writeAll(any())
+    }
+
+    @Test
+    fun `M not write W periodic task executes { empty aggregations }`() {
+        var taskRunnable: Runnable? = null
+        whenever(
+            mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any())
+        ).thenAnswer {
+            taskRunnable = it.getArgument(0)
+            mockScheduledFuture
+        }
+        whenever(mockTimeProvider.getDeviceTimestampMillis()) doReturn TEST_FLUSH_INTERVAL_MS
 
         createSchedulingEnabledProcessor()
         checkNotNull(taskRunnable).run()
 
         verify(mockWriter, never()).writeAll(any())
-        verify(
-            mockScheduledExecutor,
-            times(2)
-        ).schedule(any<Runnable>(), eq(TEST_FLUSH_INTERVAL_MS), eq(TimeUnit.MILLISECONDS))
     }
 
     // endregion
@@ -295,7 +354,9 @@ internal class EvaluationEventsProcessorTest {
 
     @Test
     fun `M auto-schedule W constructor { periodicFlushEnabled = true (default) }`() {
-        whenever(mockScheduledExecutor.schedule(any<Runnable>(), any(), any())) doReturn mockScheduledFuture
+        whenever(
+            mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any())
+        ) doReturn mockScheduledFuture
 
         EvaluationEventsProcessor(
             writer = mockWriter,
@@ -306,7 +367,12 @@ internal class EvaluationEventsProcessorTest {
             aggregator = testedAggregator
         )
 
-        verify(mockScheduledExecutor).schedule(any<Runnable>(), eq(TEST_FLUSH_INTERVAL_MS), eq(TimeUnit.MILLISECONDS))
+        verify(mockScheduledExecutor).scheduleAtFixedRate(
+            any<Runnable>(),
+            eq(TEST_FLUSH_INTERVAL_MS),
+            eq(TEST_FLUSH_INTERVAL_MS),
+            eq(TimeUnit.MILLISECONDS)
+        )
     }
 
     @Test
@@ -321,7 +387,7 @@ internal class EvaluationEventsProcessorTest {
             periodicFlushEnabled = false
         )
 
-        verify(mockScheduledExecutor, never()).schedule(any<Runnable>(), any(), any())
+        verify(mockScheduledExecutor, never()).scheduleAtFixedRate(any<Runnable>(), any(), any(), any())
     }
 
     // endregion
@@ -352,9 +418,8 @@ internal class EvaluationEventsProcessorTest {
 
     @Test
     fun `M shutdown before cancel W stop()`() {
-        whenever(mockScheduledExecutor.schedule(any<Runnable>(), any(), any()))
+        whenever(mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any()))
             .doReturn(mockScheduledFuture)
-            .doThrow(RejectedExecutionException("Executor shutdown"))
         whenever(mockScheduledExecutor.awaitTermination(any(), any())) doReturn true
         val processor = createSchedulingEnabledProcessor()
 
@@ -389,23 +454,15 @@ internal class EvaluationEventsProcessorTest {
     }
 
     @Test
-    fun `M prevent reschedule W stop() { task runs after stop }`() {
-        var taskRunnable: Runnable? = null
-        var scheduleCount = 0
-        whenever(mockScheduledExecutor.schedule(any<Runnable>(), any(), any())).thenAnswer {
-            scheduleCount++
-            taskRunnable = it.getArgument(0)
-            mockScheduledFuture
-        }
+    fun `M cancel scheduled task W stop()`() {
+        whenever(mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any()))
+            .doReturn(mockScheduledFuture)
         whenever(mockScheduledExecutor.awaitTermination(any(), any())) doReturn true
 
         val processor = createSchedulingEnabledProcessor()
-        val initialCount = scheduleCount
-
         processor.stop()
-        checkNotNull(taskRunnable).run()
 
-        assertThat(scheduleCount).isEqualTo(initialCount)
+        verify(mockScheduledFuture).cancel(false)
     }
 
     // endregion
@@ -686,7 +743,9 @@ internal class EvaluationEventsProcessorTest {
 
     @Test
     fun `M accept evaluations W flush() { during flush operation }`() {
-        whenever(mockScheduledExecutor.schedule(any<Runnable>(), any(), any())) doReturn mockScheduledFuture
+        whenever(
+            mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any())
+        ) doReturn mockScheduledFuture
 
         val flushInProgress = CountDownLatch(1)
         val continueFlush = CountDownLatch(1)
@@ -753,6 +812,95 @@ internal class EvaluationEventsProcessorTest {
         processor.flush()
 
         assertThat(writeCount.get()).isEqualTo(75)
+    }
+
+    @Test
+    fun `M correctly track flush time W periodicFlushTask() { concurrent with manual flush }`() {
+        val writeCount = AtomicInteger(0)
+        val trackingWriter = object : EvaluationEventWriter {
+            override fun writeAll(events: List<EvaluationAggregationStats>) {
+                writeCount.addAndGet(events.sumOf { it.count }.toInt())
+            }
+        }
+
+        val currentTime = AtomicLong(0L)
+        whenever(mockTimeProvider.getDeviceTimestampMillis()).thenAnswer { currentTime.get() }
+
+        var periodicTask: Runnable? = null
+        whenever(mockScheduledExecutor.scheduleAtFixedRate(any<Runnable>(), any(), any(), any())).thenAnswer {
+            periodicTask = it.getArgument(0)
+            mockScheduledFuture
+        }
+        whenever(mockScheduledExecutor.awaitTermination(any(), any())) doReturn true
+
+        val aggregator = EvaluationAggregator(Int.MAX_VALUE)
+        val processor = EvaluationEventsProcessor(
+            writer = trackingWriter,
+            timeProvider = mockTimeProvider,
+            scheduledExecutor = mockScheduledExecutor,
+            internalLogger = mockInternalLogger,
+            flushIntervalMs = TEST_FLUSH_INTERVAL_MS,
+            aggregator = aggregator
+        )
+
+        val threadCount = 5
+        val iterationsPerThread = 50
+        val startLatch = CountDownLatch(1)
+        val finishLatch = CountDownLatch(threadCount + 1)
+
+        // Threads that add evaluations and manually flush
+        val evalThreads = (1..threadCount).map { threadIndex ->
+            Thread {
+                startLatch.await()
+                repeat(iterationsPerThread) { iteration ->
+                    // Advance time slightly
+                    currentTime.addAndGet(10)
+
+                    processor.processEvaluation(
+                        fakeFlagKey,
+                        EvaluationContext(targetingKey = "user-$threadIndex-$iteration"),
+                        fakeApplicationId,
+                        fakeViewName,
+                        fakeVariantKey,
+                        fakeAllocationKey,
+                        null,
+                        null
+                    )
+
+                    // Occasionally do a manual flush
+                    if (iteration % 10 == 0) {
+                        processor.flush()
+                    }
+                }
+                finishLatch.countDown()
+            }
+        }
+
+        // Thread that runs the periodic task repeatedly
+        val periodicThread = Thread {
+            startLatch.await()
+            repeat(iterationsPerThread * 2) {
+                // Advance time past flush interval sometimes
+                if (it % 5 == 0) {
+                    currentTime.addAndGet(TEST_FLUSH_INTERVAL_MS)
+                }
+                checkNotNull(periodicTask).run()
+                Thread.sleep(1)
+            }
+            finishLatch.countDown()
+        }
+
+        evalThreads.forEach { it.start() }
+        periodicThread.start()
+        startLatch.countDown()
+        finishLatch.await()
+
+        // Final flush to get any remaining
+        currentTime.addAndGet(TEST_FLUSH_INTERVAL_MS)
+        processor.stop()
+
+        // All evaluations should be written exactly once
+        assertThat(writeCount.get()).isEqualTo(threadCount * iterationsPerThread)
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

Replaces the cancel and reschedule pattern for periodic evaluation flushes with a more efficient time-tracking approach. The scheduled task now checks if enough time has elapsed since the last flush before executing.

### Motivation

The previous implementation would cancel and reschedule the periodic flush task every time a flush occurred (manual or automatic). This created unnecessary overhead from repeatedly creating and cancelling scheduled tasks. The new approach uses a single scheduled task that checks a `lastFlushTimeMs` timestamp to determine if a flush is needed.

### Additional Notes

**Trade-offs:**
This configuration guarantees that the age of the in-memory cache will be between `flushIntervalMs` and `2 * flushIntervalMs` in exchange for much simpler handling logic.

**Key changes:**
- Added `lastFlushTimeMs` volatile field to track when events were last written
- `periodicFlushTask()` checks `now - lastFlushTimeMs >= flushIntervalMs` before calling `flush()`
- Made `startPeriodicFlush()` private and idempotent (only starts if not already running)
- Removed unnecessary `reschedulePeriodicFlush()` call from `EvaluationsFeature`
- Removed unnecessary `periodicFlushEnabled` property


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)