### PR TITLE
Fix RecorderWindowCallback crash on null menu parameter

### DIFF
--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -471,6 +471,35 @@ public final class com/datadog/android/internal/utils/DDCoreSubscription$Compani
 	public final fun create ()Lcom/datadog/android/internal/utils/DDCoreSubscription;
 }
 
+public class com/datadog/android/internal/utils/FixedWindowCallback : android/view/Window$Callback {
+	public fun <init> (Landroid/view/Window$Callback;)V
+	public fun dispatchGenericMotionEvent (Landroid/view/MotionEvent;)Z
+	public fun dispatchKeyEvent (Landroid/view/KeyEvent;)Z
+	public fun dispatchKeyShortcutEvent (Landroid/view/KeyEvent;)Z
+	public fun dispatchPopulateAccessibilityEvent (Landroid/view/accessibility/AccessibilityEvent;)Z
+	public fun dispatchTouchEvent (Landroid/view/MotionEvent;)Z
+	public fun dispatchTrackballEvent (Landroid/view/MotionEvent;)Z
+	public fun onActionModeFinished (Landroid/view/ActionMode;)V
+	public fun onActionModeStarted (Landroid/view/ActionMode;)V
+	public fun onAttachedToWindow ()V
+	public fun onContentChanged ()V
+	public fun onCreatePanelMenu (ILandroid/view/Menu;)Z
+	public fun onCreatePanelView (I)Landroid/view/View;
+	public fun onDetachedFromWindow ()V
+	public fun onMenuItemSelected (ILandroid/view/MenuItem;)Z
+	public fun onMenuOpened (ILandroid/view/Menu;)Z
+	public fun onPanelClosed (ILandroid/view/Menu;)V
+	public fun onPointerCaptureChanged (Z)V
+	public fun onPreparePanel (ILandroid/view/View;Landroid/view/Menu;)Z
+	public fun onProvideKeyboardShortcuts (Ljava/util/List;Landroid/view/Menu;I)V
+	public fun onSearchRequested ()Z
+	public fun onSearchRequested (Landroid/view/SearchEvent;)Z
+	public fun onWindowAttributesChanged (Landroid/view/WindowManager$LayoutParams;)V
+	public fun onWindowFocusChanged (Z)V
+	public fun onWindowStartingActionMode (Landroid/view/ActionMode$Callback;)Landroid/view/ActionMode;
+	public fun onWindowStartingActionMode (Landroid/view/ActionMode$Callback;I)Landroid/view/ActionMode;
+}
+
 public final class com/datadog/android/internal/utils/ImageViewUtils {
 	public static final field INSTANCE Lcom/datadog/android/internal/utils/ImageViewUtils;
 	public final fun calculateClipping (Landroid/graphics/Rect;Landroid/graphics/Rect;F)Landroid/graphics/Rect;

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/utils/FixedWindowCallback.java
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/utils/FixedWindowCallback.java
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.rum.internal;
+package com.datadog.android.internal.utils;
 
 import android.os.Build;
 import android.view.ActionMode;
@@ -23,8 +23,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
-import com.datadog.android.lint.InternalApi;
-
 import java.util.List;
 
 /**
@@ -33,7 +31,6 @@ import java.util.List;
  * with a null menu parameter.
  * To track the issue: https://issuetracker.google.com/issues/188568911
  */
-@InternalApi
 public class FixedWindowCallback implements Window.Callback {
 
     private final Window.Callback delegate;

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -326,35 +326,6 @@ public final class com/datadog/android/rum/featureoperations/FailureReason : jav
 	public static fun values ()[Lcom/datadog/android/rum/featureoperations/FailureReason;
 }
 
-public class com/datadog/android/rum/internal/FixedWindowCallback : android/view/Window$Callback {
-	public fun <init> (Landroid/view/Window$Callback;)V
-	public fun dispatchGenericMotionEvent (Landroid/view/MotionEvent;)Z
-	public fun dispatchKeyEvent (Landroid/view/KeyEvent;)Z
-	public fun dispatchKeyShortcutEvent (Landroid/view/KeyEvent;)Z
-	public fun dispatchPopulateAccessibilityEvent (Landroid/view/accessibility/AccessibilityEvent;)Z
-	public fun dispatchTouchEvent (Landroid/view/MotionEvent;)Z
-	public fun dispatchTrackballEvent (Landroid/view/MotionEvent;)Z
-	public fun onActionModeFinished (Landroid/view/ActionMode;)V
-	public fun onActionModeStarted (Landroid/view/ActionMode;)V
-	public fun onAttachedToWindow ()V
-	public fun onContentChanged ()V
-	public fun onCreatePanelMenu (ILandroid/view/Menu;)Z
-	public fun onCreatePanelView (I)Landroid/view/View;
-	public fun onDetachedFromWindow ()V
-	public fun onMenuItemSelected (ILandroid/view/MenuItem;)Z
-	public fun onMenuOpened (ILandroid/view/Menu;)Z
-	public fun onPanelClosed (ILandroid/view/Menu;)V
-	public fun onPointerCaptureChanged (Z)V
-	public fun onPreparePanel (ILandroid/view/View;Landroid/view/Menu;)Z
-	public fun onProvideKeyboardShortcuts (Ljava/util/List;Landroid/view/Menu;I)V
-	public fun onSearchRequested ()Z
-	public fun onSearchRequested (Landroid/view/SearchEvent;)Z
-	public fun onWindowAttributesChanged (Landroid/view/WindowManager$LayoutParams;)V
-	public fun onWindowFocusChanged (Z)V
-	public fun onWindowStartingActionMode (Landroid/view/ActionMode$Callback;)Landroid/view/ActionMode;
-	public fun onWindowStartingActionMode (Landroid/view/ActionMode$Callback;I)Landroid/view/ActionMode;
-}
-
 public final class com/datadog/android/rum/internal/domain/event/ResourceTiming {
 	public fun <init> ()V
 	public fun <init> (JJJJJJJJJJ)V

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapper.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapper.kt
@@ -12,10 +12,10 @@ import android.view.MotionEvent
 import android.view.Window
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
+import com.datadog.android.internal.utils.FixedWindowCallback
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
-import com.datadog.android.rum.internal.FixedWindowCallback
 import com.datadog.android.rum.internal.tracking.NoOpInteractionPredicate
 import com.datadog.android.rum.tracking.InteractionPredicate
 import com.datadog.android.rum.tracking.ViewAttributesProvider

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/utils/window/RumWindowCallbacksRegistry.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/utils/window/RumWindowCallbacksRegistry.kt
@@ -9,7 +9,7 @@ package com.datadog.android.rum.internal.utils.window
 import android.app.Activity
 import android.view.Window
 import com.datadog.android.internal.utils.DDCoreSubscription
-import com.datadog.android.rum.internal.FixedWindowCallback
+import com.datadog.android.internal.utils.FixedWindowCallback
 import java.util.WeakHashMap
 import kotlin.collections.getOrPut
 import kotlin.let

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/utils/RumWindowCallbacksRegistryTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/utils/RumWindowCallbacksRegistryTest.kt
@@ -8,7 +8,7 @@ package com.datadog.android.rum.internal.utils
 
 import android.app.Activity
 import android.view.Window
-import com.datadog.android.rum.internal.FixedWindowCallback
+import com.datadog.android.internal.utils.FixedWindowCallback
 import com.datadog.android.rum.internal.utils.window.RumWindowCallbackListener
 import com.datadog.android.rum.internal.utils.window.RumWindowCallbacksRegistryImpl
 import org.assertj.core.api.Assertions.assertThat

--- a/features/dd-sdk-android-session-replay/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay/build.gradle.kts
@@ -50,7 +50,6 @@ android {
 dependencies {
     api(project(":dd-sdk-android-core"))
     implementation(project(":dd-sdk-android-internal"))
-    compileOnly(project(":features:dd-sdk-android-rum"))
     implementation(libs.okHttp)
     implementation(libs.kotlin)
     implementation(libs.gson)
@@ -58,7 +57,6 @@ dependencies {
 
     ksp(project(":tools:noopfactory"))
 
-    testImplementation(project(":features:dd-sdk-android-rum"))
     testImplementation(project(":tools:unit")) {
         attributes {
             attribute(

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallback.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallback.kt
@@ -82,7 +82,13 @@ internal class RecorderWindowCallback(
             )
         }
 
-        return super.dispatchTouchEvent(event)
+        @Suppress("SwallowedException")
+        return try {
+            super.dispatchTouchEvent(event)
+        } catch (e: NullPointerException) {
+            logOrRethrowWrappedCallbackException(e)
+            EVENT_CONSUMED
+        }
     }
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {
@@ -175,9 +181,30 @@ internal class RecorderWindowCallback(
         lastPerformedFlushTimeInNs = timeProvider.getDeviceElapsedTimeNanos()
     }
 
+    private fun logOrRethrowWrappedCallbackException(e: NullPointerException) {
+        // When calling delegate callback, we may have something like
+        // java.lang.NullPointerException: Parameter specified as non-null is null:
+        // method xxx, parameter xxx
+        // This happens because Kotlin delegate expects non-null value incorrectly inferring
+        // non-null type from Java interface definition (seems to be solved in Kotlin 1.8 though)
+        if (e.message?.contains("Parameter specified as non-null is null") == true) {
+            internalLogger.log(
+                InternalLogger.Level.ERROR,
+                InternalLogger.Target.MAINTAINER,
+                { FAIL_TO_PROCESS_MOTION_EVENT_ERROR_MESSAGE },
+                e
+            )
+        } else {
+            @Suppress("ThrowingInternalException") // we need to let client exception to propagate
+            throw e
+        }
+    }
+
     // endregion
 
     companion object {
+        private const val EVENT_CONSUMED: Boolean = true
+
         // every frame we collect the move event positions
         internal val MOTION_UPDATE_DELAY_THRESHOLD_NS: Long =
             TimeUnit.MILLISECONDS.toNanos(16)
@@ -186,5 +213,7 @@ internal class RecorderWindowCallback(
         internal val FLUSH_BUFFER_THRESHOLD_NS: Long = MOTION_UPDATE_DELAY_THRESHOLD_NS * 10
         internal const val MOTION_EVENT_WAS_NULL_ERROR_MESSAGE =
             "RecorderWindowCallback: intercepted null motion event"
+        internal const val FAIL_TO_PROCESS_MOTION_EVENT_ERROR_MESSAGE =
+            "RecorderWindowCallback: wrapped callback failed to handle the motion event"
     }
 }


### PR DESCRIPTION
### What does this PR do?

Overrides menu-related `Window.Callback` methods in `RecorderWindowCallback` with nullable parameters, preventing Kotlin's non-null assertions from crashing when Android passes null values.

### Motivation

A customer reported a crash (`NullPointerException: Parameter specified as non-null is null: method RecorderWindowCallback.onMenuOpened, parameter p1`) when opening a custom popup menu.

`RecorderWindowCallback` uses Kotlin's `by wrappedCallback` delegation for `Window.Callback`. Kotlin generates non-null assertions for all delegated parameters, but Android can call these methods with null values (known Android bug: https://issuetracker.google.com/issues/188568911). The previous fix only handled `dispatchTouchEvent` with a try-catch, but the same issue affected all menu-related callbacks.

### Changes

- Override `onMenuOpened`, `onMenuItemSelected`, `onPanelClosed`, `onPreparePanel`, and `onCreatePanelMenu` in `RecorderWindowCallback` with nullable parameters. When null is received, methods return safe defaults (`false` or no-op) instead of crashing.
- Remove the `dispatchTouchEvent` try-catch workaround and `logOrRethrowWrappedCallbackException` helper, since `dispatchTouchEvent` already declares its parameter as nullable.
- Add tests for menu callback delegation and null-parameter handling.
- Remove obsolete try-catch tests and unused imports.

### Note

This is an alternative to #3221 with a simpler approach: nullable Kotlin overrides instead of a `FixedWindowCallback` Java wrapper class. No new files, no API surface change, no inheritance change.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)