### PR TITLE
RUM-508: Exempt telemetry configuration event from the session event count limit

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -71,7 +71,7 @@ internal class TelemetryEventHandler(
         if (!canWrite(event)) return
 
         eventIDsSeenInCurrentSession.add(event.identity)
-        totalEventsSeenInCurrentSession++
+        if (event !is InternalTelemetryEvent.Configuration) totalEventsSeenInCurrentSession++
         sdkCore.getFeature(Feature.RUM_FEATURE_NAME)?.withWriteContext(
             withFeatureContexts = setOf(
                 Feature.SESSION_REPLAY_FEATURE_NAME,
@@ -161,8 +161,8 @@ internal class TelemetryEventHandler(
     private fun canWrite(event: InternalTelemetryEvent): Boolean {
         if (!eventSampler.sample(event)) return false
 
-        if (event is InternalTelemetryEvent.Configuration && !configurationExtraSampler.sample(event)) {
-            return false
+        if (event is InternalTelemetryEvent.Configuration) {
+            return configurationExtraSampler.sample(event)
         }
 
         val eventIdentity = event.identity

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -86,6 +86,7 @@ import org.mockito.quality.Strictness
 import org.mockito.stubbing.Answer
 import java.util.Locale
 import java.util.concurrent.TimeUnit
+import kotlin.reflect.KClass
 import kotlin.reflect.jvm.jvmName
 import com.datadog.android.telemetry.model.TelemetryConfigurationEvent.ViewTrackingStrategy as VTS
 
@@ -985,7 +986,7 @@ internal class TelemetryEventHandlerTest {
 
         val events = forge.aList(
             size = MAX_EVENTS_PER_SESSION_TEST * 10
-        ) { forge.forgeWritableInternalTelemetryEvent() }
+        ) { forge.forgeWritableInternalTelemetryEvent(InternalTelemetryEvent.Configuration::class) }
             // remove unwanted identity collisions
             .groupBy { it.identity }
             .map { RumRawEvent.TelemetryEventWrapper(it.value.first()) }
@@ -1125,6 +1126,60 @@ internal class TelemetryEventHandlerTest {
             target = InternalLogger.Target.MAINTAINER,
             message = TelemetryEventHandler.MAX_EVENT_NUMBER_REACHED_MESSAGE
         )
+    }
+
+    @Test
+    fun `M still write configuration event W handleEvent() { max events per session reached }`(
+        forge: Forge,
+        @Forgery fakeConfigurationEvent: InternalTelemetryEvent.Configuration
+    ) {
+        // Given
+        repeat(MAX_EVENTS_PER_SESSION_TEST + 1) {
+            val event = forge.getForgery<InternalTelemetryEvent.Metric>()
+            testedTelemetryHandler.handleEvent(RumRawEvent.TelemetryEventWrapper(event), mockWriter)
+        }
+
+        // When
+        testedTelemetryHandler.handleEvent(
+            RumRawEvent.TelemetryEventWrapper(fakeConfigurationEvent),
+            mockWriter
+        )
+
+        // Then
+        argumentCaptor<Any> {
+            verify(
+                mockWriter,
+                times(MAX_EVENTS_PER_SESSION_TEST + 1)
+            ).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
+            assertThat(lastValue).isInstanceOf(TelemetryConfigurationEvent::class.java)
+        }
+    }
+
+    @Test
+    fun `M not count configuration toward limit W handleEvent() { configuration then other events }`(
+        forge: Forge,
+        @Forgery fakeConfigurationEvent: InternalTelemetryEvent.Configuration
+    ) {
+        // Given
+        testedTelemetryHandler.handleEvent(
+            RumRawEvent.TelemetryEventWrapper(fakeConfigurationEvent),
+            mockWriter
+        )
+
+        // When
+        repeat(MAX_EVENTS_PER_SESSION_TEST) {
+            testedTelemetryHandler.handleEvent(
+                RumRawEvent.TelemetryEventWrapper(forge.getForgery<InternalTelemetryEvent.Metric>()),
+                mockWriter
+            )
+        }
+
+        // Then
+        // 1 configuration + MAX metric events = all should be written
+        verify(
+            mockWriter,
+            times(MAX_EVENTS_PER_SESSION_TEST + 1)
+        ).write(eq(mockEventBatchWriter), any(), eq(EventType.TELEMETRY))
     }
 
     @Test
@@ -1618,13 +1673,17 @@ internal class TelemetryEventHandlerTest {
             )
     }
 
-    private fun Forge.forgeWritableInternalTelemetryEvent(): InternalTelemetryEvent {
-        return anElementFrom(
-            getForgery<InternalTelemetryEvent.Log.Error>(),
-            getForgery<InternalTelemetryEvent.Log.Debug>(),
-            getForgery<InternalTelemetryEvent.Configuration>(),
-            getForgery<InternalTelemetryEvent.Metric>()
-        )
+    private fun Forge.forgeWritableInternalTelemetryEvent(
+        vararg exclude: KClass<InternalTelemetryEvent.Configuration>
+    ): InternalTelemetryEvent {
+        val allowedClasses = setOf(
+            InternalTelemetryEvent.Log.Error::class,
+            InternalTelemetryEvent.Log.Debug::class,
+            InternalTelemetryEvent.Configuration::class,
+            InternalTelemetryEvent.Metric::class
+        ) - exclude.toSet()
+
+        return anElementFrom(allowedClasses.map { getForgery(it.java) })
     }
 
     private fun Map<String, Any?>.withDiagnosticAttributes(): Map<String, Any?> {


### PR DESCRIPTION
### What does this PR do?

Exempt `InternalTelemetryEvent.Configuration`  event from session limit (100 events per session). 

### Motivation

`InternalTelemetryEvent.Configuration` is sent with 5 seconds delay, which (in theory) could lead to missing configuration events SDK already send 100 events to the moment when `InternalTelemetryEvent.Configuration` will be processed by `TelemetryEventHandler`

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

