### PR TITLE
RUM-14471: Auto-forward TTID to next activity for interstitial pattern

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -701,21 +701,61 @@ internal class RumFeature(
             listener = object : RumAppStartupDetector.Listener {
                 private val rumFirstDrawTimeReporter = RumFirstDrawTimeReporter.create(sdkCore = sdkCore)
 
-                override fun onAppStartupDetected(scenario: RumStartupScenario) {
-                    val activity = scenario.activity.get() ?: return
-                    val rumMonitor = (GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor) ?: return
+                override fun onAppStartupDetected(scenario: RumStartupScenario): Boolean {
+                    val activity = scenario.activity.get()
+                    val rumMonitor = GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor
+                    if (activity == null || rumMonitor == null) return false
 
                     rumMonitor.sendAppStartEvent(scenario)
 
+                    val capturedScenario = scenario
                     val callback = object : RumFirstDrawTimeReporter.Callback {
                         override fun onFirstFrameDrawn(timestampNs: Long) {
+                            // Another activity may have already reported TTID
+                            val pending = rumAppStartupDetector?.getPendingScenario()
+                            if (pending !== capturedScenario) return
+
                             val durationNs = timestampNs - scenario.initialTime.nanoTime
                             val info = RumTTIDInfo(
                                 scenario = scenario,
-                                durationNs = durationNs
+                                durationNs = durationNs,
+                                wasForwarded = false
                             )
 
                             rumMonitor.sendTTIDEvent(info)
+                            rumAppStartupDetector?.clearPendingScenario()
+                        }
+                    }
+
+                    rumFirstDrawTimeReporter.subscribeToFirstFrameDrawn(
+                        activity = activity,
+                        callback = callback
+                    )
+                    return true
+                }
+
+                override fun onNextActivityCreated(
+                    pendingScenario: RumStartupScenario,
+                    activity: Activity
+                ) {
+                    val rumMonitor = (GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor) ?: return
+
+                    val capturedScenario = pendingScenario
+                    val callback = object : RumFirstDrawTimeReporter.Callback {
+                        override fun onFirstFrameDrawn(timestampNs: Long) {
+                            // Another activity may have already reported TTID
+                            val pending = rumAppStartupDetector?.getPendingScenario()
+                            if (pending !== capturedScenario) return
+
+                            val durationNs = timestampNs - pendingScenario.initialTime.nanoTime
+                            val info = RumTTIDInfo(
+                                scenario = pendingScenario,
+                                durationNs = durationNs,
+                                wasForwarded = true
+                            )
+
+                            rumMonitor.sendTTIDEvent(info)
+                            rumAppStartupDetector?.clearPendingScenario()
                         }
                     }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -701,37 +701,12 @@ internal class RumFeature(
             listener = object : RumAppStartupDetector.Listener {
                 private val rumFirstDrawTimeReporter = RumFirstDrawTimeReporter.create(sdkCore = sdkCore)
 
-                override fun onAppStartupDetected(scenario: RumStartupScenario): Boolean {
-                    val activity = scenario.activity.get()
-                    val rumMonitor = GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor
-                    if (activity == null || rumMonitor == null) return false
+                override fun onAppStartupDetected(scenario: RumStartupScenario) {
+                    val activity = scenario.activity.get() ?: return
+                    val rumMonitor = GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor ?: return
 
                     rumMonitor.sendAppStartEvent(scenario)
-
-                    val capturedScenario = scenario
-                    val callback = object : RumFirstDrawTimeReporter.Callback {
-                        override fun onFirstFrameDrawn(timestampNs: Long) {
-                            // Another activity may have already reported TTID
-                            val pending = rumAppStartupDetector?.getPendingScenario()
-                            if (pending !== capturedScenario) return
-
-                            val durationNs = timestampNs - scenario.initialTime.nanoTime
-                            val info = RumTTIDInfo(
-                                scenario = scenario,
-                                durationNs = durationNs,
-                                wasForwarded = false
-                            )
-
-                            rumMonitor.sendTTIDEvent(info)
-                            rumAppStartupDetector?.clearPendingScenario()
-                        }
-                    }
-
-                    rumFirstDrawTimeReporter.subscribeToFirstFrameDrawn(
-                        activity = activity,
-                        callback = callback
-                    )
-                    return true
+                    subscribeToFirstFrameDrawn(scenario, activity, rumMonitor, wasForwarded = false)
                 }
 
                 override fun onNextActivityCreated(
@@ -739,19 +714,26 @@ internal class RumFeature(
                     activity: Activity
                 ) {
                     val rumMonitor = (GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor) ?: return
+                    subscribeToFirstFrameDrawn(pendingScenario, activity, rumMonitor, wasForwarded = true)
+                }
 
-                    val capturedScenario = pendingScenario
+                private fun subscribeToFirstFrameDrawn(
+                    scenario: RumStartupScenario,
+                    activity: Activity,
+                    rumMonitor: AdvancedRumMonitor,
+                    wasForwarded: Boolean
+                ) {
                     val callback = object : RumFirstDrawTimeReporter.Callback {
                         override fun onFirstFrameDrawn(timestampNs: Long) {
                             // Another activity may have already reported TTID
                             val pending = rumAppStartupDetector?.getPendingScenario()
-                            if (pending !== capturedScenario) return
+                            if (pending !== scenario) return
 
-                            val durationNs = timestampNs - pendingScenario.initialTime.nanoTime
+                            val durationNs = timestampNs - scenario.initialTime.nanoTime
                             val info = RumTTIDInfo(
-                                scenario = pendingScenario,
+                                scenario = scenario,
                                 durationNs = durationNs,
-                                wasForwarded = true
+                                wasForwarded = wasForwarded
                             )
 
                             rumMonitor.sendTTIDEvent(info)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetector.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetector.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.startup
 
+import android.app.Activity
 import android.app.Application
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.internal.system.BuildSdkVersionProvider
@@ -15,10 +16,19 @@ import com.datadog.android.rum.startup.AppStartupActivityPredicate
 
 internal interface RumAppStartupDetector {
     interface Listener {
-        fun onAppStartupDetected(scenario: RumStartupScenario)
+        /**
+         * Called when a startup scenario is detected.
+         * @return true if the listener successfully subscribed to the first frame draw,
+         * false if it was unable to (e.g. activity already GC'd, RUM monitor unavailable).
+         * The detector uses this to decide whether to keep or discard pendingScenario.
+         */
+        fun onAppStartupDetected(scenario: RumStartupScenario): Boolean
+        fun onNextActivityCreated(pendingScenario: RumStartupScenario, activity: Activity)
     }
 
     fun destroy()
+    fun getPendingScenario(): RumStartupScenario?
+    fun clearPendingScenario()
 
     companion object {
         fun create(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetector.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetector.kt
@@ -18,11 +18,8 @@ internal interface RumAppStartupDetector {
     interface Listener {
         /**
          * Called when a startup scenario is detected.
-         * @return true if the listener successfully subscribed to the first frame draw,
-         * false if it was unable to (e.g. activity already GC'd, RUM monitor unavailable).
-         * The detector uses this to decide whether to keep or discard pendingScenario.
          */
-        fun onAppStartupDetected(scenario: RumStartupScenario): Boolean
+        fun onAppStartupDetected(scenario: RumStartupScenario)
         fun onNextActivityCreated(pendingScenario: RumStartupScenario, activity: Activity)
     }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImpl.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImpl.kt
@@ -11,6 +11,7 @@ import android.app.Application
 import android.os.Bundle
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.rum.internal.domain.Time
+import com.datadog.android.rum.internal.startup.RumSessionScopeStartupManagerImpl.Companion.MAX_TTID_DURATION_NS
 import com.datadog.android.rum.startup.AppStartupActivityPredicate
 import java.lang.ref.WeakReference
 import java.util.Collections
@@ -82,6 +83,15 @@ internal class RumAppStartupDetectorImpl(
 
         if (shouldTrackStartup) {
             trackedActivities.add(activity)
+        }
+
+        // Clear a stale pending scenario so a re-launch in the same process
+        // is not blocked by an interstitial that never forwarded TTID.
+        val stalePending = pendingScenario
+        if (stalePending != null &&
+            now.nanoTime - stalePending.initialTime.nanoTime > MAX_TTID_DURATION_NS
+        ) {
+            pendingScenario = null
         }
 
         val isFirstTrackedActivityWithNoPendingStartup =

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImpl.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImpl.kt
@@ -29,6 +29,7 @@ internal class RumAppStartupDetectorImpl(
     private var numberOfActivities: Int = 0
     private var isChangingConfigurations: Boolean = false
     private var isFirstActivityForProcess: Boolean = true
+    private var pendingScenario: RumStartupScenario? = null
 
     @Suppress("UnsafeThirdPartyFunctionCall") // map is initialized empty
     private val trackedActivities = Collections.newSetFromMap(WeakHashMap<Activity, Boolean>())
@@ -83,7 +84,13 @@ internal class RumAppStartupDetectorImpl(
             trackedActivities.add(activity)
         }
 
-        if (trackedActivities.size == 1 && !isChangingConfigurations && shouldTrackStartup) {
+        val isFirstTrackedActivityWithNoPendingStartup =
+            trackedActivities.size == 1 &&
+                !isChangingConfigurations &&
+                shouldTrackStartup &&
+                pendingScenario == null
+
+        if (isFirstTrackedActivityWithNoPendingStartup) {
             val processStartTime = appStartupTimeProvider()
 
             val gapNs = now.nanoTime - processStartTime.nanoTime
@@ -114,12 +121,31 @@ internal class RumAppStartupDetectorImpl(
                 )
             }
 
-            listener.onAppStartupDetected(scenario)
+            pendingScenario = scenario
+            if (!listener.onAppStartupDetected(scenario)) {
+                pendingScenario = null
+            }
             isFirstActivityForProcess = false
+        }
+
+        // If a pending scenario exists and this is a different qualifying activity,
+        // notify the listener so it can subscribe to this activity's first frame too.
+        val currentPendingScenario = pendingScenario
+        if (currentPendingScenario != null && shouldTrackStartup &&
+            currentPendingScenario.activity.get() !== activity
+        ) {
+            listener.onNextActivityCreated(currentPendingScenario, activity)
         }
     }
 
+    override fun getPendingScenario(): RumStartupScenario? = pendingScenario
+
+    override fun clearPendingScenario() {
+        pendingScenario = null
+    }
+
     override fun destroy() {
+        pendingScenario = null
         application.unregisterActivityLifecycleCallbacks(this)
     }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImpl.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImpl.kt
@@ -122,9 +122,7 @@ internal class RumAppStartupDetectorImpl(
             }
 
             pendingScenario = scenario
-            if (!listener.onAppStartupDetected(scenario)) {
-                pendingScenario = null
-            }
+            listener.onAppStartupDetected(scenario)
             isFirstActivityForProcess = false
         }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupTelemetryReporterImpl.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupTelemetryReporterImpl.kt
@@ -32,6 +32,7 @@ internal class RumAppStartupTelemetryReporterImpl(
                     put(KEY_PROCESS_START_IMPORTANCE, processStartImportance)
 
                     put(KEY_HAS_SAVED_INSTANCE_STATE, info.scenario.hasSavedInstanceStateBundle)
+                    put(KEY_WAS_FORWARDED, info.wasForwarded)
 
                     info.scenario.appStartActivityOnCreateGapNs?.let {
                         put(KEY_GAP_NS, it)
@@ -56,6 +57,7 @@ internal class RumAppStartupTelemetryReporterImpl(
         const val KEY_CP_PROCESS_START_DIFF_NS: String = "cp_process_start_diff_ns"
         const val KEY_PROCESS_START_IMPORTANCE = "process_start_importance"
         const val KEY_HAS_SAVED_INSTANCE_STATE = "has_saved_instance_state"
+        const val KEY_WAS_FORWARDED = "was_forwarded"
 
         private const val SAMPLING_RATE = 15.0f
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumTTIDInfo.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumTTIDInfo.kt
@@ -8,5 +8,6 @@ package com.datadog.android.rum.internal.startup
 
 internal data class RumTTIDInfo(
     val scenario: RumStartupScenario,
-    val durationNs: Long
+    val durationNs: Long,
+    val wasForwarded: Boolean = false
 )

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureStartupDetectorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureStartupDetectorTest.kt
@@ -162,7 +162,7 @@ internal class RumFeatureStartupDetectorTest {
     }
 
     @Test
-    fun `M return false and do nothing W onAppStartupDetected + activity GCd`() {
+    fun `M do nothing W onAppStartupDetected + activity GCd`() {
         // Given
         testedFeature.onInitialize(appContext.mockInstance)
 
@@ -178,16 +178,15 @@ internal class RumFeatureStartupDetectorTest {
         )
 
         // When
-        val result = listener.onAppStartupDetected(fakeScenario)
+        listener.onAppStartupDetected(fakeScenario)
 
         // Then
-        assertThat(result).isFalse()
         verify(mockRumMonitor, never()).sendAppStartEvent(any())
         verify(mockFirstDrawReporter, never()).subscribeToFirstFrameDrawn(any(), any())
     }
 
     @Test
-    fun `M return false and do nothing W onAppStartupDetected + monitor not AdvancedRumMonitor`() {
+    fun `M do nothing W onAppStartupDetected + monitor not AdvancedRumMonitor`() {
         // Given
         testedFeature.onInitialize(appContext.mockInstance)
 
@@ -209,10 +208,9 @@ internal class RumFeatureStartupDetectorTest {
         )
 
         // When
-        val result = listener.onAppStartupDetected(fakeScenario)
+        listener.onAppStartupDetected(fakeScenario)
 
         // Then
-        assertThat(result).isFalse()
         verify(mockFirstDrawReporter, never()).subscribeToFirstFrameDrawn(any(), any())
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureStartupDetectorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureStartupDetectorTest.kt
@@ -1,0 +1,442 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal
+
+import android.app.Activity
+import android.app.Application
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.rum.GlobalRumMonitor
+import com.datadog.android.rum.RumMonitor
+import com.datadog.android.rum.internal.domain.Time
+import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
+import com.datadog.android.rum.internal.startup.RumAppStartupDetector
+import com.datadog.android.rum.internal.startup.RumAppStartupDetectorImpl
+import com.datadog.android.rum.internal.startup.RumFirstDrawTimeReporter
+import com.datadog.android.rum.internal.startup.RumStartupScenario
+import com.datadog.android.rum.internal.startup.RumTTIDInfo
+import com.datadog.android.rum.utils.config.ApplicationContextTestConfiguration
+import com.datadog.android.rum.utils.config.MainLooperTestConfiguration
+import com.datadog.android.rum.utils.forge.Configurator
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import com.datadog.tools.unit.getFieldValue
+import com.datadog.tools.unit.setFieldValue
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import java.lang.ref.WeakReference
+import java.util.UUID
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class RumFeatureStartupDetectorTest {
+
+    private lateinit var testedFeature: RumFeature
+
+    @Forgery
+    lateinit var fakeApplicationId: UUID
+
+    @Forgery
+    lateinit var fakeConfiguration: RumFeature.Configuration
+
+    @Mock
+    lateinit var mockSdkCore: InternalSdkCore
+
+    @Mock
+    lateinit var mockRumMonitor: AdvancedRumMonitor
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @Mock
+    lateinit var mockLateCrashReporter: LateCrashReporter
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
+        whenever(mockSdkCore.timeProvider) doReturn mock()
+        whenever(mockSdkCore.createScheduledExecutorService(any())) doReturn mock()
+
+        val mockContentResolver = mock<android.content.ContentResolver>()
+        whenever(appContext.mockInstance.contentResolver) doReturn mockContentResolver
+        doNothing().whenever(appContext.mockInstance).registerComponentCallbacks(any())
+        doNothing().whenever(appContext.mockInstance).unregisterComponentCallbacks(any())
+
+        val mockResources = mock<android.content.res.Resources>()
+        whenever(appContext.mockInstance.resources) doReturn mockResources
+        whenever(mockResources.configuration) doReturn mock()
+
+        testedFeature = RumFeature(
+            mockSdkCore,
+            fakeApplicationId.toString(),
+            fakeConfiguration,
+            lateCrashReporterFactory = { mockLateCrashReporter }
+        )
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
+    }
+
+    @AfterEach
+    fun `tear down`() {
+        GlobalRumMonitor.clear()
+    }
+
+    // region onAppStartupDetected
+
+    @Test
+    fun `M send TTID with wasForwarded=false W onAppStartupDetected + first frame drawn`() {
+        // Given
+        testedFeature.onInitialize(appContext.mockInstance)
+
+        val listener = extractStartupDetectorListener()
+        val mockFirstDrawReporter = replaceFirstDrawReporterWithMock(listener)
+        val mockDetector = replaceDetectorWithMock()
+
+        val fakeActivity = mock<Activity>()
+        val fakeTime = Time(nanoTime = 100_000L)
+        val fakeScenario = RumStartupScenario.Cold(
+            hasSavedInstanceStateBundle = false,
+            activity = WeakReference(fakeActivity),
+            appStartActivityOnCreateGapNs = 0L,
+            initialTime = fakeTime
+        )
+
+        whenever(mockDetector.getPendingScenario()) doReturn fakeScenario
+
+        val callbackCaptor = argumentCaptor<RumFirstDrawTimeReporter.Callback>()
+
+        // When
+        listener.onAppStartupDetected(fakeScenario)
+
+        // Then — sendAppStartEvent should be called
+        verify(mockRumMonitor).sendAppStartEvent(fakeScenario)
+
+        verify(mockFirstDrawReporter).subscribeToFirstFrameDrawn(
+            eq(fakeActivity),
+            callbackCaptor.capture()
+        )
+
+        // When — simulate first frame drawn
+        val fakeTimestampNs = 200_000L
+        callbackCaptor.firstValue.onFirstFrameDrawn(fakeTimestampNs)
+
+        // Then
+        val ttidInfoCaptor = argumentCaptor<RumTTIDInfo>()
+        verify(mockRumMonitor).sendTTIDEvent(ttidInfoCaptor.capture())
+
+        val ttidInfo = ttidInfoCaptor.firstValue
+        assertThat(ttidInfo.scenario).isSameAs(fakeScenario)
+        assertThat(ttidInfo.durationNs).isEqualTo(fakeTimestampNs - fakeTime.nanoTime)
+        assertThat(ttidInfo.wasForwarded).isFalse()
+        verify(mockDetector).clearPendingScenario()
+    }
+
+    @Test
+    fun `M return false and do nothing W onAppStartupDetected + activity GCd`() {
+        // Given
+        testedFeature.onInitialize(appContext.mockInstance)
+
+        val listener = extractStartupDetectorListener()
+        val mockFirstDrawReporter = replaceFirstDrawReporterWithMock(listener)
+
+        val fakeTime = Time(nanoTime = 100_000L)
+        val fakeScenario = RumStartupScenario.Cold(
+            hasSavedInstanceStateBundle = false,
+            activity = WeakReference(null), // GC'd — get() returns null
+            appStartActivityOnCreateGapNs = 0L,
+            initialTime = fakeTime
+        )
+
+        // When
+        val result = listener.onAppStartupDetected(fakeScenario)
+
+        // Then
+        assertThat(result).isFalse()
+        verify(mockRumMonitor, never()).sendAppStartEvent(any())
+        verify(mockFirstDrawReporter, never()).subscribeToFirstFrameDrawn(any(), any())
+    }
+
+    @Test
+    fun `M return false and do nothing W onAppStartupDetected + monitor not AdvancedRumMonitor`() {
+        // Given
+        testedFeature.onInitialize(appContext.mockInstance)
+
+        val listener = extractStartupDetectorListener()
+        val mockFirstDrawReporter = replaceFirstDrawReporterWithMock(listener)
+
+        // Replace the registered AdvancedRumMonitor with a plain RumMonitor
+        // so the cast in onAppStartupDetected returns null
+        GlobalRumMonitor.clear()
+        GlobalRumMonitor.registerIfAbsent(mock<RumMonitor>(), mockSdkCore)
+
+        val fakeActivity = mock<Activity>()
+        val fakeTime = Time(nanoTime = 100_000L)
+        val fakeScenario = RumStartupScenario.Cold(
+            hasSavedInstanceStateBundle = false,
+            activity = WeakReference(fakeActivity),
+            appStartActivityOnCreateGapNs = 0L,
+            initialTime = fakeTime
+        )
+
+        // When
+        val result = listener.onAppStartupDetected(fakeScenario)
+
+        // Then
+        assertThat(result).isFalse()
+        verify(mockFirstDrawReporter, never()).subscribeToFirstFrameDrawn(any(), any())
+    }
+
+    @Test
+    fun `M call sendAppStartEvent only in onAppStartupDetected W startup flow`() {
+        // Given
+        testedFeature.onInitialize(appContext.mockInstance)
+
+        val listener = extractStartupDetectorListener()
+        replaceFirstDrawReporterWithMock(listener)
+        replaceDetectorWithMock()
+
+        val fakeOriginalActivity = mock<Activity>()
+        val fakeForwardedActivity = mock<Activity>()
+        val fakeTime = Time(nanoTime = 100_000L)
+        val fakeScenario = RumStartupScenario.Cold(
+            hasSavedInstanceStateBundle = false,
+            activity = WeakReference(fakeOriginalActivity),
+            appStartActivityOnCreateGapNs = 0L,
+            initialTime = fakeTime
+        )
+
+        // When
+        listener.onAppStartupDetected(fakeScenario)
+
+        // Then — sendAppStartEvent called once
+        verify(mockRumMonitor, times(1)).sendAppStartEvent(fakeScenario)
+
+        // When
+        listener.onNextActivityCreated(fakeScenario, fakeForwardedActivity)
+
+        // Then — still only called once (not from onNextActivityCreated)
+        verify(mockRumMonitor, times(1)).sendAppStartEvent(any())
+    }
+
+    // endregion
+
+    // region onNextActivityCreated
+
+    @Test
+    fun `M send TTID with wasForwarded=true W onNextActivityCreated + first frame drawn`() {
+        // Given
+        testedFeature.onInitialize(appContext.mockInstance)
+
+        val listener = extractStartupDetectorListener()
+        val mockFirstDrawReporter = replaceFirstDrawReporterWithMock(listener)
+        val mockDetector = replaceDetectorWithMock()
+
+        val fakeOriginalActivity = mock<Activity>()
+        val fakeForwardedActivity = mock<Activity>()
+        val fakeTime = Time(nanoTime = 100_000L)
+        val fakeScenario = RumStartupScenario.Cold(
+            hasSavedInstanceStateBundle = false,
+            activity = WeakReference(fakeOriginalActivity),
+            appStartActivityOnCreateGapNs = 0L,
+            initialTime = fakeTime
+        )
+
+        whenever(mockDetector.getPendingScenario()) doReturn fakeScenario
+
+        val callbackCaptor = argumentCaptor<RumFirstDrawTimeReporter.Callback>()
+
+        // When
+        listener.onNextActivityCreated(fakeScenario, fakeForwardedActivity)
+
+        // Then — sendAppStartEvent should NOT be called via onNextActivityCreated
+        verify(mockRumMonitor, times(0)).sendAppStartEvent(any())
+
+        verify(mockFirstDrawReporter).subscribeToFirstFrameDrawn(
+            eq(fakeForwardedActivity),
+            callbackCaptor.capture()
+        )
+
+        // When — simulate first frame drawn
+        val fakeTimestampNs = 200_000L
+        callbackCaptor.firstValue.onFirstFrameDrawn(fakeTimestampNs)
+
+        // Then
+        val ttidInfoCaptor = argumentCaptor<RumTTIDInfo>()
+        verify(mockRumMonitor).sendTTIDEvent(ttidInfoCaptor.capture())
+
+        val ttidInfo = ttidInfoCaptor.firstValue
+        assertThat(ttidInfo.scenario).isSameAs(fakeScenario)
+        assertThat(ttidInfo.durationNs).isEqualTo(fakeTimestampNs - fakeTime.nanoTime)
+        assertThat(ttidInfo.wasForwarded).isTrue()
+        verify(mockDetector).clearPendingScenario()
+    }
+
+    @Test
+    fun `M do nothing W onNextActivityCreated + monitor not AdvancedRumMonitor`() {
+        // Given
+        testedFeature.onInitialize(appContext.mockInstance)
+
+        val listener = extractStartupDetectorListener()
+        val mockFirstDrawReporter = replaceFirstDrawReporterWithMock(listener)
+
+        // Replace the registered AdvancedRumMonitor with a plain RumMonitor
+        // so the cast in onNextActivityCreated returns null
+        GlobalRumMonitor.clear()
+        GlobalRumMonitor.registerIfAbsent(mock<RumMonitor>(), mockSdkCore)
+
+        val fakeForwardedActivity = mock<Activity>()
+        val fakeTime = Time(nanoTime = 100_000L)
+        val fakeScenario = RumStartupScenario.Cold(
+            hasSavedInstanceStateBundle = false,
+            activity = WeakReference(mock()),
+            appStartActivityOnCreateGapNs = 0L,
+            initialTime = fakeTime
+        )
+
+        // When
+        listener.onNextActivityCreated(fakeScenario, fakeForwardedActivity)
+
+        // Then
+        verify(mockFirstDrawReporter, never()).subscribeToFirstFrameDrawn(any(), any())
+    }
+
+    // endregion
+
+    // region duplicate prevention
+
+    @Test
+    fun `M only send TTID once W both original and forwarded activity draw`() {
+        // Given
+        testedFeature.onInitialize(appContext.mockInstance)
+
+        val listener = extractStartupDetectorListener()
+        val mockFirstDrawReporter = replaceFirstDrawReporterWithMock(listener)
+        val mockDetector = replaceDetectorWithMock()
+
+        val fakeOriginalActivity = mock<Activity>()
+        val fakeForwardedActivity = mock<Activity>()
+        val fakeTime = Time(nanoTime = 100_000L)
+        val fakeScenario = RumStartupScenario.Cold(
+            hasSavedInstanceStateBundle = false,
+            activity = WeakReference(fakeOriginalActivity),
+            appStartActivityOnCreateGapNs = 0L,
+            initialTime = fakeTime
+        )
+
+        whenever(mockDetector.getPendingScenario()) doReturn fakeScenario
+
+        val callbackCaptor = argumentCaptor<RumFirstDrawTimeReporter.Callback>()
+
+        // When — trigger both callbacks
+        listener.onAppStartupDetected(fakeScenario)
+        listener.onNextActivityCreated(fakeScenario, fakeForwardedActivity)
+
+        verify(mockFirstDrawReporter, times(2)).subscribeToFirstFrameDrawn(
+            any(),
+            callbackCaptor.capture()
+        )
+
+        val originalCallback = callbackCaptor.allValues[0]
+        val forwardedCallback = callbackCaptor.allValues[1]
+
+        // First draw fires (original activity)
+        originalCallback.onFirstFrameDrawn(200_000L)
+
+        // After first TTID is sent, scenario is cleared
+        verify(mockDetector).clearPendingScenario()
+        whenever(mockDetector.getPendingScenario()) doReturn null
+
+        // Second draw fires (forwarded activity) — should be no-op
+        forwardedCallback.onFirstFrameDrawn(300_000L)
+
+        // Then — sendTTIDEvent should only be called once
+        verify(mockRumMonitor, times(1)).sendTTIDEvent(any())
+    }
+
+    // endregion
+
+    // region helpers
+
+    /**
+     * Extracts the [RumAppStartupDetector.Listener] from the real detector created during
+     * [RumFeature.onInitialize].
+     */
+    private fun extractStartupDetectorListener(): RumAppStartupDetector.Listener {
+        val detector = testedFeature.getFieldValue<RumAppStartupDetector, RumFeature>(
+            "rumAppStartupDetector",
+            RumFeature::class.java
+        )
+        val detectorImpl = detector as RumAppStartupDetectorImpl
+        return detectorImpl.getFieldValue<RumAppStartupDetector.Listener, RumAppStartupDetectorImpl>(
+            "listener",
+            RumAppStartupDetectorImpl::class.java
+        )
+    }
+
+    /**
+     * Replaces the `rumFirstDrawTimeReporter` field inside the anonymous listener with a mock,
+     * so we can capture the [RumFirstDrawTimeReporter.Callback] passed to
+     * [RumFirstDrawTimeReporter.subscribeToFirstFrameDrawn].
+     */
+    private fun replaceFirstDrawReporterWithMock(
+        listener: RumAppStartupDetector.Listener
+    ): RumFirstDrawTimeReporter {
+        val mockReporter = mock<RumFirstDrawTimeReporter>()
+        listener.setFieldValue("rumFirstDrawTimeReporter", mockReporter)
+        return mockReporter
+    }
+
+    /**
+     * Replaces the `rumAppStartupDetector` field on [RumFeature] with a mock so
+     * [RumAppStartupDetector.getPendingScenario] and [RumAppStartupDetector.clearPendingScenario]
+     * can be controlled.
+     */
+    private fun replaceDetectorWithMock(): RumAppStartupDetector {
+        val mockDetector = mock<RumAppStartupDetector>()
+        testedFeature.setFieldValue("rumAppStartupDetector", mockDetector)
+        return mockDetector
+    }
+
+    // endregion
+
+    companion object {
+        val appContext = ApplicationContextTestConfiguration(Application::class.java)
+        private val mainLooper = MainLooperTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(appContext, mainLooper)
+        }
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImplTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImplTest.kt
@@ -71,8 +71,6 @@ internal class RumAppStartupDetectorImplTest {
     @BeforeEach
     fun `set up`() {
         whenever(activity.isChangingConfigurations) doReturn false
-        // Default: listener successfully subscribes to the first frame draw
-        whenever(listener.onAppStartupDetected(any())) doReturn true
     }
 
     @Test
@@ -713,27 +711,6 @@ internal class RumAppStartupDetectorImplTest {
         assertThat(pending).isNotNull
         assertThat(pending).isInstanceOf(RumStartupScenario.Cold::class.java)
         assertThat(pending!!.activity.get()).isSameAs(activity)
-    }
-
-    @Test
-    fun `M not set pendingScenario W onAppStartupDetected listener returns false`(
-        forge: Forge
-    ) {
-        // Given - listener fails to subscribe (e.g. activity GC'd, monitor unavailable)
-        whenever(listener.onAppStartupDetected(any())) doReturn false
-        val detector = createDetector()
-        currentTime += 3.seconds
-
-        // When
-        triggerBeforeCreated(
-            forge = forge,
-            detector = detector,
-            activity = activity,
-            hasSavedInstanceStateBundle = false
-        )
-
-        // Then - pendingScenario must remain null so future startups are not blocked
-        assertThat(detector.getPendingScenario()).isNull()
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImplTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImplTest.kt
@@ -18,6 +18,7 @@ import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -28,8 +29,11 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
@@ -67,6 +71,8 @@ internal class RumAppStartupDetectorImplTest {
     @BeforeEach
     fun `set up`() {
         whenever(activity.isChangingConfigurations) doReturn false
+        // Default: listener successfully subscribes to the first frame draw
+        whenever(listener.onAppStartupDetected(any())) doReturn true
     }
 
     @Test
@@ -155,6 +161,9 @@ internal class RumAppStartupDetectorImplTest {
         )
 
         detector.onActivityDestroyed(activity)
+
+        // Simulate RumFeature reporting TTID and clearing the pending scenario
+        detector.clearPendingScenario()
 
         currentTime += 30.seconds
 
@@ -273,6 +282,7 @@ internal class RumAppStartupDetectorImplTest {
                 appStartActivityOnCreateGapNs = 3.seconds.inWholeNanoseconds
             )
         )
+        verify(listener).onNextActivityCreated(any(), eq(activity2))
         verifyNoMoreInteractions(listener)
     }
 
@@ -300,6 +310,9 @@ internal class RumAppStartupDetectorImplTest {
         detector.onActivityPaused(activity)
         detector.onActivityStopped(activity)
         detector.onActivityDestroyed(activity)
+
+        // Simulate RumFeature reporting TTID and clearing the pending scenario
+        detector.clearPendingScenario()
 
         currentTime += 30.seconds
 
@@ -381,6 +394,9 @@ internal class RumAppStartupDetectorImplTest {
 
         detector.onActivityDestroyed(activity)
 
+        // Simulate RumFeature reporting TTID and clearing the pending scenario
+        detector.clearPendingScenario()
+
         currentTime += 30.seconds
 
         val activity3 = mock<Activity>()
@@ -402,6 +418,8 @@ internal class RumAppStartupDetectorImplTest {
                     initialTime = Time(0, 0)
                 )
             )
+
+            verify(listener).onNextActivityCreated(any(), eq(activity2))
 
             listener.verifyScenarioDetected(
                 RumStartupScenario.WarmAfterActivityDestroyed(
@@ -643,6 +661,9 @@ internal class RumAppStartupDetectorImplTest {
         detector.onActivityStopped(activity1)
         detector.onActivityDestroyed(activity1)
 
+        // Simulate RumFeature reporting TTID and clearing the pending scenario
+        detector.clearPendingScenario()
+
         // When - second activity is created
         currentTime += 1.seconds
 
@@ -668,6 +689,236 @@ internal class RumAppStartupDetectorImplTest {
 
         verifyNoMoreInteractions(listener)
     }
+
+    // region pendingScenario management tests
+
+    @Test
+    fun `M set pendingScenario W onAppStartupDetected`(
+        forge: Forge
+    ) {
+        // Given
+        val detector = createDetector()
+        currentTime += 3.seconds
+
+        // When
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity,
+            hasSavedInstanceStateBundle = false
+        )
+
+        // Then
+        val pending = detector.getPendingScenario()
+        assertThat(pending).isNotNull
+        assertThat(pending).isInstanceOf(RumStartupScenario.Cold::class.java)
+        assertThat(pending!!.activity.get()).isSameAs(activity)
+    }
+
+    @Test
+    fun `M not set pendingScenario W onAppStartupDetected listener returns false`(
+        forge: Forge
+    ) {
+        // Given - listener fails to subscribe (e.g. activity GC'd, monitor unavailable)
+        whenever(listener.onAppStartupDetected(any())) doReturn false
+        val detector = createDetector()
+        currentTime += 3.seconds
+
+        // When
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity,
+            hasSavedInstanceStateBundle = false
+        )
+
+        // Then - pendingScenario must remain null so future startups are not blocked
+        assertThat(detector.getPendingScenario()).isNull()
+    }
+
+    @Test
+    fun `M clear pendingScenario W clearPendingScenario`(
+        forge: Forge
+    ) {
+        // Given
+        val detector = createDetector()
+        currentTime += 3.seconds
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity,
+            hasSavedInstanceStateBundle = false
+        )
+        assertThat(detector.getPendingScenario()).isNotNull
+
+        // When
+        detector.clearPendingScenario()
+
+        // Then
+        assertThat(detector.getPendingScenario()).isNull()
+    }
+
+    @Test
+    fun `M call onNextActivityCreated W second qualifying activity created while pending`(
+        forge: Forge
+    ) {
+        // Given
+        val detector = createDetector()
+        currentTime += 3.seconds
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity,
+            hasSavedInstanceStateBundle = false
+        )
+
+        val secondActivity: Activity = mock()
+
+        // When
+        currentTime += 1.seconds
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = secondActivity,
+            hasSavedInstanceStateBundle = false
+        )
+
+        // Then
+        val capturedScenario = detector.getPendingScenario()
+        verify(listener).onAppStartupDetected(any())
+        verify(listener).onNextActivityCreated(
+            argThat { this === capturedScenario },
+            eq(secondActivity)
+        )
+    }
+
+    @Test
+    fun `M not call onNextActivityCreated W second activity fails predicate`(
+        forge: Forge
+    ) {
+        // Given
+        val secondActivity: Activity = mock()
+        val predicate = AppStartupActivityPredicate { it !== secondActivity }
+        val detector = createDetector(appStartupActivityPredicate = predicate)
+        currentTime += 3.seconds
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity,
+            hasSavedInstanceStateBundle = false
+        )
+
+        // When
+        currentTime += 1.seconds
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = secondActivity,
+            hasSavedInstanceStateBundle = false
+        )
+
+        // Then
+        verify(listener).onAppStartupDetected(any())
+        verify(listener, never()).onNextActivityCreated(any(), any())
+    }
+
+    @Test
+    fun `M not call onNextActivityCreated W same activity as scenario`(
+        forge: Forge
+    ) {
+        // Given
+        val detector = createDetector()
+        currentTime += 3.seconds
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity,
+            hasSavedInstanceStateBundle = false
+        )
+
+        // Then - onNextActivityCreated should not have been called for the original activity
+        verify(listener).onAppStartupDetected(any())
+        verify(listener, never()).onNextActivityCreated(any(), any())
+    }
+
+    @Test
+    fun `M not call onNextActivityCreated W pendingScenario cleared`(
+        forge: Forge
+    ) {
+        // Given
+        val detector = createDetector()
+        currentTime += 3.seconds
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity,
+            hasSavedInstanceStateBundle = false
+        )
+        detector.clearPendingScenario()
+
+        val secondActivity: Activity = mock()
+
+        // When
+        currentTime += 1.seconds
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = secondActivity,
+            hasSavedInstanceStateBundle = false
+        )
+
+        // Then
+        verify(listener).onAppStartupDetected(any())
+        verify(listener, never()).onNextActivityCreated(any(), any())
+    }
+
+    @Test
+    fun `M not emit second startup W first activity destroyed before next created (async interstitial)`(
+        forge: Forge
+    ) {
+        // Given - first activity created, startup detected, then fully destroyed before
+        // the next activity is created (async interstitial pattern: finish() + Handler.postDelayed)
+        val detector = createDetector()
+        currentTime += 3.seconds
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity,
+            hasSavedInstanceStateBundle = false
+        )
+        val originalScenario = detector.getPendingScenario()
+        assertThat(originalScenario).isNotNull
+
+        detector.onActivityStarted(activity)
+        detector.onActivityResumed(activity)
+        detector.onActivityPaused(activity)
+        detector.onActivityStopped(activity)
+        detector.onActivityDestroyed(activity)
+
+        currentTime += 1.seconds
+        val secondActivity: Activity = mock()
+
+        // When - next activity created while pendingScenario still exists
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = secondActivity,
+            hasSavedInstanceStateBundle = false
+        )
+
+        // Then - onAppStartupDetected must NOT be called a second time
+        verify(listener, times(1)).onAppStartupDetected(any())
+        // pendingScenario must still be the original (not replaced by a new scenario)
+        assertThat(detector.getPendingScenario()).isSameAs(originalScenario)
+        // onNextActivityCreated must be called with the original scenario so RumFeature
+        // can subscribe to the second activity's first frame (the async forwarding path)
+        verify(listener).onNextActivityCreated(
+            argThat { this === originalScenario },
+            eq(secondActivity)
+        )
+    }
+
+    // endregion
 
     private fun createDetector(
         appStartupActivityPredicate: AppStartupActivityPredicate = AppStartupActivityPredicate { true }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImplTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImplTest.kt
@@ -11,6 +11,7 @@ import android.app.Application
 import android.os.Bundle
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.rum.internal.domain.Time
+import com.datadog.android.rum.internal.startup.RumSessionScopeStartupManagerImpl.Companion.MAX_TTID_DURATION_NS
 import com.datadog.android.rum.startup.AppStartupActivityPredicate
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -303,11 +304,7 @@ internal class RumAppStartupDetectorImplTest {
         )
 
         // When
-        detector.onActivityStarted(activity)
-        detector.onActivityResumed(activity)
-        detector.onActivityPaused(activity)
-        detector.onActivityStopped(activity)
-        detector.onActivityDestroyed(activity)
+        destroyActivity(detector, activity)
 
         // Simulate RumFeature reporting TTID and clearing the pending scenario
         detector.clearPendingScenario()
@@ -384,11 +381,7 @@ internal class RumAppStartupDetectorImplTest {
             hasSavedInstanceStateBundle = hasSavedInstanceStateBundle2
         )
 
-        detector.onActivityStarted(activity2)
-        detector.onActivityResumed(activity2)
-        detector.onActivityPaused(activity2)
-        detector.onActivityStopped(activity2)
-        detector.onActivityDestroyed(activity2)
+        destroyActivity(detector, activity2)
 
         detector.onActivityDestroyed(activity)
 
@@ -464,11 +457,7 @@ internal class RumAppStartupDetectorImplTest {
         verifyNoMoreInteractions(listener)
 
         // When - interstitial activity is destroyed and main activity is created
-        detector.onActivityStarted(interstitialActivity)
-        detector.onActivityResumed(interstitialActivity)
-        detector.onActivityPaused(interstitialActivity)
-        detector.onActivityStopped(interstitialActivity)
-        detector.onActivityDestroyed(interstitialActivity)
+        destroyActivity(detector, interstitialActivity)
 
         currentTime += 1.seconds
 
@@ -653,11 +642,7 @@ internal class RumAppStartupDetectorImplTest {
         shouldTrackActivity1 = false
 
         // And - activity is destroyed (predicate now returns false, but stored value was true)
-        detector.onActivityStarted(activity1)
-        detector.onActivityResumed(activity1)
-        detector.onActivityPaused(activity1)
-        detector.onActivityStopped(activity1)
-        detector.onActivityDestroyed(activity1)
+        destroyActivity(detector, activity1)
 
         // Simulate RumFeature reporting TTID and clearing the pending scenario
         detector.clearPendingScenario()
@@ -711,6 +696,45 @@ internal class RumAppStartupDetectorImplTest {
         assertThat(pending).isNotNull
         assertThat(pending).isInstanceOf(RumStartupScenario.Cold::class.java)
         assertThat(pending!!.activity.get()).isSameAs(activity)
+    }
+
+    @Test
+    fun `M create fresh startup scenario W stale pendingScenario exists on re-launch`(
+        forge: Forge
+    ) {
+        // Given - first launch creates a pending scenario (e.g. interstitial that never drew)
+        val detector = createDetector()
+        currentTime += 3.seconds
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity,
+            hasSavedInstanceStateBundle = false
+        )
+        val staleScenario = detector.getPendingScenario()
+        assertThat(staleScenario).isNotNull
+
+        // Simulate the interstitial activity being fully destroyed (app goes background)
+        destroyActivity(detector, activity)
+
+        // Advance time beyond the TTID timeout (1 minute)
+        currentTime += MAX_TTID_DURATION_NS.nanoseconds + 1.seconds
+
+        // When - user re-launches the app (new activity in the same process)
+        val secondActivity: Activity = mock()
+        whenever(secondActivity.isChangingConfigurations) doReturn false
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = secondActivity,
+            hasSavedInstanceStateBundle = false
+        )
+
+        // Then - stale scenario was discarded and a fresh one created for the new activity
+        val freshScenario = detector.getPendingScenario()
+        assertThat(freshScenario).isNotNull
+        assertThat(freshScenario).isNotSameAs(staleScenario)
+        assertThat(freshScenario!!.activity.get()).isSameAs(secondActivity)
     }
 
     @Test
@@ -866,11 +890,7 @@ internal class RumAppStartupDetectorImplTest {
         val originalScenario = detector.getPendingScenario()
         assertThat(originalScenario).isNotNull
 
-        detector.onActivityStarted(activity)
-        detector.onActivityResumed(activity)
-        detector.onActivityPaused(activity)
-        detector.onActivityStopped(activity)
-        detector.onActivityDestroyed(activity)
+        destroyActivity(detector, activity)
 
         currentTime += 1.seconds
         val secondActivity: Activity = mock()
@@ -937,6 +957,14 @@ internal class RumAppStartupDetectorImplTest {
         } else {
             detector.onActivityCreated(activity, bundle)
         }
+    }
+
+    private fun destroyActivity(detector: RumAppStartupDetectorImpl, activity: Activity) {
+        detector.onActivityStarted(activity)
+        detector.onActivityResumed(activity)
+        detector.onActivityPaused(activity)
+        detector.onActivityStopped(activity)
+        detector.onActivityDestroyed(activity)
     }
 
     private fun RumAppStartupDetector.Listener.verifyScenarioDetected(expected: RumStartupScenario) {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupTelemetryReporterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupTelemetryReporterTest.kt
@@ -69,9 +69,11 @@ internal class RumAppStartupTelemetryReporterTest {
         // Given
         val appStartIndex = forge.anInt(min = 0)
 
+        val wasForwarded = forge.aBool()
         val info = RumTTIDInfo(
             scenario = scenario,
-            durationNs = forge.aLong(min = 0, max = 10000)
+            durationNs = forge.aLong(min = 0, max = 10000),
+            wasForwarded = wasForwarded
         )
 
         // When
@@ -99,6 +101,8 @@ internal class RumAppStartupTelemetryReporterTest {
                     RumAppStartupTelemetryReporterImpl.KEY_HAS_SAVED_INSTANCE_STATE,
                     info.scenario.hasSavedInstanceStateBundle
                 )
+
+                put(RumAppStartupTelemetryReporterImpl.KEY_WAS_FORWARDED, wasForwarded)
 
                 info.scenario.appStartActivityOnCreateGapNs?.let {
                     put(RumAppStartupTelemetryReporterImpl.KEY_GAP_NS, it)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/AppStartupAsyncAutoForwardingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/AppStartupAsyncAutoForwardingTest.kt
@@ -9,7 +9,6 @@ package com.datadog.android.sdk.integration.rum.startup
 import android.app.Activity
 import android.app.ActivityManager
 import android.app.Application
-import android.os.Bundle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
@@ -138,7 +137,8 @@ internal class AppStartupAsyncAutoForwardingTest :
         ) {
 
         val mainActivityResumed = CountDownLatch(1)
-        private lateinit var mainActivityResumedCallback: Application.ActivityLifecycleCallbacks
+        private var mainActivityResumedCallback: Application.ActivityLifecycleCallbacks =
+            NoOpActivityLifecycleCallbacks()
 
         override fun beforeActivityLaunched() {
             super.beforeActivityLaunched()
@@ -146,16 +146,10 @@ internal class AppStartupAsyncAutoForwardingTest :
                 .targetContext.applicationContext
 
             // Register before the activity launches so we can't miss the RESUMED callback.
-            mainActivityResumedCallback = object : Application.ActivityLifecycleCallbacks {
+            mainActivityResumedCallback = object : NoOpActivityLifecycleCallbacks() {
                 override fun onActivityResumed(activity: Activity) {
                     if (activity is MainContentActivity) mainActivityResumed.countDown()
                 }
-                override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
-                override fun onActivityStarted(activity: Activity) {}
-                override fun onActivityPaused(activity: Activity) {}
-                override fun onActivityStopped(activity: Activity) {}
-                override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
-                override fun onActivityDestroyed(activity: Activity) {}
             }
             (appContext as Application).registerActivityLifecycleCallbacks(mainActivityResumedCallback)
 

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/AppStartupAsyncAutoForwardingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/AppStartupAsyncAutoForwardingTest.kt
@@ -1,0 +1,191 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sdk.integration.rum.startup
+
+import android.app.Activity
+import android.app.ActivityManager
+import android.app.Application
+import android.os.Bundle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.datadog.android.Datadog
+import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.rum.DdRumContentProvider
+import com.datadog.android.rum.Rum
+import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
+import com.datadog.android.sdk.integration.RuntimeConfig
+import com.datadog.android.sdk.integration.rum.AppLaunchMetric
+import com.datadog.android.sdk.integration.rum.ExpectedApplicationLaunchViewEvent
+import com.datadog.android.sdk.integration.rum.ExpectedEvent
+import com.datadog.android.sdk.integration.rum.ExpectedVitalAppLaunchEvent
+import com.datadog.android.sdk.integration.rum.RumTest
+import com.datadog.android.sdk.rules.RumMockServerActivityTestRule
+import com.datadog.tools.unit.ConditionWatcher
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Instrumented test verifying that TTID auto-forwarding works when the interstitial
+ * activity navigates asynchronously (via Handler.post).
+ *
+ * This exercises the deferred retarget path: the interstitial's onDestroy fires
+ * before the next activity's onCreate because startActivity + finish are posted
+ * to the message queue. At destroy time, no next candidate exists, so the detector
+ * must hold the startup scenario and retarget when the next activity is created.
+ *
+ * This test:
+ * 1. Launches AsyncInterstitialSplashActivity (posts startActivity + finish via Handler)
+ * 2. Does NOT configure any predicate (default behavior)
+ * 3. Verifies TTID is reported for MainContentActivity through deferred retarget
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+internal class AppStartupAsyncAutoForwardingTest :
+    RumTest<
+        AsyncInterstitialSplashActivity,
+        AppStartupAsyncAutoForwardingTest.AsyncAutoForwardingTestRule
+        >() {
+
+    @get:Rule
+    val mockServerRule = AsyncAutoForwardingTestRule()
+
+    override fun runInstrumentationScenario(
+        mockServerRule: AsyncAutoForwardingTestRule
+    ): MutableList<ExpectedEvent> {
+        val expectedEvents = mutableListOf<ExpectedEvent>()
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+
+        // The lifecycle callback was registered in beforeActivityLaunched() (before the activity
+        // was launched), so the latch is guaranteed to fire even on fast devices where
+        // MainContentActivity reaches RESUMED before runInstrumentationScenario is called.
+        check(mockServerRule.mainActivityResumed.await(MAIN_ACTIVITY_WAIT_SECONDS, TimeUnit.SECONDS)) {
+            "MainContentActivity did not reach RESUMED state within $MAIN_ACTIVITY_WAIT_SECONDS seconds"
+        }
+        instrumentation.waitForIdleSync()
+        waitForPendingRUMEvents()
+
+        // Expect application launch view for MainContentActivity
+        expectedEvents.add(
+            ExpectedApplicationLaunchViewEvent(
+                docVersion = 2
+            )
+        )
+
+        // TTID should be reported for MainContentActivity via deferred retarget
+        // (AsyncInterstitialSplashActivity was destroyed before MainContentActivity was created)
+        expectedEvents.add(
+            ExpectedVitalAppLaunchEvent(
+                appLaunchMetric = AppLaunchMetric.TTID,
+                viewArguments = mapOf("name" to MainContentActivity::class.java.canonicalName)
+            )
+        )
+
+        expectedEvents.add(
+            ExpectedVitalAppLaunchEvent(
+                appLaunchMetric = AppLaunchMetric.TTFD,
+                viewArguments = mapOf("name" to MainContentActivity::class.java.canonicalName)
+            )
+        )
+
+        instrumentation.waitForIdleSync()
+
+        return expectedEvents
+    }
+
+    @Test
+    fun verifyTTIDAutoForwardedToMainActivityWhenSplashNavigatesAsynchronously() {
+        val expectedEvents = runInstrumentationScenario(mockServerRule)
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        ConditionWatcher {
+            verifyExpectedEvents(
+                mockServerRule.getRequests(RuntimeConfig.rumEndpointUrl),
+                expectedEvents
+            )
+            true
+        }.doWait(timeoutMs = FINAL_WAIT_MS)
+    }
+
+    companion object {
+        private const val MAIN_ACTIVITY_WAIT_SECONDS = 30L
+    }
+
+    /**
+     * Test rule that launches AsyncInterstitialSplashActivity WITHOUT any predicate.
+     * This verifies the deferred retarget mechanism: the interstitial posts
+     * startActivity + finish via Handler, so its onDestroy fires before
+     * MainContentActivity.onCreate, and the detector must hold the startup
+     * scenario until the next tracked activity arrives.
+     *
+     * The [mainActivityResumed] latch is registered in [beforeActivityLaunched], before the
+     * activity is launched, to avoid a race where MainContentActivity reaches RESUMED before
+     * [runInstrumentationScenario] has a chance to register the callback.
+     */
+    internal class AsyncAutoForwardingTestRule :
+        RumMockServerActivityTestRule<AsyncInterstitialSplashActivity>(
+            activityClass = AsyncInterstitialSplashActivity::class.java,
+            keepRequests = true,
+            trackingConsent = TrackingConsent.GRANTED
+        ) {
+
+        val mainActivityResumed = CountDownLatch(1)
+        private lateinit var mainActivityResumedCallback: Application.ActivityLifecycleCallbacks
+
+        override fun beforeActivityLaunched() {
+            super.beforeActivityLaunched()
+            val appContext = InstrumentationRegistry.getInstrumentation()
+                .targetContext.applicationContext
+
+            // Register before the activity launches so we can't miss the RESUMED callback.
+            mainActivityResumedCallback = object : Application.ActivityLifecycleCallbacks {
+                override fun onActivityResumed(activity: Activity) {
+                    if (activity is MainContentActivity) mainActivityResumed.countDown()
+                }
+                override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
+                override fun onActivityStarted(activity: Activity) {}
+                override fun onActivityPaused(activity: Activity) {}
+                override fun onActivityStopped(activity: Activity) {}
+                override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+                override fun onActivityDestroyed(activity: Activity) {}
+            }
+            (appContext as Application).registerActivityLifecycleCallbacks(mainActivityResumedCallback)
+
+            try {
+                val config = RuntimeConfig.configBuilder()
+                    .build()
+
+                val sdkCore = Datadog.initialize(appContext, config, trackingConsent)
+                checkNotNull(sdkCore)
+
+                val rumConfig = RuntimeConfig.rumConfigBuilder()
+                    .trackUserInteractions()
+                    .trackLongTasks(RuntimeConfig.LONG_TASK_LARGE_THRESHOLD)
+                    .useViewTrackingStrategy(ActivityViewTrackingStrategy(false))
+                    // No predicate configured — deferred retarget should handle this
+                    .build()
+                Rum.enable(rumConfig, sdkCore)
+                DdRumContentProvider.processImportance =
+                    ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+            } catch (e: Throwable) {
+                appContext.unregisterActivityLifecycleCallbacks(mainActivityResumedCallback)
+                throw e
+            }
+        }
+
+        override fun afterActivityFinished() {
+            super.afterActivityFinished()
+            val appContext = InstrumentationRegistry.getInstrumentation()
+                .targetContext.applicationContext as Application
+            appContext.unregisterActivityLifecycleCallbacks(mainActivityResumedCallback)
+        }
+    }
+}

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/AppStartupAutoForwardTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/AppStartupAutoForwardTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sdk.integration.rum.startup
+
+import android.app.ActivityManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.datadog.android.Datadog
+import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.rum.DdRumContentProvider
+import com.datadog.android.rum.Rum
+import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
+import com.datadog.android.sdk.integration.RuntimeConfig
+import com.datadog.android.sdk.integration.rum.AppLaunchMetric
+import com.datadog.android.sdk.integration.rum.ExpectedApplicationLaunchViewEvent
+import com.datadog.android.sdk.integration.rum.ExpectedEvent
+import com.datadog.android.sdk.integration.rum.ExpectedVitalAppLaunchEvent
+import com.datadog.android.sdk.integration.rum.RumTest
+import com.datadog.android.sdk.rules.RumMockServerActivityTestRule
+import com.datadog.tools.unit.ConditionWatcher
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented test verifying that TTID is auto-forwarded from an interstitial
+ * activity to the next activity without needing a custom AppStartupActivityPredicate.
+ *
+ * This test:
+ * 1. Launches InterstitialSplashActivity (which immediately starts MainContentActivity and finishes)
+ * 2. Uses default behavior (no predicate configured) — the auto-subscribe mechanism detects
+ *    the interstitial and forwards TTID to MainContentActivity
+ * 3. Verifies TTID is reported for MainContentActivity, not the splash
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+internal class AppStartupAutoForwardTest :
+    RumTest<InterstitialSplashActivity, AppStartupAutoForwardTest.AutoForwardTestRule>() {
+
+    @get:Rule
+    val mockServerRule = AutoForwardTestRule()
+
+    override fun runInstrumentationScenario(
+        mockServerRule: AutoForwardTestRule
+    ): MutableList<ExpectedEvent> {
+        val expectedEvents = mutableListOf<ExpectedEvent>()
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+
+        instrumentation.waitForIdleSync()
+        waitForPendingRUMEvents()
+
+        // Expect application launch view for MainContentActivity (not InterstitialSplashActivity)
+        expectedEvents.add(
+            ExpectedApplicationLaunchViewEvent(
+                docVersion = 2
+            )
+        )
+
+        // Expect TTID to be reported for MainContentActivity
+        // (interstitial was auto-detected and TTID forwarded)
+        expectedEvents.add(
+            ExpectedVitalAppLaunchEvent(
+                appLaunchMetric = AppLaunchMetric.TTID,
+                viewArguments = mapOf("name" to MainContentActivity::class.java.canonicalName)
+            )
+        )
+
+        expectedEvents.add(
+            ExpectedVitalAppLaunchEvent(
+                appLaunchMetric = AppLaunchMetric.TTFD,
+                viewArguments = mapOf("name" to MainContentActivity::class.java.canonicalName)
+            )
+        )
+
+        instrumentation.waitForIdleSync()
+
+        return expectedEvents
+    }
+
+    @Test
+    fun verifyTTIDAutoForwardedFromInterstitialToMainActivity() {
+        val expectedEvents = runInstrumentationScenario(mockServerRule)
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        ConditionWatcher {
+            verifyExpectedEvents(
+                mockServerRule.getRequests(RuntimeConfig.rumEndpointUrl),
+                expectedEvents
+            )
+            true
+        }.doWait(timeoutMs = FINAL_WAIT_MS)
+    }
+
+    /**
+     * Test rule that configures RUM without a custom predicate,
+     * relying on the default auto-forwarding behavior.
+     */
+    internal class AutoForwardTestRule : RumMockServerActivityTestRule<InterstitialSplashActivity>(
+        activityClass = InterstitialSplashActivity::class.java,
+        keepRequests = true,
+        trackingConsent = TrackingConsent.GRANTED
+    ) {
+        override fun beforeActivityLaunched() {
+            super.beforeActivityLaunched()
+            val config = RuntimeConfig.configBuilder()
+                .build()
+
+            val sdkCore = Datadog.initialize(
+                InstrumentationRegistry.getInstrumentation().targetContext.applicationContext,
+                config,
+                trackingConsent
+            )
+            checkNotNull(sdkCore)
+
+            val rumConfig = RuntimeConfig.rumConfigBuilder()
+                .trackUserInteractions()
+                .trackLongTasks(RuntimeConfig.LONG_TASK_LARGE_THRESHOLD)
+                .useViewTrackingStrategy(ActivityViewTrackingStrategy(false))
+                // No predicate configured — rely on default auto-forwarding behavior
+                .build()
+            Rum.enable(rumConfig, sdkCore)
+            DdRumContentProvider.processImportance = ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+        }
+    }
+}

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/AppStartupAutoForwardTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/AppStartupAutoForwardTest.kt
@@ -6,7 +6,9 @@
 
 package com.datadog.android.sdk.integration.rum.startup
 
+import android.app.Activity
 import android.app.ActivityManager
+import android.app.Application
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
@@ -26,6 +28,8 @@ import com.datadog.tools.unit.ConditionWatcher
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * Instrumented test verifying that TTID is auto-forwarded from an interstitial
@@ -51,6 +55,12 @@ internal class AppStartupAutoForwardTest :
         val expectedEvents = mutableListOf<ExpectedEvent>()
         val instrumentation = InstrumentationRegistry.getInstrumentation()
 
+        // The lifecycle callback was registered in beforeActivityLaunched() (before the activity
+        // was launched), so the latch is guaranteed to fire even on slow emulators where
+        // MainContentActivity reaches RESUMED before runInstrumentationScenario is called.
+        check(mockServerRule.mainActivityResumed.await(MAIN_ACTIVITY_WAIT_SECONDS, TimeUnit.SECONDS)) {
+            "MainContentActivity did not reach RESUMED state within $MAIN_ACTIVITY_WAIT_SECONDS seconds"
+        }
         instrumentation.waitForIdleSync()
         waitForPendingRUMEvents()
 
@@ -97,35 +107,66 @@ internal class AppStartupAutoForwardTest :
         }.doWait(timeoutMs = FINAL_WAIT_MS)
     }
 
+    companion object {
+        private const val MAIN_ACTIVITY_WAIT_SECONDS = 30L
+    }
+
     /**
      * Test rule that configures RUM without a custom predicate,
      * relying on the default auto-forwarding behavior.
+     *
+     * The [mainActivityResumed] latch is registered in [beforeActivityLaunched], before the
+     * activity is launched, to avoid a race where MainContentActivity reaches RESUMED before
+     * [runInstrumentationScenario] has a chance to register the callback.
      */
     internal class AutoForwardTestRule : RumMockServerActivityTestRule<InterstitialSplashActivity>(
         activityClass = InterstitialSplashActivity::class.java,
         keepRequests = true,
         trackingConsent = TrackingConsent.GRANTED
     ) {
+        val mainActivityResumed = CountDownLatch(1)
+        private var mainActivityResumedCallback: Application.ActivityLifecycleCallbacks =
+            NoOpActivityLifecycleCallbacks()
+
         override fun beforeActivityLaunched() {
             super.beforeActivityLaunched()
-            val config = RuntimeConfig.configBuilder()
-                .build()
+            val appContext = InstrumentationRegistry.getInstrumentation()
+                .targetContext.applicationContext
 
-            val sdkCore = Datadog.initialize(
-                InstrumentationRegistry.getInstrumentation().targetContext.applicationContext,
-                config,
-                trackingConsent
-            )
-            checkNotNull(sdkCore)
+            mainActivityResumedCallback = object : NoOpActivityLifecycleCallbacks() {
+                override fun onActivityResumed(activity: Activity) {
+                    if (activity is MainContentActivity) mainActivityResumed.countDown()
+                }
+            }
+            (appContext as Application).registerActivityLifecycleCallbacks(mainActivityResumedCallback)
 
-            val rumConfig = RuntimeConfig.rumConfigBuilder()
-                .trackUserInteractions()
-                .trackLongTasks(RuntimeConfig.LONG_TASK_LARGE_THRESHOLD)
-                .useViewTrackingStrategy(ActivityViewTrackingStrategy(false))
-                // No predicate configured — rely on default auto-forwarding behavior
-                .build()
-            Rum.enable(rumConfig, sdkCore)
-            DdRumContentProvider.processImportance = ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+            try {
+                val config = RuntimeConfig.configBuilder()
+                    .build()
+
+                val sdkCore = Datadog.initialize(appContext, config, trackingConsent)
+                checkNotNull(sdkCore)
+
+                val rumConfig = RuntimeConfig.rumConfigBuilder()
+                    .trackUserInteractions()
+                    .trackLongTasks(RuntimeConfig.LONG_TASK_LARGE_THRESHOLD)
+                    .useViewTrackingStrategy(ActivityViewTrackingStrategy(false))
+                    // No predicate configured — rely on default auto-forwarding behavior
+                    .build()
+                Rum.enable(rumConfig, sdkCore)
+                DdRumContentProvider.processImportance =
+                    ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+            } catch (e: Throwable) {
+                appContext.unregisterActivityLifecycleCallbacks(mainActivityResumedCallback)
+                throw e
+            }
+        }
+
+        override fun afterActivityFinished() {
+            super.afterActivityFinished()
+            val appContext = InstrumentationRegistry.getInstrumentation()
+                .targetContext.applicationContext as Application
+            appContext.unregisterActivityLifecycleCallbacks(mainActivityResumedCallback)
         }
     }
 }

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/AppStartupChainedAutoForwardingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/AppStartupChainedAutoForwardingTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sdk.integration.rum.startup
+
+import android.app.ActivityManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.datadog.android.Datadog
+import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.rum.DdRumContentProvider
+import com.datadog.android.rum.Rum
+import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
+import com.datadog.android.sdk.integration.RuntimeConfig
+import com.datadog.android.sdk.integration.rum.AppLaunchMetric
+import com.datadog.android.sdk.integration.rum.ExpectedApplicationLaunchViewEvent
+import com.datadog.android.sdk.integration.rum.ExpectedEvent
+import com.datadog.android.sdk.integration.rum.ExpectedVitalAppLaunchEvent
+import com.datadog.android.sdk.integration.rum.RumTest
+import com.datadog.android.sdk.rules.RumMockServerActivityTestRule
+import com.datadog.tools.unit.ConditionWatcher
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Instrumented test verifying that TTID auto-forwarding works through a chain
+ * of non-drawing interstitial activities.
+ *
+ * The chain is: AuthActivity -> InterstitialSplashActivity -> MainContentActivity.
+ * Neither AuthActivity nor InterstitialSplashActivity draw a frame. The auto-forwarding
+ * must retarget twice before TTID is reported for MainContentActivity.
+ *
+ * This catches bugs where forwarding state is incorrectly cleared after the first
+ * retarget, preventing the second forward from happening.
+ */
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+internal class AppStartupChainedAutoForwardingTest :
+    RumTest<AuthActivity, AppStartupChainedAutoForwardingTest.ChainedAutoForwardingTestRule>() {
+
+    @get:Rule
+    val mockServerRule = ChainedAutoForwardingTestRule()
+
+    override fun runInstrumentationScenario(
+        mockServerRule: ChainedAutoForwardingTestRule
+    ): MutableList<ExpectedEvent> {
+        val expectedEvents = mutableListOf<ExpectedEvent>()
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+
+        instrumentation.waitForIdleSync()
+        waitForPendingRUMEvents()
+
+        expectedEvents.add(
+            ExpectedApplicationLaunchViewEvent(
+                docVersion = 2
+            )
+        )
+
+        // TTID should be reported for MainContentActivity after forwarding through
+        // AuthActivity -> InterstitialSplashActivity -> MainContentActivity
+        expectedEvents.add(
+            ExpectedVitalAppLaunchEvent(
+                appLaunchMetric = AppLaunchMetric.TTID,
+                viewArguments = mapOf("name" to MainContentActivity::class.java.canonicalName)
+            )
+        )
+
+        expectedEvents.add(
+            ExpectedVitalAppLaunchEvent(
+                appLaunchMetric = AppLaunchMetric.TTFD,
+                viewArguments = mapOf("name" to MainContentActivity::class.java.canonicalName)
+            )
+        )
+
+        instrumentation.waitForIdleSync()
+
+        return expectedEvents
+    }
+
+    @Test
+    fun verifyTTIDAutoForwardedThroughChainOfNonDrawingActivities() {
+        val expectedEvents = runInstrumentationScenario(mockServerRule)
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        ConditionWatcher {
+            verifyExpectedEvents(
+                mockServerRule.getRequests(RuntimeConfig.rumEndpointUrl),
+                expectedEvents
+            )
+            true
+        }.doWait(timeoutMs = FINAL_WAIT_MS)
+    }
+
+    /**
+     * Test rule that launches AuthActivity without any predicate.
+     * The chain AuthActivity -> InterstitialSplashActivity -> MainContentActivity
+     * exercises two consecutive auto-forwarding retargets.
+     */
+    internal class ChainedAutoForwardingTestRule : RumMockServerActivityTestRule<AuthActivity>(
+        activityClass = AuthActivity::class.java,
+        keepRequests = true,
+        trackingConsent = TrackingConsent.GRANTED
+    ) {
+        override fun beforeActivityLaunched() {
+            super.beforeActivityLaunched()
+            val config = RuntimeConfig.configBuilder()
+                .build()
+
+            val sdkCore = Datadog.initialize(
+                InstrumentationRegistry.getInstrumentation().targetContext.applicationContext,
+                config,
+                trackingConsent
+            )
+            checkNotNull(sdkCore)
+
+            val rumConfig = RuntimeConfig.rumConfigBuilder()
+                .trackUserInteractions()
+                .trackLongTasks(RuntimeConfig.LONG_TASK_LARGE_THRESHOLD)
+                .useViewTrackingStrategy(ActivityViewTrackingStrategy(false))
+                // No predicate — auto-forwarding should handle the entire chain
+                .build()
+            Rum.enable(rumConfig, sdkCore)
+            DdRumContentProvider.processImportance = ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+        }
+    }
+}

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/AppStartupChainedAutoForwardingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/AppStartupChainedAutoForwardingTest.kt
@@ -6,7 +6,9 @@
 
 package com.datadog.android.sdk.integration.rum.startup
 
+import android.app.Activity
 import android.app.ActivityManager
+import android.app.Application
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
@@ -26,6 +28,8 @@ import com.datadog.tools.unit.ConditionWatcher
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * Instrumented test verifying that TTID auto-forwarding works through a chain
@@ -52,6 +56,12 @@ internal class AppStartupChainedAutoForwardingTest :
         val expectedEvents = mutableListOf<ExpectedEvent>()
         val instrumentation = InstrumentationRegistry.getInstrumentation()
 
+        // The lifecycle callback was registered in beforeActivityLaunched() (before the activity
+        // was launched), so the latch is guaranteed to fire even on slow emulators where
+        // MainContentActivity reaches RESUMED before runInstrumentationScenario is called.
+        check(mockServerRule.mainActivityResumed.await(MAIN_ACTIVITY_WAIT_SECONDS, TimeUnit.SECONDS)) {
+            "MainContentActivity did not reach RESUMED state within $MAIN_ACTIVITY_WAIT_SECONDS seconds"
+        }
         instrumentation.waitForIdleSync()
         waitForPendingRUMEvents()
 
@@ -97,36 +107,67 @@ internal class AppStartupChainedAutoForwardingTest :
         }.doWait(timeoutMs = FINAL_WAIT_MS)
     }
 
+    companion object {
+        private const val MAIN_ACTIVITY_WAIT_SECONDS = 30L
+    }
+
     /**
      * Test rule that launches AuthActivity without any predicate.
      * The chain AuthActivity -> InterstitialSplashActivity -> MainContentActivity
      * exercises two consecutive auto-forwarding retargets.
+     *
+     * The [mainActivityResumed] latch is registered in [beforeActivityLaunched], before the
+     * activity is launched, to avoid a race where MainContentActivity reaches RESUMED before
+     * [runInstrumentationScenario] has a chance to register the callback.
      */
     internal class ChainedAutoForwardingTestRule : RumMockServerActivityTestRule<AuthActivity>(
         activityClass = AuthActivity::class.java,
         keepRequests = true,
         trackingConsent = TrackingConsent.GRANTED
     ) {
+        val mainActivityResumed = CountDownLatch(1)
+        private var mainActivityResumedCallback: Application.ActivityLifecycleCallbacks =
+            NoOpActivityLifecycleCallbacks()
+
         override fun beforeActivityLaunched() {
             super.beforeActivityLaunched()
-            val config = RuntimeConfig.configBuilder()
-                .build()
+            val appContext = InstrumentationRegistry.getInstrumentation()
+                .targetContext.applicationContext
 
-            val sdkCore = Datadog.initialize(
-                InstrumentationRegistry.getInstrumentation().targetContext.applicationContext,
-                config,
-                trackingConsent
-            )
-            checkNotNull(sdkCore)
+            mainActivityResumedCallback = object : NoOpActivityLifecycleCallbacks() {
+                override fun onActivityResumed(activity: Activity) {
+                    if (activity is MainContentActivity) mainActivityResumed.countDown()
+                }
+            }
+            (appContext as Application).registerActivityLifecycleCallbacks(mainActivityResumedCallback)
 
-            val rumConfig = RuntimeConfig.rumConfigBuilder()
-                .trackUserInteractions()
-                .trackLongTasks(RuntimeConfig.LONG_TASK_LARGE_THRESHOLD)
-                .useViewTrackingStrategy(ActivityViewTrackingStrategy(false))
-                // No predicate — auto-forwarding should handle the entire chain
-                .build()
-            Rum.enable(rumConfig, sdkCore)
-            DdRumContentProvider.processImportance = ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+            try {
+                val config = RuntimeConfig.configBuilder()
+                    .build()
+
+                val sdkCore = Datadog.initialize(appContext, config, trackingConsent)
+                checkNotNull(sdkCore)
+
+                val rumConfig = RuntimeConfig.rumConfigBuilder()
+                    .trackUserInteractions()
+                    .trackLongTasks(RuntimeConfig.LONG_TASK_LARGE_THRESHOLD)
+                    .useViewTrackingStrategy(ActivityViewTrackingStrategy(false))
+                    // No predicate — auto-forwarding should handle the entire chain
+                    .build()
+                Rum.enable(rumConfig, sdkCore)
+                DdRumContentProvider.processImportance =
+                    ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+            } catch (e: Throwable) {
+                appContext.unregisterActivityLifecycleCallbacks(mainActivityResumedCallback)
+                throw e
+            }
+        }
+
+        override fun afterActivityFinished() {
+            super.afterActivityFinished()
+            val appContext = InstrumentationRegistry.getInstrumentation()
+                .targetContext.applicationContext as Application
+            appContext.unregisterActivityLifecycleCallbacks(mainActivityResumedCallback)
         }
     }
 }

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/NoOpActivityLifecycleCallbacks.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/NoOpActivityLifecycleCallbacks.kt
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sdk.integration.rum.startup
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+
+/**
+ * No-op base implementation of [Application.ActivityLifecycleCallbacks].
+ * Subclass and override only the callbacks you care about.
+ */
+internal open class NoOpActivityLifecycleCallbacks : Application.ActivityLifecycleCallbacks {
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
+    override fun onActivityStarted(activity: Activity) {}
+    override fun onActivityResumed(activity: Activity) {}
+    override fun onActivityPaused(activity: Activity) {}
+    override fun onActivityStopped(activity: Activity) {}
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+    override fun onActivityDestroyed(activity: Activity) {}
+}

--- a/instrumented/integration/src/main/AndroidManifest.xml
+++ b/instrumented/integration/src/main/AndroidManifest.xml
@@ -105,6 +105,11 @@
         <activity android:name=".rum.startup.MainContentActivity"
             android:label="@string/activity_app_launch"
             android:windowSoftInputMode="adjustResize"/>
+        <activity android:name=".rum.startup.AuthActivity"
+            android:label="@string/activity_app_launch"
+            android:windowSoftInputMode="adjustResize"/>
+        <activity android:name=".rum.startup.AsyncInterstitialSplashActivity"
+            android:label="@string/activity_app_launch"
+            android:windowSoftInputMode="adjustResize"/>
     </application>
-
 </manifest>

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/startup/AsyncInterstitialSplashActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/startup/AsyncInterstitialSplashActivity.kt
@@ -1,0 +1,43 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sdk.integration.rum.startup
+
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * Interstitial activity that launches the main activity and finishes itself asynchronously.
+ * Unlike [InterstitialSplashActivity], the startActivity + finish calls are posted to a Handler,
+ * causing the next activity's onCreate to fire AFTER this activity's onDestroy.
+ *
+ * This simulates real-world interstitial patterns where navigation is deferred
+ * (e.g., auth checks via callbacks, deep link resolution, or framework-level async routing).
+ */
+internal class AsyncInterstitialSplashActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Capture application context before finishing so startActivity works
+        // after this activity is destroyed (required on API 29+ and avoids
+        // "activity already finishing" silent failures).
+        val appContext = applicationContext
+        finish()
+        Handler(Looper.getMainLooper()).postDelayed({
+            appContext.startActivity(
+                Intent(appContext, MainContentActivity::class.java)
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            )
+        }, NAVIGATION_DELAY_MS)
+    }
+
+    companion object {
+        private const val NAVIGATION_DELAY_MS = 100L
+    }
+}

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/startup/AuthActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/startup/AuthActivity.kt
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sdk.integration.rum.startup
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * Interstitial activity that simulates an authentication check.
+ * It immediately launches [InterstitialSplashActivity] and finishes itself
+ * without ever drawing a frame.
+ *
+ * Used in chain tests: AuthActivity -> SplashActivity -> MainContentActivity,
+ * where both auth and splash are non-drawing interstitials.
+ */
+internal class AuthActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Immediately launch splash activity without setting content view
+        val intent = Intent(this, InterstitialSplashActivity::class.java)
+        startActivity(intent)
+        finish()
+    }
+}


### PR DESCRIPTION
### What does this PR do?

**Note**: This PR is targeting [hector.morilloprieto/RUM-14471](https://github.com/DataDog/dd-sdk-android/tree/hector.morilloprieto/RUM-14471)￼, as it is an iteration of it. It's motivated by [this comment](https://github.com/DataDog/dd-sdk-android/pull/3184#discussion_r2822227426).

Automatically detects and forwards TTID (Time To Initial Display) measurement to the next qualifying activity when an interstitial activity (e.g. a splash screen) calls `startActivity()` + `finish()` without ever calling `setContentView()`. In this pattern the `OnDrawListener` never fires on the interstitial, so TTID is silently dropped. This PR makes the SDK detect that case and subscribe to the next activity's first frame draw instead — with no customer configuration required.

### Motivation

Customers using a splash/auth screen pattern were losing TTID data entirely because the SDK had no way to recover when the first tracked activity never drew a frame.

### How to test

Apply the attached [patch](https://github.com/user-attachments/files/25365831/patch.patch) to the branch:

The patch modifies the sample app to add a `SplashActivity` as the launcher activity. This activity immediately calls `startActivity(NavActivity)` + `finish()` without setting a content view, simulating an interstitial splash screen. It also sets telemetry sampling to 100% and reduces session inactivity timeout to 15 seconds for easier testing.

Run the sample app and check the RUM dashboard — you should see TTID reported for `NavActivity` with `was_forwarded: true` in the startup telemetry metric.

### Additional Notes

- **No time-based heuristics** — forwarding is triggered purely by activity lifecycle events (`onBeforeActivityCreated` while a pending startup scenario exists).
- **First-draw-wins** — if multiple activities are created concurrently, whichever draws first reports TTID; subsequent callbacks are discarded via an identity check on `pendingScenario`.
- **`wasForwarded` telemetry flag** added to `RumTTIDInfo` and reported via the telemetry metric so we can measure how often this path is taken.
- New integration tests cover synchronous interstitial, chained (A→B→C), and async/deferred navigation scenarios.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)