### PR TITLE
RUM-13023: Propagate trace and session replay sample rates to RUM ViewEvents

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -486,7 +486,7 @@ data class com.datadog.android.rum.model.ActionEvent
       fun fromJson(kotlin.String): DdSession
       fun fromJsonObject(com.google.gson.JsonObject): DdSession
   data class Configuration
-    constructor(kotlin.Number, kotlin.Number? = null, kotlin.Number? = null)
+    constructor(kotlin.Number, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Configuration
@@ -796,7 +796,7 @@ data class com.datadog.android.rum.model.ErrorEvent
       fun fromJson(kotlin.String): DdSession
       fun fromJsonObject(com.google.gson.JsonObject): DdSession
   data class Configuration
-    constructor(kotlin.Number, kotlin.Number? = null, kotlin.Number? = null)
+    constructor(kotlin.Number, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Configuration
@@ -1140,7 +1140,7 @@ data class com.datadog.android.rum.model.LongTaskEvent
       fun fromJson(kotlin.String): DdSession
       fun fromJsonObject(com.google.gson.JsonObject): DdSession
   data class Configuration
-    constructor(kotlin.Number, kotlin.Number? = null, kotlin.Number? = null)
+    constructor(kotlin.Number, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Configuration
@@ -1405,7 +1405,7 @@ data class com.datadog.android.rum.model.ResourceEvent
       fun fromJson(kotlin.String): DdSession
       fun fromJsonObject(com.google.gson.JsonObject): DdSession
   data class Configuration
-    constructor(kotlin.Number, kotlin.Number? = null, kotlin.Number? = null)
+    constructor(kotlin.Number, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Configuration
@@ -1873,7 +1873,7 @@ data class com.datadog.android.rum.model.ViewEvent
       fun fromJson(kotlin.String): DdSession
       fun fromJsonObject(com.google.gson.JsonObject): DdSession
   data class Configuration
-    constructor(kotlin.Number, kotlin.Number? = null, kotlin.Number? = null, kotlin.Boolean? = null)
+    constructor(kotlin.Number, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Boolean? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Configuration
@@ -2200,7 +2200,7 @@ data class com.datadog.android.rum.model.VitalAppLaunchEvent
       fun fromJson(kotlin.String): DdSession
       fun fromJsonObject(com.google.gson.JsonObject): DdSession
   data class Configuration
-    constructor(kotlin.Number, kotlin.Number? = null, kotlin.Number? = null)
+    constructor(kotlin.Number, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Configuration
@@ -2450,7 +2450,7 @@ data class com.datadog.android.rum.model.VitalOperationStepEvent
       fun fromJson(kotlin.String): DdSession
       fun fromJsonObject(com.google.gson.JsonObject): DdSession
   data class Configuration
-    constructor(kotlin.Number, kotlin.Number? = null, kotlin.Number? = null)
+    constructor(kotlin.Number, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Configuration

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -812,19 +812,21 @@ public final class com/datadog/android/rum/model/ActionEvent$Companion {
 
 public final class com/datadog/android/rum/model/ActionEvent$Configuration {
 	public static final field Companion Lcom/datadog/android/rum/model/ActionEvent$Configuration$Companion;
-	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)V
-	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)V
+	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Number;
 	public final fun component2 ()Ljava/lang/Number;
 	public final fun component3 ()Ljava/lang/Number;
-	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/ActionEvent$Configuration;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ActionEvent$Configuration;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ActionEvent$Configuration;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/ActionEvent$Configuration;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ActionEvent$Configuration;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ActionEvent$Configuration;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$Configuration;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ActionEvent$Configuration;
 	public final fun getProfilingSampleRate ()Ljava/lang/Number;
 	public final fun getSessionReplaySampleRate ()Ljava/lang/Number;
 	public final fun getSessionSampleRate ()Ljava/lang/Number;
+	public final fun getTraceSampleRate ()Ljava/lang/Number;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
@@ -1731,19 +1733,21 @@ public final class com/datadog/android/rum/model/ErrorEvent$Companion {
 
 public final class com/datadog/android/rum/model/ErrorEvent$Configuration {
 	public static final field Companion Lcom/datadog/android/rum/model/ErrorEvent$Configuration$Companion;
-	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)V
-	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)V
+	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Number;
 	public final fun component2 ()Ljava/lang/Number;
 	public final fun component3 ()Ljava/lang/Number;
-	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/ErrorEvent$Configuration;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ErrorEvent$Configuration;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ErrorEvent$Configuration;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/ErrorEvent$Configuration;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ErrorEvent$Configuration;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ErrorEvent$Configuration;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Configuration;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ErrorEvent$Configuration;
 	public final fun getProfilingSampleRate ()Ljava/lang/Number;
 	public final fun getSessionReplaySampleRate ()Ljava/lang/Number;
 	public final fun getSessionSampleRate ()Ljava/lang/Number;
+	public final fun getTraceSampleRate ()Ljava/lang/Number;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
@@ -2782,19 +2786,21 @@ public final class com/datadog/android/rum/model/LongTaskEvent$Companion {
 
 public final class com/datadog/android/rum/model/LongTaskEvent$Configuration {
 	public static final field Companion Lcom/datadog/android/rum/model/LongTaskEvent$Configuration$Companion;
-	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)V
-	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)V
+	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Number;
 	public final fun component2 ()Ljava/lang/Number;
 	public final fun component3 ()Ljava/lang/Number;
-	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/LongTaskEvent$Configuration;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/LongTaskEvent$Configuration;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/LongTaskEvent$Configuration;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/LongTaskEvent$Configuration;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/LongTaskEvent$Configuration;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/LongTaskEvent$Configuration;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$Configuration;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/LongTaskEvent$Configuration;
 	public final fun getProfilingSampleRate ()Ljava/lang/Number;
 	public final fun getSessionReplaySampleRate ()Ljava/lang/Number;
 	public final fun getSessionSampleRate ()Ljava/lang/Number;
+	public final fun getTraceSampleRate ()Ljava/lang/Number;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
@@ -3670,19 +3676,21 @@ public final class com/datadog/android/rum/model/ResourceEvent$Companion {
 
 public final class com/datadog/android/rum/model/ResourceEvent$Configuration {
 	public static final field Companion Lcom/datadog/android/rum/model/ResourceEvent$Configuration$Companion;
-	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)V
-	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)V
+	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Number;
 	public final fun component2 ()Ljava/lang/Number;
 	public final fun component3 ()Ljava/lang/Number;
-	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/ResourceEvent$Configuration;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ResourceEvent$Configuration;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ResourceEvent$Configuration;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/ResourceEvent$Configuration;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ResourceEvent$Configuration;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ResourceEvent$Configuration;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$Configuration;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ResourceEvent$Configuration;
 	public final fun getProfilingSampleRate ()Ljava/lang/Number;
 	public final fun getSessionReplaySampleRate ()Ljava/lang/Number;
 	public final fun getSessionSampleRate ()Ljava/lang/Number;
+	public final fun getTraceSampleRate ()Ljava/lang/Number;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
@@ -5025,14 +5033,15 @@ public final class com/datadog/android/rum/model/ViewEvent$Companion {
 
 public final class com/datadog/android/rum/model/ViewEvent$Configuration {
 	public static final field Companion Lcom/datadog/android/rum/model/ViewEvent$Configuration$Companion;
-	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Number;
 	public final fun component2 ()Ljava/lang/Number;
 	public final fun component3 ()Ljava/lang/Number;
-	public final fun component4 ()Ljava/lang/Boolean;
-	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Boolean;)Lcom/datadog/android/rum/model/ViewEvent$Configuration;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewEvent$Configuration;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewEvent$Configuration;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Boolean;)Lcom/datadog/android/rum/model/ViewEvent$Configuration;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewEvent$Configuration;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewEvent$Configuration;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$Configuration;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewEvent$Configuration;
@@ -5040,6 +5049,7 @@ public final class com/datadog/android/rum/model/ViewEvent$Configuration {
 	public final fun getSessionReplaySampleRate ()Ljava/lang/Number;
 	public final fun getSessionSampleRate ()Ljava/lang/Number;
 	public final fun getStartSessionReplayRecordingManually ()Ljava/lang/Boolean;
+	public final fun getTraceSampleRate ()Ljava/lang/Number;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
@@ -6483,19 +6493,21 @@ public final class com/datadog/android/rum/model/VitalAppLaunchEvent$Companion {
 
 public final class com/datadog/android/rum/model/VitalAppLaunchEvent$Configuration {
 	public static final field Companion Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Configuration$Companion;
-	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)V
-	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)V
+	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Number;
 	public final fun component2 ()Ljava/lang/Number;
 	public final fun component3 ()Ljava/lang/Number;
-	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Configuration;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Configuration;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Configuration;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Configuration;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Configuration;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Configuration;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Configuration;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Configuration;
 	public final fun getProfilingSampleRate ()Ljava/lang/Number;
 	public final fun getSessionReplaySampleRate ()Ljava/lang/Number;
 	public final fun getSessionSampleRate ()Ljava/lang/Number;
+	public final fun getTraceSampleRate ()Ljava/lang/Number;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
@@ -7284,19 +7296,21 @@ public final class com/datadog/android/rum/model/VitalOperationStepEvent$Compani
 
 public final class com/datadog/android/rum/model/VitalOperationStepEvent$Configuration {
 	public static final field Companion Lcom/datadog/android/rum/model/VitalOperationStepEvent$Configuration$Companion;
-	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)V
-	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)V
+	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Number;
 	public final fun component2 ()Ljava/lang/Number;
 	public final fun component3 ()Ljava/lang/Number;
-	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$Configuration;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalOperationStepEvent$Configuration;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$Configuration;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$Configuration;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalOperationStepEvent$Configuration;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$Configuration;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$Configuration;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$Configuration;
 	public final fun getProfilingSampleRate ()Ljava/lang/Number;
 	public final fun getSessionReplaySampleRate ()Ljava/lang/Number;
 	public final fun getSessionSampleRate ()Ljava/lang/Number;
+	public final fun getTraceSampleRate ()Ljava/lang/Number;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;

--- a/features/dd-sdk-android-rum/src/main/json/rum/_common-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/_common-schema.json
@@ -435,6 +435,13 @@
               "minimum": 0,
               "maximum": 100,
               "readOnly": true
+            },
+            "trace_sample_rate": {
+              "type": "number",
+              "description": "The percentage of sessions with traced resources",
+              "minimum": 0,
+              "maximum": 100,
+              "readOnly": true
             }
           }
         },

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -1343,7 +1343,11 @@ internal open class RumViewScope(
                         sessionPrecondition = rumContext.sessionStartReason.toViewSessionPrecondition()
                     ),
                     replayStats = replayStats,
-                    configuration = ViewEvent.Configuration(sessionSampleRate = sampleRate)
+                    configuration = ViewEvent.Configuration(
+                        sessionSampleRate = sampleRate,
+                        sessionReplaySampleRate = resolveSessionReplaySampleRate(datadogContext),
+                        traceSampleRate = resolveTraceSampleRate(datadogContext)
+                    )
                 ),
                 connectivity = datadogContext.networkInfo.toViewConnectivity(),
                 service = datadogContext.service,
@@ -1609,6 +1613,16 @@ internal open class RumViewScope(
         }
     }
 
+    private fun resolveSessionReplaySampleRate(datadogContext: DatadogContext): Long? {
+        val srContext = datadogContext.featuresContext[Feature.SESSION_REPLAY_FEATURE_NAME]
+        return srContext?.get(SESSION_REPLAY_SAMPLE_RATE_KEY) as? Long
+    }
+
+    private fun resolveTraceSampleRate(datadogContext: DatadogContext): Float? {
+        val tracingContext = datadogContext.featuresContext[Feature.TRACING_FEATURE_NAME]
+        return tracingContext?.get(TRACE_SAMPLE_RATE) as? Float
+    }
+
     private fun logSynthetics(key: String, value: String) {
         /**
          * We use [android.util.Log] here instead of [InternalLogger] because we want to log regardless of the
@@ -1621,6 +1635,12 @@ internal open class RumViewScope(
 
     companion object {
         internal val ONE_SECOND_NS = TimeUnit.SECONDS.toNanos(1)
+
+        // Must match SessionReplayFeature.SESSION_REPLAY_SAMPLE_RATE_KEY in dd-sdk-android-session-replay
+        internal const val SESSION_REPLAY_SAMPLE_RATE_KEY = "session_replay_sample_rate"
+
+        // Must match TracingInterceptor.OKHTTP_INTERCEPTOR_SAMPLE_RATE in dd-sdk-android-okhttp
+        internal const val TRACE_SAMPLE_RATE = "okhttp_interceptor_sample_rate"
 
         internal const val ACTION_DROPPED_WARNING = "RUM Action (%s on %s) was dropped, because" +
             " another action is still active for the same view"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -818,7 +818,8 @@ internal class DatadogRumMonitor(
                 ?.withWriteContext(
                     withFeatureContexts = setOf(
                         Feature.SESSION_REPLAY_FEATURE_NAME,
-                        Feature.PROFILING_FEATURE_NAME
+                        Feature.PROFILING_FEATURE_NAME,
+                        Feature.TRACING_FEATURE_NAME
                     )
                 ) { datadogContext, writeScope ->
                     // avoid trowing a RejectedExecutionException

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
@@ -825,6 +825,26 @@ internal class ViewEventAssert(actual: ViewEvent) :
         return this
     }
 
+    fun hasSessionReplaySampleRate(expected: Long?): ViewEventAssert {
+        assertThat(actual.dd.configuration?.sessionReplaySampleRate)
+            .overridingErrorMessage(
+                "Expected RUM event to have sessionReplaySampleRate: $expected" +
+                    " but instead was: ${actual.dd.configuration?.sessionReplaySampleRate}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasTraceSampleRate(expected: Float?): ViewEventAssert {
+        assertThat(actual.dd.configuration?.traceSampleRate)
+            .overridingErrorMessage(
+                "Expected RUM event to have traceSampleRate: $expected" +
+                    " but instead was: ${actual.dd.configuration?.traceSampleRate}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
     companion object {
 
         internal val ONE_SECOND_NS = TimeUnit.SECONDS.toNanos(1)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -821,6 +821,160 @@ internal class RumViewScopeTest {
     }
 
     @Test
+    fun `M send view event with sessionReplaySampleRate W handleEvent(StopView) { SR enabled }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeSrSampleRate = forge.aLong(min = 0L, max = 100L)
+        val contextWithSr = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext +
+                mapOf(
+                    Feature.SESSION_REPLAY_FEATURE_NAME to mapOf(
+                        RumViewScope.SESSION_REPLAY_SAMPLE_RATE_KEY to fakeSrSampleRate
+                    )
+                )
+        )
+
+        // When
+        testedScope.handleEvent(
+            RumRawEvent.StopView(fakeKey, emptyMap()),
+            contextWithSr,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue)
+                .apply {
+                    hasSessionReplaySampleRate(fakeSrSampleRate)
+                    hasSampleRate(fakeSampleRate)
+                }
+        }
+    }
+
+    @Test
+    fun `M send view event with traceSampleRate W handleEvent(StopView) { tracing enabled }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeTraceSampleRate = forge.aFloat(min = 0f, max = 100f)
+        val contextWithTracing = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext +
+                mapOf(
+                    Feature.TRACING_FEATURE_NAME to mapOf(
+                        RumViewScope.TRACE_SAMPLE_RATE to fakeTraceSampleRate
+                    )
+                )
+        )
+
+        // When
+        testedScope.handleEvent(
+            RumRawEvent.StopView(fakeKey, emptyMap()),
+            contextWithTracing,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue)
+                .apply {
+                    hasTraceSampleRate(fakeTraceSampleRate)
+                    hasSampleRate(fakeSampleRate)
+                }
+        }
+    }
+
+    @Test
+    fun `M send view event with null sample rates W handleEvent(StopView) { no SR or tracing }`() {
+        // Given - fakeDatadogContext has no SR or tracing feature context
+
+        // When
+        testedScope.handleEvent(
+            RumRawEvent.StopView(fakeKey, emptyMap()),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue)
+                .apply {
+                    hasSessionReplaySampleRate(null)
+                    hasTraceSampleRate(null)
+                    hasSampleRate(fakeSampleRate)
+                }
+        }
+    }
+
+    @Test
+    fun `M send view event with null sessionReplaySampleRate W handleEvent(StopView) { SR key present but null }`() {
+        // Given
+        val contextWithNullSrRate = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext +
+                mapOf(
+                    Feature.SESSION_REPLAY_FEATURE_NAME to mapOf(
+                        RumViewScope.SESSION_REPLAY_SAMPLE_RATE_KEY to null
+                    )
+                )
+        )
+
+        // When
+        testedScope.handleEvent(
+            RumRawEvent.StopView(fakeKey, emptyMap()),
+            contextWithNullSrRate,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue)
+                .apply {
+                    hasSessionReplaySampleRate(null)
+                    hasSampleRate(fakeSampleRate)
+                }
+        }
+    }
+
+    @Test
+    fun `M send view event with null traceSampleRate W handleEvent(StopView) { trace key present but null }`() {
+        // Given
+        val contextWithNullTraceRate = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext +
+                mapOf(
+                    Feature.TRACING_FEATURE_NAME to mapOf(
+                        RumViewScope.TRACE_SAMPLE_RATE to null
+                    )
+                )
+        )
+
+        // When
+        testedScope.handleEvent(
+            RumRawEvent.StopView(fakeKey, emptyMap()),
+            contextWithNullTraceRate,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue)
+                .apply {
+                    hasTraceSampleRate(null)
+                    hasSampleRate(fakeSampleRate)
+                }
+        }
+    }
+
+    @Test
     fun `M send event W handleEvent(StopView) on active view { pending attributes are negative }`(
         forge: Forge
     ) {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -249,7 +249,8 @@ internal class DatadogRumMonitorTest {
                 eq(
                     setOf(
                         Feature.SESSION_REPLAY_FEATURE_NAME,
-                        Feature.PROFILING_FEATURE_NAME
+                        Feature.PROFILING_FEATURE_NAME,
+                        Feature.TRACING_FEATURE_NAME
                     )
                 ),
                 any()

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/assertj/DeserializedViewEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/assertj/DeserializedViewEventAssert.kt
@@ -21,8 +21,9 @@ internal class DeserializedViewEventAssert(actual: ViewEvent) :
     fun isEqualTo(expected: ViewEvent): DeserializedViewEventAssert {
         assertThat(actual)
             .usingRecursiveComparison()
-            .ignoringFields("context", "usr", "account", "view", "device")
+            .ignoringFields("context", "usr", "account", "view", "device", "dd.configuration")
             .isEqualTo(expected)
+        assertConfigurationEquals(actual.dd.configuration, expected.dd.configuration)
         assertThat(actual.view)
             .usingRecursiveComparison()
             .ignoringFields(
@@ -77,6 +78,23 @@ internal class DeserializedViewEventAssert(actual: ViewEvent) :
             expected.context?.additionalProperties
         )
         return this
+    }
+
+    private fun assertConfigurationEquals(
+        actual: ViewEvent.Configuration?,
+        expected: ViewEvent.Configuration?
+    ) {
+        if (expected == null) {
+            assertThat(actual).isNull()
+            return
+        }
+        assertThat(actual).isNotNull()
+        assertNumberFieldEquals(actual!!.sessionSampleRate, expected.sessionSampleRate)
+        assertNumberFieldEquals(actual.sessionReplaySampleRate, expected.sessionReplaySampleRate)
+        assertNumberFieldEquals(actual.profilingSampleRate, expected.profilingSampleRate)
+        assertNumberFieldEquals(actual.traceSampleRate, expected.traceSampleRate)
+        assertThat(actual.startSessionReplayRecordingManually)
+            .isEqualTo(expected.startSessionReplayRecordingManually)
     }
 
     private fun assertPropertiesEquals(actual: Map<String, Any?>?, expected: Map<String, Any?>?) {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/assertj/DeserializedViewEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/assertj/DeserializedViewEventAssert.kt
@@ -88,8 +88,8 @@ internal class DeserializedViewEventAssert(actual: ViewEvent) :
             assertThat(actual).isNull()
             return
         }
-        assertThat(actual).isNotNull()
-        assertNumberFieldEquals(actual!!.sessionSampleRate, expected.sessionSampleRate)
+        checkNotNull(actual)
+        assertNumberFieldEquals(actual.sessionSampleRate, expected.sessionSampleRate)
         assertNumberFieldEquals(actual.sessionReplaySampleRate, expected.sessionReplaySampleRate)
         assertNumberFieldEquals(actual.profilingSampleRate, expected.profilingSampleRate)
         assertNumberFieldEquals(actual.traceSampleRate, expected.traceSampleRate)

--- a/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ViewEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/testFixtures/kotlin/com/datadog/android/rum/utils/forge/ViewEventForgeryFactory.kt
@@ -146,7 +146,14 @@ class ViewEventForgeryFactory : ForgeryFactory<ViewEvent> {
             dd = ViewEvent.Dd(
                 session = forge.aNullable { ViewEvent.DdSession(aNullable { getForgery() }) },
                 browserSdkVersion = forge.aNullable { aStringMatching("\\d+\\.\\d+\\.\\d+") },
-                documentVersion = forge.aPositiveLong(strict = true)
+                documentVersion = forge.aPositiveLong(strict = true),
+                configuration = forge.aNullable {
+                    ViewEvent.Configuration(
+                        sessionSampleRate = aFloat(min = 0f, max = 100f),
+                        sessionReplaySampleRate = aNullable { aLong(min = 0, max = 100) },
+                        traceSampleRate = aNullable { aFloat(min = 0f, max = 100f) }
+                    )
+                }
             ),
             ddtags = forge.aNullable { ddTagsString() }
         )

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -105,17 +105,9 @@ internal constructor(
     private val rumContextPropagator = RumContextPropagator { sdkCoreReference.get() as? FeatureSdkCore }
 
     init {
-        val sdkCore = sdkCoreReference.get() as? FeatureSdkCore
-
-        // update meta for the configuration telemetry reporting, can be done directly from this thread
-        sdkCore?.updateFeatureContext(Feature.TRACING_FEATURE_NAME, useContextThread = false) {
-            it[OKHTTP_INTERCEPTOR_SAMPLE_RATE] = traceSampler.getSampleRate()
-            it[OKHTTP_INTERCEPTOR_HEADER_TYPES] = TracingHeaderTypesSet(
-                tracedHosts.values.flatten()
-                    .map(TracingHeaderType::toInternalTracingHeaderType)
-                    .toSet()
-            )
-        }
+        // Trigger SDK instance acquisition. If the SDK is already initialized, this will invoke
+        // [onSdkInstanceReady] synchronously, where we populate the tracing feature context.
+        sdkCoreReference.get()
     }
 
     // region Interceptor
@@ -213,6 +205,7 @@ internal constructor(
     // region Internal
 
     internal open fun onSdkInstanceReady(sdkCore: InternalSdkCore) {
+        updateTracingFeatureContext(sdkCore)
         if (localFirstPartyHostHeaderTypeResolver.isEmpty() &&
             sdkCore.firstPartyHostResolver.isEmpty()
         ) {
@@ -221,6 +214,18 @@ internal constructor(
                 InternalLogger.Target.USER,
                 { WARNING_TRACING_NO_HOSTS },
                 onlyOnce = true
+            )
+        }
+    }
+
+    private fun updateTracingFeatureContext(sdkCore: FeatureSdkCore) {
+        // Update meta for the configuration telemetry reporting, can be done directly from this thread.
+        sdkCore.updateFeatureContext(Feature.TRACING_FEATURE_NAME, useContextThread = false) {
+            it[OKHTTP_INTERCEPTOR_SAMPLE_RATE] = traceSampler.getSampleRate()
+            it[OKHTTP_INTERCEPTOR_HEADER_TYPES] = TracingHeaderTypesSet(
+                tracedHosts.values.flatten()
+                    .map(TracingHeaderType::toInternalTracingHeaderType)
+                    .toSet()
             )
         }
     }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
@@ -1577,6 +1577,36 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
+    fun `M update tracing feature context W onSdkInstanceReady { sdk initialized after interceptor construction }`(
+        @FloatForgery(min = 0f, max = 100f) sampleRate: Float
+    ) {
+        // Given
+        datadogCore.clearRegistry()
+        whenever(mockTraceSampler.getSampleRate()) doReturn sampleRate
+
+        val contextMock = mock<MutableMap<String, Any?>>()
+        whenever(rumMonitor.mockSdkCore.updateFeatureContext(eq(Feature.TRACING_FEATURE_NAME), any(), any())) doAnswer {
+            val updater = it.getArgument<(MutableMap<String, Any?>) -> Unit>(it.arguments.lastIndex)
+            updater(contextMock)
+        }
+
+        // When
+        testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
+
+        // Then
+        verifyNoInteractions(contextMock)
+
+        // When
+        testedInterceptor.onSdkInstanceReady(rumMonitor.mockSdkCore)
+
+        // Then
+        verify(contextMock)[OKHTTP_INTERCEPTOR_SAMPLE_RATE] = sampleRate
+        verify(contextMock)[OKHTTP_INTERCEPTOR_HEADER_TYPES] =
+            TracingHeaderTypesSet(fakeLocalHosts.values.flatten().map { it.toInternalTracingHeaderType() }.toSet())
+        verifyNoMoreInteractions(contextMock)
+    }
+
+    @Test
     fun `M keep existing BAGGAGE W intercept { new values != existing values }`(
         @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery existingBaggageKey: String,

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingRumTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingRumTest.kt
@@ -27,6 +27,7 @@ import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.FloatForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
@@ -771,6 +772,80 @@ class ManualTrackingRumTest {
                 doesNotHaveField("feature_flag")
             }
     }
+    // endregion
+
+    // region Sample Rates
+
+    @RepeatedTest(16)
+    fun `M send view event with sessionReplaySampleRate W startView() + stopView() { SR context set }`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String,
+        @LongForgery(min = 0L, max = 100L) fakeSrSampleRate: Long
+    ) {
+        // Given
+        stubSdkCore.updateFeatureContext(Feature.SESSION_REPLAY_FEATURE_NAME) {
+            it["session_replay_sample_rate"] = fakeSrSampleRate
+        }
+
+        // When
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+        rumMonitor.startView(viewKey, viewName)
+        rumMonitor.stopView(viewKey)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasRumEvent(index = 1) {
+                hasType("view")
+                hasSessionReplaySampleRate(fakeSrSampleRate)
+            }
+    }
+
+    @RepeatedTest(16)
+    fun `M send view event with traceSampleRate W startView() + stopView() { tracing context set }`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String,
+        @FloatForgery(min = 0f, max = 100f) fakeTraceSampleRate: Float
+    ) {
+        // Given
+        stubSdkCore.updateFeatureContext(Feature.TRACING_FEATURE_NAME) {
+            it["okhttp_interceptor_sample_rate"] = fakeTraceSampleRate
+        }
+
+        // When
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+        rumMonitor.startView(viewKey, viewName)
+        rumMonitor.stopView(viewKey)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasRumEvent(index = 1) {
+                hasType("view")
+                hasTraceSampleRate(fakeTraceSampleRate)
+            }
+    }
+
+    @RepeatedTest(16)
+    fun `M send view event with no sample rates W startView() + stopView() { no SR or tracing context }`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String
+    ) {
+        // When
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+        rumMonitor.startView(viewKey, viewName)
+        rumMonitor.stopView(viewKey)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasRumEvent(index = 1) {
+                hasType("view")
+                doesNotHaveSessionReplaySampleRate()
+                doesNotHaveTraceSampleRate()
+            }
+    }
+
     // endregion
 
     companion object {

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/assertj/RumEventAssert.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/assertj/RumEventAssert.kt
@@ -202,6 +202,28 @@ class RumEventAssert(actual: JsonObject) :
     }
     // endregion
 
+    // region configuration
+    fun hasSessionReplaySampleRate(sampleRate: Long): RumEventAssert {
+        hasField("_dd.configuration.session_replay_sample_rate", sampleRate)
+        return this
+    }
+
+    fun hasTraceSampleRate(sampleRate: Float): RumEventAssert {
+        hasField("_dd.configuration.trace_sample_rate", sampleRate)
+        return this
+    }
+
+    fun doesNotHaveSessionReplaySampleRate(): RumEventAssert {
+        doesNotHaveField("_dd.configuration.session_replay_sample_rate")
+        return this
+    }
+
+    fun doesNotHaveTraceSampleRate(): RumEventAssert {
+        doesNotHaveField("_dd.configuration.trace_sample_rate")
+        return this
+    }
+    // endregion
+
     companion object {
         fun assertThat(actual: JsonObject): RumEventAssert {
             return RumEventAssert(actual)

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -97,40 +97,44 @@ class SampleApplication : Application() {
         "127.0.0.1"
     )
 
-    private val okHttpClient = OkHttpClient.Builder()
-        .addInterceptor(
-            DatadogInterceptor.Builder(tracedHosts)
-                .trackResourceHeaders(
-                    ResourceHeadersExtractor.Builder()
-                        .captureHeaders(
-                            "accept-ranges",
-                            "cache-control",
-                            "content-disposition",
-                            "server",
-                            "user-agent",
-                            "via",
-                            "x-cache-hits",
-                            "x-served-by"
-                        )
-                        .build()
-                )
-                .build()
-        )
-        .addNetworkInterceptor(
-            TracingInterceptor.Builder(tracedHosts)
-                .build()
-        )
-        .eventListenerFactory(DatadogEventListener.Factory())
-        .build()
+    private val okHttpClient by lazy {
+        OkHttpClient.Builder()
+            .addInterceptor(
+                DatadogInterceptor.Builder(tracedHosts)
+                    .trackResourceHeaders(
+                        ResourceHeadersExtractor.Builder()
+                            .captureHeaders(
+                                "accept-ranges",
+                                "cache-control",
+                                "content-disposition",
+                                "server",
+                                "user-agent",
+                                "via",
+                                "x-cache-hits",
+                                "x-served-by"
+                            )
+                            .build()
+                    )
+                    .build()
+            )
+            .addNetworkInterceptor(
+                TracingInterceptor.Builder(tracedHosts)
+                    .build()
+            )
+            .eventListenerFactory(DatadogEventListener.Factory())
+            .build()
+    }
 
-    private val retrofitClient = Retrofit.Builder()
-        .baseUrl("https://api.datadoghq.com/api/v2/")
-        .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
-        .addCallAdapterFactory(RxJava3CallAdapterFactory.createSynchronous())
-        .client(okHttpClient)
-        .build()
+    private val retrofitClient by lazy {
+        Retrofit.Builder()
+            .baseUrl("https://api.datadoghq.com/api/v2/")
+            .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
+            .addCallAdapterFactory(RxJava3CallAdapterFactory.createSynchronous())
+            .client(okHttpClient)
+            .build()
+    }
 
-    private val retrofitBaseDataSource = retrofitClient.create(RemoteDataSource::class.java)
+    private val retrofitBaseDataSource by lazy { retrofitClient.create(RemoteDataSource::class.java) }
 
     private val localServer = LocalServer()
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -97,44 +97,40 @@ class SampleApplication : Application() {
         "127.0.0.1"
     )
 
-    private val okHttpClient by lazy {
-        OkHttpClient.Builder()
-            .addInterceptor(
-                DatadogInterceptor.Builder(tracedHosts)
-                    .trackResourceHeaders(
-                        ResourceHeadersExtractor.Builder()
-                            .captureHeaders(
-                                "accept-ranges",
-                                "cache-control",
-                                "content-disposition",
-                                "server",
-                                "user-agent",
-                                "via",
-                                "x-cache-hits",
-                                "x-served-by"
-                            )
-                            .build()
-                    )
-                    .build()
-            )
-            .addNetworkInterceptor(
-                TracingInterceptor.Builder(tracedHosts)
-                    .build()
-            )
-            .eventListenerFactory(DatadogEventListener.Factory())
-            .build()
-    }
+    private val okHttpClient = OkHttpClient.Builder()
+        .addInterceptor(
+            DatadogInterceptor.Builder(tracedHosts)
+                .trackResourceHeaders(
+                    ResourceHeadersExtractor.Builder()
+                        .captureHeaders(
+                            "accept-ranges",
+                            "cache-control",
+                            "content-disposition",
+                            "server",
+                            "user-agent",
+                            "via",
+                            "x-cache-hits",
+                            "x-served-by"
+                        )
+                        .build()
+                )
+                .build()
+        )
+        .addNetworkInterceptor(
+            TracingInterceptor.Builder(tracedHosts)
+                .build()
+        )
+        .eventListenerFactory(DatadogEventListener.Factory())
+        .build()
 
-    private val retrofitClient by lazy {
-        Retrofit.Builder()
-            .baseUrl("https://api.datadoghq.com/api/v2/")
-            .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
-            .addCallAdapterFactory(RxJava3CallAdapterFactory.createSynchronous())
-            .client(okHttpClient)
-            .build()
-    }
+    private val retrofitClient = Retrofit.Builder()
+        .baseUrl("https://api.datadoghq.com/api/v2/")
+        .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
+        .addCallAdapterFactory(RxJava3CallAdapterFactory.createSynchronous())
+        .client(okHttpClient)
+        .build()
 
-    private val retrofitBaseDataSource by lazy { retrofitClient.create(RemoteDataSource::class.java) }
+    private val retrofitBaseDataSource = retrofitClient.create(RemoteDataSource::class.java)
 
     private val localServer = LocalServer()
 

--- a/sample/vendor-lib/src/main/kotlin/com/datadog/android/vendor/sample/LocalServer.kt
+++ b/sample/vendor-lib/src/main/kotlin/com/datadog/android/vendor/sample/LocalServer.kt
@@ -80,7 +80,7 @@ public class LocalServer {
         Logs.enable(logsConfig, instance)
 
         val tracesConfig = TraceConfiguration.Builder().build()
-        Trace.enable(tracesConfig)
+        Trace.enable(tracesConfig, instance)
         logger = Logger.Builder(instance)
             .setLogcatLogsEnabled(true)
             .build()


### PR DESCRIPTION
### What does this PR do?

Adds `traceSampleRate` and `sessionReplaySampleRate` fields to `ViewEvent.Configuration`, populating them from the tracing and session replay feature contexts when a RUM view event is written.

### Motivation

RUM-13023: These sample rates were not previously included in `ViewEvent` payloads, making it impossible for downstream consumers to know the effective sampling configuration at the time of the event. This change reads the rates from the shared `featuresContext` map and propagates them into the event schema.

### Additional Notes

- `sessionReplaySampleRate` is read as `Long` (matching `SessionReplayFeature` storage format).
- `traceSampleRate` is read as `Float` (matching `TracingInterceptor` storage format).
- `Feature.TRACING_FEATURE_NAME` was added to the `withFeatureContexts` set in `DatadogRumMonitor` so the tracing context is available when writing view events.
- The JSON schema (`_common-schema.json`) was updated with the new `trace_sample_rate` field; the generated model and API surface files were regenerated accordingly.

### How to test

To manually verify that `session_replay_sample_rate` and `trace_sample_rate` are present in RUM ViewEvent payloads, enable request body logging in the sample app and inspect logcat.

**1. Enable body logging in `CoreFeature.kt`**

In `dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt`, change:

```kotlin
// Before
builder.addNetworkInterceptor(CurlInterceptor())

// After
builder.addNetworkInterceptor(CurlInterceptor(printBody = true))
```

> This is gated by `BuildConfig.DEBUG` — safe for debug builds only. Do not commit this change.

**2. Build and install the sample app**

```sh
./gradlew :sample:kotlin:installUs1Debug
adb shell am start -n com.datadog.android.sample/.NavActivity
```

**3. Navigate between screens and check logcat**

Navigate to any screen and back to trigger a view stop event, then wait ~15s for the upload cycle:

```sh
adb logcat -s "Curl" | grep '"type":"view"'
```

Look for `_dd.configuration` in the output — both fields should be present:

```json
"configuration": {
  "session_sample_rate": 100.0,
  "session_replay_sample_rate": 100,
  "trace_sample_rate": 100.0
}
```

> ⚠️📦 A skill for this workflow is available in `.claude/skills/android-sdk-event-inspection/` — it covers the full setup including credentials and logcat filtering.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc). Be concise.