### PR TITLE
RUM-15278: Add Datadog Test Observability for tests run on MacOS runners

### DIFF
--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -340,7 +340,6 @@ test-pyramid:legacy-integration-instrumented-min-api:
     ANDROID_BUILD_TOOLS: "build-tools;$ANDROID_API.0.0"
   script:
     - !reference [.snippets, setup-macos-ami-runner]
-    - !reference [.snippets, install-android-api-components]
     - !reference [.snippets, run-legacy-integration-instrumented]
 
 test-pyramid:legacy-integration-instrumented-latest-api:
@@ -356,7 +355,6 @@ test-pyramid:legacy-integration-instrumented-latest-api:
     ANDROID_BUILD_TOOLS: "build-tools;$ANDROID_API.0.0"
   script:
     - !reference [.snippets, setup-macos-ami-runner]
-    - !reference [.snippets, install-android-api-components]
     - !reference [.snippets, run-legacy-integration-instrumented]
 
 test-pyramid:legacy-integration-instrumented-median-api:

--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -17,6 +17,23 @@ stages:
     - source ./ci/scripts/vault_config.sh
     - source ./ci/scripts/get-secret.sh
 
+  source-secrets-macos:
+    - vault login -method=aws -no-print
+    - export DD_ANDROID_SECRETS_PATH_PREFIX="kv/aws/arn:aws:iam::486234852809:role/ci-dd-sdk-android/"
+    - source ./ci/scripts/vault_config.sh
+    - source ./ci/scripts/get-secret.sh
+
+  setup-dd-tracer:
+    - export DD_TRACER_FOLDER="$HOME/dd-java-agent"
+    - mkdir -p "$DD_TRACER_FOLDER"
+    - curl -Lo "$DD_TRACER_FOLDER/dd-java-agent.jar" https://dtdg.co/latest-java-tracer
+    - export DD_API_KEY=$(get_secret $DD_ANDROID_SECRET__API_KEY)
+    - export DD_CIVISIBILITY_AGENTLESS_ENABLED=true
+
+  setup-dd-ci-cli:
+    - npm install -g @datadog/datadog-ci
+    - export DATADOG_API_KEY=$(get_secret $DD_ANDROID_SECRET__API_KEY)
+
   # macOS AMI will already have cmdline-tools installed
   install-android-api-components:
     - echo y | ~/android_sdk/cmdline-tools/latest/bin/sdkmanager --install "emulator"
@@ -26,20 +43,27 @@ stages:
     - echo y | ~/android_sdk/cmdline-tools/latest/bin/sdkmanager --install "$ANDROID_EMULATOR_IMAGE"
     - yes | ~/android_sdk/cmdline-tools/latest/bin/sdkmanager --licenses || true
     - echo "no" | ~/android_sdk/cmdline-tools/latest/bin/avdmanager --verbose create avd --force --name "$EMULATOR_NAME" --package "$ANDROID_EMULATOR_IMAGE"
+  setup-macos-ami-runner:
+    - !reference [ .snippets, source-secrets-macos ]
+    - !reference [ .snippets, setup-dd-tracer ]
+    - !reference [ .snippets, setup-dd-ci-cli ]
+    - !reference [ .snippets, install-android-api-components ]
   run-legacy-integration-instrumented:
     - set +e
     - exit_code=0
     - $ANDROID_HOME/emulator/emulator -avd "$EMULATOR_NAME" -grpc-use-jwt -no-snapstorage -no-audio -no-window -no-boot-anim -verbose -qemu -machine virt &
