### PR TITLE
Update profiling telemetry duration, add callback delay data

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
@@ -53,6 +53,9 @@ internal class PerfettoProfiler(
     private var profilingStartTime = 0L
 
     @Volatile
+    private var profilingStopTime = 0L
+
+    @Volatile
     private var profilingStartReason: ProfilingStartReason = ProfilingStartReason.UNKNOWN
 
     @Volatile
@@ -74,15 +77,21 @@ internal class PerfettoProfiler(
 
     init {
         resultCallback = Consumer<ProfilingResult> { result ->
-            val endTime = timeProvider.getDeviceTimestampMillis()
-            val duration = endTime - profilingStartTime
+            val resultCallbackTime = timeProvider.getDeviceTimestampMillis()
+            // profilingStopTime is 0L when profiling ended by timeout (stop() was never called).
+            // In that case, fall back to resultCallbackTime so duration is still meaningful.
+            val effectiveStopTime =
+                if (profilingStopTime > 0L) profilingStopTime else resultCallbackTime
+            val duration = effectiveStopTime - profilingStartTime
+            val resultCallbackDelayMs =
+                if (profilingStopTime > 0L) resultCallbackTime - profilingStopTime else 0L
             if (result.errorCode == ProfilingResult.ERROR_NONE) {
                 // TODO RUM-13679: need to delete the file after it is no longer needed
                 result.resultFilePath?.let {
                     notifyAllCallbacks(
                         PerfettoResult(
                             start = profilingStartTime,
-                            end = endTime,
+                            end = resultCallbackTime,
                             tag = result.tag.orEmpty(),
                             resultFilePath = it
                         )
@@ -93,6 +102,7 @@ internal class PerfettoProfiler(
             sendProfilingEndTelemetry(
                 result = result,
                 duration = duration,
+                resultCallbackDelayMs = resultCallbackDelayMs,
                 startReason = profilingStartReason,
                 appStartInfo = profilingAppStartInfo
             )
@@ -127,6 +137,7 @@ internal class PerfettoProfiler(
         // profiling will be launched when no instance is currently running profiling.
         if (runningInstances.compareAndSet(emptySet(), sdkInstanceNames)) {
             profilingStartTime = timeProvider.getDeviceTimestampMillis()
+            profilingStopTime = 0L
             profilingStartReason = startReason
             profilingAppStartInfo = additionalAttributes[TELEMETRY_KEY_APP_START_INFO]
             requestProfiling(
@@ -144,6 +155,7 @@ internal class PerfettoProfiler(
             // overwritten by that time. Probably need to allow a single profiler instance and stop profiler before
             // starting another request.
             stopSignal?.cancel()
+            profilingStopTime = timeProvider.getDeviceTimestampMillis()
         }
     }
 
@@ -165,6 +177,7 @@ internal class PerfettoProfiler(
     private fun sendProfilingEndTelemetry(
         result: ProfilingResult,
         duration: Long,
+        resultCallbackDelayMs: Long,
         startReason: ProfilingStartReason,
         appStartInfo: String?
     ) {
@@ -175,6 +188,7 @@ internal class PerfettoProfiler(
             errorMessage = result.errorMessage,
             filePath = result.resultFilePath,
             duration = duration,
+            resultCallbackDelayMs = resultCallbackDelayMs,
             stopReason = resolveStopReason(result.errorCode)
         )
         internalLogger?.let {
@@ -187,7 +201,7 @@ internal class PerfettoProfiler(
     }
 
     private fun resolveStopReason(errorCode: Int): String {
-        return if (stopSignal?.isCanceled == true) {
+        return if (profilingStopTime > 0L) {
             TELEMETRY_VALUE_STOPPED_REASON_MANUAL
         } else {
             when (errorCode) {
@@ -215,6 +229,7 @@ internal class PerfettoProfiler(
                     TELEMETRY_KEY_ERROR_CODE to telemetryData.errorCode,
                     TELEMETRY_KEY_START_REASON to telemetryData.startReason,
                     TELEMETRY_KEY_DURATION to telemetryData.duration,
+                    TELEMETRY_KEY_CALLBACK_DELAY to telemetryData.resultCallbackDelayMs,
                     TELEMETRY_KEY_ERROR_MESSAGE to telemetryData.errorMessage,
                     TELEMETRY_KEY_FILE_SIZE to getFileSize(telemetryData.filePath),
                     TELEMETRY_KEY_STOPPED_REASON to telemetryData.stopReason,
@@ -245,6 +260,7 @@ internal class PerfettoProfiler(
         val errorMessage: String?,
         val filePath: String?,
         val duration: Long,
+        val resultCallbackDelayMs: Long,
         val stopReason: String
     )
 
@@ -269,6 +285,7 @@ internal class PerfettoProfiler(
         private const val TELEMETRY_KEY_START_REASON = "start_reason"
         private const val TELEMETRY_KEY_ERROR_MESSAGE = "error_message"
         private const val TELEMETRY_KEY_DURATION = "duration"
+        private const val TELEMETRY_KEY_CALLBACK_DELAY = "callback_delay_ms"
         private const val TELEMETRY_KEY_FILE_SIZE = "file_size"
         private const val TELEMETRY_KEY_STOPPED_REASON = "stopped_reason"
         internal const val TELEMETRY_KEY_APP_START_INFO = "app_start_info"

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -123,7 +123,6 @@ class PerfettoProfilerTest {
 
         val result = captor.firstValue
         assertThat(result.start).isEqualTo(stubTimeProvider.startTime)
-        assertThat(result.start).isEqualTo(stubTimeProvider.endTime)
         assertThat(result.resultFilePath).isEqualTo(fakePath)
     }
 
@@ -171,7 +170,7 @@ class PerfettoProfilerTest {
     ) {
         // Given
         stubTimeProvider.startTime = fakeStartTime
-        stubTimeProvider.endTime = fakeStartTime + fakeDuration
+        stubTimeProvider.stopTime = fakeStartTime + fakeDuration
 
         // When
         testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
@@ -203,6 +202,7 @@ class PerfettoProfilerTest {
                 "error_message" to fakeErrorMessage,
                 "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
                 "duration" to fakeDuration,
+                "callback_delay_ms" to 0L,
                 "file_size" to 0L,
                 "stopped_reason" to "timeout",
                 "app_start_info" to null
@@ -232,7 +232,7 @@ class PerfettoProfilerTest {
     ) {
         // Given
         stubTimeProvider.startTime = fakeStartTime
-        stubTimeProvider.endTime = fakeStartTime + fakeDuration
+        stubTimeProvider.stopTime = fakeStartTime + fakeDuration
 
         // When
         testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
@@ -262,6 +262,7 @@ class PerfettoProfilerTest {
                 "error_code" to fakeErrorCode,
                 "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
                 "duration" to fakeDuration,
+                "callback_delay_ms" to 0L,
                 "error_message" to fakeErrorMessage,
                 "file_size" to 0L,
                 "stopped_reason" to "error",
@@ -291,7 +292,7 @@ class PerfettoProfilerTest {
     ) {
         // Given
         stubTimeProvider.startTime = fakeStartTime
-        stubTimeProvider.endTime = fakeStartTime + fakeDuration
+        stubTimeProvider.stopTime = fakeStartTime + fakeDuration
         testedProfiler.internalLogger = null
 
         // When
@@ -323,6 +324,7 @@ class PerfettoProfilerTest {
                 "error_code" to ProfilingResult.ERROR_FAILED_PROFILING_IN_PROGRESS,
                 "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
                 "duration" to fakeDuration,
+                "callback_delay_ms" to 0L,
                 "error_message" to fakeErrorMessage,
                 "file_size" to 0L,
                 "stopped_reason" to "error",
@@ -351,7 +353,7 @@ class PerfettoProfilerTest {
     ) {
         // Given
         stubTimeProvider.startTime = fakeStartTime
-        stubTimeProvider.endTime = fakeStartTime + fakeDuration
+        stubTimeProvider.stopTime = fakeStartTime + fakeDuration
 
         // When
         testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
@@ -384,7 +386,7 @@ class PerfettoProfilerTest {
     ) {
         // Given
         stubTimeProvider.startTime = fakeStartTime
-        stubTimeProvider.endTime = fakeStartTime + fakeDuration
+        stubTimeProvider.stopTime = fakeStartTime + fakeDuration
 
         // When
         testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
@@ -547,7 +549,7 @@ class PerfettoProfilerTest {
     ) {
         // Given
         stubTimeProvider.startTime = fakeStartTime
-        stubTimeProvider.endTime = fakeStartTime + fakeDuration
+        stubTimeProvider.stopTime = fakeStartTime + fakeDuration
 
         // When
         testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
@@ -629,7 +631,7 @@ class PerfettoProfilerTest {
     ) {
         // Given
         stubTimeProvider.startTime = fakeStartTime
-        stubTimeProvider.endTime = fakeStartTime + fakeDuration
+        stubTimeProvider.stopTime = fakeStartTime + fakeDuration
 
         // When
         testedProfiler.start(
@@ -662,6 +664,7 @@ class PerfettoProfilerTest {
                 "error_code" to ProfilingResult.ERROR_NONE,
                 "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
                 "duration" to fakeDuration,
+                "callback_delay_ms" to 0L,
                 "error_message" to null,
                 "file_size" to 0L,
                 "stopped_reason" to "timeout",
@@ -691,7 +694,7 @@ class PerfettoProfilerTest {
     ) {
         // Given
         stubTimeProvider.startTime = fakeStartTime
-        stubTimeProvider.endTime = fakeStartTime + fakeDuration
+        stubTimeProvider.stopTime = fakeStartTime + fakeDuration
 
         // When
         testedProfiler.start(mockContext, startReason, emptyMap(), setOf(fakeInstanceName))
@@ -719,6 +722,7 @@ class PerfettoProfilerTest {
                 "error_code" to ProfilingResult.ERROR_NONE,
                 "start_reason" to startReason.value,
                 "duration" to fakeDuration,
+                "callback_delay_ms" to 0L,
                 "error_message" to null,
                 "file_size" to 0L,
                 "stopped_reason" to "timeout",
@@ -739,16 +743,178 @@ class PerfettoProfilerTest {
         assertThat(messageCaptor.firstValue.invoke()).isEqualTo("[Mobile Metric] Profiling Session")
     }
 
+    @Test
+    fun `M send telemetry with correct callback_delay_ms W profiling finishes {after manual stop}`(
+        @StringForgery fakeErrorMessage: String,
+        @LongForgery(min = 1L, max = 100_000L) fakeStartTime: Long,
+        @LongForgery(min = 1L, max = 100_000L) fakeStopDelta: Long,
+        @LongForgery(min = 1L, max = 100_000L) fakeCallbackDelta: Long
+    ) {
+        // Given
+        stubTimeProvider.startTime = fakeStartTime
+        stubTimeProvider.stopTime = fakeStartTime + fakeStopDelta
+        stubTimeProvider.resultCallbackTime = fakeStartTime + fakeStopDelta + fakeCallbackDelta
+
+        // When
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.APPLICATION_LAUNCH,
+            emptyMap(),
+            setOf(fakeInstanceName)
+        )
+        testedProfiler.stop(fakeInstanceName)
+
+        verify(mockService)
+            .requestProfiling(
+                eq(ProfilingManager.PROFILING_TYPE_STACK_SAMPLING),
+                any<Bundle>(),
+                any<String>(),
+                any<CancellationSignal>(),
+                any(),
+                callbackCaptor.capture()
+            )
+
+        val mockResult = mock<ProfilingResult> {
+            on { errorCode } doReturn ProfilingResult.ERROR_NONE
+            on { errorMessage } doReturn fakeErrorMessage
+        }
+        callbackCaptor.firstValue.accept(mockResult)
+
+        // Then
+        val messageCaptor = argumentCaptor<() -> String>()
+        val expectedProps = mapOf(
+            "metric_type" to "profiling session",
+            "profiling_session" to mapOf(
+                "error_code" to ProfilingResult.ERROR_NONE,
+                "error_message" to fakeErrorMessage,
+                "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
+                "duration" to fakeStopDelta,
+                "callback_delay_ms" to fakeCallbackDelta,
+                "file_size" to 0L,
+                "stopped_reason" to "manual",
+                "app_start_info" to null
+            ),
+            "profiling_config" to mapOf(
+                "buffer_size" to 5120,
+                "sampling_frequency" to PROFILING_SAMPLING_RATE
+            )
+        )
+        verify(mockInternalLogger)
+            .logMetric(
+                messageCaptor.capture(),
+                eq(expectedProps),
+                eq(MethodCallSamplingRate.ALL.rate),
+                isNull()
+            )
+        assertThat(messageCaptor.firstValue.invoke()).isEqualTo("[Mobile Metric] Profiling Session")
+    }
+
+    @Test
+    fun `M report correct duration & 0 delay W 2nd session timeout {after 1st  manually stopped}`(
+        @LongForgery(min = 1L, max = 100_000L) fakeStartTime1: Long,
+        @LongForgery(min = 1L, max = 100_000L) fakeStartTime2: Long,
+        @LongForgery(min = 1L, max = 100_000L) fakeDuration2: Long
+    ) {
+        // Given
+        stubTimeProvider.startTime = fakeStartTime1
+        stubTimeProvider.stopTime = fakeStartTime1 + 5000L
+        stubTimeProvider.resultCallbackTime = fakeStartTime1 + 6000L
+
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.APPLICATION_LAUNCH,
+            emptyMap(),
+            setOf(fakeInstanceName)
+        )
+        testedProfiler.stop(fakeInstanceName)
+
+        verify(mockService)
+            .requestProfiling(
+                eq(ProfilingManager.PROFILING_TYPE_STACK_SAMPLING),
+                any<Bundle>(),
+                any<String>(),
+                any<CancellationSignal>(),
+                any(),
+                callbackCaptor.capture()
+            )
+
+        val firstResult =
+            mock<ProfilingResult> { on { errorCode } doReturn ProfilingResult.ERROR_NONE }
+        callbackCaptor.firstValue.accept(firstResult)
+
+        // Given
+        stubTimeProvider.reset()
+        stubTimeProvider.startTime = fakeStartTime2
+        stubTimeProvider.stopTime = fakeStartTime2 + fakeDuration2
+
+        // When
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.CONTINUOUS,
+            emptyMap(),
+            setOf(fakeInstanceName)
+        )
+
+        val callbackCaptor2 = argumentCaptor<Consumer<ProfilingResult>>()
+        verify(mockService, org.mockito.kotlin.times(2))
+            .requestProfiling(
+                eq(ProfilingManager.PROFILING_TYPE_STACK_SAMPLING),
+                any<Bundle>(),
+                any<String>(),
+                any<CancellationSignal>(),
+                any(),
+                callbackCaptor2.capture()
+            )
+
+        val secondResult =
+            mock<ProfilingResult> { on { errorCode } doReturn ProfilingResult.ERROR_NONE }
+        callbackCaptor2.lastValue.accept(secondResult)
+
+        // Then
+        val expectedProps = mapOf(
+            "metric_type" to "profiling session",
+            "profiling_session" to mapOf(
+                "error_code" to ProfilingResult.ERROR_NONE,
+                "error_message" to null,
+                "start_reason" to ProfilingStartReason.CONTINUOUS.value,
+                "duration" to fakeDuration2,
+                "callback_delay_ms" to 0L,
+                "file_size" to 0L,
+                "stopped_reason" to "timeout",
+                "app_start_info" to null
+            ),
+            "profiling_config" to mapOf(
+                "buffer_size" to 5120,
+                "sampling_frequency" to PROFILING_SAMPLING_RATE
+            )
+        )
+        verify(mockInternalLogger).logMetric(
+            any(),
+            eq(expectedProps),
+            eq(MethodCallSamplingRate.ALL.rate),
+            isNull()
+        )
+    }
+
     private class StubTimeProvider : TimeProvider {
         var startTime: Long = 0L
-        var endTime: Long = 0L
+
+        var stopTime: Long = 0L
+
+        var resultCallbackTime: Long = 0L
         private var queryIncrement: Int = 0
 
+        fun reset() {
+            queryIncrement = 0
+        }
+
         override fun getDeviceTimestampMillis(): Long {
-            return if (queryIncrement++ == 0) {
-                startTime
-            } else {
-                endTime
+            val current = queryIncrement
+            queryIncrement++
+            return when (current) {
+                0 -> startTime
+                1 -> stopTime
+                else -> resultCallbackTime
             }
         }
 


### PR DESCRIPTION
### What does this PR do?

Currently the duration in profiling telemetry data measures the duration from the time when `PerfettoProfiler.start` to `ProfilingMangaer` callback is called, this is composed by 3 parts:
* Delay for starting the OS profiler
* Effective profiling duration
* Delay for the result post-processing of ProfilingManager

In this case the duration data in telemetry is always bigger than the profile duration that we measure in the backend. To be closer to the effective profiling duration, This PR removes the third part - "Delay for the result post-processing" by mark the end time once `PerfettoProfiler.stop` is called, (it is still not the accurate effective profiling duration since it still contains the delay of starting and introduce the negative delay of stopping the profiler though). The callback time is still preserved so that we can have data about how much the delay that post-processing introduces.
 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

