### PR TITLE
Update profiling telemetry with more data

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -155,6 +155,7 @@ interface com.datadog.android.internal.system.BuildSdkVersionProvider
   val isAtLeastR: Boolean
   val isAtLeastS: Boolean
   val isAtLeastTiramisu: Boolean
+  val isAtLeastVanillaIceCream: Boolean
   companion object 
     val DEFAULT: BuildSdkVersionProvider
 sealed class com.datadog.android.internal.telemetry.InternalTelemetryEvent

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -295,6 +295,7 @@ public abstract interface class com/datadog/android/internal/system/BuildSdkVers
 	public abstract fun isAtLeastR ()Z
 	public abstract fun isAtLeastS ()Z
 	public abstract fun isAtLeastTiramisu ()Z
+	public abstract fun isAtLeastVanillaIceCream ()Z
 }
 
 public final class com/datadog/android/internal/system/BuildSdkVersionProvider$Companion {

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/system/BuildSdkVersionProvider.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/system/BuildSdkVersionProvider.kt
@@ -41,6 +41,9 @@ interface BuildSdkVersionProvider {
     @get:ChecksSdkIntAtLeast(api = Build.VERSION_CODES.TIRAMISU)
     val isAtLeastTiramisu: Boolean
 
+    @get:ChecksSdkIntAtLeast(api = Build.VERSION_CODES.VANILLA_ICE_CREAM)
+    val isAtLeastVanillaIceCream: Boolean
+
     companion object {
 
         /**
@@ -71,6 +74,10 @@ interface BuildSdkVersionProvider {
 
             @get:ChecksSdkIntAtLeast(api = Build.VERSION_CODES.TIRAMISU)
             override val isAtLeastTiramisu: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+
+            @get:ChecksSdkIntAtLeast(api = Build.VERSION_CODES.VANILLA_ICE_CREAM)
+            override val isAtLeastVanillaIceCream: Boolean =
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM
         }
     }
 }

--- a/features/dd-sdk-android-profiling/api/apiSurface
+++ b/features/dd-sdk-android-profiling/api/apiSurface
@@ -1,4 +1,5 @@
 class com.datadog.android.profiling.DdProfilingContentProvider : android.content.ContentProvider
+  constructor(com.datadog.android.internal.system.BuildSdkVersionProvider = DEFAULT)
   override fun onCreate(): Boolean
   override fun query(android.net.Uri, Array<String>?, String?, Array<String>?, String?): android.database.Cursor?
   override fun getType(android.net.Uri): String?

--- a/features/dd-sdk-android-profiling/api/dd-sdk-android-profiling.api
+++ b/features/dd-sdk-android-profiling/api/dd-sdk-android-profiling.api
@@ -1,5 +1,7 @@
 public final class com/datadog/android/profiling/DdProfilingContentProvider : android/content/ContentProvider {
 	public fun <init> ()V
+	public fun <init> (Lcom/datadog/android/internal/system/BuildSdkVersionProvider;)V
+	public synthetic fun <init> (Lcom/datadog/android/internal/system/BuildSdkVersionProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun delete (Landroid/net/Uri;Ljava/lang/String;[Ljava/lang/String;)I
 	public fun getType (Landroid/net/Uri;)Ljava/lang/String;
 	public fun insert (Landroid/net/Uri;Landroid/content/ContentValues;)Landroid/net/Uri;

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/DdProfilingContentProvider.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/DdProfilingContentProvider.kt
@@ -16,44 +16,65 @@ import android.net.Uri
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.datadog.android.core.sampling.RateBasedSampler
+import com.datadog.android.internal.system.BuildSdkVersionProvider
+import com.datadog.android.internal.system.BuildSdkVersionProvider.Companion.DEFAULT
+import com.datadog.android.profiling.internal.ProfilingStartReason
 import com.datadog.android.profiling.internal.ProfilingStorage
+import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
 
 /**
  * A [ContentProvider] to start Profiling request as early as possible in the app's
  * lifecycle.
  */
 @OptIn(ExperimentalProfilingApi::class)
-class DdProfilingContentProvider : ContentProvider() {
+class DdProfilingContentProvider(
+    private val buildSdkVersionProvider: BuildSdkVersionProvider = DEFAULT
+) : ContentProvider() {
 
     override fun onCreate(): Boolean {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-            context?.let {
-                val instanceNames = ProfilingStorage.getProfilingEnabledInstanceNames(it)
-                if (instanceNames.isNotEmpty() && isProcessFromLauncher()) {
-                    sampleProfiling(it, instanceNames)
-                }
+        context?.let { onStart(it) }
+        return true
+    }
+
+    internal fun onStart(context: Context) {
+        if (buildSdkVersionProvider.isAtLeastVanillaIceCream) {
+            val instanceNames = ProfilingStorage.getProfilingEnabledInstanceNames(context)
+            if (instanceNames.isNotEmpty()) {
+                sampleProfiling(context, instanceNames)
             }
         }
-        return true
     }
 
     @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
     private fun sampleProfiling(context: Context, instanceNames: Set<String>) {
+        val appStartInfo = getAppStartInfo(context) ?: return
         val sampleRate = ProfilingStorage.getSampleRate(context)
         if (RateBasedSampler<Unit>(sampleRate).sample(Unit)) {
-            Profiling.start(context, instanceNames)
+            Profiling.start(
+                context = context,
+                startReason = ProfilingStartReason.APPLICATION_LAUNCH,
+                additionalAttributes = mapOf(PerfettoProfiler.TELEMETRY_KEY_APP_START_INFO to appStartInfo),
+                sdkInstanceNames = instanceNames
+            )
         }
         ProfilingStorage.removeSampleRate(context)
     }
 
+    /**
+     * Returns the Android [ApplicationStartInfo] start reason as a telemetry string if this
+     * process was started from an eligible launcher reason, or null if profiling should not run.
+     */
     @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
-    private fun isProcessFromLauncher(): Boolean {
-        val manager = context?.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+    private fun getAppStartInfo(context: Context): String? {
+        val manager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
         val startReason = manager?.getHistoricalProcessStartReasons(1)
             ?.firstOrNull()?.reason
-        // TODO RUM-14061: Add all the necessary start reason for application profiling
-        return startReason == ApplicationStartInfo.START_REASON_LAUNCHER ||
-            startReason == ApplicationStartInfo.START_REASON_START_ACTIVITY
+        return when (startReason) {
+            ApplicationStartInfo.START_REASON_LAUNCHER -> TELEMETRY_APP_START_INFO_LAUNCHER
+            ApplicationStartInfo.START_REASON_START_ACTIVITY -> TELEMETRY_APP_START_INFO_ACTIVITY
+            ApplicationStartInfo.START_REASON_LAUNCHER_RECENTS -> TELEMETRY_APP_START_INFO_RECENTS
+            else -> null
+        }
     }
 
     override fun query(
@@ -85,5 +106,11 @@ class DdProfilingContentProvider : ContentProvider() {
         selectionArgs: Array<out String>?
     ): Int {
         return 0
+    }
+
+    internal companion object {
+        internal const val TELEMETRY_APP_START_INFO_LAUNCHER = "launcher"
+        internal const val TELEMETRY_APP_START_INFO_ACTIVITY = "start_activity"
+        internal const val TELEMETRY_APP_START_INFO_RECENTS = "recents"
     }
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/Profiling.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/Profiling.kt
@@ -16,6 +16,7 @@ import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.profiling.internal.NoOpProfiler
 import com.datadog.android.profiling.internal.Profiler
 import com.datadog.android.profiling.internal.ProfilingFeature
+import com.datadog.android.profiling.internal.ProfilingStartReason
 import com.datadog.android.profiling.internal.ProfilingStorage
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
 import java.util.concurrent.Executors
@@ -59,12 +60,19 @@ object Profiling {
      * Start profiling with given SDK instances names.
      *
      * @param context application context
+     * @param startReason reason to start a profiling session
+     * @param additionalAttributes additional attributes to include in the profiling telemetry
      * @param sdkInstanceNames the set of the SDK instances name
      */
     @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
-    internal fun start(context: Context, sdkInstanceNames: Set<String>) {
+    internal fun start(
+        context: Context,
+        startReason: ProfilingStartReason,
+        additionalAttributes: Map<String, String>,
+        sdkInstanceNames: Set<String>
+    ) {
         initializeProfiler()
-        profiler.start(context, sdkInstanceNames)
+        profiler.start(context, startReason, additionalAttributes, sdkInstanceNames)
         ProfilingStorage.removeProfilingFlag(context, sdkInstanceNames)
     }
 
@@ -72,11 +80,18 @@ object Profiling {
      * Start profiling for a given SDK instance.
      *
      * @param context application context
+     * @param startReason reason to start a profiling session
+     * @param additionalAttributes additional attributes to include in the profiling telemetry
      * @param sdkCore SDK instance to start profiling with. If not provided, default SDK instance.
      */
     @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
-    internal fun start(context: Context, sdkCore: SdkCore = Datadog.getInstance()) {
-        start(context, setOf(sdkCore.name))
+    internal fun start(
+        context: Context,
+        startReason: ProfilingStartReason,
+        additionalAttributes: Map<String, String>,
+        sdkCore: SdkCore = Datadog.getInstance()
+    ) {
+        start(context, startReason, additionalAttributes, setOf(sdkCore.name))
     }
 
     /**

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/Profiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/Profiler.kt
@@ -15,7 +15,12 @@ internal interface Profiler {
 
     var internalLogger: InternalLogger?
 
-    fun start(appContext: Context, sdkInstanceNames: Set<String>)
+    fun start(
+        appContext: Context,
+        startReason: ProfilingStartReason,
+        additionalAttributes: Map<String, String>,
+        sdkInstanceNames: Set<String>
+    )
 
     fun stop(sdkInstanceName: String)
 

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -20,7 +20,6 @@ import com.datadog.android.internal.profiling.ProfilerStopEvent
 import com.datadog.android.internal.profiling.TTIDRumContext
 import com.datadog.android.profiling.ExperimentalProfilingApi
 import com.datadog.android.profiling.ProfilingConfiguration
-import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
@@ -123,7 +122,7 @@ internal class ProfilingFeature(
     private fun tryWriteProfilingEvent() {
         val perfettoResult = perfettoResult ?: return
         val ttidRumContext = ttidRumContext ?: return
-        if (perfettoResult.tag != PerfettoProfiler.PROFILING_TAG_APPLICATION_LAUNCH) return
+        if (perfettoResult.tag != ProfilingStartReason.APPLICATION_LAUNCH.value) return
         if (!isTtidProfileSent.getAndSet(true)) {
             dataWriter.write(
                 profilingResult = perfettoResult,

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingStartReason.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingStartReason.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling.internal
+
+internal enum class ProfilingStartReason(val value: String) {
+
+    APPLICATION_LAUNCH("application_launch"),
+
+    RUM_OPERATION("rum_operation"),
+
+    CONTINUOUS("continuous"),
+
+    UNKNOWN("unknown")
+}

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
@@ -20,6 +20,7 @@ import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.profiling.internal.Profiler
 import com.datadog.android.profiling.internal.ProfilerCallback
+import com.datadog.android.profiling.internal.ProfilingStartReason
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
@@ -29,7 +30,9 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.function.Consumer
 
 /**
- * Profiler based on Android's [requestProfiling] API to record callstack samples during application launch.
+ * Profiler based on Android's [requestProfiling] API to record callstack samples.
+ *
+ * Supports multiple start reasons including application launch, RUM operations, and continuous profiling.
  *
  * @param timeProvider The time provider to use to get the current time.
  * @param profilingExecutor the executor service to run the profiling task on.
@@ -48,6 +51,12 @@ internal class PerfettoProfiler(
 
     @Volatile
     private var profilingStartTime = 0L
+
+    @Volatile
+    private var profilingStartReason: ProfilingStartReason = ProfilingStartReason.UNKNOWN
+
+    @Volatile
+    private var profilingAppStartInfo: String? = null
 
     private val pendingTelemetry: MutableSet<TelemetryData> = mutableSetOf()
 
@@ -81,16 +90,21 @@ internal class PerfettoProfiler(
                 }
             }
             runningInstances.set(emptySet())
-            sendProfilingEndTelemetry(result = result, duration = duration)
+            sendProfilingEndTelemetry(
+                result = result,
+                duration = duration,
+                startReason = profilingStartReason,
+                appStartInfo = profilingAppStartInfo
+            )
         }
     }
 
-    private fun buildStackSamplingRequest(): ProfilingRequest {
+    private fun buildStackSamplingRequest(startReason: String): ProfilingRequest {
         return CancellationSignal().let {
             this.stopSignal = it
             StackSamplingRequestBuilder()
                 .setCancellationSignal(it)
-                .setTag(PROFILING_TAG_APPLICATION_LAUNCH)
+                .setTag(startReason)
                 .setSamplingFrequencyHz(PROFILING_SAMPLING_RATE)
                 .setBufferSizeKb(BUFFER_SIZE_KB)
                 .setDurationMs(PROFILING_MAX_DURATION_MS)
@@ -104,13 +118,20 @@ internal class PerfettoProfiler(
         }
     }
 
-    override fun start(appContext: Context, sdkInstanceNames: Set<String>) {
+    override fun start(
+        appContext: Context,
+        startReason: ProfilingStartReason,
+        additionalAttributes: Map<String, String>,
+        sdkInstanceNames: Set<String>
+    ) {
         // profiling will be launched when no instance is currently running profiling.
         if (runningInstances.compareAndSet(emptySet(), sdkInstanceNames)) {
             profilingStartTime = timeProvider.getDeviceTimestampMillis()
+            profilingStartReason = startReason
+            profilingAppStartInfo = additionalAttributes[TELEMETRY_KEY_APP_START_INFO]
             requestProfiling(
                 appContext,
-                buildStackSamplingRequest(),
+                buildStackSamplingRequest(startReason.value),
                 profilingExecutor,
                 resultCallback
             )
@@ -141,8 +162,15 @@ internal class PerfettoProfiler(
         callbackMap.remove(sdkInstanceName)
     }
 
-    private fun sendProfilingEndTelemetry(result: ProfilingResult, duration: Long) {
+    private fun sendProfilingEndTelemetry(
+        result: ProfilingResult,
+        duration: Long,
+        startReason: ProfilingStartReason,
+        appStartInfo: String?
+    ) {
         val telemetryData = TelemetryData(
+            startReason = startReason.value,
+            appStartInfo = appStartInfo,
             errorCode = result.errorCode,
             errorMessage = result.errorMessage,
             filePath = result.resultFilePath,
@@ -180,14 +208,17 @@ internal class PerfettoProfiler(
 
     private fun performLogMetric(logger: InternalLogger, telemetryData: TelemetryData) {
         logger.logMetric(
-            messageBuilder = { TELEMETRY_MSG_PROFILING_APP_LAUNCH },
+            messageBuilder = { TELEMETRY_MSG_PROFILING_SESSION },
             additionalProperties = mapOf(
-                TELEMETRY_KEY_PROFILING_APP_LAUNCH to mapOf(
+                TELEMETRY_KEY_METRIC_TYPE to TELEMETRY_VALUE_METRIC_TYPE,
+                TELEMETRY_KEY_PROFILING_SESSION to mapOf(
                     TELEMETRY_KEY_ERROR_CODE to telemetryData.errorCode,
-                    TELEMETRY_KEY_ERROR_MESSAGE to telemetryData.errorMessage,
+                    TELEMETRY_KEY_START_REASON to telemetryData.startReason,
                     TELEMETRY_KEY_DURATION to telemetryData.duration,
+                    TELEMETRY_KEY_ERROR_MESSAGE to telemetryData.errorMessage,
                     TELEMETRY_KEY_FILE_SIZE to getFileSize(telemetryData.filePath),
-                    TELEMETRY_KEY_STOPPED_REASON to telemetryData.stopReason
+                    TELEMETRY_KEY_STOPPED_REASON to telemetryData.stopReason,
+                    TELEMETRY_KEY_APP_START_INFO to telemetryData.appStartInfo
                 ),
                 TELEMETRY_KEY_PROFILING_CONFIG to mapOf(
                     TELEMETRY_KEY_BUFFER_SIZE to BUFFER_SIZE_KB,
@@ -208,6 +239,8 @@ internal class PerfettoProfiler(
     }
 
     private data class TelemetryData(
+        val startReason: String,
+        val appStartInfo: String?,
         val errorCode: Int,
         val errorMessage: String?,
         val filePath: String?,
@@ -219,7 +252,6 @@ internal class PerfettoProfiler(
 
         // Duration is based on the current P99 TTID metric.
         private val PROFILING_MAX_DURATION_MS = TimeUnit.SECONDS.toMillis(10).toInt()
-        internal const val PROFILING_TAG_APPLICATION_LAUNCH = "ApplicationLaunch"
 
         // Currently we give an estimated maximum size of profiling result to 5MB, it can be
         // increased or configurable if needed.
@@ -228,17 +260,20 @@ internal class PerfettoProfiler(
         // Currently we give 201HZ frequency to balance the sampling accuracy and performance
         // overhead also to avoid lockstep sampling, it can be updated or configurable if needed.
         internal const val PROFILING_SAMPLING_RATE = 201 // 201Hz
-        private const val TELEMETRY_MSG_PROFILING_APP_LAUNCH =
-            "[Mobile Metric] Profiling App Launch"
-        private const val TELEMETRY_KEY_PROFILING_APP_LAUNCH = "profiling_app_launch"
+        private const val TELEMETRY_MSG_PROFILING_SESSION = "[Mobile Metric] Profiling Session"
+        private const val TELEMETRY_KEY_METRIC_TYPE = "metric_type"
+        private const val TELEMETRY_VALUE_METRIC_TYPE = "profiling session"
+        private const val TELEMETRY_KEY_PROFILING_SESSION = "profiling_session"
         private const val TELEMETRY_KEY_PROFILING_CONFIG = "profiling_config"
         private const val TELEMETRY_KEY_ERROR_CODE = "error_code"
+        private const val TELEMETRY_KEY_START_REASON = "start_reason"
         private const val TELEMETRY_KEY_ERROR_MESSAGE = "error_message"
         private const val TELEMETRY_KEY_DURATION = "duration"
         private const val TELEMETRY_KEY_FILE_SIZE = "file_size"
+        private const val TELEMETRY_KEY_STOPPED_REASON = "stopped_reason"
+        internal const val TELEMETRY_KEY_APP_START_INFO = "app_start_info"
         private const val TELEMETRY_KEY_BUFFER_SIZE = "buffer_size"
         private const val TELEMETRY_KEY_SAMPLING_FREQUENCY = "sampling_frequency"
-        private const val TELEMETRY_KEY_STOPPED_REASON = "stopped_reason"
         private const val TELEMETRY_VALUE_STOPPED_REASON_MANUAL = "manual"
         private const val TELEMETRY_VALUE_STOPPED_REASON_TIMEOUT = "timeout"
         private const val TELEMETRY_VALUE_STOPPED_REASON_ERROR = "error"

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/DdProfilingContentProviderTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/DdProfilingContentProviderTest.kt
@@ -1,0 +1,212 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling
+
+import android.app.ActivityManager
+import android.app.ApplicationStartInfo
+import android.content.Context
+import com.datadog.android.internal.data.SharedPreferencesStorage
+import com.datadog.android.internal.system.BuildSdkVersionProvider
+import com.datadog.android.profiling.DdProfilingContentProvider.Companion.TELEMETRY_APP_START_INFO_ACTIVITY
+import com.datadog.android.profiling.DdProfilingContentProvider.Companion.TELEMETRY_APP_START_INFO_LAUNCHER
+import com.datadog.android.profiling.DdProfilingContentProvider.Companion.TELEMETRY_APP_START_INFO_RECENTS
+import com.datadog.android.profiling.forge.Configurator
+import com.datadog.android.profiling.internal.NoOpProfiler
+import com.datadog.android.profiling.internal.Profiler
+import com.datadog.android.profiling.internal.ProfilingStartReason
+import com.datadog.android.profiling.internal.ProfilingStorage
+import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler.Companion.TELEMETRY_KEY_APP_START_INFO
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@OptIn(ExperimentalProfilingApi::class)
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+class DdProfilingContentProviderTest {
+
+    private lateinit var testedProvider: DdProfilingContentProvider
+
+    @Mock
+    private lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
+
+    @Mock
+    private lateinit var mockContext: Context
+
+    @Mock
+    private lateinit var mockActivityManager: ActivityManager
+
+    @Mock
+    private lateinit var mockApplicationStartInfo: ApplicationStartInfo
+
+    @Mock
+    private lateinit var mockProfiler: Profiler
+
+    @Mock
+    private lateinit var mockSharedPreferencesStorage: SharedPreferencesStorage
+
+    @StringForgery
+    private lateinit var fakeInstanceName: String
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(mockBuildSdkVersionProvider.isAtLeastVanillaIceCream).doReturn(true)
+        whenever(mockContext.getSystemService(Context.ACTIVITY_SERVICE)).doReturn(
+            mockActivityManager
+        )
+        whenever(mockActivityManager.getHistoricalProcessStartReasons(1))
+            .doReturn(listOf(mockApplicationStartInfo))
+
+        whenever(mockSharedPreferencesStorage.getFloat(any(), any())).doReturn(100f)
+
+        whenever(mockSharedPreferencesStorage.getStringSet(any(), any()))
+            .doReturn(setOf(fakeInstanceName))
+
+        ProfilingStorage.sharedPreferencesStorage = mockSharedPreferencesStorage
+        Profiling.profiler = mockProfiler
+        Profiling.isProfilerInitialized.set(true)
+
+        testedProvider = DdProfilingContentProvider(mockBuildSdkVersionProvider)
+    }
+
+    @AfterEach
+    fun `tear down`() {
+        Profiling.profiler = NoOpProfiler()
+        Profiling.isProfilerInitialized.set(false)
+        ProfilingStorage.sharedPreferencesStorage = null
+    }
+
+    @ParameterizedTest(name = "start reason: {0}, expected telemetry: {1}")
+    @MethodSource("eligibleStartReasons")
+    fun `M start profiling with app_start_info W onCreate { eligible start reason }`(
+        startReason: Int,
+        expectedTelemetryValue: String
+    ) {
+        // Given
+        whenever(mockApplicationStartInfo.reason).doReturn(startReason)
+
+        // When
+        testedProvider.onStart(mockContext)
+
+        // Then
+        verify(mockProfiler).start(
+            mockContext,
+            ProfilingStartReason.APPLICATION_LAUNCH,
+            mapOf(TELEMETRY_KEY_APP_START_INFO to expectedTelemetryValue),
+            setOf(fakeInstanceName)
+        )
+    }
+
+    @ParameterizedTest(name = "start reason: {0}")
+    @MethodSource("ineligibleStartReasons")
+    fun `M not start profiling W onCreate { ineligible start reason }`(startReason: Int) {
+        // Given
+        whenever(mockApplicationStartInfo.reason).doReturn(startReason)
+
+        // When
+        testedProvider.onStart(mockContext)
+
+        // Then
+        verifyNoInteractions(mockProfiler)
+    }
+
+    @ParameterizedTest(name = "start reason: {0}")
+    @MethodSource("ineligibleStartReasons")
+    fun `M not remove sample rate W onCreate { ineligible start reason }`(startReason: Int) {
+        // Given
+        whenever(mockApplicationStartInfo.reason).doReturn(startReason)
+
+        // When
+        testedProvider.onStart(mockContext)
+
+        // Then
+        verify(mockSharedPreferencesStorage, never()).remove(ProfilingStorage.KEY_PROFILING_SAMPLE_RATE)
+    }
+
+    @Test
+    fun `M not start profiling W onCreate { sampler does not sample }`() {
+        // Given
+        whenever(mockApplicationStartInfo.reason)
+            .doReturn(ApplicationStartInfo.START_REASON_LAUNCHER)
+        whenever(
+            mockSharedPreferencesStorage.getFloat(
+                eq(ProfilingStorage.KEY_PROFILING_SAMPLE_RATE),
+                any()
+            )
+        ).doReturn(0f)
+
+        // When
+        testedProvider.onStart(mockContext)
+
+        // Then
+        verifyNoInteractions(mockProfiler)
+    }
+
+    @Test
+    fun `M remove sample rate W onCreate { sampler does not sample }`() {
+        // Given
+        whenever(mockApplicationStartInfo.reason)
+            .doReturn(ApplicationStartInfo.START_REASON_LAUNCHER)
+        whenever(
+            mockSharedPreferencesStorage.getFloat(
+                eq(ProfilingStorage.KEY_PROFILING_SAMPLE_RATE),
+                any()
+            )
+        ).doReturn(0f)
+
+        // When
+        testedProvider.onStart(mockContext)
+
+        // Then
+        verify(mockSharedPreferencesStorage).remove(ProfilingStorage.KEY_PROFILING_SAMPLE_RATE)
+    }
+
+    companion object {
+        @JvmStatic
+        fun eligibleStartReasons(): List<Arguments> = listOf(
+            Arguments.of(ApplicationStartInfo.START_REASON_LAUNCHER, TELEMETRY_APP_START_INFO_LAUNCHER),
+            Arguments.of(ApplicationStartInfo.START_REASON_START_ACTIVITY, TELEMETRY_APP_START_INFO_ACTIVITY),
+            Arguments.of(ApplicationStartInfo.START_REASON_LAUNCHER_RECENTS, TELEMETRY_APP_START_INFO_RECENTS)
+        )
+
+        @JvmStatic
+        fun ineligibleStartReasons(): List<Arguments> = listOf(
+            Arguments.of(ApplicationStartInfo.START_REASON_ALARM),
+            Arguments.of(ApplicationStartInfo.START_REASON_BACKUP),
+            Arguments.of(ApplicationStartInfo.START_REASON_BOOT_COMPLETE),
+            Arguments.of(ApplicationStartInfo.START_REASON_BROADCAST),
+            Arguments.of(ApplicationStartInfo.START_REASON_CONTENT_PROVIDER),
+            Arguments.of(ApplicationStartInfo.START_REASON_JOB),
+            Arguments.of(ApplicationStartInfo.START_REASON_OTHER),
+            Arguments.of(ApplicationStartInfo.START_REASON_PUSH),
+            Arguments.of(ApplicationStartInfo.START_REASON_SERVICE)
+        )
+    }
+}

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.profiling.forge.Configurator
 import com.datadog.android.profiling.internal.NoOpProfiler
 import com.datadog.android.profiling.internal.Profiler
 import com.datadog.android.profiling.internal.ProfilingFeature
+import com.datadog.android.profiling.internal.ProfilingStartReason
 import com.datadog.android.profiling.internal.ProfilingStorage
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
 import fr.xgouchet.elmyr.annotation.Forgery
@@ -93,7 +94,7 @@ class ProfilingTest {
 
         // When
         Profiling.enable(fakeConfiguration, mockSdkCore)
-        Profiling.start(mockContext, sdkInstanceNames)
+        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), sdkInstanceNames)
 
         // Then
         verify(mockSdkCore).registerFeature(any<ProfilingFeature>())
@@ -120,7 +121,7 @@ class ProfilingTest {
         val sdkInstanceNames = setOf(fakeInstanceName)
 
         // When
-        Profiling.start(mockContext, sdkInstanceNames)
+        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), sdkInstanceNames)
         Profiling.enable(fakeConfiguration, mockSdkCore)
 
         // Then
@@ -136,11 +137,11 @@ class ProfilingTest {
         val sdkInstanceNames = setOf(fakeInstanceName)
 
         // When
-        Profiling.start(mockContext, sdkInstanceNames)
+        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), sdkInstanceNames)
 
         val firstProfiler = Profiling.profiler
 
-        Profiling.start(mockContext, sdkInstanceNames)
+        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), sdkInstanceNames)
 
         val secondProfiler = Profiling.profiler
 
@@ -159,10 +160,10 @@ class ProfilingTest {
         Profiling.isProfilerInitialized.set(true)
 
         // When
-        Profiling.start(mockContext, sdkInstanceNames)
+        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), sdkInstanceNames)
 
         // Then
-        verify(mockProfiler).start(mockContext, sdkInstanceNames)
+        verify(mockProfiler).start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), sdkInstanceNames)
     }
 
     @Test
@@ -173,10 +174,15 @@ class ProfilingTest {
         Profiling.isProfilerInitialized.set(true)
 
         // When
-        Profiling.start(mockContext, mockSdkCore)
+        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), mockSdkCore)
 
         // Then
-        verify(mockProfiler).start(mockContext, setOf(fakeInstanceName))
+        verify(mockProfiler).start(
+            mockContext,
+            ProfilingStartReason.APPLICATION_LAUNCH,
+            emptyMap(),
+            setOf(fakeInstanceName)
+        )
     }
 
     @Test
@@ -187,7 +193,7 @@ class ProfilingTest {
         Profiling.isProfilerInitialized.set(true)
 
         // When
-        Profiling.start(mockContext, mockSdkCore)
+        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), mockSdkCore)
         Profiling.stop(mockSdkCore)
 
         // Then

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -98,7 +100,7 @@ class PerfettoProfilerTest {
     @Test
     fun `M request profiling stack sampling W start()`() {
         // When
-        testedProfiler.start(mockContext, setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
 
         // Then
         verify(mockService)
@@ -128,8 +130,8 @@ class PerfettoProfilerTest {
     @Test
     fun `M request profiling stack sampling only once W several call start(){ same instance }`() {
         // When
-        testedProfiler.start(mockContext, setOf(fakeInstanceName))
-        testedProfiler.start(mockContext, setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
 
         // Then
         verify(mockService)
@@ -146,8 +148,8 @@ class PerfettoProfilerTest {
     @Test
     fun `M request profiling stack sampling only once W several call start(){ different instance }`() {
         // When
-        testedProfiler.start(mockContext, setOf(fakeInstanceName))
-        testedProfiler.start(mockContext, setOf(otherInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(otherInstanceName))
 
         // Then
         verify(mockService)
@@ -172,7 +174,7 @@ class PerfettoProfilerTest {
         stubTimeProvider.endTime = fakeStartTime + fakeDuration
 
         // When
-        testedProfiler.start(mockContext, setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
 
         // Then
         val stopSignalCaptor = argumentCaptor<CancellationSignal>()
@@ -195,12 +197,15 @@ class PerfettoProfilerTest {
 
         val messageCaptor = argumentCaptor<() -> String>()
         val expectedProps = mapOf(
-            "profiling_app_launch" to mapOf(
+            "metric_type" to "profiling session",
+            "profiling_session" to mapOf(
                 "error_code" to ProfilingResult.ERROR_NONE,
                 "error_message" to fakeErrorMessage,
+                "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
                 "duration" to fakeDuration,
                 "file_size" to 0L,
-                "stopped_reason" to "timeout"
+                "stopped_reason" to "timeout",
+                "app_start_info" to null
             ),
             "profiling_config" to mapOf(
                 "buffer_size" to 5120,
@@ -215,7 +220,7 @@ class PerfettoProfilerTest {
                 isNull()
             )
 
-        assertThat(messageCaptor.firstValue.invoke()).isEqualTo("[Mobile Metric] Profiling App Launch")
+        assertThat(messageCaptor.firstValue.invoke()).isEqualTo("[Mobile Metric] Profiling Session")
     }
 
     @Test
@@ -230,7 +235,7 @@ class PerfettoProfilerTest {
         stubTimeProvider.endTime = fakeStartTime + fakeDuration
 
         // When
-        testedProfiler.start(mockContext, setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
 
         // Then
         verify(mockService)
@@ -252,12 +257,15 @@ class PerfettoProfilerTest {
 
         val messageCaptor = argumentCaptor<() -> String>()
         val expectedProps = mapOf(
-            "profiling_app_launch" to mapOf(
+            "metric_type" to "profiling session",
+            "profiling_session" to mapOf(
                 "error_code" to fakeErrorCode,
-                "error_message" to fakeErrorMessage,
+                "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
                 "duration" to fakeDuration,
+                "error_message" to fakeErrorMessage,
                 "file_size" to 0L,
-                "stopped_reason" to "error"
+                "stopped_reason" to "error",
+                "app_start_info" to null
             ),
             "profiling_config" to mapOf(
                 "buffer_size" to 5120,
@@ -272,7 +280,7 @@ class PerfettoProfilerTest {
                 isNull()
             )
 
-        assertThat(messageCaptor.firstValue.invoke()).isEqualTo("[Mobile Metric] Profiling App Launch")
+        assertThat(messageCaptor.firstValue.invoke()).isEqualTo("[Mobile Metric] Profiling Session")
     }
 
     @Test
@@ -287,7 +295,7 @@ class PerfettoProfilerTest {
         testedProfiler.internalLogger = null
 
         // When
-        testedProfiler.start(mockContext, setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
         testedProfiler.internalLogger = mockInternalLogger
 
         verify(mockService)
@@ -310,12 +318,15 @@ class PerfettoProfilerTest {
         // Then
         val messageCaptor = argumentCaptor<() -> String>()
         val expectedProps = mapOf(
-            "profiling_app_launch" to mapOf(
+            "metric_type" to "profiling session",
+            "profiling_session" to mapOf(
                 "error_code" to ProfilingResult.ERROR_FAILED_PROFILING_IN_PROGRESS,
-                "error_message" to fakeErrorMessage,
+                "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
                 "duration" to fakeDuration,
+                "error_message" to fakeErrorMessage,
                 "file_size" to 0L,
-                "stopped_reason" to "error"
+                "stopped_reason" to "error",
+                "app_start_info" to null
             ),
             "profiling_config" to mapOf(
                 "buffer_size" to 5120,
@@ -330,7 +341,7 @@ class PerfettoProfilerTest {
                 isNull()
             )
 
-        assertThat(messageCaptor.firstValue.invoke()).isEqualTo("[Mobile Metric] Profiling App Launch")
+        assertThat(messageCaptor.firstValue.invoke()).isEqualTo("[Mobile Metric] Profiling Session")
     }
 
     @Test
@@ -343,7 +354,7 @@ class PerfettoProfilerTest {
         stubTimeProvider.endTime = fakeStartTime + fakeDuration
 
         // When
-        testedProfiler.start(mockContext, setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
 
         verify(mockService)
             .requestProfiling(
@@ -376,7 +387,7 @@ class PerfettoProfilerTest {
         stubTimeProvider.endTime = fakeStartTime + fakeDuration
 
         // When
-        testedProfiler.start(mockContext, setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
 
         verify(mockService)
             .requestProfiling(
@@ -410,7 +421,7 @@ class PerfettoProfilerTest {
     @Test
     fun `M return true W isRunning { profiler started }`() {
         // Given
-        testedProfiler.start(mockContext, setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
 
         // When
         val status = testedProfiler.isRunning(fakeInstanceName)
@@ -422,7 +433,7 @@ class PerfettoProfilerTest {
     @Test
     fun `M return false W isRunning in other instance`() {
         // Given
-        testedProfiler.start(mockContext, setOf(otherInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(otherInstanceName))
 
         // When
         val status = testedProfiler.isRunning(fakeInstanceName)
@@ -434,7 +445,7 @@ class PerfettoProfilerTest {
     @Test
     fun `M return false W isRunning { profiler stopped by same instance}`() {
         // Given
-        testedProfiler.start(mockContext, setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
         testedProfiler.stop(fakeInstanceName)
 
         // When
@@ -462,7 +473,7 @@ class PerfettoProfilerTest {
     @Test
     fun `M return true W isRunning { profiler stopped by other instance}`() {
         // Given
-        testedProfiler.start(mockContext, setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
         testedProfiler.stop(otherInstanceName)
 
         // When
@@ -475,7 +486,12 @@ class PerfettoProfilerTest {
     @Test
     fun `M call the all the instance's callback W several call start()`() {
         // When
-        testedProfiler.start(mockContext, setOf(fakeInstanceName, otherInstanceName))
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.APPLICATION_LAUNCH,
+            emptyMap(),
+            setOf(fakeInstanceName, otherInstanceName)
+        )
 
         // Then
         val callbackCaptor = argumentCaptor<Consumer<ProfilingResult>>()
@@ -501,7 +517,7 @@ class PerfettoProfilerTest {
     @Test
     fun `M not call the instance's callback W call start without it()`() {
         // When
-        testedProfiler.start(mockContext, setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
 
         // Then
         val callbackCaptor = argumentCaptor<Consumer<ProfilingResult>>()
@@ -534,7 +550,7 @@ class PerfettoProfilerTest {
         stubTimeProvider.endTime = fakeStartTime + fakeDuration
 
         // When
-        testedProfiler.start(mockContext, setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
         testedProfiler.unregisterProfilingCallback(fakeInstanceName)
 
         // Then
@@ -562,7 +578,12 @@ class PerfettoProfilerTest {
         inOrder(mockService) {
             // When
             // First request
-            testedProfiler.start(mockContext, setOf(fakeInstanceName))
+            testedProfiler.start(
+                mockContext,
+                ProfilingStartReason.APPLICATION_LAUNCH,
+                emptyMap(),
+                setOf(fakeInstanceName)
+            )
             val stopSignalCaptor = argumentCaptor<CancellationSignal>()
             testedProfiler.stop(fakeInstanceName)
 
@@ -582,7 +603,12 @@ class PerfettoProfilerTest {
             callbackCaptor.firstValue.accept(successResult)
 
             // Second request
-            testedProfiler.start(mockContext, setOf(fakeInstanceName))
+            testedProfiler.start(
+                mockContext,
+                ProfilingStartReason.APPLICATION_LAUNCH,
+                emptyMap(),
+                setOf(fakeInstanceName)
+            )
             verify(mockService).requestProfiling(
                 eq(ProfilingManager.PROFILING_TYPE_STACK_SAMPLING),
                 any<Bundle>(),
@@ -593,6 +619,124 @@ class PerfettoProfilerTest {
             )
             assertThat(stopSignalCaptor.firstValue).isNotSameAs(stopSignalCaptor.secondValue)
         }
+    }
+
+    @Test
+    fun `M include app_start_info in telemetry W profiling finishes { additionalAttributes contains app_start_info }`(
+        @StringForgery fakeAppStartInfo: String,
+        @LongForgery(min = 0L) fakeStartTime: Long,
+        @LongForgery(min = 0L) fakeDuration: Long
+    ) {
+        // Given
+        stubTimeProvider.startTime = fakeStartTime
+        stubTimeProvider.endTime = fakeStartTime + fakeDuration
+
+        // When
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.APPLICATION_LAUNCH,
+            mapOf(PerfettoProfiler.TELEMETRY_KEY_APP_START_INFO to fakeAppStartInfo),
+            setOf(fakeInstanceName)
+        )
+
+        // Then
+        verify(mockService)
+            .requestProfiling(
+                eq(ProfilingManager.PROFILING_TYPE_STACK_SAMPLING),
+                any<Bundle>(),
+                any<String>(),
+                any<CancellationSignal>(),
+                any(),
+                callbackCaptor.capture()
+            )
+
+        val mockResult = mock<ProfilingResult> {
+            on { errorCode } doReturn ProfilingResult.ERROR_NONE
+        }
+        callbackCaptor.firstValue.accept(mockResult)
+
+        val messageCaptor = argumentCaptor<() -> String>()
+        val expectedProps = mapOf(
+            "metric_type" to "profiling session",
+            "profiling_session" to mapOf(
+                "error_code" to ProfilingResult.ERROR_NONE,
+                "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
+                "duration" to fakeDuration,
+                "error_message" to null,
+                "file_size" to 0L,
+                "stopped_reason" to "timeout",
+                "app_start_info" to fakeAppStartInfo
+            ),
+            "profiling_config" to mapOf(
+                "buffer_size" to 5120,
+                "sampling_frequency" to PROFILING_SAMPLING_RATE
+            )
+        )
+        verify(mockInternalLogger)
+            .logMetric(
+                messageCaptor.capture(),
+                eq(expectedProps),
+                eq(MethodCallSamplingRate.ALL.rate),
+                isNull()
+            )
+        assertThat(messageCaptor.firstValue.invoke()).isEqualTo("[Mobile Metric] Profiling Session")
+    }
+
+    @ParameterizedTest(name = "startReason: {0}")
+    @EnumSource(ProfilingStartReason::class)
+    internal fun `M include start_reason in telemetry W profiling finishes { startReason }`(
+        startReason: ProfilingStartReason,
+        @LongForgery(min = 0L) fakeStartTime: Long,
+        @LongForgery(min = 0L) fakeDuration: Long
+    ) {
+        // Given
+        stubTimeProvider.startTime = fakeStartTime
+        stubTimeProvider.endTime = fakeStartTime + fakeDuration
+
+        // When
+        testedProfiler.start(mockContext, startReason, emptyMap(), setOf(fakeInstanceName))
+
+        // Then
+        verify(mockService)
+            .requestProfiling(
+                eq(ProfilingManager.PROFILING_TYPE_STACK_SAMPLING),
+                any<Bundle>(),
+                any<String>(),
+                any<CancellationSignal>(),
+                any(),
+                callbackCaptor.capture()
+            )
+
+        val mockResult = mock<ProfilingResult> {
+            on { errorCode } doReturn ProfilingResult.ERROR_NONE
+        }
+        callbackCaptor.firstValue.accept(mockResult)
+
+        val messageCaptor = argumentCaptor<() -> String>()
+        val expectedProps = mapOf(
+            "metric_type" to "profiling session",
+            "profiling_session" to mapOf(
+                "error_code" to ProfilingResult.ERROR_NONE,
+                "start_reason" to startReason.value,
+                "duration" to fakeDuration,
+                "error_message" to null,
+                "file_size" to 0L,
+                "stopped_reason" to "timeout",
+                "app_start_info" to null
+            ),
+            "profiling_config" to mapOf(
+                "buffer_size" to 5120,
+                "sampling_frequency" to PROFILING_SAMPLING_RATE
+            )
+        )
+        verify(mockInternalLogger)
+            .logMetric(
+                messageCaptor.capture(),
+                eq(expectedProps),
+                eq(MethodCallSamplingRate.ALL.rate),
+                isNull()
+            )
+        assertThat(messageCaptor.firstValue.invoke()).isEqualTo("[Mobile Metric] Profiling Session")
     }
 
     private class StubTimeProvider : TimeProvider {


### PR DESCRIPTION
### What does this PR do?

* This PR updates the profiling telemetry format
  * Message from "[Mobile Metric] App Launch" to  "[Mobile Metric] Profiling Session"
  * Add "start_reason" attribute: currently "application_launch", "rum_operation"/"continuous" in the future
  * Add "app_start_info" attribute for application launch profiling
* Update `DdProfilingContentProvider` to be more testable
* Add `DdProfilingContentProvider` Test

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

