### PR TITLE
RUM-15334: Add id to RumAnrEvent and RumLongTaskEvent

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -146,9 +146,9 @@ sealed class com.datadog.android.internal.profiling.ProfilerEvent
     constructor(ProfilingRumContext, String, String?)
   object TTIDNotTracked : ProfilerEvent
   data class RumAnrEvent : ProfilerEvent
-    constructor(Long, Long, ProfilingRumContext)
+    constructor(String, Long, Long, ProfilingRumContext)
   data class RumLongTaskEvent : ProfilerEvent
-    constructor(Long, Long, ProfilingRumContext)
+    constructor(String, Long, Long, ProfilingRumContext)
 data class com.datadog.android.internal.profiling.ProfilingRumContext
   constructor(String, String, String?, String?)
 data class com.datadog.android.internal.rum.RumSessionRenewedEvent

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -254,14 +254,16 @@ public abstract class com/datadog/android/internal/profiling/ProfilerEvent {
 }
 
 public final class com/datadog/android/internal/profiling/ProfilerEvent$RumAnrEvent : com/datadog/android/internal/profiling/ProfilerEvent {
-	public fun <init> (JJLcom/datadog/android/internal/profiling/ProfilingRumContext;)V
-	public final fun component1 ()J
+	public fun <init> (Ljava/lang/String;JJLcom/datadog/android/internal/profiling/ProfilingRumContext;)V
+	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()J
-	public final fun component3 ()Lcom/datadog/android/internal/profiling/ProfilingRumContext;
-	public final fun copy (JJLcom/datadog/android/internal/profiling/ProfilingRumContext;)Lcom/datadog/android/internal/profiling/ProfilerEvent$RumAnrEvent;
-	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/ProfilerEvent$RumAnrEvent;JJLcom/datadog/android/internal/profiling/ProfilingRumContext;ILjava/lang/Object;)Lcom/datadog/android/internal/profiling/ProfilerEvent$RumAnrEvent;
+	public final fun component3 ()J
+	public final fun component4 ()Lcom/datadog/android/internal/profiling/ProfilingRumContext;
+	public final fun copy (Ljava/lang/String;JJLcom/datadog/android/internal/profiling/ProfilingRumContext;)Lcom/datadog/android/internal/profiling/ProfilerEvent$RumAnrEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/ProfilerEvent$RumAnrEvent;Ljava/lang/String;JJLcom/datadog/android/internal/profiling/ProfilingRumContext;ILjava/lang/Object;)Lcom/datadog/android/internal/profiling/ProfilerEvent$RumAnrEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDurationNs ()J
+	public final fun getId ()Ljava/lang/String;
 	public final fun getRumContext ()Lcom/datadog/android/internal/profiling/ProfilingRumContext;
 	public final fun getStartMs ()J
 	public fun hashCode ()I
