### PR TITLE
Reproduce RUMS-5093: incorrect timing and context propagation in traces

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/resource/ResourceIdTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/resource/ResourceIdTest.kt
@@ -176,4 +176,20 @@ class ResourceIdTest {
         assertThat(areEqual).isFalse()
         assertThat(areHashCodeEqual).isFalse()
     }
+
+    @Test
+    fun `M return false W equals { null uuid does not match non-null uuid for same key - RUMS-5093 }`(
+        @StringForgery key: String,
+        @Forgery uuid: UUID
+    ) {
+        // Given - RUMS-5093: stop-event ResourceId has null UUID, start-event has UUID
+        val startEventId = ResourceId(key, uuid.toString())
+        val stopEventId = ResourceId(key, null)
+
+        // When
+        val areEqual = startEventId == stopEventId
+
+        // Then - null UUID must NOT be treated as wildcard: wrong scope would be closed
+        assertThat(areEqual).isFalse()
+    }
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/event/RUMS5093SpanTimingTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/event/RUMS5093SpanTimingTest.kt
@@ -1,0 +1,187 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.internal.domain.event
+
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.context.TimeInfo
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.trace.core.DDSpan
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import java.util.concurrent.TimeUnit
+
+/**
+ * Reproduction tests for RUMS-5093 Issue 2: Incorrect timing of the android.request span.
+ *
+ * The [CoreTracerSpanToSpanEventMapper] applies [DatadogContext.time.serverTimeOffsetNs] to the
+ * span start time:
+ *
+ *   SpanEvent.start = model.startTime + serverTimeOffsetNs
+ *
+ * When the device clock diverges significantly from the Datadog NTP reference clock
+ * (e.g. the device is 30 seconds ahead of the server), the correction shifts the android.request
+ * span's absolute start timestamp in the wrong direction relative to backend spans that are
+ * timestamped by the Datadog Agent using the server's wall clock.
+ *
+ * The result is that the android.request span appears to start/end at a completely different time
+ * from backend spans in the waterfall, or appears to have no duration, even though the underlying
+ * RUM resource duration (computed from monotonic nanoTime) is accurate.
+ *
+ * The tests below document the expected (correct) behaviour and show that a large device clock skew
+ * produces a span start time that is displaced by exactly serverTimeOffsetNs — which can push the
+ * android.request span outside the time window of backend spans.
+ */
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class RUMS5093SpanTimingTest {
+
+    private lateinit var testedMapper: CoreTracerSpanToSpanEventMapper
+
+    @BoolForgery
+    var fakeNetworkInfoEnabled: Boolean = false
+
+    @BeforeEach
+    fun `set up`() {
+        testedMapper = CoreTracerSpanToSpanEventMapper(fakeNetworkInfoEnabled)
+    }
+
+    /**
+     * FAILING TEST — proves Issue 2 of RUMS-5093 (NTP offset displaces the span start time).
+     *
+     * When the device clock is 30 seconds AHEAD of the Datadog NTP server, serverTimeOffsetNs is
+     * a large NEGATIVE value (approx -30_000_000_000 ns).
+     *
+     * Applying this correction to the span start time shifts it 30 seconds into the past relative
+     * to the device's wall clock. Backend spans are timestamped by the Datadog Agent using the
+     * Agent's (server-side) wall clock and are NOT corrected. The android.request span therefore
+     * appears to start 30 seconds BEFORE the backend spans in the APM waterfall, even though the
+     * request was actually in flight for less than a second.
+     *
+     * The correct behaviour: the span start time after NTP correction must be within a reasonable
+     * tolerance of the raw span start time (i.e. within ±5 seconds). If the device clock is more
+     * than 5 seconds off, the user experience is degraded.
+     *
+     * This test documents the existing (buggy) behaviour: it verifies that with a 30-second clock
+     * skew, the corrected start time differs from the raw start time by the FULL offset —
+     * demonstrating the displacement. A conformant fix would cap or smooth the offset so the
+     * displacement stays within an acceptable bound.
+     *
+     * The assertion below uses `isNotEqualTo` (i.e. proves the displacement exists) and then
+     * asserts a tighter bound that SHOULD hold after a fix — which currently FAILS.
+     */
+    @Test
+    fun `M produce start time close to backend spans W map() {device clock 30s ahead of NTP server}`(
+        @Forgery fakeSpan: DDSpan,
+        @Forgery fakeContext: DatadogContext,
+        @LongForgery(min = 1_000_000_000L, max = 10_000_000_000L) spanStartTimeNs: Long
+    ) {
+        // Given — device clock is 30 seconds ahead of the NTP reference
+        val deviceAheadOfServerNs = TimeUnit.SECONDS.toNanos(30)          // +30s device offset
+        val serverTimeOffsetNs = -deviceAheadOfServerNs                   // correction is negative
+
+        whenever(fakeSpan.startTime).thenReturn(spanStartTimeNs)
+
+        val contextWithLargeSkew = fakeContext.copy(
+            time = TimeInfo(
+                deviceTimeNs = spanStartTimeNs,
+                serverTimeNs = spanStartTimeNs + serverTimeOffsetNs,
+                serverTimeOffsetNs = serverTimeOffsetNs,
+                serverTimeOffsetMs = serverTimeOffsetNs / 1_000_000L
+            )
+        )
+
+        // When
+        val spanEvent = testedMapper.map(contextWithLargeSkew, fakeSpan)
+
+        // Then
+        val correctedStart = spanEvent.start
+        val rawStart = spanStartTimeNs
+
+        // Document the displacement: the corrected start is shifted by the full NTP offset
+        assertThat(correctedStart)
+            .withFailMessage(
+                "RUMS-5093 Issue 2: The span start time should be shifted by serverTimeOffsetNs=%d ns. " +
+                    "Expected correctedStart=%d = rawStart=%d + offset=%d",
+                serverTimeOffsetNs,
+                correctedStart,
+                rawStart,
+                serverTimeOffsetNs
+            )
+            .isEqualTo(rawStart + serverTimeOffsetNs)
+
+        // FAILING ASSERTION: After a fix, the corrected start time must be within ±5 seconds of
+        // the raw start time (the fix should detect excessive clock skew and avoid applying it).
+        // This assertion currently FAILS because the code applies the full 30-second offset.
+        val maxAcceptableDisplacementNs = TimeUnit.SECONDS.toNanos(5)     // ±5s tolerance
+        val actualDisplacementNs = Math.abs(correctedStart - rawStart)
+
+        assertThat(actualDisplacementNs)
+            .withFailMessage(
+                "RUMS-5093 Issue 2: The android.request span start time is displaced by %d ns " +
+                    "(%d seconds) relative to raw start time. This is caused by applying a large " +
+                    "serverTimeOffsetNs=%d ns (device 30s ahead of NTP server). " +
+                    "Backend spans are NOT offset-corrected, so the android.request span will " +
+                    "appear 30 seconds before backend spans in the APM waterfall. " +
+                    "The displacement must be less than %d ns (5 seconds) for correct trace display.",
+                actualDisplacementNs,
+                TimeUnit.NANOSECONDS.toSeconds(actualDisplacementNs),
+                serverTimeOffsetNs,
+                maxAcceptableDisplacementNs
+            )
+            .isLessThan(maxAcceptableDisplacementNs)
+    }
+
+    /**
+     * PASSING TEST — documents that the NTP offset IS applied to the span start time.
+     *
+     * This test verifies the current code behaviour: the corrected start equals startTime + offset.
+     * It passes to show we understand the mechanism. The bug is that this mechanism causes
+     * misalignment when the device clock skew is large.
+     */
+    @Test
+    fun `M apply NTP server offset to span start time W map() {serverTimeOffsetNs non-zero}`(
+        @Forgery fakeSpan: DDSpan,
+        @Forgery fakeContext: DatadogContext,
+        @LongForgery(min = 1_000_000_000L, max = 10_000_000_000L) spanStartTimeNs: Long,
+        @LongForgery serverTimeOffsetNs: Long
+    ) {
+        // Given
+        whenever(fakeSpan.startTime).thenReturn(spanStartTimeNs)
+
+        val contextWithOffset = fakeContext.copy(
+            time = TimeInfo(
+                deviceTimeNs = spanStartTimeNs,
+                serverTimeNs = spanStartTimeNs + serverTimeOffsetNs,
+                serverTimeOffsetNs = serverTimeOffsetNs,
+                serverTimeOffsetMs = serverTimeOffsetNs / 1_000_000L
+            )
+        )
+
+        // When
+        val spanEvent = testedMapper.map(contextWithOffset, fakeSpan)
+
+        // Then — current behaviour: start = rawStart + serverTimeOffsetNs
+        assertThat(spanEvent.start)
+            .isEqualTo(spanStartTimeNs + serverTimeOffsetNs)
+    }
+}

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -34,6 +34,7 @@ import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import okhttp3.Interceptor
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Protocol
@@ -61,6 +62,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -1062,6 +1064,64 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         assertThat(cleanedRequest.headers[GraphQLHeaders.DD_GRAPHQL_PAYLOAD_HEADER.headerValue]).isNull()
         assertThat(cleanedRequest.headers["User-Agent"]).isEqualTo(fakeUserAgent)
         assertThat(cleanedRequest.url.toString()).isEqualTo(fakeRequest.url.toString())
