### PR TITLE
Use feature flag variant `key` instead of `value` for RUM Feature Flag Tracking

### DIFF
--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/DatadogFlagsClient.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/DatadogFlagsClient.kt
@@ -14,7 +14,6 @@ import com.datadog.android.flags.FlagsConfiguration
 import com.datadog.android.flags.StateObservable
 import com.datadog.android.flags.internal.evaluation.EvaluationsManager
 import com.datadog.android.flags.internal.model.PrecomputedFlag
-import com.datadog.android.flags.internal.model.VariationType
 import com.datadog.android.flags.internal.repository.FlagsRepository
 import com.datadog.android.flags.model.ErrorCode
 import com.datadog.android.flags.model.EvaluationContext
@@ -447,13 +446,12 @@ internal class DatadogFlagsClient(
     }
 
     private fun <T : Any> trackResolution(resolution: InternalResolution.Success<T>) {
-        trackResolution(resolution.flagKey, resolution.flag, resolution.value, resolution.context)
+        trackResolution(resolution.flagKey, resolution.flag, resolution.context)
     }
 
-    private fun <T : Any> trackResolution(
+    private fun trackResolution(
         flagKey: String,
         flag: UnparsedFlag,
-        flagValue: T,
         context: EvaluationContext
     ) {
         // Exposure logging (only when doLog=true)
@@ -461,9 +459,11 @@ internal class DatadogFlagsClient(
             if (flagsConfiguration.trackExposures) {
                 writeExposureEvent(flagKey, flag, context)
             }
-            if (flagsConfiguration.rumIntegrationEnabled) {
-                logEvaluation(flagKey, flagValue)
-            }
+        }
+
+        // RUM feature flag tracking - fires for all successful evaluations with a variant key
+        if (flagsConfiguration.rumIntegrationEnabled && flag.variationKey.isNotBlank()) {
+            logEvaluation(flagKey, flag.variationKey)
         }
 
         // Evaluation logging for all evaluations (when enabled)
@@ -515,39 +515,8 @@ internal class DatadogFlagsClient(
      * Supposed to be used by internal Datadog packages to track flag evaluations from an exact flags state snapshot.
      */
     internal fun trackFlagSnapshotEvaluation(flagKey: String, flag: UnparsedFlag, context: EvaluationContext) {
-        val flagValue = parseFlagValueString(flagKey, flag)
-
-        trackResolution(flagKey, flag, flagValue, context)
-    }
-
-    private fun parseFlagValueString(flagKey: String, flag: UnparsedFlag): Any {
-        val kClass = variationTypeToKClass[flag.variationType] ?: String::class
-
-        val conversionResult = FlagValueConverter.convert(flag.variationValue, flag.variationType, kClass)
-        val flagValue = conversionResult.getOrElse { exception ->
-            featureSdkCore.internalLogger.log(
-                InternalLogger.Level.WARN,
-                InternalLogger.Target.USER,
-                { "Flag '$flagKey': Failed to parse value '${flag.variationValue}' as '${flag.variationType}'" },
-                exception
-            )
-            // Pass raw value as a string to not lose information.
-            flag.variationValue
-        }
-
-        return flagValue
+        trackResolution(flagKey, flag, context)
     }
 
     // endregion
-
-    companion object {
-        private val variationTypeToKClass = mapOf(
-            VariationType.BOOLEAN.value to Boolean::class,
-            VariationType.STRING.value to String::class,
-            VariationType.INTEGER.value to Int::class,
-            VariationType.NUMBER.value to Double::class,
-            VariationType.FLOAT.value to Double::class,
-            VariationType.OBJECT.value to JSONObject::class
-        )
-    }
 }

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/DatadogFlagsClientTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/DatadogFlagsClientTest.kt
@@ -236,7 +236,7 @@ internal class DatadogFlagsClientTest {
         assertThat(result).isEqualTo(fakeFlagValue)
         verify(mockRumEvaluationLogger).logEvaluation(
             flagKey = fakeFlagKey,
-            value = fakeFlagValue
+            value = fakeFlag.variationKey
         )
     }
 
@@ -309,7 +309,7 @@ internal class DatadogFlagsClientTest {
         assertThat(result).isEqualTo(fakeFlagValue)
         verify(mockRumEvaluationLogger).logEvaluation(
             flagKey = fakeFlagKey,
-            value = fakeFlagValue
+            value = fakeFlag.variationKey
         )
     }
 
@@ -1340,7 +1340,7 @@ internal class DatadogFlagsClientTest {
         assertThat(result).isEqualTo(fakeFlagValue)
         verify(mockRumEvaluationLogger).logEvaluation(
             flagKey = fakeFlagKey,
-            value = fakeFlagValue
+            value = fakeFlag.variationKey
         )
     }
 
@@ -1703,7 +1703,7 @@ internal class DatadogFlagsClientTest {
         )
         verify(mockRumEvaluationLogger).logEvaluation(
             flagKey = fakeFlagKey,
-            value = fakeFlagValue
+            value = fakeFlag.variationKey
         )
     }
 
@@ -1733,7 +1733,7 @@ internal class DatadogFlagsClientTest {
         )
         verify(mockRumEvaluationLogger).logEvaluation(
             flagKey = fakeFlagKey,
-            value = fakeFlagValue
+            value = fakeFlag.variationKey
         )
     }
 
@@ -1763,7 +1763,7 @@ internal class DatadogFlagsClientTest {
         )
         verify(mockRumEvaluationLogger).logEvaluation(
             flagKey = fakeFlagKey,
-            value = fakeFlagValue
+            value = fakeFlag.variationKey
         )
     }
 
