### PR TITLE
FFL-1880: Emit initial state when observe() flow is collected

### DIFF
--- a/features/dd-sdk-android-flags-openfeature/src/main/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProvider.kt
+++ b/features/dd-sdk-android-flags-openfeature/src/main/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProvider.kt
@@ -205,6 +205,11 @@ class DatadogFlagsProvider private constructor(private val flagsClient: FlagsCli
      * - [FlagsClientState.NotReady]: Pre-initialization state, [initialize] blocks
      * - [FlagsClientState.Reconciling]: Context reconciliation, SDK handles via blocking [onContextSet]
      *
+     * **Initial State Delivery**:
+     * When the flow is collected, the current state is emitted immediately if it maps to a
+     * provider event. This ensures handlers attached after the provider is already in an
+     * associated state receive the event immediately.
+     *
      * The Flow automatically cleans up the listener when the collector is cancelled.
      *
      * @return Flow of provider state change events
@@ -212,18 +217,12 @@ class DatadogFlagsProvider private constructor(private val flagsClient: FlagsCli
     // Safe: We properly call awaitClose to cleanup listener, satisfying callbackFlow requirements
     @Suppress("UnsafeThirdPartyFunctionCall")
     override fun observe(): Flow<OpenFeatureProviderEvents> = callbackFlow {
+        // Emit initial state immediately when flow is collected
+        mapStateToEvent(flagsClient.state.getCurrentState())?.let { trySend(it) }
+
         val listener = object : FlagsStateListener {
             override fun onStateChanged(newState: FlagsClientState) {
-                val providerEvent: OpenFeatureProviderEvents? = when (newState) {
-                    FlagsClientState.NotReady -> null // SDK handles via blocking initialize()
-                    FlagsClientState.Reconciling -> null // SDK emits PROVIDER_RECONCILING
-                    FlagsClientState.Ready -> OpenFeatureProviderEvents.ProviderReady
-                    FlagsClientState.Stale -> OpenFeatureProviderEvents.ProviderStale
-                    is FlagsClientState.Error -> OpenFeatureProviderEvents.ProviderError(
-                        error = OpenFeatureError.ProviderFatalError()
-                    )
-                }
-                providerEvent?.let { trySend(it) }
+                mapStateToEvent(newState)?.let { trySend(it) }
             }
         }
 
@@ -232,6 +231,18 @@ class DatadogFlagsProvider private constructor(private val flagsClient: FlagsCli
         @Suppress("UnsafeThirdPartyFunctionCall")
         awaitClose {
             flagsClient.state.removeListener(listener)
+        }
+    }
+
+    private fun mapStateToEvent(state: FlagsClientState): OpenFeatureProviderEvents? {
+        return when (state) {
+            FlagsClientState.NotReady -> null // SDK handles via blocking initialize()
+            FlagsClientState.Reconciling -> null // SDK emits PROVIDER_RECONCILING
+            FlagsClientState.Ready -> OpenFeatureProviderEvents.ProviderReady
+            FlagsClientState.Stale -> OpenFeatureProviderEvents.ProviderStale
+            is FlagsClientState.Error -> OpenFeatureProviderEvents.ProviderError(
+                error = OpenFeatureError.ProviderFatalError()
+            )
         }
     }
 

--- a/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProviderTest.kt
+++ b/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProviderTest.kt
@@ -495,6 +495,84 @@ internal class DatadogFlagsProviderTest {
         assertThat(events).isEmpty()
     }
 
+    // region Initial State Delivery
+
+    @Test
+    fun `M emit initial ProviderReady W observe() {already in Ready state}`() = runTest {
+        // Given - provider is already in Ready state before collecting
+        whenever(mockStateObservable.getCurrentState()).thenReturn(FlagsClientState.Ready)
+        val events = mutableListOf<OpenFeatureProviderEvents>()
+
+        // When
+        val job = launch {
+            provider.observe().collect { events.add(it) }
+        }
+        testScheduler.runCurrent()
+        job.cancel()
+
+        // Then - initial Ready state is emitted immediately
+        assertThat(events).hasSize(1)
+        assertThat(events[0]).isInstanceOf(OpenFeatureProviderEvents.ProviderReady::class.java)
+    }
+
+    @Test
+    fun `M emit initial ProviderStale W observe() {already in Stale state}`() = runTest {
+        // Given - provider is already in Stale state before collecting
+        whenever(mockStateObservable.getCurrentState()).thenReturn(FlagsClientState.Stale)
+        val events = mutableListOf<OpenFeatureProviderEvents>()
+
+        // When
+        val job = launch {
+            provider.observe().collect { events.add(it) }
+        }
+        testScheduler.runCurrent()
+        job.cancel()
+
+        // Then - initial Stale state is emitted immediately
+        assertThat(events).hasSize(1)
+        assertThat(events[0]).isInstanceOf(OpenFeatureProviderEvents.ProviderStale::class.java)
+    }
+
+    @Test
+    fun `M emit initial ProviderError W observe() {already in Error state}`() = runTest {
+        // Given - provider is already in Error state before collecting
+        val errorState = FlagsClientState.Error(RuntimeException("test error"))
+        whenever(mockStateObservable.getCurrentState()).thenReturn(errorState)
+        val events = mutableListOf<OpenFeatureProviderEvents>()
+
+        // When
+        val job = launch {
+            provider.observe().collect { events.add(it) }
+        }
+        testScheduler.runCurrent()
+        job.cancel()
+
+        // Then - initial Error state is emitted immediately
+        assertThat(events).hasSize(1)
+        assertThat(events[0]).isInstanceOf(OpenFeatureProviderEvents.ProviderError::class.java)
+    }
+
+    @Test
+    fun `M not emit initial event W observe() {in NotReady or Reconciling state}`() = runTest {
+        listOf(FlagsClientState.NotReady, FlagsClientState.Reconciling).forEach { state ->
+            // Given - provider is in a filtered state
+            whenever(mockStateObservable.getCurrentState()).thenReturn(state)
+            val events = mutableListOf<OpenFeatureProviderEvents>()
+
+            // When
+            val job = launch {
+                provider.observe().collect { events.add(it) }
+            }
+            testScheduler.runCurrent()
+            job.cancel()
+
+            // Then - no initial event emitted for filtered states
+            assertThat(events).isEmpty()
+        }
+    }
+
+    // endregion
+
     @Test
     fun `M unregister listener W observe() {flow cancelled}`() = runTest {
         // When


### PR DESCRIPTION
### What does this PR do?

Modifies `observe()` in `DatadogFlagsProvider` to emit the current state immediately when the flow is collected. This ensures handlers attached after the provider is already in an associated state receive the event immediately [OpenFeature Requirement 5.3.3](https://openfeature.dev/specification/sections/events#requirement-533).

Changes:
- Emit initial state when flow collection starts
- Extract state-to-event mapping into reusable `mapStateToEvent()` function
- Add tests for initial state delivery behavior

### Motivation

OpenFeature Requirement 5.3.3 states that handlers attached after the provider is already in the associated state MUST run immediately. The previous implementation only emitted events on state changes, not the current state when subscribing.

### Additional Notes

Tests added:
- `M emit initial ProviderReady W observe() {already in Ready state}`
- `M emit initial ProviderStale W observe() {already in Stale state}`
- `M emit initial ProviderError W observe() {already in Error state}`
- `M not emit initial event W observe() {in NotReady or Reconciling state}`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)