### PR TITLE
Reproduce RUMS-5535: global attributes missing when view stopped by StartView

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -8424,6 +8424,98 @@ internal class RumViewScopeTest {
         assertThat(newScope.stopped).isEqualTo(false)
     }
 
+    // region RUMS-5535 regression tests
+
+    @Test
+    fun `RUMS5535 M include global attributes in view update W view stopped via StartView then ErrorSent`(
+        @Forgery otherKey: RumScopeKey
+    ) {
+        // Given
+        val fakeGlobalAttributes = mapOf<String, Any?>("platform" to "bonehorse", "department" to "eng")
+        whenever(mockParentScope.getCustomAttributes()) doReturn fakeGlobalAttributes
+
+        testedScope = newRumViewScope()
+
+        // Stop the view implicitly via a StartView event (onStartView path — no sideEffect lambda,
+        // so memoizedParentAttributes stays emptyMap())
+        testedScope.handleEvent(
+            RumRawEvent.StartView(otherKey, emptyMap()),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Simulate a pending error confirmation arriving after the view was stopped
+        testedScope.pendingErrorCount = 1
+        testedScope.handleEvent(
+            RumRawEvent.ErrorSent(testedScope.viewId),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then — the post-stop view update must contain the global attributes
+        argumentCaptor<ViewEvent> {
+            // Two writes: one from StartView stop, one from ErrorSent
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            val errorSentViewUpdate = lastValue
+            assertThat(errorSentViewUpdate.context?.additionalProperties)
+                .overridingErrorMessage(
+                    "Expected post-stop view update to contain global attributes " +
+                        "$fakeGlobalAttributes but was ${errorSentViewUpdate.context?.additionalProperties}"
+                )
+                .containsAllEntriesOf(fakeGlobalAttributes)
+        }
+    }
+
+    @Test
+    fun `RUMS5535 M include global attributes in view update W renewed scope after session renewal`(
+        @Forgery otherKey: RumScopeKey
+    ) {
+        // Given
+        val fakeGlobalAttributes = mapOf<String, Any?>("platform" to "bonehorse", "department" to "eng")
+        whenever(mockParentScope.getCustomAttributes()) doReturn fakeGlobalAttributes
+
+        testedScope = newRumViewScope()
+
+        // Stop the original view implicitly via StartView (no sideEffect lambda → memoizedParentAttributes stays empty)
+        testedScope.handleEvent(
+            RumRawEvent.StartView(otherKey, emptyMap()),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Renew the view scope as RumViewManagerScope does on session renewal.
+        // parentScope = testedScope (now stopped, memoizedParentAttributes = emptyMap)
+        val renewedScope = testedScope.renew(fakeEventTime)
+        mockSessionReplayContext(renewedScope)
+
+        // Simulate a pending error confirmation on the renewed scope
+        renewedScope.pendingErrorCount = 1
+        renewedScope.handleEvent(
+            RumRawEvent.ErrorSent(renewedScope.viewId),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then — the renewed scope's view update must contain the global attributes.
+        // Currently FAILS because renewedScope.getCustomAttributes() delegates to
+        // testedScope.getCustomAttributes() which is stopped with memoizedParentAttributes = emptyMap.
+        argumentCaptor<ViewEvent> {
+            // Two writes: one from StartView implicit stop, one from ErrorSent on renewed scope
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            val renewedViewUpdate = lastValue
+            assertThat(renewedViewUpdate.context?.additionalProperties)
+                .overridingErrorMessage(
+                    "Expected renewed-scope view update to contain global attributes " +
+                        "$fakeGlobalAttributes but was ${renewedViewUpdate.context?.additionalProperties}"
+                )
+                .containsAllEntriesOf(fakeGlobalAttributes)
+        }
+    }
+
     // endregion
 
     // region Feature Operations

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -9036,6 +9036,89 @@ internal class RumViewScopeTest {
     }
     // endregion
 
+    // region RUMS-5535: Global attributes missing when view stopped by StartView
+
+    @Test
+    fun `M lose global attributes W getCustomAttributes() after view stopped by StartView`(
+        @Forgery newKey: RumScopeKey
+    ) {
+        // Given: parent scope returns a known global attribute
+        val globalAttributeKey = "platform"
+        val globalAttributeValue = "bonehorse"
+        whenever(mockParentScope.getCustomAttributes())
+            .doReturn(mapOf(globalAttributeKey to globalAttributeValue))
+        testedScope = newRumViewScope(initialAttributes = emptyMap())
+        mockSessionReplayContext(testedScope)
+
+        // When: view is stopped implicitly by a StartView event (onStartView -> stopScope without sideEffect)
+        testedScope.handleEvent(
+            RumRawEvent.StartView(newKey, emptyMap()),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then: global attribute is MISSING from the stopped scope's custom attributes
+        // This assertion FAILS before the fix (proving the bug) and PASSES after the fix.
+        val customAttributes = testedScope.getCustomAttributes()
+        assertThat(customAttributes).containsEntry(globalAttributeKey, globalAttributeValue)
+    }
+
+    @Test
+    fun `M retain global attributes W getCustomAttributes() after view stopped by StopView`() {
+        // Given: parent scope returns a known global attribute
+        val globalAttributeKey = "platform"
+        val globalAttributeValue = "bonehorse"
+        whenever(mockParentScope.getCustomAttributes())
+            .doReturn(mapOf(globalAttributeKey to globalAttributeValue))
+        testedScope = newRumViewScope(initialAttributes = emptyMap())
+        mockSessionReplayContext(testedScope)
+
+        // When: view is stopped explicitly via StopView (onStopView -> stopScope WITH sideEffect that sets memoizedParentAttributes)
+        testedScope.handleEvent(
+            RumRawEvent.StopView(fakeKey, emptyMap()),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then: global attribute IS present in the stopped scope's custom attributes
+        // This assertion PASSES both before and after the fix (baseline/regression guard).
+        val customAttributes = testedScope.getCustomAttributes()
+        assertThat(customAttributes).containsEntry(globalAttributeKey, globalAttributeValue)
+    }
+
+    @Test
+    fun `M write ViewEvent without global attributes W handleEvent(StartView) stops active view`(
+        @Forgery newKey: RumScopeKey
+    ) {
+        // Given: parent scope returns a known global attribute
+        val globalAttributeKey = "platform"
+        val globalAttributeValue = "bonehorse"
+        whenever(mockParentScope.getCustomAttributes())
+            .doReturn(mapOf(globalAttributeKey to globalAttributeValue))
+        testedScope = newRumViewScope(initialAttributes = emptyMap())
+        mockSessionReplayContext(testedScope)
+
+        // When: view is stopped implicitly by a StartView navigation event
+        testedScope.handleEvent(
+            RumRawEvent.StartView(newKey, emptyMap()),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then: the written ViewEvent is missing the global attribute in context.additionalProperties
+        // This assertion FAILS before the fix (proving the bug) and PASSES after the fix.
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue.context?.additionalProperties)
+                .containsEntry(globalAttributeKey, globalAttributeValue)
+        }
+    }
+
+    // endregion
+
     // region Internal
     private fun withAttributesCheckingMergeWithViewAttributes(
         forge: Forge


### PR DESCRIPTION
## Summary

- Adds 3 unit tests to `RumViewScopeTest` that reproduce RUMS-5535: global attributes (registered via `GlobalRumMonitor.addAttribute()`) are silently missing from RUM view events when a view is stopped implicitly by a `StartView` navigation event
- The root cause is that `onStartView()` calls `stopScope()` without a sideEffect lambda, leaving `memoizedParentAttributes` as an empty map; subsequent calls to `getCustomAttributes()` on the stopped scope return the empty memoized map instead of the live global attributes
- Tests 1 and 3 FAIL before the fix (proving the bug); Test 2 PASSES as a baseline/regression guard confirming `StopView` correctly captures parent attributes

## Test plan

- [ ] `M lose global attributes W getCustomAttributes() after view stopped by StartView` — FAILS before fix, proves `getCustomAttributes()` returns empty map when stopped via StartView
- [ ] `M retain global attributes W getCustomAttributes() after view stopped by StopView` — PASSES both before and after fix (regression guard)
- [ ] `M write ViewEvent without global attributes W handleEvent(StartView) stops active view` — FAILS before fix, proves the written ViewEvent's `context.additionalProperties` is missing global attributes when view is stopped by navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