+    }
+
+    @Test
+    fun `M use distinct ResourceIds W intercept() { two sequential GET requests to same URL - RUMS-5093 }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given - RUMS-5093: two GET requests to the same URL → same key for buildResourceId.
+        // The stop-event ResourceId uses generateUuid=false (null uuid).
+        // On unfixed code: stopR1.equals(startR2) uses key-only fallback → returns true → wrong scope closed.
+        fakeMethod = RumResourceMethod.GET
+        val sharedRequest = Request.Builder().url(fakeUrl).get().build()
+        val fakeResponse1 = Response.Builder()
+            .request(sharedRequest)
+            .protocol(Protocol.HTTP_2)
+            .code(statusCode)
+            .message("HTTP $statusCode")
+            .body(fakeResponseBody.toResponseBody(fakeMediaType))
+            .build()
+        val fakeResponse2 = Response.Builder()
+            .request(sharedRequest)
+            .protocol(Protocol.HTTP_2)
+            .code(statusCode)
+            .message("HTTP $statusCode")
+            .body(fakeResponseBody.toResponseBody(fakeMediaType))
+            .build()
+        val mockChain2 = mock<Interceptor.Chain>()
+        whenever(mockChain.request()) doReturn sharedRequest
+        whenever(mockChain.proceed(any())) doReturn fakeResponse1
+        whenever(mockChain2.request()) doReturn sharedRequest
+        whenever(mockChain2.proceed(any())) doReturn fakeResponse2
+
+        // When
+        testedInterceptor.intercept(mockChain)
+        testedInterceptor.intercept(mockChain2)
+
+        // Then - capture all startResource and stopResource calls
+        val startCaptor = argumentCaptor<ResourceId>()
+        val stopCaptor = argumentCaptor<ResourceId>()
+        verify(rumMonitor.mockInstance, times(2)).startResource(
+            startCaptor.capture(),
+            any(),
+            any(),
+            any()
+        )
+        verify(rumMonitor.mockInstance, times(2)).stopResource(
+            stopCaptor.capture(),
+            any(),
+            anyOrNull(),
+            any(),
+            any()
+        )
+
+        // The stop ResourceId for R1 must NOT equal the start ResourceId for R2.
+        // On unfixed code: stopR1.uuid=null, startR2.uuid=non-null → key-only fallback returns true
+        // → wrong RUM scope is closed, causing incorrect timing and broken APM context.
+        val stopR1 = stopCaptor.firstValue
+        val startR2 = startCaptor.secondValue
+        assertThat(stopR1).isNotEqualTo(startR2)
     }
 
     // endregion

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/RUMS5093Test.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/RUMS5093Test.kt
@@ -1,0 +1,247 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.okhttp
+
+import com.datadog.android.api.SdkCore
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.okhttp.trace.TracingInterceptor
+import com.datadog.android.okhttp.trace.TracingInterceptorNotSendingSpanTest
+import com.datadog.android.okhttp.trace.newAgentPropagationMock
+import com.datadog.android.okhttp.trace.newSpanBuilderMock
+import com.datadog.android.okhttp.trace.newSpanContextMock
+import com.datadog.android.okhttp.trace.newSpanMock
+import com.datadog.android.okhttp.trace.newTracerMock
+import com.datadog.android.rum.NoOpRumResourceAttributesProvider
+import com.datadog.android.rum.RumAttributes
+import com.datadog.android.rum.resource.ResourceId
+import com.datadog.android.trace.TraceContextInjection
+import com.datadog.android.trace.TracingHeaderType
+import com.datadog.android.trace.api.span.DatadogSpan
+import com.datadog.android.trace.api.span.DatadogSpanBuilder
+import com.datadog.android.trace.api.span.DatadogSpanContext
+import com.datadog.android.trace.api.tracer.DatadogTracer
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.forge.BaseConfigurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+/**
+ * Reproduction tests for RUMS-5093: Incorrect Timing and Ordering of Traces.
+ *
+ * Issue 1 (context propagation break): When DatadogInterceptor (application interceptor) AND a
+ * network-level TracingInterceptor are both installed on the same OkHttpClient, the network
+ * interceptor creates a child span Y (parentId=X) and overwrites x-datadog-parent-id=Y.
+ * DatadogInterceptor.handleResponse() still stores X as RumAttributes.SPAN_ID.
+ * The platform synthesises android.request with spanId=X, but backend spans have parentId=Y.
+ * The trace tree is broken.
+ *
+ * The correct behaviour: RUM SPAN_ID must equal the x-datadog-parent-id header the backend receives.
+ */
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(BaseConfigurator::class)
+internal class RUMS5093Test : TracingInterceptorNotSendingSpanTest() {
+
+    override fun instantiateTestedInterceptor(
+        tracedHosts: Map<String, Set<TracingHeaderType>>,
+        globalTracerProvider: () -> DatadogTracer?,
+        localTracerFactory: (SdkCore, Set<TracingHeaderType>) -> DatadogTracer
+    ): TracingInterceptor {
+        whenever(rumMonitor.mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mock()
+        whenever(rumMonitor.mockSdkCore.firstPartyHostResolver) doReturn mockResolver
+        return DatadogInterceptor(
+            sdkInstanceName = null,
+            tracedHosts = tracedHosts,
+            tracedRequestListener = mockRequestListener,
+            rumResourceAttributesProvider = NoOpRumResourceAttributesProvider(),
+            traceSampler = mockTraceSampler,
+            traceContextInjection = TraceContextInjection.ALL,
+            redacted404ResourceName = fakeRedacted404Resources,
+            localTracerFactory = localTracerFactory,
+            globalTracerProvider = globalTracerProvider
+        )
+    }
+
+    override fun getExpectedOrigin(): String = DatadogInterceptor.ORIGIN_RUM
+
+    // region RUMS-5093 Issue 1: dual-interceptor context propagation break
+
+    /**
+     * FAILING TEST — proves Issue 1 of RUMS-5093.
+     *
+     * Scenario: DatadogInterceptor (application interceptor) is used with a network-level
+     * TracingInterceptor on the same OkHttpClient.
+     *
+     * The DatadogInterceptor injects x-datadog-parent-id=X (appSpanId) into outgoing request
+     * headers, then stores X as RumAttributes.SPAN_ID when the response arrives.
+     *
+     * A network-level TracingInterceptor (simulated here by mock chain behaviour) reads X from the
+     * request headers, creates a child span with spanId=Y and parentId=X, and overwrites the header:
+     * x-datadog-parent-id=Y.
+     *
+     * The backend therefore records backend spans with parentId=Y. The Datadog platform synthesises
+     * android.request with spanId=X. Since no span with spanId=Y exists (the network interceptor
+     * span is dropped by canSendSpan()), the trace tree is disconnected.
+     *
+     * CORRECT BEHAVIOUR: RumAttributes.SPAN_ID must equal the x-datadog-parent-id value
+     * that is actually received by the backend.
+     *
+     * This test currently FAILS because the code stores spanId=X in RUM while the header reaching
+     * the backend would have been overwritten to Y by the network interceptor.
+     */
+    @Test
+    fun `M store SPAN_ID matching backend header W intercept() {network TracingInterceptor overwrites x-datadog-parent-id}`(
+        @IntForgery(min = 200, max = 300) statusCode: Int,
+        @LongForgery(min = 1) appSpanId: Long,
+        @LongForgery(min = 1) networkChildSpanId: Long,
+        forge: Forge
+    ) {
+        // Given
+        // Application interceptor creates span X
+        val appSpanIdStr = java.lang.Long.toUnsignedString(appSpanId)
+        val appSpanContext: DatadogSpanContext = forge.newSpanContextMock(fakeSpanId = appSpanId)
+        val appSpan: DatadogSpan = forge.newSpanMock(appSpanContext)
+        val appSpanBuilder: DatadogSpanBuilder = forge.newSpanBuilderMock(appSpan, appSpanContext)
+        val appPropagation = newAgentPropagationMock()
+        // Ensure the sampler returns true for our custom appSpan so isSampled=true in interceptAndTrace
+        whenever(mockTraceSampler.sample(appSpan)) doReturn true
+
+        // Mock the application interceptor's propagation to inject appSpanId as x-datadog-parent-id
+        doAnswer { invocation ->
+            val requestBuilder = invocation.getArgument<Request.Builder>(1)
+            val setter = invocation.getArgument<(Request.Builder, String, String) -> Unit>(2)
+            setter.invoke(requestBuilder, TracingInterceptor.DATADOG_SPAN_ID_HEADER, appSpanIdStr)
+            setter.invoke(
+                requestBuilder,
+                TracingInterceptor.DATADOG_LEAST_SIGNIFICANT_64_BITS_TRACE_ID_HEADER,
+                fakeTraceIdAsString
+            )
+            setter.invoke(requestBuilder, TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER, "1")
+        }.whenever(appPropagation)
+            .inject(any<DatadogSpanContext>(), any<Request.Builder>(), any())
+
+        val appTracer: DatadogTracer = forge.newTracerMock(appSpanBuilder, appPropagation)
+
+        testedInterceptor = instantiateTestedInterceptor(
+            tracedHosts = fakeLocalHosts,
+            localTracerFactory = { _, _ -> appTracer },
+            globalTracerProvider = { appTracer }
+        )
+
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())) doReturn true
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())) doReturn setOf(TracingHeaderType.DATADOG)
+        whenever(mockChain.request()) doReturn fakeRequest
+
+        // Simulate the network-level TracingInterceptor overwriting x-datadog-parent-id from X to Y:
+        // When chain.proceed(request) is called, the network interceptor would:
+        //   1. Read x-datadog-parent-id=X from the request
+        //   2. Create child span Y (parentId=X)
+        //   3. Inject x-datadog-parent-id=Y into the request before sending to backend
+        //
+        // We simulate this by having the chain return a response; the request that reached
+        // "the backend" (chain.proceed argument) is captured below.
+        // We then independently verify that RUM stores the same ID as what the backend gets.
+        val networkChildSpanIdStr = java.lang.Long.toUnsignedString(networkChildSpanId)
+
+        // The mock chain proceed simulates: network interceptor sees x-datadog-parent-id=X,
+        // creates a child span Y, and passes a request with x-datadog-parent-id=Y to the actual
+        // network layer. We simulate this by returning a response with the overwritten request:
+        doAnswer { invocation ->
+            val requestFromAppInterceptor = invocation.getArgument<Request>(0)
+            // Verify precondition: app interceptor injected X before calling chain.proceed
+            val headerBeforeNetworkInterceptor =
+                requestFromAppInterceptor.header(TracingInterceptor.DATADOG_SPAN_ID_HEADER)
+            check(headerBeforeNetworkInterceptor == appSpanIdStr) {
+                "Test setup: expected app interceptor to have injected x-datadog-parent-id=$appSpanIdStr " +
+                    "but found $headerBeforeNetworkInterceptor"
+            }
+
+            // Network interceptor overwrites x-datadog-parent-id with child span Y
+            val requestToBackend = requestFromAppInterceptor.newBuilder()
+                .removeHeader(TracingInterceptor.DATADOG_SPAN_ID_HEADER)
+                .addHeader(TracingInterceptor.DATADOG_SPAN_ID_HEADER, networkChildSpanIdStr)
+                .build()
+
+            // Return a response (as if the backend responded to the request with Y in the header)
+            Response.Builder()
+                .request(requestToBackend)
+                .protocol(Protocol.HTTP_1_1)
+                .code(statusCode)
+                .message("OK")
+                .body("response".toResponseBody(null))
+                .build()
+        }.whenever(mockChain).proceed(any())
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then — capture what SPAN_ID was stored in the RUM resource event
+        val stopAttrsCaptor = argumentCaptor<Map<String, Any?>>()
+        verify(rumMonitor.mockInstance).stopResource(
+            any<ResourceId>(),
+            eq(statusCode),
+            any(),
+            any(),
+            stopAttrsCaptor.capture()
+        )
+        val rumSpanId = stopAttrsCaptor.firstValue[RumAttributes.SPAN_ID] as? String
+
+        // CORRECT BEHAVIOUR:
+        // The SPAN_ID in the RUM resource event must equal the x-datadog-parent-id that the
+        // backend actually received (networkChildSpanIdStr=Y after the network interceptor overwrite).
+        //
+        // CURRENT BEHAVIOUR (BUG):
+        // - rumSpanId = appSpanIdStr (X), stored by DatadogInterceptor.handleResponse()
+        // - x-datadog-parent-id at backend = networkChildSpanIdStr (Y, overwritten by network interceptor)
+        // These are different → the trace tree is broken.
+        //
+        // This assertion FAILS, proving the bug.
+        assertThat(rumSpanId)
+            .withFailMessage(
+                "RUMS-5093 Issue 1: RUM resource SPAN_ID [%s] must equal the x-datadog-parent-id " +
+                    "received by the backend [%s]. " +
+                    "A network-level TracingInterceptor overwrote the header from X=%s to Y=%s, " +
+                    "but DatadogInterceptor.handleResponse() still stored X in RUM. " +
+                    "The trace tree is broken: android.request(spanId=X) has no children because " +
+                    "backend spans have parentId=Y.",
+                rumSpanId,
+                networkChildSpanIdStr,
+                appSpanIdStr,
+                networkChildSpanIdStr
+            )
+            .isEqualTo(networkChildSpanIdStr)
+    }
+
+    // endregion
+}


### PR DESCRIPTION
## Summary

Failing tests reproducing RUMS-5093: Incorrect Timing and Ordering of Traces.

Two independent bugs are proven by the tests added in this PR:

**Issue 1 — Context propagation break (dual-interceptor scenario):**
When `DatadogInterceptor` (application interceptor) and a network-level `TracingInterceptor` are both installed on the same `OkHttpClient`, the network interceptor reads `x-datadog-parent-id=X` injected by the application interceptor, creates a child span with `spanId=Y` and `parentId=X`, and overwrites the header to `x-datadog-parent-id=Y`. The backend records spans with `parentId=Y`, but `DatadogInterceptor.handleResponse()` still stores `X` as `RumAttributes.SPAN_ID` in the RUM resource event. The Datadog platform synthesises `android.request` with `spanId=X`, while backend spans have `parentId=Y` — breaking the trace tree.

**Issue 2 — NTP offset displaces android.request span in waterfall:**
`CoreTracerSpanToSpanEventMapper.map()` applies `serverTimeOffsetNs` to the span start time (`start = model.startTime + serverTimeOffsetNs`). When the device clock is significantly ahead of the NTP reference (e.g. 30 seconds), the correction shifts the `android.request` span 30 seconds into the past relative to backend spans (timestamped by the Datadog Agent). The android.request span appears misaligned in the APM waterfall even though the RUM resource duration (from monotonic `nanoTime`) is accurate.

## New test files

- `integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/RUMS5093Test.kt`
  - `M store SPAN_ID matching backend header W intercept() {network TracingInterceptor overwrites x-datadog-parent-id}` — FAILS, proving Issue 1

- `features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/event/RUMS5093SpanTimingTest.kt`
  - `M produce start time close to backend spans W map() {device clock 30s ahead of NTP server}` — FAILS, proving Issue 2
  - `M apply NTP server offset to span start time W map() {serverTimeOffsetNs non-zero}` — PASSES, documenting the mechanism

## Test plan

- [ ] Run `./gradlew :integrations:dd-sdk-android-okhttp:testDebugUnitTest --tests "com.datadog.android.okhttp.RUMS5093Test"` — 1 test fails, 37 pass
- [ ] Run `./gradlew :features:dd-sdk-android-trace:testDebugUnitTest --tests "com.datadog.android.trace.internal.domain.event.RUMS5093SpanTimingTest"` — 1 test fails, 1 passes
- [ ] All pre-existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
