### PR TITLE
RUM-15454: Add Profiler status in RUM debug widget

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
@@ -10,10 +10,12 @@ import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.internal.utils.scheduleSafe
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.internal.profiling.ProfilerEvent
+import com.datadog.android.profiling.internal.ProfilingFeature.Companion.PROFILER_IS_RUNNING
 import java.util.Locale
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ScheduledExecutorService
@@ -124,6 +126,9 @@ internal class ContinuousProfilingScheduler(
                 sdkInstanceNames = setOf(sdkCore.name),
                 durationMs = activeMs.toInt()
             )
+            sdkCore.updateFeatureContext(Feature.PROFILING_FEATURE_NAME) { context ->
+                context[PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
+            }
         } else {
             logToUser { LOG_ACTIVE_WINDOW_SKIPPED }
         }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -67,7 +67,6 @@ internal class ProfilingFeature(
         // Set the profiling flag in SharedPreferences to profile for the next app launch
         ProfilingStorage.addProfilingFlag(appContext, sdkCore.name)
         sdkCore.setEventReceiver(name, this)
-        // TODO RUM-13678: we need to update context from the actual profiler start call, not from here
         sdkCore.updateFeatureContext(Feature.PROFILING_FEATURE_NAME) { context ->
             context[PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
         }
@@ -211,6 +210,6 @@ internal class ProfilingFeature(
     companion object {
         private const val UNSUPPORTED_EVENT_TYPE =
             "Profiling feature received an event of unsupported type=%s."
-        private const val PROFILER_IS_RUNNING = "profiler_is_running"
+        internal const val PROFILER_IS_RUNNING = "profiler_is_running"
     }
 }

--- a/features/dd-sdk-android-rum-debug-widget/src/main/kotlin/com/datadog/android/insights/internal/DefaultInsightsCollector.kt
+++ b/features/dd-sdk-android-rum-debug-widget/src/main/kotlin/com/datadog/android/insights/internal/DefaultInsightsCollector.kt
@@ -8,6 +8,9 @@ package com.datadog.android.insights.internal
 
 import android.os.Handler
 import android.os.Looper
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureContextUpdateReceiver
+import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.insights.internal.domain.TimelineEvent
 import com.datadog.android.insights.internal.extensions.Mb
 import com.datadog.android.insights.internal.extensions.round
@@ -31,7 +34,7 @@ internal class DefaultInsightsCollector internal constructor(
     updateIntervalMs: Long,
     private val handler: Handler,
     private val platform: Platform
-) : InsightsCollector {
+) : InsightsCollector, FeatureContextUpdateReceiver {
 
     constructor(
         maxSize: Int = 50,
@@ -66,6 +69,8 @@ internal class DefaultInsightsCollector internal constructor(
     internal var slowFramesRate: Double = Double.NaN
         private set
     internal var cpuTicksPerSecond: Double = Double.NaN
+        private set
+    internal var isProfilingRunning: Boolean = false
         private set
 
     override var maxSize: Int = maxSize
@@ -128,6 +133,24 @@ internal class DefaultInsightsCollector internal constructor(
         slowFramesRate = rate.round(PRECISION)
     }
 
+    override fun bindSdkCore(sdkCore: FeatureSdkCore) {
+        sdkCore.setContextUpdateReceiver(this)
+    }
+
+    override fun unbindSdkCore(sdkCore: FeatureSdkCore) {
+        sdkCore.removeContextUpdateReceiver(this)
+    }
+
+    override fun onContextUpdate(featureName: String, context: Map<String, Any?>) {
+        if (featureName == Feature.PROFILING_FEATURE_NAME) {
+            val running = context[PROFILER_IS_RUNNING] as? Boolean ?: false
+            handler.post {
+                isProfilingRunning = running
+                updatesListeners.forEach(InsightsUpdatesListener::onDataUpdated)
+            }
+        }
+    }
+
     private fun clear() = withListenersUpdate {
         events.clear()
     }
@@ -173,5 +196,8 @@ internal class DefaultInsightsCollector internal constructor(
         internal const val PRECISION = 2
         internal const val GC_COUNT = "art.gc.gc-count"
         internal const val ONE_SECOND_NS = 1_000_000_000L
+
+        // Contract key; must match ProfilingFeature.PROFILER_IS_RUNNING in dd-sdk-android-profiling.
+        private const val PROFILER_IS_RUNNING = "profiler_is_running"
     }
 }

--- a/features/dd-sdk-android-rum-debug-widget/src/main/kotlin/com/datadog/android/insights/internal/overlay/DefaultInsightsOverlay.kt
+++ b/features/dd-sdk-android-rum-debug-widget/src/main/kotlin/com/datadog/android/insights/internal/overlay/DefaultInsightsOverlay.kt
@@ -46,6 +46,7 @@ internal class DefaultInsightsOverlay(
     private var gcValue: ChartView? = null
     private var slowFrameRate: ChartView? = null
     private var timelineLegend: TextView? = null
+    private var profilerIndicator: TextView? = null
 
     private var isPaused: Boolean = false
     private var isTransitioning: Boolean = false
@@ -99,6 +100,8 @@ internal class DefaultInsightsOverlay(
                 labelText = "SFR (ms/s)",
                 enableChart = false
             )
+
+            profilerIndicator = overlayView.findViewById(R.id.profiler_indicator)
 
             insightsCollector.addUpdateListener(this)
         }
@@ -195,6 +198,7 @@ internal class DefaultInsightsOverlay(
         gcValue = null
         slowFrameRate = null
         timelineLegend = null
+        profilerIndicator = null
     }
 
     private fun View.restoreVisibility(shouldBeVisible: Boolean) {
@@ -216,6 +220,16 @@ internal class DefaultInsightsOverlay(
             nativeMemoryValue?.update(insightsCollector.nativeHeapMb)
             threadsValue?.update(insightsCollector.threadsCount.toDouble())
             slowFrameRate?.update(insightsCollector.slowFramesRate)
+            updateProfilerIndicator(insightsCollector.isProfilingRunning)
+        }
+    }
+
+    private fun updateProfilerIndicator(isRunning: Boolean) {
+        profilerIndicator?.let { view ->
+            val statusColor = view.color(if (isRunning) R.color.profiler_on else R.color.profiler_off)
+            val label = if (isRunning) PROFILER_ON else PROFILER_OFF
+            view.text = SpannableStringBuilder()
+                .appendColored(PROFILER_DOT + label, statusColor)
         }
     }
 
@@ -225,5 +239,8 @@ internal class DefaultInsightsOverlay(
         private const val RESOURCE = "Resource"
         private const val SLOW_FRAME = "Slow"
         private const val FROZEN_FRAME = "Frozen"
+        private const val PROFILER_DOT = "● "
+        private const val PROFILER_ON = "Profiler: ON"
+        private const val PROFILER_OFF = "Profiler: OFF"
     }
 }

--- a/features/dd-sdk-android-rum-debug-widget/src/main/res/layout/layout_dd_insights_widget.xml
+++ b/features/dd-sdk-android-rum-debug-widget/src/main/res/layout/layout_dd_insights_widget.xml
@@ -36,14 +36,36 @@
         android:textSize="14sp" />
 
     <!--
-        layout_marginTop = (40 + 8) = 48:
-         icon
-         offset
+        layout_marginTop = (40 + 8) = 48: icon + offset
+        Profiler running indicator, placed just below the title row.
+    -->
+    <TextView
+        android:id="@+id/profiler_indicator"
+        android:layout_width="match_parent"
+        android:layout_height="24dp"
+        android:layout_marginTop="48dp"
+        android:gravity="start|center_vertical"
+        android:textSize="12sp"
+        android:textStyle="bold" />
+
+    <!--
+        layout_marginTop = (40 + 8 + 24 + 4) = 76: icon + offset + indicator + gap
+        Divider separating the profiler indicator from the vitals section.
+    -->
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="76dp"
+        android:background="@color/vital_bg" />
+
+    <!--
+        layout_marginTop = (40 + 8 + 24 + 4 + 1 + 3) = 80:
+         icon + offset + indicator + gap + divider + gap
     -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="44dp"
-        android:layout_marginTop="48dp"
+        android:layout_marginTop="80dp"
         android:baselineAligned="false"
         android:orientation="horizontal">
 
@@ -76,16 +98,13 @@
     </LinearLayout>
 
     <!--
-    layout_marginTop = (40 + 8 + 44 + 8) = 100:
-     icon
-     offset
-     row
-     offset
--->
+        layout_marginTop = (80 + 44 + 8) = 132:
+         row + offset
+    -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="44dp"
-        android:layout_marginTop="100dp"
+        android:layout_marginTop="132dp"
         android:baselineAligned="false"
         android:orientation="horizontal">
 
@@ -118,42 +137,26 @@
     </LinearLayout>
 
     <!--
-        layout_marginTop = (40 + 8 + 44 + 8 + 44 + 8) = 152
-        icon
-        offset
-        row
-        offset
-        row
-        offset
+        layout_marginTop = (132 + 44 + 8) = 184
     -->
     <com.datadog.android.insights.internal.widgets.TimelineView
         android:id="@+id/timeline"
         android:layout_width="match_parent"
         android:layout_height="40dp"
         android:background="@color/vital_bg"
-        android:layout_marginTop="152dp" />
+        android:layout_marginTop="184dp" />
 
     <!--
-    layout_marginTop = (40 + 8 + 44 + 8 + 44 + 8 + 40 + 8) = 200
-    icon
-    offset
-    row
-    offset
-    row
-    offset
-    timeline
-    offset
-    legend
--->
+        layout_marginTop = (184 + 40 + 8) = 232
+    -->
     <TextView
         android:id="@+id/timeline_legend"
-        android:layout_marginTop="200dp"
+        android:layout_marginTop="232dp"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="4dp"
         android:textColor="@color/widget_text"
         android:gravity="center_horizontal"
-        android:textSize="11sp"
-
-        />
+        android:textSize="11sp" />
 
 </FrameLayout>

--- a/features/dd-sdk-android-rum-debug-widget/src/main/res/values/colors.xml
+++ b/features/dd-sdk-android-rum-debug-widget/src/main/res/values/colors.xml
@@ -14,4 +14,6 @@
     <color name="timeline_slow_frame">#B8860B</color>
     <color name="timeline_freeze_frame">#CC0000</color>
     <color name="timeline_resource">#228B22</color>
+    <color name="profiler_on">#228B22</color>
+    <color name="profiler_off">#9E9E9E</color>
 </resources>

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -220,6 +220,8 @@ interface com.datadog.android.rum.internal.instrumentation.insights.InsightsColl
   fun onCpuVital(Double?)
   fun onMemoryVital(Double?)
   fun onSlowFrameRate(Double?)
+  fun bindSdkCore(com.datadog.android.api.feature.FeatureSdkCore)
+  fun unbindSdkCore(com.datadog.android.api.feature.FeatureSdkCore)
 interface com.datadog.android.rum.internal.instrumentation.insights.InsightsUpdatesListener
   fun onDataUpdated()
 interface com.datadog.android.rum.internal.monitor.AdvancedNetworkRumMonitor : com.datadog.android.rum.RumMonitor

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -369,6 +369,7 @@ public abstract class com/datadog/android/rum/internal/instrumentation/gestures/
 
 public abstract interface class com/datadog/android/rum/internal/instrumentation/insights/InsightsCollector {
 	public abstract fun addUpdateListener (Lcom/datadog/android/rum/internal/instrumentation/insights/InsightsUpdatesListener;)V
+	public abstract fun bindSdkCore (Lcom/datadog/android/api/feature/FeatureSdkCore;)V
 	public abstract fun getMaxSize ()I
 	public abstract fun getUpdateIntervalMs ()J
 	public abstract fun onAction ()V
@@ -382,6 +383,7 @@ public abstract interface class com/datadog/android/rum/internal/instrumentation
 	public abstract fun removeUpdateListener (Lcom/datadog/android/rum/internal/instrumentation/insights/InsightsUpdatesListener;)V
 	public abstract fun setMaxSize (I)V
 	public abstract fun setUpdateIntervalMs (J)V
+	public abstract fun unbindSdkCore (Lcom/datadog/android/api/feature/FeatureSdkCore;)V
 }
 
 public abstract interface class com/datadog/android/rum/internal/instrumentation/insights/InsightsUpdatesListener {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -201,6 +201,7 @@ internal class RumFeature(
         initialResourceIdentifier = configuration.initialResourceIdentifier
         lastInteractionIdentifier = configuration.lastInteractionIdentifier
         insightsCollector = configuration.insightsCollector
+        insightsCollector.bindSdkCore(sdkCore)
 
         dataWriter = createDataWriter(
             configuration,
@@ -335,6 +336,7 @@ internal class RumFeature(
             sdkCore.removeContextUpdateReceiver(it)
         }
         rumContextUpdateReceivers.clear()
+        insightsCollector.unbindSdkCore(sdkCore)
 
         unregisterTrackingStrategies(appContext)
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/insights/InsightsCollector.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/insights/InsightsCollector.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.instrumentation.insights
 
+import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.lint.InternalApi
 import com.datadog.tools.annotation.NoOpImplementation
 
@@ -14,6 +15,7 @@ import com.datadog.tools.annotation.NoOpImplementation
  */
 @InternalApi
 @NoOpImplementation
+@Suppress("TooManyFunctions")
 interface InsightsCollector {
 
     /**
@@ -94,6 +96,22 @@ interface InsightsCollector {
      * @param rate the slow frame rate value.
      */
     fun onSlowFrameRate(rate: Double?)
+
+    /**
+     * Binds this collector to the given [sdkCore] so it can subscribe to feature context updates.
+     * Called once by the RUM feature during initialization.
+     *
+     * @param sdkCore the specific SDK core instance this widget is bound to.
+     */
+    fun bindSdkCore(sdkCore: FeatureSdkCore)
+
+    /**
+     * Unbinds this collector from the given [sdkCore], unsubscribing from feature context updates.
+     * Called by the RUM feature when it stops.
+     *
+     * @param sdkCore the specific SDK core instance this widget is bound to.
+     */
+    fun unbindSdkCore(sdkCore: FeatureSdkCore)
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?

* Add profiler status indicator into RUM debug widget by reading Profiling context
* Fix a minor bug that when continuous profiling active window starts, the feature context is not updated.

### Motivation

It's convenient for debugging continuous profiling

### Demo

<img width="209" height="430" alt="Screenshot 2026-04-03 at 14 52 23" src="https://github.com/user-attachments/assets/cf731a93-64ea-426c-b144-c1052c32801d" />

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

