### PR TITLE
RUM-15307: Report failure through ProfilerCallback

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilerCallback.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilerCallback.kt
@@ -8,6 +8,8 @@ package com.datadog.android.profiling.internal
 
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 
-internal fun interface ProfilerCallback {
+internal interface ProfilerCallback {
     fun onSuccess(result: PerfettoResult)
+
+    fun onFailure(tag: String)
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -31,7 +31,7 @@ internal class ProfilingFeature(
     private val sdkCore: FeatureSdkCore,
     private val configuration: ProfilingConfiguration,
     private val profiler: Profiler
-) : StorageBackedFeature, FeatureEventReceiver {
+) : StorageBackedFeature, FeatureEventReceiver, ProfilerCallback {
 
     private var dataWriter: ProfilingWriter = NoOpProfilingWriter()
 
@@ -67,15 +67,7 @@ internal class ProfilingFeature(
         this.appContext = appContext
         profiler.apply {
             this.internalLogger = sdkCore.internalLogger
-            registerProfilingCallback(sdkCore.name) { result ->
-                perfettoResult = result
-                tryWriteProfilingEvent()
-                // if profiler stopped before TTID event, still update the status: in such case TTID profiling
-                // is incomplete
-                sdkCore.updateFeatureContext(Feature.PROFILING_FEATURE_NAME) { context ->
-                    context[PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
-                }
-            }
+            registerProfilingCallback(sdkCore.name, this@ProfilingFeature)
         }
         setMinimumSampleRate(appContext, configuration.applicationLaunchSampleRate)
         // Set the profiling flag in SharedPreferences to profile for the next app launch
@@ -116,6 +108,25 @@ internal class ProfilingFeature(
                 InternalLogger.Target.MAINTAINER,
                 { UNSUPPORTED_EVENT_TYPE.format(Locale.US, event::class.java.canonicalName) }
             )
+        }
+    }
+
+    override fun onSuccess(result: PerfettoResult) {
+        perfettoResult = result
+        tryWriteProfilingEvent()
+        sdkCore.updateFeatureContext(Feature.PROFILING_FEATURE_NAME) { context ->
+            context[PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
+        }
+    }
+
+    override fun onFailure(tag: String) {
+        if (tag == ProfilingStartReason.APPLICATION_LAUNCH.value) {
+            // Launch profiling ended with error such as rate limiting error.
+            // Unblock the continuous scheduler so it doesn't wait forever.
+            continuousProfilingScheduler?.onAppLaunchProfilingComplete()
+        }
+        sdkCore.updateFeatureContext(Feature.PROFILING_FEATURE_NAME) { context ->
+            context[PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
         }
     }
 

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
@@ -90,18 +90,23 @@ internal class PerfettoProfiler(
             val duration = effectiveStopTime - profilingStartTime
             val resultCallbackDelayMs =
                 if (profilingStopTime > 0L) resultCallbackTime - profilingStopTime else 0L
+            val tag = result.tag.orEmpty()
             if (result.errorCode == ProfilingResult.ERROR_NONE) {
                 // TODO RUM-13679: need to delete the file after it is no longer needed
                 result.resultFilePath?.let {
-                    notifyAllCallbacks(
-                        PerfettoResult(
-                            start = profilingStartTime,
-                            end = resultCallbackTime,
-                            tag = result.tag.orEmpty(),
-                            resultFilePath = it
+                    notifyCallbacks {
+                        onSuccess(
+                            PerfettoResult(
+                                start = profilingStartTime,
+                                end = resultCallbackTime,
+                                tag = tag,
+                                resultFilePath = it
+                            )
                         )
-                    )
-                }
+                    }
+                } ?: notifyCallbacks { onFailure(tag) }
+            } else {
+                notifyCallbacks { onFailure(tag) }
             }
             runningInstances.set(emptySet())
             sendProfilingEndTelemetry(
@@ -130,9 +135,10 @@ internal class PerfettoProfiler(
         }
     }
 
-    private fun notifyAllCallbacks(result: PerfettoResult) {
-        callbackMap.filter { runningInstances.get().contains(it.key) }.forEach { callback ->
-            callback.value.onSuccess(result)
+    private fun notifyCallbacks(dispatch: ProfilerCallback.() -> Unit) {
+        val running = runningInstances.get()
+        callbackMap.forEach { (key, callback) ->
+            if (running.contains(key)) callback.dispatch()
         }
     }
 

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -91,6 +91,9 @@ class ProfilingFeatureTest {
     @Forgery
     private lateinit var fakeConfiguration: ProfilingConfiguration
 
+    @StringForgery
+    private lateinit var fakeSessionId: String
+
     @Forgery
     private lateinit var fakeTTID: ProfilerStopEvent.TTID
 
@@ -277,6 +280,76 @@ class ProfilingFeatureTest {
         verify(mockProfiler).start(
             appContext = eq(mockContext),
             startReason = eq(ProfilingStartReason.CONTINUOUS),
+            additionalAttributes = any(),
+            sdkInstanceNames = any(),
+            durationMs = any()
+        )
+    }
+
+    @Test
+    fun `M start continuous cycle W profiler failure received {APPLICATION_LAUNCH tag}`() {
+        // Given
+        testedFeature = ProfilingFeature(
+            mockSdkCore,
+            ProfilingConfiguration(
+                customEndpointUrl = null,
+                applicationLaunchSampleRate = 100f,
+                continuousSampleRate = 100f
+            ),
+            mockProfiler
+        )
+        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        val callbackCaptor = argumentCaptor<ProfilerCallback>()
+        testedFeature.onInitialize(mockContext)
+        verify(mockProfiler).registerProfilingCallback(
+            eq(fakeInstanceName),
+            callbackCaptor.capture()
+        )
+        testedFeature.onReceive(
+            RumSessionRenewedEvent(sessionId = fakeSessionId, sessionSampled = true)
+        )
+        testedFeature.onReceive(ProfilerStopEvent.TTID(rumContext = null))
+
+        // When
+        callbackCaptor.firstValue.onFailure(ProfilingStartReason.APPLICATION_LAUNCH.value)
+
+        // Then
+        verify(mockProfiler).start(
+            appContext = eq(mockContext),
+            startReason = eq(ProfilingStartReason.CONTINUOUS),
+            additionalAttributes = any(),
+            sdkInstanceNames = any(),
+            durationMs = any()
+        )
+    }
+
+    @Test
+    fun `M not start continuous cycle W profiler failure received {CONTINUOUS tag}`() {
+        // Given
+        testedFeature = ProfilingFeature(
+            mockSdkCore,
+            ProfilingConfiguration(
+                customEndpointUrl = null,
+                applicationLaunchSampleRate = 100f,
+                continuousSampleRate = 100f
+            ),
+            mockProfiler
+        )
+        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn false
+        val callbackCaptor = argumentCaptor<ProfilerCallback>()
+        testedFeature.onInitialize(mockContext)
+        verify(mockProfiler).registerProfilingCallback(
+            eq(fakeInstanceName),
+            callbackCaptor.capture()
+        )
+
+        // When
+        callbackCaptor.firstValue.onFailure(ProfilingStartReason.CONTINUOUS.value)
+
+        // Then
+        verify(mockProfiler, never()).start(
+            appContext = any(),
+            startReason = any(),
             additionalAttributes = any(),
             sdkInstanceNames = any(),
             durationMs = any()

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -43,6 +43,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.util.concurrent.ScheduledExecutorService
@@ -425,6 +426,69 @@ class PerfettoProfilerTest {
 
         // Then
         assertThat(status).isFalse
+    }
+
+    @Test
+    fun `M call onFailure W callback is called {error code}`(
+        @IntForgery(min = 1) fakeErrorCode: Int
+    ) {
+        // Given
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
+        verify(mockService).requestProfiling(any(), any(), any(), any(), any(), callbackCaptor.capture())
+
+        val mockResult = mock<ProfilingResult> {
+            on { errorCode } doReturn fakeErrorCode
+            on { tag } doReturn ProfilingStartReason.APPLICATION_LAUNCH.value
+        }
+
+        // When
+        callbackCaptor.firstValue.accept(mockResult)
+
+        // Then
+        verify(mockProfilerCallback).onFailure(ProfilingStartReason.APPLICATION_LAUNCH.value)
+        verifyNoMoreInteractions(mockProfilerCallback)
+    }
+
+    @Test
+    fun `M call onFailure W callback is called {null file path}`() {
+        // Given
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
+        verify(mockService).requestProfiling(any(), any(), any(), any(), any(), callbackCaptor.capture())
+
+        val mockResult = mock<ProfilingResult> {
+            on { errorCode } doReturn ProfilingResult.ERROR_NONE
+            on { resultFilePath } doReturn null
+            on { tag } doReturn ProfilingStartReason.APPLICATION_LAUNCH.value
+        }
+
+        // When
+        callbackCaptor.firstValue.accept(mockResult)
+
+        // Then
+        verify(mockProfilerCallback).onFailure(ProfilingStartReason.APPLICATION_LAUNCH.value)
+        verifyNoMoreInteractions(mockProfilerCallback)
+    }
+
+    @Test
+    fun `M not call onFailure W callback is called {success}`(
+        @StringForgery fakePath: String
+    ) {
+        // Given
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
+        verify(mockService).requestProfiling(any(), any(), any(), any(), any(), callbackCaptor.capture())
+
+        val mockResult = mock<ProfilingResult> {
+            on { errorCode } doReturn ProfilingResult.ERROR_NONE
+            on { resultFilePath } doReturn fakePath
+            on { tag } doReturn ProfilingStartReason.APPLICATION_LAUNCH.value
+        }
+
+        // When
+        callbackCaptor.firstValue.accept(mockResult)
+
+        // Then
+        verify(mockProfilerCallback).onSuccess(any())
+        verifyNoMoreInteractions(mockProfilerCallback)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

* Add `onFaliure()` into `ProfilerCallback` so that any failure of app launch profiling is reported to `ContinuousProfilingScheduler`, in order to notify it the app launch profiling has completed.

### Motivation

RUM-15307


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

