### PR TITLE
RUM-15324: Decouple continuous profiling from SDK instance names

### DIFF
--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -601,6 +601,7 @@ datadog:
       - "java.util.concurrent.atomic.AtomicReference.constructor(kotlin.String?)"
       - "java.util.concurrent.atomic.AtomicReference.constructor(kotlin.collections.Set?)"
       - "java.util.concurrent.atomic.AtomicReference.get()"
+      - "java.util.concurrent.atomic.AtomicReference.getAndSet(kotlin.collections.Set?)"
       - "java.util.concurrent.atomic.AtomicReference.set(android.app.Application.ActivityLifecycleCallbacks?)"
       - "java.util.concurrent.atomic.AtomicReference.set(com.datadog.android.api.FeatureEventReceiver?)"
       - "java.util.concurrent.atomic.AtomicReference.set(com.datadog.android.api.SdkCore?)"

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
@@ -81,7 +81,6 @@ internal class ContinuousProfilingScheduler(
                 appContext = appContext,
                 startReason = ProfilingStartReason.CONTINUOUS,
                 additionalAttributes = emptyMap(),
-                sdkInstanceNames = setOf(sdkCore.name),
                 durationMs = activeMs.toInt()
             )
         } else {

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/NoOpProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/NoOpProfiler.kt
@@ -22,7 +22,14 @@ internal class NoOpProfiler : Profiler {
         appContext: Context,
         startReason: ProfilingStartReason,
         additionalAttributes: Map<String, String>,
-        sdkInstanceNames: Set<String>,
+        sdkInstanceNames: Set<String>
+    ) {
+    }
+
+    override fun start(
+        appContext: Context,
+        startReason: ProfilingStartReason,
+        additionalAttributes: Map<String, String>,
         durationMs: Int
     ) {
     }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/Profiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/Profiler.kt
@@ -20,7 +20,13 @@ internal interface Profiler {
         appContext: Context,
         startReason: ProfilingStartReason,
         additionalAttributes: Map<String, String>,
-        sdkInstanceNames: Set<String>,
+        sdkInstanceNames: Set<String>
+    )
+
+    fun start(
+        appContext: Context,
+        startReason: ProfilingStartReason,
+        additionalAttributes: Map<String, String>,
         durationMs: Int = 0
     )
 

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.Consumer
 import kotlin.random.Random
@@ -48,8 +49,11 @@ internal class PerfettoProfiler(
     internal var stopSignal: CancellationSignal? = null
     private val resultCallback: Consumer<ProfilingResult>
 
-    // This flag represents which instance of this class is working for.
+    // Tracks which SDK instances started app-launch profiling.
     private val runningInstances: AtomicReference<Set<String>> = AtomicReference(emptySet())
+
+    // Tracks whether continuous profiling is currently running.
+    private val continuousProfilingRunning: AtomicBoolean = AtomicBoolean(false)
 
     @Volatile
     private var profilingStartTime = 0L
@@ -108,7 +112,6 @@ internal class PerfettoProfiler(
             } else {
                 notifyCallbacks { onFailure(tag) }
             }
-            runningInstances.set(emptySet())
             sendProfilingEndTelemetry(
                 result = result,
                 duration = duration,
@@ -136,9 +139,18 @@ internal class PerfettoProfiler(
     }
 
     private fun notifyCallbacks(dispatch: ProfilerCallback.() -> Unit) {
-        val running = runningInstances.get()
-        callbackMap.forEach { (key, callback) ->
-            if (running.contains(key)) callback.dispatch()
+        val running = runningInstances.getAndSet(emptySet())
+        if (running.isEmpty()) {
+            // Continuous profiling: start(durationMs) never sets runningInstances, so notify
+            // all registered callbacks.
+            continuousProfilingRunning.set(false)
+            callbackMap.values.forEach { it.dispatch() }
+        } else {
+            // App-launch profiling: start(sdkInstanceNames) set runningInstances to the
+            // initiating instances — only notify those.
+            callbackMap.forEach { (key, callback) ->
+                if (running.contains(key)) callback.dispatch()
+            }
         }
     }
 
@@ -146,12 +158,11 @@ internal class PerfettoProfiler(
         appContext: Context,
         startReason: ProfilingStartReason,
         additionalAttributes: Map<String, String>,
-        sdkInstanceNames: Set<String>,
-        durationMs: Int
+        sdkInstanceNames: Set<String>
     ) {
-        val effectiveDurationMs =
-            if (durationMs > 0) durationMs else getDefaultDurationMs(startReason)
+        val effectiveDurationMs = getDefaultDurationMs(startReason)
         // profiling will be launched when no instance is currently running profiling.
+        if (continuousProfilingRunning.get()) return
         if (runningInstances.compareAndSet(emptySet(), sdkInstanceNames)) {
             profilingStartTime = timeProvider.getDeviceTimestampMillis()
             profilingStopTime = 0L
@@ -183,8 +194,31 @@ internal class PerfettoProfiler(
         }
     }
 
+    override fun start(
+        appContext: Context,
+        startReason: ProfilingStartReason,
+        additionalAttributes: Map<String, String>,
+        durationMs: Int
+    ) {
+        if (!continuousProfilingRunning.compareAndSet(false, true)) return
+        if (runningInstances.get().isNotEmpty()) {
+            continuousProfilingRunning.set(false)
+            return
+        }
+        profilingStartTime = timeProvider.getDeviceTimestampMillis()
+        profilingStopTime = 0L
+        profilingStartReason = startReason
+        profilingAppStartInfo = null
+        requestProfiling(
+            appContext,
+            buildStackSamplingRequest(startReason, durationMs),
+            scheduledExecutorService,
+            resultCallback
+        )
+    }
+
     override fun stop(sdkInstanceName: String) {
-        if (runningInstances.get().contains(sdkInstanceName)) {
+        if (runningInstances.get().contains(sdkInstanceName) || continuousProfilingRunning.get()) {
             // note: if we call this while another request is being built, stopSignal will be
             // overwritten by that time. Probably need to allow a single profiler instance and stop profiler before
             // starting another request.
@@ -194,7 +228,7 @@ internal class PerfettoProfiler(
     }
 
     override fun isRunning(sdkInstanceName: String): Boolean {
-        return runningInstances.get().contains(sdkInstanceName)
+        return runningInstances.get().contains(sdkInstanceName) || continuousProfilingRunning.get()
     }
 
     override fun registerProfilingCallback(

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -281,7 +281,6 @@ class ProfilingFeatureTest {
             appContext = eq(mockContext),
             startReason = eq(ProfilingStartReason.CONTINUOUS),
             additionalAttributes = any(),
-            sdkInstanceNames = any(),
             durationMs = any()
         )
     }
@@ -318,7 +317,6 @@ class ProfilingFeatureTest {
             appContext = eq(mockContext),
             startReason = eq(ProfilingStartReason.CONTINUOUS),
             additionalAttributes = any(),
-            sdkInstanceNames = any(),
             durationMs = any()
         )
     }
@@ -351,7 +349,6 @@ class ProfilingFeatureTest {
             appContext = any(),
             startReason = any(),
             additionalAttributes = any(),
-            sdkInstanceNames = any(),
             durationMs = any()
         )
     }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ContinuousProfilingSchedulerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ContinuousProfilingSchedulerTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.profiling.internal
 
 import android.app.Application
+import android.content.Context
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.profiling.forge.Configurator
@@ -120,7 +121,6 @@ internal class ContinuousProfilingSchedulerTest {
             appContext = eq(mockApplication),
             startReason = eq(ProfilingStartReason.CONTINUOUS),
             additionalAttributes = eq(emptyMap()),
-            sdkInstanceNames = eq(setOf(fakeInstanceName)),
             durationMs = durationCaptor.capture()
         )
         val captured = durationCaptor.firstValue.toLong()
@@ -134,7 +134,7 @@ internal class ContinuousProfilingSchedulerTest {
         testedScheduler.start(launchProfilingActive = true)
 
         // Then
-        verify(mockProfiler, never()).start(any(), any(), any(), any(), any())
+        verify(mockProfiler, never()).start(any<Context>(), any(), any(), any<Int>())
         verifyNoInteractions(mockSchedulerExecutor)
     }
 
@@ -162,7 +162,7 @@ internal class ContinuousProfilingSchedulerTest {
         testedScheduler.start(launchProfilingActive = false)
 
         // Then
-        verify(mockProfiler, never()).start(any(), any(), any(), any(), any())
+        verify(mockProfiler, never()).start(any<Context>(), any(), any(), any<Int>())
     }
 
     @Test
@@ -201,7 +201,7 @@ internal class ContinuousProfilingSchedulerTest {
         testedScheduler.onAppLaunchProfilingComplete()
 
         // Then
-        verify(mockProfiler, never()).start(any(), any(), any(), any(), any())
+        verify(mockProfiler, never()).start(any<Context>(), any(), any(), any<Int>())
     }
 
     @Test
@@ -218,7 +218,6 @@ internal class ContinuousProfilingSchedulerTest {
             appContext = eq(mockApplication),
             startReason = eq(ProfilingStartReason.CONTINUOUS),
             additionalAttributes = eq(emptyMap()),
-            sdkInstanceNames = eq(setOf(fakeInstanceName)),
             durationMs = any()
         )
     }
@@ -285,7 +284,7 @@ internal class ContinuousProfilingSchedulerTest {
         runnableCaptor.firstValue.run()
 
         // Then
-        verify(mockProfiler, never()).start(any(), any(), any(), any(), any())
+        verify(mockProfiler, never()).start(any<Context>(), any(), any(), any<Int>())
     }
 
     @Test
@@ -321,8 +320,7 @@ internal class ContinuousProfilingSchedulerTest {
 
         // Then
         verify(mockProfiler, atLeastOnce()).start(
-            any(),
-            any(),
+            any<Context>(),
             any(),
             any(),
             durationCaptor.capture()

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -41,6 +41,7 @@ import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
@@ -923,11 +924,11 @@ class PerfettoProfilerTest {
             mockContext,
             ProfilingStartReason.CONTINUOUS,
             emptyMap(),
-            setOf(fakeInstanceName)
+            fakeDuration2.toInt()
         )
 
         val callbackCaptor2 = argumentCaptor<Consumer<ProfilingResult>>()
-        verify(mockService, org.mockito.kotlin.times(2))
+        verify(mockService, times(2))
             .requestProfiling(
                 eq(ProfilingManager.PROFILING_TYPE_STACK_SAMPLING),
                 any<Bundle>(),
@@ -1050,6 +1051,325 @@ class PerfettoProfilerTest {
         // Then
         verify(mockStopSignal, never()).cancel()
     }
+
+    @Test
+    fun `M request profiling W start(durationMs)`(
+        @IntForgery(min = 1000, max = 60_000) fakeDurationMs: Int
+    ) {
+        // When
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.CONTINUOUS,
+            emptyMap(),
+            fakeDurationMs
+        )
+
+        // Then
+        verify(mockService).requestProfiling(
+            eq(ProfilingManager.PROFILING_TYPE_STACK_SAMPLING),
+            any<Bundle>(),
+            any<String>(),
+            any<CancellationSignal>(),
+            any(),
+            any()
+        )
+    }
+
+    @Test
+    fun `M not request profiling W start(durationMs) {app launch session running}`(
+        @IntForgery(min = 1000, max = 60_000) fakeDurationMs: Int
+    ) {
+        // Given
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.APPLICATION_LAUNCH,
+            emptyMap(),
+            setOf(fakeInstanceName)
+        )
+
+        // When
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.CONTINUOUS,
+            emptyMap(),
+            fakeDurationMs
+        )
+
+        // Then
+        verify(mockService, times(1)).requestProfiling(any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `M not request profiling W start(durationMs) {continuous session already running}`(
+        @IntForgery(min = 1000, max = 60_000) fakeDurationMs: Int
+    ) {
+        // Given
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.CONTINUOUS,
+            emptyMap(),
+            fakeDurationMs
+        )
+
+        // When
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.CONTINUOUS,
+            emptyMap(),
+            fakeDurationMs
+        )
+
+        // Then
+        verify(mockService, times(1)).requestProfiling(any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `M isRunning returns true for any instance W start(durationMs)`(
+        @IntForgery(min = 1000, max = 60_000) fakeDurationMs: Int
+    ) {
+        // When
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.CONTINUOUS,
+            emptyMap(),
+            fakeDurationMs
+        )
+
+        // Then
+        assertThat(testedProfiler.isRunning(fakeInstanceName)).isTrue
+        assertThat(testedProfiler.isRunning(otherInstanceName)).isTrue
+    }
+
+    @Test
+    fun `M isRunning returns false W continuous profiling result received`(
+        @IntForgery(min = 1000, max = 60_000) fakeDurationMs: Int
+    ) {
+        // Given
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.CONTINUOUS,
+            emptyMap(),
+            fakeDurationMs
+        )
+        verify(mockService).requestProfiling(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            callbackCaptor.capture()
+        )
+        val successResult = mock<ProfilingResult> {
+            on { errorCode } doReturn ProfilingResult.ERROR_NONE
+            on { resultFilePath } doReturn fakePath
+        }
+
+        // When
+        callbackCaptor.firstValue.accept(successResult)
+
+        // Then
+        assertThat(testedProfiler.isRunning(fakeInstanceName)).isFalse
+        assertThat(testedProfiler.isRunning(otherInstanceName)).isFalse
+    }
+
+    @Test
+    fun `M notify all registered callbacks W continuous profiling result received`(
+        @IntForgery(min = 1000, max = 60_000) fakeDurationMs: Int
+    ) {
+        // Given
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.CONTINUOUS,
+            emptyMap(),
+            fakeDurationMs
+        )
+        verify(mockService).requestProfiling(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            callbackCaptor.capture()
+        )
+        val successResult = mock<ProfilingResult> {
+            on { errorCode } doReturn ProfilingResult.ERROR_NONE
+            on { resultFilePath } doReturn fakePath
+        }
+
+        // When
+        callbackCaptor.firstValue.accept(successResult)
+
+        // Then
+        verify(mockProfilerCallback).onSuccess(any())
+        verify(mockOtherProfilerCallback).onSuccess(any())
+    }
+
+    @Test
+    fun `M not notify unregistered callback W continuous profiling result received`(
+        @IntForgery(min = 1000, max = 60_000) fakeDurationMs: Int
+    ) {
+        // Given
+        testedProfiler.unregisterProfilingCallback(otherInstanceName)
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.CONTINUOUS,
+            emptyMap(),
+            fakeDurationMs
+        )
+        verify(mockService).requestProfiling(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            callbackCaptor.capture()
+        )
+        val successResult = mock<ProfilingResult> {
+            on { errorCode } doReturn ProfilingResult.ERROR_NONE
+            on { resultFilePath } doReturn fakePath
+        }
+
+        // When
+        callbackCaptor.firstValue.accept(successResult)
+
+        // Then
+        verify(mockProfilerCallback).onSuccess(any())
+        verifyNoInteractions(mockOtherProfilerCallback)
+    }
+
+    @Test
+    fun `M allow start(durationMs) from within onSuccess callback W app launch result received`(
+        @IntForgery(min = 1000, max = 60_000) fakeDurationMs: Int
+    ) {
+        // Given
+        // ProfilingFeature path where onAppLaunchProfilingComplete() → profiler.start(durationMs).
+        whenever(mockProfilerCallback.onSuccess(any())).thenAnswer {
+            testedProfiler.start(
+                mockContext,
+                ProfilingStartReason.CONTINUOUS,
+                emptyMap(),
+                fakeDurationMs
+            )
+        }
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.APPLICATION_LAUNCH,
+            emptyMap(),
+            setOf(fakeInstanceName)
+        )
+        verify(mockService).requestProfiling(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            callbackCaptor.capture()
+        )
+        val successResult = mock<ProfilingResult> {
+            on { errorCode } doReturn ProfilingResult.ERROR_NONE
+            on { resultFilePath } doReturn fakePath
+        }
+
+        // When
+        callbackCaptor.firstValue.accept(successResult)
+
+        // Then
+        verify(mockService, times(2)).requestProfiling(any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `M cancel stop signal W stop() called {during continuous profiling}`(
+        @IntForgery(min = 1000, max = 60_000) fakeDurationMs: Int
+    ) {
+        // Given
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.CONTINUOUS,
+            emptyMap(),
+            fakeDurationMs
+        )
+        testedProfiler.stopSignal = mockStopSignal
+
+        // When
+        testedProfiler.stop(fakeInstanceName)
+
+        // Then
+        verify(mockStopSignal).cancel()
+    }
+
+    @Test
+    fun `M call onFailure for all callbacks W continuous profiling ends {with error}`(
+        @IntForgery(min = 1000, max = 60_000) fakeDurationMs: Int
+    ) {
+        // Given
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.CONTINUOUS,
+            emptyMap(),
+            fakeDurationMs
+        )
+        verify(mockService).requestProfiling(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            callbackCaptor.capture()
+        )
+        val errorResult = mock<ProfilingResult> {
+            on { errorCode } doReturn ProfilingResult.ERROR_FAILED_PROFILING_IN_PROGRESS
+            on { tag } doReturn ProfilingStartReason.CONTINUOUS.value
+        }
+
+        // When
+        callbackCaptor.firstValue.accept(errorResult)
+
+        // Then
+        verify(mockProfilerCallback).onFailure(ProfilingStartReason.CONTINUOUS.value)
+        verify(mockOtherProfilerCallback).onFailure(ProfilingStartReason.CONTINUOUS.value)
+    }
+
+    @Test
+    fun `M allow start(durationMs) from within onFailure callback W continuous result received {with error}`(
+        @IntForgery(min = 1000, max = 60_000) fakeDurationMs: Int,
+        @IntForgery(min = 1000, max = 60_000) fakeDurationMs2: Int
+    ) {
+        // Given
+        whenever(mockProfilerCallback.onFailure(any())).thenAnswer {
+            testedProfiler.start(
+                mockContext,
+                ProfilingStartReason.CONTINUOUS,
+                emptyMap(),
+                fakeDurationMs2
+            )
+        }
+        testedProfiler.start(
+            mockContext,
+            ProfilingStartReason.CONTINUOUS,
+            emptyMap(),
+            fakeDurationMs
+        )
+        verify(mockService).requestProfiling(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            callbackCaptor.capture()
+        )
+        val errorResult = mock<ProfilingResult> {
+            on { errorCode } doReturn ProfilingResult.ERROR_FAILED_PROFILING_IN_PROGRESS
+            on { tag } doReturn ProfilingStartReason.CONTINUOUS.value
+        }
+
+        // When
+        callbackCaptor.firstValue.accept(errorResult)
+
+        // Then
+        verify(mockService, times(2)).requestProfiling(any(), any(), any(), any(), any(), any())
+    }
+
+    // endregion
 
     private class StubTimeProvider : TimeProvider {
         var startTime: Long = 0L


### PR DESCRIPTION
### What does this PR do?

This PR decouples continuous profiling from app-launch profiling by adding a new start(durationMs) overload to the Profiler interface that does not require an SDK instance name. Continuous profiling is global — it runs once across all SDK instances rather than being tied to whichever instance triggered it. If ContinuousProfilingScheduler tries to start a session while PerfettoProfiler is already running (either from another SDK  instance's continuous cycle or from an app-launch session), it will skip the request.

This changes the callback notification behaviour:
* Before: the profiling result for each active window was broadcast only to the SDK instance that started it.
* After: the result is broadcast to all registered SDK instances.


### Motivation

RUM-15324


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

