### PR TITLE
Reproduce RUMS-5184: missing resource timing due to ResourceId UUID mismatch

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -1124,6 +1124,70 @@ internal class RumResourceScopeTest {
     }
 
     @Test
+    fun `M send Resource with timing W handleEvent(WaitForResourceTiming+AddResourceTiming+StopResource) { ResourceId same key different UUID }`(
+        // Reproduces RUMS-5184: DatadogEventListener.Factory.create() produces ResourceId(key, uuid_A)
+        // while DatadogInterceptor produces ResourceId(key, uuid_B). Because ResourceId.equals() requires
+        // uuid fields to match when both are non-null, the timing events are silently discarded by
+        // RumResourceScope even though the key strings are identical.
+        //
+        // This test SHOULD pass when the bug is fixed (scope accepts timing with same key-string, different UUID).
+        // This test WILL FAIL against the buggy code because ResourceId.equals() returns false when UUIDs differ,
+        // so waitForTiming stays false and timing is not applied, resulting in null dns/connect/ssl/firstByte/download.
+        @Forgery kind: RumResourceKind,
+        @LongForgery(200, 600) statusCode: Long,
+        @LongForgery(0, 1024) size: Long,
+        @Forgery timing: ResourceTiming,
+        forge: Forge
+    ) {
+        // Given
+        // The scope is created with uuid_A (simulating DatadogInterceptor's key)
+        val scopeKeyString = fakeKey.key
+        val uuidA = java.util.UUID.randomUUID().toString()
+        val uuidB = java.util.UUID.randomUUID().toString()
+        val scopeKey = ResourceId(scopeKeyString, uuidA)
+
+        // The event listener produces uuid_B for the same key string (simulating DatadogEventListener.Factory)
+        val listenerKey = ResourceId(scopeKeyString, uuidB)
+
+        val scopeWithMismatchedKey = RumResourceScope(
+            parentScope = mockParentScope,
+            sdkCore = rumMonitor.mockSdkCore,
+            url = fakeUrl,
+            method = fakeMethod,
+            key = scopeKey,
+            eventTime = fakeEventTime,
+            initialAttributes = fakeResourceAttributes,
+            serverTimeOffsetInMs = fakeServerOffset,
+            firstPartyHostHeaderTypeResolver = mockResolver,
+            featuresContextResolver = mockFeaturesContextResolver,
+            sampleRate = fakeSampleRate,
+            networkSettledMetricResolver = mockNetworkSettledMetricResolver,
+            rumSessionTypeOverride = fakeRumSessionType,
+            insightsCollector = mockInsightsCollector
+        )
+
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeResourceAttributes.keys)
+
+        // When – timing events arrive with listenerKey (uuid_B) while scope holds scopeKey (uuid_A)
+        mockEvent = RumRawEvent.WaitForResourceTiming(listenerKey)
+        scopeWithMismatchedKey.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        mockEvent = RumRawEvent.AddResourceTiming(listenerKey, timing)
+        scopeWithMismatchedKey.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        Thread.sleep(RESOURCE_DURATION_MS)
+        mockEvent = RumRawEvent.StopResource(scopeKey, statusCode, size, kind, attributes)
+        scopeWithMismatchedKey.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then – the timing SHOULD have been applied (this assertion will FAIL on buggy code because
+        // ResourceId.equals() rejects listenerKey != scopeKey, leaving timing null)
+        argumentCaptor<ResourceEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(firstValue).hasTiming(timing)
+        }
+    }
+
+    @Test
     fun `M send Resource W handleEvent(AddResourceTiming+StopResource) {unrelated timing}`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogEventListenerFactoryTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogEventListenerFactoryTest.kt
@@ -70,6 +70,28 @@ internal class DatadogEventListenerFactoryTest {
     }
 
     @Test
+    fun `M produce matching ResourceId keys W create() { factory and interceptor use same request }`() {
+        // Reproduces RUMS-5184: DatadogEventListener.Factory.create() calls buildResourceId(generateUuid=true)
+        // and DatadogInterceptor.intercept() independently calls buildResourceId(generateUuid=true) on the
+        // same Request. Because no UUID tag is set on the request, each invocation generates a fresh
+        // UUID.randomUUID(), so the two ResourceId objects will never be equal, causing timing to be
+        // silently discarded in RumResourceScope.
+        //
+        // This test SHOULD pass when the bug is fixed (both keys share the same UUID).
+        // This test WILL FAIL against the buggy code because each call produces a different UUID.
+
+        // When
+        val listenerResult = testedFactory.create(mockCall)
+
+        // Simulate what DatadogInterceptor does: call buildResourceId(generateUuid=true) on the same request
+        val interceptorKey = fakeRequest.buildResourceId(generateUuid = true)
+
+        // Then: the listener's resource key must equal the interceptor's resource key
+        check(listenerResult is DatadogEventListener)
+        assertThat(listenerResult.key).isEqualTo(interceptorKey)
+    }
+
+    @Test
     fun `M create no-op event listener W create() { SDK instance is not ready }`(
         @StringForgery fakeSdkInstanceName: String
     ) {


### PR DESCRIPTION
## Summary

Adds failing tests that reproduce RUMS-5184: missing request duration breakdown (dns, connect, ssl, firstByte, download) on Android due to ResourceId UUID mismatch between `DatadogEventListener.Factory` and `DatadogInterceptor`.

- `DatadogEventListener.Factory.create()` calls `buildResourceId(generateUuid=true)` → produces `ResourceId(key, uuid_A)`
- `DatadogInterceptor.intercept()` independently calls `buildResourceId(generateUuid=true)` on the same request → produces `ResourceId(key, uuid_B)`
- Since no UUID tag is set on the request, each call generates a fresh `UUID.randomUUID()`, so `uuid_A != uuid_B`
- `ResourceId.equals()` requires both UUIDs to match when neither is null/blank, so the keys are never equal
- `RumResourceScope` guards all timing updates with `if (key == event.key)`, silently discarding timing → Resource event sent with all timing fields null

## Test plan

- [ ] `DatadogEventListenerFactoryTest.M produce matching ResourceId keys W create() { factory and interceptor use same request }` — fails because `buildResourceId(generateUuid=true)` generates independent UUIDs on each call
- [ ] `RumResourceScopeTest.M send Resource with timing W handleEvent(WaitForResourceTiming+AddResourceTiming+StopResource) { ResourceId same key different UUID }` — fails because `WaitForResourceTiming` and `AddResourceTiming` events carrying `uuid_B` are rejected by a scope holding `uuid_A`, resulting in null timing on the sent ResourceEvent

Both tests assert the **correct** behavior and are expected to fail against the current buggy implementation, confirming the root cause identified in RUMS-5184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
