### PR TITLE
RUM-7740: Extract drawable key generation from ResourcesLRUCache

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
@@ -36,6 +36,7 @@ import com.datadog.android.sessionreplay.internal.recorder.resources.BitmapPool
 import com.datadog.android.sessionreplay.internal.recorder.resources.DefaultImageWireframeHelper
 import com.datadog.android.sessionreplay.internal.recorder.resources.ImageTypeResolver
 import com.datadog.android.sessionreplay.internal.recorder.resources.MD5HashGenerator
+import com.datadog.android.sessionreplay.internal.recorder.resources.ResourceDrawableKeyGenerator
 import com.datadog.android.sessionreplay.internal.recorder.resources.ResourceResolver
 import com.datadog.android.sessionreplay.internal.recorder.resources.ResourcesLRUCache
 import com.datadog.android.sessionreplay.internal.recorder.resources.WebPImageCompression
@@ -137,7 +138,8 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         val bitmapCachesManager = BitmapCachesManager(
             bitmapPool = BitmapPool(),
             resourcesLRUCache = ResourcesLRUCache(),
-            logger = internalLogger
+            logger = internalLogger,
+            keyGenerator = ResourceDrawableKeyGenerator()
         )
 
         this.resourceResolver = ResourceResolver(

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/BitmapCachesManager.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/BitmapCachesManager.kt
@@ -16,7 +16,8 @@ import com.datadog.android.api.InternalLogger
 internal class BitmapCachesManager(
     private val resourcesLRUCache: Cache<String, ByteArray>,
     private val bitmapPool: BitmapPool,
-    private val logger: InternalLogger
+    private val logger: InternalLogger,
+    private val keyGenerator: DrawableKeyGenerator
 ) {
     private var isResourcesCacheRegisteredForCallbacks: Boolean = false
     private var isBitmapPoolRegisteredForCallbacks: Boolean = false
@@ -60,9 +61,8 @@ internal class BitmapCachesManager(
         return String(resourceId, Charsets.UTF_8)
     }
 
-    internal fun generateResourceKeyFromDrawable(drawable: Drawable): String? {
-        // TODO RUM-7740 - Handle unsafe cast
-        return (resourcesLRUCache as? ResourcesLRUCache)?.generateKeyFromDrawable(drawable)
+    internal fun generateResourceKeyFromDrawable(drawable: Drawable): String {
+        return keyGenerator.generateKeyFromDrawable(drawable)
     }
 
     internal fun putInBitmapPool(bitmap: Bitmap) {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DrawableKeyGenerator.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DrawableKeyGenerator.kt
@@ -1,0 +1,13 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.resources
+
+import android.graphics.drawable.Drawable
+
+internal interface DrawableKeyGenerator {
+    fun generateKeyFromDrawable(drawable: Drawable): String
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceDrawableKeyGenerator.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceDrawableKeyGenerator.kt
@@ -41,6 +41,6 @@ internal class ResourceDrawableKeyGenerator : DrawableKeyGenerator {
             sb.append(layerHash)
             sb.append("-")
         }
-        return "$sb"
+        return sb.toString()
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceDrawableKeyGenerator.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceDrawableKeyGenerator.kt
@@ -1,0 +1,46 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.resources
+
+import android.graphics.drawable.AnimationDrawable
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.DrawableContainer
+import android.graphics.drawable.LayerDrawable
+import com.datadog.android.sessionreplay.internal.recorder.safeGetDrawable
+
+internal class ResourceDrawableKeyGenerator : DrawableKeyGenerator {
+
+    override fun generateKeyFromDrawable(drawable: Drawable): String =
+        generatePrefix(drawable) + System.identityHashCode(drawable)
+
+    private fun generatePrefix(drawable: Drawable): String {
+        return when (drawable) {
+            is DrawableContainer -> getPrefixForDrawableContainer(drawable)
+            is LayerDrawable -> getPrefixForLayerDrawable(drawable)
+            else -> ""
+        }
+    }
+
+    private fun getPrefixForDrawableContainer(drawable: DrawableContainer): String {
+        if (drawable !is AnimationDrawable) {
+            return drawable.state.joinToString(separator = "", postfix = "-")
+        }
+
+        return ""
+    }
+
+    private fun getPrefixForLayerDrawable(drawable: LayerDrawable): String {
+        val sb = StringBuilder()
+        for (index in 0 until drawable.numberOfLayers) {
+            val layer = drawable.safeGetDrawable(index)
+            val layerHash = System.identityHashCode(layer).toString()
+            sb.append(layerHash)
+            sb.append("-")
+        }
+        return "$sb"
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourcesLRUCache.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourcesLRUCache.kt
@@ -8,12 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder.resources
 
 import android.content.ComponentCallbacks2
 import android.content.res.Configuration
-import android.graphics.drawable.AnimationDrawable
-import android.graphics.drawable.Drawable
-import android.graphics.drawable.DrawableContainer
-import android.graphics.drawable.LayerDrawable
 import androidx.collection.LruCache
-import com.datadog.android.sessionreplay.internal.recorder.safeGetDrawable
 import com.datadog.android.sessionreplay.internal.utils.CacheUtils
 import com.datadog.android.sessionreplay.internal.utils.InvocationUtils
 
@@ -71,36 +66,6 @@ internal class ResourcesLRUCache(
             call = { cache.evictAll() },
             failureMessage = FAILURE_MSG_EVICT_CACHE_CONTENTS
         )
-    }
-
-    internal fun generateKeyFromDrawable(element: Drawable): String =
-        generatePrefix(element) + System.identityHashCode(element)
-
-    private fun generatePrefix(drawable: Drawable): String {
-        return when (drawable) {
-            is DrawableContainer -> getPrefixForDrawableContainer(drawable)
-            is LayerDrawable -> getPrefixForLayerDrawable(drawable)
-            else -> ""
-        }
-    }
-
-    private fun getPrefixForDrawableContainer(drawable: DrawableContainer): String {
-        if (drawable !is AnimationDrawable) {
-            return drawable.state.joinToString(separator = "", postfix = "-")
-        }
-
-        return ""
-    }
-
-    private fun getPrefixForLayerDrawable(drawable: LayerDrawable): String {
-        val sb = StringBuilder()
-        for (index in 0 until drawable.numberOfLayers) {
-            val layer = drawable.safeGetDrawable(index)
-            val layerHash = System.identityHashCode(layer).toString()
-            sb.append(layerHash)
-            sb.append("-")
-        }
-        return "$sb"
     }
 
     internal companion object {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/BitmapCachesManagerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/BitmapCachesManagerTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder.resources
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.drawable.Drawable
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.utils.verifyLog
@@ -21,9 +22,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
+import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
-import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -41,7 +42,10 @@ internal class BitmapCachesManagerTest {
     lateinit var mockBitmapPool: BitmapPool
 
     @Mock
-    lateinit var mockResourcesCache: ResourcesLRUCache
+    lateinit var mockResourcesCache: Cache<String, ByteArray>
+
+    @Mock
+    lateinit var mockKeyGenerator: DrawableKeyGenerator
 
     @Mock
     lateinit var mockLogger: InternalLogger
@@ -52,6 +56,9 @@ internal class BitmapCachesManagerTest {
     @Mock
     lateinit var mockBitmap: Bitmap
 
+    @Mock
+    lateinit var mockDrawable: Drawable
+
     @StringForgery
     lateinit var fakeResourceId: String
 
@@ -60,24 +67,32 @@ internal class BitmapCachesManagerTest {
 
     @BeforeEach
     fun `set up`() {
-        whenever(mockResourcesCache.generateKeyFromDrawable(any())).thenReturn(fakeResourceId)
-
         testedCachesManager = createBitmapCachesManager(
             bitmapPool = mockBitmapPool,
             resourcesLRUCache = mockResourcesCache,
+            keyGenerator = mockKeyGenerator,
             logger = mockLogger
         )
     }
 
     @Test
     fun `M register callbacks only once W registerCallbacks`() {
+        // Given
+        val mockComponentCallbacksCache = mock(ResourcesLRUCache::class.java)
+        testedCachesManager = createBitmapCachesManager(
+            bitmapPool = mockBitmapPool,
+            resourcesLRUCache = mockComponentCallbacksCache,
+            keyGenerator = mockKeyGenerator,
+            logger = mockLogger
+        )
+
         // When
         repeat(times = 5) {
             testedCachesManager.registerCallbacks(mockApplicationContext)
         }
 
         // Then
-        verify(mockApplicationContext).registerComponentCallbacks(mockResourcesCache)
+        verify(mockApplicationContext).registerComponentCallbacks(mockComponentCallbacksCache)
         verify(mockApplicationContext).registerComponentCallbacks(mockBitmapPool)
     }
 
@@ -88,6 +103,7 @@ internal class BitmapCachesManagerTest {
         testedCachesManager = createBitmapCachesManager(
             bitmapPool = mockBitmapPool,
             resourcesLRUCache = fakeBase64CacheInstance,
+            keyGenerator = mockKeyGenerator,
             logger = mockLogger
         )
 
@@ -132,6 +148,19 @@ internal class BitmapCachesManagerTest {
         // Then
         verify(mockResourcesCache).get(fakeResourceKey)
         assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M delegate to key generator W generateResourceKeyFromDrawable`() {
+        // Given
+        whenever(mockKeyGenerator.generateKeyFromDrawable(mockDrawable)).thenReturn(fakeResourceKey)
+
+        // When
+        val result = testedCachesManager.generateResourceKeyFromDrawable(mockDrawable)
+
+        // Then
+        verify(mockKeyGenerator).generateKeyFromDrawable(mockDrawable)
+        assertThat(result).isEqualTo(fakeResourceKey)
     }
 
     @Test
@@ -190,11 +219,13 @@ internal class BitmapCachesManagerTest {
     private fun createBitmapCachesManager(
         bitmapPool: BitmapPool,
         resourcesLRUCache: Cache<String, ByteArray>,
+        keyGenerator: DrawableKeyGenerator,
         logger: InternalLogger
     ): BitmapCachesManager =
         BitmapCachesManager(
             bitmapPool = bitmapPool,
             resourcesLRUCache = resourcesLRUCache,
+            keyGenerator = keyGenerator,
             logger = logger
         )
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceDrawableKeyGeneratorTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceDrawableKeyGeneratorTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.resources
+
+import android.graphics.drawable.AnimationDrawable
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.RippleDrawable
+import android.graphics.drawable.StateListDrawable
+import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.android.sessionreplay.internal.recorder.safeGetDrawable
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class ResourceDrawableKeyGeneratorTest {
+
+    private lateinit var testedKeyGenerator: ResourceDrawableKeyGenerator
+
+    @BeforeEach
+    fun setUp() {
+        testedKeyGenerator = ResourceDrawableKeyGenerator()
+    }
+
+    @Test
+    fun `M not generate prefix W generateKeyFromDrawable() { animationDrawable }`() {
+        // Given
+        val mockAnimationDrawable: AnimationDrawable = mock()
+
+        // When
+        val key = testedKeyGenerator.generateKeyFromDrawable(mockAnimationDrawable)
+
+        // Then
+        assertThat(key).doesNotContain("-")
+    }
+
+    @Test
+    fun `M generate key prefix with state W generateKeyFromDrawable() { drawableContainer }`(
+        forge: Forge
+    ) {
+        // Given
+        val mockStatelistDrawable: StateListDrawable = mock()
+        val fakeStateArray = intArrayOf(forge.aPositiveInt())
+        val expectedPrefix = fakeStateArray[0].toString() + "-"
+        whenever(mockStatelistDrawable.state).thenReturn(fakeStateArray)
+
+        // When
+        val key = testedKeyGenerator.generateKeyFromDrawable(mockStatelistDrawable)
+
+        // Then
+        assertThat(key).startsWith(expectedPrefix)
+    }
+
+    @Test
+    fun `M generate key prefix with layer hash W generateKeyFromDrawable() { layerDrawable }`() {
+        // Given
+        val mockRippleDrawable: RippleDrawable = mock()
+        val mockBackgroundLayer: Drawable = mock()
+        val mockForegroundLayer: Drawable = mock()
+        whenever(mockRippleDrawable.numberOfLayers).thenReturn(2)
+        whenever(mockRippleDrawable.safeGetDrawable(0)).thenReturn(mockBackgroundLayer)
+        whenever(mockRippleDrawable.safeGetDrawable(1)).thenReturn(mockForegroundLayer)
+
+        val expectedPrefix = System.identityHashCode(mockBackgroundLayer).toString() + "-" +
+            System.identityHashCode(mockForegroundLayer).toString() + "-"
+        val expectedHash = System.identityHashCode(mockRippleDrawable).toString()
+
+        // When
+        val key = testedKeyGenerator.generateKeyFromDrawable(mockRippleDrawable)
+
+        // Then
+        assertThat(key).isEqualTo(expectedPrefix + expectedHash)
+    }
+
+    @Test
+    fun `M not generate key prefix W generateKeyFromDrawable() { layerDrawable with only one layer }`(
+        @Mock mockRippleDrawable: RippleDrawable,
+        @Mock mockBackgroundLayer: Drawable
+    ) {
+        // Given
+        whenever(mockRippleDrawable.numberOfLayers).thenReturn(1)
+        whenever(mockRippleDrawable.safeGetDrawable(0)).thenReturn(mockBackgroundLayer)
+
+        val expectedPrefix = System.identityHashCode(mockBackgroundLayer).toString() + "-"
+        val drawableHash = System.identityHashCode(mockRippleDrawable).toString()
+
+        // When
+        val key = testedKeyGenerator.generateKeyFromDrawable(mockRippleDrawable)
+
+        // Then
+        assertThat(key).isEqualTo(expectedPrefix + drawableHash)
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolverTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolverTest.kt
@@ -965,9 +965,9 @@ internal class ResourceResolverTest {
     }
 
     @Test
-    fun `M return cache miss W resolveResourceId() { failed to generate resource key }`() {
+    fun `M proceed to copy drawable W resolveResourceId() { cache miss }`() {
         // Given
-        whenever(mockBitmapCachesManager.generateResourceKeyFromDrawable(mockDrawable)).thenReturn(null)
+        // getFromResourceCache returns null by default (cache miss)
 
         // When
         testedResourceResolver.resolveResourceIdFromDrawable(

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourcesLRUCacheTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourcesLRUCacheTest.kt
@@ -6,16 +6,10 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.resources
 
-import android.graphics.drawable.AnimationDrawable
-import android.graphics.drawable.Drawable
-import android.graphics.drawable.RippleDrawable
-import android.graphics.drawable.StateListDrawable
 import androidx.collection.LruCache
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.resources.ResourcesLRUCache.Companion.MAX_CACHE_MEMORY_SIZE_BYTES
-import com.datadog.android.sessionreplay.internal.recorder.safeGetDrawable
 import com.datadog.android.sessionreplay.internal.utils.InvocationUtils
-import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -25,11 +19,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
-import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 
 @Extensions(
@@ -42,15 +33,10 @@ internal class ResourcesLRUCacheTest {
     private lateinit var testedCache: ResourcesLRUCache
 
     @Mock
-    lateinit var mockDrawable: Drawable
-
-    @Mock
     lateinit var mockInvocationUtils: InvocationUtils
 
     @StringForgery
     lateinit var fakeResourceKey: String
-
-    val argumentCaptor = argumentCaptor<String>()
 
     @BeforeEach
     fun setup() {
@@ -83,77 +69,5 @@ internal class ResourcesLRUCacheTest {
 
         // Then
         assertThat(cacheItem).isEqualTo(fakeResourceIdByteArray)
-    }
-
-    @Test
-    fun `M not generate prefix W put() { animationDrawable }`() {
-        // Given
-        val mockAnimationDrawable: AnimationDrawable = mock()
-
-        // When
-        val key = testedCache.generateKeyFromDrawable(mockAnimationDrawable)
-
-        // Then
-        assertThat(key).doesNotContain("-")
-    }
-
-    @Test
-    fun `M generate key prefix with state W put() { drawableContainer }`(
-        forge: Forge
-    ) {
-        // Given
-        val mockStatelistDrawable: StateListDrawable = mock()
-        val fakeStateArray = intArrayOf(forge.aPositiveInt())
-        val expectedPrefix = fakeStateArray[0].toString() + "-"
-        whenever(mockStatelistDrawable.state).thenReturn(fakeStateArray)
-
-        // When
-        val key = testedCache.generateKeyFromDrawable(mockStatelistDrawable)
-
-        // Then
-        assertThat(key).startsWith(expectedPrefix)
-    }
-
-    @Test
-    fun `M generate key prefix with layer hash W put() { layerDrawable }`() {
-        // Given
-        val mockRippleDrawable: RippleDrawable = mock()
-        val mockBackgroundLayer: Drawable = mock()
-        val mockForegroundLayer: Drawable = mock()
-        whenever(mockRippleDrawable.numberOfLayers).thenReturn(2)
-        whenever(mockRippleDrawable.safeGetDrawable(0))
-            .thenReturn(mockBackgroundLayer)
-        whenever(mockRippleDrawable.safeGetDrawable(1))
-            .thenReturn(mockForegroundLayer)
-        whenever(mockRippleDrawable.numberOfLayers).thenReturn(2)
-
-        val expectedPrefix = System.identityHashCode(mockBackgroundLayer).toString() + "-" +
-            System.identityHashCode(mockForegroundLayer).toString() + "-"
-        val expectedHash = System.identityHashCode(mockRippleDrawable).toString()
-
-        // When
-        val key = testedCache.generateKeyFromDrawable(mockRippleDrawable)
-
-        // Then
-        assertThat(key).isEqualTo(expectedPrefix + expectedHash)
-    }
-
-    @Test
-    fun `M not generate key prefix W put() { layerDrawable with only one layer }`(
-        @Mock mockRippleDrawable: RippleDrawable,
-        @Mock mockBackgroundLayer: Drawable
-    ) {
-        // Given
-        whenever(mockRippleDrawable.numberOfLayers).thenReturn(1)
-        whenever(mockRippleDrawable.safeGetDrawable(0)).thenReturn(mockBackgroundLayer)
-
-        val expectedPrefix = System.identityHashCode(mockBackgroundLayer).toString() + "-"
-        val drawableHash = System.identityHashCode(mockRippleDrawable).toString()
-
-        // When
-        val key = testedCache.generateKeyFromDrawable(mockRippleDrawable)
-
-        // Then
-        assertThat(key).isEqualTo(expectedPrefix + drawableHash)
     }
 }


### PR DESCRIPTION
### What does this PR do?
Removes the unsafe `as? ResourcesLRUCache` downcast in
`BitmapCachesManager.generateResourceKeyFromDrawable` by extracting key
generation into a dedicated `DrawableKeyGenerator` interface with a
`ResourceDrawableKeyGenerator` implementation. `BitmapCachesManager` now
accepts a `DrawableKeyGenerator` as an injected dependency, eliminating
the need to know about the concrete cache type.

### Motivation
The original code performed a silent safe-cast to `ResourcesLRUCache`
inside `BitmapCachesManager`, meaning any non-`ResourcesLRUCache`
implementation of `Cache<String, ByteArray>` would silently return `null`
from `generateResourceKeyFromDrawable`. The new design separates storage
from key generation and makes the dependency explicit and mockable in tests.

### Additional Notes
No public API surface changes.

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)