-    - GRADLE_OPTS="-Xmx3072m" ./gradlew :instrumented:integration:connectedDebugAndroidTest --stacktrace --no-daemon $( (( $ANDROID_API <= 23 )) && echo "-Puse-api21-java-backport -Puse-desugaring" ) || exit_code=$?
+    - GRADLE_OPTS="-Xmx3072m -javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar=$DD_COMMON_AGENT_CONFIG" DD_TAGS="test.configuration.android_api:$ANDROID_API" ./gradlew :instrumented:integration:connectedDebugAndroidTest --stacktrace --no-daemon $( (( $ANDROID_API <= 23 )) && echo "-Puse-api21-java-backport -Puse-desugaring" ) || exit_code=$?
     - $ANDROID_HOME/platform-tools/adb emu kill
+    - datadog-ci junit upload --service dd-sdk-android --tags test.configuration.android_api:$ANDROID_API --xpath-tag test.suite=/testcase/@classname instrumented/integration/build/outputs/androidTest-results/connected/debug/
     - if [[ "$exit_code" -ne 0 ]]; then exit 1; fi
     - exit 0
   run-core-it-instrumented:
     - set +e
     - exit_code=0
     - $ANDROID_HOME/emulator/emulator -avd "$EMULATOR_NAME" -grpc-use-jwt -no-snapstorage -no-audio -no-window -no-boot-anim -verbose -qemu -machine virt &
-    - GRADLE_OPTS="-Xmx3072m" ./gradlew :reliability:core-it:connectedDebugAndroidTest --stacktrace --no-daemon $( (( $ANDROID_API <= 23 )) && echo "-Puse-api21-java-backport -Puse-desugaring" ) || exit_code=$?
+    - GRADLE_OPTS="-Xmx3072m -javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar=$DD_COMMON_AGENT_CONFIG" DD_TAGS="test.configuration.android_api:$ANDROID_API" ./gradlew :reliability:core-it:connectedDebugAndroidTest --stacktrace --no-daemon $( (( $ANDROID_API <= 23 )) && echo "-Puse-api21-java-backport -Puse-desugaring" ) || exit_code=$?
     - $ANDROID_HOME/platform-tools/adb emu kill
+    - datadog-ci junit upload --service dd-sdk-android --tags test.configuration.android_api:$ANDROID_API --xpath-tag test.suite=/testcase/@classname reliability/core-it/build/outputs/androidTest-results/connected/debug/
     - if [[ "$exit_code" -ne 0 ]]; then exit 1; fi
     - exit 0
   set-publishing-credentials:
@@ -200,7 +224,7 @@ test-pyramid:core-it-min-api:
     ANDROID_PLATFORM: "platforms;android-$ANDROID_API"
     ANDROID_BUILD_TOOLS: "build-tools;$ANDROID_API.0.0"
   script:
-    - !reference [.snippets, install-android-api-components]
+    - !reference [.snippets, setup-macos-ami-runner]
     - !reference [.snippets, run-core-it-instrumented]
 
 test-pyramid:core-it-latest-api:
@@ -215,7 +239,7 @@ test-pyramid:core-it-latest-api:
     ANDROID_PLATFORM: "platforms;android-$ANDROID_API"
     ANDROID_BUILD_TOOLS: "build-tools;$ANDROID_API.0.0"
   script:
-    - !reference [.snippets, install-android-api-components]
+    - !reference [.snippets, setup-macos-ami-runner]
     - !reference [.snippets, run-core-it-instrumented]
 
 test-pyramid:core-it-median-api:
@@ -230,7 +254,7 @@ test-pyramid:core-it-median-api:
     ANDROID_PLATFORM: "platforms;android-$ANDROID_API"
     ANDROID_BUILD_TOOLS: "build-tools;$ANDROID_API.0.0"
   script:
-    - !reference [.snippets, install-android-api-components]
+    - !reference [.snippets, setup-macos-ami-runner]
     - !reference [.snippets, run-core-it-instrumented]
 
 test-pyramid:single-fit-logs:
@@ -315,6 +339,7 @@ test-pyramid:legacy-integration-instrumented-min-api:
     ANDROID_PLATFORM: "platforms;android-$ANDROID_API"
     ANDROID_BUILD_TOOLS: "build-tools;$ANDROID_API.0.0"
   script:
