### PR TITLE
Use modified request in resource headers feature

### DIFF
--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -196,13 +196,12 @@ open class DatadogInterceptor internal constructor(
 
     private fun extractHeaderAttributes(
         sdkCore: FeatureSdkCore,
-        request: Request,
         response: Response
     ): Map<String, Any?> {
         val extractor = resourceHeadersExtractor ?: return emptyMap()
         val reqHeaders = _RumInternalProxy.extractRequestHeaders(
             extractor,
-            request.headers.toMultimap(),
+            response.request.headers.toMultimap(),
             sdkCore.internalLogger
         )
         val resHeaders = _RumInternalProxy.extractResponseHeaders(
@@ -253,7 +252,7 @@ open class DatadogInterceptor internal constructor(
             }
         }
 
-        val headerAttributes = extractHeaderAttributes(sdkCore, request, response)
+        val headerAttributes = extractHeaderAttributes(sdkCore, response)
 
         @Suppress("DEPRECATION")
         (GlobalRumMonitor.get(sdkCore) as? AdvancedNetworkRumMonitor)?.stopResource(


### PR DESCRIPTION
### What does this PR do?

- Use `response.request` instead of `request` so that customers are able to capture internal Datadog Tracing Headers, such as `x-datadog-trace-id`, `x-datadog-tags`, `x-datadog-parent-id`.
- This aligns with iOS and Browser behaviour.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

