### PR TITLE
RUM-4120: Add Detekt rule to enforce copyright headers on Kotlin source files

### DIFF
--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DefaultUploadSchedulerStrategyTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DefaultUploadSchedulerStrategyTest.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.core.internal.data.upload
 
 import com.datadog.android.core.configuration.UploadSchedulerStrategy

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AsyncEventWriteScopeTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AsyncEventWriteScopeTest.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.core.internal.persistence
 
 import com.datadog.android.api.InternalLogger

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileHelperTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileHelperTest.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.core.internal.persistence.datastore
 
 import com.datadog.android.api.InternalLogger

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/sampling/DeterministicSamplerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/sampling/DeterministicSamplerTest.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.core.sampling
 
 import com.datadog.android.utils.forge.Configurator

--- a/dd-sdk-android-internal/build.gradle.kts
+++ b/dd-sdk-android-internal/build.gradle.kts
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
 import com.datadog.gradle.config.detektCustomConfig

--- a/detekt_custom_general.yml
+++ b/detekt_custom_general.yml
@@ -52,7 +52,20 @@ output-reports:
   # - 'SarifOutputReport'
 
 comments:
-  active: false
+  active: true
+  AbsentOrWrongFileLicense:
+    active: true
+    licenseTemplateFile: 'license.template'
+    licenseTemplateIsRegex: false
+    excludes:
+      # Gradle build outputs and generated artifacts.
+      - '**/build/**'
+      # Auto-generated Kotlin model fixtures produced by the buildSrc JSON-to-Kotlin code generator.
+      - '**/buildSrc/src/test/kotlin/com/example/model/**'
+      # Fixture files for the NoOpFactory annotation processor tests, read as text data rather than compiled.
+      - '**/tools/noopfactory/src/test/resources/**'
+      # Vendored test files ported from the upstream dd-trace-java library.
+      - '**/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/**'
 
 complexity:
   active: false

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/resource/ResourceIdTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/resource/ResourceIdTest.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.rum.resource
 
 import com.datadog.android.rum.utils.forge.Configurator

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/BundleExtTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/BundleExtTest.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.rum.tracking
 
 import android.os.Bundle

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/CheckboxSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/CheckboxSemanticsNodeMapper.kt
@@ -1,7 +1,7 @@
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
- * Copyright CHECKBOX_SIZE16-Present Datadog, Inc.
+ * Copyright 2016-Present Datadog, Inc.
  */
 
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/androidx/appcompat/widget/DatadogActionBarContainerAccessor.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/androidx/appcompat/widget/DatadogActionBarContainerAccessor.kt
@@ -1,9 +1,10 @@
-@file:Suppress("PackageNaming")
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2016-Present Datadog, Inc.
  */
+
+@file:Suppress("PackageNaming")
 
 package androidx.appcompat.widget
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/MobileSegmentExtTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/MobileSegmentExtTest.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.sessionreplay.internal.processor
 
 import com.datadog.android.api.InternalLogger

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ProgressBarWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ProgressBarWireframeMapperTest.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.content.res.ColorStateList

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapperTest.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.content.res.ColorStateList

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/EditTextMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/EditTextMapperTest.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.sessionreplay.recorder.mapper
 
 import android.graphics.Typeface

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapperTest.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.sessionreplay.recorder.mapper
 
 import android.graphics.Typeface

