### PR TITLE
Fix continuous profiling back-to-back with app launch by inserting a cooldown window

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
@@ -59,6 +59,7 @@ internal class ContinuousProfilingScheduler(
     }
 
     fun stop() {
+        isScheduling = false
         logToUser { LOG_STOPPED }
         pendingFuture?.cancel(false)
     }
@@ -66,7 +67,7 @@ internal class ContinuousProfilingScheduler(
     fun onAppLaunchProfilingComplete() {
         if (!isScheduling) return
         logToUser { LOG_LAUNCH_COMPLETE }
-        scheduleNextCycle()
+        scheduleCooldown(jitter(CONTINUOUS_COOLDOWN_DURATION_MS))
     }
 
     fun onRumSessionRenewed(sessionSampled: Boolean) {

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -266,6 +266,8 @@ class ProfilingFeatureTest {
 
         testedFeature.onReceive(ProfilerEvent.TTIDNotTracked)
 
+        val runnableCaptor = argumentCaptor<Runnable>()
+
         // When
         callbackCaptor.firstValue.onSuccess(
             PerfettoResult(
@@ -275,6 +277,9 @@ class ProfilingFeatureTest {
                 resultFilePath = "/fake/path"
             )
         )
+
+        verify(mockSchedulerExecutor).schedule(runnableCaptor.capture(), any(), any())
+        runnableCaptor.firstValue.run()
 
         // Then
         verify(mockProfiler).start(
@@ -310,8 +315,13 @@ class ProfilingFeatureTest {
         )
         testedFeature.onReceive(ProfilerEvent.TTIDNotTracked)
 
+        val runnableCaptor = argumentCaptor<Runnable>()
+
         // When
         callbackCaptor.firstValue.onFailure(ProfilingStartReason.APPLICATION_LAUNCH.value)
+
+        verify(mockSchedulerExecutor).schedule(runnableCaptor.capture(), any(), any())
+        runnableCaptor.firstValue.run()
 
         // Then
         verify(mockProfiler).start(

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ContinuousProfilingSchedulerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ContinuousProfilingSchedulerTest.kt
@@ -205,13 +205,29 @@ internal class ContinuousProfilingSchedulerTest {
     }
 
     @Test
-    fun `M start profiling cycle immediately W onAppLaunchProfilingComplete()`() {
+    fun `M NOT start profiling immediately W onAppLaunchProfilingComplete()`() {
         // Given
         testedScheduler.onRumSessionRenewed(sessionSampled = true)
         testedScheduler.start(launchProfilingActive = true)
 
         // When
         testedScheduler.onAppLaunchProfilingComplete()
+
+        // Then — profiling must not start until the cooldown fires
+        verify(mockProfiler, never()).start(any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun `M start profiling cycle after cooldown fires W onAppLaunchProfilingComplete()`() {
+        // Given
+        testedScheduler.onRumSessionRenewed(sessionSampled = true)
+        testedScheduler.start(launchProfilingActive = true)
+        val runnableCaptor = argumentCaptor<Runnable>()
+        testedScheduler.onAppLaunchProfilingComplete()
+        verify(mockSchedulerExecutor).schedule(runnableCaptor.capture(), any(), any())
+
+        // When — fire the cooldown runnable
+        runnableCaptor.firstValue.run()
 
         // Then
         verify(mockProfiler).start(
@@ -224,7 +240,7 @@ internal class ContinuousProfilingSchedulerTest {
     }
 
     @Test
-    fun `M schedule jittered active window end timer W onAppLaunchProfilingComplete()`() {
+    fun `M schedule jittered cooldown timer W onAppLaunchProfilingComplete()`() {
         // Given
         testedScheduler.start(launchProfilingActive = true)
         val delayCaptor = argumentCaptor<Long>()
@@ -236,9 +252,9 @@ internal class ContinuousProfilingSchedulerTest {
         testedScheduler.onAppLaunchProfilingComplete()
 
         // Then
-        val windowBase = ContinuousProfilingScheduler.CONTINUOUS_WINDOW_DURATION_MS
+        val cooldownBase = ContinuousProfilingScheduler.CONTINUOUS_COOLDOWN_DURATION_MS
         assertThat(delayCaptor.firstValue)
-            .isBetween((windowBase * 0.8).toLong(), (windowBase * 1.2).toLong())
+            .isBetween((cooldownBase * 0.8).toLong(), (cooldownBase * 1.2).toLong())
     }
 
     // endregion
@@ -259,13 +275,15 @@ internal class ContinuousProfilingSchedulerTest {
             )
         ) doReturn mockFuture
         testedScheduler.onAppLaunchProfilingComplete()
-
-        // When
+        // Fire the post-launch cooldown runnable to reach scheduleNextCycle
         runnableCaptor.firstValue.run()
+
+        // When — fire the active window end runnable
+        runnableCaptor.secondValue.run()
 
         // Then
         val cooldownBase = ContinuousProfilingScheduler.CONTINUOUS_COOLDOWN_DURATION_MS
-        assertThat(delayCaptor.secondValue)
+        assertThat(delayCaptor.thirdValue)
             .isBetween((cooldownBase * 0.8).toLong(), (cooldownBase * 1.2).toLong())
     }
 


### PR DESCRIPTION
### What does this PR do?

Before this PR the second active window of continuous profiling is launched immediately after app-launch profiling, which causes some back-to-back issue.

This PR fixes it by inserting a cooldown window after app launch profiling has completed as RFC described.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

