### PR TITLE
RUM-15081: Fix memory corruption in NDK module

### DIFF
--- a/features/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.cpp
+++ b/features/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.cpp
@@ -95,7 +95,7 @@ bool copyString(const std::string &str, char *ptr, size_t max_size) {
     size_t str_size = str.size();
     size_t copy_size = std::min(str_size, max_size - 1);
     memcpy(ptr, str.data(), copy_size);
-    ptr[str.size()] = '\0';
+    ptr[copy_size] = '\0';
     return copy_size == str_size;
 }
 
@@ -119,7 +119,3 @@ bool generate_backtrace(char *backtrace_ptr, size_t start_index, size_t max_size
     }
     return copyString(backtrace, backtrace_ptr, max_size);
 }
-
-
-
-

--- a/features/dd-sdk-android-ndk/src/test/cpp/test-generate-backtrace.cpp
+++ b/features/dd-sdk-android-ndk/src/test/cpp/test-generate-backtrace.cpp
@@ -7,6 +7,8 @@
 #include "greatest/greatest.h"
 #include "utils/backtrace-handler.h"
 
+extern bool copyString(const std::string &str, char *ptr, size_t max_size);
+
 TEST test_generate_backtrace(void) {
     char backtrace[max_stack_size];
     const bool was_successful = generate_backtrace(backtrace, 0, max_stack_size);
@@ -55,10 +57,25 @@ TEST test_generate_backtrace_will_return_truncated_string_if_size_is_exceeded(vo
             PASS();
 }
 
+TEST test_copy_string_will_null_terminate_within_bounds_when_truncated(void) {
+    const std::string source = "abcdef";
+    char destination[4] = {'x', 'x', 'x', 'z'};
+
+    const bool was_copied = copyString(source, destination, sizeof(destination));
+
+            ASSERT_FALSE(was_copied);
+            ASSERT_EQ(destination[0], 'a');
+            ASSERT_EQ(destination[1], 'b');
+            ASSERT_EQ(destination[2], 'c');
+            ASSERT_EQ(destination[3], '\0');
+            PASS();
+}
+
 
 SUITE (backtrace_generation) {
             RUN_TEST(test_generate_backtrace);
             RUN_TEST(test_generate_backtrace_will_return_false_if_size_is_exceeded);
             RUN_TEST(test_generate_backtrace_will_return_truncated_string_if_size_is_exceeded);
             RUN_TEST(test_generate_backtrace_starts_from_the_given_frame_index);
+            RUN_TEST(test_copy_string_will_null_terminate_within_bounds_when_truncated);
 }


### PR DESCRIPTION
### What does this PR do?

Backtrace copy logic in NDK can corrupt memory by accessing the address outside of boundary in case if `str.size()` is bigger than `max_size` we reserved.

This PR puts the termination char at the correct position.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

