### PR TITLE
RUM-15323: RUM sends ANR & LongTask events to Profiling Feature

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -141,11 +141,17 @@ object com.datadog.android.internal.profiler.GlobalBenchmark
   fun getProfiler(): BenchmarkProfiler
   fun getBenchmarkSdkUploads(): BenchmarkSdkUploads
   fun createExecutionTimer(String, com.datadog.android.internal.time.TimeProvider): ExecutionTimer
+data class com.datadog.android.internal.profiling.ContinuousProfilingRumContext
+  constructor(String, String, String?, String?)
 sealed class com.datadog.android.internal.profiling.ProfilerStopEvent
   data class TTID : ProfilerStopEvent
     constructor(TTIDRumContext? = null)
 data class com.datadog.android.internal.profiling.TTIDRumContext
   constructor(String, String, String, String?, String?, String?)
+data class com.datadog.android.internal.profiling.RumAnrEvent
+  constructor(Long, Long, ContinuousProfilingRumContext)
+data class com.datadog.android.internal.profiling.RumLongTaskEvent
+  constructor(Long, Long, ContinuousProfilingRumContext)
 data class com.datadog.android.internal.rum.RumSessionRenewedEvent
   constructor(String, Boolean)
 interface com.datadog.android.internal.system.BuildSdkVersionProvider

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -250,6 +250,23 @@ public final class com/datadog/android/internal/profiler/GlobalBenchmark {
 	public final fun register (Lcom/datadog/android/internal/profiler/BenchmarkSdkUploads;)V
 }
 
+public final class com/datadog/android/internal/profiling/ContinuousProfilingRumContext {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/internal/profiling/ContinuousProfilingRumContext;
+	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/ContinuousProfilingRumContext;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/internal/profiling/ContinuousProfilingRumContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApplicationId ()Ljava/lang/String;
+	public final fun getSessionId ()Ljava/lang/String;
+	public final fun getViewId ()Ljava/lang/String;
+	public final fun getViewName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract class com/datadog/android/internal/profiling/ProfilerStopEvent {
 }
 
@@ -262,6 +279,36 @@ public final class com/datadog/android/internal/profiling/ProfilerStopEvent$TTID
 	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/ProfilerStopEvent$TTID;Lcom/datadog/android/internal/profiling/TTIDRumContext;ILjava/lang/Object;)Lcom/datadog/android/internal/profiling/ProfilerStopEvent$TTID;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRumContext ()Lcom/datadog/android/internal/profiling/TTIDRumContext;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/internal/profiling/RumAnrEvent {
+	public fun <init> (JJLcom/datadog/android/internal/profiling/ContinuousProfilingRumContext;)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun component3 ()Lcom/datadog/android/internal/profiling/ContinuousProfilingRumContext;
+	public final fun copy (JJLcom/datadog/android/internal/profiling/ContinuousProfilingRumContext;)Lcom/datadog/android/internal/profiling/RumAnrEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/RumAnrEvent;JJLcom/datadog/android/internal/profiling/ContinuousProfilingRumContext;ILjava/lang/Object;)Lcom/datadog/android/internal/profiling/RumAnrEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDurationNs ()J
+	public final fun getRumContext ()Lcom/datadog/android/internal/profiling/ContinuousProfilingRumContext;
+	public final fun getStartMs ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/internal/profiling/RumLongTaskEvent {
+	public fun <init> (JJLcom/datadog/android/internal/profiling/ContinuousProfilingRumContext;)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun component3 ()Lcom/datadog/android/internal/profiling/ContinuousProfilingRumContext;
+	public final fun copy (JJLcom/datadog/android/internal/profiling/ContinuousProfilingRumContext;)Lcom/datadog/android/internal/profiling/RumLongTaskEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/RumLongTaskEvent;JJLcom/datadog/android/internal/profiling/ContinuousProfilingRumContext;ILjava/lang/Object;)Lcom/datadog/android/internal/profiling/RumLongTaskEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDurationNs ()J
+	public final fun getRumContext ()Lcom/datadog/android/internal/profiling/ContinuousProfilingRumContext;
+	public final fun getStartMs ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ContinuousProfilingRumContext.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ContinuousProfilingRumContext.kt
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.profiling
+
+/**
+ * RUM context attached to continuous profiling events.
+ *
+ * @param applicationId The RUM application ID.
+ * @param sessionId The ID of the active RUM session.
+ * @param viewId The ID of the active RUM view, or null if unavailable.
+ * @param viewName The name of the active RUM view, or null if unavailable.
+ */
+// TODO RUM-15334: Commonize ContinuousProfilingRumContext & TTIDRumContext
+data class ContinuousProfilingRumContext(
+    val applicationId: String,
+    val sessionId: String,
+    val viewId: String?,
+    val viewName: String?
+)

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/RumAnrEvent.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/RumAnrEvent.kt
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.profiling
+
+/**
+ * Sent by the RUM feature to the profiling feature whenever an ANR is detected.
+ *
+ * @param startMs Start timestamp in milliseconds since epoch (server time-adjusted).
+ * @param durationNs Duration of the ANR in nanoseconds.
+ * @param rumContext RUM context at the time of the ANR.
+ */
+data class RumAnrEvent(
+    val startMs: Long,
+    val durationNs: Long,
+    val rumContext: ContinuousProfilingRumContext
+)

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/RumLongTaskEvent.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/RumLongTaskEvent.kt
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.profiling
+
+/**
+ * Sent by the RUM feature to the profiling feature whenever a long task is detected.
+ *
+ * @param startMs Start timestamp in milliseconds since epoch (server time-adjusted).
+ * @param durationNs Duration of the long task in nanoseconds.
+ * @param rumContext RUM context at the time of the long task.
+ */
+data class RumLongTaskEvent(
+    val startMs: Long,
+    val durationNs: Long,
+    val rumContext: ContinuousProfilingRumContext
+)

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -18,6 +18,8 @@ import com.datadog.android.api.net.RequestFactory
 import com.datadog.android.api.storage.FeatureStorageConfiguration
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.internal.profiling.ProfilerStopEvent
+import com.datadog.android.internal.profiling.RumAnrEvent
+import com.datadog.android.internal.profiling.RumLongTaskEvent
 import com.datadog.android.internal.profiling.TTIDRumContext
 import com.datadog.android.internal.rum.RumSessionRenewedEvent
 import com.datadog.android.profiling.ExperimentalProfilingApi
