### PR TITLE
Reproduce RUMS-5363: double listener registration in NavigationViewTrackingStrategy

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
@@ -49,6 +49,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -437,6 +438,40 @@ internal class NavigationViewTrackingStrategyTest {
         testedStrategy.onActivityPaused(mockActivity)
 
         verifyNoInteractions(rumMonitor.mockInstance)
+    }
+
+    @Test
+    fun `testStartTrackingTwiceRegistersListenerOnlyOnce`() {
+        // Given: onActivityStarted calls startTracking() once automatically
+        testedStrategy.onActivityStarted(mockActivity)
+
+        // When: developer calls startTracking() manually a second time (dynamic nav setup)
+        testedStrategy.startTracking()
+
+        // Then: the listener should only be registered once — fails on current code because
+        // there is no idempotency guard and addOnDestinationChangedListener is called twice
+        verify(mockNavController, times(1)).addOnDestinationChangedListener(testedStrategy)
+    }
+
+    @Test
+    fun `testOnDestinationChangedCalledOnceEvenIfStartedTwice`() {
+        // Given: startTracking() called twice (simulating double registration)
+        whenever(mockPredicate.accept(mockNavDestination)) doReturn true
+        testedStrategy.onActivityStarted(mockActivity)
+        testedStrategy.startTracking()
+
+        // When: NavController fires onDestinationChanged twice because the listener
+        // was registered twice (one call per registration)
+        testedStrategy.onDestinationChanged(mockNavController, mockNavDestination, null)
+        testedStrategy.onDestinationChanged(mockNavController, mockNavDestination, null)
+
+        // Then: startView should only be called once for a single navigation event —
+        // fails on current code because the double registration causes two calls
+        verify(rumMonitor.mockInstance, times(1)).startView(
+            eq(mockNavDestination),
+            any(),
+            any()
+        )
     }
 
     // endregion


### PR DESCRIPTION
## Reproduction for RUMS-5363

**Jira:** [RUMS-5363](https://datadoghq.atlassian.net/browse/RUMS-5363)

### Issue Summary
NavigationViewTrackingStrategy.startTracking() registers the destination-changed listener without an idempotency guard, allowing it to be registered twice when called manually after the automatic onActivityStarted call (as documented for dynamic navigation setups).

### Reproduction Tests
- Unit tests: 2 (in NavigationViewTrackingStrategyTest.kt)

### What the Tests Prove
1. testStartTrackingTwiceRegistersListenerOnlyOnce: calling startTracking() twice registers the NavController listener twice (fails because no guard)
2. testOnDestinationChangedCalledOnceEvenIfStartedTwice: with two registrations, a single navigation event calls startView twice (fails because no deduplication)

### Root Cause Analysis
NavigationViewTrackingStrategy.startTracking() calls navController.addOnDestinationChangedListener(this) at line 148 with no check for existing registration. Android NavController stores listeners in a list without deduplication, so calling addOnDestinationChangedListener with the same listener twice results in two registrations and onDestinationChanged being called twice per navigation event.

### Call Chain
NavigationViewTrackingStrategy.onActivityStarted() → startTracking()
→ navController.addOnDestinationChangedListener(this) [first registration]
Developer calls startTracking() manually [second registration]  
→ NavController fires onDestinationChanged twice per navigation event
→ rumMonitor.startView() called twice → duplicate resource events

---
*Generated by rum:tee-triage-insights*