### PR TITLE
Merge develop into feature/view-update

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -19,3 +19,7 @@ ignore:
   - build
   - .*/build/.*
   - .*/src/test/.*
+  - .*/src/testDebug/.*
+  - .*/src/testRelease/.*
+  - .*/src/testFixtures/.*
+  - sample

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/DetektCustomConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/DetektCustomConfig.kt
@@ -127,27 +127,12 @@ fun Project.detektCustomConfig() {
         args("-ex", "**/*.kts")
         args("--jvm-target", "11")
 
-        val moduleDependencies = configurations
-            .filter { it.name == "implementation" || it.name == "api" }
-            .flatMap { it.dependencies.filterIsInstance<ProjectDependency>() }
-            .map { it.path }
-            .toSet()
-            .let {
-                // api configurations have canBeResolved=false, so we cannot go inside them to see transitive
-                // module dependencies, so including common modules
-                if (project.path == ":dd-sdk-android-internal") {
-                    it
-                } else if (project.path == ":dd-sdk-android-core") {
-                    it + ":dd-sdk-android-internal"
-                } else {
-                    it + setOf(":dd-sdk-android-core", ":dd-sdk-android-internal")
-                }
-            }
+        val moduleDependencies = collectTransitiveProjectDependencies(project)
 
         val externalDependencies = File("${projectDir.absolutePath}/detekt_classpath").readText()
-        val moduleDependenciesClasses = moduleDependencies.map {
+        val moduleDependenciesClasses = moduleDependencies.joinToString(":") {
             "${rootDir.absolutePath}${it.replace(':', '/')}/build/extracted/classes.jar"
-        }.joinToString(":")
+        }
 
         val dependencies = if (moduleDependenciesClasses.isBlank()) {
             externalDependencies
@@ -157,4 +142,21 @@ fun Project.detektCustomConfig() {
 
         args("-cp", dependencies)
     }
+}
+
+private fun collectTransitiveProjectDependencies(project: Project): Set<String> {
+    val rootProject = project.rootProject
+    val visited = mutableSetOf<String>()
+    val queue = ArrayDeque<Project>()
+    queue.add(project)
+    while (queue.isNotEmpty()) {
+        val current = queue.removeFirst()
+        val depPaths = current.configurations
+            .filter { it.name == "implementation" || it.name == "api" }
+            .flatMap { it.dependencies.filterIsInstance<ProjectDependency>() }
+            .map { it.path }
+            .filter { visited.add(it) }
+        depPaths.mapNotNull { rootProject.findProject(it) }.forEach { queue.add(it) }
+    }
+    return visited
 }

--- a/code-coverage.datadog.yml
+++ b/code-coverage.datadog.yml
@@ -3,3 +3,7 @@ ignore:
   - "build/"
   - "**/build/"
   - "**/src/test/"
+  - "**/src/testDebug/"
+  - "**/src/testRelease/"
+  - "**/src/testFixtures/"
+  - "sample/"

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsDownloader.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsDownloader.kt
@@ -65,6 +65,9 @@ internal class PrecomputedAssignmentsDownloader(
             onlyOnce = true
         )
 
+        @Suppress("UnsafeThirdPartyFunctionCall") // Safe: wrapped in outer try-catch
+        response.body?.close()
+
         null
     }
 }

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsDownloaderTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsDownloaderTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.flags.model.EvaluationContext
 import com.datadog.android.flags.utils.forge.ForgeConfigurator
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -21,6 +22,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
+import okhttp3.ResponseBody
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -35,6 +37,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isA
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -365,6 +368,34 @@ internal class PrecomputedAssignmentsDownloaderTest {
 
         // Then
         assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M close response body W readPrecomputedFlags()`(
+        @StringForgery(regex = "https://[a-z]+\\.(com|net)/[a-z]+") fakeUrl: String,
+        @BoolForgery fakeIsSuccessfulResponse: Boolean
+    ) {
+        // Given
+        val fakeRequest = Request.Builder()
+            .url(fakeUrl)
+            .build()
+
+        val fakeResponseBody = mock<ResponseBody>()
+        val fakeResponse = mock<Response> {
+            on { isSuccessful } doReturn fakeIsSuccessfulResponse
+            on { body } doReturn fakeResponseBody
+        }
+
+        whenever(mockRequestFactory.create(fakeEvaluationContext, fakeDatadogContext))
+            .doReturn(fakeRequest)
+        whenever(mockCallFactory.newCall(fakeRequest)).doReturn(mockCall)
+        whenever(mockCall.execute()).doReturn(fakeResponse)
+
+        // When
+        testedDownloader.readPrecomputedFlags(fakeEvaluationContext, fakeDatadogContext)
+
+        // Then
+        verify(fakeResponseBody).close()
     }
 
     // endregion

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
@@ -36,6 +36,7 @@ import com.datadog.android.sessionreplay.internal.recorder.resources.BitmapPool
 import com.datadog.android.sessionreplay.internal.recorder.resources.DefaultImageWireframeHelper
 import com.datadog.android.sessionreplay.internal.recorder.resources.ImageTypeResolver
 import com.datadog.android.sessionreplay.internal.recorder.resources.MD5HashGenerator
+import com.datadog.android.sessionreplay.internal.recorder.resources.ResourceDrawableKeyGenerator
 import com.datadog.android.sessionreplay.internal.recorder.resources.ResourceResolver
 import com.datadog.android.sessionreplay.internal.recorder.resources.ResourcesLRUCache
 import com.datadog.android.sessionreplay.internal.recorder.resources.WebPImageCompression
@@ -137,7 +138,8 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         val bitmapCachesManager = BitmapCachesManager(
             bitmapPool = BitmapPool(),
             resourcesLRUCache = ResourcesLRUCache(),
-            logger = internalLogger
+            logger = internalLogger,
+            keyGenerator = ResourceDrawableKeyGenerator()
         )
 
         this.resourceResolver = ResourceResolver(

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/BitmapCachesManager.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/BitmapCachesManager.kt
@@ -16,7 +16,8 @@ import com.datadog.android.api.InternalLogger
 internal class BitmapCachesManager(
     private val resourcesLRUCache: Cache<String, ByteArray>,
     private val bitmapPool: BitmapPool,
-    private val logger: InternalLogger
+    private val logger: InternalLogger,
+    private val keyGenerator: DrawableKeyGenerator
 ) {
     private var isResourcesCacheRegisteredForCallbacks: Boolean = false
     private var isBitmapPoolRegisteredForCallbacks: Boolean = false
@@ -60,9 +61,8 @@ internal class BitmapCachesManager(
         return String(resourceId, Charsets.UTF_8)
     }
 
-    internal fun generateResourceKeyFromDrawable(drawable: Drawable): String? {
-        // TODO RUM-7740 - Handle unsafe cast
-        return (resourcesLRUCache as? ResourcesLRUCache)?.generateKeyFromDrawable(drawable)
+    internal fun generateResourceKeyFromDrawable(drawable: Drawable): String {
+        return keyGenerator.generateKeyFromDrawable(drawable)
     }
 
     internal fun putInBitmapPool(bitmap: Bitmap) {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DrawableKeyGenerator.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DrawableKeyGenerator.kt
@@ -1,0 +1,13 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.resources
+
+import android.graphics.drawable.Drawable
+
+internal interface DrawableKeyGenerator {
+    fun generateKeyFromDrawable(drawable: Drawable): String
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceDrawableKeyGenerator.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceDrawableKeyGenerator.kt
@@ -41,6 +41,6 @@ internal class ResourceDrawableKeyGenerator : DrawableKeyGenerator {
             sb.append(layerHash)
             sb.append("-")
         }
-        return "$sb"
+        return sb.toString()
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceDrawableKeyGenerator.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceDrawableKeyGenerator.kt
@@ -1,0 +1,46 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.resources
+
+import android.graphics.drawable.AnimationDrawable
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.DrawableContainer
+import android.graphics.drawable.LayerDrawable
+import com.datadog.android.sessionreplay.internal.recorder.safeGetDrawable
+
+internal class ResourceDrawableKeyGenerator : DrawableKeyGenerator {
+
+    override fun generateKeyFromDrawable(drawable: Drawable): String =
+        generatePrefix(drawable) + System.identityHashCode(drawable)
+
+    private fun generatePrefix(drawable: Drawable): String {
+        return when (drawable) {
+            is DrawableContainer -> getPrefixForDrawableContainer(drawable)
+            is LayerDrawable -> getPrefixForLayerDrawable(drawable)
+            else -> ""
+        }
+    }
+
+    private fun getPrefixForDrawableContainer(drawable: DrawableContainer): String {
+        if (drawable !is AnimationDrawable) {
+            return drawable.state.joinToString(separator = "", postfix = "-")
+        }
+
+        return ""
+    }
+
+    private fun getPrefixForLayerDrawable(drawable: LayerDrawable): String {
+        val sb = StringBuilder()
+        for (index in 0 until drawable.numberOfLayers) {
+            val layer = drawable.safeGetDrawable(index)
+            val layerHash = System.identityHashCode(layer).toString()
+            sb.append(layerHash)
+            sb.append("-")
+        }
+        return "$sb"
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourcesLRUCache.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourcesLRUCache.kt
@@ -8,12 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder.resources
 
 import android.content.ComponentCallbacks2
 import android.content.res.Configuration
-import android.graphics.drawable.AnimationDrawable
-import android.graphics.drawable.Drawable
-import android.graphics.drawable.DrawableContainer
-import android.graphics.drawable.LayerDrawable
 import androidx.collection.LruCache
-import com.datadog.android.sessionreplay.internal.recorder.safeGetDrawable
 import com.datadog.android.sessionreplay.internal.utils.CacheUtils
 import com.datadog.android.sessionreplay.internal.utils.InvocationUtils
 
@@ -71,36 +66,6 @@ internal class ResourcesLRUCache(
             call = { cache.evictAll() },
             failureMessage = FAILURE_MSG_EVICT_CACHE_CONTENTS
         )
-    }
-
-    internal fun generateKeyFromDrawable(element: Drawable): String =
-        generatePrefix(element) + System.identityHashCode(element)
-
-    private fun generatePrefix(drawable: Drawable): String {
-        return when (drawable) {
-            is DrawableContainer -> getPrefixForDrawableContainer(drawable)
-            is LayerDrawable -> getPrefixForLayerDrawable(drawable)
-            else -> ""
-        }
-    }
-
-    private fun getPrefixForDrawableContainer(drawable: DrawableContainer): String {
-        if (drawable !is AnimationDrawable) {
-            return drawable.state.joinToString(separator = "", postfix = "-")
-        }
-
-        return ""
-    }
-
-    private fun getPrefixForLayerDrawable(drawable: LayerDrawable): String {
-        val sb = StringBuilder()
-        for (index in 0 until drawable.numberOfLayers) {
-            val layer = drawable.safeGetDrawable(index)
-            val layerHash = System.identityHashCode(layer).toString()
-            sb.append(layerHash)
-            sb.append("-")
-        }
-        return "$sb"
     }
 
     internal companion object {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/BitmapCachesManagerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/BitmapCachesManagerTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder.resources
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.drawable.Drawable
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.utils.verifyLog
@@ -21,9 +22,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
+import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
-import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -41,7 +42,10 @@ internal class BitmapCachesManagerTest {
     lateinit var mockBitmapPool: BitmapPool
 
     @Mock
-    lateinit var mockResourcesCache: ResourcesLRUCache
+    lateinit var mockResourcesCache: Cache<String, ByteArray>
+
+    @Mock
+    lateinit var mockKeyGenerator: DrawableKeyGenerator
 
     @Mock
     lateinit var mockLogger: InternalLogger
@@ -52,6 +56,9 @@ internal class BitmapCachesManagerTest {
     @Mock
     lateinit var mockBitmap: Bitmap
 
+    @Mock
+    lateinit var mockDrawable: Drawable
+
     @StringForgery
     lateinit var fakeResourceId: String
 
@@ -60,24 +67,32 @@ internal class BitmapCachesManagerTest {
 
     @BeforeEach
     fun `set up`() {
-        whenever(mockResourcesCache.generateKeyFromDrawable(any())).thenReturn(fakeResourceId)
-
         testedCachesManager = createBitmapCachesManager(
             bitmapPool = mockBitmapPool,
             resourcesLRUCache = mockResourcesCache,
+            keyGenerator = mockKeyGenerator,
             logger = mockLogger
         )
     }
 
     @Test
     fun `M register callbacks only once W registerCallbacks`() {
+        // Given
+        val mockComponentCallbacksCache = mock(ResourcesLRUCache::class.java)
+        testedCachesManager = createBitmapCachesManager(
+            bitmapPool = mockBitmapPool,
+            resourcesLRUCache = mockComponentCallbacksCache,
+            keyGenerator = mockKeyGenerator,
+            logger = mockLogger
+        )
+
         // When
         repeat(times = 5) {
             testedCachesManager.registerCallbacks(mockApplicationContext)
         }
 
         // Then
-        verify(mockApplicationContext).registerComponentCallbacks(mockResourcesCache)
+        verify(mockApplicationContext).registerComponentCallbacks(mockComponentCallbacksCache)
         verify(mockApplicationContext).registerComponentCallbacks(mockBitmapPool)
     }
 
@@ -88,6 +103,7 @@ internal class BitmapCachesManagerTest {
         testedCachesManager = createBitmapCachesManager(
             bitmapPool = mockBitmapPool,
             resourcesLRUCache = fakeBase64CacheInstance,
+            keyGenerator = mockKeyGenerator,
             logger = mockLogger
         )
 
@@ -132,6 +148,19 @@ internal class BitmapCachesManagerTest {
         // Then
         verify(mockResourcesCache).get(fakeResourceKey)
         assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M delegate to key generator W generateResourceKeyFromDrawable`() {
+        // Given
+        whenever(mockKeyGenerator.generateKeyFromDrawable(mockDrawable)).thenReturn(fakeResourceKey)
+
+        // When
+        val result = testedCachesManager.generateResourceKeyFromDrawable(mockDrawable)
+
+        // Then
+        verify(mockKeyGenerator).generateKeyFromDrawable(mockDrawable)
+        assertThat(result).isEqualTo(fakeResourceKey)
     }
 
     @Test
@@ -190,11 +219,13 @@ internal class BitmapCachesManagerTest {
     private fun createBitmapCachesManager(
         bitmapPool: BitmapPool,
         resourcesLRUCache: Cache<String, ByteArray>,
+        keyGenerator: DrawableKeyGenerator,
         logger: InternalLogger
     ): BitmapCachesManager =
         BitmapCachesManager(
             bitmapPool = bitmapPool,
             resourcesLRUCache = resourcesLRUCache,
+            keyGenerator = keyGenerator,
             logger = logger
         )
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceDrawableKeyGeneratorTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceDrawableKeyGeneratorTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.resources
+
+import android.graphics.drawable.AnimationDrawable
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.RippleDrawable
+import android.graphics.drawable.StateListDrawable
+import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.android.sessionreplay.internal.recorder.safeGetDrawable
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class ResourceDrawableKeyGeneratorTest {
+
+    private lateinit var testedKeyGenerator: ResourceDrawableKeyGenerator
+
+    @BeforeEach
+    fun setUp() {
+        testedKeyGenerator = ResourceDrawableKeyGenerator()
+    }
+
+    @Test
+    fun `M not generate prefix W generateKeyFromDrawable() { animationDrawable }`() {
+        // Given
+        val mockAnimationDrawable: AnimationDrawable = mock()
+
+        // When
+        val key = testedKeyGenerator.generateKeyFromDrawable(mockAnimationDrawable)
+
+        // Then
+        assertThat(key).doesNotContain("-")
+    }
+
+    @Test
+    fun `M generate key prefix with state W generateKeyFromDrawable() { drawableContainer }`(
+        forge: Forge
+    ) {
+        // Given
+        val mockStatelistDrawable: StateListDrawable = mock()
+        val fakeStateArray = intArrayOf(forge.aPositiveInt())
+        val expectedPrefix = fakeStateArray[0].toString() + "-"
+        whenever(mockStatelistDrawable.state).thenReturn(fakeStateArray)
+
+        // When
+        val key = testedKeyGenerator.generateKeyFromDrawable(mockStatelistDrawable)
+
+        // Then
+        assertThat(key).startsWith(expectedPrefix)
+    }
+
+    @Test
+    fun `M generate key prefix with layer hash W generateKeyFromDrawable() { layerDrawable }`() {
+        // Given
+        val mockRippleDrawable: RippleDrawable = mock()
+        val mockBackgroundLayer: Drawable = mock()
+        val mockForegroundLayer: Drawable = mock()
+        whenever(mockRippleDrawable.numberOfLayers).thenReturn(2)
+        whenever(mockRippleDrawable.safeGetDrawable(0)).thenReturn(mockBackgroundLayer)
+        whenever(mockRippleDrawable.safeGetDrawable(1)).thenReturn(mockForegroundLayer)
+
+        val expectedPrefix = System.identityHashCode(mockBackgroundLayer).toString() + "-" +
+            System.identityHashCode(mockForegroundLayer).toString() + "-"
+        val expectedHash = System.identityHashCode(mockRippleDrawable).toString()
+
+        // When
+        val key = testedKeyGenerator.generateKeyFromDrawable(mockRippleDrawable)
+
+        // Then
+        assertThat(key).isEqualTo(expectedPrefix + expectedHash)
+    }
+
+    @Test
+    fun `M not generate key prefix W generateKeyFromDrawable() { layerDrawable with only one layer }`(
+        @Mock mockRippleDrawable: RippleDrawable,
+        @Mock mockBackgroundLayer: Drawable
+    ) {
+        // Given
+        whenever(mockRippleDrawable.numberOfLayers).thenReturn(1)
+        whenever(mockRippleDrawable.safeGetDrawable(0)).thenReturn(mockBackgroundLayer)
+
+        val expectedPrefix = System.identityHashCode(mockBackgroundLayer).toString() + "-"
+        val drawableHash = System.identityHashCode(mockRippleDrawable).toString()
+
+        // When
+        val key = testedKeyGenerator.generateKeyFromDrawable(mockRippleDrawable)
+
+        // Then
+        assertThat(key).isEqualTo(expectedPrefix + drawableHash)
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolverTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolverTest.kt
@@ -965,9 +965,9 @@ internal class ResourceResolverTest {
     }
 
     @Test
-    fun `M return cache miss W resolveResourceId() { failed to generate resource key }`() {
+    fun `M proceed to copy drawable W resolveResourceId() { cache miss }`() {
         // Given
-        whenever(mockBitmapCachesManager.generateResourceKeyFromDrawable(mockDrawable)).thenReturn(null)
+        // getFromResourceCache returns null by default (cache miss)
 
         // When
         testedResourceResolver.resolveResourceIdFromDrawable(

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourcesLRUCacheTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourcesLRUCacheTest.kt
@@ -6,16 +6,10 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.resources
 
-import android.graphics.drawable.AnimationDrawable
-import android.graphics.drawable.Drawable
-import android.graphics.drawable.RippleDrawable
-import android.graphics.drawable.StateListDrawable
 import androidx.collection.LruCache
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.resources.ResourcesLRUCache.Companion.MAX_CACHE_MEMORY_SIZE_BYTES
-import com.datadog.android.sessionreplay.internal.recorder.safeGetDrawable
 import com.datadog.android.sessionreplay.internal.utils.InvocationUtils
-import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -25,11 +19,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
-import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 
 @Extensions(
@@ -42,15 +33,10 @@ internal class ResourcesLRUCacheTest {
     private lateinit var testedCache: ResourcesLRUCache
 
     @Mock
-    lateinit var mockDrawable: Drawable
-
-    @Mock
     lateinit var mockInvocationUtils: InvocationUtils
 
     @StringForgery
     lateinit var fakeResourceKey: String
-
-    val argumentCaptor = argumentCaptor<String>()
 
     @BeforeEach
     fun setup() {
@@ -83,77 +69,5 @@ internal class ResourcesLRUCacheTest {
 
         // Then
         assertThat(cacheItem).isEqualTo(fakeResourceIdByteArray)
-    }
-
-    @Test
-    fun `M not generate prefix W put() { animationDrawable }`() {
-        // Given
-        val mockAnimationDrawable: AnimationDrawable = mock()
-
-        // When
-        val key = testedCache.generateKeyFromDrawable(mockAnimationDrawable)
-
-        // Then
-        assertThat(key).doesNotContain("-")
-    }
-
-    @Test
-    fun `M generate key prefix with state W put() { drawableContainer }`(
-        forge: Forge
-    ) {
-        // Given
-        val mockStatelistDrawable: StateListDrawable = mock()
-        val fakeStateArray = intArrayOf(forge.aPositiveInt())
-        val expectedPrefix = fakeStateArray[0].toString() + "-"
-        whenever(mockStatelistDrawable.state).thenReturn(fakeStateArray)
-
-        // When
-        val key = testedCache.generateKeyFromDrawable(mockStatelistDrawable)
-
-        // Then
-        assertThat(key).startsWith(expectedPrefix)
-    }
-
-    @Test
-    fun `M generate key prefix with layer hash W put() { layerDrawable }`() {
-        // Given
-        val mockRippleDrawable: RippleDrawable = mock()
-        val mockBackgroundLayer: Drawable = mock()
-        val mockForegroundLayer: Drawable = mock()
-        whenever(mockRippleDrawable.numberOfLayers).thenReturn(2)
-        whenever(mockRippleDrawable.safeGetDrawable(0))
-            .thenReturn(mockBackgroundLayer)
-        whenever(mockRippleDrawable.safeGetDrawable(1))
-            .thenReturn(mockForegroundLayer)
-        whenever(mockRippleDrawable.numberOfLayers).thenReturn(2)
-
-        val expectedPrefix = System.identityHashCode(mockBackgroundLayer).toString() + "-" +
-            System.identityHashCode(mockForegroundLayer).toString() + "-"
-        val expectedHash = System.identityHashCode(mockRippleDrawable).toString()
-
-        // When
-        val key = testedCache.generateKeyFromDrawable(mockRippleDrawable)
-
-        // Then
-        assertThat(key).isEqualTo(expectedPrefix + expectedHash)
-    }
-
-    @Test
-    fun `M not generate key prefix W put() { layerDrawable with only one layer }`(
-        @Mock mockRippleDrawable: RippleDrawable,
-        @Mock mockBackgroundLayer: Drawable
-    ) {
-        // Given
-        whenever(mockRippleDrawable.numberOfLayers).thenReturn(1)
-        whenever(mockRippleDrawable.safeGetDrawable(0)).thenReturn(mockBackgroundLayer)
-
-        val expectedPrefix = System.identityHashCode(mockBackgroundLayer).toString() + "-"
-        val drawableHash = System.identityHashCode(mockRippleDrawable).toString()
-
-        // When
-        val key = testedCache.generateKeyFromDrawable(mockRippleDrawable)
-
-        // Then
-        assertThat(key).isEqualTo(expectedPrefix + drawableHash)
     }
 }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/DatadogPropagationHelper.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/DatadogPropagationHelper.kt
@@ -390,16 +390,14 @@ class DatadogPropagationHelper internal constructor() {
             val spanId = span.context().spanId.toString()
             addHeader(
                 W3CHttpCodec.TRACE_PARENT_KEY,
-                // TODO RUM-11445 InvalidStringFormat false alarm
-                @Suppress("UnsafeThirdPartyFunctionCall", "InvalidStringFormat") // Format string is static
+                @Suppress("UnsafeThirdPartyFunctionCall") // Format string is static
                 W3C_TRACE_PARENT_DROP_SAMPLING_DECISION.format(
                     traceId.padStart(length = W3C_TRACE_ID_LENGTH, padChar = '0'),
                     spanId.padStart(length = W3C_PARENT_ID_LENGTH, padChar = '0')
                 )
             )
             // TODO RUM-2121 3rd party vendor information will be erased
-            // TODO RUM-11445 InvalidStringFormat false alarm
-            @Suppress("UnsafeThirdPartyFunctionCall", "InvalidStringFormat") // Format string is static
+            @Suppress("UnsafeThirdPartyFunctionCall") // Format string is static
             var traceStateHeader = W3C_TRACE_STATE_DROP_SAMPLING_DECISION
                 .format(spanId.padStart(length = W3C_PARENT_ID_LENGTH, padChar = '0'))
             if (traceOrigin != null) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,7 +60,7 @@ kover = "0.7.6"
 kspTesting = "1.5.0"
 
 # Tools
-detekt = "1.23.0"
+detekt = "1.23.4"
 dokka = "2.1.0"
 unmock = "0.9.0"
 robolectric = "4.4_r1-robolectric-r2"
@@ -209,7 +209,6 @@ androidLintTests = { module = "com.android.tools.lint:lint-tests", version.ref =
 systemStubsJupiter = { module = "uk.org.webcompere:system-stubs-jupiter", version.ref = "systemStubsJupiter" }
 
 # Tools
-detektCli = { module = "io.gitlab.arturbosch.detekt:detekt-cli", version.ref = "detekt" }
 detektApi = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detekt" }
 detektTest = { module = "io.gitlab.arturbosch.detekt:detekt-test", version.ref = "detekt" }
 okHttpMock = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okHttp" }

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -528,16 +528,14 @@ internal constructor(
             val spanId = span.context().spanId.toString()
             requestBuilder.addHeader(
                 W3C_TRACEPARENT_KEY,
-                // TODO RUM-11445 InvalidStringFormat false alarm
-                @Suppress("UnsafeThirdPartyFunctionCall", "InvalidStringFormat") // Format string is static
+                @Suppress("UnsafeThirdPartyFunctionCall") // Format string is static
                 W3C_TRACEPARENT_DROP_SAMPLING_DECISION.format(
                     traceId.padStart(length = W3C_TRACE_ID_LENGTH, padChar = '0'),
                     spanId.padStart(length = W3C_PARENT_ID_LENGTH, padChar = '0')
                 )
             )
             // TODO RUM-2121 3rd party vendor information will be erased
-            // TODO RUM-11445 InvalidStringFormat false alarm
-            @Suppress("UnsafeThirdPartyFunctionCall", "InvalidStringFormat") // Format string is static
+            @Suppress("UnsafeThirdPartyFunctionCall") // Format string is static
             var traceStateHeader = W3C_TRACESTATE_DROP_SAMPLING_DECISION
                 .format(spanId.padStart(length = W3C_PARENT_ID_LENGTH, padChar = '0'))
             if (traceOrigin != null) {

--- a/local_ci.sh
+++ b/local_ci.sh
@@ -164,7 +164,7 @@ if [[ $ANALYSIS == 1 ]]; then
     detekt --config detekt_custom_general.yml,detekt_custom_safe_calls.yml,detekt_custom_unsafe_calls.yml --plugins tools/detekt/build/libs/detekt.jar -cp "$classpath" --jvm-target 11 -ex "**/*.kts"
 
     echo "------ Detekt test pyramid rules"
-    rm apiSurface.log apiUsage.log
+    rm -f apiSurface.log apiUsage.log
     detekt --config detekt_test_pyramid.yml --plugins tools/detekt/build/libs/detekt.jar -cp "$classpath" --jvm-target 11 -ex "**/*.kts"
 
     grep -v -f apiUsage.log apiSurface.log > apiCoverageMiss.log

--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/ext/ReceiverExt.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/ext/ReceiverExt.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 import org.jetbrains.kotlin.resolve.scopes.receivers.ClassQualifier
 import org.jetbrains.kotlin.resolve.scopes.receivers.ExpressionReceiver
 import org.jetbrains.kotlin.resolve.scopes.receivers.ImplicitReceiver
+import org.jetbrains.kotlin.resolve.scopes.receivers.PackageQualifier
 import org.jetbrains.kotlin.resolve.scopes.receivers.Receiver
 import org.jetbrains.kotlin.types.FlexibleType
 import org.jetbrains.kotlin.types.lowerIfFlexible
@@ -51,6 +52,10 @@ internal fun Receiver.type(
 
         is ImplicitReceiver -> {
             type.fqNameOrNull()?.toString()
+        }
+
+        is PackageQualifier -> {
+            descriptor.fqName.asString()
         }
 
         else -> {

--- a/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/sdk/InvalidStringFormatTest.kt
+++ b/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/sdk/InvalidStringFormatTest.kt
@@ -485,7 +485,7 @@ internal class InvalidStringFormatTest {
             .compileAndLintWithContext(kotlinEnv.env, code)
 
         // Then
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -509,7 +509,7 @@ internal class InvalidStringFormatTest {
             .compileAndLintWithContext(kotlinEnv.env, code)
 
         // Then
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -531,7 +531,7 @@ internal class InvalidStringFormatTest {
             .compileAndLintWithContext(kotlinEnv.env, code)
 
         // Then
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -555,7 +555,7 @@ internal class InvalidStringFormatTest {
             .compileAndLintWithContext(kotlinEnv.env, code)
 
         // Then
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -580,7 +580,7 @@ internal class InvalidStringFormatTest {
             .compileAndLintWithContext(kotlinEnv.env, code)
 
         // Then
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -598,7 +598,7 @@ internal class InvalidStringFormatTest {
             .compileAndLintWithContext(kotlinEnv.env, code)
 
         // Then
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
     }
 
     @Test
@@ -616,7 +616,83 @@ internal class InvalidStringFormatTest {
             .compileAndLintWithContext(kotlinEnv.env, code)
 
         // Then
-        assertThat(findings).hasSize(0)
+        assertThat(findings).isEmpty()
+    }
+
+    // endregion
+
+    // region Test same-class companion object constants
+
+    @Test
+    fun `Ignores valid String format {same class companion object constant, ext}`() {
+        // Given
+        val code =
+            """
+                class Foo {
+                    companion object {
+                        private const val PATTERN = "00-%s-%s-00"
+                    }
+
+                    fun test(a: String, b: String): String {
+                        return PATTERN.format(a, b)
+                    }
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `Warns invalid argument count {same class companion object constant, ext}`() {
+        // Given
+        val code =
+            """
+                class Foo {
+                    companion object {
+                        private const val PATTERN = "00-%s-%s-00"
+                    }
+
+                    fun test(a: String): String {
+                        return PATTERN.format(a)
+                    }
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `Ignores valid String format {same class companion object constant, single arg}`() {
+        // Given
+        val code =
+            """
+                class Foo {
+                    companion object {
+                        private const val PATTERN = "dd=p:%s;s:0"
+                    }
+
+                    fun test(a: String): String {
+                        return PATTERN.format(a)
+                    }
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).isEmpty()
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

Brings the following commits from `develop` into `feature/view-update`:

- RUM-7740: Extract drawable key generation from `ResourcesLRUCache` into a dedicated class
- RUM-7740: Use `sb.toString()` instead of string template interpolation
- RUM-11445: Fix detekt `InvalidStringFormat` false alarms
- RUM-11445: Add unit tests as suggested
- Close flags precomputed assignments body for unsuccessful response
- Exclude test variant, test fixtures and sample apps folders from code coverage setup

### Motivation

Keep `feature/view-update` up to date with `develop` so it doesn't fall behind and future merges remain conflict-free.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)