### PR TITLE
RUM-15189: Add setContinuousSampleRate API to ProfilingConfiguration

### DIFF
--- a/features/dd-sdk-android-profiling/api/apiSurface
+++ b/features/dd-sdk-android-profiling/api/apiSurface
@@ -12,6 +12,7 @@ object com.datadog.android.profiling.Profiling
 data class com.datadog.android.profiling.ProfilingConfiguration
   class Builder
     fun setApplicationLaunchSampleRate(Float): Builder
+    fun setContinuousSampleRate(Float): Builder
     fun useCustomEndpoint(String): Builder
     fun build(): ProfilingConfiguration
   companion object 

--- a/features/dd-sdk-android-profiling/api/dd-sdk-android-profiling.api
+++ b/features/dd-sdk-android-profiling/api/dd-sdk-android-profiling.api
@@ -23,8 +23,8 @@ public final class com/datadog/android/profiling/Profiling {
 
 public final class com/datadog/android/profiling/ProfilingConfiguration {
 	public static final field Companion Lcom/datadog/android/profiling/ProfilingConfiguration$Companion;
-	public final fun copy (Ljava/lang/String;F)Lcom/datadog/android/profiling/ProfilingConfiguration;
-	public static synthetic fun copy$default (Lcom/datadog/android/profiling/ProfilingConfiguration;Ljava/lang/String;FILjava/lang/Object;)Lcom/datadog/android/profiling/ProfilingConfiguration;
+	public final fun copy (Ljava/lang/String;FF)Lcom/datadog/android/profiling/ProfilingConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/profiling/ProfilingConfiguration;Ljava/lang/String;FFILjava/lang/Object;)Lcom/datadog/android/profiling/ProfilingConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -34,6 +34,7 @@ public final class com/datadog/android/profiling/ProfilingConfiguration$Builder 
 	public fun <init> ()V
 	public final fun build ()Lcom/datadog/android/profiling/ProfilingConfiguration;
 	public final fun setApplicationLaunchSampleRate (F)Lcom/datadog/android/profiling/ProfilingConfiguration$Builder;
+	public final fun setContinuousSampleRate (F)Lcom/datadog/android/profiling/ProfilingConfiguration$Builder;
 	public final fun useCustomEndpoint (Ljava/lang/String;)Lcom/datadog/android/profiling/ProfilingConfiguration$Builder;
 }
 

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/ProfilingConfiguration.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/ProfilingConfiguration.kt
@@ -14,7 +14,8 @@ import androidx.annotation.FloatRange
 @ExperimentalProfilingApi
 data class ProfilingConfiguration internal constructor(
     internal val customEndpointUrl: String?,
-    internal val sampleRate: Float
+    internal val applicationLaunchSampleRate: Float,
+    internal val continuousSampleRate: Float
 ) {
 
     /**
@@ -24,6 +25,7 @@ data class ProfilingConfiguration internal constructor(
 
         private var customEndpointUrl: String? = null
         private var applicationLaunchSampleRate: Float = DEFAULT_APPLICATION_LAUNCH_SAMPLE_RATE
+        private var continuousSampleRate: Float = DEFAULT_CONTINUOUS_SAMPLE_RATE
 
         /**
          * Sets the sampling rate for Application Launch profiling. It will be applied on the next application launch.
@@ -36,6 +38,21 @@ data class ProfilingConfiguration internal constructor(
          */
         fun setApplicationLaunchSampleRate(@FloatRange(from = 0.0, to = 100.0) sampleRate: Float): Builder {
             this.applicationLaunchSampleRate = sampleRate
+            return this
+        }
+
+        /**
+         * Sets the sampling rate for Continuous Profiling.
+         *
+         * @param sampleRate The sample rate, expressed as a percentage between 0 and 100 (inclusive).
+         * A value of 0 disables Continuous Profiling entirely. A value of 100 enables
+         * Continuous Profiling for all eligible RUM sessions, subject to rate limiting enforced by
+         * [android.os.ProfilingManager].
+         */
+        fun setContinuousSampleRate(
+            @FloatRange(from = 0.0, to = 100.0) sampleRate: Float
+        ): Builder {
+            this.continuousSampleRate = sampleRate
             return this
         }
 
@@ -54,7 +71,8 @@ data class ProfilingConfiguration internal constructor(
         fun build(): ProfilingConfiguration {
             return ProfilingConfiguration(
                 customEndpointUrl = customEndpointUrl,
-                sampleRate = applicationLaunchSampleRate
+                applicationLaunchSampleRate = applicationLaunchSampleRate,
+                continuousSampleRate = continuousSampleRate
             )
         }
     }
@@ -62,6 +80,11 @@ data class ProfilingConfiguration internal constructor(
     companion object {
 
         private const val DEFAULT_APPLICATION_LAUNCH_SAMPLE_RATE = 15f
+
+        /**
+         * Default sampling rate for Continuous Profiling.
+         */
+        internal const val DEFAULT_CONTINUOUS_SAMPLE_RATE: Float = 15f
 
         /**
          * A default configuration for the Profiling feature.

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -68,7 +68,7 @@ internal class ProfilingFeature(
                 }
             }
         }
-        setMinimumSampleRate(appContext, configuration.sampleRate)
+        setMinimumSampleRate(appContext, configuration.applicationLaunchSampleRate)
         // Set the profiling flag in SharedPreferences to profile for the next app launch
         ProfilingStorage.addProfilingFlag(appContext, sdkCore.name)
         sdkCore.setEventReceiver(name, this)
@@ -114,7 +114,7 @@ internal class ProfilingFeature(
         // if old value doesn't exist (we use negative default value in case of absence) or
         // the value is bigger than the sample rate, we update the sample rate.
         if (oldValue !in 0f..sampleRate) {
-            ProfilingStorage.setSampleRate(appContext, configuration.sampleRate)
+            ProfilingStorage.setSampleRate(appContext, configuration.applicationLaunchSampleRate)
         }
     }
 

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -140,7 +140,7 @@ class ProfilingFeatureTest {
         // Then
         verify(mockSharedPreferencesStorage).putFloat(
             "dd_profiling_sample_rate",
-            fakeConfiguration.sampleRate
+            fakeConfiguration.applicationLaunchSampleRate
         )
     }
 
@@ -150,7 +150,7 @@ class ProfilingFeatureTest {
         whenever(
             mockSharedPreferencesStorage
                 .getFloat("dd_profiling_sample_rate", -1f)
-        ) doReturn fakeConfiguration.sampleRate - 1f
+        ) doReturn fakeConfiguration.applicationLaunchSampleRate - 1f
 
         // When
         testedFeature.onInitialize(mockContext)
@@ -158,7 +158,7 @@ class ProfilingFeatureTest {
         // Then
         verify(mockSharedPreferencesStorage, never()).putFloat(
             "dd_profiling_sample_rate",
-            fakeConfiguration.sampleRate
+            fakeConfiguration.applicationLaunchSampleRate
         )
     }
 
@@ -166,7 +166,7 @@ class ProfilingFeatureTest {
     fun `M set Profiling sample rate W initialize() {bigger sample rate exists}`() {
         whenever(
             mockSharedPreferencesStorage.getFloat("dd_profiling_sample_rate", -1f)
-        ) doReturn fakeConfiguration.sampleRate + 1f
+        ) doReturn fakeConfiguration.applicationLaunchSampleRate + 1f
 
         // When
         testedFeature.onInitialize(mockContext)
@@ -175,7 +175,7 @@ class ProfilingFeatureTest {
         // Since the existing value was higher, it should be updated to the configuration value
         verify(mockSharedPreferencesStorage).putFloat(
             "dd_profiling_sample_rate",
-            fakeConfiguration.sampleRate
+            fakeConfiguration.applicationLaunchSampleRate
         )
     }
 

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/ProfilingConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/ProfilingConfigurationForgeryFactory.kt
@@ -16,7 +16,8 @@ class ProfilingConfigurationForgeryFactory :
     ForgeryFactory<ProfilingConfiguration> {
     override fun getForgery(forge: Forge): ProfilingConfiguration {
         return ProfilingConfiguration(
-            sampleRate = forge.aFloat(min = 0f, max = 100f),
+            applicationLaunchSampleRate = forge.aFloat(min = 0f, max = 100f),
+            continuousSampleRate = forge.aFloat(min = 0f, max = 100f),
             customEndpointUrl = forge.aNullable {
                 aStringMatching("http(s?)://[a-z]+\\.com/\\w+")
             }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingConfigurationBuilderTest.kt
@@ -8,6 +8,8 @@ package com.datadog.android.profiling.internal
 
 import com.datadog.android.profiling.ExperimentalProfilingApi
 import com.datadog.android.profiling.ProfilingConfiguration
+import com.datadog.android.profiling.ProfilingConfiguration.Companion.DEFAULT_CONTINUOUS_SAMPLE_RATE
+import fr.xgouchet.elmyr.annotation.FloatForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -41,6 +43,20 @@ internal class ProfilingConfigurationBuilderTest {
 
         // Then
         assertThat(configuration.customEndpointUrl).isNull()
+        assertThat(configuration.continuousSampleRate).isEqualTo(DEFAULT_CONTINUOUS_SAMPLE_RATE)
+    }
+
+    @Test
+    fun `M build config with continuous sample rate W setContinuousSampleRate() and build()`(
+        @FloatForgery(min = 0f, max = 100f) sampleRate: Float
+    ) {
+        // When
+        val configuration = testedBuilder
+            .setContinuousSampleRate(sampleRate)
+            .build()
+
+        // Then
+        assertThat(configuration.continuousSampleRate).isEqualTo(sampleRate)
     }
 
     @Test

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingConfigurationTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingConfigurationTest.kt
@@ -29,7 +29,7 @@ internal class ProfilingConfigurationTest {
 
         // Then
         assertThat(config.customEndpointUrl).isNull()
-        assertThat(config.sampleRate).isEqualTo(15f)
+        assertThat(config.applicationLaunchSampleRate).isEqualTo(15f)
     }
 
     @Test
@@ -55,7 +55,7 @@ internal class ProfilingConfigurationTest {
             .build()
 
         // Then
-        assertThat(config.sampleRate).isEqualTo(sampleRate)
+        assertThat(config.applicationLaunchSampleRate).isEqualTo(sampleRate)
     }
 
     @Test
@@ -69,13 +69,13 @@ internal class ProfilingConfigurationTest {
         // When
         val modified = original.copy(
             customEndpointUrl = endpoint,
-            sampleRate = sampleRate
+            applicationLaunchSampleRate = sampleRate
         )
 
         // Then
         assertThat(original.customEndpointUrl).isNull()
-        assertThat(original.sampleRate).isEqualTo(15f)
+        assertThat(original.applicationLaunchSampleRate).isEqualTo(15f)
         assertThat(modified.customEndpointUrl).isEqualTo(endpoint)
-        assertThat(modified.sampleRate).isEqualTo(sampleRate)
+        assertThat(modified.applicationLaunchSampleRate).isEqualTo(sampleRate)
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PRs implements `setContinuousSampleRate`  API in `ProfilingConfiguration`, during the initialization of `ProfilingFeature`, this sample rate will be persist for next app launch profiling to decide if it needs to extends.

The continuous profiling sample rate persisting follows the same rules of app launch profiling, if multiple SDK instances enable profiling feature, the smallest sample rate is persisted.

### Motivation

RUM-15189


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