@@ -269,14 +271,16 @@ public final class com/datadog/android/internal/profiling/ProfilerEvent$RumAnrEv
 }
 
 public final class com/datadog/android/internal/profiling/ProfilerEvent$RumLongTaskEvent : com/datadog/android/internal/profiling/ProfilerEvent {
-	public fun <init> (JJLcom/datadog/android/internal/profiling/ProfilingRumContext;)V
-	public final fun component1 ()J
+	public fun <init> (Ljava/lang/String;JJLcom/datadog/android/internal/profiling/ProfilingRumContext;)V
+	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()J
-	public final fun component3 ()Lcom/datadog/android/internal/profiling/ProfilingRumContext;
-	public final fun copy (JJLcom/datadog/android/internal/profiling/ProfilingRumContext;)Lcom/datadog/android/internal/profiling/ProfilerEvent$RumLongTaskEvent;
-	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/ProfilerEvent$RumLongTaskEvent;JJLcom/datadog/android/internal/profiling/ProfilingRumContext;ILjava/lang/Object;)Lcom/datadog/android/internal/profiling/ProfilerEvent$RumLongTaskEvent;
+	public final fun component3 ()J
+	public final fun component4 ()Lcom/datadog/android/internal/profiling/ProfilingRumContext;
+	public final fun copy (Ljava/lang/String;JJLcom/datadog/android/internal/profiling/ProfilingRumContext;)Lcom/datadog/android/internal/profiling/ProfilerEvent$RumLongTaskEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/ProfilerEvent$RumLongTaskEvent;Ljava/lang/String;JJLcom/datadog/android/internal/profiling/ProfilingRumContext;ILjava/lang/Object;)Lcom/datadog/android/internal/profiling/ProfilerEvent$RumLongTaskEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDurationNs ()J
+	public final fun getId ()Ljava/lang/String;
 	public final fun getRumContext ()Lcom/datadog/android/internal/profiling/ProfilingRumContext;
 	public final fun getStartMs ()J
 	public fun hashCode ()I

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilerEvent.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilerEvent.kt
@@ -32,11 +32,13 @@ sealed class ProfilerEvent {
     /**
      * Sent by the RUM feature to the profiling feature whenever an ANR is detected.
      *
+     * @param id The ID of the corresponding RUM error event.
      * @param startMs Start timestamp in milliseconds since epoch (server time-adjusted).
      * @param durationNs Duration of the ANR in nanoseconds.
      * @param rumContext RUM context at the time of the ANR.
      */
     data class RumAnrEvent(
+        val id: String,
         val startMs: Long,
         val durationNs: Long,
         val rumContext: ProfilingRumContext
@@ -45,11 +47,13 @@ sealed class ProfilerEvent {
     /**
      * Sent by the RUM feature to the profiling feature whenever a long task is detected.
      *
+     * @param id The ID of the corresponding RUM long task event.
      * @param startMs Start timestamp in milliseconds since epoch (server time-adjusted).
      * @param durationNs Duration of the long task in nanoseconds.
      * @param rumContext RUM context at the time of the long task.
      */
     data class RumLongTaskEvent(
+        val id: String,
         val startMs: Long,
         val durationNs: Long,
         val rumContext: ProfilingRumContext

--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilerEventRumAnrEventFactory.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilerEventRumAnrEventFactory.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.tests.elmyr
+
+import com.datadog.android.internal.profiling.ProfilerEvent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+class ProfilerEventRumAnrEventFactory : ForgeryFactory<ProfilerEvent.RumAnrEvent> {
+    override fun getForgery(forge: Forge): ProfilerEvent.RumAnrEvent {
+        return ProfilerEvent.RumAnrEvent(
+            id = forge.anHexadecimalString(),
+            startMs = forge.aLong(min = 0L),
+            durationNs = forge.aLong(min = 1L),
+            rumContext = forge.getForgery()
+        )
+    }
+}

--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilerEventRumLongTaskEventFactory.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilerEventRumLongTaskEventFactory.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.tests.elmyr
+
+import com.datadog.android.internal.profiling.ProfilerEvent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+class ProfilerEventRumLongTaskEventFactory : ForgeryFactory<ProfilerEvent.RumLongTaskEvent> {
+    override fun getForgery(forge: Forge): ProfilerEvent.RumLongTaskEvent {
+        return ProfilerEvent.RumLongTaskEvent(
+            id = forge.anHexadecimalString(),
+            startMs = forge.aLong(min = 0L),
+            durationNs = forge.aLong(min = 1L),
+            rumContext = forge.getForgery()
+        )
+    }
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -704,6 +704,7 @@ internal open class RumViewScope(
             rumContext.viewId.orEmpty()
         )
 
+        val errorId = UUID.randomUUID().toString()
         // region profiling
         var profilingStatus: ErrorEvent.Profiling? = null
         // Fatal ANR comes from last session, in this case we don't attach it to Profiling Event.
@@ -716,6 +717,7 @@ internal open class RumViewScope(
             profilingStatus = resolveErrorProfilingStatus(datadogContext)
             sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.sendEvent(
                 ProfilerEvent.RumAnrEvent(
+                    id = errorId,
                     startMs = anrStartMs,
                     durationNs = anrDurationNs,
                     rumContext = ProfilingRumContext(
@@ -754,7 +756,7 @@ internal open class RumViewScope(
                 date = event.eventTime.timestamp + serverTimeOffsetInMs,
                 featureFlags = ErrorEvent.Context(eventFeatureFlags),
                 error = ErrorEvent.Error(
-                    id = UUID.randomUUID().toString(),
+                    id = errorId,
                     message = message,
                     source = event.source.toSchemaSource(),
                     stack = event.stacktrace ?: event.throwable?.loggableStackTrace(),
@@ -1470,8 +1472,10 @@ internal open class RumViewScope(
             rumContext.viewId.orEmpty()
         )
 
+        val longTaskId = UUID.randomUUID().toString()
         sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.sendEvent(
             ProfilerEvent.RumLongTaskEvent(
+                id = longTaskId,
                 startMs = timestamp - TimeUnit.NANOSECONDS.toMillis(event.durationNs),
                 durationNs = event.durationNs,
                 rumContext = ProfilingRumContext(
@@ -1506,7 +1510,7 @@ internal open class RumViewScope(
             LongTaskEvent(
                 date = timestamp - TimeUnit.NANOSECONDS.toMillis(event.durationNs),
                 longTask = LongTaskEvent.LongTask(
-                    id = UUID.randomUUID().toString(),
+                    id = longTaskId,
                     duration = event.durationNs,
                     isFrozenFrame = isFrozenFrame
                 ),

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -3926,6 +3926,7 @@ internal class RumViewScopeTest {
         // Then
         argumentCaptor<ProfilerEvent.RumAnrEvent> {
             verify(mockProfilingFeatureScope).sendEvent(capture())
+            assertThat(firstValue.id).isNotEmpty()
             assertThat(firstValue.startMs).isEqualTo(expectedStartMs)
             assertThat(firstValue.durationNs).isEqualTo(expectedDurationNs)
             assertThat(firstValue.rumContext).isEqualTo(
@@ -5614,6 +5615,37 @@ internal class RumViewScopeTest {
         argumentCaptor<LongTaskEvent> {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue).hasNoProfiling()
+        }
+    }
+
+    @Test
+    fun `M send RumLongTaskEvent to profiling W handleEvent(AddLongTask) {profiling feature registered}`(
+        @LongForgery(0L, 700_000_000L) durationNs: Long,
+        @StringForgery target: String
+    ) {
+        // Given
+        testedScope.activeActionScope = null
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        val expectedStartMs = resolveExpectedTimestamp(fakeEvent.eventTime.timestamp) -
+            TimeUnit.NANOSECONDS.toMillis(durationNs)
+
+        // When
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        argumentCaptor<ProfilerEvent.RumLongTaskEvent> {
+            verify(mockProfilingFeatureScope).sendEvent(capture())
+            assertThat(firstValue.id).isNotEmpty()
+            assertThat(firstValue.startMs).isEqualTo(expectedStartMs)
+            assertThat(firstValue.durationNs).isEqualTo(durationNs)
+            assertThat(firstValue.rumContext).isEqualTo(
+                ProfilingRumContext(
+                    applicationId = fakeParentContext.applicationId,
+                    sessionId = fakeParentContext.sessionId,
+                    viewId = testedScope.viewId,
+                    viewName = fakeKey.name
+                )
+            )
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

`RumAnrEvent` and `RumLongTaskEvent` should have unique id when sending them to ProfilingFeature.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