@@ -1793,7 +1793,7 @@ internal class DatadogFlagsClientTest {
         )
         verify(mockRumEvaluationLogger).logEvaluation(
             flagKey = fakeFlagKey,
-            value = fakeFlagValue
+            value = fakeFlag.variationKey
         )
     }
 
@@ -1823,105 +1823,14 @@ internal class DatadogFlagsClientTest {
             context = fakeContext,
             data = fakeFlag
         )
-        argumentCaptor<Any> {
-            verify(mockRumEvaluationLogger).logEvaluation(
-                flagKey = eq(fakeFlagKey),
-                value = capture()
-            )
-            assertThat(lastValue.toString()).isEqualTo(fakeFlagValue.toString())
-        }
-    }
-
-    @Test
-    fun `M track raw value and warn W trackFlagSnapshotEvaluation() { invalid JSON object }`(forge: Forge) {
-        // Given
-        val fakeFlagKey = forge.anAlphabeticalString()
-        val invalidJson = "{invalid-json"
-        val fakeFlag = forge.getForgery<PrecomputedFlag>().copy(
-            variationType = VariationType.OBJECT.value,
-            variationValue = invalidJson,
-            doLog = true
-        )
-        val fakeContext = EvaluationContext(
-            targetingKey = forge.anAlphabeticalString(),
-            attributes = emptyMap()
-        )
-
-        // When
-        testedClient.trackFlagSnapshotEvaluation(fakeFlagKey, fakeFlag, fakeContext)
-
-        // Then
-        verify(mockProcessor).processEvent(
-            flagName = fakeFlagKey,
-            context = fakeContext,
-            data = fakeFlag
-        )
         verify(mockRumEvaluationLogger).logEvaluation(
             flagKey = fakeFlagKey,
-            value = invalidJson
+            value = fakeFlag.variationKey
         )
-        argumentCaptor<() -> String> {
-            verify(mockInternalLogger).log(
-                eq(InternalLogger.Level.WARN),
-                eq(InternalLogger.Target.USER),
-                capture(),
-                anyOrNull(),
-                eq(false),
-                eq(null)
-            )
-
-            val message = firstValue.invoke()
-            assertThat(message).contains("Flag '$fakeFlagKey'")
-            assertThat(message).contains("Failed to parse value '$invalidJson' as 'object'")
-        }
     }
 
     @Test
-    fun `M track raw value and warn W trackFlagSnapshotEvaluation() { unknown type }`(forge: Forge) {
-        // Given
-        val fakeFlagKey = forge.anAlphabeticalString()
-        val fakeValue = "some-value"
-        val unknownType = "unknown-type"
-        val fakeFlag = forge.getForgery<PrecomputedFlag>().copy(
-            variationType = unknownType,
-            variationValue = fakeValue,
-            doLog = true
-        )
-        val fakeContext = EvaluationContext(
-            targetingKey = forge.anAlphabeticalString(),
-            attributes = emptyMap()
-        )
-
-        // When
-        testedClient.trackFlagSnapshotEvaluation(fakeFlagKey, fakeFlag, fakeContext)
-
-        // Then
-        verify(mockProcessor).processEvent(
-            flagName = fakeFlagKey,
-            context = fakeContext,
-            data = fakeFlag
-        )
-        verify(mockRumEvaluationLogger).logEvaluation(
-            flagKey = fakeFlagKey,
-            value = fakeValue
-        )
-        argumentCaptor<() -> String> {
-            verify(mockInternalLogger).log(
-                eq(InternalLogger.Level.WARN),
-                eq(InternalLogger.Target.USER),
-                capture(),
-                anyOrNull(),
-                eq(false),
-                eq(null)
-            )
-            val message = firstValue.invoke()
-            assertThat(message).contains("Flag '$fakeFlagKey'")
-            assertThat(message).contains("Failed to parse value '$fakeValue' as '$unknownType'")
-        }
-    }
-
-    @Test
-    fun `M not track exposure W trackFlagSnapshotEvaluation() { doLog is false }`(forge: Forge) {
+    fun `M not track exposure but still log RUM W trackFlagSnapshotEvaluation() { doLog is false }`(forge: Forge) {
         // Given
         val fakeFlagKey = forge.anAlphabeticalString()
         val fakeFlagValue = forge.aBool()
@@ -1940,7 +1849,10 @@ internal class DatadogFlagsClientTest {
 
         // Then
         verifyNoInteractions(mockProcessor)
-        verifyNoInteractions(mockRumEvaluationLogger)
+        verify(mockRumEvaluationLogger).logEvaluation(
+            flagKey = fakeFlagKey,
+            value = fakeFlag.variationKey
+        )
     }
 
     @Test
@@ -1979,7 +1891,7 @@ internal class DatadogFlagsClientTest {
         verifyNoInteractions(mockProcessor)
         verify(mockRumEvaluationLogger).logEvaluation(
             flagKey = fakeFlagKey,
-            value = fakeFlagValue
+            value = fakeFlag.variationKey
         )
     }
 


### PR DESCRIPTION
### What does this PR do?
This PR updates how we Datadog Feature Flags are tracked in RUM, using a variant's `key` rather than the variant's `value`.

### Motivation
Previously, when using Datadog Feature Flags, the `value` would be set as the evaluated variant. This is not ideal, particularly when using JSON type flags. JSON flags can be very large, and are not friendly from a UX perspective when typing filters/viewing results. Each variant in a Datadog Feature Flag contains a `key`, which is a string with a maximum length of 64 characters. This `key` is better suited for tracking feature flags in RUM. 

### Review checklist (to be filled by reviewers)
- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