+    - !reference [.snippets, setup-macos-ami-runner]
     - !reference [.snippets, install-android-api-components]
     - !reference [.snippets, run-legacy-integration-instrumented]
 
@@ -330,6 +355,7 @@ test-pyramid:legacy-integration-instrumented-latest-api:
     ANDROID_PLATFORM: "platforms;android-$ANDROID_API"
     ANDROID_BUILD_TOOLS: "build-tools;$ANDROID_API.0.0"
   script:
+    - !reference [.snippets, setup-macos-ami-runner]
     - !reference [.snippets, install-android-api-components]
     - !reference [.snippets, run-legacy-integration-instrumented]
 
@@ -345,7 +371,7 @@ test-pyramid:legacy-integration-instrumented-median-api:
     ANDROID_PLATFORM: "platforms;android-$ANDROID_API"
     ANDROID_BUILD_TOOLS: "build-tools;$ANDROID_API.0.0"
   script:
-    - !reference [.snippets, install-android-api-components]
+    - !reference [.snippets, setup-macos-ami-runner]
     - !reference [.snippets, run-legacy-integration-instrumented]
 
 test-pyramid:detekt-api-coverage:

--- a/ci/scripts/vault_config.sh
+++ b/ci/scripts/vault_config.sh
@@ -7,7 +7,7 @@
 #
 
 DD_VAULT_ADDR=https://vault.us1.ddbuild.io
-DD_ANDROID_SECRETS_PATH_PREFIX='kv/k8s/gitlab-runner/dd-sdk-android/'
+DD_ANDROID_SECRETS_PATH_PREFIX=${DD_ANDROID_SECRETS_PATH_PREFIX:-'kv/k8s/gitlab-runner/dd-sdk-android/'}
 
 DD_ANDROID_SECRET__TEST_SECRET="test.secret"
 DD_ANDROID_SECRET__GRADLE_PROPERTIES="gradle.properties"


### PR DESCRIPTION
Making the results of the tests that are run on MacOS AMI runners available in Datadog CI Visibility.

### How it works

We are using 2 things here:
1. Manual upload of test results in JUnit format using `datadog-ci` tool.
2. We add Java tracer to the invocation of Gradle.

### How results look like

For example [here](https://app.datadoghq.com/ci/test/runs?query=test_level%3Asession%20%40git.branch%3Aaleksandr-gringauz%2FRUM-15278%2Fmacos-runners-test-observability%20%40ci.job.name%3A%22test-pyramid%3Alegacy-integration-instrumented-latest-api%22%20ci.pipeline_correlation_id%3A8fc4c14ec1052d3e&agg_m=count&agg_m_source=base&agg_t=count&colorByAttr=meta%5B%27_dd.ci.test_level%27%5D&currentTab=overview&eventStack=&fromUser=false&graphType=waterfall&index=citest&refresh_mode=sliding&start=1774376648048&end=1774981448048&paused=false) are the results for `test-pyramid:legacy-integration-instrumented-latest-api` job in this PR. You can see 3 entries there:
1. The one for `datadog-ci` upload with test results.
2. 2 entries for gradle tasks execution (`:buildSrc` is separate). They might be useful to look at the duration of gradle tasks.

[Here](https://app.datadoghq.com/ci/test-runs?query=%20%40ci.job.url%3A%22https%3A%2F%2Fgitlab.ddbuild.io%2FDataDog%2Fdd-sdk-android%2F-%2Fjobs%2F1555104843%22) is a list of test results for `test-pyramid:legacy-integration-instrumented-latest-api`.

### Why do we need `datadog-ci`

Another option is using Java Agent like described [here](https://docs.datadoghq.com/tests/setup/java?tab=ciproviderwithautoinstrumentationsupport). But it doesn't work for Android tests, because the tracer isn't able to instrument the tests run on Android emulator using `AndroidJnitRunner`.

