### PR TITLE
RUM-14581: Redirect TraceStructureWriter default output from stderr to stdout

### DIFF
--- a/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/common/writer/TraceStructureWriter.java
+++ b/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/common/writer/TraceStructureWriter.java
@@ -52,7 +52,7 @@ public class TraceStructureWriter implements Writer {
     try {
       String[] args = parseArgs(outputFile);
       String fileName = args[0];
-      this.out = fileName.isEmpty() ? System.err : new PrintStream(new FileOutputStream(fileName));
+      this.out = fileName.isEmpty() ? System.out : new PrintStream(new FileOutputStream(fileName));
       for (int i = 1; i < args.length; i++) {
         switch (args[i].toLowerCase(Locale.ROOT)) {
           case "includeresource":
@@ -172,7 +172,7 @@ public class TraceStructureWriter implements Writer {
 
   @Override
   public void close() {
-    if (out != System.err) {
+    if (out != System.out) {
       out.close();
     }
   }


### PR DESCRIPTION
### What does this PR do?

Changes the default output stream in `TraceStructureWriter` from `System.err` to `System.out`, and updates the `close()` guard accordingly. This eliminates noisy `STANDARD_ERROR` output during test runs.

You can see the difference between [this report](https://gitlab.ddbuild.io/DataDog/dd-sdk-android/-/jobs/1435129194) (before this PR) and the [PR one](https://gitlab.ddbuild.io/DataDog/dd-sdk-android/-/jobs/1442153992).

### Motivation

After #3163 enabled `TestLogEvent.STANDARD_ERROR` in the JUnit configuration, pre-existing `System.err` usage in `TraceStructureWriter` became visible as noisy output during test runs. The trace structure output is informational/debug data, not error output, so it belongs on stdout.

### Additional Notes

- `TraceStructureWriter` is only instantiated by `ListWriter` (a test-only writer), so this has no production impact.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)