### PR TITLE
[RUM-14471] Fix flaky AppStartupActivityPredicateTest

### DIFF
--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/AppStartupActivityPredicateTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/AppStartupActivityPredicateTest.kt
@@ -6,7 +6,9 @@
 
 package com.datadog.android.sdk.integration.rum.startup
 
+import android.app.Activity
 import android.app.ActivityManager
+import android.app.Application
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
@@ -27,6 +29,8 @@ import com.datadog.tools.unit.ConditionWatcher
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * Instrumented test verifying that AppStartupActivityPredicate correctly filters
@@ -51,6 +55,12 @@ internal class AppStartupActivityPredicateTest :
         val expectedEvents = mutableListOf<ExpectedEvent>()
         val instrumentation = InstrumentationRegistry.getInstrumentation()
 
+        // The lifecycle callback was registered in beforeActivityLaunched() (before the activity
+        // was launched), so the latch is guaranteed to fire even on fast devices where
+        // MainContentActivity reaches RESUMED before runInstrumentationScenario is called.
+        check(mockServerRule.mainActivityResumed.await(MAIN_ACTIVITY_WAIT_SECONDS, TimeUnit.SECONDS)) {
+            "MainContentActivity did not reach RESUMED state within $MAIN_ACTIVITY_WAIT_SECONDS seconds"
+        }
         instrumentation.waitForIdleSync()
         waitForPendingRUMEvents()
 
@@ -82,6 +92,10 @@ internal class AppStartupActivityPredicateTest :
         return expectedEvents
     }
 
+    companion object {
+        private const val MAIN_ACTIVITY_WAIT_SECONDS = 30L
+    }
+
     @Test
     fun verifyTTIDReportedForMainActivityWhenInterstitialExcluded() {
         val expectedEvents = runInstrumentationScenario(mockServerRule)
@@ -99,36 +113,64 @@ internal class AppStartupActivityPredicateTest :
 
     /**
      * Test rule that configures RUM with a predicate excluding InterstitialSplashActivity.
+     *
+     * The [mainActivityResumed] latch is registered in [beforeActivityLaunched], before the
+     * activity is launched, to avoid a race where MainContentActivity reaches RESUMED before
+     * [runInstrumentationScenario] has a chance to register the callback.
      */
     internal class AppStartupPredicateTestRule : RumMockServerActivityTestRule<InterstitialSplashActivity>(
         activityClass = InterstitialSplashActivity::class.java,
         keepRequests = true,
         trackingConsent = TrackingConsent.GRANTED
     ) {
+        val mainActivityResumed = CountDownLatch(1)
+        private var mainActivityResumedCallback: Application.ActivityLifecycleCallbacks =
+            NoOpActivityLifecycleCallbacks()
+
         @OptIn(ExperimentalRumApi::class)
         override fun beforeActivityLaunched() {
             super.beforeActivityLaunched()
-            val config = RuntimeConfig.configBuilder()
-                .build()
+            val appContext = InstrumentationRegistry.getInstrumentation()
+                .targetContext.applicationContext
 
-            val sdkCore = Datadog.initialize(
-                InstrumentationRegistry.getInstrumentation().targetContext.applicationContext,
-                config,
-                trackingConsent
-            )
-            checkNotNull(sdkCore)
-
-            val rumConfig = RuntimeConfig.rumConfigBuilder()
-                .trackUserInteractions()
-                .trackLongTasks(RuntimeConfig.LONG_TASK_LARGE_THRESHOLD)
-                .useViewTrackingStrategy(ActivityViewTrackingStrategy(false))
-                // Exclude InterstitialSplashActivity from TTID measurement
-                .setAppStartupActivityPredicate { activity ->
-                    activity !is InterstitialSplashActivity
+            // Register before the activity launches so we can't miss the RESUMED callback.
+            mainActivityResumedCallback = object : NoOpActivityLifecycleCallbacks() {
+                override fun onActivityResumed(activity: Activity) {
+                    if (activity is MainContentActivity) mainActivityResumed.countDown()
                 }
-                .build()
-            Rum.enable(rumConfig, sdkCore)
-            DdRumContentProvider.processImportance = ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+            }
+            (appContext as Application).registerActivityLifecycleCallbacks(mainActivityResumedCallback)
+
+            try {
+                val config = RuntimeConfig.configBuilder()
+                    .build()
+
+                val sdkCore = Datadog.initialize(appContext, config, trackingConsent)
+                checkNotNull(sdkCore)
+
+                val rumConfig = RuntimeConfig.rumConfigBuilder()
+                    .trackUserInteractions()
+                    .trackLongTasks(RuntimeConfig.LONG_TASK_LARGE_THRESHOLD)
+                    .useViewTrackingStrategy(ActivityViewTrackingStrategy(false))
+                    // Exclude InterstitialSplashActivity from TTID measurement
+                    .setAppStartupActivityPredicate { activity ->
+                        activity !is InterstitialSplashActivity
+                    }
+                    .build()
+                Rum.enable(rumConfig, sdkCore)
+                DdRumContentProvider.processImportance =
+                    ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+            } catch (e: Throwable) {
+                appContext.unregisterActivityLifecycleCallbacks(mainActivityResumedCallback)
+                throw e
+            }
+        }
+
+        override fun afterActivityFinished() {
+            super.afterActivityFinished()
+            val appContext = InstrumentationRegistry.getInstrumentation()
+                .targetContext.applicationContext as Application
+            appContext.unregisterActivityLifecycleCallbacks(mainActivityResumedCallback)
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Fixes a race condition in `AppStartupActivityPredicateTest` introduced in #3199. Applies the same `CountDownLatch` + `ActivityLifecycleCallbacks` pattern already used in `AppStartupAutoForwardTest` and `AppStartupAsyncAutoForwardingTest` to ensure the test waits for `MainContentActivity` to reach `RESUMED` before asserting RUM events.

### Motivation

The test was flaky because `InterstitialSplashActivity` immediately starts and finishes synchronously, so `MainContentActivity` could reach `RESUMED` before `runInstrumentationScenario` began checking — causing the 60s `ConditionWatcher` to time out with the underlying assertion never satisfied.

### Additional Notes

No production code changes. Test-only fix following the existing pattern in the same package.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)