### PR TITLE
Remove `:tools:benchmark` module from sample app dependencies

### DIFF
--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -175,7 +175,6 @@ dependencies {
     implementation(project(":integrations:dd-sdk-android-cronet"))
     implementation(project(":integrations:dd-sdk-android-okhttp"))
     implementation(project(":integrations:dd-sdk-android-okhttp-otel"))
-    implementation(project(":tools:benchmark"))
 
     // Desugaring SDK
     coreLibraryDesugaring(libs.androidDesugaringSdk)


### PR DESCRIPTION
### What does this PR do?

It is not used by the sample app but having it as a dependency declared triggers redundant compilation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

