### PR TITLE
Reproduce RUMS-4466: loggableStackTrace missing tab causes partial deobfuscation

### DIFF
--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/ThreadExtTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/ThreadExtTest.kt
@@ -46,4 +46,30 @@ internal class ThreadExtTest {
             assertThat(lines[i]).contains(frame.toString())
         }
     }
+
+    @Test
+    fun `M use tab prefix W loggableStackTrace() { each line must start with tab+at for deobfuscation }`() {
+        // Given
+        // The Datadog backend deobfuscation-api retrace tool only processes stack frame lines
+        // that start with "\tat " (tab + "at "). Lines starting with "at " (no tab) are ignored
+        // and left obfuscated. This test verifies Array<StackTraceElement>.loggableStackTrace()
+        // produces the standard JVM format required for deobfuscation to work correctly.
+        val stack = Thread.currentThread().stackTrace
+
+        // When
+        val result = stack.loggableStackTrace()
+
+        // Then
+        val lines = result.lines()
+        lines.forEachIndexed { index, line ->
+            assertThat(line)
+                .withFailMessage(
+                    "Line $index in loggableStackTrace() output does not start with \"\\tat \" " +
+                        "(tab + at). The backend deobfuscation-api retrace tool requires this " +
+                        "prefix to recognize and deobfuscate stack frames. " +
+                        "Actual line: \"$line\""
+                )
+                .startsWith("\tat ")
+        }
+    }
 }


### PR DESCRIPTION
## Reproduction for RUMS-4466: deobfuscation malfunction

**Jira:** [RUMS-4466](https://datadoghq.atlassian.net/browse/RUMS-4466)

### Issue Summary
Partial deobfuscation of Android crash stack traces: frames from the crashed thread are correctly
deobfuscated, but frames from secondary threads remain obfuscated after prettification.

### Root Cause
`Array<StackTraceElement>.loggableStackTrace()` in `ThreadExt.kt:31` produces lines with `"at $it"`
(no leading tab) instead of the standard JVM format `"\tat $it"`. The Datadog backend
deobfuscation-api retrace tool only processes lines that start with `"\tat "`, so secondary thread
stacks are skipped during deobfuscation.

### Reproduction Tests
Unit tests asserting that `loggableStackTrace()` output uses the standard `\tat ` prefix. Tests
FAIL with the pre-fix code, confirming the bug.

### Call Chain
DatadogExceptionHandler.getThreadDumps()
  → e.loggableStackTrace() (Throwable) → correct "\tat " format for crashed thread
  → stackTrace.loggableStackTrace() (Array) → "at $it" missing tab for secondary threads
  → backend retrace skips frames without "\tat " prefix → partial deobfuscation

---
*Generated by rum:tee-triage-insights*


[RUMS-4466]: https://datadoghq.atlassian.net/browse/RUMS-4466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