### PR TITLE
Fix #2983: Fix self-referential test assertions in serialization round-trip tests

### DIFF
--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/api/context/NetworkInfoTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/api/context/NetworkInfoTest.kt
@@ -36,6 +36,6 @@ internal class NetworkInfoTest {
         val result = NetworkInfo.fromJson(json)
 
         // Then
-        Assertions.assertThat(result).isEqualTo(result)
+        Assertions.assertThat(result.toJson().toString()).isEqualTo(json)
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/api/context/UserInfoTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/api/context/UserInfoTest.kt
@@ -36,6 +36,6 @@ internal class UserInfoTest {
         val result = UserInfo.fromJson(json)
 
         // Then
-        Assertions.assertThat(result).isEqualTo(result)
+        Assertions.assertThat(result.toJson().toString()).isEqualTo(json)
     }
 }

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/model/LogEventTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/model/LogEventTest.kt
@@ -36,6 +36,6 @@ internal class LogEventTest {
         val result = LogEvent.fromJson(json)
 
         // Then
-        assertThat(result).isEqualTo(result)
+        assertThat(result.toJson().toString()).isEqualTo(json)
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/model/ActionEventTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/model/ActionEventTest.kt
@@ -36,6 +36,6 @@ internal class ActionEventTest {
         val result = ActionEvent.fromJson(json)
 
         // Then
-        Assertions.assertThat(result).isEqualTo(result)
+        Assertions.assertThat(result.toJson().toString()).isEqualTo(json)
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/model/ErrorEventTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/model/ErrorEventTest.kt
@@ -36,6 +36,6 @@ internal class ErrorEventTest {
         val result = ErrorEvent.fromJson(json)
 
         // Then
-        Assertions.assertThat(result).isEqualTo(result)
+        Assertions.assertThat(result.toJson().toString()).isEqualTo(json)
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/model/LongTaskEventTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/model/LongTaskEventTest.kt
@@ -36,6 +36,6 @@ internal class LongTaskEventTest {
         val result = LongTaskEvent.fromJson(json)
 
         // Then
-        Assertions.assertThat(result).isEqualTo(result)
+        Assertions.assertThat(result.toJson().toString()).isEqualTo(json)
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/model/ResourceEventTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/model/ResourceEventTest.kt
@@ -36,6 +36,6 @@ internal class ResourceEventTest {
         val result = ResourceEvent.fromJson(json)
 
         // Then
-        Assertions.assertThat(result).isEqualTo(result)
+        Assertions.assertThat(result.toJson().toString()).isEqualTo(json)
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/model/ViewEventTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/model/ViewEventTest.kt
@@ -36,6 +36,6 @@ internal class ViewEventTest {
         val result = ViewEvent.fromJson(json)
 
         // Then
-        Assertions.assertThat(result).isEqualTo(result)
+        Assertions.assertThat(result.toJson().toString()).isEqualTo(json)
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/model/TelemetryDebugEventTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/model/TelemetryDebugEventTest.kt
@@ -36,6 +36,6 @@ class TelemetryDebugEventTest {
         val result = TelemetryDebugEvent.fromJson(json)
 
         // Then
-        Assertions.assertThat(result).isEqualTo(result)
+        Assertions.assertThat(result.toJson().toString()).isEqualTo(json)
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/model/TelemetryErrorEventTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/model/TelemetryErrorEventTest.kt
@@ -36,6 +36,6 @@ class TelemetryErrorEventTest {
         val result = TelemetryErrorEvent.fromJson(json)
 
         // Then
-        Assertions.assertThat(result).isEqualTo(result)
+        Assertions.assertThat(result.toJson().toString()).isEqualTo(json)
     }
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/model/SpanEventTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/model/SpanEventTest.kt
@@ -36,6 +36,6 @@ internal class SpanEventTest {
         val result = SpanEvent.fromJson(json)
 
         // Then
-        Assertions.assertThat(result).isEqualTo(result)
+        Assertions.assertThat(result.toJson().toString()).isEqualTo(json)
     }
 }


### PR DESCRIPTION
## Issue

Fixes #2983: Some tests always pass due to wrong assertion

**GitHub Issue:** https://github.com/DataDog/dd-sdk-android/issues/2983

## Root Cause Analysis

All 11 serialization round-trip tests used self-referential assertions (`assertThat(result).isEqualTo(result)`) instead of comparing the deserialized result against the original input. This made the tests tautological — they always passed regardless of whether `toJson()`/`fromJson()` worked correctly.

## Changes

Changed all 11 test assertions from `assertThat(result).isEqualTo(result)` to `assertThat(result.toJson().toString()).isEqualTo(json)`, which validates that JSON data survives a full round-trip through `fromJson()`/`toJson()`.

The JSON string comparison approach was chosen over object equality (`isEqualTo(event)`) because:
- Some generated model classes (e.g., `SpanEvent.Span`) are not `data class` and lack `equals()` implementations
- JSON type coercion (Long → Double) causes false equality failures even for data classes

### Files Changed

| File | Change |
|------|--------|
| `ActionEventTest.kt` | Fix assertion to compare JSON strings |
| `ErrorEventTest.kt` | Fix assertion to compare JSON strings |
| `LongTaskEventTest.kt` | Fix assertion to compare JSON strings |
| `ResourceEventTest.kt` | Fix assertion to compare JSON strings |
| `ViewEventTest.kt` | Fix assertion to compare JSON strings |
| `TelemetryDebugEventTest.kt` | Fix assertion to compare JSON strings |
| `TelemetryErrorEventTest.kt` | Fix assertion to compare JSON strings |
| `NetworkInfoTest.kt` | Fix assertion to compare JSON strings |
| `UserInfoTest.kt` | Fix assertion to compare JSON strings |
| `LogEventTest.kt` | Fix assertion to compare JSON strings |
| `SpanEventTest.kt` | Fix assertion to compare JSON strings |

## Test Coverage

- **Tests fixed:** 11 (across 4 modules: core, rum, logs, trace)
- **Local verification:** core (PASS), logs (PASS), trace (PASS)
- **Note:** RUM module has a pre-existing compilation error (`RumVitalAppLaunchEvent` redeclaration) on `develop`, unrelated to this change

## Investigation Log

### Issue Analysis
The issue reporter identified that multiple test files contained `assertThat(result).isEqualTo(result)` which always passes. This was confirmed across 11 files in 4 modules (2 more than originally reported).

### Reproduction
All 11 affected files follow the same pattern: forge a random event, serialize to JSON, deserialize, and compare. The self-referential assertion never catches serialization bugs.

### Fix Approach
1. First attempted `assertThat(result).isEqualTo(event)` — this revealed real serialization differences (non-data-class types, JSON type coercion)
2. Switched to JSON string comparison which correctly validates round-trip fidelity without depending on object `equals()`