### PR TITLE
Add Datadog code coverage upload

### DIFF
--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -177,6 +177,8 @@ test:kover:
     - GRADLE_OPTS="-Xmx3072m" DD_TAGS="test.configuration.variant:release" ./gradlew :koverReportFeatures  --no-daemon --build-cache --gradle-user-home cache/ -Dorg.gradle.jvmargs=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar=$DD_COMMON_AGENT_CONFIG
     - GRADLE_OPTS="-Xmx3072m" DD_TAGS="test.configuration.variant:release" ./gradlew :koverReportIntegrations  --no-daemon --build-cache --gradle-user-home cache/ -Dorg.gradle.jvmargs=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar=$DD_COMMON_AGENT_CONFIG
     - bash <(cat ./ci/scripts/codecov.sh) -t $CODECOV_TOKEN
+    - npm install -g @datadog/datadog-ci
+    - datadog-ci coverage upload --format=jacoco . || true
   artifacts:
     when: always
     expire_in: 1 week

--- a/code-coverage.datadog.yml
+++ b/code-coverage.datadog.yml
@@ -1,0 +1,5 @@
+schema-version: v1
+ignore:
+  - "build/"
+  - "**/build/"
+  - "**/src/test/"


### PR DESCRIPTION
## What

This PR adds **Datadog Code Coverage** reporting alongside the existing Codecov integration. It's part of a company-wide initiative to migrate all DataDog repositories from Codecov to our own [Code Coverage](https://docs.datadoghq.com/code_coverage/) product.

**Nothing is removed** — Codecov continues to work exactly as before. This PR only *adds* a Datadog upload so we can run both systems side-by-side and verify coverage parity before fully switching over.

## Why

Datadog Code Coverage is our in-house replacement for Codecov. It integrates natively with CI Visibility, provides PR comments and coverage gates, and removes the dependency on a third-party service. All DataDog repositories are being migrated.

## Changes

### 1. `ci/pipelines/default-pipeline.yml`
Added two lines to the `test:kover` job, **after** the existing Codecov upload:
```yaml
- npm install -g @datadog/datadog-ci
- datadog-ci coverage upload --format=jacoco . || true
```
- Installs the `datadog-ci` CLI and uploads all Kover XML (JaCoCo format) reports to Datadog
- Uses the existing `DD_API_KEY` already set in this job (from Vault via `DD_ANDROID_SECRET__API_KEY`)
- `|| true` ensures the upload is **non-blocking** — if it fails for any reason, the build still passes

### 2. `code-coverage.datadog.yml` (new file)
Configuration for Datadog Code Coverage, equivalent to your existing `.codecov.yml`:
```yaml
schema-version: v1
ignore:
  - "build/"
  - "**/build/"
  - "**/src/test/"
```
These ignore paths mirror what's already in `.codecov.yml` (`build`, `.*/build/.*`, `.*/src/test/.*`).

## Validation

We compared coverage on the same commit (`b94905c2` on `develop`) in both systems:

| System | Overall Coverage |
|--------|-----------------|
| Codecov | 71.39% |
| Datadog | 71.42% |
| **Difference** | **+0.03%** |

Coverage parity is confirmed — the difference is negligible.

## Impact

- **Zero risk to existing CI**: Codecov upload is untouched, and the Datadog upload is non-blocking (`|| true`)
- **No new secrets needed**: `DD_API_KEY` is already available in the `test:kover` job
- **No behavior changes**: This only adds an extra upload step after tests complete

## Next Steps (not part of this PR)

Once we've confirmed everything works in production for a few cycles, a follow-up PR will:
1. Remove the Codecov upload step and `.codecov.yml`
2. Optionally configure PR Gates (coverage thresholds) in `code-coverage.datadog.yml`

If you have any questions about Datadog Code Coverage, see the [docs](https://docs.datadoghq.com/code_coverage/) or reach out to us.