### PR TITLE
RUM-1061: Don't send rum context when sessionId is NULL_UUID

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -800,9 +800,9 @@ internal class DatadogRumMonitor(
                     val (datadogContext, eventWriteScope) = writeContext
                     @Suppress("ThreadSafety") // Crash handling, can't delegate to another thread
                     rootScope.handleEvent(event, datadogContext, eventWriteScope, writer)
-                    val currentFeatureContext = currentRumContext()
                     sdkCore.updateFeatureContext(Feature.RUM_FEATURE_NAME) {
-                        it.putAll(currentFeatureContext.toMap())
+                        it.clear()
+                        currentRumContext()?.toMap()?.let(it::putAll)
                     }
                 } else {
                     sdkCore.internalLogger.log(
@@ -831,7 +831,7 @@ internal class DatadogRumMonitor(
                         val future = executorService.submitSafe(
                             "Rum event handling",
                             sdkCore.internalLogger,
-                            NamedCallable<RumContext>("${event::class.simpleName}") {
+                            NamedCallable("${event::class.simpleName}") {
                                 synchronized(rootScope) {
                                     handleEventWithMethodCallPerf(event, datadogContext, writeScope)
                                     notifyDebugListenerWithState()
@@ -840,11 +840,10 @@ internal class DatadogRumMonitor(
                             }
                         )
                         val rumContext = future.getSafe("Rum get context", sdkCore.internalLogger)
-                        if (rumContext != null) {
-                            // we are on the context thread already, so useContextThread=false
-                            sdkCore.updateFeatureContext(Feature.RUM_FEATURE_NAME, useContextThread = false) {
-                                it.putAll(rumContext.toMap())
-                            }
+                        // we are on the context thread already, so useContextThread=false
+                        sdkCore.updateFeatureContext(Feature.RUM_FEATURE_NAME, useContextThread = false) {
+                            it.clear()
+                            rumContext?.toMap()?.let(it::putAll)
                         }
                     }
                 }
@@ -890,12 +889,11 @@ internal class DatadogRumMonitor(
         }
     }
 
-    private fun currentRumContext(): RumContext {
-        val activeSession = rootScope.activeSession
-        val context = activeSession?.activeView?.getRumContext()
-            ?: activeSession?.getRumContext()
-            ?: rootScope.getRumContext()
-        return context
+    private fun currentRumContext(): RumContext? {
+        val activeSession = rootScope.activeSession ?: return null
+        val context = activeSession.activeView?.getRumContext()
+            ?: activeSession.getRumContext()
+        return if (context.sessionId == RumContext.NULL_UUID) null else context
     }
 
     internal fun notifyDebugListenerWithState() {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -800,9 +800,10 @@ internal class DatadogRumMonitor(
                     val (datadogContext, eventWriteScope) = writeContext
                     @Suppress("ThreadSafety") // Crash handling, can't delegate to another thread
                     rootScope.handleEvent(event, datadogContext, eventWriteScope, writer)
+                    val rumContext = currentRumContext()
                     sdkCore.updateFeatureContext(Feature.RUM_FEATURE_NAME) {
                         it.clear()
-                        currentRumContext()?.toMap()?.let(it::putAll)
+                        rumContext?.toMap()?.let(it::putAll)
                     }
                 } else {
                     sdkCore.internalLogger.log(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -233,9 +233,9 @@ internal class DatadogRumMonitorTest {
         whenever(mockExecutorService.execute(any<Runnable>())) doAnswer {
             it.getArgument<Runnable>(0).run()
         }
-        whenever(mockExecutorService.submit(any<Callable<RumContext>>())) doAnswer {
-            val rumContext = it.getArgument<Callable<RumContext>>(0).call()
-            mock<Future<RumContext>>().apply { whenever(get()) doReturn rumContext }
+        whenever(mockExecutorService.submit(any<Callable<RumContext?>>())) doAnswer {
+            val rumContext = it.getArgument<Callable<RumContext?>>(0).call()
+            mock<Future<RumContext?>>().apply { whenever(get()) doReturn rumContext }
         }
 
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
@@ -273,6 +273,7 @@ internal class DatadogRumMonitorTest {
         fakeRumSessionType = forge.aNullable { aValueFrom(RumSessionType::class.java) }
 
         whenever(mockSessionSampler.getSampleRate()).thenReturn(fakeSampleRate)
+        whenever(mockApplicationScope.getRumContext()) doReturn forge.getForgery<RumContext>()
 
         testedMonitor = DatadogRumMonitor(
             applicationId = fakeApplicationId,
@@ -2454,6 +2455,7 @@ internal class DatadogRumMonitorTest {
         // Given
         var isMethodOccupied = false
         val mockRootScope = mock<RumApplicationScope>().apply {
+            whenever(getRumContext()) doReturn forge.getForgery<RumContext>()
             whenever(handleEvent(any(), any(), any(), any())) doAnswer {
                 if (isMethodOccupied) {
                     throw IllegalStateException(
@@ -2693,13 +2695,11 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
-    fun `M update feature context W handleEvent() { no active session }`(
-        @Forgery fakeRumEvent: RumRawEvent,
-        @Forgery fakeRumContext: RumContext
+    fun `M clear feature context W handleEvent() { no active session }`(
+        @Forgery fakeRumEvent: RumRawEvent
     ) {
         // Given
         val mockApplicationScope = mock<RumApplicationScope>()
-        whenever(mockApplicationScope.getRumContext()) doReturn fakeRumContext
         whenever(mockApplicationScope.activeSession) doReturn null
         testedMonitor.rootScope = mockApplicationScope
 
@@ -2709,9 +2709,9 @@ internal class DatadogRumMonitorTest {
         // Then
         argumentCaptor<(MutableMap<String, Any?>) -> Unit> {
             verify(mockSdkCore).updateFeatureContext(eq(Feature.RUM_FEATURE_NAME), any(), capture())
-            val acc = mutableMapOf<String, Any?>()
+            val acc = mutableMapOf<String, Any?>("stale_key" to "stale_value")
             firstValue.invoke(acc)
-            assertThat(acc).isEqualTo(fakeRumContext.toMap())
+            assertThat(acc).isEmpty()
         }
     }
 
@@ -2732,6 +2732,28 @@ internal class DatadogRumMonitorTest {
 
         // Then
         verify(mockSdkCore, never()).updateFeatureContext(eq(Feature.RUM_FEATURE_NAME), any(), any())
+    }
+
+    @Test
+    fun `M clear feature context W handleEvent() { session id is NULL_UUID }`(
+        @Forgery fakeRumEvent: RumRawEvent,
+        @Forgery fakeRumContext: RumContext
+    ) {
+        // Given
+        whenever(mockApplicationScope.getRumContext()) doReturn fakeRumContext.copy(
+            sessionId = RumContext.NULL_UUID
+        )
+
+        // When
+        testedMonitor.handleEvent(fakeRumEvent)
+
+        // Then
+        argumentCaptor<(MutableMap<String, Any?>) -> Unit> {
+            verify(mockSdkCore).updateFeatureContext(eq(Feature.RUM_FEATURE_NAME), any(), capture())
+            val acc = mutableMapOf<String, Any?>("stale_key" to "stale_value")
+            firstValue.invoke(acc)
+            assertThat(acc).isEmpty()
+        }
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

- [Align with iOS](https://github.com/DataDog/dd-sdk-ios/blob/2cad2f40579afe9a24e3c2c980a018ffede359f4/DatadogRUM/Sources/RUMMonitor/Monitor.swift#L151) to return `null RumContext` when `activeSession` is `null`.
- Prevent `NULL_UUID` RUM session ids from being published to the shared feature context. The context is now also cleared of any stale values from a previous session.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

