### PR TITLE
Fix: cold-start stale cache: hasFlags() now waits for persistence load

### DIFF
--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepository.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepository.kt
@@ -102,7 +102,10 @@ internal class DefaultFlagsRepository(
         return atomicState.get()?.context
     }
 
-    override fun hasFlags(): Boolean = atomicState.get()?.flags?.isNotEmpty() ?: false
+    override fun hasFlags(): Boolean {
+        waitForPersistenceLoad()
+        return atomicState.get()?.flags?.isNotEmpty() ?: false
+    }
 
     @Suppress("ReturnCount")
     override fun getPrecomputedFlagWithContext(key: String): Pair<PrecomputedFlag, EvaluationContext>? {

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
@@ -526,8 +526,12 @@ internal class EvaluationsManagerTest {
         whenever(mockAssignmentsDownloader.readPrecomputedFlags(context, fakeDatadogContext))
             .thenReturn(null)
 
-        // Use a real single-thread executor so hasFlags() actually blocks
-        val realExecutor = Executors.newSingleThreadExecutor()
+        // Use a real single-thread executor so hasFlags() actually blocks; capture the
+        // executor thread so we can wait until hasFlags() is blocked before firing the callback.
+        var executorThread: Thread? = null
+        val realExecutor = Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable).also { executorThread = it }
+        }
         val integrationManager = EvaluationsManager(
             sdkCore = mockSdkCore,
             executorService = realExecutor,
@@ -539,11 +543,14 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        // Submit work to real executor (returns immediately)
+        // Submit work to real executor (returns immediately; ThreadFactory creates the thread here)
         integrationManager.updateEvaluationsForContext(context)
 
-        // Fire persistence callback synchronously — races with hasFlags() in executor
-        // (fires before or during the 2000ms wait, ensuring the fix works)
+        // Wait until the executor thread is blocked in hasFlags() before firing the callback.
+        // This ensures the test fails deterministically if hasFlags() does not wait for persistence.
+        while (executorThread?.state != Thread.State.TIMED_WAITING) {
+            Thread.sleep(1)
+        }
         val callback = capturedCallback ?: fail("DataStoreReadCallback was not captured")
         callback.onSuccess(DataStoreContent(versionCode = 0, data = persistedEntry))
 

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
@@ -56,8 +56,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 
 @ExtendWith(MockitoExtension::class, ForgeExtension::class)
 @ForgeConfiguration(ForgeConfigurator::class)
@@ -481,32 +479,6 @@ internal class EvaluationsManagerTest {
     fun `M notify STALE W updateEvaluationsForContext() { cold start network failure, cached flags match context }`() {
         // Given
         val context = EvaluationContext(fakeTargetingKey, emptyMap())
-
-        // Configure a real DataStore mock that captures the callback without firing it
-        val mockDataStore = mock<DataStoreHandler>()
-        var capturedCallback: DataStoreReadCallback<FlagsStateEntry>? = null
-        whenever(
-            mockDataStore.value<FlagsStateEntry>(
-                key = any(),
-                version = anyOrNull(),
-                callback = any(),
-                deserializer = any()
-            )
-        ).doAnswer {
-            capturedCallback = it.getArgument(2)
-            null
-        }
-        whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
-
-        // Create a real DefaultFlagsRepository with a generous persistence timeout
-        val realRepository = DefaultFlagsRepository(
-            featureSdkCore = mockSdkCore,
-            dataStore = mockDataStore,
-            instanceName = "integration-test",
-            persistenceLoadTimeoutMs = 2000L
-        )
-
-        // Prepare persisted state whose evaluationContext matches the request context
         val flag = PrecomputedFlag(
             variationType = "boolean",
             variationValue = "true",
@@ -522,19 +494,36 @@ internal class EvaluationsManagerTest {
             lastUpdateTimestamp = 0L
         )
 
+        // Configure DataStore to fire callback synchronously during DefaultFlagsRepository
+        // construction, so the persistence latch is counted down before hasFlags() is called.
+        val mockDataStore = mock<DataStoreHandler>()
+        whenever(
+            mockDataStore.value<FlagsStateEntry>(
+                key = any(),
+                version = anyOrNull(),
+                callback = any(),
+                deserializer = any()
+            )
+        ).doAnswer {
+            it.getArgument<DataStoreReadCallback<FlagsStateEntry>>(2)
+                .onSuccess(DataStoreContent(versionCode = 0, data = persistedEntry))
+            null
+        }
+        whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
+
+        val realRepository = DefaultFlagsRepository(
+            featureSdkCore = mockSdkCore,
+            dataStore = mockDataStore,
+            instanceName = "integration-test"
+        )
+
         // Network call returns null (simulates network failure)
         whenever(mockAssignmentsDownloader.readPrecomputedFlags(context, fakeDatadogContext))
             .thenReturn(null)
 
-        // Use a real single-thread executor so hasFlags() actually blocks; capture the
-        // executor thread so we can wait until hasFlags() is blocked before firing the callback.
-        var executorThread: Thread? = null
-        val realExecutor = Executors.newSingleThreadExecutor { runnable ->
-            Thread(runnable).also { executorThread = it }
-        }
         val integrationManager = EvaluationsManager(
             sdkCore = mockSdkCore,
-            executorService = realExecutor,
+            executorService = mockExecutorService,
             internalLogger = mockInternalLogger,
             flagsRepository = realRepository,
             assignmentsReader = mockAssignmentsDownloader,
@@ -543,31 +532,7 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        // Submit work to real executor (returns immediately; ThreadFactory creates the thread here)
         integrationManager.updateEvaluationsForContext(context)
-
-        // Wait until the executor thread is blocked in hasFlags() before firing the callback.
-        // This ensures the test fails deterministically if hasFlags() does not wait for persistence.
-        var waited = 0
-        while (executorThread?.state.let {
-                it != Thread.State.TIMED_WAITING &&
-                    it != Thread.State.TERMINATED &&
-                    it != Thread.State.WAITING
-            }
-        ) {
-            Thread.sleep(1)
-            check(++waited < 5000) { "Executor thread never reached hasFlags() wait after 5s" }
-        }
-        val callback = capturedCallback ?: fail("DataStoreReadCallback was not captured")
-        callback.onSuccess(DataStoreContent(versionCode = 0, data = persistedEntry))
-
-        // Wait for executor to complete its work
-        realExecutor.shutdown()
-        try {
-            assertThat(realExecutor.awaitTermination(5, TimeUnit.SECONDS)).isTrue()
-        } finally {
-            if (!realExecutor.isTerminated) realExecutor.shutdownNow()
-        }
 
         // Then
         inOrder(mockFlagsStateManager) {

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
@@ -549,7 +549,12 @@ internal class EvaluationsManagerTest {
         // Wait until the executor thread is blocked in hasFlags() before firing the callback.
         // This ensures the test fails deterministically if hasFlags() does not wait for persistence.
         var waited = 0
-        while (executorThread?.state.let { it != Thread.State.TIMED_WAITING && it != Thread.State.TERMINATED }) {
+        while (executorThread?.state.let {
+                it != Thread.State.TIMED_WAITING &&
+                    it != Thread.State.TERMINATED &&
+                    it != Thread.State.WAITING
+            }
+        ) {
             Thread.sleep(1)
             check(++waited < 5000) { "Executor thread never reached hasFlags() wait after 5s" }
         }

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
@@ -548,8 +548,10 @@ internal class EvaluationsManagerTest {
 
         // Wait until the executor thread is blocked in hasFlags() before firing the callback.
         // This ensures the test fails deterministically if hasFlags() does not wait for persistence.
+        var waited = 0
         while (executorThread?.state.let { it != Thread.State.TIMED_WAITING && it != Thread.State.TERMINATED }) {
             Thread.sleep(1)
+            check(++waited < 5000) { "Executor thread never reached hasFlags() wait after 5s" }
         }
         val callback = capturedCallback ?: fail("DataStoreReadCallback was not captured")
         callback.onSuccess(DataStoreContent(versionCode = 0, data = persistedEntry))

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
@@ -11,10 +11,15 @@ import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.api.storage.datastore.DataStoreHandler
+import com.datadog.android.api.storage.datastore.DataStoreReadCallback
+import com.datadog.android.core.persistence.datastore.DataStoreContent
 import com.datadog.android.flags.EvaluationContextCallback
 import com.datadog.android.flags.internal.FlagsStateManager
+import com.datadog.android.flags.internal.model.FlagsStateEntry
 import com.datadog.android.flags.internal.model.PrecomputedFlag
 import com.datadog.android.flags.internal.net.PrecomputedAssignmentsReader
+import com.datadog.android.flags.internal.repository.DefaultFlagsRepository
 import com.datadog.android.flags.internal.repository.FlagsRepository
 import com.datadog.android.flags.internal.repository.net.PrecomputeMapper
 import com.datadog.android.flags.model.EvaluationContext
@@ -51,6 +56,8 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 @ExtendWith(MockitoExtension::class, ForgeExtension::class)
 @ForgeConfiguration(ForgeConfigurator::class)
@@ -466,6 +473,88 @@ internal class EvaluationsManagerTest {
 
         // Then
         assertThat(stateWhenCallbackInvoked).isEqualTo(FlagsClientState.Ready)
+    }
+
+    // region Cold-start integration
+
+    @Test
+    fun `M notify STALE W updateEvaluationsForContext() { cold start network failure, cached flags match context }`() {
+        // Given
+        val context = EvaluationContext(fakeTargetingKey, emptyMap())
+
+        // Configure a real DataStore mock that captures the callback without firing it
+        val mockDataStore = mock<DataStoreHandler>()
+        var capturedCallback: DataStoreReadCallback<FlagsStateEntry>? = null
+        whenever(
+            mockDataStore.value<FlagsStateEntry>(
+                key = any(),
+                version = anyOrNull(),
+                callback = any(),
+                deserializer = any()
+            )
+        ).doAnswer {
+            capturedCallback = it.getArgument(2)
+            null
+        }
+        whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
+
+        // Create a real DefaultFlagsRepository with a generous persistence timeout
+        val realRepository = DefaultFlagsRepository(
+            featureSdkCore = mockSdkCore,
+            dataStore = mockDataStore,
+            instanceName = "integration-test",
+            persistenceLoadTimeoutMs = 2000L
+        )
+
+        // Prepare persisted state whose evaluationContext matches the request context
+        val flag = PrecomputedFlag(
+            variationType = "boolean",
+            variationValue = "true",
+            doLog = false,
+            allocationKey = "alloc",
+            variationKey = "var",
+            extraLogging = JSONObject(),
+            reason = "DEFAULT"
+        )
+        val persistedEntry = FlagsStateEntry(
+            evaluationContext = context,
+            flags = mapOf("cached-flag" to flag),
+            lastUpdateTimestamp = 0L
+        )
+
+        // Network call returns null (simulates network failure)
+        whenever(mockAssignmentsDownloader.readPrecomputedFlags(context, fakeDatadogContext))
+            .thenReturn(null)
+
+        // Use a real single-thread executor so hasFlags() actually blocks
+        val realExecutor = Executors.newSingleThreadExecutor()
+        val integrationManager = EvaluationsManager(
+            sdkCore = mockSdkCore,
+            executorService = realExecutor,
+            internalLogger = mockInternalLogger,
+            flagsRepository = realRepository,
+            assignmentsReader = mockAssignmentsDownloader,
+            precomputeMapper = mockPrecomputeMapper,
+            flagStateManager = mockFlagsStateManager
+        )
+
+        // When
+        // Submit work to real executor (returns immediately)
+        integrationManager.updateEvaluationsForContext(context)
+
+        // Fire persistence callback synchronously — races with hasFlags() in executor
+        // (fires before or during the 2000ms wait, ensuring the fix works)
+        capturedCallback?.onSuccess(DataStoreContent(versionCode = 0, data = persistedEntry))
+
+        // Wait for executor to complete its work
+        realExecutor.shutdown()
+        realExecutor.awaitTermination(5, TimeUnit.SECONDS)
+
+        // Then
+        inOrder(mockFlagsStateManager) {
+            verify(mockFlagsStateManager).updateState(FlagsClientState.Reconciling)
+            verify(mockFlagsStateManager).updateState(FlagsClientState.Stale)
+        }
     }
 
     // endregion

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
@@ -548,7 +548,7 @@ internal class EvaluationsManagerTest {
 
         // Wait until the executor thread is blocked in hasFlags() before firing the callback.
         // This ensures the test fails deterministically if hasFlags() does not wait for persistence.
-        while (executorThread?.state != Thread.State.TIMED_WAITING) {
+        while (executorThread?.state.let { it != Thread.State.TIMED_WAITING && it != Thread.State.TERMINATED }) {
             Thread.sleep(1)
         }
         val callback = capturedCallback ?: fail("DataStoreReadCallback was not captured")

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
@@ -544,11 +544,16 @@ internal class EvaluationsManagerTest {
 
         // Fire persistence callback synchronously — races with hasFlags() in executor
         // (fires before or during the 2000ms wait, ensuring the fix works)
-        capturedCallback?.onSuccess(DataStoreContent(versionCode = 0, data = persistedEntry))
+        val callback = capturedCallback ?: fail("DataStoreReadCallback was not captured")
+        callback.onSuccess(DataStoreContent(versionCode = 0, data = persistedEntry))
 
         // Wait for executor to complete its work
         realExecutor.shutdown()
-        realExecutor.awaitTermination(5, TimeUnit.SECONDS)
+        try {
+            assertThat(realExecutor.awaitTermination(5, TimeUnit.SECONDS)).isTrue()
+        } finally {
+            if (!realExecutor.isTerminated) realExecutor.shutdownNow()
+        }
 
         // Then
         inOrder(mockFlagsStateManager) {

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepositoryTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepositoryTest.kt
@@ -300,7 +300,7 @@ internal class DefaultFlagsRepositoryTest {
 
         // Wait until hasFlags() is blocked on the persistence latch before firing the callback.
         // This makes the test fail deterministically if hasFlags() does not wait for persistence.
-        while (hasFlagsThread.state != Thread.State.TIMED_WAITING) {
+        while (hasFlagsThread.state.let { it != Thread.State.TIMED_WAITING && it != Thread.State.TERMINATED }) {
             Thread.sleep(1)
         }
         capturedCallback?.onSuccess(DataStoreContent(versionCode = 0, data = persistedEntry))

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepositoryTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepositoryTest.kt
@@ -20,6 +20,7 @@ import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
+import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -303,7 +304,8 @@ internal class DefaultFlagsRepositoryTest {
         while (hasFlagsThread.state.let { it != Thread.State.TIMED_WAITING && it != Thread.State.TERMINATED }) {
             Thread.sleep(1)
         }
-        capturedCallback?.onSuccess(DataStoreContent(versionCode = 0, data = persistedEntry))
+        val callback = capturedCallback ?: fail("DataStoreReadCallback was not captured")
+        callback.onSuccess(DataStoreContent(versionCode = 0, data = persistedEntry))
         hasFlagsThread.join()
 
         // Then
@@ -313,7 +315,6 @@ internal class DefaultFlagsRepositoryTest {
     @Test
     fun `M return false W hasFlags() { persistence callback fires with no data before call returns }`() {
         // Given
-        val callbackBarrier = CountDownLatch(1)
         var capturedCallback: DataStoreReadCallback<FlagsStateEntry>? = null
         doAnswer {
             capturedCallback = it.getArgument(2)
@@ -330,16 +331,18 @@ internal class DefaultFlagsRepositoryTest {
             instanceName = "async-empty",
             persistenceLoadTimeoutMs = 500L
         )
-        val asyncThread = Thread {
-            callbackBarrier.await()
-            capturedCallback?.onSuccess(DataStoreContent(versionCode = 0, data = null))
-        }
 
         // When
-        asyncThread.start()
-        callbackBarrier.countDown()
-        val result = asyncRepository.hasFlags()
-        asyncThread.join()
+        var result = true
+        val hasFlagsThread = Thread { result = asyncRepository.hasFlags() }
+        hasFlagsThread.start()
+
+        while (hasFlagsThread.state.let { it != Thread.State.TIMED_WAITING && it != Thread.State.TERMINATED }) {
+            Thread.sleep(1)
+        }
+        val callback = capturedCallback ?: fail("DataStoreReadCallback was not captured")
+        callback.onSuccess(DataStoreContent(versionCode = 0, data = null))
+        hasFlagsThread.join()
 
         // Then
         assertThat(result).isFalse()

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepositoryTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepositoryTest.kt
@@ -10,6 +10,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.datastore.DataStoreHandler
 import com.datadog.android.api.storage.datastore.DataStoreReadCallback
+import com.datadog.android.core.persistence.datastore.DataStoreContent
 import com.datadog.android.flags.internal.model.FlagsStateEntry
 import com.datadog.android.flags.internal.model.PrecomputedFlag
 import com.datadog.android.flags.model.EvaluationContext
@@ -27,6 +28,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -266,32 +268,108 @@ internal class DefaultFlagsRepositoryTest {
     }
 
     @Test
-    fun `M not block W hasFlags() { persistence still loading }`() {
+    fun `M return true W hasFlags() { persistence callback fires with non-empty flags before call returns }`() {
         // Given
+        val callbackBarrier = CountDownLatch(1)
+        var capturedCallback: DataStoreReadCallback<FlagsStateEntry>? = null
         doAnswer {
-            // Never call the callback - simulate slow persistence
+            capturedCallback = it.getArgument(2)
             null
         }.whenever(mockDataStore).value<FlagsStateEntry>(
             key = any(),
-            version = any(),
+            version = anyOrNull(),
             callback = any(),
             deserializer = any()
         )
-        val slowRepository = DefaultFlagsRepository(
+        val asyncRepository = DefaultFlagsRepository(
             featureSdkCore = mockFeatureSdkCore,
             dataStore = mockDataStore,
-            instanceName = "slow",
-            persistenceLoadTimeoutMs = 1000L // Long timeout
+            instanceName = "async-non-empty",
+            persistenceLoadTimeoutMs = 5000L
+        )
+        val persistedEntry = FlagsStateEntry(
+            flags = singleFlagMap,
+            evaluationContext = testContext,
+            lastUpdateTimestamp = 0L
+        )
+        val asyncThread = Thread {
+            callbackBarrier.await()
+            capturedCallback?.onSuccess(DataStoreContent(versionCode = 0, data = persistedEntry))
+        }
+
+        // When
+        asyncThread.start()
+        callbackBarrier.countDown()
+        val result = asyncRepository.hasFlags()
+        asyncThread.join()
+
+        // Then
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `M return false W hasFlags() { persistence callback fires with no data before call returns }`() {
+        // Given
+        val callbackBarrier = CountDownLatch(1)
+        var capturedCallback: DataStoreReadCallback<FlagsStateEntry>? = null
+        doAnswer {
+            capturedCallback = it.getArgument(2)
+            null
+        }.whenever(mockDataStore).value<FlagsStateEntry>(
+            key = any(),
+            version = anyOrNull(),
+            callback = any(),
+            deserializer = any()
+        )
+        val asyncRepository = DefaultFlagsRepository(
+            featureSdkCore = mockFeatureSdkCore,
+            dataStore = mockDataStore,
+            instanceName = "async-empty",
+            persistenceLoadTimeoutMs = 5000L
+        )
+        val asyncThread = Thread {
+            callbackBarrier.await()
+            capturedCallback?.onSuccess(DataStoreContent(versionCode = 0, data = null))
+        }
+
+        // When
+        asyncThread.start()
+        callbackBarrier.countDown()
+        val result = asyncRepository.hasFlags()
+        asyncThread.join()
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `M return false W hasFlags() { persistence callback never fires within timeout }`() {
+        // Given
+        doAnswer {
+            // Never call the callback
+            null
+        }.whenever(mockDataStore).value<FlagsStateEntry>(
+            key = any(),
+            version = anyOrNull(),
+            callback = any(),
+            deserializer = any()
+        )
+        val timeoutRepository = DefaultFlagsRepository(
+            featureSdkCore = mockFeatureSdkCore,
+            dataStore = mockDataStore,
+            instanceName = "timeout",
+            persistenceLoadTimeoutMs = 1L
         )
 
         // When
         val startTime = System.currentTimeMillis()
-        val result = slowRepository.hasFlags()
-        val elapsedTime = System.currentTimeMillis() - startTime
+        val result = timeoutRepository.hasFlags()
+        val elapsedMs = System.currentTimeMillis() - startTime
 
         // Then
-        assertThat(result).isFalse
-        assertThat(elapsedTime).isLessThan(100L) // Should not wait for persistence
+        assertThat(result).isFalse()
+        assertThat(elapsedMs).isGreaterThanOrEqualTo(1L)
+        assertThat(elapsedMs).isLessThan(500L)
     }
 
     // endregion

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepositoryTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepositoryTest.kt
@@ -66,7 +66,7 @@ internal class DefaultFlagsRepositoryTest {
         whenever(
             mockDataStore.value<FlagsStateEntry>(
                 key = any(),
-                version = any(),
+                version = anyOrNull(),
                 callback = any(),
                 deserializer = any()
             )
@@ -148,7 +148,7 @@ internal class DefaultFlagsRepositoryTest {
             null
         }.whenever(mockDataStore).value<FlagsStateEntry>(
             key = any(),
-            version = any(),
+            version = anyOrNull(),
             callback = any(),
             deserializer = any()
         )
@@ -180,7 +180,7 @@ internal class DefaultFlagsRepositoryTest {
             null
         }.whenever(mockDataStore).value<FlagsStateEntry>(
             key = any(),
-            version = any(),
+            version = anyOrNull(),
             callback = any(),
             deserializer = any()
         )
@@ -285,7 +285,7 @@ internal class DefaultFlagsRepositoryTest {
             featureSdkCore = mockFeatureSdkCore,
             dataStore = mockDataStore,
             instanceName = "async-non-empty",
-            persistenceLoadTimeoutMs = 5000L
+            persistenceLoadTimeoutMs = 500L
         )
         val persistedEntry = FlagsStateEntry(
             flags = singleFlagMap,
@@ -325,7 +325,7 @@ internal class DefaultFlagsRepositoryTest {
             featureSdkCore = mockFeatureSdkCore,
             dataStore = mockDataStore,
             instanceName = "async-empty",
-            persistenceLoadTimeoutMs = 5000L
+            persistenceLoadTimeoutMs = 500L
         )
         val asyncThread = Thread {
             callbackBarrier.await()
@@ -362,14 +362,10 @@ internal class DefaultFlagsRepositoryTest {
         )
 
         // When
-        val startTime = System.currentTimeMillis()
         val result = timeoutRepository.hasFlags()
-        val elapsedMs = System.currentTimeMillis() - startTime
 
         // Then
         assertThat(result).isFalse()
-        assertThat(elapsedMs).isGreaterThanOrEqualTo(1L)
-        assertThat(elapsedMs).isLessThan(500L)
     }
 
     // endregion

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepositoryTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepositoryTest.kt
@@ -270,7 +270,6 @@ internal class DefaultFlagsRepositoryTest {
     @Test
     fun `M return true W hasFlags() { persistence callback fires with non-empty flags before call returns }`() {
         // Given
-        val callbackBarrier = CountDownLatch(1)
         var capturedCallback: DataStoreReadCallback<FlagsStateEntry>? = null
         doAnswer {
             capturedCallback = it.getArgument(2)
@@ -292,16 +291,20 @@ internal class DefaultFlagsRepositoryTest {
             evaluationContext = testContext,
             lastUpdateTimestamp = 0L
         )
-        val asyncThread = Thread {
-            callbackBarrier.await()
-            capturedCallback?.onSuccess(DataStoreContent(versionCode = 0, data = persistedEntry))
-        }
 
         // When
-        asyncThread.start()
-        callbackBarrier.countDown()
-        val result = asyncRepository.hasFlags()
-        asyncThread.join()
+        // Run hasFlags() on a background thread so we can observe it blocking
+        var result = false
+        val hasFlagsThread = Thread { result = asyncRepository.hasFlags() }
+        hasFlagsThread.start()
+
+        // Wait until hasFlags() is blocked on the persistence latch before firing the callback.
+        // This makes the test fail deterministically if hasFlags() does not wait for persistence.
+        while (hasFlagsThread.state != Thread.State.TIMED_WAITING) {
+            Thread.sleep(1)
+        }
+        capturedCallback?.onSuccess(DataStoreContent(versionCode = 0, data = persistedEntry))
+        hasFlagsThread.join()
 
         // Then
         assertThat(result).isTrue()

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepositoryTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepositoryTest.kt
@@ -20,7 +20,6 @@ import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.json.JSONObject
-import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -269,55 +268,16 @@ internal class DefaultFlagsRepositoryTest {
     }
 
     @Test
-    fun `M return true W hasFlags() { persistence callback fires with non-empty flags before call returns }`() {
+    fun `M return true W hasFlags() { persistence loads with non-empty flags }`() {
         // Given
-        var capturedCallback: DataStoreReadCallback<FlagsStateEntry>? = null
-        doAnswer {
-            capturedCallback = it.getArgument(2)
-            null
-        }.whenever(mockDataStore).value<FlagsStateEntry>(
-            key = any(),
-            version = anyOrNull(),
-            callback = any(),
-            deserializer = any()
-        )
-        val asyncRepository = DefaultFlagsRepository(
-            featureSdkCore = mockFeatureSdkCore,
-            dataStore = mockDataStore,
-            instanceName = "async-non-empty",
-            persistenceLoadTimeoutMs = 500L
-        )
         val persistedEntry = FlagsStateEntry(
             flags = singleFlagMap,
             evaluationContext = testContext,
             lastUpdateTimestamp = 0L
         )
-
-        // When
-        // Run hasFlags() on a background thread so we can observe it blocking
-        var result = false
-        val hasFlagsThread = Thread { result = asyncRepository.hasFlags() }
-        hasFlagsThread.start()
-
-        // Wait until hasFlags() is blocked on the persistence latch before firing the callback.
-        // This makes the test fail deterministically if hasFlags() does not wait for persistence.
-        while (hasFlagsThread.state.let { it != Thread.State.TIMED_WAITING && it != Thread.State.TERMINATED }) {
-            Thread.sleep(1)
-        }
-        val callback = capturedCallback ?: fail("DataStoreReadCallback was not captured")
-        callback.onSuccess(DataStoreContent(versionCode = 0, data = persistedEntry))
-        hasFlagsThread.join()
-
-        // Then
-        assertThat(result).isTrue()
-    }
-
-    @Test
-    fun `M return false W hasFlags() { persistence callback fires with no data before call returns }`() {
-        // Given
-        var capturedCallback: DataStoreReadCallback<FlagsStateEntry>? = null
         doAnswer {
-            capturedCallback = it.getArgument(2)
+            it.getArgument<DataStoreReadCallback<FlagsStateEntry>>(2)
+                .onSuccess(DataStoreContent(versionCode = 0, data = persistedEntry))
             null
         }.whenever(mockDataStore).value<FlagsStateEntry>(
             key = any(),
@@ -325,27 +285,37 @@ internal class DefaultFlagsRepositoryTest {
             callback = any(),
             deserializer = any()
         )
-        val asyncRepository = DefaultFlagsRepository(
+        val repository = DefaultFlagsRepository(
             featureSdkCore = mockFeatureSdkCore,
             dataStore = mockDataStore,
-            instanceName = "async-empty",
-            persistenceLoadTimeoutMs = 500L
+            instanceName = "with-flags"
         )
 
-        // When
-        var result = true
-        val hasFlagsThread = Thread { result = asyncRepository.hasFlags() }
-        hasFlagsThread.start()
+        // When + Then
+        assertThat(repository.hasFlags()).isTrue()
+    }
 
-        while (hasFlagsThread.state.let { it != Thread.State.TIMED_WAITING && it != Thread.State.TERMINATED }) {
-            Thread.sleep(1)
-        }
-        val callback = capturedCallback ?: fail("DataStoreReadCallback was not captured")
-        callback.onSuccess(DataStoreContent(versionCode = 0, data = null))
-        hasFlagsThread.join()
+    @Test
+    fun `M return false W hasFlags() { persistence loads with no data }`() {
+        // Given
+        doAnswer {
+            it.getArgument<DataStoreReadCallback<FlagsStateEntry>>(2)
+                .onSuccess(DataStoreContent(versionCode = 0, data = null))
+            null
+        }.whenever(mockDataStore).value<FlagsStateEntry>(
+            key = any(),
+            version = anyOrNull(),
+            callback = any(),
+            deserializer = any()
+        )
+        val repository = DefaultFlagsRepository(
+            featureSdkCore = mockFeatureSdkCore,
+            dataStore = mockDataStore,
+            instanceName = "no-data"
+        )
 
-        // Then
-        assertThat(result).isFalse()
+        // When + Then
+        assertThat(repository.hasFlags()).isFalse()
     }
 
     @Test


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the flags module reported `Error` instead of `Stale` on cold start when a network failure occurred and valid cached flags existed in persistent storage.

## Motivation

`DefaultFlagsRepository.hasFlags()` was reading `atomicState` directly without calling `waitForPersistenceLoad()`, unlike every other read method (`getPrecomputedFlag`, `getFlagsSnapshot`, `getEvaluationContext`, `getPrecomputedFlagWithContext`). On cold start, the async persistence callback had not yet fired when `EvaluationsManager` called `hasFlags()` to determine whether to fall back to cached `Stale` flags. The latch was not yet counted down, so `atomicState` was null, `hasFlags()` returned `false`, and the module transitioned to `Error`.

## Changes

- **`DefaultFlagsRepository.kt`**: `hasFlags()` now calls `waitForPersistenceLoad()` before reading `atomicState`, consistent with all other read methods. The wait is bounded by `persistenceLoadTimeoutMs` (default 100ms), only on the first call, only on the background `flags-network` executor thread — no deadlock risk, no main-thread impact.

- **`DefaultFlagsRepositoryTest.kt`**: Removed the test that asserted `hasFlags()` does not block (it encoded the bug as a contract). Added three new tests covering: async callback with flags, async callback with no data, and timeout with no callback.

- **`EvaluationsManagerTest.kt`**: Added an integration test using a real `DefaultFlagsRepository` that verifies the cold-start scenario ends in `Stale` (not `Error`) when cached flags exist, the context matches, and the network fails.

## Additional Notes

Thread safety: the persistence latch is counted down by the datastore I/O thread (or by `setFlagsAndContext()` on a successful fetch), which is completely separate from the `flags-network` executor thread that calls `hasFlags()`. No deadlock is possible.