### PR TITLE
RUM-2780: Return no-op core when instance is already initialized

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -71,7 +71,7 @@ object Datadog {
                     InternalLogger.Target.USER,
                     { MESSAGE_ALREADY_INITIALIZED }
                 )
-                return existing
+                return NoOpInternalSdkCore
             }
 
             val sdkInstanceId = hashGenerator.generate(

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -128,9 +128,9 @@ internal class DatadogTest {
     }
 
     @Test
-    fun `M warn W initialize() + initialize()`() {
+    fun `M warn and return no-op W initialize() + initialize()`() {
         // When
-        val initialized1 = Datadog.initialize(
+        Datadog.initialize(
             appContext.mockInstance,
             fakeConfiguration,
             fakeConsent
@@ -147,7 +147,7 @@ internal class DatadogTest {
             InternalLogger.Target.USER,
             Datadog.MESSAGE_ALREADY_INITIALIZED
         )
-        assertThat(initialized2).isSameAs(initialized1)
+        assertThat(initialized2).isSameAs(NoOpInternalSdkCore)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

we should return a no-op instance and prevent leaks between orgs.

### Motivation

RUM-2780

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

