### PR TITLE
Send event to Profiling feature when RUM session is renewed

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -146,6 +146,8 @@ sealed class com.datadog.android.internal.profiling.ProfilerStopEvent
     constructor(TTIDRumContext? = null)
 data class com.datadog.android.internal.profiling.TTIDRumContext
   constructor(String, String, String, String?, String?, String?)
+data class com.datadog.android.internal.rum.RumSessionRenewedEvent
+  constructor(String, Boolean)
 interface com.datadog.android.internal.system.BuildSdkVersionProvider
   val version: Int
   val isAtLeastN: Boolean

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -287,6 +287,19 @@ public final class com/datadog/android/internal/profiling/TTIDRumContext {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/datadog/android/internal/rum/RumSessionRenewedEvent {
+	public fun <init> (Ljava/lang/String;Z)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/lang/String;Z)Lcom/datadog/android/internal/rum/RumSessionRenewedEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/internal/rum/RumSessionRenewedEvent;Ljava/lang/String;ZILjava/lang/Object;)Lcom/datadog/android/internal/rum/RumSessionRenewedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSessionId ()Ljava/lang/String;
+	public final fun getSessionSampled ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/datadog/android/internal/system/BuildSdkVersionProvider {
 	public static final field Companion Lcom/datadog/android/internal/system/BuildSdkVersionProvider$Companion;
 	public abstract fun getVersion ()I

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/rum/RumSessionRenewedEvent.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/rum/RumSessionRenewedEvent.kt
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.rum
+
+/**
+ * Event broadcast by RUM whenever a session is renewed (created for the first time, or renewed
+ * after inactivity timeout, max-duration timeout, or an explicit reset).
+ *
+ * @param sessionId The ID of the newly renewed RUM session.
+ * @param sessionSampled Whether the new session is sampled in for RUM (i.e. TRACKED).
+ */
+data class RumSessionRenewedEvent(
+    val sessionId: String,
+    val sessionSampled: Boolean
+)

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -19,6 +19,7 @@ import com.datadog.android.api.storage.FeatureStorageConfiguration
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.internal.profiling.ProfilerStopEvent
 import com.datadog.android.internal.profiling.TTIDRumContext
+import com.datadog.android.internal.rum.RumSessionRenewedEvent
 import com.datadog.android.profiling.ExperimentalProfilingApi
 import com.datadog.android.profiling.ProfilingConfiguration
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
@@ -90,15 +91,18 @@ internal class ProfilingFeature(
     }
 
     override fun onReceive(event: Any) {
-        if (event !is ProfilerStopEvent.TTID) {
-            sdkCore.internalLogger.log(
+        when (event) {
+            is ProfilerStopEvent.TTID -> onTtidEvent(event)
+            is RumSessionRenewedEvent -> onRumSessionRenewed(event)
+            else -> sdkCore.internalLogger.log(
                 InternalLogger.Level.WARN,
                 InternalLogger.Target.MAINTAINER,
                 { UNSUPPORTED_EVENT_TYPE.format(Locale.US, event::class.java.canonicalName) }
             )
-            return
         }
+    }
 
+    private fun onTtidEvent(event: ProfilerStopEvent.TTID) {
         if (ttidRumContext == null) {
             ttidRumContext = event.rumContext
             profiler.stop(sdkCore.name)
@@ -109,6 +113,11 @@ internal class ProfilingFeature(
                 { "Profiling stopped with TTID reason" }
             )
         }
+    }
+
+    @Suppress("UnusedParameter", "UNUSED_PARAMETER")
+    private fun onRumSessionRenewed(event: RumSessionRenewedEvent) {
+        // TODO RUM-15190: forward to ContinuousProfilingScheduler once it is implemented.
     }
 
     private fun setMinimumSampleRate(appContext: Context, sampleRate: Float) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -16,6 +16,7 @@ import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.internal.profiling.ProfilerStopEvent
+import com.datadog.android.internal.rum.RumSessionRenewedEvent
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.domain.InfoProvider
@@ -296,6 +297,8 @@ internal class RumSessionScope(
             )
         }
         sessionListener?.onSessionStarted(sessionId, !keepSession)
+        // Notifies `ProfilingFeature` that the RUM session has been renewed.
+        updateContinuousProfilingForSession(sessionState, sessionId)
     }
 
     private fun updateSessionStateForSessionReplay(state: State, sessionId: String) {
@@ -305,6 +308,16 @@ internal class RumSessionScope(
                 SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to RUM_SESSION_RENEWED_BUS_MESSAGE,
                 RUM_KEEP_SESSION_BUS_MESSAGE_KEY to keepSession,
                 RUM_SESSION_ID_BUS_MESSAGE_KEY to sessionId
+            )
+        )
+    }
+
+    private fun updateContinuousProfilingForSession(state: State, sessionId: String) {
+        val sessionSampled = (state == State.TRACKED)
+        sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.sendEvent(
+            RumSessionRenewedEvent(
+                sessionId = sessionId,
+                sessionSampled = sessionSampled
             )
         )
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -21,6 +21,7 @@ import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.sampling.DeterministicSampler
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.internal.profiling.ProfilerStopEvent
+import com.datadog.android.internal.rum.RumSessionRenewedEvent
 import com.datadog.android.internal.tests.stub.StubTimeProvider
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.RumSessionType
@@ -144,6 +145,9 @@ internal class RumSessionScopeTest {
     lateinit var mockSessionReplayFeatureScope: FeatureScope
 
     @Mock
+    lateinit var mockProfilingFeatureScope: FeatureScope
+
+    @Mock
     lateinit var mockNetworkSettledResourceIdentifier: InitialResourceIdentifier
 
     @Mock
@@ -207,6 +211,8 @@ internal class RumSessionScopeTest {
         whenever(mockChildScope.handleEvent(any(), any(), any(), any())) doReturn mockChildScope
         whenever(mockSdkCore.getFeature(Feature.SESSION_REPLAY_FEATURE_NAME)) doReturn
             mockSessionReplayFeatureScope
+        whenever(mockSdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)) doReturn
+            mockProfilingFeatureScope
         whenever(mockSdkCore.time) doReturn (fakeTimeInfo)
         whenever(mockSdkCore.internalLogger) doReturn mock()
         whenever(mockSdkCore.timeProvider) doReturn stubTimeProvider
@@ -1705,6 +1711,135 @@ internal class RumSessionScopeTest {
         )
 
         verifyNoMoreInteractions(mockRumSessionScopeStartupManager)
+    }
+
+    // endregion
+
+    // region Continuous Profiling Event Bus
+
+    @Test
+    fun `M send RumSessionRenewedEvent W session first created { sampled }`(
+        forge: Forge
+    ) {
+        // Given
+        whenever(mockSessionSampler.sample(any())).thenReturn(true)
+        initializeTestedScope()
+
+        // When
+        testedScope.handleEvent(forge.startViewEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        val sessionId = testedScope.getRumContext().sessionId
+
+        // Then
+        verify(mockProfilingFeatureScope).sendEvent(
+            RumSessionRenewedEvent(sessionId = sessionId, sessionSampled = true)
+        )
+    }
+
+    @Test
+    fun `M send RumSessionRenewedEvent W session first created { not sampled }`(
+        forge: Forge
+    ) {
+        // Given
+        whenever(mockSessionSampler.sample(any())).thenReturn(false)
+        initializeTestedScope()
+
+        // When
+        testedScope.handleEvent(forge.startViewEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        val sessionId = testedScope.getRumContext().sessionId
+
+        // Then
+        verify(mockProfilingFeatureScope).sendEvent(
+            RumSessionRenewedEvent(sessionId = sessionId, sessionSampled = false)
+        )
+    }
+
+    @Test
+    fun `M send RumSessionRenewedEvent W session renewed { timed out }`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        val firstSessionId = testedScope.getRumContext().sessionId
+
+        // When
+        advanceTimeByMs(TEST_MAX_DURATION_MS)
+        val newEvent = forge.startViewEvent()
+        testedScope.handleEvent(newEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+        val secondSessionId = testedScope.getRumContext().sessionId
+
+        // Then
+        val captor = argumentCaptor<Any>()
+        verify(mockProfilingFeatureScope, times(2)).sendEvent(captor.capture())
+        assertThat(captor.firstValue).isEqualTo(
+            RumSessionRenewedEvent(sessionId = firstSessionId, sessionSampled = true)
+        )
+        assertThat(captor.secondValue).isEqualTo(
+            RumSessionRenewedEvent(sessionId = secondSessionId, sessionSampled = true)
+        )
+    }
+
+    @Test
+    fun `M send RumSessionRenewedEvent W session renewed { expired }`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        val firstSessionId = testedScope.getRumContext().sessionId
+
+        // When
+        advanceTimeByMs(TEST_INACTIVITY_MS)
+        val newEvent = forge.startViewEvent()
+        testedScope.handleEvent(newEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+        val secondSessionId = testedScope.getRumContext().sessionId
+
+        // Then
+        val captor = argumentCaptor<Any>()
+        verify(mockProfilingFeatureScope, times(2)).sendEvent(captor.capture())
+        assertThat(captor.firstValue).isEqualTo(
+            RumSessionRenewedEvent(sessionId = firstSessionId, sessionSampled = true)
+        )
+        assertThat(captor.secondValue).isEqualTo(
+            RumSessionRenewedEvent(sessionId = secondSessionId, sessionSampled = true)
+        )
+    }
+
+    @Test
+    fun `M send RumSessionRenewedEvent W session renewed { manual reset }`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        val firstSessionId = testedScope.getRumContext().sessionId
+
+        // When
+        val resetEvent = RumRawEvent.ResetSession()
+        testedScope.handleEvent(resetEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+        val secondSessionId = testedScope.getRumContext().sessionId
+
+        // Then
+        val captor = argumentCaptor<Any>()
+        verify(mockProfilingFeatureScope, times(2)).sendEvent(captor.capture())
+        assertThat(captor.firstValue).isEqualTo(
+            RumSessionRenewedEvent(sessionId = firstSessionId, sessionSampled = true)
+        )
+        assertThat(captor.secondValue).isEqualTo(
+            RumSessionRenewedEvent(sessionId = secondSessionId, sessionSampled = true)
+        )
+    }
+
+    @Test
+    fun `M send RumSessionRenewedEvent only on renewal W repeated events { no renewal }`(
+        forge: Forge
+    ) {
+        // Given — first renewal on first interaction
+        testedScope.handleEvent(forge.startViewEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // When — subsequent events within the same session do NOT trigger renewSession
+        testedScope.handleEvent(forge.startViewEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        testedScope.handleEvent(forge.startActionEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then — only one event sent (for the initial session creation, not for subsequent interactions)
+        verify(mockProfilingFeatureScope, times(1)).sendEvent(any())
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

This PR implements the logic that RUM should send event to Profiling feature when RUM session is renewed before continuous profiling is implemented.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

