### PR TITLE
RUM-14902: Track GraphQL errors

### DIFF
--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ForgeExt.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ForgeExt.kt
@@ -60,6 +60,7 @@ fun <T : Forge> T.useCoreFactories(): T {
     addFactory(ThreadDumpForgeryFactory())
     addFactory(RequestExecutionContextForgeryFactory())
     addFactory(RequestInfoForgeryFactory())
+    addFactory(MutableRequestInfoForgeryFactory())
 
     return this
 }
@@ -72,7 +73,7 @@ fun Forge.aHostName(): String {
 fun Forge.anUrlString(): String = aStringMatching(URL_FORGERY_PATTERN)
 
 fun Forge.anHttpRequestInfo(headers: Map<String, String>): HttpRequestInfo {
-    return (getForgery<HttpRequestInfo>() as MutableHttpRequestInfo)
+    return getForgery<MutableHttpRequestInfo>()
         .newBuilder()
         .apply { headers.forEach { (key, value) -> addHeader(key, value) } }
         .build()

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ForgeExt.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ForgeExt.kt
@@ -6,6 +6,8 @@
 
 package com.datadog.android.tests.elmyr
 
+import com.datadog.android.api.instrumentation.network.HttpRequestInfo
+import com.datadog.android.api.instrumentation.network.MutableHttpRequestInfo
 import fr.xgouchet.elmyr.Case
 import fr.xgouchet.elmyr.Forge
 import okhttp3.Protocol
@@ -68,6 +70,13 @@ fun Forge.aHostName(): String {
 }
 
 fun Forge.anUrlString(): String = aStringMatching(URL_FORGERY_PATTERN)
+
+fun Forge.anHttpRequestInfo(headers: Map<String, String>): HttpRequestInfo {
+    return (getForgery<HttpRequestInfo>() as MutableHttpRequestInfo)
+        .newBuilder()
+        .apply { headers.forEach { (key, value) -> addHeader(key, value) } }
+        .build()
+}
 
 fun Forge.anOkHttpResponse(
     request: Request,

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/RequestInfoForgeryFactory.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/RequestInfoForgeryFactory.kt
@@ -32,8 +32,8 @@ class RequestInfoForgeryFactory : ForgeryFactory<HttpRequestInfo> {
         override val headers: Map<String, List<String>>,
         override val contentType: String?,
         override val method: String,
-        internal val contentLength: Long?,
-        internal val tags: Map<Any, Any?>
+        val contentLength: Long?,
+        val tags: Map<Any, Any?>
     ) : HttpRequestInfo, ExtendedRequestInfo, MutableHttpRequestInfo {
 
         @Suppress("UNCHECKED_CAST")
@@ -64,5 +64,11 @@ class RequestInfoForgeryFactory : ForgeryFactory<HttpRequestInfo> {
         ) = apply { request = request.copy(method = method) }
 
         override fun build(): HttpRequestInfo = request.copy()
+    }
+}
+
+class MutableRequestInfoForgeryFactory : ForgeryFactory<MutableHttpRequestInfo> {
+    override fun getForgery(forge: Forge): MutableHttpRequestInfo {
+        return RequestInfoForgeryFactory().getForgery(forge) as MutableHttpRequestInfo
     }
 }

--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -239,6 +239,8 @@ fun <T> allowThreadDiskReads(() -> T): T
 fun <T> allowThreadDiskWrites(() -> T): T
 fun StringBuilder.appendIfNotEmpty(String)
 fun StringBuilder.appendIfNotEmpty(Char)
+fun String.toBase64(): String
+fun String.fromBase64(): String?
 fun Thread.safeGetThreadId(): Long
 fun Thread.State.asString(): String
 fun Array<StackTraceElement>.loggableStackTrace(): String

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -553,6 +553,11 @@ public final class com/datadog/android/internal/utils/StringBuilderExtKt {
 	public static final fun appendIfNotEmpty (Ljava/lang/StringBuilder;Ljava/lang/String;)Ljava/lang/StringBuilder;
 }
 
+public final class com/datadog/android/internal/utils/StringExtKt {
+	public static final fun fromBase64 (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun toBase64 (Ljava/lang/String;)Ljava/lang/String;
+}
+
 public final class com/datadog/android/internal/utils/ThreadExtKt {
 	public static final fun asString (Ljava/lang/Thread$State;)Ljava/lang/String;
 	public static final fun loggableStackTrace ([Ljava/lang/StackTraceElement;)Ljava/lang/String;

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/utils/StringExt.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/utils/StringExt.kt
@@ -1,0 +1,34 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.utils
+
+import android.util.Base64
+
+/**
+ * Encodes this string to Base64 using UTF-8 encoding.
+ *
+ * @return the Base64-encoded representation of this string, without line wrapping.
+ */
+fun String.toBase64(): String {
+    val bytes = this.toByteArray(Charsets.UTF_8)
+    @Suppress("UnsafeThirdPartyFunctionCall") // cannot throw UnsupportedEncodingException
+    return Base64.encodeToString(bytes, Base64.NO_WRAP)
+}
+
+/**
+ * Decodes this Base64-encoded string back to its original UTF-8 representation.
+ *
+ * @return the decoded string, or `null` if the input is not valid Base64.
+ */
+fun String.fromBase64(): String? {
+    return try {
+        val decodedBytes = Base64.decode(this, Base64.NO_WRAP)
+        decodedBytes?.toString(Charsets.UTF_8)
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+}

--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -1029,6 +1029,7 @@ datadog:
       - "kotlin.collections.Set.isNotEmpty()"
       - "kotlin.collections.Set.joinToString(kotlin.CharSequence, kotlin.CharSequence, kotlin.CharSequence, kotlin.Int, kotlin.CharSequence, kotlin.Function1?)"
       - "kotlin.collections.Set.map(kotlin.Function1)"
+      - "kotlin.collections.Set.none(kotlin.Function1)"
       - "kotlin.collections.Set.orEmpty()"
       - "kotlin.collections.Set.plus(kotlin.collections.Iterable)"
       - "kotlin.collections.Set.toHashSet()"
@@ -1362,14 +1363,18 @@ datadog:
       - "okio.Buffer.constructor()"
       # endregion
       # region org.json
+      - "org.json.JSONArray.constructor()"
       - "org.json.JSONArray.length()"
+      - "org.json.JSONArray.put(kotlin.Any?)"
       - "org.json.JSONArray.toJsonArray()"
       - "org.json.JSONObject.constructor()"
+      - "org.json.JSONObject.has(kotlin.String?)"
       - "org.json.JSONObject.keys()"
-      - "org.json.JSONObject.optString(kotlin.String?, kotlin.String?)"
-      - "org.json.JSONObject.toJsonObject()"
       - "org.json.JSONObject.length()"
       - "org.json.JSONObject.opt(kotlin.String?)"
+      - "org.json.JSONObject.optJSONObject(kotlin.String?)"
+      - "org.json.JSONObject.optString(kotlin.String?, kotlin.String?)"
+      - "org.json.JSONObject.toJsonObject()"
       # endregion
       # region OpenFeature
       - "dev.openfeature.kotlin.sdk.EvaluationContext.asMap()"

--- a/detekt_custom_unsafe_calls.yml
+++ b/detekt_custom_unsafe_calls.yml
@@ -250,8 +250,10 @@ datadog:
       # endregion
       # region org.json
       - "org.json.JSONArray.get(kotlin.Int):org.json.JSONException"
+      - "org.json.JSONArray.getJSONObject(kotlin.Int):org.json.JSONException"
       - "org.json.JSONObject.constructor(kotlin.String?):org.json.JSONException"
       - "org.json.JSONObject.get(kotlin.String):org.json.JSONException"
+      - "org.json.JSONObject.getJSONArray(kotlin.String?):org.json.JSONException"
       - "org.json.JSONObject.getString(kotlin.String?):org.json.JSONException"
       - "org.json.JSONObject.put(kotlin.String?, kotlin.Any?):org.json.JSONException"
       - "org.json.JSONObject.put(kotlin.String?, kotlin.Long):org.json.JSONException"

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -231,6 +231,11 @@ interface com.datadog.android.rum.internal.monitor.AdvancedNetworkRumMonitor : c
   fun stopResource(com.datadog.android.rum.resource.ResourceId, Int?, Long?, com.datadog.android.rum.RumResourceKind, Map<String, Any?> = emptyMap())
   fun stopResourceWithError(com.datadog.android.rum.resource.ResourceId, Int?, String, com.datadog.android.rum.RumErrorSource, Throwable, Map<String, Any?> = emptyMap())
   fun stopResourceWithError(com.datadog.android.rum.resource.ResourceId, Int?, String, com.datadog.android.rum.RumErrorSource, String, String?, Map<String, Any?> = emptyMap())
+class com.datadog.android.rum.internal.net.GraphQLExtractor
+  fun extractGraphQLAttributes(com.datadog.android.api.instrumentation.network.HttpRequestInfo): Map<String, Any?>
+  fun extractGraphQLErrors(String?, String?, com.datadog.android.api.InternalLogger): String?
+  companion object 
+    const val MAX_GRAPHQL_BODY_PEEK: Long
 class com.datadog.android.rum.internal.net.RumNetworkInstrumentation
   fun sendWaitForResourceTimingEvent(com.datadog.android.api.instrumentation.network.HttpRequestInfo)
   fun sendTiming(com.datadog.android.api.instrumentation.network.HttpRequestInfo, com.datadog.android.rum.internal.domain.event.ResourceTiming)

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -406,6 +406,17 @@ public final class com/datadog/android/rum/internal/monitor/AdvancedNetworkRumMo
 	public static synthetic fun stopResourceWithError$default (Lcom/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor;Lcom/datadog/android/rum/resource/ResourceId;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;ILjava/lang/Object;)V
 }
 
+public final class com/datadog/android/rum/internal/net/GraphQLExtractor {
+	public static final field Companion Lcom/datadog/android/rum/internal/net/GraphQLExtractor$Companion;
+	public static final field MAX_GRAPHQL_BODY_PEEK J
+	public fun <init> ()V
+	public final fun extractGraphQLAttributes (Lcom/datadog/android/api/instrumentation/network/HttpRequestInfo;)Ljava/util/Map;
+	public final fun extractGraphQLErrors (Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/internal/net/GraphQLExtractor$Companion {
+}
+
 public final class com/datadog/android/rum/internal/net/RumNetworkInstrumentation {
 	public static final field Companion Lcom/datadog/android/rum/internal/net/RumNetworkInstrumentation$Companion;
 	public final fun reportInstrumentationError (Lkotlin/jvm/functions/Function0;)V

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/net/GraphQLExtractor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/net/GraphQLExtractor.kt
@@ -1,0 +1,116 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.net
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.instrumentation.network.HttpRequestInfo
+import com.datadog.android.internal.network.GraphQLHeaders
+import com.datadog.android.internal.utils.fromBase64
+import com.datadog.android.lint.InternalApi
+import com.datadog.android.rum.RumAttributes
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * Extracts GraphQL-related attributes and errors from network requests and responses.
+ */
+@InternalApi
+class GraphQLExtractor {
+
+    /**
+     * Extracts GraphQL attributes (operation name, type, variables, payload) from the request headers.
+     * @param requestInfo the HTTP request info containing headers
+     * @return a map of GraphQL attributes decoded from Base64 header values
+     */
+    fun extractGraphQLAttributes(requestInfo: HttpRequestInfo): Map<String, Any?> {
+        return buildMap {
+            GRAPHQL_HEADER_TO_ATTRIBUTE.forEach { (header, attribute) ->
+                requestInfo.headers[header.headerValue]?.firstOrNull()?.let {
+                    put(attribute, it.fromBase64())
+                }
+            }
+        }
+    }
+
+    /**
+     * Extracts and normalizes GraphQL errors from a JSON response body.
+     * @param contentType the content type of the response
+     * @param body the response body string
+     * @param internalLogger the logger for reporting parsing failures
+     * @return a JSON array string of normalized errors, or null if none found
+     */
+    fun extractGraphQLErrors(
+        contentType: String?,
+        body: String?,
+        internalLogger: InternalLogger
+    ): String? {
+        if (body == null || contentType == null || JSON_CONTENT_TYPES.none { contentType.startsWith(it) }) return null
+
+        return try {
+            val json = JSONObject(body)
+            val errorsArray = if (json.has(ERRORS_KEY)) json.getJSONArray(ERRORS_KEY) else null
+
+            if (errorsArray == null || errorsArray.length() == 0) {
+                null
+            } else {
+                val normalizedErrors = JSONArray()
+                for (i in 0 until errorsArray.length()) {
+                    @Suppress("UnsafeThirdPartyFunctionCall") // JSONException is caught and we are in array bounds
+                    val error = errorsArray.getJSONObject(i)
+                    normalizeErrorCode(error)
+                    normalizedErrors.put(error)
+                }
+                normalizedErrors.toString()
+            }
+        } catch (e: JSONException) {
+            internalLogger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.MAINTAINER,
+                { ERROR_EXTRACT_GRAPHQL_ERRORS },
+                e
+            )
+            null
+        }
+    }
+
+    private fun normalizeErrorCode(error: JSONObject) {
+        if (!error.has(CODE_KEY)) {
+            val code = error.optJSONObject(EXTENSIONS_KEY)?.opt(CODE_KEY)
+            if (code != null) {
+                @Suppress("UnsafeThirdPartyFunctionCall") // caught by caller's catch blocks
+                error.put(CODE_KEY, code)
+            }
+        }
+    }
+
+    companion object {
+
+        /** Maximum number of bytes to peek from a response body when extracting GraphQL errors. */
+        const val MAX_GRAPHQL_BODY_PEEK: Long = 512L * 1024L
+
+        internal const val ERROR_EXTRACT_GRAPHQL_ERRORS =
+            "Failed to extract GraphQL errors from response body."
+
+        private const val ERRORS_KEY = "errors"
+        private const val EXTENSIONS_KEY = "extensions"
+        private const val CODE_KEY = "code"
+
+        private val GRAPHQL_HEADER_TO_ATTRIBUTE = mapOf(
+            GraphQLHeaders.DD_GRAPHQL_NAME_HEADER to RumAttributes.GRAPHQL_OPERATION_NAME,
+            GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER to RumAttributes.GRAPHQL_OPERATION_TYPE,
+            GraphQLHeaders.DD_GRAPHQL_VARIABLES_HEADER to RumAttributes.GRAPHQL_VARIABLES,
+            GraphQLHeaders.DD_GRAPHQL_PAYLOAD_HEADER to RumAttributes.GRAPHQL_PAYLOAD
+        )
+
+        internal val JSON_CONTENT_TYPES = setOf(
+            "application/json",
+            "application/graphql+json",
+            "application/graphql-response+json"
+        )
+    }
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/net/GraphQLExtractor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/net/GraphQLExtractor.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.internal.net
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.instrumentation.network.HttpRequestInfo
 import com.datadog.android.internal.network.GraphQLHeaders
+import com.datadog.android.internal.network.HttpSpec
 import com.datadog.android.internal.utils.fromBase64
 import com.datadog.android.lint.InternalApi
 import com.datadog.android.rum.RumAttributes
@@ -108,7 +109,7 @@ class GraphQLExtractor {
         )
 
         internal val JSON_CONTENT_TYPES = setOf(
-            "application/json",
+            HttpSpec.ContentType.APPLICATION_JSON,
             "application/graphql+json",
             "application/graphql-response+json"
         )

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/net/GraphQLExtractorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/net/GraphQLExtractorTest.kt
@@ -1,0 +1,235 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.net
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.instrumentation.network.HttpRequestInfo
+import com.datadog.android.internal.network.GraphQLHeaders
+import com.datadog.android.internal.utils.toBase64
+import com.datadog.android.rum.RumAttributes
+import com.datadog.android.rum.internal.net.GraphQLExtractor.Companion.JSON_CONTENT_TYPES
+import com.datadog.android.rum.utils.forge.Configurator
+import com.datadog.android.tests.elmyr.anHttpRequestInfo
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@ForgeConfiguration(Configurator::class)
+internal class GraphQLExtractorTest {
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    lateinit var testedExtractor: GraphQLExtractor
+
+    @BeforeEach
+    fun `set up`() {
+        testedExtractor = GraphQLExtractor()
+    }
+
+    // region extractGraphQLAttributes
+
+    @Test
+    fun `M return all attributes W extractGraphQLAttributes() {all headers present}`(
+        forge: Forge,
+        @StringForgery fakeGraphQLName: String,
+        @StringForgery fakeGraphQLType: String,
+        @StringForgery fakeGraphQLVariables: String,
+        @StringForgery fakeGraphQLPayload: String
+    ) {
+        // Given
+        val requestInfo = forge.anHttpRequestInfo(
+            mapOf(
+                GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue to fakeGraphQLName.toBase64(),
+                GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER.headerValue to fakeGraphQLType.toBase64(),
+                GraphQLHeaders.DD_GRAPHQL_VARIABLES_HEADER.headerValue to fakeGraphQLVariables.toBase64(),
+                GraphQLHeaders.DD_GRAPHQL_PAYLOAD_HEADER.headerValue to fakeGraphQLPayload.toBase64()
+            )
+        )
+
+        // When
+        val result = testedExtractor.extractGraphQLAttributes(requestInfo)
+
+        // Then
+        assertThat(result).containsEntry(RumAttributes.GRAPHQL_OPERATION_NAME, fakeGraphQLName)
+        assertThat(result).containsEntry(RumAttributes.GRAPHQL_OPERATION_TYPE, fakeGraphQLType)
+        assertThat(result).containsEntry(RumAttributes.GRAPHQL_VARIABLES, fakeGraphQLVariables)
+        assertThat(result).containsEntry(RumAttributes.GRAPHQL_PAYLOAD, fakeGraphQLPayload)
+        assertThat(result).hasSize(4)
+    }
+
+    @Test
+    fun `M return empty map W extractGraphQLAttributes() {no headers}`(@Forgery fakeRequestInfo: HttpRequestInfo) {
+        // When
+        val result = testedExtractor.extractGraphQLAttributes(fakeRequestInfo)
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `M return null values W extractGraphQLAttributes() {invalid base64}`(forge: Forge) {
+        // Given
+        val requestInfo = forge.anHttpRequestInfo(
+            mapOf(
+                GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue to "!!!invalid-base64!!!"
+            )
+        )
+
+        // When
+        val result = testedExtractor.extractGraphQLAttributes(requestInfo)
+
+        // Then
+        assertThat(result).containsEntry(RumAttributes.GRAPHQL_OPERATION_NAME, null)
+        assertThat(result).hasSize(1)
+    }
+
+    // endregion
+
+    // region extractGraphQLErrors
+
+    @Test
+    fun `M return errors JSON W extractGraphQLErrors() {response with errors}`(forge: Forge) {
+        // Given
+        val body =
+            """{"data":null,"errors":[{"message":"Something went wrong","locations":[{"line":1,"column":1}]}]}"""
+
+        // When
+        val result = testedExtractor.extractGraphQLErrors(
+            forge.anElementFrom(JSON_CONTENT_TYPES),
+            body,
+            mockInternalLogger
+        )
+
+        // Then
+        assertThat(result).isNotNull
+        assertThat(result).contains("Something went wrong")
+    }
+
+    @Test
+    fun `M return null W extractGraphQLErrors() {empty errors array}`(forge: Forge) {
+        // Given
+        val body = """{"data":{"user":{"name":"John"}},"errors":[]}"""
+
+        // When
+        val result = testedExtractor.extractGraphQLErrors(
+            forge.anElementFrom(JSON_CONTENT_TYPES),
+            body,
+            mockInternalLogger
+        )
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M return null W extractGraphQLErrors() {no errors key}`(forge: Forge) {
+        // Given
+        val body = """{"data":{"user":{"name":"John"}}}"""
+
+        // When
+        val result = testedExtractor.extractGraphQLErrors(
+            forge.anElementFrom(JSON_CONTENT_TYPES),
+            body,
+            mockInternalLogger
+        )
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M return null W extractGraphQLErrors() {non-JSON content type}`(@StringForgery fakeContentType: String) {
+        // Given
+        val body = """{"errors":[{"message":"err"}]}"""
+
+        // When
+        val result = testedExtractor.extractGraphQLErrors(fakeContentType, body, mockInternalLogger)
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M normalize extensions code W extractGraphQLErrors() {extensions code without top-level code}`(forge: Forge) {
+        // Given
+        val body = """{"errors":[{"message":"Unauthorized","extensions":{"code":"UNAUTHENTICATED"}}]}"""
+
+        // When
+        val result = testedExtractor.extractGraphQLErrors(
+            forge.anElementFrom(JSON_CONTENT_TYPES),
+            body,
+            mockInternalLogger
+        )
+
+        // Then
+        assertThat(result).isNotNull
+        assertThat(result).contains("\"code\"")
+        assertThat(result).contains("UNAUTHENTICATED")
+    }
+
+    @Test
+    fun `M preserve top-level code W extractGraphQLErrors() {both code and extensions code}`(forge: Forge) {
+        // Given
+        val body = """{"errors":[{"message":"err","code":"TOP_LEVEL","extensions":{"code":"EXT_CODE"}}]}"""
+
+        // When
+        val result = testedExtractor.extractGraphQLErrors(
+            forge.anElementFrom(JSON_CONTENT_TYPES),
+            body,
+            mockInternalLogger
+        )
+
+        // Then
+        assertThat(result).isNotNull
+        assertThat(result).contains("TOP_LEVEL")
+    }
+
+    @Test
+    fun `M return null W extractGraphQLErrors() {invalid JSON}`(forge: Forge) {
+        // Given
+        val body = forge.aString()
+
+        // When
+        val result = testedExtractor.extractGraphQLErrors(
+            forge.anElementFrom(JSON_CONTENT_TYPES),
+            body,
+            mockInternalLogger
+        )
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M return null W extractGraphQLErrors() {null body}`(forge: Forge) {
+        // When
+        val result = testedExtractor.extractGraphQLErrors(
+            forge.anElementFrom(JSON_CONTENT_TYPES),
+            null,
+            mockInternalLogger
+        )
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    // endregion
+}

--- a/integrations/dd-sdk-android-apollo/src/main/java/com/datadog/android/apollo/DatadogApolloInterceptor.kt
+++ b/integrations/dd-sdk-android-apollo/src/main/java/com/datadog/android/apollo/DatadogApolloInterceptor.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.apollo
 
-import android.util.Base64
 import com.apollographql.apollo.api.ApolloRequest
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.CustomScalarAdapters
@@ -18,6 +17,7 @@ import com.apollographql.apollo.interceptor.ApolloInterceptorChain
 import com.datadog.android.apollo.internal.DefaultVariablesExtractor
 import com.datadog.android.apollo.internal.VariablesExtractor
 import com.datadog.android.internal.network.GraphQLHeaders
+import com.datadog.android.internal.utils.toBase64
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -88,10 +88,4 @@ class DatadogApolloInterceptor(
         buildJsonString {
             operation.composeJsonRequest(this, adapters)
         }
-
-    private fun String.toBase64(): String {
-        val bytes = this.toByteArray(Charsets.UTF_8)
-        @Suppress("UnsafeThirdPartyFunctionCall") // cannot throw UnsupportedEncodingException
-        return Base64.encodeToString(bytes, Base64.NO_WRAP)
-    }
 }

--- a/integrations/dd-sdk-android-apollo/src/test/java/com/datadog/android/apollo/DatadogApolloInterceptorTest.kt
+++ b/integrations/dd-sdk-android-apollo/src/test/java/com/datadog/android/apollo/DatadogApolloInterceptorTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.apollo
 
-import android.util.Base64
 import com.apollographql.apollo.api.ApolloRequest
 import com.apollographql.apollo.api.CustomScalarAdapters
 import com.apollographql.apollo.api.ExecutionContext
@@ -14,6 +13,7 @@ import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain
 import com.datadog.android.apollo.internal.VariablesExtractor
 import com.datadog.android.internal.network.GraphQLHeaders
+import com.datadog.android.internal.utils.toBase64
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -427,11 +427,6 @@ internal class DatadogApolloInterceptorTest {
         } else {
             verify(requestBuilder).addHttpHeader(eq(headerName), any<String>())
         }
-    }
-
-    private fun String.toBase64(): String {
-        val bytes = this.toByteArray(Charsets.UTF_8)
-        return Base64.encodeToString(bytes, Base64.NO_WRAP)
     }
 
     private fun checkHeaderWasNotAdded(

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.okhttp
 
+import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
@@ -109,6 +110,7 @@ open class DatadogInterceptor internal constructor(
     // region Interceptor
 
     /** @inheritdoc */
+    @WorkerThread
     override fun intercept(chain: Interceptor.Chain): Response {
         val sdkCore = sdkCoreReference.get() as? FeatureSdkCore
         val rumFeature = sdkCore?.getFeature(Feature.RUM_FEATURE_NAME)
@@ -153,6 +155,7 @@ open class DatadogInterceptor internal constructor(
     // region TracingInterceptor
 
     /** @inheritdoc */
+    @WorkerThread
     override fun onRequestIntercepted(
         sdkCore: FeatureSdkCore,
         request: Request,
@@ -213,6 +216,7 @@ open class DatadogInterceptor internal constructor(
         }
     }
 
+    @WorkerThread
     private fun handleResponse(
         sdkCore: FeatureSdkCore,
         request: Request,

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.okhttp
 
-import android.util.Base64
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
@@ -14,9 +13,9 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.sampling.Sampler
-import com.datadog.android.internal.network.GraphQLHeaders
 import com.datadog.android.okhttp.internal.RumResourceAttributesProviderCompatibilityAdapter
 import com.datadog.android.okhttp.internal.buildResourceId
+import com.datadog.android.okhttp.internal.graphql.OkHttpGraphQLAdapter
 import com.datadog.android.okhttp.trace.TracedRequestListener
 import com.datadog.android.okhttp.trace.TracingInterceptor
 import com.datadog.android.rum.GlobalRumMonitor
@@ -35,7 +34,6 @@ import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.api.span.DatadogSpan
 import com.datadog.android.trace.api.tracer.DatadogTracer
-import okhttp3.Headers
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -51,10 +49,10 @@ import java.util.UUID
  * For RUM integration: this interceptor will log the request as a RUM Resource, and fill the
  * request information (url, method, status code, optional error). Note that RUM Resources are only
  * tracked when a view is active. You can use one of the existing [ViewTrackingStrategy] when
- * configuring the SDK (see [RumConfiguration.Builder.useViewTrackingStrategy]) or start a view
+ * configuring the SDK (see [com.datadog.android.rum.RumConfiguration.Builder.useViewTrackingStrategy]) or start a view
  * manually (see [RumMonitor.startView]).
  *
- * For APM integration: This interceptor will create a [Span] around the request and fill the
+ * For APM integration: This interceptor will create a [DatadogSpan] around the request and fill the
  * request information (url, method, status code, optional error). It will also propagate the span
  * and trace information in the request header to link it with backend spans.
  *
@@ -106,6 +104,8 @@ open class DatadogInterceptor internal constructor(
                 sdkReference = sdkCoreReference
             )
 
+    private val okHttpGraphQLAdapter = OkHttpGraphQLAdapter()
+
     // region Interceptor
 
     /** @inheritdoc */
@@ -143,10 +143,7 @@ open class DatadogInterceptor internal constructor(
         }
 
         val internalLogger = (sdkCore?.internalLogger ?: InternalLogger.UNBOUND)
-        val localChain = chainWithoutDDHeaders(
-            internalLogger = internalLogger,
-            originalChain = chain
-        )
+        val localChain = okHttpGraphQLAdapter.wrapChainWithoutDDHeaders(internalLogger, chain)
 
         return doIntercept(localChain, request)
     }
@@ -233,23 +230,18 @@ open class DatadogInterceptor internal constructor(
         val attributes = if (!isSampled || span == null) {
             emptyMap<String, Any?>()
         } else {
+            val graphqlAttributes = okHttpGraphQLAdapter.extractGraphQLAttributes(request)
+            val graphqlErrorAttributes = okHttpGraphQLAdapter.extractGraphQLErrorAttributes(
+                response,
+                graphqlAttributes,
+                sdkCore.internalLogger
+            )
             buildMap {
                 put(RumAttributes.TRACE_ID, span.context().traceId.toHexString())
                 put(RumAttributes.SPAN_ID, span.context().spanId.toString())
                 put(RumAttributes.RULE_PSR, (traceSampler.getSampleRate() ?: ZERO_SAMPLE_RATE) / ALL_IN_SAMPLE_RATE)
-
-                request.headers[GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue]?.let {
-                    put(RumAttributes.GRAPHQL_OPERATION_NAME, it.fromBase64())
-                }
-                request.headers[GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER.headerValue]?.let {
-                    put(RumAttributes.GRAPHQL_OPERATION_TYPE, it.fromBase64())
-                }
-                request.headers[GraphQLHeaders.DD_GRAPHQL_VARIABLES_HEADER.headerValue]?.let {
-                    put(RumAttributes.GRAPHQL_VARIABLES, it.fromBase64())
-                }
-                request.headers[GraphQLHeaders.DD_GRAPHQL_PAYLOAD_HEADER.headerValue]?.let {
-                    put(RumAttributes.GRAPHQL_PAYLOAD, it.fromBase64())
-                }
+                putAll(graphqlAttributes)
+                putAll(graphqlErrorAttributes)
             }
         }
 
@@ -265,52 +257,12 @@ open class DatadogInterceptor internal constructor(
         )
     }
 
-    private fun chainWithoutDDHeaders(
-        internalLogger: InternalLogger,
-        originalChain: Interceptor.Chain
-    ): Interceptor.Chain {
-        return if (hasGraphQLHeaders(originalChain.request().headers)) {
-            object : Interceptor.Chain by originalChain {
-                override fun proceed(request: Request): Response {
-                    return try {
-                        val cleanedRequest = request.newBuilder().apply {
-                            removeGraphQLHeaders(this)
-                        }.build()
-                        return originalChain.proceed(cleanedRequest)
-                    } catch (e: IllegalStateException) {
-                        internalLogger.log(
-                            level = InternalLogger.Level.WARN,
-                            target = InternalLogger.Target.MAINTAINER,
-                            messageBuilder = { ERROR_FAILED_BUILD_REQUEST },
-                            throwable = e
-                        )
-                        originalChain.proceed(request) // fallback to the original request
-                    } catch (e: IOException) {
-                        internalLogger.log(
-                            level = InternalLogger.Level.WARN,
-                            target = InternalLogger.Target.MAINTAINER,
-                            messageBuilder = { ERROR_FAILED_BUILD_REQUEST },
-                            throwable = e
-                        )
-                        originalChain.proceed(request) // fallback to the original request
-                    }
-                }
-            }
-        } else {
-            originalChain
-        }
-    }
-
     private fun Request.Builder.safeBuild(): Request? {
         return try {
             build()
         } catch (_: IllegalStateException) {
             null
         }
-    }
-
-    private fun removeGraphQLHeaders(requestBuilder: Request.Builder) {
-        GraphQLHeaders.values().forEach { requestBuilder.removeHeader(it.headerValue) }
     }
 
     private fun handleThrowable(
@@ -400,22 +352,9 @@ open class DatadogInterceptor internal constructor(
         }
     }
 
-    private fun hasGraphQLHeaders(headers: Headers): Boolean {
-        return GraphQLHeaders.values().any { headers[it.headerValue] != null }
-    }
-
     private fun ResponseBody.contentLengthOrNull(): Long? {
         return contentLength().let {
             if (it < 0L) null else it
-        }
-    }
-
-    private fun String.fromBase64(): String? {
-        return try {
-            val decodedBytes = Base64.decode(this, Base64.NO_WRAP)
-            decodedBytes?.toString(Charsets.UTF_8)
-        } catch (_: IllegalArgumentException) {
-            null
         }
     }
 
@@ -472,7 +411,7 @@ open class DatadogInterceptor internal constructor(
 
         /**
          * Sets the [RumResourceAttributesProvider] to use to provide custom attributes to the RUM.
-         * By default it won't attach any custom attributes.
+         * By default, it won't attach any custom attributes.
          * @param rumResourceAttributesProvider the [RumResourceAttributesProvider] to use.
          */
         fun setRumResourceAttributesProvider(rumResourceAttributesProvider: RumResourceAttributesProvider): Builder {
@@ -508,9 +447,6 @@ open class DatadogInterceptor internal constructor(
             "You set up a DatadogInterceptor for %s, but RUM features are disabled. " +
                 "Make sure you initialized the Datadog SDK with a valid Application Id, " +
                 "and that RUM features are enabled."
-
-        internal const val ERROR_FAILED_BUILD_REQUEST =
-            "Failed to build interceptor chain after removing DD headers. Falling back to original chain."
 
         internal const val ERROR_NO_RESPONSE =
             "The request ended with no response nor any exception."

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapter.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapter.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.okhttp.internal.graphql
 
+import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.network.GraphQLHeaders
 import com.datadog.android.okhttp.internal.OkHttpHttpResponseInfo
@@ -61,6 +62,7 @@ internal class OkHttpGraphQLAdapter(
     fun extractGraphQLAttributes(request: Request): Map<String, Any?> =
         graphQLExtractor.extractGraphQLAttributes(OkHttpRequestInfo(request))
 
+    @WorkerThread
     fun extractGraphQLErrorAttributes(
         response: Response,
         graphqlAttributes: Map<String, Any?>,

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapter.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapter.kt
@@ -1,0 +1,109 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.okhttp.internal.graphql
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.internal.network.GraphQLHeaders
+import com.datadog.android.okhttp.internal.OkHttpHttpResponseInfo
+import com.datadog.android.okhttp.internal.OkHttpRequestInfo
+import com.datadog.android.rum.RumAttributes
+import com.datadog.android.rum.internal.net.GraphQLExtractor
+import okhttp3.Headers
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import java.io.IOException
+
+internal class OkHttpGraphQLAdapter(
+    private val graphQLExtractor: GraphQLExtractor = GraphQLExtractor()
+) {
+
+    fun wrapChainWithoutDDHeaders(
+        internalLogger: InternalLogger,
+        originalChain: Interceptor.Chain
+    ): Interceptor.Chain {
+        return if (hasGraphQLHeaders(originalChain.request().headers)) {
+            object : Interceptor.Chain by originalChain {
+                override fun proceed(request: Request): Response {
+                    return try {
+                        val cleanedRequest = request.newBuilder().apply {
+                            removeGraphQLHeaders(this)
+                        }.build()
+                        return originalChain.proceed(cleanedRequest)
+                    } catch (e: IllegalStateException) {
+                        internalLogger.log(
+                            level = InternalLogger.Level.WARN,
+                            target = InternalLogger.Target.MAINTAINER,
+                            messageBuilder = { ERROR_FAILED_BUILD_REQUEST },
+                            throwable = e
+                        )
+                        originalChain.proceed(request) // fallback to the original request
+                    } catch (e: IOException) {
+                        internalLogger.log(
+                            level = InternalLogger.Level.WARN,
+                            target = InternalLogger.Target.MAINTAINER,
+                            messageBuilder = { ERROR_FAILED_BUILD_REQUEST },
+                            throwable = e
+                        )
+                        originalChain.proceed(request) // fallback to the original request
+                    }
+                }
+            }
+        } else {
+            originalChain
+        }
+    }
+
+    fun extractGraphQLAttributes(request: Request): Map<String, Any?> =
+        graphQLExtractor.extractGraphQLAttributes(OkHttpRequestInfo(request))
+
+    fun extractGraphQLErrorAttributes(
+        response: Response,
+        graphqlAttributes: Map<String, Any?>,
+        internalLogger: InternalLogger
+    ): Map<String, Any> {
+        if (graphqlAttributes.isEmpty()) return emptyMap()
+        return try {
+            val responseInfo = OkHttpHttpResponseInfo(response, internalLogger)
+
+            @Suppress("UnsafeThirdPartyFunctionCall") // exceptions are caught
+            val body = response
+                .peekBody(GraphQLExtractor.MAX_GRAPHQL_BODY_PEEK)
+                .string()
+            graphQLExtractor.extractGraphQLErrors(
+                responseInfo.contentType,
+                body,
+                internalLogger
+            )?.let {
+                mapOf(RumAttributes.GRAPHQL_ERRORS to it)
+            } ?: emptyMap()
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            internalLogger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.MAINTAINER,
+                { ERROR_PEEK_BODY_GRAPHQL },
+                e
+            )
+            emptyMap()
+        }
+    }
+
+    internal fun hasGraphQLHeaders(headers: Headers): Boolean =
+        GraphQLHeaders.values().any { headers[it.headerValue] != null }
+
+    private fun removeGraphQLHeaders(requestBuilder: Request.Builder) {
+        GraphQLHeaders.values().forEach { requestBuilder.removeHeader(it.headerValue) }
+    }
+
+    internal companion object {
+        internal const val ERROR_FAILED_BUILD_REQUEST =
+            "Failed to build interceptor chain after removing DD headers. Falling back to original chain."
+
+        internal const val ERROR_PEEK_BODY_GRAPHQL =
+            "Failed to peek response body for GraphQL errors."
+    }
+}

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -9,6 +9,7 @@
 package com.datadog.android.okhttp.trace
 
 import androidx.annotation.FloatRange
+import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
@@ -113,6 +114,7 @@ internal constructor(
     // region Interceptor
 
     /** @inheritdoc */
+    @WorkerThread
     override fun intercept(chain: Interceptor.Chain): Response {
         return doIntercept(chain, chain.request())
     }
@@ -121,6 +123,7 @@ internal constructor(
      * This method is a part of Datadog SDK internal API. It is not meant for public use.
      */
     @InternalApi
+    @WorkerThread
     protected fun doIntercept(
         chain: Interceptor.Chain,
         request: Request

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -6,11 +6,12 @@
 
 package com.datadog.android.okhttp
 
-import android.util.Base64
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.internal.network.GraphQLHeaders
+import com.datadog.android.internal.network.HttpSpec
+import com.datadog.android.internal.utils.toBase64
 import com.datadog.android.okhttp.trace.NoOpTracedRequestListener
 import com.datadog.android.okhttp.trace.TracingInterceptor
 import com.datadog.android.okhttp.trace.TracingInterceptorNotSendingSpanTest
@@ -473,11 +474,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                 assertThat(firstValue.uuid).isEqualTo(secondValue.uuid).isNotNull
             }
         }
-    }
-
-    private fun String.toBase64(): String {
-        val bytes = this.toByteArray(Charsets.UTF_8)
-        return Base64.encodeToString(bytes, Base64.NO_WRAP)
     }
 
     @Test
@@ -1063,6 +1059,170 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         assertThat(cleanedRequest.headers[GraphQLHeaders.DD_GRAPHQL_PAYLOAD_HEADER.headerValue]).isNull()
         assertThat(cleanedRequest.headers["User-Agent"]).isEqualTo(fakeUserAgent)
         assertThat(cleanedRequest.url.toString()).isEqualTo(fakeRequest.url.toString())
+    }
+
+    // endregion
+
+    // region GraphQL attributes when not sampled
+
+    @Test
+    fun `M not pass GraphQL attributes W intercept() {request with GraphQL headers + not sampled}`(
+        @IntForgery(min = 200, max = 300) statusCode: Int,
+        @StringForgery fakeGraphQLName: String,
+        @StringForgery fakeGraphQLType: String
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample(any())).thenReturn(false)
+        fakeRequest = forgeRequest { builder ->
+            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeGraphQLName.toBase64())
+            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER.headerValue, fakeGraphQLType.toBase64())
+        }
+        stubChain(mockChain, statusCode)
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        inOrder(rumMonitor.mockInstance) {
+            argumentCaptor<ResourceId> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(fakeMethod),
+                    eq(fakeUrl),
+                    eq(emptyMap())
+                )
+
+                val stopAttrsCaptor = argumentCaptor<Map<String, Any?>>()
+                verify(rumMonitor.mockInstance).stopResource(
+                    capture(),
+                    eq(statusCode),
+                    eq(fakeResponseBody.toByteArray().size.toLong()),
+                    any(),
+                    stopAttrsCaptor.capture()
+                )
+
+                // Neither GraphQL nor trace attributes should be present when not sampled
+                assertThat(stopAttrsCaptor.firstValue.keys).doesNotContainAnyElementsOf(
+                    listOf(
+                        RumAttributes.GRAPHQL_OPERATION_NAME,
+                        RumAttributes.GRAPHQL_OPERATION_TYPE,
+                        RumAttributes.TRACE_ID,
+                        RumAttributes.SPAN_ID
+                    )
+                )
+
+                assertThat(firstValue).isEqualTo(secondValue)
+                assertThat(firstValue.uuid).isEqualTo(secondValue.uuid).isNotNull
+            }
+        }
+    }
+
+    // endregion
+
+    // region GraphQL errors
+
+    @Test
+    fun `M pass GraphQL errors W intercept() {GraphQL response with errors}`(
+        @IntForgery(min = 200, max = 300) statusCode: Int,
+        @StringForgery fakeGraphQLName: String,
+        @StringForgery fakeGraphQLType: String
+    ) {
+        // Given
+        fakeRequest = forgeRequest { builder ->
+            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeGraphQLName.toBase64())
+            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER.headerValue, fakeGraphQLType.toBase64())
+        }
+        val graphQLResponseBody = """{"data":null,"errors":[{"message":"Something went wrong"}]}"""
+        stubChain(mockChain, statusCode) {
+            body(graphQLResponseBody.toResponseBody(HttpSpec.ContentType.APPLICATION_JSON.toMediaType()))
+            header(TracingInterceptor.HEADER_CT, HttpSpec.ContentType.APPLICATION_JSON)
+        }
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        argumentCaptor<ResourceId> {
+            val stopAttrsCaptor = argumentCaptor<Map<String, Any?>>()
+            verify(rumMonitor.mockInstance).stopResource(
+                capture(),
+                eq(statusCode),
+                any(),
+                any(),
+                stopAttrsCaptor.capture()
+            )
+
+            val actualStopAttrs = stopAttrsCaptor.firstValue
+            assertThat(actualStopAttrs[RumAttributes.GRAPHQL_OPERATION_NAME]).isEqualTo(fakeGraphQLName)
+            assertThat(actualStopAttrs[RumAttributes.GRAPHQL_OPERATION_TYPE]).isEqualTo(fakeGraphQLType)
+            assertThat(actualStopAttrs[RumAttributes.GRAPHQL_ERRORS]).isNotNull
+            assertThat(actualStopAttrs[RumAttributes.GRAPHQL_ERRORS] as? String).contains("Something went wrong")
+        }
+    }
+
+    @Test
+    fun `M not pass GraphQL errors W intercept() {GraphQL response without errors}`(
+        @IntForgery(min = 200, max = 300) statusCode: Int,
+        @StringForgery fakeGraphQLName: String,
+        @StringForgery fakeGraphQLType: String
+    ) {
+        // Given
+        fakeRequest = forgeRequest { builder ->
+            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeGraphQLName.toBase64())
+            builder.addHeader(GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER.headerValue, fakeGraphQLType.toBase64())
+        }
+        val graphQLResponseBody = """{"data":{"user":{"name":"John"}}}"""
+        stubChain(mockChain, statusCode) {
+            body(graphQLResponseBody.toResponseBody(HttpSpec.ContentType.APPLICATION_JSON.toMediaType()))
+            header(TracingInterceptor.HEADER_CT, HttpSpec.ContentType.APPLICATION_JSON)
+        }
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        argumentCaptor<ResourceId> {
+            val stopAttrsCaptor = argumentCaptor<Map<String, Any?>>()
+            verify(rumMonitor.mockInstance).stopResource(
+                capture(),
+                eq(statusCode),
+                any(),
+                any(),
+                stopAttrsCaptor.capture()
+            )
+
+            assertThat(stopAttrsCaptor.firstValue).doesNotContainKey(RumAttributes.GRAPHQL_ERRORS)
+        }
+    }
+
+    @Test
+    fun `M not pass GraphQL errors W intercept() {non-GraphQL request}`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given
+        // No GraphQL headers on fakeRequest
+        val responseBody = """{"errors":[{"message":"Something went wrong"}]}"""
+        stubChain(mockChain, statusCode) {
+            body(responseBody.toResponseBody("application/json".toMediaType()))
+            header(TracingInterceptor.HEADER_CT, "application/json")
+        }
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        argumentCaptor<ResourceId> {
+            val stopAttrsCaptor = argumentCaptor<Map<String, Any?>>()
+            verify(rumMonitor.mockInstance).stopResource(
+                capture(),
+                eq(statusCode),
+                any(),
+                any(),
+                stopAttrsCaptor.capture()
+            )
+
+            assertThat(stopAttrsCaptor.firstValue).doesNotContainKey(RumAttributes.GRAPHQL_ERRORS)
+        }
     }
 
     // endregion

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapterTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapterTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.okhttp.internal.graphql
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.network.GraphQLHeaders
+import com.datadog.android.internal.network.HttpSpec
 import com.datadog.android.internal.utils.toBase64
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.internal.net.GraphQLExtractor
@@ -77,7 +78,7 @@ internal class OkHttpGraphQLAdapterTest {
             .addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeGraphQLName.toBase64())
             .build()
         val response = forge.anOkHttpResponse(request, 200) {
-            body("""{"data":{}}""".toResponseBody("application/json".toMediaType()))
+            body("""{"data":{}}""".toResponseBody(HttpSpec.ContentType.APPLICATION_JSON.toMediaType()))
         }
         whenever(mockChain.request()) doReturn request
         whenever(mockChain.proceed(any())) doReturn response

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapterTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapterTest.kt
@@ -1,0 +1,278 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.okhttp.internal.graphql
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.internal.network.GraphQLHeaders
+import com.datadog.android.internal.utils.toBase64
+import com.datadog.android.rum.RumAttributes
+import com.datadog.android.rum.internal.net.GraphQLExtractor
+import com.datadog.android.tests.elmyr.anOkHttpResponse
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import okhttp3.Interceptor
+import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.BufferedSource
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.io.IOException
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+internal class OkHttpGraphQLAdapterTest {
+
+    @Mock
+    lateinit var mockGraphQLExtractor: GraphQLExtractor
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @Mock
+    lateinit var mockChain: Interceptor.Chain
+
+    lateinit var testedHelper: OkHttpGraphQLAdapter
+
+    lateinit var forge: Forge
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        this.forge = forge
+        testedHelper = OkHttpGraphQLAdapter(mockGraphQLExtractor)
+    }
+
+    // region wrapChainWithoutDDHeaders
+
+    @Test
+    fun `M strip GraphQL headers W wrapChainWithoutDDHeaders() {with DD headers}`(
+        @StringForgery fakeGraphQLName: String,
+        @StringForgery fakeUserAgent: String
+    ) {
+        // Given
+        val request = Request.Builder()
+            .url("https://example.com/graphql")
+            .addHeader("User-Agent", fakeUserAgent)
+            .addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeGraphQLName.toBase64())
+            .build()
+        val response = forge.anOkHttpResponse(request, 200) {
+            body("""{"data":{}}""".toResponseBody("application/json".toMediaType()))
+        }
+        whenever(mockChain.request()) doReturn request
+        whenever(mockChain.proceed(any())) doReturn response
+
+        // When
+        val wrappedChain = testedHelper.wrapChainWithoutDDHeaders(mockInternalLogger, mockChain)
+        wrappedChain.proceed(request)
+
+        // Then
+        val requestCaptor = argumentCaptor<Request>()
+        verify(mockChain).proceed(requestCaptor.capture())
+        val cleanedRequest = requestCaptor.firstValue
+        assertThat(cleanedRequest.headers[GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue]).isNull()
+        assertThat(cleanedRequest.headers["User-Agent"]).isEqualTo(fakeUserAgent)
+    }
+
+    @Test
+    fun `M return original chain W wrapChainWithoutDDHeaders() {without DD headers}`(
+        @StringForgery fakeUserAgent: String
+    ) {
+        // Given
+        val request = Request.Builder()
+            .url("https://example.com/graphql")
+            .addHeader("User-Agent", fakeUserAgent)
+            .build()
+
+        whenever(mockChain.request()) doReturn request
+
+        // When
+        val wrappedChain = testedHelper.wrapChainWithoutDDHeaders(mockInternalLogger, mockChain)
+
+        // Then
+        assertThat(wrappedChain).isSameAs(mockChain)
+    }
+
+    // endregion
+
+    // region hasGraphQLHeaders
+
+    @Test
+    fun `M return true W hasGraphQLHeaders() {with any GraphQL header}`(
+        @StringForgery fakeValue: String
+    ) {
+        // Given
+        val request = Request.Builder()
+            .url("https://example.com/graphql")
+            .addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeValue)
+            .build()
+
+        // When
+        val result = testedHelper.hasGraphQLHeaders(request.headers)
+
+        // Then
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `M return false W hasGraphQLHeaders() {without GraphQL headers}`() {
+        // Given
+        val request = Request.Builder()
+            .url("https://example.com/graphql")
+            .addHeader("User-Agent", "test")
+            .build()
+
+        // When
+        val result = testedHelper.hasGraphQLHeaders(request.headers)
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    // endregion
+
+    // region extractGraphQLAttributes
+
+    @Test
+    fun `M delegate to graphQLExtractor W extractGraphQLAttributes()`(
+        @StringForgery fakeGraphQLName: String
+    ) {
+        // Given
+        val request = Request.Builder()
+            .url("https://example.com/graphql")
+            .addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeGraphQLName.toBase64())
+            .build()
+        val expectedAttributes = mapOf("key" to "value")
+        whenever(mockGraphQLExtractor.extractGraphQLAttributes(any())) doReturn expectedAttributes
+
+        // When
+        val result = testedHelper.extractGraphQLAttributes(request)
+
+        // Then
+        assertThat(result).isEqualTo(expectedAttributes)
+        verify(mockGraphQLExtractor).extractGraphQLAttributes(any())
+    }
+
+    // endregion
+
+    // region extractGraphQLErrorAttributes
+
+    @Test
+    fun `M return error attributes W extractGraphQLErrorAttributes() {graphql errors present}`(
+        @StringForgery fakeErrorsJson: String
+    ) {
+        // Given
+        val request = Request.Builder()
+            .url("https://example.com/graphql")
+            .build()
+        val response = forge.anOkHttpResponse(request, 200) {
+            body(
+                """{"errors":[{"message":"err"}]}""".toResponseBody(
+                    HttpSpec.ContentType.APPLICATION_JSON.toMediaType()
+                )
+            )
+            header("Content-Type", HttpSpec.ContentType.APPLICATION_JSON)
+        }
+        val graphqlAttributes = mapOf<String, Any?>(RumAttributes.GRAPHQL_OPERATION_NAME to "GetUser")
+        whenever(mockGraphQLExtractor.extractGraphQLErrors(any(), any(), any())) doReturn fakeErrorsJson
+
+        // When
+        val result = testedHelper.extractGraphQLErrorAttributes(response, graphqlAttributes, mockInternalLogger)
+
+        // Then
+        assertThat(result).containsEntry(RumAttributes.GRAPHQL_ERRORS, fakeErrorsJson)
+    }
+
+    @Test
+    fun `M return empty map W extractGraphQLErrorAttributes() {no graphql errors}`() {
+        // Given
+        val request = Request.Builder()
+            .url("https://example.com/graphql")
+            .build()
+        val response = forge.anOkHttpResponse(request, 200) {
+            body(
+                """{"data":{"user":"John"}}""".toResponseBody(
+                    HttpSpec.ContentType.APPLICATION_JSON.toMediaType()
+                )
+            )
+            header("Content-Type", HttpSpec.ContentType.APPLICATION_JSON)
+        }
+        val graphqlAttributes = mapOf<String, Any?>(RumAttributes.GRAPHQL_OPERATION_NAME to "GetUser")
+        whenever(mockGraphQLExtractor.extractGraphQLErrors(any(), any(), any())) doReturn null
+
+        // When
+        val result = testedHelper.extractGraphQLErrorAttributes(response, graphqlAttributes, mockInternalLogger)
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `M return empty map W extractGraphQLErrorAttributes() {empty graphql attributes}`() {
+        // Given
+        val request = Request.Builder()
+            .url("https://example.com/graphql")
+            .build()
+        val response = forge.anOkHttpResponse(request, 200)
+
+        // When
+        val result = testedHelper.extractGraphQLErrorAttributes(response, emptyMap(), mockInternalLogger)
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `M return empty map and log W extractGraphQLErrorAttributes() {peekBody throws}`() {
+        // Given
+        val request = Request.Builder()
+            .url("https://example.com/graphql")
+            .build()
+        val response = forge.anOkHttpResponse(request, 200) {
+            body(object : ResponseBody() {
+                override fun contentType(): MediaType? = null
+                override fun contentLength(): Long = -1L
+                override fun source(): BufferedSource {
+                    throw IOException("peekBody failed")
+                }
+            })
+        }
+        val graphqlAttributes = mapOf<String, Any?>(RumAttributes.GRAPHQL_OPERATION_NAME to "GetUser")
+
+        // When
+        val result = testedHelper.extractGraphQLErrorAttributes(response, graphqlAttributes, mockInternalLogger)
+
+        // Then
+        assertThat(result).isEmpty()
+        verify(mockInternalLogger).log(
+            eq(InternalLogger.Level.WARN),
+            eq(InternalLogger.Target.MAINTAINER),
+            any<() -> String>(),
+            any<Throwable>(),
+            any<Boolean>(),
+            anyOrNull()
+        )
+    }
+
+    // endregion
+}

--- a/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/ApolloIntegrationTest.kt
+++ b/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/ApolloIntegrationTest.kt
@@ -13,8 +13,10 @@ import com.datadog.android.Datadog
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.apollo.DatadogApolloInterceptor
+import com.datadog.android.core.stub.StubEvent
 import com.datadog.android.core.stub.StubSDKCore
 import com.datadog.android.internal.network.GraphQLHeaders
+import com.datadog.android.internal.network.HttpSpec
 import com.datadog.android.okhttp.tests.elmyr.OkHttpConfigurator
 import com.datadog.android.okhttp.tests.utils.MainLooperTestConfiguration
 import com.datadog.android.okhttp.trace.TracingInterceptor
@@ -33,6 +35,7 @@ import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.getFieldValue
 import com.datadog.tools.unit.getStaticValue
+import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -251,19 +254,7 @@ class ApolloIntegrationTest {
         ).execute()
 
         // Then
-        val events = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
-        assertThat(events).isNotEmpty()
-
-        val resourceEvents = events.filter { event ->
-            val json = JsonParser.parseString(event.eventData).asJsonObject
-            json.get("type")?.asString == "resource"
-        }
-        assertThat(resourceEvents).isNotEmpty()
-
-        val resourceEvent = resourceEvents.first()
-        val resourceJson = JsonParser.parseString(resourceEvent.eventData).asJsonObject
-        assertThat(resourceJson.get("resource")?.asJsonObject?.get("url")?.asString)
-            .contains(mockServer.hostName)
+        val resourceEvents = getResourceEvents()
 
         resourceEvents.forEach { event ->
             val eventResourceJson = JsonParser.parseString(event.eventData).asJsonObject
@@ -286,14 +277,7 @@ class ApolloIntegrationTest {
         ).execute()
 
         // Then
-        val events = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
-        assertThat(events).isNotEmpty()
-
-        val resourceEvents = events.filter { event ->
-            val json = JsonParser.parseString(event.eventData).asJsonObject
-            json.get("type")?.asString == "resource"
-        }
-        assertThat(resourceEvents).isNotEmpty()
+        val resourceEvents = getResourceEvents()
 
         resourceEvents.forEach { resourceEvent ->
             val eventJson = JsonParser.parseString(resourceEvent.eventData).asJsonObject
@@ -320,12 +304,7 @@ class ApolloIntegrationTest {
             ).execute()
 
             // Then
-            val events = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
-            val resourceEvents = events.filter { event ->
-                val json = JsonParser.parseString(event.eventData).asJsonObject
-                json.get("type")?.asString == "resource"
-            }
-            assertThat(resourceEvents).isNotEmpty()
+            val resourceEvents = getResourceEvents()
 
             val resourceEvent = resourceEvents.first()
             val resourceJson = JsonParser.parseString(resourceEvent.eventData).asJsonObject
@@ -352,12 +331,7 @@ class ApolloIntegrationTest {
             ).execute()
 
             // Then
-            val events = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
-            val resourceEvents = events.filter { event ->
-                val json = JsonParser.parseString(event.eventData).asJsonObject
-                json.get("type")?.asString == "resource"
-            }
-            assertThat(resourceEvents).isNotEmpty()
+            val resourceEvents = getResourceEvents()
 
             val resourceEvent = resourceEvents.first()
             val resourceJson = JsonParser.parseString(resourceEvent.eventData).asJsonObject
@@ -365,6 +339,108 @@ class ApolloIntegrationTest {
 
             assertThat(resourceData?.has("duration")).isTrue()
             assertThat(resourceData?.get("duration")?.asLong).isGreaterThan(0)
+        }
+    }
+
+    // endregion
+
+    // region GraphQL errors
+
+    @Test
+    fun `M extract GraphQL errors W DatadogInterceptor { response body contains errors }`() {
+        runBlocking {
+            // Given
+            rumMonitor.startView(fakeViewKey, fakeViewName)
+            // Drain the default response enqueued in setUp, then enqueue our GraphQL error response
+            apolloClient.query(FakeQuery(userId = fakeUserId, filters = Optional.present(emptyList()))).execute()
+            mockServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", HttpSpec.ContentType.APPLICATION_JSON)
+                    .setBody(GRAPHQL_ERROR_RESPONSE_BODY)
+            )
+
+            // When
+            apolloClient.query(
+                FakeQuery(
+                    userId = fakeUserId,
+                    filters = Optional.present(listOf(fakeFilter1))
+                )
+            ).execute()
+
+            // Then
+            val graphQL = getGraphQLData()
+            assertThat(graphQL.get("operationType")?.asString).isEqualTo("query")
+            assertThat(graphQL.get("operationName")?.asString).isEqualTo("FakeQuery")
+
+            val errors = graphQL.getAsJsonArray("errors")
+            assertThat(errors).hasSize(1)
+            val error = errors.get(0).asJsonObject
+            assertThat(error.get("message")?.asString).isEqualTo("User not found")
+            assertThat(error.get("code")?.asString).isEqualTo("NOT_FOUND")
+        }
+    }
+
+    @Test
+    fun `M extract multiple GraphQL errors W DatadogInterceptor { response body contains multiple errors }`() {
+        runBlocking {
+            // Given
+            rumMonitor.startView(fakeViewKey, fakeViewName)
+            apolloClient.query(FakeQuery(userId = fakeUserId, filters = Optional.present(emptyList()))).execute()
+            mockServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/graphql-response+json")
+                    .setBody(GRAPHQL_MULTIPLE_ERRORS_RESPONSE_BODY)
+            )
+
+            // When
+            apolloClient.query(
+                FakeQuery(
+                    userId = fakeUserId,
+                    filters = Optional.present(listOf(fakeFilter1))
+                )
+            ).execute()
+
+            // Then
+            val graphQLData = getGraphQLData()
+
+            val errors = graphQLData.getAsJsonArray("errors")
+            assertThat(errors).hasSize(2)
+            val firstError = errors.get(0).asJsonObject
+            val secondError = errors.get(1).asJsonObject
+
+            assertThat(firstError.get("message")?.asString).isEqualTo("Unauthorized")
+            assertThat(firstError.get("code")?.asString).isEqualTo("AUTH_ERROR")
+            assertThat(secondError.get("message")?.asString).isEqualTo("Rate limited")
+        }
+    }
+
+    @Test
+    fun `M not extract GraphQL errors W DatadogInterceptor { response body has no errors }`() {
+        runBlocking {
+            // Given
+            rumMonitor.startView(fakeViewKey, fakeViewName)
+            apolloClient.query(FakeQuery(userId = fakeUserId, filters = Optional.present(emptyList()))).execute()
+            mockServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", HttpSpec.ContentType.APPLICATION_JSON)
+                    .setBody(GRAPHQL_SUCCESS_RESPONSE_BODY)
+            )
+
+            // When
+            apolloClient.query(
+                FakeQuery(
+                    userId = fakeUserId,
+                    filters = Optional.present(listOf(fakeFilter1))
+                )
+            ).execute()
+
+            // Then
+            val graphQLData = getGraphQLData()
+            assertThat(graphQLData.get("operationType")?.asString).isEqualTo("query")
+            assertThat(graphQLData.getAsJsonArray("errors")).isNull()
         }
     }
 
@@ -388,24 +464,11 @@ class ApolloIntegrationTest {
             ).execute()
 
             // Then
-            val events = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
-            val resourceEvents = events.filter { event ->
-                val json = JsonParser.parseString(event.eventData).asJsonObject
-                json.get("type")?.asString == "resource"
-            }
-            assertThat(resourceEvents).isNotEmpty()
+            val graphQLData = getGraphQLData(last = false)
+            assertThat(graphQLData.get("operationType")?.asString).isEqualTo("mutation")
+            assertThat(graphQLData.get("operationName")?.asString).isEqualTo("FakeMutation")
 
-            val resourceEvent = resourceEvents.first()
-            val resourceJson = JsonParser.parseString(resourceEvent.eventData).asJsonObject
-            val resourceData = resourceJson.get("resource")?.asJsonObject
-            val graphqlData = resourceData?.get("graphql")?.asJsonObject
-
-            assertThat(graphqlData).isNotNull
-            assertThat(graphqlData?.get("operationType")?.asString).isEqualTo("mutation")
-            assertThat(graphqlData?.get("operationName")?.asString).isEqualTo("FakeMutation")
-
-            val variables = graphqlData?.get("variables")?.asString
-            assertThat(variables).isNotNull
+            val variables = graphQLData.get("variables")?.asString
             assertThat(variables).contains(nonAsciiName)
             assertThat(variables).contains(nonAsciiEmail)
         }
@@ -429,24 +492,11 @@ class ApolloIntegrationTest {
             ).execute()
 
             // Then
-            val events = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
-            val resourceEvents = events.filter { event ->
-                val json = JsonParser.parseString(event.eventData).asJsonObject
-                json.get("type")?.asString == "resource"
-            }
-            assertThat(resourceEvents).isNotEmpty()
+            val graphQLData = getGraphQLData(last = false)
+            assertThat(graphQLData.get("operationType")?.asString).isEqualTo("query")
+            assertThat(graphQLData.get("operationName")?.asString).isEqualTo("FakeQuery")
 
-            val resourceEvent = resourceEvents.first()
-            val resourceJson = JsonParser.parseString(resourceEvent.eventData).asJsonObject
-            val resourceData = resourceJson.get("resource")?.asJsonObject
-            val graphqlData = resourceData?.get("graphql")?.asJsonObject
-
-            assertThat(graphqlData).isNotNull
-            assertThat(graphqlData?.get("operationType")?.asString).isEqualTo("query")
-            assertThat(graphqlData?.get("operationName")?.asString).isEqualTo("FakeQuery")
-
-            val payload = graphqlData?.get("payload")?.asString
-            assertThat(payload).isNotNull
+            val payload = graphQLData.get("payload")?.asString
             assertThat(payload).contains(nonAsciiFilter)
         }
     }
@@ -477,6 +527,31 @@ class ApolloIntegrationTest {
 
     // endregion
 
+    private fun getResourceEvents(): List<StubEvent> {
+        val events = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(events).isNotEmpty()
+        return events.filter { event ->
+            val json = JsonParser.parseString(event.eventData).asJsonObject
+            json.get("type")?.asString == "resource"
+        }.also { assertThat(it).isNotEmpty() }
+    }
+
+    private fun getGraphQLData(last: Boolean = true): JsonObject {
+        val resourceEvents = getResourceEvents()
+        val event = if (last) {
+            assertThat(resourceEvents.size).isGreaterThanOrEqualTo(2)
+            resourceEvents.last()
+        } else {
+            resourceEvents.first()
+        }
+        val resourceJson = JsonParser.parseString(event.eventData).asJsonObject
+        val graphQLData = resourceJson
+            .getAsJsonObject("resource")
+            ?.getAsJsonObject("graphql")
+        assertThat(graphQLData).isNotNull
+        return graphQLData!!
+    }
+
     companion object {
         private val mainLooper = MainLooperTestConfiguration()
 
@@ -486,5 +561,38 @@ class ApolloIntegrationTest {
         fun getTestConfigurations(): List<TestConfiguration> {
             return listOf(mainLooper)
         }
+
+        private const val GRAPHQL_ERROR_RESPONSE_BODY = """
+            {
+                "data": null,
+                "errors": [
+                    {
+                        "message": "User not found",
+                        "extensions": { "code": "NOT_FOUND" }
+                    }
+                ]
+            }
+        """
+
+        private const val GRAPHQL_MULTIPLE_ERRORS_RESPONSE_BODY = """
+            {
+                "data": null,
+                "errors": [
+                    {
+                        "message": "Unauthorized",
+                        "extensions": { "code": "AUTH_ERROR" }
+                    },
+                    {
+                        "message": "Rate limited"
+                    }
+                ]
+            }
+        """
+
+        private const val GRAPHQL_SUCCESS_RESPONSE_BODY = """
+            {
+                "data": { "user": { "id": "123", "name": "Test" } }
+            }
+        """
     }
 }


### PR DESCRIPTION
### What does this PR do?

- Track GraphQL errors on `DatadogInterceptor` for `OkHttp` requests.
- Create `GraphQLExtractor` with 2 main functions: `extractGraphQLAttributes` (already existing logic, moved from `DatadogInterceptor` for better separation of concerns) & `extractGraphQLErrors` (new logic). This is a reusable extraction in `rum` module that can be reused in the future with other networking libraries (no coupling with OkHttp).
- Create `OkHttpGraphQLAdapter` to encapsulate some already existing logic and delegate to the class above.
- Some cleanup (create `StringExt` on `internal` module to reuse `String.toBase64` & `String.fromBase64` extension functions).
 
### Motivation

GraphQL APIs return HTTP 200 regardless of succeeding or not. Errors are reported inside the response body's `errors` array rather than through HTTP status codes.

Now these errors are properly caught, allowing customers to detect GraphQL failures that would otherwise go unnoticed.

### Additional notes

iOS counterpart: https://github.com/DataDog/dd-sdk-ios/pull/2552

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

