### PR TITLE
RUM-13454: Add TODO for getResourceName inconsistency

### DIFF
--- a/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/core/DDSpanContext.java
+++ b/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/core/DDSpanContext.java
@@ -400,7 +400,8 @@ public class DDSpanContext
     this.topLevel = isTopLevel(parentServiceName, this.serviceName);
   }
 
-  // TODO this logic is inconsistent with hasResourceName
+  // TODO RUM-13454 this logic is inconsistent with hasResourceName, to be fixed in the next major
+  //  release. See https://github.com/DataDog/dd-sdk-android/pull/3244
   public CharSequence getResourceName() {
     return isResourceNameSet() ? resourceName : operationName;
   }


### PR DESCRIPTION
## Summary
- Adds JIRA ticket (RUM-13454) and PR reference to the existing TODO comment on `getResourceName()` 
- Defers the `getResourceName`/`hasResourceName` inconsistency fix to the next major release, per team review feedback on #3244

## Context
PR #3244 attempted to fix the inconsistency between `getResourceName()` and `hasResourceName()` but reviewers flagged that changing behavior in a minor release could skew existing dashboards/monitors. The team agreed to defer this to the next major release.

## Test plan
- [ ] Comment-only change, no behavior modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)