### PR TITLE
Enable CurlInterceptor body logging in debug builds

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -629,7 +629,7 @@ internal class CoreFeature(
             // Add debug or production interceptors
             if (BuildConfig.DEBUG) {
                 @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
-                builder.addNetworkInterceptor(CurlInterceptor())
+                builder.addNetworkInterceptor(CurlInterceptor(printBody = true))
             } else {
                 @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
                 builder.addInterceptor(GzipRequestInterceptor(internalLogger))


### PR DESCRIPTION
## Summary

- Enable `CurlInterceptor(printBody = true)` in `CoreFeature.kt` for debug builds
- Makes full JSON request bodies visible in logcat under the `Curl` tag when developing/debugging locally
- No effect on release builds (gated by `BuildConfig.DEBUG`)

## How to verify

1. Build and install the sample app: `./gradlew :sample:kotlin:installUs1Debug`
2. Stream logcat: `adb logcat -s "Curl" "*:S"`
3. Confirm `-d '[{...}]'` body appears in curl log lines for logs/RUM/traces uploads