### PR TITLE
Refactor test forge helpers

### DIFF
--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/CurlInterceptorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/CurlInterceptorTest.kt
@@ -6,10 +6,11 @@
 
 package com.datadog.android.core.internal.data.upload
 
+import com.datadog.android.tests.elmyr.anOkHttpResponse
 import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.AdvancedForgery
 import fr.xgouchet.elmyr.annotation.BoolForgery
-import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.MapForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
@@ -18,7 +19,6 @@ import fr.xgouchet.elmyr.junit5.ForgeExtension
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
-import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
@@ -81,24 +81,23 @@ internal class CurlInterceptorTest {
     @StringForgery
     lateinit var fakeBody: String
 
+    lateinit var forge: Forge
+
     @BeforeEach
-    fun `set up`() {
+    fun `set up`(forge: Forge) {
+        this.forge = forge
         val qp = fakeQueryParams.map { "${it.key}=${it.value}" }.joinToString("&")
         fakeUrl = "https://$fakeHost/$fakePath?$qp"
     }
 
     @Test
-    fun `M output curl command W intercept() {GET}`(
-        @IntForgery(200, 600) statusCode: Int,
-        @BoolForgery withBody: Boolean
-    ) {
+    fun `M output curl command W intercept() {GET}`(@BoolForgery withBody: Boolean) {
         // Given
         testedInterceptor = CurlInterceptor(withBody, mockOutput)
         fakeRequest = Request.Builder()
             .url(fakeUrl)
             .get()
             .build()
-        fakeResponse = forgeResponse(statusCode)
         stubChain()
 
         // When
@@ -111,16 +110,13 @@ internal class CurlInterceptorTest {
     }
 
     @Test
-    fun `M output curl command W intercept() {POST, no body}`(
-        @IntForgery(200, 600) statusCode: Int
-    ) {
+    fun `M output curl command W intercept() {POST, no body}`() {
         // Given
         testedInterceptor = CurlInterceptor(false, mockOutput)
         fakeRequest = Request.Builder()
             .url(fakeUrl)
             .post(fakeBody.toByteArray().toRequestBody(null))
             .build()
-        fakeResponse = forgeResponse(statusCode)
         stubChain()
 
         // When
@@ -133,16 +129,13 @@ internal class CurlInterceptorTest {
     }
 
     @Test
-    fun `M output curl command W intercept() {POST, body}`(
-        @IntForgery(200, 600) statusCode: Int
-    ) {
+    fun `M output curl command W intercept() {POST, body}`() {
         // Given
         testedInterceptor = CurlInterceptor(true, mockOutput)
         fakeRequest = Request.Builder()
             .url(fakeUrl)
             .post(fakeBody.toByteArray().toRequestBody(null))
             .build()
-        fakeResponse = forgeResponse(statusCode)
         stubChain()
 
         // When
@@ -156,7 +149,6 @@ internal class CurlInterceptorTest {
 
     @Test
     fun `M output curl command W intercept() {GET with headers}`(
-        @IntForgery(200, 600) statusCode: Int,
         @BoolForgery withBody: Boolean,
         @StringForgery(StringForgeryType.ALPHABETICAL) headerName: String,
         @StringForgery headerValue: String
@@ -168,7 +160,6 @@ internal class CurlInterceptorTest {
             .get()
             .addHeader(headerName, headerValue)
             .build()
-        fakeResponse = forgeResponse(statusCode)
         stubChain()
 
         // When
@@ -184,7 +175,6 @@ internal class CurlInterceptorTest {
 
     @Test
     fun `M output curl command W intercept() {POST, content type}`(
-        @IntForgery(200, 600) statusCode: Int,
         @StringForgery type: String,
         @StringForgery subtype: String
     ) {
@@ -194,7 +184,6 @@ internal class CurlInterceptorTest {
             .url(fakeUrl)
             .post(fakeBody.toByteArray().toRequestBody("$type/$subtype".toMediaTypeOrNull()))
             .build()
-        fakeResponse = forgeResponse(statusCode)
         stubChain()
 
         // When
@@ -209,7 +198,6 @@ internal class CurlInterceptorTest {
 
     @Test
     fun `M output curl command W intercept() {POST, multipart body}`(
-        @IntForgery(200, 600) statusCode: Int,
         @StringForgery type: String,
         @StringForgery subtype: String,
         @StringForgery fakeFormKey: String,
@@ -230,7 +218,6 @@ internal class CurlInterceptorTest {
                     .build()
             )
             .build()
-        fakeResponse = forgeResponse(statusCode)
         stubChain()
 
         // When
@@ -252,16 +239,9 @@ internal class CurlInterceptorTest {
 
     // region Internal
 
-    private fun forgeResponse(statusCode: Int): Response {
-        val builder = Response.Builder()
-            .request(fakeRequest)
-            .protocol(Protocol.HTTP_2)
-            .code(statusCode)
-            .message("{}")
-        return builder.build()
-    }
-
     private fun stubChain() {
+        fakeResponse = forge.anOkHttpResponse(fakeRequest, forge.anInt(min = 200, max = 600))
+
         whenever(mockChain.request()) doReturn fakeRequest
         whenever(mockChain.proceed(any())) doReturn fakeResponse
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/GzipRequestInterceptorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/GzipRequestInterceptorTest.kt
@@ -7,13 +7,13 @@
 package com.datadog.android.core.internal.data.upload
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.tests.elmyr.anOkHttpResponse
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import okhttp3.Interceptor
 import okhttp3.MultipartBody
-import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
@@ -52,9 +52,11 @@ internal class GzipRequestInterceptorTest {
     lateinit var fakeRequest: Request
     lateinit var fakeResponse: Response
     lateinit var fakeBody: String
+    lateinit var forge: Forge
 
     @BeforeEach
     fun `set up`(forge: Forge) {
+        this.forge = forge
         val fakeUrl = forge.aStringMatching("http://[a-z0-9_]{8}\\.[a-z]{3}")
         fakeBody = forge.anAlphabeticalString()
         fakeRequest = Request.Builder()
@@ -66,7 +68,6 @@ internal class GzipRequestInterceptorTest {
 
     @Test
     fun `compress body when no encoding is used`() {
-        fakeResponse = forgeResponse()
         stubChain()
 
         val response = testedInterceptor.intercept(mockChain)
@@ -93,7 +94,6 @@ internal class GzipRequestInterceptorTest {
         fakeRequest = fakeRequest.newBuilder()
             .header("Content-Encoding", "identity")
             .build()
-        fakeResponse = forgeResponse()
         stubChain()
 
         val response = testedInterceptor.intercept(mockChain)
@@ -115,7 +115,7 @@ internal class GzipRequestInterceptorTest {
     }
 
     @Test
-    fun `M keep original body W intercept { MultipartBody }`(forge: Forge) {
+    fun `M keep original body W intercept { MultipartBody }`() {
         // Given
         val fakeMultipartBody = MultipartBody
             .Builder()
@@ -129,7 +129,6 @@ internal class GzipRequestInterceptorTest {
         fakeRequest = fakeRequest.newBuilder()
             .post(fakeMultipartBody)
             .build()
-        fakeResponse = forgeResponse()
         stubChain()
 
         // When
@@ -156,7 +155,6 @@ internal class GzipRequestInterceptorTest {
         fakeRequest = fakeRequest.newBuilder()
             .get()
             .build()
-        fakeResponse = forgeResponse()
         stubChain()
 
         val response = testedInterceptor.intercept(mockChain)
@@ -174,16 +172,9 @@ internal class GzipRequestInterceptorTest {
 
     // region Internal
 
-    private fun forgeResponse(): Response {
-        val builder = Response.Builder()
-            .request(fakeRequest)
-            .protocol(Protocol.HTTP_2)
-            .code(200)
-            .message("{}")
-        return builder.build()
-    }
-
     private fun stubChain() {
+        fakeResponse = forge.anOkHttpResponse(fakeRequest, 200)
+
         whenever(mockChain.request()) doReturn fakeRequest
         whenever(mockChain.proceed(any())) doReturn fakeResponse
     }

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ForgeExt.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ForgeExt.kt
@@ -8,6 +8,7 @@ package com.datadog.android.tests.elmyr
 
 import fr.xgouchet.elmyr.Case
 import fr.xgouchet.elmyr.Forge
+import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import org.json.JSONArray
@@ -75,7 +76,7 @@ fun Forge.anOkHttpResponse(
 ): Response =
     Response.Builder()
         .request(request)
-        .protocol(okhttp3.Protocol.HTTP_2)
+        .protocol(Protocol.HTTP_2)
         .code(statusCode)
         .message(anAsciiString())
         .apply(configure)

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ForgeExt.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ForgeExt.kt
@@ -8,6 +8,8 @@ package com.datadog.android.tests.elmyr
 
 import fr.xgouchet.elmyr.Case
 import fr.xgouchet.elmyr.Forge
+import okhttp3.Request
+import okhttp3.Response
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
@@ -65,3 +67,16 @@ fun Forge.aHostName(): String {
 }
 
 fun Forge.anUrlString(): String = aStringMatching(URL_FORGERY_PATTERN)
+
+fun Forge.anOkHttpResponse(
+    request: Request,
+    statusCode: Int,
+    configure: Response.Builder.() -> Unit = {}
+): Response =
+    Response.Builder()
+        .request(request)
+        .protocol(okhttp3.Protocol.HTTP_2)
+        .code(statusCode)
+        .message(anAsciiString())
+        .apply(configure)
+        .build()

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -40,7 +40,6 @@ import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody
@@ -300,8 +299,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
     @Test
     fun `M start and stop RUM Resource W intercept() {successful streaming request}`(
-        @IntForgery(min = 200, max = 300) statusCode: Int,
-        forge: Forge
+        @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         // Given
         val mimeType = forge.anElementFrom(DatadogInterceptor.STREAM_CONTENT_TYPES)
@@ -388,7 +386,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
     @Test
     fun `M remove all GraphQL headers W intercept() {request with GraphQL headers}`(
-        forge: Forge,
         @StringForgery fakeGraphQLName: String,
         @StringForgery fakeGraphQLType: String,
         @StringForgery fakeGraphQLVariables: String,
@@ -396,7 +393,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         @StringForgery fakeUserAgent: String
     ) {
         // Given
-        fakeRequest = forgeRequest(forge) { builder ->
+        fakeRequest = forgeRequest { builder ->
             builder.addHeader("User-Agent", fakeUserAgent)
             builder.addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeGraphQLName.toBase64())
             builder.addHeader(GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER.headerValue, fakeGraphQLType.toBase64())
@@ -424,7 +421,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
     @Test
     fun `M pass GraphQL attributes to RUM W intercept() {request with GraphQL headers}`(
-        forge: Forge,
         @IntForgery(min = 200, max = 300) statusCode: Int,
         @StringForgery fakeGraphQLName: String,
         @StringForgery fakeGraphQLType: String,
@@ -432,7 +428,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         @StringForgery fakeGraphQLPayload: String
     ) {
         // Given
-        fakeRequest = forgeRequest(forge) { builder ->
+        fakeRequest = forgeRequest { builder ->
             builder.addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeGraphQLName.toBase64())
             builder.addHeader(GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER.headerValue, fakeGraphQLType.toBase64())
             builder.addHeader(GraphQLHeaders.DD_GRAPHQL_VARIABLES_HEADER.headerValue, fakeGraphQLVariables.toBase64())
@@ -487,11 +483,10 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
     @Test
     fun `M start and stop RUM Resource W intercept() {successful request, unknown method}`(
         @IntForgery(min = 200, max = 300) statusCode: Int,
-        @StringForgery fakeMethod: String,
-        forge: Forge
+        @StringForgery fakeMethod: String
     ) {
         // Given
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.method(fakeMethod, null)
         }
         stubChain(mockChain, statusCode)
@@ -584,15 +579,9 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         // Given
-        stubChain(mockChain) {
-            Response.Builder()
-                .request(fakeRequest)
-                .protocol(Protocol.HTTP_2)
-                .code(statusCode)
-                .message("HTTP $statusCode")
-                .body("".toResponseBody(fakeMediaType))
-                .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
-                .build()
+        stubChain(mockChain, statusCode) {
+            body("".toResponseBody(fakeMediaType))
+            header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
         }
         val expectedStopAttrs = mapOf(
             RumAttributes.TRACE_ID to fakeTraceIdAsString,
@@ -635,14 +624,9 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         // Given
-        stubChain(mockChain) {
-            Response.Builder()
-                .request(fakeRequest)
-                .protocol(Protocol.HTTP_2)
-                .code(statusCode)
-                .message("HTTP $statusCode")
-                .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
-                .build()
+        stubChain(mockChain, statusCode) {
+            header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
+            body(null)
         }
         val expectedStopAttrs = mapOf(
             RumAttributes.TRACE_ID to fakeTraceIdAsString,
@@ -686,15 +670,8 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
     ) {
         // Given
         whenever(mockTraceSampler.sample(any())).thenReturn(false)
-        stubChain(mockChain) {
-            Response.Builder()
-                .request(fakeRequest)
-                .protocol(Protocol.HTTP_2)
-                .code(statusCode)
-                .message("HTTP $statusCode")
-                .body("".toResponseBody(fakeMediaType))
-                .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
-                .build()
+        stubChain(mockChain, statusCode) {
+            body("".toResponseBody(fakeMediaType))
         }
         // no span -> shouldn't have trace/spans IDs
         val expectedStopAttrs = fakeAttributes
@@ -735,14 +712,9 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
     ) {
         // Given
         whenever(mockTraceSampler.sample(any())).thenReturn(false)
-        stubChain(mockChain) {
-            Response.Builder()
-                .request(fakeRequest)
-                .protocol(Protocol.HTTP_2)
-                .code(statusCode)
-                .message("HTTP $statusCode")
-                .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
-                .build()
+        stubChain(mockChain, statusCode) {
+            header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
+            body(null)
         }
         // no span -> shouldn't have trace/spans IDs
         val expectedStopAttrs = fakeAttributes
@@ -782,26 +754,20 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         // Given
-        stubChain(mockChain) {
-            Response.Builder()
-                .request(fakeRequest)
-                .protocol(Protocol.HTTP_2)
-                .code(statusCode)
-                .message("HTTP $statusCode")
-                .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
-                .body(object : ResponseBody() {
-                    override fun contentType(): MediaType? = fakeMediaType
+        stubChain(mockChain, statusCode) {
+            header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
+            body(object : ResponseBody() {
+                override fun contentType(): MediaType? = fakeMediaType
 
-                    override fun contentLength(): Long = -1L
+                override fun contentLength(): Long = -1L
 
-                    override fun source(): BufferedSource {
-                        val buffer = Buffer()
-                        return spy(buffer).apply {
-                            whenever(request(any())) doThrow IOException()
-                        }
+                override fun source(): BufferedSource {
+                    val buffer = Buffer()
+                    return spy(buffer).apply {
+                        whenever(request(any())) doThrow IOException()
                     }
-                })
-                .build()
+                }
+            })
         }
         val expectedStartAttrs = emptyMap<String, Any?>()
         val expectedStopAttrs = mapOf(
@@ -846,26 +812,20 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
     ) {
         // Given
         whenever(mockTraceSampler.sample(any())).thenReturn(false)
-        stubChain(mockChain) {
-            Response.Builder()
-                .request(fakeRequest)
-                .protocol(Protocol.HTTP_2)
-                .code(statusCode)
-                .message("HTTP $statusCode")
-                .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
-                .body(object : ResponseBody() {
-                    override fun contentType(): MediaType? = fakeMediaType
+        stubChain(mockChain, statusCode) {
+            header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
+            body(object : ResponseBody() {
+                override fun contentType(): MediaType? = fakeMediaType
 
-                    override fun contentLength(): Long = -1
+                override fun contentLength(): Long = -1
 
-                    override fun source(): BufferedSource {
-                        val buffer = Buffer()
-                        return spy(buffer).apply {
-                            whenever(request(any())) doThrow IOException()
-                        }
+                override fun source(): BufferedSource {
+                    val buffer = Buffer()
+                    return spy(buffer).apply {
+                        whenever(request(any())) doThrow IOException()
                     }
-                })
-                .build()
+                }
+            })
         }
         val expectedStartAttrs = emptyMap<String, Any?>()
         // no span -> shouldn't have trace/spans IDs
@@ -1026,12 +986,11 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
     @Test
     fun `M pass request unchanged W intercept() {request without GraphQL headers}`(
-        forge: Forge,
         @StringForgery fakeUserAgent: String,
         @StringForgery fakeCustomHeader: String
     ) {
         // Given
-        fakeRequest = forgeRequest(forge) { builder ->
+        fakeRequest = forgeRequest { builder ->
             builder.addHeader("User-Agent", fakeUserAgent)
             builder.addHeader("Custom-Header", fakeCustomHeader)
         }
@@ -1052,12 +1011,11 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
     @Test
     fun `M remove partial GraphQL headers W intercept() {request with some GraphQL headers}`(
-        forge: Forge,
         @StringForgery fakeGraphQLName: String,
         @StringForgery fakeUserAgent: String
     ) {
         // Given
-        fakeRequest = forgeRequest(forge) { builder ->
+        fakeRequest = forgeRequest { builder ->
             builder.addHeader("User-Agent", fakeUserAgent)
             builder.addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeGraphQLName.toBase64())
         }
@@ -1081,11 +1039,10 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
     @Test
     fun `M remove GraphQL headers with empty values W intercept() {request with empty GraphQL headers}`(
-        forge: Forge,
         @StringForgery fakeUserAgent: String
     ) {
         // Given
-        fakeRequest = forgeRequest(forge) { builder ->
+        fakeRequest = forgeRequest { builder ->
             builder.addHeader("User-Agent", fakeUserAgent)
             builder.addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, "".toBase64())
             builder.addHeader(GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER.headerValue, "".toBase64())
@@ -1114,8 +1071,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
     @Test
     fun `M include header attributes in stopResource W intercept() { trackResourceHeaders enabled }`(
-        @IntForgery(min = 200, max = 300) statusCode: Int,
-        forge: Forge
+        @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         // Given
         resourceHeadersExtractor = ResourceHeadersExtractor.Builder(includeDefaults = false)
@@ -1124,7 +1080,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
 
-        fakeRequest = forgeRequest(forge) { it.addHeader("X-Request-Id", "abc-123") }
+        fakeRequest = forgeRequest { it.addHeader("X-Request-Id", "abc-123") }
         stubChain(mockChain, statusCode)
 
         // When
@@ -1172,8 +1128,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
     @Test
     fun `M capture response headers W intercept() { trackResourceHeaders enabled }`(
-        @IntForgery(min = 200, max = 300) statusCode: Int,
-        forge: Forge
+        @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         // Given
         resourceHeadersExtractor = ResourceHeadersExtractor.Builder(includeDefaults = false)
@@ -1182,7 +1137,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
 
-        fakeRequest = forgeRequest(forge)
+        fakeRequest = forgeRequest()
         fakeResponseBody = forge.anAlphabeticalString()
         fakeMediaType = "text/plain".toMediaType()
         stubChain(mockChain, statusCode) {
@@ -1210,8 +1165,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
     @Test
     fun `M header attributes override provider attributes W intercept() { conflicting keys }`(
-        @IntForgery(min = 200, max = 300) statusCode: Int,
-        forge: Forge
+        @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         // Given
         val fakeProviderAttributes = mapOf(
@@ -1237,7 +1191,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
 
-        fakeRequest = forgeRequest(forge) { builder ->
+        fakeRequest = forgeRequest { builder ->
             fakeActualRequestHeaders.forEach { (key, value) -> builder.addHeader(key, value) }
         }
         stubChain(mockChain, statusCode) {

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
@@ -26,6 +26,7 @@ import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.resource.ResourceId
 import com.datadog.android.tests.config.DatadogSingletonTestConfiguration
+import com.datadog.android.tests.elmyr.anOkHttpResponse
 import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.api.propagation.DatadogPropagation
 import com.datadog.android.trace.api.span.DatadogSpan
@@ -52,7 +53,6 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
@@ -148,10 +148,14 @@ internal class DatadogInterceptorWithoutTracesTest {
 
     @BoolForgery
     var fakeRedacted404Resources: Boolean = true
+
+    lateinit var forge: Forge
+
     // endregion
 
     @BeforeEach
     fun `set up`(forge: Forge) {
+        this.forge = forge
         fakeTraceId = forge.aDatadogTraceId(fakeTraceIdString)
         mockSpanContext = forge.newSpanContextMock(fakeTraceId, fakeSpanId)
         fakeSpan = forge.newSpanMock(mockSpanContext)
@@ -166,7 +170,7 @@ internal class DatadogInterceptorWithoutTracesTest {
         val mediaType = forge.anElementFrom("application", "image", "text", "model") +
             "/" + forge.anAlphabeticalString()
         fakeMediaType = mediaType.toMediaTypeOrNull()
-        fakeRequest = forgeRequest(forge)
+        fakeRequest = forgeRequest()
         testedInterceptor = DatadogInterceptor(
             sdkInstanceName = null,
             tracedHosts = emptyMap(),
@@ -235,11 +239,10 @@ internal class DatadogInterceptorWithoutTracesTest {
     @Test
     fun `M start and stop RUM Resource W intercept() for successful request { unknown method }`(
         @IntForgery(min = 200, max = 300) statusCode: Int,
-        @StringForgery fakeMethod: String,
-        forge: Forge
+        @StringForgery fakeMethod: String
     ) {
         // Given
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.method(fakeMethod, null)
         }
         stubChain(mockChain, statusCode)
@@ -389,18 +392,18 @@ internal class DatadogInterceptorWithoutTracesTest {
     // region Internal
 
     private fun stubChain(chain: Interceptor.Chain, statusCode: Int) {
-        fakeResponse = forgeResponse(statusCode)
+        fakeResponse = forge.anOkHttpResponse(fakeRequest, statusCode) {
+            header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
+            body(fakeResponseBody.toResponseBody(fakeMediaType))
+        }
 
         whenever(chain.request()) doReturn fakeRequest
         whenever(chain.proceed(any())) doReturn fakeResponse
     }
 
-    private fun forgeRequest(
-        forge: Forge,
-        configure: (Request.Builder) -> Unit = {}
-    ): Request {
+    private fun forgeRequest(configure: (Request.Builder) -> Unit = {}): Request {
         val protocol = forge.anElementFrom("http", "https")
-        // RUMM-2900 host is by definition case insensitive,
+        // RUMM-2900 host is by definition case-insensitive,
         // and OkHttp lowercases it when building the request
         val host = forge.aStringMatching(TracingInterceptorTest.HOSTNAME_PATTERN).lowercase(Locale.US)
         val path = forge.anAlphaNumericalString()
@@ -429,17 +432,6 @@ internal class DatadogInterceptorWithoutTracesTest {
 
         configure(builder)
 
-        return builder.build()
-    }
-
-    private fun forgeResponse(statusCode: Int): Response {
-        val builder = Response.Builder()
-            .request(fakeRequest)
-            .protocol(Protocol.HTTP_2)
-            .code(statusCode)
-            .message("HTTP $statusCode")
-            .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
-            .body(fakeResponseBody.toResponseBody(fakeMediaType))
         return builder.build()
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorContextInjectionSampledTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorContextInjectionSampledTest.kt
@@ -14,6 +14,7 @@ import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.okhttp.internal.utils.forge.OkHttpConfigurator
 import com.datadog.android.okhttp.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.tests.config.DatadogSingletonTestConfiguration
+import com.datadog.android.tests.elmyr.anOkHttpResponse
 import com.datadog.android.trace.DeterministicTraceSampler
 import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
@@ -47,7 +48,6 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
@@ -157,10 +157,13 @@ internal class TracingInterceptorContextInjectionSampledTest {
 
     private lateinit var fakeLocalHosts: Map<String, Set<TracingHeaderType>>
 
+    private lateinit var forge: Forge
+
     // endregion
 
     @BeforeEach
     fun `set up`(forge: Forge) {
+        this.forge = forge
         fakeOrigin = forge.anAlphabeticalString()
         fakeTraceId = forge.aDatadogTraceId(fakeTraceIdAsString)
         mockSpanContext = forge.newSpanContextMock(fakeTraceId, fakeSpanId)
@@ -176,8 +179,8 @@ internal class TracingInterceptorContextInjectionSampledTest {
         fakeLocalHosts =
             forge.aMap { forge.aStringMatching(HOSTNAME_PATTERN) to setOf(TracingHeaderType.DATADOG) }
         fakeMediaType = mediaType.toMediaTypeOrNull()
-        fakeUrl = forgeUrlWithQueryParams(forge)
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrlWithQueryParams()
+        fakeRequest = forgeRequest()
         whenever(rumMonitor.mockSdkCore.getFeature(Feature.TRACING_FEATURE_NAME)) doReturn mock()
         whenever(rumMonitor.mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(rumMonitor.mockSdkCore.firstPartyHostResolver) doReturn mockResolver
@@ -204,7 +207,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
             .build()
     }
 
-    fun getExpectedOrigin(): String? {
+    fun getExpectedOrigin(): String {
         return fakeOrigin
     }
 
@@ -259,11 +262,9 @@ internal class TracingInterceptorContextInjectionSampledTest {
     @Test
     fun `M inject tracing header W intercept() {global known host}`(
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -292,10 +293,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
     // region sampled out
 
     @Test
-    fun `M clear all datadog headers W intercept() {global known host + sampled out}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M clear all datadog headers W intercept() {global known host + sampled out}`() {
         // Given
         val datadogContextKeys = listOf(
             TracingInterceptor.DATADOG_TAGS_HEADER,
@@ -320,7 +318,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
             }
             carrier.addHeader(nonDatadogContextKey, nonDatadogContextKeyValue)
         }.whenever(mockPropagation).inject(any<DatadogSpanContext>(), any<Request.Builder>(), any())
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -339,9 +337,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
     }
 
     @Test
-    fun `M clear all b3multi headers W intercept() {global known host + sampled out}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M clear all b3multi headers W intercept() {global known host + sampled out}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -350,7 +346,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
                 TracingHeaderType.B3MULTI
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -367,9 +363,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
     }
 
     @Test
-    fun `M clear all b3 headers W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M clear all b3 headers W intercept() {global known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -378,7 +372,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
                 TracingHeaderType.B3
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -392,9 +386,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
     }
 
     @Test
-    fun `M clear all tracecontext headers W intercept() {global known host + sampled out}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M clear all tracecontext headers W intercept() {global known host + sampled out}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -403,7 +395,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
                 TracingHeaderType.B3
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -422,10 +414,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
     // region sampled in
 
     @Test
-    fun `M inject all datadog headers W intercept() {global known host + sampled in}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject all datadog headers W intercept() {global known host + sampled in}`() {
         // Given
         val datadogContext = listOf(
             TracingInterceptor.DATADOG_TAGS_HEADER,
@@ -442,7 +431,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
                 TracingHeaderType.DATADOG
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         mockPropagation.wheneverInjectCalledPassContextToHeaders(
             datadogContext,
             nonDatadogContextKey,
@@ -467,14 +456,13 @@ internal class TracingInterceptorContextInjectionSampledTest {
     fun `M inject tracing header W intercept() for request with parent span`(
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @IntForgery(min = 200, max = 300) statusCode: Int,
-        forge: Forge
+        @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         val parentSpanContext: DatadogSpanContext = forge.newSpanContextMock<DatadogSpanContext>(samplingPriority = 1)
         val parentSpan: DatadogSpan = forge.newSpanMock(parentSpanContext)
         whenever(parentSpan.context()) doReturn parentSpanContext
         whenever(mockSpanBuilder.withParentContext(parentSpanContext)) doReturn mockSpanBuilder
-        fakeRequest = forgeRequest(forge) { it.tag(DatadogSpan::class.java, parentSpan) }
+        fakeRequest = forgeRequest { it.tag(DatadogSpan::class.java, parentSpan) }
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
@@ -495,8 +483,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
         @IntForgery(min = 200, max = 300) statusCode: Int,
-        @Forgery fakeTraceContext: TraceContext,
-        forge: Forge
+        @Forgery fakeTraceContext: TraceContext
     ) {
         // Given
         val fakeExpectedTraceId = DatadogTraceId.fromHex(fakeTraceContext.traceId)
@@ -505,7 +492,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
             fakeExpectedTraceId,
             fakeExpectedSpanId
         )
-        fakeRequest = forgeRequest(forge) { it.tag(TraceContext::class.java, fakeTraceContext) }
+        fakeRequest = forgeRequest { it.tag(TraceContext::class.java, fakeTraceContext) }
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
         stubChain(mockChain, statusCode)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -540,11 +527,10 @@ internal class TracingInterceptorContextInjectionSampledTest {
     fun `M replace existing tracing header W intercept() {global known host}`(
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.HEXADECIMAL) value: String,
-        @StringForgery(type = StringForgeryType.ALPHABETICAL) previousValue: String,
-        @IntForgery(min = 200, max = 600) statusCode: Int
+        @StringForgery(type = StringForgeryType.ALPHABETICAL) previousValue: String
     ) {
         fakeRequest = fakeRequest.newBuilder().addHeader(key, previousValue).build()
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -561,14 +547,12 @@ internal class TracingInterceptorContextInjectionSampledTest {
     fun `M replace existing tracing header W intercept() {local known host}`(
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @StringForgery(type = StringForgeryType.ALPHABETICAL) previousValue: String,
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHABETICAL) previousValue: String
     ) {
-        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge).newBuilder().addHeader(key, previousValue).build()
+        fakeUrl = forgeUrlWithQueryParams(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest().newBuilder().addHeader(key, previousValue).build()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -581,15 +565,11 @@ internal class TracingInterceptorContextInjectionSampledTest {
     }
 
     @Test
-    fun `M ignore inject exception W intercept() {IllegalStateException}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        @StringForgery message: String,
-        forge: Forge
-    ) {
-        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+    fun `M ignore inject exception W intercept() {IllegalStateException}`(@StringForgery message: String) {
+        fakeUrl = forgeUrlWithQueryParams(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         mockPropagation.wheneverInjectThenThrow(IllegalStateException(message))
 
         val response = testedInterceptor.intercept(mockChain)
@@ -637,14 +617,12 @@ internal class TracingInterceptorContextInjectionSampledTest {
 
     @Test
     fun `M respect sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER,
                 forge.anElementFrom(
@@ -653,7 +631,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
                 )
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -670,20 +648,18 @@ internal class TracingInterceptorContextInjectionSampledTest {
 
     @Test
     fun `M respect b3multi sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3M_SAMPLING_PRIORITY_KEY,
                 DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP.toString()
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -700,21 +676,19 @@ internal class TracingInterceptorContextInjectionSampledTest {
 
     @Test
     fun `M respect b3 sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
 
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3_HEADER_KEY,
                 forge.aStringMatching("[a-f0-9]{32}\\-[a-f0-9]{16}\\-1")
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -731,21 +705,19 @@ internal class TracingInterceptorContextInjectionSampledTest {
 
     @Test
     fun `M respect tracecontext sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
 
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.W3C_TRACEPARENT_KEY,
                 forge.aStringMatching("00-[a-f0-9]{32}\\-[a-f0-9]{16}\\-01")
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -765,10 +737,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
     // region sample out upstream
 
     @Test
-    fun `M respect sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         val datadogContext = listOf(
             TracingInterceptor.DATADOG_TAGS_HEADER,
@@ -790,7 +759,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
                 TracingHeaderType.DATADOG
             )
         )
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER,
                 forge.anElementFrom(
@@ -799,7 +768,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
                 )
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -818,10 +787,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
     }
 
     @Test
-    fun `M respect b3multi sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect b3multi sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -829,13 +795,13 @@ internal class TracingInterceptorContextInjectionSampledTest {
                 TracingHeaderType.B3MULTI
             )
         )
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3M_SAMPLING_PRIORITY_KEY,
                 DatadogTracingConstants.PrioritySampling.SAMPLER_DROP.toString()
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -852,10 +818,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
     }
 
     @Test
-    fun `M respect b3 sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect b3 sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -863,7 +826,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
                 TracingHeaderType.B3
             )
         )
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3_HEADER_KEY,
                 forge.anElementFrom(
@@ -872,7 +835,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
                 )
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -887,10 +850,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
     }
 
     @Test
-    fun `M respect tracecontext sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect tracecontext sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -898,13 +858,13 @@ internal class TracingInterceptorContextInjectionSampledTest {
                 TracingHeaderType.TRACECONTEXT
             )
         )
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.W3C_TRACEPARENT_KEY,
                 forge.aStringMatching("00-[a-f0-9]{32}\\-[a-f0-9]{16}\\-00")
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -941,12 +901,11 @@ internal class TracingInterceptorContextInjectionSampledTest {
     }
 
     @Test
-    fun `M create a span with info W intercept() { resource url with no query paramaters }`(
-        @IntForgery(min = 200, max = 300) statusCode: Int,
-        forge: Forge
+    fun `M create a span with info W intercept() { resource url with no query parameters }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
-        val fakeUrlWithoutQueryParams = forgeUrlWithoutQueryParams(forge)
-        fakeRequest = forgeRequest(forge, fakeUrlWithoutQueryParams)
+        val fakeUrlWithoutQueryParams = forgeUrlWithoutQueryParams()
+        fakeRequest = forgeRequest(fakeUrlWithoutQueryParams)
         whenever(mockResolver.isFirstPartyUrl(fakeUrlWithoutQueryParams.toHttpUrl()))
             .thenReturn(true)
         stubChain(mockChain, statusCode)
@@ -1072,7 +1031,6 @@ internal class TracingInterceptorContextInjectionSampledTest {
 
     @Test
     fun `M create a span with automatic tracer W intercept() if no tracer registered`(
-        forge: Forge,
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         val localSpan: DatadogSpan = forge.newSpanMock(mockSpanContext)
@@ -1106,7 +1064,6 @@ internal class TracingInterceptorContextInjectionSampledTest {
 
     @Test
     fun `M drop automatic tracer W intercept() and global tracer registered`(
-        forge: Forge,
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         val localSpan: DatadogSpan = forge.newSpanMock(mockSpanContext)
@@ -1208,13 +1165,11 @@ internal class TracingInterceptorContextInjectionSampledTest {
     }
 
     @Test
-    fun `M not call the listener W intercept() for completed request { not sampled }`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M not call the listener W intercept() for completed request { not sampled }`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -1354,33 +1309,32 @@ internal class TracingInterceptorContextInjectionSampledTest {
 
     // region Internal
 
-    private fun stubChain(chain: Interceptor.Chain, statusCode: Int) {
-        fakeResponse = forgeResponse(statusCode)
+    private fun stubChain(chain: Interceptor.Chain, statusCode: Int = forge.anInt(min = 200, max = 600)) {
+        fakeResponse = forge.anOkHttpResponse(fakeRequest, statusCode) {
+            header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
+            body(fakeResponseBody.toResponseBody(fakeMediaType))
+        }
 
         whenever(chain.request()) doReturn fakeRequest
         whenever(chain.proceed(any())) doReturn fakeResponse
     }
 
-    private fun forgeUrlWithoutQueryParams(forge: Forge, knownHost: String? = null): String {
+    private fun forgeUrlWithoutQueryParams(knownHost: String? = null): String {
         val protocol = forge.anElementFrom("http", "https")
         val host = knownHost ?: forge.aStringMatching(HOSTNAME_PATTERN)
         val path = forge.anAlphaNumericalString()
         return "$protocol://$host/$path"
     }
 
-    private fun forgeUrlWithQueryParams(forge: Forge, knownHost: String? = null): String {
-        fakeBaseUrl = forgeUrlWithoutQueryParams(forge, knownHost)
+    private fun forgeUrlWithQueryParams(knownHost: String? = null): String {
+        fakeBaseUrl = forgeUrlWithoutQueryParams(knownHost)
         val fakeQueryParams = forge.aList(forge.anInt(min = 0, max = 5)) {
             "${forge.anAlphabeticalString()}=${forge.anAlphabeticalString()}"
         }.joinToString("&")
         return "$fakeBaseUrl?$fakeQueryParams"
     }
 
-    private fun forgeRequest(
-        forge: Forge,
-        url: String = fakeUrl,
-        configure: (Request.Builder) -> Unit = {}
-    ): Request {
+    private fun forgeRequest(url: String = fakeUrl, configure: (Request.Builder) -> Unit = {}): Request {
         val builder = Request.Builder().url(url)
         if (forge.aBool()) {
             fakeMethod = forge.anElementFrom("POST", "PUT", "PATCH")
@@ -1404,17 +1358,6 @@ internal class TracingInterceptorContextInjectionSampledTest {
 
         configure(builder)
 
-        return builder.build()
-    }
-
-    private fun forgeResponse(statusCode: Int): Response {
-        val builder = Response.Builder()
-            .request(fakeRequest)
-            .protocol(Protocol.HTTP_2)
-            .code(statusCode)
-            .message("HTTP $statusCode")
-            .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
-            .body(fakeResponseBody.toResponseBody(fakeMediaType))
         return builder.build()
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.okhttp.utils.assertj.HeadersAssert.Companion.assertThat
 import com.datadog.android.tests.config.DatadogSingletonTestConfiguration
+import com.datadog.android.tests.elmyr.anOkHttpResponse
 import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.api.DatadogTracingConstants
@@ -44,7 +45,6 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
@@ -164,10 +164,13 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     @BoolForgery
     var fakeRedacted404Resources: Boolean = true
 
+    lateinit var forge: Forge
+
     // endregion
 
     @BeforeEach
     open fun `set up`(forge: Forge) {
+        this.forge = forge
         fakeTraceId = forge.aDatadogTraceId(fakeTraceIdAsString)
         fakeOrigin = forge.aNullable { anAlphabeticalString() }
         mockSpanContext = forge.newSpanContextMock(fakeTraceId, fakeSpanId)
@@ -190,8 +193,8 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
                 TracingHeaderType.DATADOG
             )
         }
-        fakeUrl = forgeUrl(forge)
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrl()
+        fakeRequest = forgeRequest()
         whenever(datadogCore.mockInstance.getFeature(Feature.TRACING_FEATURE_NAME)) doReturn mock()
         whenever(datadogCore.mockInstance.internalLogger) doReturn mockInternalLogger
         whenever(datadogCore.mockInstance.firstPartyHostResolver) doReturn mockResolver
@@ -231,11 +234,10 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     @Test
     fun `M inject tracing header W intercept() {global known host}`(
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @IntForgery(min = 200, max = 600) statusCode: Int
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -248,9 +250,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     }
 
     @Test
-    fun `M inject non-tracing header W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M inject non-tracing header W intercept() {global known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -259,7 +259,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
                 TracingHeaderType.DATADOG
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -278,9 +278,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     }
 
     @Test
-    fun `M inject non-tracing b3multi header W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M inject non-tracing b3multi header W intercept() {global known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -289,7 +287,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
                 TracingHeaderType.B3MULTI
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -306,9 +304,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     }
 
     @Test
-    fun `M inject non-tracing b3 header W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M inject non-tracing b3 header W intercept() {global known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -317,7 +313,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
                 TracingHeaderType.B3
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -332,9 +328,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     }
 
     @Test
-    fun `M inject non-tracing tracecontext header W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M inject non-tracing tracecontext header W intercept() {global known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -343,7 +337,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
                 TracingHeaderType.TRACECONTEXT
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -369,14 +363,12 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     @Test
     fun `M inject tracing header W intercept() {local known host}`(
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
-        fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrl(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -389,16 +381,13 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     }
 
     @Test
-    fun `M inject non-tracing header W intercept() {local known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject non-tracing header W intercept() {local known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
-        fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrl(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -417,10 +406,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     }
 
     @Test
-    fun `M inject non-tracing b3multi header W intercept() {local known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject non-tracing b3multi header W intercept() {local known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
@@ -429,10 +415,10 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             )
         }
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
-        fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrl(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -449,10 +435,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     }
 
     @Test
-    fun `M inject non-tracing b3 header W intercept() {local known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject non-tracing b3 header W intercept() {local known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
@@ -461,10 +444,10 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             )
         }
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
-        fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrl(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -479,10 +462,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     }
 
     @Test
-    fun `M inject non-tracing tracecontext header W intercept() {local known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject non-tracing tracecontext header W intercept() {local known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
@@ -491,10 +471,10 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             )
         }
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
-        fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrl(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -521,14 +501,13 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     fun `M inject tracing header W intercept() for request with parent span`(
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @IntForgery(min = 200, max = 300) statusCode: Int,
-        forge: Forge
+        @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         val parentSpanContext: DatadogSpanContext = forge.newSpanContextMock<DatadogSpanContext>(samplingPriority = 1)
         val parentSpan: DatadogSpan = forge.newSpanMock(parentSpanContext)
         whenever(parentSpan.context()) doReturn parentSpanContext
         whenever(mockSpanBuilder.withParentContext(parentSpanContext)) doReturn mockSpanBuilder
-        fakeRequest = forgeRequest(forge) { it.tag(DatadogSpan::class.java, parentSpan) }
+        fakeRequest = forgeRequest { it.tag(DatadogSpan::class.java, parentSpan) }
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(fakeUrl.toHttpUrl())
         stubChain(mockChain, statusCode)
@@ -548,15 +527,14 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     fun `M update header with parent context W intercept() for request with tracing headers`(
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @IntForgery(min = 200, max = 300) statusCode: Int,
-        forge: Forge
+        @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         val parentSpanContext: DatadogSpanContext = mock()
         whenever(mockSpanBuilder.withParentContext(any<DatadogSpanContext>())) doReturn mockSpanBuilder
         whenever(mockPropagation.extract(any<Request>(), any())) doReturn parentSpanContext
         whenever(mockPropagationHelper.isExtractedContext(parentSpanContext)) doReturn true
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        fakeRequest = forgeRequest(forge)
+        fakeRequest = forgeRequest()
         doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(fakeUrl.toHttpUrl())
         stubChain(mockChain, statusCode)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
@@ -574,14 +552,12 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
     @Test
     fun `M respect sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER,
                 forge.anElementFrom(
@@ -590,7 +566,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
                 )
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -607,20 +583,18 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
     @Test
     fun `M respect b3multi sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3M_SAMPLING_PRIORITY_KEY,
                 DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP.toString()
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -637,20 +611,18 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
     @Test
     fun `M respect b3 sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3_HEADER_KEY,
                 forge.aStringMatching("[a-f0-9]{32}\\-[a-f0-9]{16}\\-1")
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -667,20 +639,18 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
     @Test
     fun `M respect tracecontext sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.W3C_TRACEPARENT_KEY,
                 forge.aStringMatching("00-[a-f0-9]{32}\\-[a-f0-9]{16}\\-01")
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -696,10 +666,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     }
 
     @Test
-    fun `M respect sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -708,7 +675,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             )
         )
 
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER,
                 forge.anElementFrom(
@@ -717,7 +684,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
                 )
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -737,10 +704,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     }
 
     @Test
-    fun `M respect b3multi sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect b3multi sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -749,13 +713,13 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             )
         )
 
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3M_SAMPLING_PRIORITY_KEY,
                 DatadogTracingConstants.PrioritySampling.SAMPLER_DROP.toString()
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -773,10 +737,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     }
 
     @Test
-    fun `M respect b3 sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect b3 sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -785,7 +746,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             )
         )
 
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3_HEADER_KEY,
                 forge.anElementFrom(
@@ -794,7 +755,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
                 )
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -810,10 +771,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     }
 
     @Test
-    fun `M respect tracecontext sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect tracecontext sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -822,13 +780,13 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             )
         )
 
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.W3C_TRACEPARENT_KEY,
                 forge.aStringMatching("00-[a-f0-9]{32}\\-[a-f0-9]{16}\\-00")
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -853,13 +811,11 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     }
 
     @Test
-    fun `M not create a span W intercept() { not sampled }`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M not create a span W intercept() { not sampled }`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -977,7 +933,6 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
     @Test
     fun `M create a span with automatic tracer W intercept() if no tracer registered`(
-        forge: Forge,
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         val localSpan: DatadogSpan = forge.newSpanMock()
@@ -1009,7 +964,6 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
     @Test
     fun `M drop automatic tracer W intercept() and global tracer registered`(
-        forge: Forge,
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         val localSpan: DatadogSpan = forge.newSpanMock(mockSpanContext)
@@ -1107,13 +1061,11 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     }
 
     @Test
-    fun `M not call the listener W intercept() for completed request { not sampled }`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M not call the listener W intercept() for completed request { not sampled }`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -1173,10 +1125,9 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
     @Test
     fun `M do nothing W intercept() for request with unknown host`(
-        @IntForgery(min = 200, max = 300) statusCode: Int,
-        forge: Forge
+        @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
-        fakeRequest = forgeRequest(forge)
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
@@ -1257,33 +1208,25 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
     // region Internal
 
-    private fun stubChain(chain: Interceptor.Chain, statusCode: Int) {
-        return stubChain(chain) { forgeResponse(statusCode) }
-    }
-
-    private fun stubChain(
-        chain: Interceptor.Chain,
-        responseBuilder: () -> Response
-    ) {
-        fakeResponse = responseBuilder()
+    private fun stubChain(chain: Interceptor.Chain, statusCode: Int = forge.anInt(min = 200, max = 600)) {
+        fakeResponse = forge.anOkHttpResponse(fakeRequest, statusCode) {
+            body(fakeResponseBody.toResponseBody(fakeMediaType))
+        }
 
         whenever(chain.request()) doReturn fakeRequest
         whenever(chain.proceed(any())) doReturn fakeResponse
     }
 
-    private fun forgeUrl(forge: Forge, knownHost: String? = null): String {
+    private fun forgeUrl(knownHost: String? = null): String {
         val protocol = forge.anElementFrom("http", "https")
         val host = knownHost ?: forge.aStringMatching(TracingInterceptorTest.HOSTNAME_PATTERN)
         val path = forge.anAlphaNumericalString()
-        // RUMM-2900 host is by definition case insensitive,
+        // RUMM-2900 host is by definition case-insensitive,
         // and OkHttp lowercases it when building the request
         return "$protocol://${host.lowercase(Locale.US)}/$path"
     }
 
-    private fun forgeRequest(
-        forge: Forge,
-        configure: (Request.Builder) -> Unit = {}
-    ): Request {
+    private fun forgeRequest(configure: (Request.Builder) -> Unit = {}): Request {
         val builder = Request.Builder().url(fakeUrl)
         if (forge.aBool()) {
             fakeMethod = forge.anElementFrom("POST", "PUT", "PATCH")
@@ -1307,19 +1250,6 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
         configure(builder)
 
-        return builder.build()
-    }
-
-    private fun forgeResponse(statusCode: Int): Response {
-        val builder = Response.Builder()
-            .request(fakeRequest)
-            .protocol(Protocol.HTTP_2)
-            .code(statusCode)
-            .message("HTTP $statusCode")
-            .body(fakeResponseBody.toResponseBody(fakeMediaType))
-        if (fakeMediaType != null) {
-            builder.header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
-        }
         return builder.build()
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.okhttp.utils.assertj.HeadersAssert.Companion.assertThat
 import com.datadog.android.tests.config.DatadogSingletonTestConfiguration
+import com.datadog.android.tests.elmyr.anOkHttpResponse
 import com.datadog.android.trace.DeterministicTraceSampler
 import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
@@ -45,7 +46,6 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
@@ -159,10 +159,13 @@ internal open class TracingInterceptorNonDdTracerTest {
     @BoolForgery
     var fakeRedacted404Resources: Boolean = true
 
+    lateinit var forge: Forge
+
     // endregion
 
     @BeforeEach
     fun `set up`(forge: Forge) {
+        this.forge = forge
         fakeTraceId = forge.aDatadogTraceId(fakeTraceIdAsString)
         fakeOrigin = forge.aNullable { anAlphabeticalString() }
         mockSpanContext = forge.newSpanContextMock(fakeTraceId, fakeSpanId)
@@ -181,8 +184,8 @@ internal open class TracingInterceptorNonDdTracerTest {
             )
         }
         fakeMediaType = mediaType.toMediaTypeOrNull()
-        fakeUrl = forgeUrlWithQueryParams(forge)
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrlWithQueryParams()
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(datadogCore.mockInstance.getFeature(Feature.TRACING_FEATURE_NAME)) doReturn mock()
         whenever(datadogCore.mockInstance.internalLogger) doReturn mockInternalLogger
@@ -255,10 +258,9 @@ internal open class TracingInterceptorNonDdTracerTest {
     @Test
     fun `M inject tracing header W intercept() {global known host}`(
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @IntForgery(min = 200, max = 600) statusCode: Int
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -272,9 +274,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     }
 
     @Test
-    fun `M inject non-tracing header W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M inject non-tracing header W intercept() {global known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -283,7 +283,7 @@ internal open class TracingInterceptorNonDdTracerTest {
                 TracingHeaderType.DATADOG
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -301,9 +301,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     }
 
     @Test
-    fun `M inject non-tracing b3multi header W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M inject non-tracing b3multi header W intercept() {global known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -312,7 +310,7 @@ internal open class TracingInterceptorNonDdTracerTest {
                 TracingHeaderType.B3MULTI
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -329,9 +327,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     }
 
     @Test
-    fun `M inject non-tracing b3 header W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M inject non-tracing b3 header W intercept() {global known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -340,7 +336,7 @@ internal open class TracingInterceptorNonDdTracerTest {
                 TracingHeaderType.B3
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -355,9 +351,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     }
 
     @Test
-    fun `M inject non-tracing tracecontext header W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M inject non-tracing tracecontext header W intercept() {global known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -366,7 +360,7 @@ internal open class TracingInterceptorNonDdTracerTest {
                 TracingHeaderType.TRACECONTEXT
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -392,14 +386,12 @@ internal open class TracingInterceptorNonDdTracerTest {
     @Test
     fun `M inject tracing header W intercept() {local known host}`(
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
-        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrlWithQueryParams(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -412,16 +404,13 @@ internal open class TracingInterceptorNonDdTracerTest {
     }
 
     @Test
-    fun `M inject non-tracing header W intercept() {local known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject non-tracing header W intercept() {local known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
-        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrlWithQueryParams(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -440,10 +429,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     }
 
     @Test
-    fun `M inject non-tracing b3multi header W intercept() {local known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject non-tracing b3multi header W intercept() {local known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
@@ -452,10 +438,10 @@ internal open class TracingInterceptorNonDdTracerTest {
             )
         }
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
-        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrlWithQueryParams(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -472,10 +458,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     }
 
     @Test
-    fun `M inject non-tracing b3 header W intercept() {local known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject non-tracing b3 header W intercept() {local known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
@@ -484,10 +467,10 @@ internal open class TracingInterceptorNonDdTracerTest {
             )
         }
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
-        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrlWithQueryParams(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -502,10 +485,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     }
 
     @Test
-    fun `M inject non-tracing tracecontext header W intercept() {local known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject non-tracing tracecontext header W intercept() {local known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
@@ -518,10 +498,10 @@ internal open class TracingInterceptorNonDdTracerTest {
             localTracerFactory = { _, _ -> mockLocalTracer },
             globalTracerProvider = { mockTracer }
         )
-        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrlWithQueryParams(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -548,14 +528,13 @@ internal open class TracingInterceptorNonDdTracerTest {
     fun `M inject tracing header W intercept() for request with parent span`(
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @IntForgery(min = 200, max = 300) statusCode: Int,
-        forge: Forge
+        @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         val parentSpanContext: DatadogSpanContext = forge.newSpanContextMock<DatadogSpanContext>(samplingPriority = 1)
         val parentSpan: DatadogSpan = forge.newSpanMock(parentSpanContext)
         whenever(parentSpan.context()) doReturn parentSpanContext
         whenever(mockSpanBuilder.withParentContext(parentSpanContext)) doReturn mockSpanBuilder
-        fakeRequest = forgeRequest(forge) { it.tag(DatadogSpan::class.java, parentSpan) }
+        fakeRequest = forgeRequest { it.tag(DatadogSpan::class.java, parentSpan) }
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
@@ -574,11 +553,10 @@ internal open class TracingInterceptorNonDdTracerTest {
     fun `M replace existing tracing header W intercept() {global known host}`(
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.HEXADECIMAL) value: String,
-        @StringForgery(type = StringForgeryType.ALPHABETICAL) previousValue: String,
-        @IntForgery(min = 200, max = 600) statusCode: Int
+        @StringForgery(type = StringForgeryType.ALPHABETICAL) previousValue: String
     ) {
         fakeRequest = fakeRequest.newBuilder().addHeader(key, previousValue).build()
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -595,14 +573,12 @@ internal open class TracingInterceptorNonDdTracerTest {
     fun `M replace existing tracing header W intercept() {local known host}`(
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @StringForgery(type = StringForgeryType.ALPHABETICAL) previousValue: String,
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHABETICAL) previousValue: String
     ) {
-        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge).newBuilder().addHeader(key, previousValue).build()
+        fakeUrl = forgeUrlWithQueryParams(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest().newBuilder().addHeader(key, previousValue).build()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -616,14 +592,12 @@ internal open class TracingInterceptorNonDdTracerTest {
 
     @Test
     fun `M ignore inject exception W intercept() {IllegalStateException}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        @StringForgery message: String,
-        forge: Forge
+        @StringForgery message: String
     ) {
-        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrlWithQueryParams(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         doThrow(IllegalStateException(message)).whenever(mockPropagation)
             .inject(any<DatadogSpanContext>(), any<Request>(), any())
 
@@ -664,10 +638,8 @@ internal open class TracingInterceptorNonDdTracerTest {
 
     @Test
     fun `M respect sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -676,7 +648,7 @@ internal open class TracingInterceptorNonDdTracerTest {
                 TracingHeaderType.DATADOG
             )
         )
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER,
                 forge.anElementFrom(
@@ -685,7 +657,7 @@ internal open class TracingInterceptorNonDdTracerTest {
                 )
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -702,10 +674,8 @@ internal open class TracingInterceptorNonDdTracerTest {
 
     @Test
     fun `M respect b3multi sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -714,13 +684,13 @@ internal open class TracingInterceptorNonDdTracerTest {
                 TracingHeaderType.B3MULTI
             )
         )
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3M_SAMPLING_PRIORITY_KEY,
                 DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP.toString()
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -737,10 +707,8 @@ internal open class TracingInterceptorNonDdTracerTest {
 
     @Test
     fun `M respect b3 sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -749,13 +717,13 @@ internal open class TracingInterceptorNonDdTracerTest {
                 TracingHeaderType.B3
             )
         )
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3_HEADER_KEY,
                 forge.aStringMatching("[a-f0-9]{32}\\-[a-f0-9]{16}\\-1")
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -772,10 +740,8 @@ internal open class TracingInterceptorNonDdTracerTest {
 
     @Test
     fun `M respect tracecontext sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -784,13 +750,13 @@ internal open class TracingInterceptorNonDdTracerTest {
                 TracingHeaderType.TRACECONTEXT
             )
         )
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.W3C_TRACEPARENT_KEY,
                 forge.aStringMatching("00-[a-f0-9]{32}\\-[a-f0-9]{16}\\-01")
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -806,10 +772,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     }
 
     @Test
-    fun `M respect sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -818,7 +781,7 @@ internal open class TracingInterceptorNonDdTracerTest {
             )
         )
 
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER,
                 forge.anElementFrom(
@@ -827,7 +790,7 @@ internal open class TracingInterceptorNonDdTracerTest {
                 )
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -847,10 +810,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     }
 
     @Test
-    fun `M respect b3multi sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect b3multi sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -859,13 +819,13 @@ internal open class TracingInterceptorNonDdTracerTest {
             )
         )
 
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3M_SAMPLING_PRIORITY_KEY,
                 DatadogTracingConstants.PrioritySampling.SAMPLER_DROP.toString()
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -883,10 +843,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     }
 
     @Test
-    fun `M respect b3 sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect b3 sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -895,7 +852,7 @@ internal open class TracingInterceptorNonDdTracerTest {
             )
         )
 
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3_HEADER_KEY,
                 forge.anElementFrom(
@@ -904,7 +861,7 @@ internal open class TracingInterceptorNonDdTracerTest {
                 )
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -920,10 +877,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     }
 
     @Test
-    fun `M respect tracecontext sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect tracecontext sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -932,13 +886,13 @@ internal open class TracingInterceptorNonDdTracerTest {
             )
         )
 
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.W3C_TRACEPARENT_KEY,
                 forge.aStringMatching("00-[a-f0-9]{32}\\-[a-f0-9]{16}\\-00")
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -980,12 +934,11 @@ internal open class TracingInterceptorNonDdTracerTest {
     }
 
     @Test
-    fun `M create a span with info W intercept() { resource url with no query paramaters }`(
-        @IntForgery(min = 200, max = 300) statusCode: Int,
-        forge: Forge
+    fun `M create a span with info W intercept() { resource url with no query parameters }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
-        val fakeUrlWithoutQueryParams = forgeUrlWithoutQueryParams(forge)
-        fakeRequest = forgeRequest(forge, fakeUrlWithoutQueryParams)
+        val fakeUrlWithoutQueryParams = forgeUrlWithoutQueryParams()
+        fakeRequest = forgeRequest(fakeUrlWithoutQueryParams)
         whenever(mockResolver.isFirstPartyUrl(fakeUrlWithoutQueryParams.toHttpUrl()))
             .thenReturn(true)
         stubChain(mockChain, statusCode)
@@ -1093,7 +1046,6 @@ internal open class TracingInterceptorNonDdTracerTest {
 
     @Test
     fun `M create a span with automatic tracer W intercept() if no tracer registered`(
-        forge: Forge,
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         val localSpan: DatadogSpan = forge.newSpanMock(mockSpanContext)
@@ -1125,7 +1077,6 @@ internal open class TracingInterceptorNonDdTracerTest {
 
     @Test
     fun `M drop automatic tracer W intercept() and global tracer registered`(
-        forge: Forge,
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         val localSpan: DatadogSpan = forge.newSpanMock(mockSpanContext)
@@ -1220,13 +1171,11 @@ internal open class TracingInterceptorNonDdTracerTest {
     }
 
     @Test
-    fun `M not call the listener W intercept() for completed request { not sampled }`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M not call the listener W intercept() for completed request { not sampled }`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -1365,33 +1314,32 @@ internal open class TracingInterceptorNonDdTracerTest {
 
     // region Internal
 
-    private fun stubChain(chain: Interceptor.Chain, statusCode: Int) {
-        fakeResponse = forgeResponse(statusCode)
+    private fun stubChain(chain: Interceptor.Chain, statusCode: Int = forge.anInt(min = 200, max = 600)) {
+        fakeResponse = forge.anOkHttpResponse(fakeRequest, statusCode) {
+            header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
+            body(fakeResponseBody.toResponseBody(fakeMediaType))
+        }
 
         whenever(chain.request()) doReturn fakeRequest
         whenever(chain.proceed(any())) doReturn fakeResponse
     }
 
-    private fun forgeUrlWithoutQueryParams(forge: Forge, knownHost: String? = null): String {
+    private fun forgeUrlWithoutQueryParams(knownHost: String? = null): String {
         val protocol = forge.anElementFrom("http", "https")
         val host = knownHost ?: forge.aStringMatching(HOSTNAME_PATTERN)
         val path = forge.anAlphaNumericalString()
         return "$protocol://$host/$path"
     }
 
-    private fun forgeUrlWithQueryParams(forge: Forge, knownHost: String? = null): String {
-        fakeBaseUrl = forgeUrlWithoutQueryParams(forge, knownHost)
+    private fun forgeUrlWithQueryParams(knownHost: String? = null): String {
+        fakeBaseUrl = forgeUrlWithoutQueryParams(knownHost)
         val fakeQueryParams = forge.aList(forge.anInt(min = 0, max = 5)) {
             "${forge.anAlphabeticalString()}=${forge.anAlphabeticalString()}"
         }.joinToString("&")
         return "$fakeBaseUrl?$fakeQueryParams"
     }
 
-    private fun forgeRequest(
-        forge: Forge,
-        url: String = fakeUrl,
-        configure: (Request.Builder) -> Unit = {}
-    ): Request {
+    private fun forgeRequest(url: String = fakeUrl, configure: (Request.Builder) -> Unit = {}): Request {
         val builder = Request.Builder().url(url)
         if (forge.aBool()) {
             fakeMethod = forge.anElementFrom("POST", "PUT", "PATCH")
@@ -1415,17 +1363,6 @@ internal open class TracingInterceptorNonDdTracerTest {
 
         configure(builder)
 
-        return builder.build()
-    }
-
-    private fun forgeResponse(statusCode: Int): Response {
-        val builder = Response.Builder()
-            .request(fakeRequest)
-            .protocol(Protocol.HTTP_2)
-            .code(statusCode)
-            .message("HTTP $statusCode")
-            .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
-            .body(fakeResponseBody.toResponseBody(fakeMediaType))
         return builder.build()
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.okhttp.utils.assertj.HeadersAssert.Companion.assertTh
 import com.datadog.android.okhttp.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.tests.config.DatadogSingletonTestConfiguration
+import com.datadog.android.tests.elmyr.anOkHttpResponse
 import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.api.DatadogTracingConstants
@@ -46,7 +47,6 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
@@ -161,10 +161,13 @@ internal open class TracingInterceptorNotSendingSpanTest {
     @BoolForgery
     var fakeRedacted404Resources: Boolean = true
 
+    lateinit var forge: Forge
+
     // endregion
 
     @BeforeEach
     open fun `set up`(forge: Forge) {
+        this.forge = forge
         fakeTraceId = forge.aDatadogTraceId(fakeTraceIdAsString)
         fakeOrigin = forge.aNullable { anAlphabeticalString() }
         mockSpanContext = forge.newSpanContextMock(fakeTraceId, fakeSpanId)
@@ -187,8 +190,8 @@ internal open class TracingInterceptorNotSendingSpanTest {
                 TracingHeaderType.DATADOG
             )
         }
-        fakeUrl = forgeUrl(forge)
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrl()
+        fakeRequest = forgeRequest()
         whenever(rumMonitor.mockSdkCore.getFeature(Feature.TRACING_FEATURE_NAME)) doReturn mock()
         whenever(rumMonitor.mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(rumMonitor.mockSdkCore.firstPartyHostResolver) doReturn mockResolver
@@ -232,9 +235,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     @Test
     fun `M inject tracing header W intercept() {global known host}`(
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -249,7 +250,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
                 )
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -262,9 +263,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     }
 
     @Test
-    fun `M inject non-tracing header W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M inject non-tracing header W intercept() {global known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -273,7 +272,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
                 TracingHeaderType.DATADOG
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -292,9 +291,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     }
 
     @Test
-    fun `M inject non-tracing b3mult header W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M inject non-tracing b3mult header W intercept() {global known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -303,7 +300,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
                 TracingHeaderType.B3MULTI
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -320,9 +317,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     }
 
     @Test
-    fun `M inject non-tracing b3 header W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M inject non-tracing b3 header W intercept() {global known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -331,7 +326,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
                 TracingHeaderType.B3
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -346,9 +341,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     }
 
     @Test
-    fun `M inject non-tracing tracecontext header W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M inject non-tracing tracecontext header W intercept() {global known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -357,7 +350,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
                 TracingHeaderType.TRACECONTEXT
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -381,9 +374,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     }
 
     @Test
-    fun `M inject all non-tracing header W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M inject all non-tracing header W intercept() {global known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -395,7 +386,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
                 TracingHeaderType.TRACECONTEXT
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -433,14 +424,12 @@ internal open class TracingInterceptorNotSendingSpanTest {
     @Test
     fun `M inject tracing header W intercept() {local known host}`(
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
-        fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrl(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -453,16 +442,13 @@ internal open class TracingInterceptorNotSendingSpanTest {
     }
 
     @Test
-    fun `M inject non-tracing header W intercept() {local known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject non-tracing header W intercept() {local known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
-        fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrl(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -481,10 +467,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     }
 
     @Test
-    fun `M inject non-tracing b3multi header W intercept() {local known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject non-tracing b3multi header W intercept() {local known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
@@ -493,10 +476,10 @@ internal open class TracingInterceptorNotSendingSpanTest {
             )
         }
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
-        fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrl(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -513,10 +496,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     }
 
     @Test
-    fun `M inject non-tracing b3 header W intercept() {local known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject non-tracing b3 header W intercept() {local known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
@@ -525,10 +505,10 @@ internal open class TracingInterceptorNotSendingSpanTest {
             )
         }
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
-        fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrl(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -543,10 +523,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     }
 
     @Test
-    fun `M inject non-tracing tracecontext header W intercept() {local known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject non-tracing tracecontext header W intercept() {local known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
@@ -555,10 +532,10 @@ internal open class TracingInterceptorNotSendingSpanTest {
             )
         }
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
-        fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrl(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -585,13 +562,12 @@ internal open class TracingInterceptorNotSendingSpanTest {
     fun `M inject tracing header W intercept() for request with parent span`(
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @IntForgery(min = 200, max = 300) statusCode: Int,
-        forge: Forge
+        @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         val parentSpanContext: DatadogSpanContext = forge.newSpanContextMock<DatadogSpanContext>(samplingPriority = 1)
         val parentSpan: DatadogSpan = forge.newSpanMock(parentSpanContext)
         whenever(mockSpanBuilder.withParentContext(parentSpanContext)) doReturn mockSpanBuilder
-        fakeRequest = forgeRequest(forge) { it.tag(DatadogSpan::class.java, parentSpan) }
+        fakeRequest = forgeRequest { it.tag(DatadogSpan::class.java, parentSpan) }
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(fakeUrl.toHttpUrl())
         stubChain(mockChain, statusCode)
@@ -612,15 +588,14 @@ internal open class TracingInterceptorNotSendingSpanTest {
     fun `M update header with parent context W intercept() for request with tracing headers`(
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @IntForgery(min = 200, max = 300) statusCode: Int,
-        forge: Forge
+        @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         val parentSpanContext: DatadogSpanContext = mock()
         whenever(mockPropagation.extract(any<Request>(), any())) doReturn parentSpanContext
         whenever(mockPropagationHelper.isExtractedContext(parentSpanContext)) doReturn true
         whenever(mockSpanBuilder.withParentContext(any<DatadogSpanContext>())) doReturn mockSpanBuilder
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        fakeRequest = forgeRequest(forge)
+        fakeRequest = forgeRequest()
         doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(fakeUrl.toHttpUrl())
         stubChain(mockChain, statusCode)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
@@ -640,14 +615,12 @@ internal open class TracingInterceptorNotSendingSpanTest {
 
     @Test
     fun `M respect sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER,
                 forge.anElementFrom(
@@ -656,7 +629,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
                 )
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -673,20 +646,18 @@ internal open class TracingInterceptorNotSendingSpanTest {
 
     @Test
     fun `M respect b3multi sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3M_SAMPLING_PRIORITY_KEY,
                 DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP.toString()
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -703,20 +674,18 @@ internal open class TracingInterceptorNotSendingSpanTest {
 
     @Test
     fun `M respect b3 sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3_HEADER_KEY,
                 forge.aStringMatching("[a-f0-9]{32}\\-[a-f0-9]{16}\\-1")
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -733,20 +702,18 @@ internal open class TracingInterceptorNotSendingSpanTest {
 
     @Test
     fun `M respect tracecontext sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.W3C_TRACEPARENT_KEY,
                 forge.aStringMatching("00-[a-f0-9]{32}\\-[a-f0-9]{16}\\-01")
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -762,10 +729,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     }
 
     @Test
-    fun `M respect sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -773,7 +737,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
                 TracingHeaderType.DATADOG
             )
         )
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER,
                 forge.anElementFrom(
@@ -782,7 +746,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
                 )
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -802,23 +766,20 @@ internal open class TracingInterceptorNotSendingSpanTest {
     }
 
     @Test
-    fun `M respect b3multi sampling decision W intercept1`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect b3multi sampling decision W intercept1`() {
         // Given
         val localSpanBuilder = forge.newSpanBuilderMock()
         whenever(mockLocalTracer.buildSpan(any<CharSequence>())).thenReturn(localSpanBuilder)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(setOf(TracingHeaderType.B3MULTI))
 
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3M_SAMPLING_PRIORITY_KEY,
                 DatadogTracingConstants.PrioritySampling.SAMPLER_DROP.toString()
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -835,10 +796,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     }
 
     @Test
-    fun `M respect b3 sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect b3 sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -846,7 +804,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
                 TracingHeaderType.B3
             )
         )
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3_HEADER_KEY,
                 forge.anElementFrom(
@@ -855,7 +813,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
                 )
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -871,10 +829,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     }
 
     @Test
-    fun `M respect tracecontext sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect tracecontext sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -882,13 +837,13 @@ internal open class TracingInterceptorNotSendingSpanTest {
                 TracingHeaderType.TRACECONTEXT
             )
         )
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.W3C_TRACEPARENT_KEY,
                 forge.aStringMatching("00-[a-f0-9]{32}\\-[a-f0-9]{16}\\-00")
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -1040,7 +995,6 @@ internal open class TracingInterceptorNotSendingSpanTest {
 
     @Test
     fun `M create a span with automatic tracer W intercept() if no tracer registered`(
-        forge: Forge,
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         val localSpan: DatadogSpan = forge.newSpanMock(mockSpanContext)
@@ -1075,7 +1029,6 @@ internal open class TracingInterceptorNotSendingSpanTest {
 
     @Test
     fun `M drop automatic tracer W intercept() and global tracer registered`(
-        forge: Forge,
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         val localSpan: DatadogSpan = forge.newSpanMock(mockSpanContext)
@@ -1183,13 +1136,11 @@ internal open class TracingInterceptorNotSendingSpanTest {
     }
 
     @Test
-    fun `M not call the listener W intercept() for completed request { not sampled }`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M not call the listener W intercept() for completed request { not sampled }`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -1252,10 +1203,9 @@ internal open class TracingInterceptorNotSendingSpanTest {
 
     @Test
     fun `M do nothing W intercept() for request with unknown host`(
-        @IntForgery(min = 200, max = 300) statusCode: Int,
-        forge: Forge
+        @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
-        fakeRequest = forgeRequest(forge)
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
@@ -1293,7 +1243,6 @@ internal open class TracingInterceptorNotSendingSpanTest {
 
     @Test
     fun `M create only one local tracer W intercept() called from multiple threads`(
-        forge: Forge,
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         // Given
@@ -1335,35 +1284,31 @@ internal open class TracingInterceptorNotSendingSpanTest {
 
     internal fun stubChain(
         chain: Interceptor.Chain,
-        statusCode: Int,
-        responseBuilder: Response.Builder.() -> Unit = {}
+        statusCode: Int = forge.anInt(min = 200, max = 600),
+        configure: Response.Builder.() -> Unit = {}
     ) {
-        return stubChain(chain) { forgeResponse(statusCode, responseBuilder) }
-    }
-
-    internal fun stubChain(
-        chain: Interceptor.Chain,
-        responseBuilder: () -> Response
-    ) {
-        fakeResponse = responseBuilder()
+        fakeResponse = forge.anOkHttpResponse(fakeRequest, statusCode) {
+            body(fakeResponseBody.toResponseBody(fakeMediaType))
+            if (fakeMediaType != null) {
+                header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
+            }
+            configure()
+        }
 
         whenever(chain.request()) doReturn fakeRequest
         whenever(chain.proceed(any())) doReturn fakeResponse
     }
 
-    private fun forgeUrl(forge: Forge, knownHost: String? = null): String {
+    private fun forgeUrl(knownHost: String? = null): String {
         val protocol = forge.anElementFrom("http", "https")
         val host = knownHost ?: forge.aStringMatching(TracingInterceptorTest.HOSTNAME_PATTERN)
         val path = forge.anAlphaNumericalString()
-        // RUMM-2900 host is by definition case insensitive,
+        // RUMM-2900 host is by definition case-insensitive,
         // and OkHttp lowercases it when building the request
         return "$protocol://${host.lowercase(Locale.US)}/$path"
     }
 
-    protected fun forgeRequest(
-        forge: Forge,
-        configure: (Request.Builder) -> Unit = {}
-    ): Request {
+    protected fun forgeRequest(configure: (Request.Builder) -> Unit = {}): Request {
         val builder = Request.Builder().url(fakeUrl)
         if (forge.aBool()) {
             fakeMethod = forge.anElementFrom(
@@ -1388,20 +1333,6 @@ internal open class TracingInterceptorNotSendingSpanTest {
 
         configure(builder)
 
-        return builder.build()
-    }
-
-    private fun forgeResponse(statusCode: Int, additionalConfig: Response.Builder.() -> Unit = {}): Response {
-        val builder = Response.Builder()
-            .request(fakeRequest)
-            .protocol(Protocol.HTTP_2)
-            .code(statusCode)
-            .message("HTTP $statusCode")
-            .body(fakeResponseBody.toResponseBody(fakeMediaType))
-        if (fakeMediaType != null) {
-            builder.header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
-        }
-        builder.additionalConfig()
         return builder.build()
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
@@ -20,6 +20,7 @@ import com.datadog.android.okhttp.trace.TracingInterceptor.Companion.OKHTTP_INTE
 import com.datadog.android.okhttp.utils.assertj.HeadersAssert.Companion.assertThat
 import com.datadog.android.okhttp.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.tests.config.DatadogSingletonTestConfiguration
+import com.datadog.android.tests.elmyr.anOkHttpResponse
 import com.datadog.android.trace.DeterministicTraceSampler
 import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
@@ -54,7 +55,6 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
@@ -147,6 +147,7 @@ internal open class TracingInterceptorTest {
 
     lateinit var fakeRequest: Request
     lateinit var fakeResponse: Response
+    lateinit var forge: Forge
 
     @LongForgery
     var fakeSpanId: Long = 0L
@@ -167,6 +168,7 @@ internal open class TracingInterceptorTest {
 
     @BeforeEach
     fun `set up`(forge: Forge) {
+        this.forge = forge
         fakeTraceId = forge.aDatadogTraceId(fakeTraceIdAsString)
         fakeOrigin = forge.aNullable { anAlphabeticalString() }
         mockSpanContext = forge.newSpanContextMock(fakeTraceId, fakeSpanId)
@@ -182,8 +184,8 @@ internal open class TracingInterceptorTest {
         fakeLocalHosts =
             forge.aMap { forge.aStringMatching(HOSTNAME_PATTERN) to setOf(TracingHeaderType.DATADOG) }
         fakeMediaType = mediaType.toMediaTypeOrNull()
-        fakeUrl = forgeUrlWithQueryParams(forge)
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrlWithQueryParams()
+        fakeRequest = forgeRequest()
         whenever(rumMonitor.mockSdkCore.getFeature(Feature.TRACING_FEATURE_NAME)) doReturn mock()
         whenever(rumMonitor.mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(rumMonitor.mockSdkCore.firstPartyHostResolver) doReturn mockResolver
@@ -296,11 +298,9 @@ internal open class TracingInterceptorTest {
     @Test
     fun `M inject tracing header W intercept() {global known host}`(
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -327,9 +327,7 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M inject non-tracing b3multi header W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M inject non-tracing b3multi header W intercept() {global known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -338,7 +336,7 @@ internal open class TracingInterceptorTest {
                 TracingHeaderType.B3MULTI
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -355,9 +353,7 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M inject non-tracing b3 header W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M inject non-tracing b3 header W intercept() {global known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -366,7 +362,7 @@ internal open class TracingInterceptorTest {
                 TracingHeaderType.B3
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -381,9 +377,7 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M inject non-tracing tracecontext header W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M inject non-tracing tracecontext header W intercept() {global known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
@@ -392,7 +386,7 @@ internal open class TracingInterceptorTest {
                 TracingHeaderType.TRACECONTEXT
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -416,10 +410,7 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M inject datadog headers W intercept() {global known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject datadog headers W intercept() {global known host + not sampled}`() {
         // Given
         val nonDatadogContextKey = forge.anAlphabeticalString()
         val nonDatadogContextKeyValue = forge.anAlphabeticalString()
@@ -444,7 +435,7 @@ internal open class TracingInterceptorTest {
                 TracingHeaderType.TRACECONTEXT
             )
         )
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -479,14 +470,12 @@ internal open class TracingInterceptorTest {
     @Test
     fun `M inject tracing header W intercept() {local known host}`(
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
-        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrlWithQueryParams(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -499,10 +488,7 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M inject datadog headers W intercept() {local known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject datadog headers W intercept() {local known host + not sampled}`() {
         // Given
         val nonDatadogContextKey = forge.anAlphabeticalString()
         val nonDatadogContextKeyValue = forge.anAlphabeticalString()
@@ -520,10 +506,10 @@ internal open class TracingInterceptorTest {
         )
 
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
-        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrlWithQueryParams(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -542,19 +528,16 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M inject non-tracing b3multi header W intercept() {local known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject non-tracing b3multi header W intercept() {local known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts =
             forge.aMap { forge.aStringMatching(HOSTNAME_PATTERN) to setOf(TracingHeaderType.B3MULTI) }
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
-        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrlWithQueryParams(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -571,20 +554,17 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M inject non-tracing b3 header W intercept() {local known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject non-tracing b3 header W intercept() {local known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts =
             forge.aMap { forge.aStringMatching(HOSTNAME_PATTERN) to setOf(TracingHeaderType.B3) }
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
-        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrlWithQueryParams(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
 
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -599,21 +579,18 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M inject non-tracing tracecontext header W intercept() {local known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject non-tracing tracecontext header W intercept() {local known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts =
             forge.aMap { forge.aStringMatching(HOSTNAME_PATTERN) to setOf(TracingHeaderType.TRACECONTEXT) }
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
 
-        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrlWithQueryParams(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
 
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -637,10 +614,7 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M inject all non-tracing headers W intercept() {local known host + not sampled}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M inject all non-tracing headers W intercept() {local known host + not sampled}`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
@@ -653,11 +627,11 @@ internal open class TracingInterceptorTest {
         }
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
 
-        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+        fakeUrl = forgeUrlWithQueryParams(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
 
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -696,14 +670,13 @@ internal open class TracingInterceptorTest {
     fun `M inject tracing header W intercept() for request with parent span`(
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @IntForgery(min = 200, max = 300) statusCode: Int,
-        forge: Forge
+        @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         val parentSpanContext: DatadogSpanContext = forge.newSpanContextMock<DatadogSpanContext>(samplingPriority = 1)
         val parentSpan: DatadogSpan = forge.newSpanMock(parentSpanContext)
 
         whenever(mockSpanBuilder.withParentContext(parentSpanContext)) doReturn mockSpanBuilder
-        fakeRequest = forgeRequest(forge) { it.tag(DatadogSpan::class.java, parentSpan) }
+        fakeRequest = forgeRequest { it.tag(DatadogSpan::class.java, parentSpan) }
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
@@ -724,8 +697,7 @@ internal open class TracingInterceptorTest {
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
         @IntForgery(min = 200, max = 300) statusCode: Int,
-        @Forgery fakeTraceContext: TraceContext,
-        forge: Forge
+        @Forgery fakeTraceContext: TraceContext
     ) {
         // Given
 
@@ -737,7 +709,7 @@ internal open class TracingInterceptorTest {
         )
         whenever(mockPropagationHelper.createExtractedContext(any(), any(), any())) doReturn fakeExtractedContext
         whenever(mockSpanBuilder.withParentContext(any<DatadogSpanContext>())) doReturn mockSpanBuilder
-        fakeRequest = forgeRequest(forge) { it.tag(TraceContext::class.java, fakeTraceContext) }
+        fakeRequest = forgeRequest { it.tag(TraceContext::class.java, fakeTraceContext) }
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
@@ -770,11 +742,10 @@ internal open class TracingInterceptorTest {
     fun `M replace existing tracing header W intercept() {global known host}`(
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.HEXADECIMAL) value: String,
-        @StringForgery(type = StringForgeryType.ALPHABETICAL) previousValue: String,
-        @IntForgery(min = 200, max = 600) statusCode: Int
+        @StringForgery(type = StringForgeryType.ALPHABETICAL) previousValue: String
     ) {
         fakeRequest = fakeRequest.newBuilder().addHeader(key, previousValue).build()
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -791,14 +762,12 @@ internal open class TracingInterceptorTest {
     fun `M replace existing tracing header W intercept() {local known host}`(
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        @StringForgery(type = StringForgeryType.ALPHABETICAL) previousValue: String,
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHABETICAL) previousValue: String
     ) {
-        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge).newBuilder().addHeader(key, previousValue).build()
+        fakeUrl = forgeUrlWithQueryParams(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest().newBuilder().addHeader(key, previousValue).build()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -811,15 +780,11 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M ignore inject exception W intercept() {IllegalStateException}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        @StringForgery message: String,
-        forge: Forge
-    ) {
-        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
-        fakeRequest = forgeRequest(forge)
+    fun `M ignore inject exception W intercept() {IllegalStateException}`(@StringForgery message: String) {
+        fakeUrl = forgeUrlWithQueryParams(forge.anElementFrom(fakeLocalHosts.keys))
+        fakeRequest = forgeRequest()
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         doThrow(IllegalStateException(message))
             .whenever(mockPropagation)
@@ -867,13 +832,11 @@ internal open class TracingInterceptorTest {
     @Test
     fun `M respect sampling decision W intercept() {sampled in upstream interceptor}`(
         @StringForgery key: String,
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER,
                 forge.anElementFrom(
@@ -882,7 +845,7 @@ internal open class TracingInterceptorTest {
                 )
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -899,20 +862,18 @@ internal open class TracingInterceptorTest {
 
     @Test
     fun `M respect b3multi sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3M_SAMPLING_PRIORITY_KEY,
                 PrioritySampling.SAMPLER_KEEP.toString()
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -929,21 +890,19 @@ internal open class TracingInterceptorTest {
 
     @Test
     fun `M respect b3 sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
 
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3_HEADER_KEY,
                 forge.aStringMatching("[a-f0-9]{32}\\-[a-f0-9]{16}\\-1")
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -960,21 +919,19 @@ internal open class TracingInterceptorTest {
 
     @Test
     fun `M respect tracecontext sampling decision W intercept() {sampled in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery key: String,
-        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
-        forge: Forge
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String
     ) {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
 
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.W3C_TRACEPARENT_KEY,
                 forge.aStringMatching("00-[a-f0-9]{32}\\-[a-f0-9]{16}\\-01")
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
@@ -990,10 +947,7 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M respect sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -1001,7 +955,7 @@ internal open class TracingInterceptorTest {
                 TracingHeaderType.DATADOG
             )
         )
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER,
                 forge.anElementFrom(
@@ -1010,7 +964,7 @@ internal open class TracingInterceptorTest {
                 )
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -1030,10 +984,7 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M respect b3multi sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect b3multi sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -1041,13 +992,13 @@ internal open class TracingInterceptorTest {
                 TracingHeaderType.B3MULTI
             )
         )
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3M_SAMPLING_PRIORITY_KEY,
                 PrioritySampling.SAMPLER_DROP.toString()
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -1065,10 +1016,7 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M respect b3 sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect b3 sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -1076,7 +1024,7 @@ internal open class TracingInterceptorTest {
                 TracingHeaderType.B3
             )
         )
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.B3_HEADER_KEY,
                 forge.anElementFrom(
@@ -1085,7 +1033,7 @@ internal open class TracingInterceptorTest {
                 )
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -1101,10 +1049,7 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M respect tracecontext sampling decision W intercept() {sampled out in upstream interceptor}`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M respect tracecontext sampling decision W intercept() {sampled out in upstream interceptor}`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
@@ -1112,13 +1057,13 @@ internal open class TracingInterceptorTest {
                 TracingHeaderType.TRACECONTEXT
             )
         )
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(
                 TracingInterceptor.W3C_TRACEPARENT_KEY,
                 forge.aStringMatching("00-[a-f0-9]{32}\\-[a-f0-9]{16}\\-00")
             )
         }
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
@@ -1163,11 +1108,10 @@ internal open class TracingInterceptorTest {
 
     @Test
     fun `M create a span with info W intercept() { resource url with no query paramaters }`(
-        @IntForgery(min = 200, max = 300) statusCode: Int,
-        forge: Forge
+        @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
-        val fakeUrlWithoutQueryParams = forgeUrlWithoutQueryParams(forge)
-        fakeRequest = forgeRequest(forge, fakeUrlWithoutQueryParams)
+        val fakeUrlWithoutQueryParams = forgeUrlWithoutQueryParams()
+        fakeRequest = forgeRequest(fakeUrlWithoutQueryParams)
         whenever(mockResolver.isFirstPartyUrl(fakeUrlWithoutQueryParams.toHttpUrl()))
             .thenReturn(true)
         stubChain(mockChain, statusCode)
@@ -1293,7 +1237,6 @@ internal open class TracingInterceptorTest {
 
     @Test
     fun `M create a span with automatic tracer W intercept() if no tracer registered`(
-        forge: Forge,
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         val localSpanContext = forge.newSpanContextMock<DatadogSpanContext>(fakeTraceId, fakeSpanId)
@@ -1329,7 +1272,6 @@ internal open class TracingInterceptorTest {
 
     @Test
     fun `M drop automatic tracer W intercept() and global tracer registered`(
-        forge: Forge,
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         val localSpan: DatadogSpan = forge.newSpanMock()
@@ -1405,13 +1347,11 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M not call the listener W intercept() for completed request { not sampled }`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M not call the listener W intercept() for completed request { not sampled }`() {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -1608,11 +1548,9 @@ internal open class TracingInterceptorTest {
 
     @Test
     fun `M keep existing BAGGAGE W intercept { new values != existing values }`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery existingBaggageKey: String,
         @StringForgery existingBaggageValue: String,
-        @StringForgery uniqueString: String,
-        forge: Forge
+        @StringForgery uniqueString: String
     ) {
         // Given
         // Ensure that the new values differ from the existing ones.
@@ -1622,10 +1560,10 @@ internal open class TracingInterceptorTest {
         val existingBaggage = "$existingBaggageKey=$existingBaggageValue"
         val newBaggage = "$newBaggageKey=$newBaggageValue"
 
-        fakeRequest = forgeRequest(forge) { it.addHeader(BAGGAGE_HEADER, existingBaggage) }
+        fakeRequest = forgeRequest { it.addHeader(BAGGAGE_HEADER, existingBaggage) }
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         mockPropagation.wheneverInjectThenValueToHeaders(BAGGAGE_HEADER, newBaggage)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         testedInterceptor.intercept(mockChain)
@@ -1642,11 +1580,9 @@ internal open class TracingInterceptorTest {
 
     @Test
     fun `M replace existing BAGGAGE W intercept { new values intersects existing values }`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
         @StringForgery existingBaggageKey: String,
         @StringForgery existingBaggageValue: String,
-        @StringForgery uniqueString: String,
-        forge: Forge
+        @StringForgery uniqueString: String
     ) {
         // Given
         // Ensure that the new values differ from the existing ones.
@@ -1655,12 +1591,12 @@ internal open class TracingInterceptorTest {
         val existingBaggage = "$existingBaggageKey=$existingBaggageValue"
         val newBaggage = "$existingBaggageKey=$newBaggageValue"
 
-        fakeRequest = forgeRequest(forge) {
+        fakeRequest = forgeRequest {
             it.addHeader(BAGGAGE_HEADER, existingBaggage)
         }
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         mockPropagation.wheneverInjectThenValueToHeaders(BAGGAGE_HEADER, newBaggage)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         testedInterceptor.intercept(mockChain)
@@ -1673,16 +1609,13 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M blocks on DatadogContext future W intercept { new values intersects existing values }`(
-        @IntForgery(min = 200, max = 600) statusCode: Int,
-        forge: Forge
-    ) {
+    fun `M blocks on DatadogContext future W intercept { new values intersects existing values }`() {
         // Given
         val mockFuture = mock<Future<DatadogContext>>()
-        fakeRequest = forgeRequest(forge)
+        fakeRequest = forgeRequest()
         whenever(mockSpan.getTag(DATADOG_INITIAL_CONTEXT)).thenReturn(mockFuture)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         // When
         testedInterceptor.intercept(mockChain)
@@ -1692,12 +1625,10 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M log error and rethrow W listener causes StackOverflowError`(
-        @IntForgery(min = 200, max = 600) statusCode: Int
-    ) {
+    fun `M log error and rethrow W listener causes StackOverflowError`() {
         // Given
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
-        stubChain(mockChain, statusCode)
+        stubChain(mockChain)
 
         whenever(
             mockRequestListener.onRequestIntercepted(any(), any(), anyOrNull(), anyOrNull())
@@ -1723,22 +1654,25 @@ internal open class TracingInterceptorTest {
 
     // region Internal
 
-    internal fun stubChain(chain: Interceptor.Chain, statusCode: Int) {
-        fakeResponse = forgeResponse(statusCode)
+    internal fun stubChain(chain: Interceptor.Chain, statusCode: Int = forge.anInt(min = 200, max = 600)) {
+        fakeResponse = forge.anOkHttpResponse(fakeRequest, statusCode) {
+            header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
+            body(fakeResponseBody.toResponseBody(fakeMediaType))
+        }
 
         whenever(chain.request()) doReturn fakeRequest
         whenever(chain.proceed(any())) doReturn fakeResponse
     }
 
-    private fun forgeUrlWithoutQueryParams(forge: Forge, knownHost: String? = null): String {
+    private fun forgeUrlWithoutQueryParams(knownHost: String? = null): String {
         val protocol = forge.anElementFrom("http", "https")
         val host = knownHost ?: forge.aStringMatching(HOSTNAME_PATTERN)
         val path = forge.anAlphaNumericalString()
         return "$protocol://$host/$path"
     }
 
-    private fun forgeUrlWithQueryParams(forge: Forge, knownHost: String? = null): String {
-        fakeBaseUrl = forgeUrlWithoutQueryParams(forge, knownHost)
+    private fun forgeUrlWithQueryParams(knownHost: String? = null): String {
+        fakeBaseUrl = forgeUrlWithoutQueryParams(knownHost)
         val fakeQueryParams = forge.aList(forge.anInt(min = 0, max = 5)) {
             "${forge.anAlphabeticalString()}=${forge.anAlphabeticalString()}"
         }.joinToString("&")
@@ -1746,7 +1680,6 @@ internal open class TracingInterceptorTest {
     }
 
     private fun forgeRequest(
-        forge: Forge,
         url: String = fakeUrl,
         configure: (Request.Builder) -> Unit = {}
     ): Request {
@@ -1773,17 +1706,6 @@ internal open class TracingInterceptorTest {
 
         configure(builder)
 
-        return builder.build()
-    }
-
-    private fun forgeResponse(statusCode: Int): Response {
-        val builder = Response.Builder()
-            .request(fakeRequest)
-            .protocol(Protocol.HTTP_2)
-            .code(statusCode)
-            .message("HTTP $statusCode")
-            .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
-            .body(fakeResponseBody.toResponseBody(fakeMediaType))
         return builder.build()
     }
 


### PR DESCRIPTION
### What does this PR do?

- Delete repeated `forgeResponse` & `Response.Builder` functions.
- Create `Forge.anOkHttpResponse` which I will need in upcoming PR #3275 and we can reuse in already existing logic, where there was a lot of repeated code.
- Reuse the same `forge: Forge` per test class.
- Remove `@IntForgery statusCode` parameter where no value is expected/needed (200 to 600).
- General cleanup.

I plan on continuing this idea after and create a centralized `Forge.anOkHttpRequest` function, removing repeated `forgeRequest` and `Request.Builder` calls in the `InterceptorTest` classes.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

