### PR TITLE
Add Play SDK console verification token to new modules

### DIFF
--- a/dd-sdk-android-internal/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-internal/verification.properties
+++ b/dd-sdk-android-internal/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-internal/verification.properties
@@ -1,0 +1,3 @@
+#This is the verification token for the com.datadoghq:dd-sdk-android-internal SDK.
+#Wed Mar 04 02:24:25 PST 2026
+token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/features/dd-sdk-android-session-replay-compose/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-session-replay-compose/verification.properties
+++ b/features/dd-sdk-android-session-replay-compose/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-session-replay-compose/verification.properties
@@ -1,0 +1,3 @@
+#This is the verification token for the com.datadoghq:dd-sdk-android-session-replay-compose SDK.
+#Wed Mar 04 02:25:09 PST 2026
+token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/features/dd-sdk-android-session-replay-material/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-session-replay-material/verification.properties
+++ b/features/dd-sdk-android-session-replay-material/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-session-replay-material/verification.properties
@@ -1,0 +1,3 @@
+#This is the verification token for the com.datadoghq:dd-sdk-android-session-replay-material SDK.
+#Wed Mar 04 02:23:55 PST 2026
+token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/features/dd-sdk-android-trace-api/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-trace-api/verification.properties
+++ b/features/dd-sdk-android-trace-api/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-trace-api/verification.properties
@@ -1,0 +1,3 @@
+#This is the verification token for the com.datadoghq:dd-sdk-android-trace-api SDK.
+#Wed Mar 04 02:23:32 PST 2026
+token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/features/dd-sdk-android-trace-internal/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-trace-internal/verification.properties
+++ b/features/dd-sdk-android-trace-internal/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-trace-internal/verification.properties
@@ -1,0 +1,3 @@
+#This is the verification token for the com.datadoghq:dd-sdk-android-trace-internal SDK.
+#Wed Mar 04 02:23:08 PST 2026
+token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/features/dd-sdk-android-trace-otel/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-trace-otel/verification.properties
+++ b/features/dd-sdk-android-trace-otel/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-trace-otel/verification.properties
@@ -1,0 +1,3 @@
+#This is the verification token for the com.datadoghq:dd-sdk-android-trace-otel SDK.
+#Wed Mar 04 02:22:35 PST 2026
+token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/integrations/dd-sdk-android-apollo/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-apollo/verification.properties
+++ b/integrations/dd-sdk-android-apollo/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-apollo/verification.properties
@@ -1,0 +1,3 @@
+#This is the verification token for the com.datadoghq:dd-sdk-android-apollo SDK.
+#Wed Mar 04 02:22:08 PST 2026
+token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/integrations/dd-sdk-android-coil/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-coil/verification.properties
+++ b/integrations/dd-sdk-android-coil/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-coil/verification.properties
@@ -1,0 +1,3 @@
+#This is the verification token for the com.datadoghq:dd-sdk-android-coil SDK.
+#Wed Mar 04 02:21:37 PST 2026
+token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/integrations/dd-sdk-android-compose/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-compose/verification.properties
+++ b/integrations/dd-sdk-android-compose/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-compose/verification.properties
@@ -1,0 +1,3 @@
+#This is the verification token for the com.datadoghq:dd-sdk-android-compose SDK.
+#Wed Mar 04 02:21:03 PST 2026
+token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/integrations/dd-sdk-android-glide/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-glide/verification.properties
+++ b/integrations/dd-sdk-android-glide/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-glide/verification.properties
@@ -1,0 +1,3 @@
+#This is the verification token for the com.datadoghq:dd-sdk-android-glide SDK.
+#Wed Mar 04 02:20:27 PST 2026
+token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/integrations/dd-sdk-android-rum-coroutines/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-rum-coroutines/verification.properties
+++ b/integrations/dd-sdk-android-rum-coroutines/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-rum-coroutines/verification.properties
@@ -1,0 +1,3 @@
+#This is the verification token for the com.datadoghq:dd-sdk-android-rum-coroutines SDK.
+#Wed Mar 04 02:18:08 PST 2026
+token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/integrations/dd-sdk-android-trace-coroutines/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-trace-coroutines/verification.properties
+++ b/integrations/dd-sdk-android-trace-coroutines/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-trace-coroutines/verification.properties
@@ -1,0 +1,3 @@
+#This is the verification token for the com.datadoghq:dd-sdk-android-trace-coroutines SDK.
+#Wed Mar 04 02:16:30 PST 2026
+token=JLJEBFEWEBGZZMPAVEFV3655AM


### PR DESCRIPTION
### What does this PR do?

This PR adds verification token to the new modules in order to claim their ownership in the Play SDK console.

It is completely fine to have them public, it is just a token, not a security credential.

The verification process is described here https://support.google.com/googleplay/android-developer/answer/12244916#Verify_ownership

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

