### PR TITLE
RUM-7784: Remove deprecation suppression from `Path.computeBounds` call site

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/PathUtils.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/PathUtils.kt
@@ -77,7 +77,6 @@ internal class PathUtils(
         // path initial bounds
         val originalBounds = RectF()
 
-        @Suppress("DEPRECATION") // # TODO RUM-7784 replace when possible
         path.computeBounds(originalBounds, true)
 
         // calculate the scale factor


### PR DESCRIPTION
### What does this PR do?

`Path.computeBounds(Rect, bool)` deprecation was reverted in https://cs.android.com/android/_/android/platform/frameworks/base/+/790631a15d8d0696cb28f478b5fcafe43b80411c.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

