### PR TITLE
fix: Only exclude files inside the repo

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/GenerateCompilerMetaTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/GenerateCompilerMetaTask.kt
@@ -39,10 +39,11 @@ abstract class GenerateCompilerMetaTask @Inject constructor(
         val classFile = classesDir
             .walkTopDown()
             .filter {
+                val relativePath = it.relativeTo(classesDir).path
                 it.extension == "class" &&
                     !it.name.contains("$") &&
                     it.path.contains("datadog") &&
-                    !it.path.contains("test", ignoreCase = true)
+                    !relativePath.contains("test", ignoreCase = true)
             }
             .firstOrNull()
 


### PR DESCRIPTION
### What does this PR do?

Fix an issue where GenerateCompilerMetaTask was ignoring all files in the repo if the path contained "test" anywhere in the path. Instead, make the path relative before checking if "test" is in the path.

### Motivation

This is to fix an issue where the integration test library wants to include the SDK as a submodule / composite build.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

