### PR TITLE
Fix RecorderWindowCallback crash on null menu parameter

### DIFF
--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -154,6 +154,36 @@ public final class com/datadog/android/sessionreplay/internal/TouchPrivacyManage
 	public final fun addTouchOverrideArea (Landroid/graphics/Rect;Lcom/datadog/android/sessionreplay/TouchPrivacy;)V
 }
 
+public class com/datadog/android/sessionreplay/internal/recorder/callback/FixedWindowCallback : android/view/Window$Callback {
+	public fun <init> (Landroid/view/Window$Callback;)V
+	public fun dispatchGenericMotionEvent (Landroid/view/MotionEvent;)Z
+	public fun dispatchKeyEvent (Landroid/view/KeyEvent;)Z
+	public fun dispatchKeyShortcutEvent (Landroid/view/KeyEvent;)Z
+	public fun dispatchPopulateAccessibilityEvent (Landroid/view/accessibility/AccessibilityEvent;)Z
+	public fun dispatchTouchEvent (Landroid/view/MotionEvent;)Z
+	public fun dispatchTrackballEvent (Landroid/view/MotionEvent;)Z
+	public fun getDelegate ()Landroid/view/Window$Callback;
+	public fun onActionModeFinished (Landroid/view/ActionMode;)V
+	public fun onActionModeStarted (Landroid/view/ActionMode;)V
+	public fun onAttachedToWindow ()V
+	public fun onContentChanged ()V
+	public fun onCreatePanelMenu (ILandroid/view/Menu;)Z
+	public fun onCreatePanelView (I)Landroid/view/View;
+	public fun onDetachedFromWindow ()V
+	public fun onMenuItemSelected (ILandroid/view/MenuItem;)Z
+	public fun onMenuOpened (ILandroid/view/Menu;)Z
+	public fun onPanelClosed (ILandroid/view/Menu;)V
+	public fun onPointerCaptureChanged (Z)V
+	public fun onPreparePanel (ILandroid/view/View;Landroid/view/Menu;)Z
+	public fun onProvideKeyboardShortcuts (Ljava/util/List;Landroid/view/Menu;I)V
+	public fun onSearchRequested ()Z
+	public fun onSearchRequested (Landroid/view/SearchEvent;)Z
+	public fun onWindowAttributesChanged (Landroid/view/WindowManager$LayoutParams;)V
+	public fun onWindowFocusChanged (Z)V
+	public fun onWindowStartingActionMode (Landroid/view/ActionMode$Callback;)Landroid/view/ActionMode;
+	public fun onWindowStartingActionMode (Landroid/view/ActionMode$Callback;I)Landroid/view/ActionMode;
+}
+
 public abstract interface class com/datadog/android/sessionreplay/internal/recorder/obfuscator/StringObfuscator {
 	public static final field Companion Lcom/datadog/android/sessionreplay/internal/recorder/obfuscator/StringObfuscator$Companion;
 	public abstract fun obfuscate (Ljava/lang/String;)Ljava/lang/String;

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptor.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptor.kt
@@ -71,7 +71,7 @@ internal class WindowCallbackInterceptor(
     private fun unwrapWindowCallback(window: Window) {
         val callback = window.callback
         if (callback is RecorderWindowCallback) {
-            val wrappedCallback = callback.wrappedCallback
+            val wrappedCallback = callback.delegate
             if (wrappedCallback !is NoOpWindowCallback) {
                 window.callback = wrappedCallback
             } else {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/FixedWindowCallback.java
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/FixedWindowCallback.java
@@ -1,0 +1,181 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.callback;
+
+import android.os.Build;
+import android.view.ActionMode;
+import android.view.KeyEvent;
+import android.view.KeyboardShortcutGroup;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.MotionEvent;
+import android.view.SearchEvent;
+import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
+import android.view.accessibility.AccessibilityEvent;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+import java.util.List;
+
+/**
+ * A wrapper for {@link Window.Callback} that annotates parameters as {@code @Nullable}
+ * where Android can pass null values, preventing Kotlin's non-null assertions from crashing.
+ * This fixes the known Android bug: https://issuetracker.google.com/issues/188568911
+ */
+public class FixedWindowCallback implements Window.Callback {
+
+    @NonNull
+    private final Window.Callback delegate;
+
+    public FixedWindowCallback(@NonNull Window.Callback delegate) {
+        this.delegate = delegate;
+    }
+
+    @NonNull
+    public Window.Callback getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public boolean dispatchGenericMotionEvent(MotionEvent event) {
+        return delegate.dispatchGenericMotionEvent(event);
+    }
+
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+        return delegate.dispatchKeyEvent(event);
+    }
+
+    @Override
+    public boolean dispatchKeyShortcutEvent(KeyEvent event) {
+        return delegate.dispatchKeyShortcutEvent(event);
+    }
+
+    @Override
+    public boolean dispatchPopulateAccessibilityEvent(AccessibilityEvent event) {
+        return delegate.dispatchPopulateAccessibilityEvent(event);
+    }
+
+    @Override
+    public boolean dispatchTouchEvent(@Nullable MotionEvent event) {
+        return delegate.dispatchTouchEvent(event);
+    }
+
+    @Override
+    public boolean dispatchTrackballEvent(MotionEvent event) {
+        return delegate.dispatchTrackballEvent(event);
+    }
+
+    @Override
+    public void onActionModeFinished(ActionMode mode) {
+        delegate.onActionModeFinished(mode);
+    }
+
+    @Override
+    public void onActionModeStarted(ActionMode mode) {
+        delegate.onActionModeStarted(mode);
+    }
+
+    @Override
+    public void onAttachedToWindow() {
+        delegate.onAttachedToWindow();
+    }
+
+    @Override
+    public void onContentChanged() {
+        delegate.onContentChanged();
+    }
+
+    @Override
+    public boolean onCreatePanelMenu(int featureId, @Nullable Menu menu) {
+        if (menu == null) return false;
+        return delegate.onCreatePanelMenu(featureId, menu);
+    }
+
+    @Nullable
+    @Override
+    public View onCreatePanelView(int featureId) {
+        return delegate.onCreatePanelView(featureId);
+    }
+
+    @Override
+    public void onDetachedFromWindow() {
+        delegate.onDetachedFromWindow();
+    }
+
+    @Override
+    public boolean onMenuItemSelected(int featureId, @Nullable MenuItem item) {
+        if (item == null) return false;
+        return delegate.onMenuItemSelected(featureId, item);
+    }
+
+    @Override
+    public boolean onMenuOpened(int featureId, @Nullable Menu menu) {
+        if (menu == null) return false;
+        return delegate.onMenuOpened(featureId, menu);
+    }
+
+    @Override
+    public void onPanelClosed(int featureId, @Nullable Menu menu) {
+        if (menu == null) return;
+        delegate.onPanelClosed(featureId, menu);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    @Override
+    public void onPointerCaptureChanged(boolean hasCapture) {
+        delegate.onPointerCaptureChanged(hasCapture);
+    }
+
+    @Override
+    public boolean onPreparePanel(int featureId, @Nullable View view, @Nullable Menu menu) {
+        if (menu == null) return false;
+        return delegate.onPreparePanel(featureId, view, menu);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    @Override
+    public void onProvideKeyboardShortcuts(List<KeyboardShortcutGroup> data, @Nullable Menu menu, int deviceId) {
+        delegate.onProvideKeyboardShortcuts(data, menu, deviceId);
+    }
+
+    @Override
+    public boolean onSearchRequested() {
+        return delegate.onSearchRequested();
+    }
+
+    @Override
+    public boolean onSearchRequested(SearchEvent searchEvent) {
+        return delegate.onSearchRequested(searchEvent);
+    }
+
+    @Override
+    public void onWindowAttributesChanged(WindowManager.LayoutParams attrs) {
+        delegate.onWindowAttributesChanged(attrs);
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        delegate.onWindowFocusChanged(hasFocus);
+    }
+
+    @Nullable
+    @Override
+    public ActionMode onWindowStartingActionMode(ActionMode.Callback callback) {
+        return delegate.onWindowStartingActionMode(callback);
+    }
+
+    @Nullable
+    @Override
+    public ActionMode onWindowStartingActionMode(ActionMode.Callback callback, int type) {
+        return delegate.onWindowStartingActionMode(callback, type);
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallback.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallback.kt
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit
 internal class RecorderWindowCallback(
     appContext: Context,
     private val recordedDataQueueHandler: RecordedDataQueueHandler,
-    internal val wrappedCallback: Window.Callback,
+    wrappedCallback: Window.Callback,
     private val timeProvider: TimeProvider,
     private val rumContextProvider: RumContextProvider,
     private val viewOnDrawInterceptor: ViewOnDrawInterceptor,
@@ -45,7 +45,7 @@ internal class RecorderWindowCallback(
     private val motionUpdateThresholdInNs: Long = MOTION_UPDATE_DELAY_THRESHOLD_NS,
     private val flushPositionBufferThresholdInNs: Long = FLUSH_BUFFER_THRESHOLD_NS,
     private val windowInspector: WindowInspector = WindowInspector
-) : Window.Callback by wrappedCallback {
+) : FixedWindowCallback(wrappedCallback) {
     private val pixelsDensity = appContext.resources.displayMetrics.density
     internal val pointerInteractions: MutableList<MobileSegment.MobileRecord> = LinkedList()
     private var lastOnMoveUpdateTimeInNs: Long = 0L
@@ -81,13 +81,22 @@ internal class RecorderWindowCallback(
             )
         }
 
-        @Suppress("SwallowedException")
-        return try {
-            wrappedCallback.dispatchTouchEvent(event)
-        } catch (e: NullPointerException) {
-            logOrRethrowWrappedCallbackException(e)
-            EVENT_CONSUMED
+        return super.dispatchTouchEvent(event)
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        val rootViews = windowInspector.getGlobalWindowViews(internalLogger)
+        if (rootViews.isNotEmpty()) {
+            // a new window was added or removed so we stop recording the previous root views
+            // and we start recording the new ones.
+            viewOnDrawInterceptor.stopIntercepting()
+            viewOnDrawInterceptor.intercept(
+                decorViews = rootViews,
+                textAndInputPrivacy = privacy,
+                imagePrivacy = imagePrivacy
+            )
         }
+        super.onWindowFocusChanged(hasFocus)
     }
 
     // endregion
@@ -165,45 +174,9 @@ internal class RecorderWindowCallback(
         lastPerformedFlushTimeInNs = timeProvider.getDeviceElapsedTimeNanos()
     }
 
-    private fun logOrRethrowWrappedCallbackException(e: NullPointerException) {
-        // When calling delegate callback, we may have something like
-        // java.lang.NullPointerException: Parameter specified as non-null is null:
-        // method xxx, parameter xxx
-        // This happens because Kotlin delegate expects non-null value incorrectly inferring
-        // non-null type from Java interface definition (seems to be solved in Kotlin 1.8 though)
-        if (e.message?.contains("Parameter specified as non-null is null") == true) {
-            internalLogger.log(
-                InternalLogger.Level.ERROR,
-                InternalLogger.Target.MAINTAINER,
-                { FAIL_TO_PROCESS_MOTION_EVENT_ERROR_MESSAGE },
-                e
-            )
-        } else {
-            @Suppress("ThrowingInternalException") // we need to let client exception to propagate
-            throw e
-        }
-    }
-
-    override fun onWindowFocusChanged(hasFocus: Boolean) {
-        val rootViews = windowInspector.getGlobalWindowViews(internalLogger)
-        if (rootViews.isNotEmpty()) {
-            // a new window was added or removed so we stop recording the previous root views
-            // and we start recording the new ones.
-            viewOnDrawInterceptor.stopIntercepting()
-            viewOnDrawInterceptor.intercept(
-                decorViews = rootViews,
-                textAndInputPrivacy = privacy,
-                imagePrivacy = imagePrivacy
-            )
-        }
-        wrappedCallback.onWindowFocusChanged(hasFocus)
-    }
-
     // endregion
 
     companion object {
-        private const val EVENT_CONSUMED: Boolean = true
-
         // every frame we collect the move event positions
         internal val MOTION_UPDATE_DELAY_THRESHOLD_NS: Long =
             TimeUnit.MILLISECONDS.toNanos(16)
@@ -212,7 +185,5 @@ internal class RecorderWindowCallback(
         internal val FLUSH_BUFFER_THRESHOLD_NS: Long = MOTION_UPDATE_DELAY_THRESHOLD_NS * 10
         internal const val MOTION_EVENT_WAS_NULL_ERROR_MESSAGE =
             "RecorderWindowCallback: intercepted null motion event"
-        internal const val FAIL_TO_PROCESS_MOTION_EVENT_ERROR_MESSAGE =
-            "RecorderWindowCallback: wrapped callback failed to handle the motion event"
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptorTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptorTest.kt
@@ -103,7 +103,7 @@ internal class WindowCallbackInterceptorTest {
             val captor = argumentCaptor<Window.Callback>()
             verify(it).callback = captor.capture()
             assertThat(captor.firstValue).isInstanceOf(RecorderWindowCallback::class.java)
-            assertThat((captor.firstValue as RecorderWindowCallback).wrappedCallback)
+            assertThat((captor.firstValue as RecorderWindowCallback).delegate)
                 .isEqualTo(it.callback)
         }
     }
@@ -123,7 +123,7 @@ internal class WindowCallbackInterceptorTest {
             val captor = argumentCaptor<Window.Callback>()
             verify(it).callback = captor.capture()
             assertThat(captor.firstValue).isInstanceOf(RecorderWindowCallback::class.java)
-            assertThat((captor.firstValue as RecorderWindowCallback).wrappedCallback)
+            assertThat((captor.firstValue as RecorderWindowCallback).delegate)
                 .isInstanceOf(NoOpWindowCallback::class.java)
         }
     }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallbackTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallbackTest.kt
@@ -9,6 +9,8 @@ package com.datadog.android.sessionreplay.internal.recorder.callback
 import android.content.Context
 import android.content.res.Resources
 import android.util.DisplayMetrics
+import android.view.Menu
+import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
 import android.view.Window
@@ -37,7 +39,6 @@ import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
@@ -53,7 +54,6 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.util.concurrent.TimeUnit
-import kotlin.jvm.internal.Intrinsics
 import kotlin.math.pow
 
 @Extensions(
@@ -181,42 +181,6 @@ internal class RecorderWindowCallbackTest {
         // Then
         verify(mockWrappedCallback).dispatchTouchEvent(mockEvent)
         verify(mockEvent).recycle()
-    }
-
-    @Test
-    fun `M log the exception W wrappedCallback throws { null parameter }`() {
-        // Given
-        val mockEvent: MotionEvent = mock()
-        whenever(mockWrappedCallback.dispatchTouchEvent(mockEvent)).thenAnswer {
-            Intrinsics.checkNotNullParameter(
-                null,
-                "event"
-            )
-        }
-
-        // When
-        testedWindowCallback.dispatchTouchEvent(mockEvent)
-
-        // Then
-        verify(mockWrappedCallback).dispatchTouchEvent(mockEvent)
-        mockInternalLogger.verifyLog(
-            InternalLogger.Level.ERROR,
-            InternalLogger.Target.MAINTAINER,
-            RecorderWindowCallback.FAIL_TO_PROCESS_MOTION_EVENT_ERROR_MESSAGE,
-            throwableClass = NullPointerException::class.java
-        )
-    }
-
-    @Test
-    fun `M propagate the exception W wrappedCallback throws`(@Forgery fakeException: Exception) {
-        // Given
-        val mockEvent: MotionEvent = mock()
-        whenever(mockWrappedCallback.dispatchTouchEvent(mockEvent)).thenThrow(fakeException)
-
-        // When + Then
-        val exceptionCaught =
-            assertThrows<Exception> { testedWindowCallback.dispatchTouchEvent(mockEvent) }
-        assertThat(exceptionCaught).isSameAs(fakeException)
     }
 
     @Test
@@ -482,6 +446,92 @@ internal class RecorderWindowCallbackTest {
 
         // Then
         verify(mockWrappedCallback).onWindowFocusChanged(fakeHasFocus)
+    }
+
+    // endregion
+
+    // region Menu callbacks (delegation through FixedWindowCallback)
+
+    @Test
+    fun `M delegate to wrapped callback W onMenuOpened`(forge: Forge) {
+        // Given
+        val fakeFeatureId = forge.anInt()
+        val mockMenu: Menu = mock()
+        val fakeReturnedValue = forge.aBool()
+        whenever(mockWrappedCallback.onMenuOpened(fakeFeatureId, mockMenu))
+            .thenReturn(fakeReturnedValue)
+
+        // When
+        val result = testedWindowCallback.onMenuOpened(fakeFeatureId, mockMenu)
+
+        // Then
+        verify(mockWrappedCallback).onMenuOpened(fakeFeatureId, mockMenu)
+        assertThat(result).isEqualTo(fakeReturnedValue)
+    }
+
+    @Test
+    fun `M delegate to wrapped callback W onMenuItemSelected`(forge: Forge) {
+        // Given
+        val fakeFeatureId = forge.anInt()
+        val mockItem: MenuItem = mock()
+        val fakeReturnedValue = forge.aBool()
+        whenever(mockWrappedCallback.onMenuItemSelected(fakeFeatureId, mockItem))
+            .thenReturn(fakeReturnedValue)
+
+        // When
+        val result = testedWindowCallback.onMenuItemSelected(fakeFeatureId, mockItem)
+
+        // Then
+        verify(mockWrappedCallback).onMenuItemSelected(fakeFeatureId, mockItem)
+        assertThat(result).isEqualTo(fakeReturnedValue)
+    }
+
+    @Test
+    fun `M delegate to wrapped callback W onPanelClosed`(forge: Forge) {
+        // Given
+        val fakeFeatureId = forge.anInt()
+        val mockMenu: Menu = mock()
+
+        // When
+        testedWindowCallback.onPanelClosed(fakeFeatureId, mockMenu)
+
+        // Then
+        verify(mockWrappedCallback).onPanelClosed(fakeFeatureId, mockMenu)
+    }
+
+    @Test
+    fun `M delegate to wrapped callback W onPreparePanel`(forge: Forge) {
+        // Given
+        val fakeFeatureId = forge.anInt()
+        val mockView: View = mock()
+        val mockMenu: Menu = mock()
+        val fakeReturnedValue = forge.aBool()
+        whenever(mockWrappedCallback.onPreparePanel(fakeFeatureId, mockView, mockMenu))
+            .thenReturn(fakeReturnedValue)
+
+        // When
+        val result = testedWindowCallback.onPreparePanel(fakeFeatureId, mockView, mockMenu)
+
+        // Then
+        verify(mockWrappedCallback).onPreparePanel(fakeFeatureId, mockView, mockMenu)
+        assertThat(result).isEqualTo(fakeReturnedValue)
+    }
+
+    @Test
+    fun `M delegate to wrapped callback W onCreatePanelMenu`(forge: Forge) {
+        // Given
+        val fakeFeatureId = forge.anInt()
+        val mockMenu: Menu = mock()
+        val fakeReturnedValue = forge.aBool()
+        whenever(mockWrappedCallback.onCreatePanelMenu(fakeFeatureId, mockMenu))
+            .thenReturn(fakeReturnedValue)
+
+        // When
+        val result = testedWindowCallback.onCreatePanelMenu(fakeFeatureId, mockMenu)
+
+        // Then
+        verify(mockWrappedCallback).onCreatePanelMenu(fakeFeatureId, mockMenu)
+        assertThat(result).isEqualTo(fakeReturnedValue)
     }
 
     // endregion

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/AppStartupActivityPredicateTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/startup/AppStartupActivityPredicateTest.kt
@@ -6,9 +6,7 @@
 
 package com.datadog.android.sdk.integration.rum.startup
 
-import android.app.Activity
 import android.app.ActivityManager
-import android.app.Application
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
@@ -29,8 +27,6 @@ import com.datadog.tools.unit.ConditionWatcher
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 /**
  * Instrumented test verifying that AppStartupActivityPredicate correctly filters
@@ -55,12 +51,6 @@ internal class AppStartupActivityPredicateTest :
         val expectedEvents = mutableListOf<ExpectedEvent>()
         val instrumentation = InstrumentationRegistry.getInstrumentation()
 
-        // The lifecycle callback was registered in beforeActivityLaunched() (before the activity
-        // was launched), so the latch is guaranteed to fire even on fast devices where
-        // MainContentActivity reaches RESUMED before runInstrumentationScenario is called.
-        check(mockServerRule.mainActivityResumed.await(MAIN_ACTIVITY_WAIT_SECONDS, TimeUnit.SECONDS)) {
-            "MainContentActivity did not reach RESUMED state within $MAIN_ACTIVITY_WAIT_SECONDS seconds"
-        }
         instrumentation.waitForIdleSync()
         waitForPendingRUMEvents()
 
@@ -92,10 +82,6 @@ internal class AppStartupActivityPredicateTest :
         return expectedEvents
     }
 
-    companion object {
-        private const val MAIN_ACTIVITY_WAIT_SECONDS = 30L
-    }
-
     @Test
     fun verifyTTIDReportedForMainActivityWhenInterstitialExcluded() {
         val expectedEvents = runInstrumentationScenario(mockServerRule)
@@ -113,64 +99,36 @@ internal class AppStartupActivityPredicateTest :
 
     /**
      * Test rule that configures RUM with a predicate excluding InterstitialSplashActivity.
-     *
-     * The [mainActivityResumed] latch is registered in [beforeActivityLaunched], before the
-     * activity is launched, to avoid a race where MainContentActivity reaches RESUMED before
-     * [runInstrumentationScenario] has a chance to register the callback.
      */
     internal class AppStartupPredicateTestRule : RumMockServerActivityTestRule<InterstitialSplashActivity>(
         activityClass = InterstitialSplashActivity::class.java,
         keepRequests = true,
         trackingConsent = TrackingConsent.GRANTED
     ) {
-        val mainActivityResumed = CountDownLatch(1)
-        private var mainActivityResumedCallback: Application.ActivityLifecycleCallbacks =
-            NoOpActivityLifecycleCallbacks()
-
         @OptIn(ExperimentalRumApi::class)
         override fun beforeActivityLaunched() {
             super.beforeActivityLaunched()
-            val appContext = InstrumentationRegistry.getInstrumentation()
-                .targetContext.applicationContext
+            val config = RuntimeConfig.configBuilder()
+                .build()
 
-            // Register before the activity launches so we can't miss the RESUMED callback.
-            mainActivityResumedCallback = object : NoOpActivityLifecycleCallbacks() {
-                override fun onActivityResumed(activity: Activity) {
-                    if (activity is MainContentActivity) mainActivityResumed.countDown()
+            val sdkCore = Datadog.initialize(
+                InstrumentationRegistry.getInstrumentation().targetContext.applicationContext,
+                config,
+                trackingConsent
+            )
+            checkNotNull(sdkCore)
+
+            val rumConfig = RuntimeConfig.rumConfigBuilder()
+                .trackUserInteractions()
+                .trackLongTasks(RuntimeConfig.LONG_TASK_LARGE_THRESHOLD)
+                .useViewTrackingStrategy(ActivityViewTrackingStrategy(false))
+                // Exclude InterstitialSplashActivity from TTID measurement
+                .setAppStartupActivityPredicate { activity ->
+                    activity !is InterstitialSplashActivity
                 }
-            }
-            (appContext as Application).registerActivityLifecycleCallbacks(mainActivityResumedCallback)
-
-            try {
-                val config = RuntimeConfig.configBuilder()
-                    .build()
-
-                val sdkCore = Datadog.initialize(appContext, config, trackingConsent)
-                checkNotNull(sdkCore)
-
-                val rumConfig = RuntimeConfig.rumConfigBuilder()
-                    .trackUserInteractions()
-                    .trackLongTasks(RuntimeConfig.LONG_TASK_LARGE_THRESHOLD)
-                    .useViewTrackingStrategy(ActivityViewTrackingStrategy(false))
-                    // Exclude InterstitialSplashActivity from TTID measurement
-                    .setAppStartupActivityPredicate { activity ->
-                        activity !is InterstitialSplashActivity
-                    }
-                    .build()
-                Rum.enable(rumConfig, sdkCore)
-                DdRumContentProvider.processImportance =
-                    ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
-            } catch (e: Throwable) {
-                appContext.unregisterActivityLifecycleCallbacks(mainActivityResumedCallback)
-                throw e
-            }
-        }
-
-        override fun afterActivityFinished() {
-            super.afterActivityFinished()
-            val appContext = InstrumentationRegistry.getInstrumentation()
-                .targetContext.applicationContext as Application
-            appContext.unregisterActivityLifecycleCallbacks(mainActivityResumedCallback)
+                .build()
+            Rum.enable(rumConfig, sdkCore)
+            DdRumContentProvider.processImportance = ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Introduces a `FixedWindowCallback` Java wrapper in Session Replay that annotates nullable parameters correctly, preventing Kotlin's non-null assertions from crashing when Android passes null values to `Window.Callback` methods. `RecorderWindowCallback` now extends `FixedWindowCallback` instead of using Kotlin's `by` delegation.

Also simplifies `AppStartupActivityPredicateTest` by removing unnecessary synchronization logic.

### Motivation

A customer reported a crash (`NullPointerException: Parameter specified as non-null is null: method RecorderWindowCallback.onMenuOpened, parameter p1`) when opening a custom popup menu.

`RecorderWindowCallback` previously used Kotlin's `by wrappedCallback` delegation for `Window.Callback`. Kotlin generates non-null assertions for all parameters, but Android can call these methods with null values (known Android bug: https://issuetracker.google.com/issues/188568911). The previous fix only handled `dispatchTouchEvent` with a try-catch, but the same issue affected all menu-related callbacks.

### Changes

#### Fix RecorderWindowCallback crash on null menu parameter
- **New `FixedWindowCallback.java`**: A Java `Window.Callback` wrapper that annotates parameters as `@Nullable` where Android may pass null (e.g., `Menu`, `MenuItem`, `MotionEvent`). For null menu/item parameters, methods return safe defaults (`false` or no-op) instead of forwarding to the delegate.
- **Refactored `RecorderWindowCallback`**: Now extends `FixedWindowCallback` instead of using `by wrappedCallback` delegation. This eliminates the need for the try-catch workaround in `dispatchTouchEvent` and the `logOrRethrowWrappedCallbackException` helper.
- **Updated `WindowCallbackInterceptor`**: Uses `.delegate` (from `FixedWindowCallback`) instead of `.wrappedCallback` to unwrap callbacks.
- **Updated tests**: Added tests for menu callback delegation (`onMenuOpened`, `onMenuItemSelected`, `onPanelClosed`, `onPreparePanel`, `onCreatePanelMenu`) and null-parameter handling. Removed obsolete try-catch tests.

#### Simplify AppStartupActivityPredicateTest synchronization
- Removed `CountDownLatch`-based synchronization and lifecycle callback registration, relying on `waitForIdleSync()` instead.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)