### PR TITLE
Reproduce RUMS-5184: missing resource timing breakdown

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -2623,6 +2623,84 @@ internal class RumResourceScopeTest {
         assertThat(resultTiming).isEqualTo(null)
     }
 
+    // region RUMS-5184 regression tests
+
+    @Test
+    fun `RUMS-5184 M include timing in Resource W handleEvent(WaitForResourceTiming+AddResourceTiming+StopResource) { same key string but different UUID }`(
+        @Forgery kind: RumResourceKind,
+        @LongForgery(200, 600) statusCode: Long,
+        @LongForgery(0, 1024) size: Long,
+        @Forgery timing: ResourceTiming,
+        forge: Forge
+    ) {
+        // Given
+        // The interceptor generates uuid_A for the ResourceId it stores in the scope.
+        // The event listener independently generates uuid_B for the same key string.
+        // This mirrors the bug: buildResourceId(generateUuid=true) is called independently
+        // by both components on the same Request, producing two distinct UUIDs.
+        val keyString = forge.aStringMatching("https://[a-z]+\\.[a-z]{3}/[a-z0-9]+")
+        val uuidA = java.util.UUID.randomUUID().toString()
+        val uuidB = java.util.UUID.randomUUID().toString()
+
+        val interceptorResourceId = ResourceId(keyString, uuidA)
+        val listenerResourceId = ResourceId(keyString, uuidB)
+
+        // Build a scope with interceptorResourceId (uuid_A) — this is what the interceptor does.
+        val scopeUnderTest = RumResourceScope(
+            parentScope = mockParentScope,
+            sdkCore = rumMonitor.mockSdkCore,
+            url = fakeUrl,
+            method = fakeMethod,
+            key = interceptorResourceId,
+            eventTime = fakeEventTime,
+            initialAttributes = fakeResourceAttributes,
+            serverTimeOffsetInMs = fakeServerOffset,
+            firstPartyHostHeaderTypeResolver = mockResolver,
+            featuresContextResolver = mockFeaturesContextResolver,
+            sampleRate = fakeSampleRate,
+            networkSettledMetricResolver = mockNetworkSettledMetricResolver,
+            rumSessionTypeOverride = fakeRumSessionType,
+            insightsCollector = mockInsightsCollector
+        )
+
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeResourceAttributes.keys)
+
+        // When
+        // The event listener sends WaitForResourceTiming with listenerResourceId (uuid_B).
+        // RumResourceScope checks `key == event.key`:
+        //   ResourceId(keyString, uuid_A) == ResourceId(keyString, uuid_B)
+        // Because both UUIDs are non-null and different, equals() returns false →
+        // waitForTiming stays false.
+        mockEvent = RumRawEvent.WaitForResourceTiming(listenerResourceId)
+        val resultWait = scopeUnderTest.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // The event listener sends AddResourceTiming with listenerResourceId (uuid_B).
+        // The same guard `key != event.key` causes the timing to be silently discarded.
+        mockEvent = RumRawEvent.AddResourceTiming(listenerResourceId, timing)
+        val resultTiming = scopeUnderTest.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        Thread.sleep(50L)
+
+        // The interceptor sends StopResource with interceptorResourceId (uuid_A) — this matches.
+        // But waitForTiming=false and timing=null, so the resource is sent without any timing data.
+        mockEvent = RumRawEvent.StopResource(interceptorResourceId, statusCode, size, kind, attributes)
+        val resultStop = scopeUnderTest.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        // The CORRECT behaviour is that the ResourceEvent contains the timing breakdown that
+        // the event listener reported. This assertion will FAIL on the buggy code because the
+        // scope silently discarded the timing due to the UUID mismatch.
+        argumentCaptor<ResourceEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(firstValue).hasTiming(timing)
+        }
+        assertThat(resultWait).isSameAs(scopeUnderTest)
+        assertThat(resultTiming).isSameAs(scopeUnderTest)
+        assertThat(resultStop).isNull()
+    }
+
+    // endregion
+
     @Test
     fun `M use explicit timings W handleEvent { AddResourceTiming + StopResource }`(
         @Forgery kind: RumResourceKind,

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogEventListenerFactoryTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogEventListenerFactoryTest.kt
@@ -81,6 +81,33 @@ internal class DatadogEventListenerFactoryTest {
         assertThat(result).isSameAs(DatadogEventListener.Factory.NO_OP_EVENT_LISTENER)
     }
 
+    // region RUMS-5184 regression tests
+
+    @Test
+    fun `RUMS-5184 M produce different ResourceIds W buildResourceId called twice without UUID tag`() {
+        // Given
+        // A Request with no UUID tag — simulating what DatadogInterceptor and
+        // DatadogEventListener.Factory each see independently.
+        val request = Request.Builder()
+            .get().url("https://$fakeDomain/api/resource")
+            .build()
+
+        // When
+        // Interceptor calls buildResourceId(generateUuid=true) → ResourceId(key, uuid_A)
+        val interceptorResourceId = request.buildResourceId(generateUuid = true)
+        // Factory.create() calls buildResourceId(generateUuid=true) → ResourceId(key, uuid_B)
+        val factoryResourceId = request.buildResourceId(generateUuid = true)
+
+        // Then
+        // The two IDs share the same key but have different UUIDs because buildResourceId()
+        // never stores the generated UUID back on the request tag. Correct behaviour would be
+        // that the two IDs are equal so that timing events are matched to the right scope.
+        // This assertion documents the CORRECT expected behaviour; it FAILS on the buggy code.
+        assertThat(interceptorResourceId).isEqualTo(factoryResourceId)
+    }
+
+    // endregion
+
     companion object {
         val datadogCore = DatadogSingletonTestConfiguration()
 


### PR DESCRIPTION
## Summary

- Proves RUMS-5184: `buildResourceId(generateUuid=true)` never stores the generated UUID back on the OkHttp Request tag, so `DatadogInterceptor` and `DatadogEventListener.Factory` each generate independent UUIDs for the same request
- Proves that `RumResourceScope` silently discards `WaitForResourceTiming` and `AddResourceTiming` events when the `ResourceId` carries the same key string but a different UUID than the scope was started with, because `ResourceId.equals()` requires both UUID and key to match when neither UUID is null
- Both tests assert the CORRECT expected behavior (timing should be present) and FAIL on the pre-fix code at commit `7c2f1849845476fd593d16d913119ad3fb98e878`

## Test plan

- [x] `DatadogEventListenerFactoryTest#RUMS-5184 M produce different ResourceIds W buildResourceId called twice without UUID tag` — fails with "not equal" assertion on two ResourceIds from the same Request
- [x] `RumResourceScopeTest#RUMS-5184 M include timing in Resource W handleEvent(WaitForResourceTiming+AddResourceTiming+StopResource) { same key string but different UUID }` — fails with "Expected resource.dns.start X but was null"

🤖 Generated with [Claude Code](https://claude.com/claude-code)