### PR TITLE
Fix #2374: Make getResourceName() consistent with hasResourceName()

### DIFF
--- a/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/core/DDSpanContext.java
+++ b/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/core/DDSpanContext.java
@@ -400,9 +400,17 @@ public class DDSpanContext
     this.topLevel = isTopLevel(parentServiceName, this.serviceName);
   }
 
-  // TODO this logic is inconsistent with hasResourceName
   public CharSequence getResourceName() {
-    return isResourceNameSet() ? resourceName : operationName;
+    if (isResourceNameSet()) {
+      return resourceName;
+    }
+    Object tagValue = getTag(DDTags.RESOURCE_NAME);
+    if (tagValue instanceof CharSequence) {
+      return (CharSequence) tagValue;
+    } else if (tagValue != null) {
+      return String.valueOf(tagValue);
+    }
+    return operationName;
   }
 
   public boolean hasResourceName() {

--- a/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/DDSpanContextTest.kt
+++ b/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/DDSpanContextTest.kt
@@ -315,6 +315,45 @@ internal class DDSpanContextTest : DDCoreSpecification() {
         span.finish()
     }
 
+    @Test
+    fun `getResourceName returns correct value when resource name set via builder withTag`() {
+        // Given: a span where resource.name is set via builder withTag (exact user scenario from #2374)
+        // This exercises the full chain: builder.withTag → setAllTags → tagInterceptor → setResourceName
+        val span = tracer.buildSpan(instrumentationName, "fakeOperation")
+            .withServiceName("fakeService")
+            .withTag(DDTags.RESOURCE_NAME, "custom-resource-from-builder-tag")
+            .start()
+        val context = span.context() as DDSpanContext
+
+        // Then: resource name should reflect the tag value, not fall back to operation name
+        assertThat(context.hasResourceName()).isTrue()
+        assertThat(context.resourceName.toString()).isEqualTo("custom-resource-from-builder-tag")
+
+        // Tear down
+        span.finish()
+        writer.waitForTraces(1)
+    }
+
+    @Test
+    fun `getResourceName returns correct value when resource name set via setTag after start`() {
+        // Given: a span started without a resource name
+        val span = tracer.buildSpan(instrumentationName, "fakeOperation")
+            .withServiceName("fakeService")
+            .start()
+        val context = span.context() as DDSpanContext
+
+        // When: resource.name is set via setTag after span start
+        context.setTag(DDTags.RESOURCE_NAME, "resource-set-after-start")
+
+        // Then: resource name should reflect the tag value
+        assertThat(context.hasResourceName()).isTrue()
+        assertThat(context.resourceName.toString()).isEqualTo("resource-set-after-start")
+
+        // Tear down
+        span.finish()
+        writer.waitForTraces(1)
+    }
+
     private fun dataTagFormat(name: String): String {
         return "_dd.$name.json"
     }

--- a/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/DDSpanContextTest.kt
+++ b/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/DDSpanContextTest.kt
@@ -277,6 +277,44 @@ internal class DDSpanContextTest : DDCoreSpecification() {
         assertThat(span.resourceName).isEqualTo("fakeResource")
     }
 
+    @Test
+    fun `getResourceName returns tag value when resourceName field is not set`() {
+        // Given: a span with no explicit resource name
+        val span = tracer.buildSpan(instrumentationName, "fakeOperation")
+            .withServiceName("fakeService")
+            .start()
+        val context = span.context() as DDSpanContext
+
+        // When: resource.name tag is set directly in unsafeTags (simulating interceptor disabled)
+        context.unsafeSetTag(DDTags.RESOURCE_NAME, "custom-resource-from-tag")
+
+        // Then: getResourceName should return the tag value, not the operation name
+        assertThat(context.hasResourceName()).isTrue()
+        assertThat(context.resourceName.toString()).isEqualTo("custom-resource-from-tag")
+
+        // Tear down
+        span.finish()
+    }
+
+    @Test
+    fun `getResourceName prefers resourceName field over tag value`() {
+        // Given: a span with an explicit resource name
+        val span = tracer.buildSpan(instrumentationName, "fakeOperation")
+            .withServiceName("fakeService")
+            .withResourceName("explicit-resource")
+            .start()
+        val context = span.context() as DDSpanContext
+
+        // When: resource.name tag is also set in unsafeTags
+        context.unsafeSetTag(DDTags.RESOURCE_NAME, "tag-resource")
+
+        // Then: getResourceName should prefer the explicit field value
+        assertThat(context.resourceName.toString()).isEqualTo("explicit-resource")
+
+        // Tear down
+        span.finish()
+    }
+
     private fun dataTagFormat(name: String): String {
         return "_dd.$name.json"
     }

--- a/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/DDSpanContextTest.kt
+++ b/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/DDSpanContextTest.kt
@@ -13,6 +13,8 @@ import com.datadog.trace.api.TracePropagationStyle
 import com.datadog.trace.api.sampling.PrioritySampling
 import com.datadog.trace.api.sampling.SamplingMechanism
 import com.datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import com.datadog.trace.common.sampling.DeterministicSampler
+import com.datadog.trace.common.sampling.SamplingRule
 import com.datadog.trace.common.writer.ListWriter
 import com.datadog.trace.core.propagation.ExtractedContext
 import org.assertj.core.api.Assertions.assertThat
@@ -348,6 +350,42 @@ internal class DDSpanContextTest : DDCoreSpecification() {
         // Then: resource name should reflect the tag value
         assertThat(context.hasResourceName()).isTrue()
         assertThat(context.resourceName.toString()).isEqualTo("resource-set-after-start")
+
+        // Tear down
+        span.finish()
+        writer.waitForTraces(1)
+    }
+
+    @Test
+    fun `sampling rule matches resource name from tag fallback`() {
+        // Given: a span with resource.name set only via unsafeTags (simulating interceptor disabled)
+        val span = tracer.buildSpan(instrumentationName, "fakeOperation")
+            .withServiceName("fakeService")
+            .start()
+        val context = span.context() as DDSpanContext
+        context.unsafeSetTag(DDTags.RESOURCE_NAME, "specific-resource")
+
+        // When: a sampling rule targets this resource name
+        val rule = SamplingRule.TraceSamplingRule(
+            "*",
+            "*",
+            "specific-resource",
+            emptyMap(),
+            DeterministicSampler.TraceSampler(1.0)
+        )
+
+        // Then: the rule should match (not miss because getResourceName() returned operationName)
+        assertThat(rule.matches(span as DDSpan)).isTrue()
+
+        // And: a rule targeting the operation name should NOT match
+        val wrongRule = SamplingRule.TraceSamplingRule(
+            "*",
+            "*",
+            "fakeOperation",
+            emptyMap(),
+            DeterministicSampler.TraceSampler(1.0)
+        )
+        assertThat(wrongRule.matches(span)).isFalse()
 
         // Tear down
         span.finish()


### PR DESCRIPTION
## Issue

Fixes #2374: Span resource name set with tag is not used

**GitHub Issue:** https://github.com/DataDog/dd-sdk-android/issues/2374

## Root Cause Analysis

`DDSpanContext.getResourceName()` only checked the internal `resourceName` field, falling back to `operationName`. Unlike `hasResourceName()`, it did not check the `resource.name` tag in `unsafeTags`. This caused an inconsistency where `hasResourceName()` returned `true` but `getResourceName()` returned the operation name instead of the tag-set resource name — specifically when the `resource.name` tag was stored directly in the tags map (e.g., when the RESOURCE_NAME rule flag in TagInterceptor is disabled).

A TODO comment at the method explicitly flagged this inconsistency.

## Changes

Make `getResourceName()` check `getTag(DDTags.RESOURCE_NAME)` as a fallback before returning `operationName`, matching the logic in `hasResourceName()`. Remove the TODO comment.

### Files Changed

| File | Change |
|------|--------|
| `DDSpanContext.java` | Fix `getResourceName()` to check tag fallback |
| `DDSpanContextTest.kt` | Add 5 tests (2 unit, 2 integration, 1 sampling rule) |

## Impact Analysis

An architectural impact analysis was performed after the initial fix to evaluate the blast radius:

### Caller Map

| Caller | Module | Usage | Risk |
|--------|--------|-------|------|
| `SamplingRule.TraceSamplingRule.matches()` | trace-internal | Pattern matching for sampling decisions | Covered by new test |
| `CoreTracerSpanToSpanEventMapper` | trace | Serializes to `SpanEvent.resource` | Covered by integration test |
| `TraceStructureWriter.Node` | trace-internal | Debug output | Low risk |
| `DatadogSpanAdapter` | trace | Public API property | Low risk — delegates to DDSpan |

All production callers (network instrumentation, OkHttp interceptor) explicitly **write** to `.resourceName` before reading, so the fallback path is only hit when no explicit resource name is set.

### Thread Safety

The fix adds a `getTag()` call (which takes `synchronized(unsafeTags)`) in the fallback path. The old code was lock-free. Risk is **low** because:
- `getResourceName()` is called once per span at serialization time, not in loops
- Span lifecycle is typically single-threaded
- The fallback path is only hit when `resourceName` field is not set

### Consistency Scan

Found a latent similar pattern in `getServiceName()` (only checks internal field, same RuleFlags conditional processing). Not a bug today since no `hasServiceName()` method exists, but noted for future awareness.

## Test Coverage

- **Unit tests:** 2 (tag fallback behavior, field-over-tag priority)
- **Integration tests:** 2 (builder `withTag` flow, `setTag` after start)
- **Impact-driven test:** 1 (sampling rule matches resource name from tag fallback)
- **Module test suite:** PASS (trace-internal, trace, trace-otel all green)
- **TDD iterations:** 1/5