@@ -94,6 +96,13 @@ internal class ProfilingFeature(
         when (event) {
             is ProfilerStopEvent.TTID -> onTtidEvent(event)
             is RumSessionRenewedEvent -> onRumSessionRenewed(event)
+            is RumLongTaskEvent -> {
+                // TODO RUM-15321: forward to ContinuousProfilingScheduler
+            }
+
+            is RumAnrEvent -> {
+                // TODO RUM-15321: forward to ContinuousProfilingScheduler
+            }
             else -> sdkCore.internalLogger.log(
                 InternalLogger.Level.WARN,
                 InternalLogger.Target.MAINTAINER,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnable.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnable.kt
@@ -151,7 +151,7 @@ internal class ANRDetectorRunnable(
     }
 
     companion object {
-        private const val ANR_THRESHOLD_MS = 5000L
+        internal const val ANR_THRESHOLD_MS = 5000L
         private const val ANR_TEST_DELAY_MS = 500L
 
         internal const val ANR_MESSAGE = "Application Not Responding"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -18,6 +18,9 @@ import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.internal.attributes.LocalAttribute
 import com.datadog.android.internal.attributes.ViewScopeInstrumentationType
+import com.datadog.android.internal.profiling.ContinuousProfilingRumContext
+import com.datadog.android.internal.profiling.RumAnrEvent
+import com.datadog.android.internal.profiling.RumLongTaskEvent
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.RumActionType
@@ -25,6 +28,7 @@ import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.FeaturesContextResolver
+import com.datadog.android.rum.internal.anr.ANRDetectorRunnable
 import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.domain.InfoProvider
 import com.datadog.android.rum.internal.domain.RumContext
@@ -701,6 +705,31 @@ internal open class RumViewScope(
             rumContext.viewId.orEmpty()
         )
 
+        // region profiling
+        var profilingStatus: ErrorEvent.Profiling? = null
+        // Fatal ANR comes from last session, in this case we don't attach it to Profiling Event.
+        // TODO RUM-15344: address non-fatal ANR over Android API 30
+        if (event.throwable is ANRException && !isFatal) {
+            val anrDurationMs = ANRDetectorRunnable.ANR_THRESHOLD_MS
+            val anrStartMs = event.eventTime.timestamp + serverTimeOffsetInMs - anrDurationMs
+            val anrDurationNs = TimeUnit.MILLISECONDS.toNanos(anrDurationMs)
+
+            profilingStatus = resolveErrorProfilingStatus(datadogContext)
+            sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.sendEvent(
+                RumAnrEvent(
+                    startMs = anrStartMs,
+                    durationNs = anrDurationNs,
+                    rumContext = ContinuousProfilingRumContext(
+                        applicationId = rumContext.applicationId,
+                        sessionId = rumContext.sessionId,
+                        viewId = rumContext.viewId,
+                        viewName = rumContext.viewName
+                    )
+                )
+            )
+        }
+        // end region
+
         sdkCore.newRumEventWriteOperation(datadogContext, writeScope, writer, eventType) {
             val user = datadogContext.userInfo
             val syntheticsAttribute = if (
@@ -809,7 +838,8 @@ internal open class RumViewScope(
                     session = ErrorEvent.DdSession(
                         sessionPrecondition = rumContext.sessionStartReason.toErrorSessionPrecondition()
                     ),
-                    configuration = ErrorEvent.Configuration(sessionSampleRate = sampleRate)
+                    configuration = ErrorEvent.Configuration(sessionSampleRate = sampleRate),
+                    profiling = profilingStatus
                 ),
                 service = datadogContext.service,
                 version = datadogContext.version,
@@ -1440,6 +1470,20 @@ internal open class RumViewScope(
             datadogContext,
             rumContext.viewId.orEmpty()
         )
+
+        sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.sendEvent(
+            RumLongTaskEvent(
+                startMs = timestamp - TimeUnit.NANOSECONDS.toMillis(event.durationNs),
+                durationNs = event.durationNs,
+                rumContext = ContinuousProfilingRumContext(
+                    applicationId = rumContext.applicationId,
+                    sessionId = rumContext.sessionId,
+                    viewId = rumContext.viewId,
+                    viewName = rumContext.viewName
+                )
+            )
+        )
+
         sdkCore.newRumEventWriteOperation(datadogContext, writeScope, writer) {
             val user = datadogContext.userInfo
             val syntheticsAttribute = if (
@@ -1523,7 +1567,8 @@ internal open class RumViewScope(
                     session = LongTaskEvent.DdSession(
                         sessionPrecondition = rumContext.sessionStartReason.toLongTaskSessionPrecondition()
                     ),
-                    configuration = LongTaskEvent.Configuration(sessionSampleRate = sampleRate)
+                    configuration = LongTaskEvent.Configuration(sessionSampleRate = sampleRate),
+                    profiling = resolveLongTaskProfilingStatus(datadogContext)
                 ),
                 service = datadogContext.service,
                 version = datadogContext.version,
@@ -1623,6 +1668,31 @@ internal open class RumViewScope(
         return tracingContext?.get(TRACE_SAMPLE_RATE) as? Float
     }
 
+    private fun resolveErrorProfilingStatus(datadogContext: DatadogContext): ErrorEvent.Profiling? {
+        return if (resolveProfilingRunning(datadogContext)) {
+            ErrorEvent.Profiling(status = ErrorEvent.ProfilingStatus.RUNNING)
+        } else {
+            null
+        }
+    }
+
+    private fun resolveLongTaskProfilingStatus(datadogContext: DatadogContext): LongTaskEvent.Profiling? {
+        return if (resolveProfilingRunning(datadogContext)) {
+            LongTaskEvent.Profiling(status = LongTaskEvent.ProfilingStatus.RUNNING)
+        } else {
+            null
+        }
+    }
+
+    private fun resolveProfilingRunning(datadogContext: DatadogContext): Boolean {
+        val profilingFeature = sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)
+        return profilingFeature?.let {
+            datadogContext.featuresContext[Feature.PROFILING_FEATURE_NAME]?.get(
+                PROFILER_IS_RUNNING
+            ) == true
+        } ?: false
+    }
+
     private fun logSynthetics(key: String, value: String) {
         /**
          * We use [android.util.Log] here instead of [InternalLogger] because we want to log regardless of the
@@ -1634,6 +1704,9 @@ internal open class RumViewScope(
     // endregion
 
     companion object {
+
+        private const val PROFILER_IS_RUNNING = "profiler_is_running"
+
         internal val ONE_SECOND_NS = TimeUnit.SECONDS.toNanos(1)
 
         // Must match SessionReplayFeature.SESSION_REPLAY_SAMPLE_RATE_KEY in dd-sdk-android-session-replay

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
@@ -691,6 +691,26 @@ internal class ErrorEventAssert(actual: ErrorEvent) :
         return this
     }
 
+    fun hasProfilingStatus(profilingStatus: ErrorEvent.ProfilingStatus?): ErrorEventAssert {
+        assertThat(actual.dd.profiling?.status)
+            .overridingErrorMessage(
+                "Expected RUM event to have profiling status: $profilingStatus" +
+                    " but instead was: ${actual.dd.profiling?.status}"
+            )
+            .isEqualTo(profilingStatus)
+        return this
+    }
+
+    fun hasNoProfiling(): ErrorEventAssert {
+        assertThat(actual.dd.profiling)
+            .overridingErrorMessage(
+                "Expected RUM event to have no profiling" +
+                    " but instead was: ${actual.dd.profiling}"
+            )
+            .isNull()
+        return this
+    }
+
     companion object {
         internal const val TIMESTAMP_THRESHOLD_MS = 50L
         internal fun assertThat(actual: ErrorEvent): ErrorEventAssert =

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/LongTaskEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/LongTaskEventAssert.kt
@@ -430,6 +430,26 @@ internal class LongTaskEventAssert(actual: LongTaskEvent) :
         return this
     }
 
+    fun hasProfilingStatus(profilingStatus: LongTaskEvent.ProfilingStatus?): LongTaskEventAssert {
+        assertThat(actual.dd.profiling?.status)
+            .overridingErrorMessage(
+                "Expected RUM event to have profiling status: $profilingStatus" +
+                    " but instead was: ${actual.dd.profiling?.status}"
+            )
+            .isEqualTo(profilingStatus)
+        return this
+    }
+
+    fun hasNoProfiling(): LongTaskEventAssert {
+        assertThat(actual.dd.profiling)
+            .overridingErrorMessage(
+                "Expected RUM event to have no profiling" +
+                    " but instead was: ${actual.dd.profiling}"
+            )
+            .isNull()
+        return this
+    }
+
     companion object {
         internal const val TIMESTAMP_THRESHOLD_MS = 50L
         internal fun assertThat(actual: LongTaskEvent): LongTaskEventAssert =

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -12,12 +12,15 @@ import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.api.context.TimeInfo
 import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.feature.event.ThreadDump
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
+import com.datadog.android.internal.profiling.ContinuousProfilingRumContext
+import com.datadog.android.internal.profiling.RumAnrEvent
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.RumActionType
@@ -35,6 +38,7 @@ import com.datadog.android.rum.assertj.VitalFeatureOperationPropertiesAssert
 import com.datadog.android.rum.featureoperations.FailureReason
 import com.datadog.android.rum.internal.FeaturesContextResolver
 import com.datadog.android.rum.internal.RumErrorSourceType
+import com.datadog.android.rum.internal.anr.ANRDetectorRunnable
 import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.domain.InfoProvider
 import com.datadog.android.rum.internal.domain.RumContext
@@ -229,6 +233,9 @@ internal class RumViewScopeTest {
     var fakeReplayRecordsCount: Long = 0
 
     @Mock
+    lateinit var mockProfilingFeatureScope: FeatureScope
+
+    @Mock
     lateinit var mockFeaturesContextResolver: FeaturesContextResolver
 
     @Mock
@@ -378,6 +385,8 @@ internal class RumViewScopeTest {
         whenever(rumMonitorConfiguration.mockSdkCore.time) doReturn fakeTimeInfoAtScopeStart
         whenever(rumMonitorConfiguration.mockSdkCore.networkInfo) doReturn fakeNetworkInfoAtScopeStart
         whenever(rumMonitorConfiguration.mockSdkCore.internalLogger) doReturn mockInternalLogger
+        whenever(rumMonitorConfiguration.mockSdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)) doReturn
+            mockProfilingFeatureScope
         whenever(mockEventWriteScope.invoke(any())) doAnswer {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
@@ -3880,10 +3889,82 @@ internal class RumViewScopeTest {
                     hasBuildId(fakeDatadogContext.appBuildId)
                     hasSampleRate(fakeSampleRate)
                     hasBuildId(fakeDatadogContext.appBuildId)
+                    hasNoProfiling()
                 }
         }
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
+    }
+
+    @Test
+    fun `M send RumAnrEvent to profiling W handleEvent(AddError) {throwable is ANRException}`(
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @StringForgery stacktrace: String,
+        forge: Forge
+    ) {
+        // Given
+        val throwable = ANRException(Thread.currentThread())
+        testedScope.activeActionScope = mockActionScope
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        fakeEvent = RumRawEvent.AddError(
+            message,
+            source,
+            throwable,
+            stacktrace,
+            isFatal = false,
+            threads = emptyList(),
+            attributes = attributes
+        )
+        val expectedDurationNs = TimeUnit.MILLISECONDS.toNanos(ANRDetectorRunnable.ANR_THRESHOLD_MS)
+        val expectedStartMs = resolveExpectedTimestamp(fakeEvent.eventTime.timestamp) -
+            ANRDetectorRunnable.ANR_THRESHOLD_MS
+
+        // When
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        argumentCaptor<RumAnrEvent> {
+            verify(mockProfilingFeatureScope).sendEvent(capture())
+            assertThat(firstValue.startMs).isEqualTo(expectedStartMs)
+            assertThat(firstValue.durationNs).isEqualTo(expectedDurationNs)
+            assertThat(firstValue.rumContext).isEqualTo(
+                ContinuousProfilingRumContext(
+                    applicationId = fakeParentContext.applicationId,
+                    sessionId = fakeParentContext.sessionId,
+                    viewId = testedScope.viewId,
+                    viewName = fakeKey.name
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `M not send RumAnrEvent to profiling W handleEvent(AddError) {throwable is not ANRException}`(
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @StringForgery stacktrace: String,
+        forge: Forge
+    ) {
+        // Given
+        val throwable = RuntimeException("not an ANR")
+        testedScope.activeActionScope = mockActionScope
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        fakeEvent = RumRawEvent.AddError(
+            message,
+            source,
+            throwable,
+            stacktrace,
+            isFatal = false,
+            threads = emptyList(),
+            attributes = attributes
+        )
+
+        // When
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        verify(mockProfilingFeatureScope, never()).sendEvent(isA<RumAnrEvent>())
     }
 
     @Test
@@ -5202,6 +5283,7 @@ internal class RumViewScopeTest {
                     hasBuildVersion(fakeDatadogContext.versionCode)
                     hasBuildId(fakeDatadogContext.appBuildId)
                     hasSampleRate(fakeSampleRate)
+                    hasNoProfiling()
                 }
         }
         verifyNoMoreInteractions(mockWriter)
@@ -5263,6 +5345,7 @@ internal class RumViewScopeTest {
                     hasBuildVersion(fakeDatadogContext.versionCode)
                     hasBuildId(fakeDatadogContext.appBuildId)
                     hasSampleRate(fakeSampleRate)
+                    hasNoProfiling()
                 }
         }
         verifyNoMoreInteractions(mockWriter)
@@ -5464,6 +5547,182 @@ internal class RumViewScopeTest {
         assertThat(testedScope.pendingLongTaskCount).isEqualTo(1)
         assertThat(testedScope.pendingFrozenFrameCount).isEqualTo(1)
         assertThat(result).isSameAs(testedScope)
+    }
+
+    @Test
+    fun `M not crash W handleEvent(AddLongTask) {profiling feature absent}`(
+        @LongForgery(0L, 700_000_000L) durationNs: Long,
+        @StringForgery target: String
+    ) {
+        // Given
+        testedScope.activeActionScope = null
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        whenever(rumMonitorConfiguration.mockSdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)) doReturn null
+
+        // When
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        argumentCaptor<LongTaskEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(firstValue).hasNoProfiling()
+        }
+    }
+
+    @Test
+    fun `M set profiling status RUNNING in LongTaskEvent W handleEvent(AddLongTask) {profiler running}`(
+        @LongForgery(0L, 700_000_000L) durationNs: Long,
+        @StringForgery target: String
+    ) {
+        // Given
+        testedScope.activeActionScope = null
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        val datadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(Feature.PROFILING_FEATURE_NAME, mapOf("profiler_is_running" to true))
+            }
+        )
+
+        // When
+        testedScope.handleEvent(fakeEvent, datadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        argumentCaptor<LongTaskEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(firstValue).hasProfilingStatus(LongTaskEvent.ProfilingStatus.RUNNING)
+        }
+    }
+
+    @Test
+    fun `M not set profiling status in LongTaskEvent W handleEvent(AddLongTask) {profiler not running}`(
+        @LongForgery(0L, 700_000_000L) durationNs: Long,
+        @StringForgery target: String
+    ) {
+        // Given
+        testedScope.activeActionScope = null
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        val datadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(Feature.PROFILING_FEATURE_NAME, mapOf("profiler_is_running" to false))
+            }
+        )
+
+        // When
+        testedScope.handleEvent(fakeEvent, datadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        argumentCaptor<LongTaskEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(firstValue).hasNoProfiling()
+        }
+    }
+
+    @Test
+    fun `M set profiling status RUNNING in ErrorEvent W handleEvent(AddError) {ANR, profiler running}`(
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @StringForgery stacktrace: String,
+        forge: Forge
+    ) {
+        // Given
+        val throwable = ANRException(Thread.currentThread())
+        testedScope.activeActionScope = mockActionScope
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        fakeEvent = RumRawEvent.AddError(
+            message,
+            source,
+            throwable,
+            stacktrace,
+            isFatal = false,
+            threads = emptyList(),
+            attributes = attributes
+        )
+        val datadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(Feature.PROFILING_FEATURE_NAME, mapOf("profiler_is_running" to true))
+            }
+        )
+
+        // When
+        testedScope.handleEvent(fakeEvent, datadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        argumentCaptor<ErrorEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(firstValue).hasProfilingStatus(ErrorEvent.ProfilingStatus.RUNNING)
+        }
+    }
+
+    @Test
+    fun `M not set profiling status in ErrorEvent W handleEvent(AddError) {ANR, profiler not running}`(
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @StringForgery stacktrace: String,
+        forge: Forge
+    ) {
+        // Given
+        val throwable = ANRException(Thread.currentThread())
+        testedScope.activeActionScope = mockActionScope
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        fakeEvent = RumRawEvent.AddError(
+            message,
+            source,
+            throwable,
+            stacktrace,
+            isFatal = false,
+            threads = emptyList(),
+            attributes = attributes
+        )
+        val datadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(Feature.PROFILING_FEATURE_NAME, mapOf("profiler_is_running" to false))
+            }
+        )
+
+        // When
+        testedScope.handleEvent(fakeEvent, datadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        argumentCaptor<ErrorEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(firstValue).hasNoProfiling()
+        }
+    }
+
+    @Test
+    fun `M not set profiling status in ErrorEvent W handleEvent(AddError) {non-ANR error}`(
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @StringForgery stacktrace: String,
+        forge: Forge
+    ) {
+        // Given
+        val throwable = RuntimeException("not an ANR")
+        testedScope.activeActionScope = mockActionScope
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        fakeEvent = RumRawEvent.AddError(
+            message,
+            source,
+            throwable,
+            stacktrace,
+            isFatal = false,
+            threads = emptyList(),
+            attributes = attributes
+        )
+        val datadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(Feature.PROFILING_FEATURE_NAME, mapOf("profiler_is_running" to true))
+            }
+        )
+
+        // When
+        testedScope.handleEvent(fakeEvent, datadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        argumentCaptor<ErrorEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(firstValue).hasNoProfiling()
+        }
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

This PR implements the logic of sending RUM long-task and ANR events to the Profiling feature for continuous profiling correlation.

It also adds the profiling status for these two RUM events.

### Motivation

RUM-15323


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

