### PR TITLE
Update Proguard rules for `GlobalDatadogTracer`

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -496,7 +496,7 @@ internal class TelemetryEventHandler(
                     InternalLogger.Target.TELEMETRY,
                     {
                         "GlobalDatadogTracer class exists in the runtime classpath, " +
-                            "but there is an error invoking isRegistered method"
+                            "but there is an error invoking getOrNull method"
                     },
                     t
                 )

--- a/features/dd-sdk-android-trace/consumer-rules.pro
+++ b/features/dd-sdk-android-trace/consumer-rules.pro
@@ -1,4 +1,4 @@
--keepnames class com.datadog.android.trace.GlobalDatadogTracer {
+-keep class com.datadog.android.trace.GlobalDatadogTracer {
     public com.datadog.android.trace.api.tracer.DatadogTracer getOrNull();
     public static com.datadog.android.trace.GlobalDatadogTracer INSTANCE;
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes the following exception:

```
java.lang.NoSuchMethodException: com.datadog.android.trace.GlobalDatadogTracer.getOrNull []

GlobalDatadogTracer class exists in the runtime classpath, but there is an error invoking isRegistered method
```

It is because of the `keepnames` usage, which a [shorthand](https://www.guardsquare.com/manual/configuration/usage#keepnames) for `-keep, allowshrinking`: it will keep the name, but the method can still be shrinked. Switching to `-keep`, which won't allow method removal.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