--- a/features/dd-sdk-android-trace-internal/src/main/kotlin/com/datadog/android/trace/internal/compat/function/BiConsumer.kt
+++ b/features/dd-sdk-android-trace-internal/src/main/kotlin/com/datadog/android/trace/internal/compat/function/BiConsumer.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.trace.internal.compat.function
 
 internal interface BiConsumer<T, U> {

--- a/features/dd-sdk-android-trace-internal/src/main/kotlin/com/datadog/android/trace/internal/compat/function/BiFunction.kt
+++ b/features/dd-sdk-android-trace-internal/src/main/kotlin/com/datadog/android/trace/internal/compat/function/BiFunction.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.trace.internal.compat.function
 
 internal interface BiFunction<T, U, R> {

--- a/features/dd-sdk-android-trace-internal/src/main/kotlin/com/datadog/android/trace/internal/compat/function/Consumer.kt
+++ b/features/dd-sdk-android-trace-internal/src/main/kotlin/com/datadog/android/trace/internal/compat/function/Consumer.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.trace.internal.compat.function
 
 internal interface Consumer<T> {

--- a/features/dd-sdk-android-trace-internal/src/main/kotlin/com/datadog/android/trace/internal/compat/function/Function.kt
+++ b/features/dd-sdk-android-trace-internal/src/main/kotlin/com/datadog/android/trace/internal/compat/function/Function.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.trace.internal.compat.function
 
 internal interface Function<T, R> {

--- a/features/dd-sdk-android-trace-internal/src/main/kotlin/com/datadog/android/trace/internal/compat/function/IntFunction.kt
+++ b/features/dd-sdk-android-trace-internal/src/main/kotlin/com/datadog/android/trace/internal/compat/function/IntFunction.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.trace.internal.compat.function
 
 internal interface IntFunction<R> {

--- a/features/dd-sdk-android-trace-internal/src/main/kotlin/com/datadog/android/trace/internal/compat/function/IntPredicate.kt
+++ b/features/dd-sdk-android-trace-internal/src/main/kotlin/com/datadog/android/trace/internal/compat/function/IntPredicate.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.trace.internal.compat.function
 
 internal interface IntPredicate {

--- a/features/dd-sdk-android-trace-internal/src/main/kotlin/com/datadog/android/trace/internal/compat/function/Supplier.kt
+++ b/features/dd-sdk-android-trace-internal/src/main/kotlin/com/datadog/android/trace/internal/compat/function/Supplier.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.trace.internal.compat.function
 
 internal interface Supplier<T> {

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/event/CoreTracerSpanToSpanEventMapper.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/event/CoreTracerSpanToSpanEventMapper.kt
@@ -1,8 +1,8 @@
 /*
-* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-* This product includes software developed at Datadog (https://www.datadoghq.com/).
-* Copyright 2016-Present Datadog, Inc.
-*/
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
 
 package com.datadog.android.trace.internal.domain.event
 

--- a/integrations/dd-sdk-android-apollo/build.gradle.kts
+++ b/integrations/dd-sdk-android-apollo/build.gradle.kts
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/ComposeInstrumentation.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/ComposeInstrumentation.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.compose
 
 /**

--- a/license.template
+++ b/license.template
@@ -1,0 +1,5 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */

--- a/sample/automotive/build.gradle.kts
+++ b/sample/automotive/build.gradle.kts
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.configureFlavorForAutoApp
 import com.datadog.gradle.config.dependencyUpdateConfig

--- a/sample/benchmark/build.gradle.kts
+++ b/sample/benchmark/build.gradle.kts
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.configureFlavorForBenchmark
 import com.datadog.gradle.config.dependencyUpdateConfig

--- a/tools/benchmark/src/main/java/com/datadog/benchmark/exporter/DatadogMetricExporter.kt
+++ b/tools/benchmark/src/main/java/com/datadog/benchmark/exporter/DatadogMetricExporter.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.benchmark.exporter
 
 import android.os.Build

--- a/tools/javabackport/src/main/kotlin/java/nio/file/Path.kt
+++ b/tools/javabackport/src/main/kotlin/java/nio/file/Path.kt
@@ -1,10 +1,10 @@
-@file:Suppress("PackageNaming")
-
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2016-Present Datadog, Inc.
  */
+
+@file:Suppress("PackageNaming")
 
 package java.nio.file
 

--- a/tools/javabackport/src/main/kotlin/java/util/concurrent/CompletableFuture.kt
+++ b/tools/javabackport/src/main/kotlin/java/util/concurrent/CompletableFuture.kt
@@ -1,10 +1,10 @@
-@file:Suppress("PackageNaming")
-
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2016-Present Datadog, Inc.
  */
+
+@file:Suppress("PackageNaming")
 
 package java.util.concurrent
 

--- a/tools/javabackport/src/main/kotlin/java/util/concurrent/atomic/LongAdder.kt
+++ b/tools/javabackport/src/main/kotlin/java/util/concurrent/atomic/LongAdder.kt
@@ -1,10 +1,10 @@
-@file:Suppress("PackageNaming", "EmptyClassBlock")
-
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2016-Present Datadog, Inc.
  */
+
+@file:Suppress("PackageNaming", "EmptyClassBlock")
 
 package java.util.concurrent.atomic
 


### PR DESCRIPTION
### What does this PR do?
- Introduces a Detekt [AbsentOrWrongFileLicense](https://detekt.dev/docs/rules/comments/#absentorwrongfilelicense) rule that verifies every `.kt` source file in the repository starts with the standard DataDog header. 
- Fixes all pre-existing violations found across the codebase.

### Motivation
Copyright headers were only enforced via the IDE's IDEA copyright profile, which relies on developers remembering to apply it. Several files had missing, incorrectly indented, or typoed headers with no automated safety net. This rule makes violations a CI failure.

### Additional Notes
- A `license.template` file is added at the repo root — this is the single source of truth for the expected header, read by Detekt at analysis time.
- Exclusions are narrowly scoped: `build` outputs, auto-generated buildSrc model fixtures, NoOpFactory test resource fixtures, and vendored dd-trace-java test files.
- `.kts` files were already excluded from the Detekt Gradle task (`-ex "**/*.kts"`). The copyright headers on `.kts` files have been added and are correct. We can dive deeper into this if needed.

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)