### PR TITLE
Fix RUM-13135: Compose Instrumentation modifying expected layout

### DIFF
--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/DatadogModifier.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/DatadogModifier.kt
@@ -61,10 +61,8 @@ internal var SemanticsPropertyReceiver.datadog by DatadogSemanticsPropertyKey
  * node is explicitly excluded from the layout measurement chain, ensuring it never modifies
  * constraints passed to child composables.
  */
-internal data class DatadogSemanticsElement(
-    val name: String,
-    val isImage: Boolean
-) : ModifierNodeElement<DatadogSemanticsNode>() {
+internal data class DatadogSemanticsElement(val name: String, val isImage: Boolean) :
+    ModifierNodeElement<DatadogSemanticsNode>() {
     override fun create(): DatadogSemanticsNode = DatadogSemanticsNode(name, isImage)
 
     override fun update(node: DatadogSemanticsNode) {
@@ -83,10 +81,9 @@ internal data class DatadogSemanticsElement(
  * This node does NOT implement `LayoutModifierNode`, so it is never consulted during
  * layout measurement and cannot modify constraints.
  */
-internal class DatadogSemanticsNode(
-    var name: String,
-    var isImage: Boolean
-) : Modifier.Node(), SemanticsModifierNode {
+internal class DatadogSemanticsNode(var name: String, var isImage: Boolean) :
+    Modifier.Node(),
+    SemanticsModifierNode {
     override val shouldMergeDescendantSemantics: Boolean get() = false
     override val shouldClearDescendantSemantics: Boolean get() = false
 

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/DatadogModifier.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/DatadogModifier.kt
@@ -61,8 +61,10 @@ internal var SemanticsPropertyReceiver.datadog by DatadogSemanticsPropertyKey
  * node is explicitly excluded from the layout measurement chain, ensuring it never modifies
  * constraints passed to child composables.
  */
-internal class DatadogSemanticsElement(private val name: String, private val isImage: Boolean) :
-    ModifierNodeElement<DatadogSemanticsNode>() {
+internal class DatadogSemanticsElement(
+    private val name: String,
+    private val isImage: Boolean
+) : ModifierNodeElement<DatadogSemanticsNode>() {
     override fun create(): DatadogSemanticsNode = DatadogSemanticsNode(name, isImage)
 
     override fun update(node: DatadogSemanticsNode) {
@@ -93,9 +95,10 @@ internal class DatadogSemanticsElement(private val name: String, private val isI
  * This node does NOT implement `LayoutModifierNode`, so it is never consulted during
  * layout measurement and cannot modify constraints.
  */
-internal class DatadogSemanticsNode(var name: String, var isImage: Boolean) :
-    Modifier.Node(),
-    SemanticsModifierNode {
+internal class DatadogSemanticsNode(
+    var name: String,
+    var isImage: Boolean
+) : Modifier.Node(), SemanticsModifierNode {
     override val shouldMergeDescendantSemantics: Boolean get() = false
     override val shouldClearDescendantSemantics: Boolean get() = false
 

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/DatadogModifier.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/DatadogModifier.kt
@@ -8,11 +8,13 @@
 package com.datadog.android.compose
 
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.SemanticsModifierNode
+import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
-import androidx.compose.ui.semantics.semantics
 import com.datadog.android.compose.internal.InstrumentationType
 import com.datadog.android.compose.internal.sendTelemetry
 
@@ -28,7 +30,7 @@ import com.datadog.android.compose.internal.sendTelemetry
  */
 fun Modifier.datadog(name: String, isImage: Boolean = false): Modifier {
     sendTelemetry(autoInstrumented = false, InstrumentationType.Semantics)
-    return this.datadogSemantics(name, isImage)
+    return this.then(DatadogSemanticsElement(name, isImage))
 }
 
 /**
@@ -37,16 +39,7 @@ fun Modifier.datadog(name: String, isImage: Boolean = false): Modifier {
  */
 internal fun Modifier.instrumentedDatadog(name: String, isImage: Boolean): Modifier {
     sendTelemetry(autoInstrumented = true, InstrumentationType.Semantics)
-    return this.datadogSemantics(name, isImage)
-}
-
-private fun Modifier.datadogSemantics(name: String, isImage: Boolean): Modifier {
-    return this.semantics {
-        this.datadog = name
-        if (isImage) {
-            this[SemanticsProperties.Role] = Role.Image
-        }
-    }
+    return this.then(DatadogSemanticsElement(name, isImage))
 }
 
 internal val DatadogSemanticsPropertyKey: SemanticsPropertyKey<String> = SemanticsPropertyKey(
@@ -56,4 +49,51 @@ internal val DatadogSemanticsPropertyKey: SemanticsPropertyKey<String> = Semanti
     }
 )
 
-private var SemanticsPropertyReceiver.datadog by DatadogSemanticsPropertyKey
+internal var SemanticsPropertyReceiver.datadog by DatadogSemanticsPropertyKey
+
+/**
+ * A custom [ModifierNodeElement] that provides Datadog semantics without participating in
+ * layout measurement. This replaces the previous `Modifier.semantics {}` approach to avoid
+ * interference with layout constraint propagation in components like `SubcomposeLayout`
+ * (e.g., Coil's `SubcomposeAsyncImage`) inside `LazyRow`/`LazyColumn`.
+ *
+ * By implementing only [SemanticsModifierNode] (and not `LayoutModifierNode`), this modifier
+ * node is explicitly excluded from the layout measurement chain, ensuring it never modifies
+ * constraints passed to child composables.
+ */
+internal data class DatadogSemanticsElement(
+    val name: String,
+    val isImage: Boolean
+) : ModifierNodeElement<DatadogSemanticsNode>() {
+    override fun create(): DatadogSemanticsNode = DatadogSemanticsNode(name, isImage)
+
+    override fun update(node: DatadogSemanticsNode) {
+        node.name = name
+        node.isImage = isImage
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        this.properties["name"] = name
+        this.properties["isImage"] = isImage
+    }
+}
+
+/**
+ * A [SemanticsModifierNode] that attaches Datadog component metadata to the semantics tree.
+ * This node does NOT implement `LayoutModifierNode`, so it is never consulted during
+ * layout measurement and cannot modify constraints.
+ */
+internal class DatadogSemanticsNode(
+    var name: String,
+    var isImage: Boolean
+) : Modifier.Node(), SemanticsModifierNode {
+    override val shouldMergeDescendantSemantics: Boolean get() = false
+    override val shouldClearDescendantSemantics: Boolean get() = false
+
+    override fun SemanticsPropertyReceiver.applySemantics() {
+        this.datadog = name
+        if (isImage) {
+            this[SemanticsProperties.Role] = Role.Image
+        }
+    }
+}

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/DatadogModifier.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/DatadogModifier.kt
@@ -61,7 +61,7 @@ internal var SemanticsPropertyReceiver.datadog by DatadogSemanticsPropertyKey
  * node is explicitly excluded from the layout measurement chain, ensuring it never modifies
  * constraints passed to child composables.
  */
-internal data class DatadogSemanticsElement(val name: String, val isImage: Boolean) :
+internal class DatadogSemanticsElement(private val name: String, private val isImage: Boolean) :
     ModifierNodeElement<DatadogSemanticsNode>() {
     override fun create(): DatadogSemanticsNode = DatadogSemanticsNode(name, isImage)
 
@@ -73,6 +73,18 @@ internal data class DatadogSemanticsElement(val name: String, val isImage: Boole
     override fun InspectorInfo.inspectableProperties() {
         this.properties["name"] = name
         this.properties["isImage"] = isImage
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DatadogSemanticsElement) return false
+        return name == other.name && isImage == other.isImage
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + isImage.hashCode()
+        return result
     }
 }
 

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/DatadogSemanticsElementTest.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/DatadogSemanticsElementTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.compose
+
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+class DatadogSemanticsElementTest {
+
+    @Test
+    fun `M create node with correct properties W create()`(
+        @StringForgery name: String,
+        @BoolForgery isImage: Boolean
+    ) {
+        // Given
+        val element = DatadogSemanticsElement(name, isImage)
+
+        // When
+        val node = element.create()
+
+        // Then
+        assertThat(node.name).isEqualTo(name)
+        assertThat(node.isImage).isEqualTo(isImage)
+    }
+
+    @Test
+    fun `M update node properties W update()`(
+        @StringForgery initialName: String,
+        @StringForgery updatedName: String,
+        @BoolForgery initialIsImage: Boolean
+    ) {
+        // Given
+        val element = DatadogSemanticsElement(initialName, initialIsImage)
+        val node = element.create()
+        val updatedElement = DatadogSemanticsElement(updatedName, !initialIsImage)
+
+        // When
+        updatedElement.update(node)
+
+        // Then
+        assertThat(node.name).isEqualTo(updatedName)
+        assertThat(node.isImage).isEqualTo(!initialIsImage)
+    }
+
+    @Test
+    fun `M be equal W same properties`(
+        @StringForgery name: String,
+        @BoolForgery isImage: Boolean
+    ) {
+        // Given
+        val element1 = DatadogSemanticsElement(name, isImage)
+        val element2 = DatadogSemanticsElement(name, isImage)
+
+        // Then
+        assertThat(element1).isEqualTo(element2)
+        assertThat(element1.hashCode()).isEqualTo(element2.hashCode())
+    }
+
+    @Test
+    fun `M not be equal W different name`(
+        @StringForgery name1: String,
+        @StringForgery name2: String,
+        @BoolForgery isImage: Boolean
+    ) {
+        // Given
+        val element1 = DatadogSemanticsElement(name1, isImage)
+        val element2 = DatadogSemanticsElement(name2, isImage)
+
+        // Then
+        if (name1 != name2) {
+            assertThat(element1).isNotEqualTo(element2)
+        }
+    }
+
+    @Test
+    fun `M not be equal W different isImage`(
+        @StringForgery name: String
+    ) {
+        // Given
+        val element1 = DatadogSemanticsElement(name, true)
+        val element2 = DatadogSemanticsElement(name, false)
+
+        // Then
+        assertThat(element1).isNotEqualTo(element2)
+    }
+
+    @Test
+    fun `M node not merge descendants W shouldMergeDescendantSemantics`(
+        @StringForgery name: String,
+        @BoolForgery isImage: Boolean
+    ) {
+        // Given
+        val element = DatadogSemanticsElement(name, isImage)
+        val node = element.create()
+
+        // Then
+        assertThat(node.shouldMergeDescendantSemantics).isFalse()
+    }
+
+    @Test
+    fun `M node not clear descendants W shouldClearDescendantSemantics`(
+        @StringForgery name: String,
+        @BoolForgery isImage: Boolean
+    ) {
+        // Given
+        val element = DatadogSemanticsElement(name, isImage)
+        val node = element.create()
+
+        // Then
+        assertThat(node.shouldClearDescendantSemantics).isFalse()
+    }
+}

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/DatadogSemanticsElementTest.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/DatadogSemanticsElementTest.kt
@@ -23,10 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 class DatadogSemanticsElementTest {
 
     @Test
-    fun `M create node with correct properties W create()`(
-        @StringForgery name: String,
-        @BoolForgery isImage: Boolean
-    ) {
+    fun `M create node with correct properties W create()`(@StringForgery name: String, @BoolForgery isImage: Boolean) {
         // Given
         val element = DatadogSemanticsElement(name, isImage)
 
@@ -58,10 +55,7 @@ class DatadogSemanticsElementTest {
     }
 
     @Test
-    fun `M be equal W same properties`(
-        @StringForgery name: String,
-        @BoolForgery isImage: Boolean
-    ) {
+    fun `M be equal W same properties`(@StringForgery name: String, @BoolForgery isImage: Boolean) {
         // Given
         val element1 = DatadogSemanticsElement(name, isImage)
         val element2 = DatadogSemanticsElement(name, isImage)
@@ -88,9 +82,7 @@ class DatadogSemanticsElementTest {
     }
 
     @Test
-    fun `M not be equal W different isImage`(
-        @StringForgery name: String
-    ) {
+    fun `M not be equal W different isImage`(@StringForgery name: String) {
         // Given
         val element1 = DatadogSemanticsElement(name, true)
         val element2 = DatadogSemanticsElement(name, false)

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/DatadogSemanticsElementTest.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/DatadogSemanticsElementTest.kt
@@ -23,7 +23,10 @@ import org.mockito.junit.jupiter.MockitoExtension
 class DatadogSemanticsElementTest {
 
     @Test
-    fun `M create node with correct properties W create()`(@StringForgery name: String, @BoolForgery isImage: Boolean) {
+    fun `M create node with correct properties W create()`(
+        @StringForgery name: String,
+        @BoolForgery isImage: Boolean
+    ) {
         // Given
         val element = DatadogSemanticsElement(name, isImage)
 
@@ -55,7 +58,10 @@ class DatadogSemanticsElementTest {
     }
 
     @Test
-    fun `M be equal W same properties`(@StringForgery name: String, @BoolForgery isImage: Boolean) {
+    fun `M be equal W same properties`(
+        @StringForgery name: String,
+        @BoolForgery isImage: Boolean
+    ) {
         // Given
         val element1 = DatadogSemanticsElement(name, isImage)
         val element2 = DatadogSemanticsElement(name, isImage)


### PR DESCRIPTION
## Summary

Fixes layout constraint propagation issue caused by Datadog Compose auto-instrumentation. When the compiler plugin prepends `Modifier.semantics {}` to composable modifier chains, it can interfere with `SubcomposeLayout`-based components (e.g., Coil's `SubcomposeAsyncImage`) inside `LazyRow`/`LazyColumn`, causing `hasBoundedHeight` to become `false` and `minHeight` to become `0`.

[RUM-13135](https://datadoghq.atlassian.net/browse/RUM-13135)

## Root Cause

The Datadog Kotlin Compiler Plugin (`ComposeTagTransformer`) auto-instruments composable functions by inserting `instrumentedDatadog(name).then(originalModifier)` at every composable call site. The `instrumentedDatadog()` function previously used `Modifier.semantics {}` (from `CoreSemanticsModifierNode`), which in certain Compose framework versions may participate in the layout measurement chain, modifying constraint propagation.

## Changes

- **`DatadogModifier.kt`**: Replaced `Modifier.semantics {}` with custom `DatadogSemanticsElement`/`DatadogSemanticsNode` using the `ModifierNodeElement` API
  - `DatadogSemanticsNode` explicitly implements only `SemanticsModifierNode` (NOT `LayoutModifierNode`)
  - Guarantees the node never interferes with layout constraint measurement
  - `DatadogSemanticsPropertyKey` and public `Modifier.datadog()` API remain unchanged
- **`DatadogSemanticsElementTest.kt`**: 7 unit tests for the new element/node

## Companion Change (separate repo)

`dd-sdk-android-gradle-plugin`: `ComposeTagTransformer.buildIrExpression()` should change modifier order from `datadogTag.then(original)` to `original.then(datadogTag)`, placing semantics INNER instead of OUTER so layout modifiers process constraints first.

## Test Plan

- [x] New unit tests for `DatadogSemanticsElement` and `DatadogSemanticsNode`
- [x] All existing compose module tests pass
- [x] Public API surface unchanged
- [ ] Integration test with LazyRow + SubcomposeAsyncImage (requires Android emulator)
- [ ] Compiler plugin companion PR

---
*Generated by rum:fix-jira-issues*

[RUM-13135]: https://datadoghq.atlassian.net/browse/RUM-13135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