### PR TITLE
RUM-15103: Fix`compose-ui` compatibility issue

### DIFF
--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeUtils.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeUtils.kt
@@ -25,6 +25,8 @@ import com.datadog.android.rum.RumAttributes.ACTION_TARGET_SELECTED
 
 internal class LayoutNodeUtils {
 
+    private var reflectionFallbackModeActivated = false
+
     @Suppress("NestedBlockDepth", "CyclomaticComplexMethod")
     fun resolveLayoutNode(node: LayoutNode): TargetNode? {
         return runSafe("resolveLayoutNode") {
@@ -97,20 +99,29 @@ internal class LayoutNodeUtils {
         }
     }
 
-    fun getLayoutNodeBoundsInWindow(node: LayoutNode): Rect? {
-        return runSafe("getLayoutNodeBoundsInWindow") {
-            node.layoutDelegate.outerCoordinator.coordinates.boundsInWindow()
-        } ?: runSafe("getLayoutNodeBoundsInWindow[reflection]") {
-            // TODO RUM-13454 Update compose bom and remove this block
-            val coordinates = node.getMethod("getLayoutDelegate")
-                ?.getMethod("getOuterCoordinator")
-                ?.getMethod("getCoordinates")
+    fun getLayoutNodeBoundsInWindow(node: LayoutNode): Rect? = if (reflectionFallbackModeActivated) {
+        getLayoutNodeBoundsInWindowReflection(node)
+    } else {
+        getLayoutNodeBoundsInWindowInternal(node) ?: getLayoutNodeBoundsInWindowReflection(node)
+    }
 
-            @Suppress("UnsafeThirdPartyFunctionCall") // it's okay if exception will be thrown here
-            Class.forName("androidx.compose.ui.layout.LayoutCoordinatesKt")
-                .getMethod("boundsInWindow", Class.forName("androidx.compose.ui.layout.LayoutCoordinates"))
-                .invoke(null, coordinates) as? Rect
-        }
+    private fun getLayoutNodeBoundsInWindowInternal(node: LayoutNode): Rect? = runSafe(
+        "getLayoutNodeBoundsInWindow"
+    ) { node.layoutDelegate.outerCoordinator.coordinates.boundsInWindow() }
+
+    private fun getLayoutNodeBoundsInWindowReflection(node: LayoutNode) = runSafe(
+        "getLayoutNodeBoundsInWindow[reflection]"
+    ) {
+        // TODO RUM-13454 Update compose bom and remove this method
+        reflectionFallbackModeActivated = true
+        val coordinates = node.getMethod("getLayoutDelegate")
+            ?.getMethod("getOuterCoordinator")
+            ?.getMethod("getCoordinates")
+
+        @Suppress("UnsafeThirdPartyFunctionCall") // it's okay if exception will be thrown here
+        Class.forName("androidx.compose.ui.layout.LayoutCoordinatesKt")
+            .getMethod("boundsInWindow", Class.forName("androidx.compose.ui.layout.LayoutCoordinates"))
+            .invoke(null, coordinates) as? Rect
     }
 
     private fun Any.getMethod(prefix: String): Any? {

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeUtils.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeUtils.kt
@@ -100,7 +100,22 @@ internal class LayoutNodeUtils {
     fun getLayoutNodeBoundsInWindow(node: LayoutNode): Rect? {
         return runSafe("getLayoutNodeBoundsInWindow") {
             node.layoutDelegate.outerCoordinator.coordinates.boundsInWindow()
+        } ?: runSafe("getLayoutNodeBoundsInWindow[reflection]") {
+            // TODO RUM-13454 Update compose bom and remove this block
+            val coordinates = node.getMethod("getLayoutDelegate")
+                ?.getMethod("getOuterCoordinator")
+                ?.getMethod("getCoordinates")
+
+            @Suppress("UnsafeThirdPartyFunctionCall") // it's okay if exception will be thrown here
+            Class.forName("androidx.compose.ui.layout.LayoutCoordinatesKt")
+                .getMethod("boundsInWindow", Class.forName("androidx.compose.ui.layout.LayoutCoordinates"))
+                .invoke(null, coordinates) as? Rect
         }
+    }
+
+    private fun Any.getMethod(prefix: String): Any? {
+        return this.javaClass.methods.firstOrNull { it.name == prefix || it.name.startsWith("$prefix$") }
+            ?.invoke(this)
     }
 
     private fun <T> runSafe(callSite: String, action: () -> T): T? {

--- a/integrations/dd-sdk-android-compose/src/test/java/com/datadog/android/compose/internal/utils/FakeLayoutNodeUi.java
+++ b/integrations/dd-sdk-android-compose/src/test/java/com/datadog/android/compose/internal/utils/FakeLayoutNodeUi.java
@@ -1,0 +1,34 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.compose.internal.utils;
+
+/**
+ * Fake object used in tests to simulate an internal Compose class that exposes
+ * methods with the {@code $ui} module-suffix naming convention (the JVM-mangled
+ * name for {@code internal} members in the {@code androidx.compose.ui} module).
+ * Used to verify the reflection fallback in {@link LayoutNodeUtils}.
+ */
+public class FakeLayoutNodeUi {
+
+    public final Object value;
+
+    public FakeLayoutNodeUi(Object value) {
+        this.value = value;
+    }
+
+    public Object getLayoutDelegate$ui() {
+        return value;
+    }
+
+    public Object getOuterCoordinator$ui() {
+        return value;
+    }
+
+    public Object getCoordinates$ui() {
+        return value;
+    }
+}

--- a/integrations/dd-sdk-android-compose/src/test/java/com/datadog/android/compose/internal/utils/FakeLayoutNodeUiRelease.java
+++ b/integrations/dd-sdk-android-compose/src/test/java/com/datadog/android/compose/internal/utils/FakeLayoutNodeUiRelease.java
@@ -1,0 +1,35 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.compose.internal.utils;
+
+/**
+ * Fake object used in tests to simulate an internal Compose class that exposes
+ * methods with the {@code $ui_release} module-suffix naming convention (the JVM-mangled
+ * name for {@code internal} members in the release variant of the
+ * {@code androidx.compose.ui} module).
+ * Used to verify the reflection fallback in {@link LayoutNodeUtils}.
+ */
+public class FakeLayoutNodeUiRelease {
+
+    public final Object value;
+
+    public FakeLayoutNodeUiRelease(Object value) {
+        this.value = value;
+    }
+
+    public Object getLayoutDelegate$ui_release() {
+        return value;
+    }
+
+    public Object getOuterCoordinator$ui_release() {
+        return value;
+    }
+
+    public Object getCoordinates$ui_release() {
+        return value;
+    }
+}

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeGetMethodTest.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeGetMethodTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.compose.internal.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Method
+
+/**
+ * Tests for the [LayoutNodeUtils.getMethod] reflection helper that resolves
+ * Kotlin-internal method names regardless of module-suffix mangling.
+ *
+ * Compose internal properties are compiled to JVM methods whose names are mangled
+ * with a module identifier suffix, e.g. {@code getLayoutDelegate$ui} (debug) or
+ * {@code getLayoutDelegate$ui_release} (release).  [FakeLayoutNodeUi] and
+ * [FakeLayoutNodeUiRelease] simulate these two naming conventions.
+ */
+internal class LayoutNodeGetMethodTest {
+
+    private val testedLayoutNodeUtils = LayoutNodeUtils()
+
+    // getMethod is private fun Any.getMethod(prefix: String): Any? compiled as an
+    // instance method with signature getMethod(Object, String) in the JVM.
+    private val getMethodFn: Method = LayoutNodeUtils::class.java
+        .getDeclaredMethod("getMethod", Any::class.java, String::class.java)
+        .also { it.isAccessible = true }
+
+    // region $ui suffix
+
+    @Test
+    fun `M find method W getMethod {method has dollar ui suffix}`() {
+        // Given
+        val expected = Any()
+        val fakeNode = FakeLayoutNodeUi(expected)
+
+        // When
+        val result = getMethodFn.invoke(testedLayoutNodeUtils, fakeNode, "getLayoutDelegate")
+
+        // Then
+        assertThat(result).isSameAs(expected)
+    }
+
+    @Test
+    fun `M find method W getMethod {outer coordinator method has dollar ui suffix}`() {
+        // Given
+        val expected = Any()
+        val fakeNode = FakeLayoutNodeUi(expected)
+
+        // When
+        val result = getMethodFn.invoke(testedLayoutNodeUtils, fakeNode, "getOuterCoordinator")
+
+        // Then
+        assertThat(result).isSameAs(expected)
+    }
+
+    @Test
+    fun `M find method W getMethod {coordinates method has dollar ui suffix}`() {
+        // Given
+        val expected = Any()
+        val fakeNode = FakeLayoutNodeUi(expected)
+
+        // When
+        val result = getMethodFn.invoke(testedLayoutNodeUtils, fakeNode, "getCoordinates")
+
+        // Then
+        assertThat(result).isSameAs(expected)
+    }
+
+    // endregion
+
+    // region $ui_release suffix
+
+    @Test
+    fun `M find method W getMethod {method has dollar ui_release suffix}`() {
+        // Given
+        val expected = Any()
+        val fakeNode = FakeLayoutNodeUiRelease(expected)
+
+        // When
+        val result = getMethodFn.invoke(testedLayoutNodeUtils, fakeNode, "getLayoutDelegate")
+
+        // Then
+        assertThat(result).isSameAs(expected)
+    }
+
+    @Test
+    fun `M find method W getMethod {outer coordinator method has dollar ui_release suffix}`() {
+        // Given
+        val expected = Any()
+        val fakeNode = FakeLayoutNodeUiRelease(expected)
+
+        // When
+        val result = getMethodFn.invoke(testedLayoutNodeUtils, fakeNode, "getOuterCoordinator")
+
+        // Then
+        assertThat(result).isSameAs(expected)
+    }
+
+    @Test
+    fun `M find method W getMethod {coordinates method has dollar ui_release suffix}`() {
+        // Given
+        val expected = Any()
+        val fakeNode = FakeLayoutNodeUiRelease(expected)
+
+        // When
+        val result = getMethodFn.invoke(testedLayoutNodeUtils, fakeNode, "getCoordinates")
+
+        // Then
+        assertThat(result).isSameAs(expected)
+    }
+
+    // endregion
+
+    // region no match
+
+    @Test
+    fun `M return null W getMethod {no matching method}`() {
+        // Given
+        val fakeNode = Any()
+
+        // When
+        val result = getMethodFn.invoke(testedLayoutNodeUtils, fakeNode, "getLayoutDelegate")
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    // endregion
+}


### PR DESCRIPTION
## What does this PR do?

Fix compatibility with the latest `compose-ui` where Google migrated from android-compose to KMP-compatible Compose. This change caused method mangling differences — the Kotlin compiler now adds `$ui` suffix instead of `$ui_release` for internal members.

Added reflection-based fallback in `getLayoutNodeBoundsInWindow()` that searches for methods without `$` suffix with the new `getMethod()` helper.

<img width="1434" height="124" alt="Screenshot 2026-03-27 at 16 17 05" src="https://github.com/user-attachments/assets/80a490a5-be09-4185-b623-427f7787ba24" />



## Motivation
Google's migration of Compose to KMP-compatible version (https://android-review.googlesource.com/c/platform/frameworks/support/+/3684165) introduced breaking changes in method mangling for internal members. Our SDK is compiled with Compose BOM 2023.10.01, and upgrading would pull in kotlin-coroutines dependencies that some users don't want.

<table>
  <tr>
  <th>Before fix</th>
  <th>After fix</th>
  </tr>
  <tr>
  <td>

  [Record of the issue](https://github.com/user-attachments/assets/5485ce53-f37b-4268-a1bf-4013d7819a3e)

  </td>
  <td>

  [Record after the fix](https://github.com/user-attachments/assets/8d5b9eeb-96ba-42bf-9016-1c9259c8be73)

  </td>
  </tr>
  </table>


