### PR TITLE
Reproduce RUMS-5535: global attributes lost after session renewal

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -8424,6 +8424,103 @@ internal class RumViewScopeTest {
         assertThat(newScope.stopped).isEqualTo(false)
     }
 
+    // region Regression - RUMS-5535: global attributes lost after session renewal via StartView/StopSession
+
+    @Test
+    fun `M preserve global attributes in renewed scope W old scope stopped via StartView {RUMS-5535}`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeGlobalAttributeKey = forge.anAlphabeticalString()
+        val fakeGlobalAttributeValue = forge.anAlphabeticalString()
+        val globalAttributes = mapOf<String, Any?>(fakeGlobalAttributeKey to fakeGlobalAttributeValue)
+        whenever(mockParentScope.getCustomAttributes()) doReturn globalAttributes
+
+        // Simulate session renewal: renewedScope has testedScope (old) as parent
+        val renewedScope = testedScope.renew(Time())
+
+        // Stop old scope via StartView (the buggy path — does NOT set memoizedParentAttributes pre-fix)
+        val startViewEvent = RumRawEvent.StartView(
+            key = forge.getForgery(),
+            attributes = emptyMap()
+        )
+        testedScope.handleEvent(startViewEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // When: renewed scope queries custom attributes — old scope is stopped, returns memoizedParentAttributes
+        val customAttributes = renewedScope.getCustomAttributes()
+
+        // Then: global attributes must still be present
+        // Pre-fix: memoizedParentAttributes = emptyMap() → global attributes are lost
+        // Post-fix: memoizedParentAttributes is correctly set at stop time → global attributes preserved
+        assertThat(customAttributes).containsEntry(fakeGlobalAttributeKey, fakeGlobalAttributeValue)
+    }
+
+    @Test
+    fun `M preserve global attributes in renewed scope W old scope stopped via StopSession {RUMS-5535}`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeGlobalAttributeKey = forge.anAlphabeticalString()
+        val fakeGlobalAttributeValue = forge.anAlphabeticalString()
+        val globalAttributes = mapOf<String, Any?>(fakeGlobalAttributeKey to fakeGlobalAttributeValue)
+        whenever(mockParentScope.getCustomAttributes()) doReturn globalAttributes
+
+        // Simulate session renewal: renewedScope has testedScope (old) as parent
+        val renewedScope = testedScope.renew(Time())
+
+        // Stop old scope via StopSession (the buggy path — does NOT set memoizedParentAttributes pre-fix)
+        testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // When: renewed scope queries custom attributes — old scope is stopped, returns memoizedParentAttributes
+        val customAttributes = renewedScope.getCustomAttributes()
+
+        // Then: global attributes must still be present
+        // Pre-fix: memoizedParentAttributes = emptyMap() → global attributes are lost
+        // Post-fix: memoizedParentAttributes is correctly set at stop time → global attributes preserved
+        assertThat(customAttributes).containsEntry(fakeGlobalAttributeKey, fakeGlobalAttributeValue)
+    }
+
+    @Test
+    fun `M include global attributes in ViewEvent written by renewed scope after StartView stop {RUMS-5535}`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeGlobalAttributeKey = forge.anAlphabeticalString()
+        val fakeGlobalAttributeValue = forge.anAlphabeticalString()
+        val globalAttributes = mapOf<String, Any?>(fakeGlobalAttributeKey to fakeGlobalAttributeValue)
+        whenever(mockParentScope.getCustomAttributes()) doReturn globalAttributes
+
+        // Simulate session renewal: renewedScope has testedScope (old) as parent
+        val renewedScope = testedScope.renew(Time())
+        mockSessionReplayContext(renewedScope)
+
+        // Stop old scope via StartView (the buggy path)
+        val startViewEvent = RumRawEvent.StartView(
+            key = forge.getForgery(),
+            attributes = emptyMap()
+        )
+        testedScope.handleEvent(startViewEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Trigger a view update on the renewed scope via StopView, which writes a ViewEvent
+        val stopViewEvent = RumRawEvent.StopView(
+            key = renewedScope.key,
+            attributes = emptyMap()
+        )
+        renewedScope.handleEvent(stopViewEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then: the ViewEvent written by the renewed scope must contain the global attributes
+        // Pre-fix: context.additionalProperties is missing the global attributes
+        // Post-fix: context.additionalProperties contains all global attributes
+        val viewEventCaptor = argumentCaptor<ViewEvent>()
+        verify(mockWriter, org.mockito.kotlin.atLeastOnce())
+            .write(eq(mockEventBatchWriter), viewEventCaptor.capture(), eq(EventType.DEFAULT))
+        val renewedViewEvent = viewEventCaptor.allValues.last()
+        assertThat(renewedViewEvent.context?.additionalProperties)
+            .containsEntry(fakeGlobalAttributeKey, fakeGlobalAttributeValue)
+    }
+
+    // endregion
+
     // endregion
 
     // region Feature Operations


### PR DESCRIPTION
## Summary

This PR adds failing unit tests that reproduce RUMS-5535: global RUM attributes are silently dropped from events when a view scope is renewed after session timeout or `stopSession()`.

- When `RumViewScope.renew()` creates a renewed scope, it sets `parentScope = old view scope`
- The old scope is subsequently stopped via `onStartView()` or `onStopSession()` — both call `stopScope()` WITHOUT the `sideEffect` lambda that captures `memoizedParentAttributes = parentScope.getCustomAttributes().toMap()`
- As a result, `memoizedParentAttributes` stays `emptyMap()` on the stopped old scope
- The renewed scope's `getCustomAttributes()` traverses to the stopped old parent, which returns `emptyMap() + viewAttributes`, losing all global attributes set via `GlobalRumMonitor.addAttribute()`

## Tests Added

Three regression tests in `RumViewScopeTest`:

1. `M preserve global attributes in renewed scope W old scope stopped via StartView {RUMS-5535}` — verifies `getCustomAttributes()` on renewed scope returns global attributes after old scope is stopped via `StartView`
2. `M preserve global attributes in renewed scope W old scope stopped via StopSession {RUMS-5535}` — same for `StopSession` stop path
3. `M include global attributes in ViewEvent written by renewed scope after StartView stop {RUMS-5535}` — end-to-end check that the written `ViewEvent.context.additionalProperties` contains the global attributes

All three tests **fail** on the pre-fix commit (`369ea6cffc7a351be679ad1371c7759aef9e73f4`) and are expected to **pass** after fixing `onStartView()` and `onStopSession()` to set `memoizedParentAttributes` in their `stopScope()` call.

## Test Plan

- [x] Tests compile without errors
- [x] All 3 tests fail on pre-fix code (confirmed via `./gradlew :features:dd-sdk-android-rum:testDebugUnitTest --tests "*RUMS-5535*"`)
- [ ] Tests should pass after the fix is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
