### PR TITLE
Revert "Add Play SDK console verification token to new modules"

### DIFF
--- a/dd-sdk-android-internal/build.gradle.kts
+++ b/dd-sdk-android-internal/build.gradle.kts
@@ -48,14 +48,6 @@ android {
     testFixtures {
         enable = true
     }
-
-    libraryVariants.all {
-        packageLibraryProvider.configure {
-            from("src/main/resources") {
-                include("META-INF/**/verification.properties")
-            }
-        }
-    }
 }
 
 dependencies {

--- a/dd-sdk-android-internal/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-internal/verification.properties
+++ b/dd-sdk-android-internal/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-internal/verification.properties
@@ -1,3 +1,0 @@
-#This is the verification token for the com.datadoghq:dd-sdk-android-internal SDK.
-#Wed Mar 04 02:24:25 PST 2026
-token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/features/dd-sdk-android-session-replay-compose/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-compose/build.gradle.kts
@@ -48,14 +48,6 @@ android {
     buildFeatures {
         compose = true
     }
-
-    libraryVariants.all {
-        packageLibraryProvider.configure {
-            from("src/main/resources") {
-                include("META-INF/**/verification.properties")
-            }
-        }
-    }
 }
 
 dependencies {

--- a/features/dd-sdk-android-session-replay-compose/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-session-replay-compose/verification.properties
+++ b/features/dd-sdk-android-session-replay-compose/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-session-replay-compose/verification.properties
@@ -1,3 +1,0 @@
-#This is the verification token for the com.datadoghq:dd-sdk-android-session-replay-compose SDK.
-#Wed Mar 04 02:25:09 PST 2026
-token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/features/dd-sdk-android-session-replay-material/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-material/build.gradle.kts
@@ -43,14 +43,6 @@ android {
     }
 
     namespace = "com.datadog.android.sessionreplay.material"
-
-    libraryVariants.all {
-        packageLibraryProvider.configure {
-            from("src/main/resources") {
-                include("META-INF/**/verification.properties")
-            }
-        }
-    }
 }
 
 dependencies {

--- a/features/dd-sdk-android-session-replay-material/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-session-replay-material/verification.properties
+++ b/features/dd-sdk-android-session-replay-material/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-session-replay-material/verification.properties
@@ -1,3 +1,0 @@
-#This is the verification token for the com.datadoghq:dd-sdk-android-session-replay-material SDK.
-#Wed Mar 04 02:23:55 PST 2026
-token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/features/dd-sdk-android-trace-api/build.gradle.kts
+++ b/features/dd-sdk-android-trace-api/build.gradle.kts
@@ -41,14 +41,6 @@ plugins {
 
 android {
     namespace = "com.datadog.android.trace.api"
-
-    libraryVariants.all {
-        packageLibraryProvider.configure {
-            from("src/main/resources") {
-                include("META-INF/**/verification.properties")
-            }
-        }
-    }
 }
 
 dependencies {

--- a/features/dd-sdk-android-trace-api/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-trace-api/verification.properties
+++ b/features/dd-sdk-android-trace-api/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-trace-api/verification.properties
@@ -1,3 +1,0 @@
-#This is the verification token for the com.datadoghq:dd-sdk-android-trace-api SDK.
-#Wed Mar 04 02:23:32 PST 2026
-token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/features/dd-sdk-android-trace-internal/build.gradle.kts
+++ b/features/dd-sdk-android-trace-internal/build.gradle.kts
@@ -42,14 +42,6 @@ plugins {
 
 android {
     namespace = "com.datadog.android.trace.internal"
-
-    libraryVariants.all {
-        packageLibraryProvider.configure {
-            from("src/main/resources") {
-                include("META-INF/**/verification.properties")
-            }
-        }
-    }
 }
 
 dependencies {

--- a/features/dd-sdk-android-trace-internal/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-trace-internal/verification.properties
+++ b/features/dd-sdk-android-trace-internal/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-trace-internal/verification.properties
@@ -1,3 +1,0 @@
-#This is the verification token for the com.datadoghq:dd-sdk-android-trace-internal SDK.
-#Wed Mar 04 02:23:08 PST 2026
-token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/features/dd-sdk-android-trace-otel/build.gradle.kts
+++ b/features/dd-sdk-android-trace-otel/build.gradle.kts
@@ -52,14 +52,6 @@ android {
         )
     }
     namespace = "com.datadog.android.trace.opentelemetry"
-
-    libraryVariants.all {
-        packageLibraryProvider.configure {
-            from("src/main/resources") {
-                include("META-INF/**/verification.properties")
-            }
-        }
-    }
 }
 
 dependencies {

--- a/features/dd-sdk-android-trace-otel/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-trace-otel/verification.properties
+++ b/features/dd-sdk-android-trace-otel/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-trace-otel/verification.properties
@@ -1,3 +1,0 @@
-#This is the verification token for the com.datadoghq:dd-sdk-android-trace-otel SDK.
-#Wed Mar 04 02:22:35 PST 2026
-token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/integrations/dd-sdk-android-apollo/build.gradle.kts
+++ b/integrations/dd-sdk-android-apollo/build.gradle.kts
@@ -36,14 +36,6 @@ plugins {
 
 android {
     namespace = "com.datadog.android.apollo"
-
-    libraryVariants.all {
-        packageLibraryProvider.configure {
-            from("src/main/resources") {
-                include("META-INF/**/verification.properties")
-            }
-        }
-    }
 }
 
 dependencies {

--- a/integrations/dd-sdk-android-apollo/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-apollo/verification.properties
+++ b/integrations/dd-sdk-android-apollo/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-apollo/verification.properties
@@ -1,3 +1,0 @@
-#This is the verification token for the com.datadoghq:dd-sdk-android-apollo SDK.
-#Wed Mar 04 02:22:08 PST 2026
-token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/integrations/dd-sdk-android-coil/build.gradle.kts
+++ b/integrations/dd-sdk-android-coil/build.gradle.kts
@@ -39,14 +39,6 @@ plugins {
 
 android {
     namespace = "com.datadog.android.coil"
-
-    libraryVariants.all {
-        packageLibraryProvider.configure {
-            from("src/main/resources") {
-                include("META-INF/**/verification.properties")
-            }
-        }
-    }
 }
 
 dependencies {

--- a/integrations/dd-sdk-android-coil/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-coil/verification.properties
+++ b/integrations/dd-sdk-android-coil/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-coil/verification.properties
@@ -1,3 +1,0 @@
-#This is the verification token for the com.datadoghq:dd-sdk-android-coil SDK.
-#Wed Mar 04 02:21:37 PST 2026
-token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/integrations/dd-sdk-android-compose/build.gradle.kts
+++ b/integrations/dd-sdk-android-compose/build.gradle.kts
@@ -47,14 +47,6 @@ android {
     buildFeatures {
         compose = true
     }
-
-    libraryVariants.all {
-        packageLibraryProvider.configure {
-            from("src/main/resources") {
-                include("META-INF/**/verification.properties")
-            }
-        }
-    }
 }
 
 dependencies {

--- a/integrations/dd-sdk-android-compose/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-compose/verification.properties
+++ b/integrations/dd-sdk-android-compose/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-compose/verification.properties
@@ -1,3 +1,0 @@
-#This is the verification token for the com.datadoghq:dd-sdk-android-compose SDK.
-#Wed Mar 04 02:21:03 PST 2026
-token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/integrations/dd-sdk-android-glide/build.gradle.kts
+++ b/integrations/dd-sdk-android-glide/build.gradle.kts
@@ -39,14 +39,6 @@ plugins {
 
 android {
     namespace = "com.datadog.android.glide"
-
-    libraryVariants.all {
-        packageLibraryProvider.configure {
-            from("src/main/resources") {
-                include("META-INF/**/verification.properties")
-            }
-        }
-    }
 }
 
 dependencies {

--- a/integrations/dd-sdk-android-glide/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-glide/verification.properties
+++ b/integrations/dd-sdk-android-glide/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-glide/verification.properties
@@ -1,3 +1,0 @@
-#This is the verification token for the com.datadoghq:dd-sdk-android-glide SDK.
-#Wed Mar 04 02:20:27 PST 2026
-token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
@@ -38,14 +38,6 @@ plugins {
 
 android {
     namespace = "com.datadog.android.rum.coroutines"
-
-    libraryVariants.all {
-        packageLibraryProvider.configure {
-            from("src/main/resources") {
-                include("META-INF/**/verification.properties")
-            }
-        }
-    }
 }
 
 dependencies {

--- a/integrations/dd-sdk-android-rum-coroutines/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-rum-coroutines/verification.properties
+++ b/integrations/dd-sdk-android-rum-coroutines/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-rum-coroutines/verification.properties
@@ -1,3 +1,0 @@
-#This is the verification token for the com.datadoghq:dd-sdk-android-rum-coroutines SDK.
-#Wed Mar 04 02:18:08 PST 2026
-token=JLJEBFEWEBGZZMPAVEFV3655AM

--- a/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
@@ -38,14 +38,6 @@ plugins {
 
 android {
     namespace = "com.datadog.android.trace.coroutines"
-
-    libraryVariants.all {
-        packageLibraryProvider.configure {
-            from("src/main/resources") {
-                include("META-INF/**/verification.properties")
-            }
-        }
-    }
 }
 
 dependencies {

--- a/integrations/dd-sdk-android-trace-coroutines/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-trace-coroutines/verification.properties
+++ b/integrations/dd-sdk-android-trace-coroutines/src/main/resources/META-INF/com/datadoghq/dd-sdk-android-trace-coroutines/verification.properties
@@ -1,3 +1,0 @@
-#This is the verification token for the com.datadoghq:dd-sdk-android-trace-coroutines SDK.
-#Wed Mar 04 02:16:30 PST 2026
-token=JLJEBFEWEBGZZMPAVEFV3655AM


### PR DESCRIPTION
### What does this PR do?

This reverts commit aabefd7d037b8b2cbd09b0b9bfcaff8a1eb9bf94.

3.8.0 is published, so we don't need these tokens anymore, they are used only for one-time ownership validation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

