### PR TITLE
Reproduce RUMS-4466: deobfuscation fails for non-tab-prefixed stack frames

### DIFF
--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/ThreadExtTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/ThreadExtTest.kt
@@ -46,4 +46,28 @@ internal class ThreadExtTest {
             assertThat(lines[i]).contains(frame.toString())
         }
     }
+
+    @Test
+    fun `M produce tab-prefixed frame lines W loggableStackTrace() { matches standard Java printStackTrace format }`() {
+        // Given
+        val stack = Thread.currentThread().stackTrace
+
+        // When
+        val result = stack.loggableStackTrace()
+
+        // Then
+        // The standard Java Throwable.printStackTrace() format requires "\tat ClassName.method(File:line)".
+        // The Datadog deobfuscation-api retrace tool parses only lines with the "\tat " prefix.
+        // This test will FAIL because the current implementation produces "at $it" (no leading tab).
+        val lines = result.lines()
+        lines.forEach { line ->
+            assertThat(line)
+                .withFailMessage(
+                    "Expected frame line to start with '\\tat ' (tab + 'at ') to match " +
+                        "standard Java printStackTrace format required by the deobfuscation-api, " +
+                        "but was: '$line'"
+                )
+                .startsWith("\tat ")
+        }
+    }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -385,7 +385,7 @@ internal class DatadogExceptionHandlerTest {
     }
 
     @Test
-    fun `M produce tab-prefixed frame lines for non-crashed threads W caught exception { matches standard Java printStackTrace format }`() {
+    fun `M produce tab-prefixed frame lines for non-crashed threads W caught exception`() {
         // Given
         val currentThread = Thread.currentThread()
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -384,6 +384,42 @@ internal class DatadogExceptionHandlerTest {
         verify(mockPreviousHandler).uncaughtException(crashedThread, fakeThrowable)
     }
 
+    @Test
+    fun `M produce tab-prefixed frame lines for non-crashed threads W caught exception { matches standard Java printStackTrace format }`() {
+        // Given
+        val currentThread = Thread.currentThread()
+
+        // When
+        testedHandler.uncaughtException(currentThread, fakeThrowable)
+
+        // Then
+        // Non-crashed thread stacks are built via Array<StackTraceElement>.loggableStackTrace() in ThreadExt.kt.
+        // The Datadog deobfuscation-api retrace tool requires the "\tat " prefix (standard Java format).
+        // This test will FAIL because the current implementation produces "at $it" (no leading tab),
+        // causing the backend to skip those frames and leave them obfuscated.
+        argumentCaptor<Any> {
+            verify(mockLogsFeatureScope).sendEvent(capture())
+
+            assertThat(lastValue).isInstanceOf(JvmCrash.Logs::class.java)
+
+            val logEvent = lastValue as JvmCrash.Logs
+            val nonCrashedThreads = logEvent.threads.filter { !it.crashed }
+            assertThat(nonCrashedThreads).isNotEmpty
+
+            nonCrashedThreads.forEach { threadDump ->
+                threadDump.stack.lines().forEach { line ->
+                    assertThat(line)
+                        .withFailMessage(
+                            "Non-crashed thread '${threadDump.name}' stack frame should start " +
+                                "with '\\tat ' to match standard Java printStackTrace format " +
+                                "required by the deobfuscation-api, but was: '$line'"
+                        )
+                        .startsWith("\tat ")
+                }
+            }
+        }
+    }
+
     // endregion
 
     @Test


### PR DESCRIPTION
## Reproduction for RUMS-4466

**Jira:** [RUMS-4466](https://datadoghq.atlassian.net/browse/RUMS-4466)

### Issue Summary
`Array<StackTraceElement>.loggableStackTrace()` in `ThreadExt.kt` produces frame lines as `"at ClassName.method(File:line)"` (no leading tab), while the standard Java stack trace format requires `"\tat ClassName.method(File:line)"`. The Datadog deobfuscation-api retrace tool only processes `\tat`-prefixed lines, leaving non-crashed thread stacks obfuscated.

### Reproduction Tests
- Unit tests demonstrating the missing tab character in stack frame formatting

### What the Tests Prove
Tests assert that `loggableStackTrace()` produces `\tat`-prefixed frame lines matching standard Java `printStackTrace()` format. Tests currently fail because the implementation uses `"at $it"` (no tab).

### Root Cause Analysis
`ThreadExt.kt` line 31: `joinToString("\n") { "at $it" }` — missing leading `\t`. This causes the Datadog backend deobfuscation-api to skip these frames during retrace, resulting in partial deobfuscation: crashed-thread frames (via `Throwable.loggableStackTrace()`) are correctly retraced, but non-crashed thread frames remain obfuscated.

### Call Chain
`DatadogExceptionHandler.uncaughtException()` → `getThreadDumps()` → `thread.stackTrace.loggableStackTrace()` → `joinToString("\n") { "at $it" }` (missing `\t`) → `ThreadDump.stack` → `ErrorEvent.error.threads[n].stack` → deobfuscation-api skips (no `\tat` prefix)

### Failure Output
```
Expected frame line to start with '\tat ' (tab + 'at ') to match standard Java printStackTrace format required by the deobfuscation-api, but was: 'at ...'
```

---
*Generated by rum:tee-triage-insights*
