### PR TITLE
Reproduce RUMS-5469: TTID not emitted for interstitial Activity pattern

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImplTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImplTest.kt
@@ -337,6 +337,51 @@ internal class RumAppStartupDetectorImplTest {
     }
 
     @Test
+    fun `M NOT detect startup for activityB W RumAppStartupDetector {interstitial activityA still alive when activityB is created}`(
+        forge: Forge,
+        @BoolForgery hasSavedInstanceStateBundle: Boolean,
+        @BoolForgery hasSavedInstanceStateBundle2: Boolean
+    ) {
+        // Given - reproduces RUMS-5469: interstitial/splash Activity A starts Activity B while A is still alive.
+        // numberOfActivities == 2 when B is created, so the guard `numberOfActivities == 1` prevents
+        // startup detection for B. TTID is never registered on B. This test PASSES (confirms the bug)
+        // and must FAIL once a proper fix re-triggers startup detection after A finishes.
+        val detector = createDetector()
+        currentTime += 3.seconds
+        val activityB = mock<Activity>()
+
+        // When - Activity A is created (numberOfActivities=1 → startup detected for A)
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle
+        )
+
+        // Activity B is created while A is still alive (numberOfActivities=2 → guard FAILS for B)
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activityB,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle2
+        )
+
+        // Activity A finishes (splash/interstitial) — numberOfActivities drops back to 1 but no re-trigger
+        detector.onActivityDestroyed(activity)
+
+        // Then - listener is called ONLY ONCE (for A), never for B — this confirms the bug
+        listener.verifyScenarioDetected(
+            RumStartupScenario.Cold(
+                initialTime = Time(0, 0),
+                hasSavedInstanceStateBundle = hasSavedInstanceStateBundle,
+                activity = activity.wrapWeak(),
+                appStartActivityOnCreateGapNs = 3.seconds.inWholeNanoseconds
+            )
+        )
+        verifyNoMoreInteractions(listener)
+    }
+
+    @Test
     fun `M detect WarmAfterActivityDestroyed W RumAppStartupDetector {2 activities created, destroyed and 3rd created}`(
         forge: Forge,
         @BoolForgery hasSavedInstanceStateBundle: Boolean,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImplTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImplTest.kt
@@ -337,7 +337,7 @@ internal class RumAppStartupDetectorImplTest {
     }
 
     @Test
-    fun `M NOT detect startup for activityB W RumAppStartupDetector {interstitial activityA still alive when activityB is created}`(
+    fun `M NOT detect startup for activityB W RumAppStartupDetector {interstitial A alive at B creation}`(
         forge: Forge,
         @BoolForgery hasSavedInstanceStateBundle: Boolean,
         @BoolForgery hasSavedInstanceStateBundle2: Boolean

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumFirstDrawTimeReporterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumFirstDrawTimeReporterTest.kt
@@ -30,12 +30,12 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -258,7 +258,7 @@ class RumFirstDrawTimeReporterTest {
     }
 
     @Test
-    fun `M NOT call onFirstFrameDrawn W subscribeToFirstFrameDrawn { decorView detaches before any draw — no fallback exists }`() {
+    fun `M NOT call onFirstFrameDrawn W subscribeToFirstFrameDrawn { decorView detaches before any draw }`() {
         // Given - reproduces RUMS-5469: Activity registered for TTID finish()es before any Choreographer
         // frame fires (common on API 34 emulators). The OnAttachStateChangeListener.onViewDetachedFromWindow
         // is a no-op, so the callback is silently dropped and TTID is never emitted.

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumFirstDrawTimeReporterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumFirstDrawTimeReporterTest.kt
@@ -30,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
@@ -254,6 +255,28 @@ class RumFirstDrawTimeReporterTest {
             verify(viewTreeObserver).removeOnDrawListener(any())
             verifyNoMoreInteractions()
         }
+    }
+
+    @Test
+    fun `M NOT call onFirstFrameDrawn W subscribeToFirstFrameDrawn { decorView detaches before any draw — no fallback exists }`() {
+        // Given - reproduces RUMS-5469: Activity registered for TTID finish()es before any Choreographer
+        // frame fires (common on API 34 emulators). The OnAttachStateChangeListener.onViewDetachedFromWindow
+        // is a no-op, so the callback is silently dropped and TTID is never emitted.
+        // This test PASSES (confirms the bug) and must FAIL once a fallback is added.
+        whenever(window.peekDecorView()) doReturn decorView
+        whenever(decorView.isAttachedToWindow) doReturn false
+
+        // When - subscribe so that the OnAttachStateChangeListener is registered
+        reporter.subscribeToFirstFrameDrawn(activity, callback)
+
+        // Capture the attach-state listener and fire only the detach branch (no draw ever happens)
+        argumentCaptor<View.OnAttachStateChangeListener> {
+            verify(decorView).addOnAttachStateChangeListener(capture())
+            firstValue.onViewDetachedFromWindow(decorView)
+        }
+
+        // Then - callback is never invoked because onViewDetachedFromWindow is a no-op
+        verifyNoInteractions(callback)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Reproduces RUMS-5469: Android TTID not emitted when an interstitial/splash Activity starts a destination Activity and finishes before drawing any frame.
- Adds a test to `RumAppStartupDetectorImplTest` proving the `numberOfActivities == 1` guard blocks startup detection for Activity B when Activity A is still alive at B's creation time.
- Adds a test to `RumFirstDrawTimeReporterTest` proving `onViewDetachedFromWindow` is a no-op — no TTID callback is ever fired when the subscribed decorView detaches without a draw event.

## Root Cause (confirmed)

`RumAppStartupDetectorImpl.onBeforeActivityCreated` only notifies the startup listener when `numberOfActivities == 1`. In the interstitial pattern, Activity B is created while Activity A is still alive (`numberOfActivities == 2`), so the TTID draw subscriber is bound exclusively to A. A then calls `finish()` before any Choreographer frame is dispatched; `onViewDetachedFromWindow` is empty, so the `OnDrawListener` is never invoked and TTID is silently dropped.

## Test plan

- [x] `RumAppStartupDetectorImplTest` — new test simulates interstitial pattern (A created, B created while A alive, A destroyed) and asserts listener called ONLY for A
- [x] `RumFirstDrawTimeReporterTest` — new test registers subscriber, fires `onViewDetachedFromWindow` without a draw, asserts callback never invoked
- [x] Both new tests PASS (confirm the bug) and will FAIL once the bug is fixed
- [x] Full `RumAppStartupDetectorImplTest` and `RumFirstDrawTimeReporterTest` test suites pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
