### PR TITLE
RUM-14784: Network headers common instrumentation

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -187,11 +187,11 @@ class com.datadog.android.rum._RumInternalProxy
     fun setDisableJankStats(com.datadog.android.rum.RumConfiguration.Builder, Boolean): com.datadog.android.rum.RumConfiguration.Builder
     fun setInsightsCollector(com.datadog.android.rum.RumConfiguration.Builder, com.datadog.android.rum.internal.instrumentation.insights.InsightsCollector): com.datadog.android.rum.RumConfiguration.Builder
     fun createRumNetworkInstrumentation(String, com.datadog.android.internal.telemetry.InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType, com.datadog.android.rum.configuration.RumNetworkInstrumentationConfiguration)
-    fun extractRequestHeaders(com.datadog.android.rum.resource.ResourceHeadersExtractor, Map<String, List<String>>, com.datadog.android.api.InternalLogger)
-    fun extractResponseHeaders(com.datadog.android.rum.resource.ResourceHeadersExtractor, Map<String, List<String>>, com.datadog.android.api.InternalLogger)
+    fun toResourceAttributes(com.datadog.android.rum.resource.ResourceHeadersExtractor, Map<String, List<String>>, Map<String, List<String>>, com.datadog.android.api.InternalLogger)
 class com.datadog.android.rum.configuration.RumNetworkInstrumentationConfiguration
   fun setSdkInstanceName(String)
   fun setRumResourceAttributesProvider(com.datadog.android.rum.RumResourceAttributesProvider)
+  fun trackResourceHeaders(com.datadog.android.rum.resource.ResourceHeadersExtractor = ResourceHeadersExtractor.Builder().build())
 data class com.datadog.android.rum.configuration.SlowFramesConfiguration
   constructor(Int = DEFAULT_SLOW_FRAME_RECORDS_MAX_AMOUNT, Long = DEFAULT_FROZEN_FRAME_THRESHOLD_NS, Long = DEFAULT_CONTINUOUS_SLOW_FRAME_THRESHOLD_NS, Long = DEFAULT_FREEZE_DURATION_NS, Long = DEFAULT_VIEW_LIFETIME_THRESHOLD_NS)
   companion object 

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -283,20 +283,21 @@ public final class com/datadog/android/rum/_RumInternalProxy {
 
 public final class com/datadog/android/rum/_RumInternalProxy$Companion {
 	public final fun createRumNetworkInstrumentation (Ljava/lang/String;Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$NetworkInstrumentation$LibraryType;Lcom/datadog/android/rum/configuration/RumNetworkInstrumentationConfiguration;)Lcom/datadog/android/rum/internal/net/RumNetworkInstrumentation;
-	public final fun extractRequestHeaders (Lcom/datadog/android/rum/resource/ResourceHeadersExtractor;Ljava/util/Map;Lcom/datadog/android/api/InternalLogger;)Ljava/util/Map;
-	public final fun extractResponseHeaders (Lcom/datadog/android/rum/resource/ResourceHeadersExtractor;Ljava/util/Map;Lcom/datadog/android/api/InternalLogger;)Ljava/util/Map;
 	public final fun setAdditionalConfiguration (Lcom/datadog/android/rum/RumConfiguration$Builder;Ljava/util/Map;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setComposeActionTrackingStrategy (Lcom/datadog/android/rum/RumConfiguration$Builder;Lcom/datadog/android/rum/tracking/ActionTrackingStrategy;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setDisableJankStats (Lcom/datadog/android/rum/RumConfiguration$Builder;Z)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setInsightsCollector (Lcom/datadog/android/rum/RumConfiguration$Builder;Lcom/datadog/android/rum/internal/instrumentation/insights/InsightsCollector;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setRumSessionTypeOverride (Lcom/datadog/android/rum/RumConfiguration$Builder;Lcom/datadog/android/rum/RumSessionType;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setTelemetryConfigurationEventMapper (Lcom/datadog/android/rum/RumConfiguration$Builder;Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
+	public final fun toResourceAttributes (Lcom/datadog/android/rum/resource/ResourceHeadersExtractor;Ljava/util/Map;Ljava/util/Map;Lcom/datadog/android/api/InternalLogger;)Ljava/util/Map;
 }
 
 public final class com/datadog/android/rum/configuration/RumNetworkInstrumentationConfiguration {
 	public fun <init> ()V
 	public final fun setRumResourceAttributesProvider (Lcom/datadog/android/rum/RumResourceAttributesProvider;)Lcom/datadog/android/rum/configuration/RumNetworkInstrumentationConfiguration;
 	public final fun setSdkInstanceName (Ljava/lang/String;)Lcom/datadog/android/rum/configuration/RumNetworkInstrumentationConfiguration;
+	public final fun trackResourceHeaders (Lcom/datadog/android/rum/resource/ResourceHeadersExtractor;)Lcom/datadog/android/rum/configuration/RumNetworkInstrumentationConfiguration;
+	public static synthetic fun trackResourceHeaders$default (Lcom/datadog/android/rum/configuration/RumNetworkInstrumentationConfiguration;Lcom/datadog/android/rum/resource/ResourceHeadersExtractor;ILjava/lang/Object;)Lcom/datadog/android/rum/configuration/RumNetworkInstrumentationConfiguration;
 }
 
 public final class com/datadog/android/rum/configuration/SlowFramesConfiguration {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
@@ -143,9 +143,9 @@ class _RumInternalProxy internal constructor(private val rumMonitor: AdvancedRum
 
         fun toResourceAttributes(
             extractor: ResourceHeadersExtractor,
-            requestHeaders: Map<String, List<String>>,
-            responseHeaders: Map<String, List<String>>,
+            rawRequestHeaders: Map<String, List<String>>,
+            rawResponseHeaders: Map<String, List<String>>,
             internalLogger: InternalLogger
-        ) = extractor.toResourceAttributes(requestHeaders, responseHeaders, internalLogger)
+        ) = extractor.toResourceAttributes(rawRequestHeaders, rawResponseHeaders, internalLogger)
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
@@ -141,16 +141,11 @@ class _RumInternalProxy internal constructor(private val rumMonitor: AdvancedRum
             configuration: RumNetworkInstrumentationConfiguration
         ) = configuration.createInstrumentation(name, libraryType)
 
-        fun extractRequestHeaders(
+        fun toResourceAttributes(
             extractor: ResourceHeadersExtractor,
-            headers: Map<String, List<String>>,
+            requestHeaders: Map<String, List<String>>,
+            responseHeaders: Map<String, List<String>>,
             internalLogger: InternalLogger
-        ) = extractor.extractRequestHeaders(headers, internalLogger)
-
-        fun extractResponseHeaders(
-            extractor: ResourceHeadersExtractor,
-            headers: Map<String, List<String>>,
-            internalLogger: InternalLogger
-        ) = extractor.extractResponseHeaders(headers, internalLogger)
+        ) = extractor.toResourceAttributes(requestHeaders, responseHeaders, internalLogger)
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/configuration/RumNetworkInstrumentationConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/configuration/RumNetworkInstrumentationConfiguration.kt
@@ -10,6 +10,7 @@ import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.rum.NoOpRumResourceAttributesProvider
 import com.datadog.android.rum.RumResourceAttributesProvider
 import com.datadog.android.rum.internal.net.RumNetworkInstrumentation
+import com.datadog.android.rum.resource.ResourceHeadersExtractor
 
 /**
  * Configuration that allows to configure RUM resource tracking for network requests.
@@ -17,6 +18,7 @@ import com.datadog.android.rum.internal.net.RumNetworkInstrumentation
 class RumNetworkInstrumentationConfiguration {
     private var sdkInstanceName: String? = null
     private var resourceAttributesProvider: RumResourceAttributesProvider = NoOpRumResourceAttributesProvider()
+    private var resourceHeadersExtractor: ResourceHeadersExtractor? = null
 
     /**
      * Set the SDK instance name to bind to, the default value is null.
@@ -29,7 +31,7 @@ class RumNetworkInstrumentationConfiguration {
 
     /**
      * Sets the [RumResourceAttributesProvider] to use to provide custom attributes to the RUM.
-     * By default it won't attach any custom attributes.
+     * By default, it won't attach any custom attributes.
      * @param rumResourceAttributesProvider the [RumResourceAttributesProvider] to use.
      */
     fun setRumResourceAttributesProvider(
@@ -38,6 +40,17 @@ class RumNetworkInstrumentationConfiguration {
         this.resourceAttributesProvider = rumResourceAttributesProvider
     }
 
+    /**
+     * Enables capturing HTTP request and response headers in RUM Resource events.
+     *
+     * @param extractor the [ResourceHeadersExtractor] specifying which headers to capture.
+     * Defaults to a configuration that captures common safe headers.
+     * @return this configuration for chaining.
+     */
+    fun trackResourceHeaders(
+        extractor: ResourceHeadersExtractor = ResourceHeadersExtractor.Builder().build()
+    ) = apply { resourceHeadersExtractor = extractor }
+
     internal fun createInstrumentation(
         instrumentationName: String,
         libraryType: InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType
@@ -45,6 +58,7 @@ class RumNetworkInstrumentationConfiguration {
         sdkInstanceName = sdkInstanceName,
         networkInstrumentationName = instrumentationName,
         rumResourceAttributesProvider = resourceAttributesProvider,
-        libraryType = libraryType
+        libraryType = libraryType,
+        resourceHeadersExtractor = resourceHeadersExtractor
     )
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/configuration/RumNetworkInstrumentationConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/configuration/RumNetworkInstrumentationConfiguration.kt
@@ -43,6 +43,8 @@ class RumNetworkInstrumentationConfiguration {
     /**
      * Enables capturing HTTP request and response headers in RUM Resource events.
      *
+     * Sensitive headers matching the [ResourceHeadersExtractor.SECURITY_PATTERN] are automatically filtered out, even if specified in the [extractor].
+     *
      * @param extractor the [ResourceHeadersExtractor] specifying which headers to capture.
      * Defaults to a configuration that captures common safe headers.
      * @return this configuration for chaining.

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/net/RumNetworkInstrumentation.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/net/RumNetworkInstrumentation.kt
@@ -24,6 +24,7 @@ import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.internal.monitor.AdvancedNetworkRumMonitor
+import com.datadog.android.rum.resource.ResourceHeadersExtractor
 import com.datadog.android.rum.resource.ResourceId
 import java.util.Locale
 import java.util.UUID
@@ -36,19 +37,21 @@ import java.util.UUID
  *
  * This class operates as a middle layer between any specific library instrumentation and SDK core
  * components, making it possible to share the same logic between different networking libraries
- * (OkHttp, Cronet, etc).
+ * (OkHttp, Cronet, etc.).
  *
  * @param sdkInstanceName the name of the SDK instance to use, or null for the default instance
  * @param networkInstrumentationName the name of the network layer being instrumented (e.g., "OkHttp", "Cronet")
  * @param rumResourceAttributesProvider provider for custom attributes to attach to RUM resources
  * @param libraryType the type of networking library being instrumented, used for telemetry reporting
+ * @param resourceHeadersExtractor optional extractor for capturing HTTP request/response headers in RUM Resource events
  */
 @InternalApi
 class RumNetworkInstrumentation internal constructor(
     internal val sdkInstanceName: String?,
     internal val networkInstrumentationName: String,
     internal val rumResourceAttributesProvider: RumResourceAttributesProvider,
-    internal val libraryType: InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType
+    internal val libraryType: InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType,
+    internal val resourceHeadersExtractor: ResourceHeadersExtractor? = null
 ) {
     private val sdkCoreReference = SdkReference(sdkInstanceName) {
         it.networkMonitor?.apply {
@@ -105,12 +108,19 @@ class RumNetworkInstrumentation internal constructor(
         responseInfo: HttpResponseInfo,
         attributes: Map<String, Any?> = emptyMap()
     ) = ifRumEnabled { sdkCore ->
+        val resourceHeaderAttributes = resourceHeadersExtractor?.toResourceAttributes(
+            requestHeaders = requestInfo.headers,
+            responseHeaders = responseInfo.headers,
+            internalLogger = sdkCore.internalLogger
+        ) ?: emptyMap()
         sdkCore.networkMonitor?.stopResource(
             buildResourceId(requestInfo, generateUuid = false),
             responseInfo.statusCode,
             responseInfo.getBodyLength(),
             responseInfo.getRumResourceKind(),
-            attributes + rumResourceAttributesProvider.onProvideAttributes(requestInfo, responseInfo, null)
+            attributes +
+                rumResourceAttributesProvider.onProvideAttributes(requestInfo, responseInfo, null) +
+                resourceHeaderAttributes
         )
     }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/net/RumNetworkInstrumentation.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/net/RumNetworkInstrumentation.kt
@@ -51,7 +51,7 @@ class RumNetworkInstrumentation internal constructor(
     internal val networkInstrumentationName: String,
     internal val rumResourceAttributesProvider: RumResourceAttributesProvider,
     internal val libraryType: InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType,
-    internal val resourceHeadersExtractor: ResourceHeadersExtractor? = null
+    internal val resourceHeadersExtractor: ResourceHeadersExtractor?
 ) {
     private val sdkCoreReference = SdkReference(sdkInstanceName) {
         it.networkMonitor?.apply {
@@ -109,8 +109,8 @@ class RumNetworkInstrumentation internal constructor(
         attributes: Map<String, Any?> = emptyMap()
     ) = ifRumEnabled { sdkCore ->
         val resourceHeaderAttributes = resourceHeadersExtractor?.toResourceAttributes(
-            requestHeaders = requestInfo.headers,
-            responseHeaders = responseInfo.headers,
+            rawRequestHeaders = responseInfo.request?.headers ?: requestInfo.headers,
+            rawResponseHeaders = responseInfo.headers,
             internalLogger = sdkCore.internalLogger
         ) ?: emptyMap()
         sdkCore.networkMonitor?.stopResource(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/resource/ResourceHeadersExtractor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/resource/ResourceHeadersExtractor.kt
@@ -21,8 +21,8 @@ import java.util.Locale
  *  @see Builder
  */
 class ResourceHeadersExtractor private constructor(
-    internal val requestHeaders: List<String>,
-    internal val responseHeaders: List<String>
+    internal val allowedRequestHeaders: List<String>,
+    internal val allowedResponseHeaders: List<String>
 ) {
 
     /**
@@ -54,7 +54,7 @@ class ResourceHeadersExtractor private constructor(
          * @return a new [ResourceHeadersExtractor] instance.
          */
         fun build(): ResourceHeadersExtractor {
-            val (sensitiveRequested, filteredCustom) = customHeaders.partition(SECURITY_PATTERN::containsMatchIn)
+            val (sensitiveRequested, safeCustomHeaders) = customHeaders.partition(SECURITY_PATTERN::containsMatchIn)
 
             if (sensitiveRequested.isNotEmpty()) {
                 logger.log(
@@ -66,19 +66,19 @@ class ResourceHeadersExtractor private constructor(
                 )
             }
 
-            val requestHeaders = if (includeDefaults) {
-                (DEFAULT_REQUEST_HEADERS + filteredCustom).distinct()
+            val allowedRequestHeaders = if (includeDefaults) {
+                (DEFAULT_REQUEST_HEADERS + safeCustomHeaders).distinct()
             } else {
-                filteredCustom.distinct()
+                safeCustomHeaders.distinct()
             }
 
-            val responseHeaders = if (includeDefaults) {
-                (DEFAULT_RESPONSE_HEADERS + filteredCustom).distinct()
+            val allowedResponseHeaders = if (includeDefaults) {
+                (DEFAULT_RESPONSE_HEADERS + safeCustomHeaders).distinct()
             } else {
-                filteredCustom.distinct()
+                safeCustomHeaders.distinct()
             }
 
-            if (requestHeaders.isEmpty() && responseHeaders.isEmpty()) {
+            if (allowedRequestHeaders.isEmpty() && allowedResponseHeaders.isEmpty()) {
                 logger.log(
                     level = InternalLogger.Level.WARN,
                     target = InternalLogger.Target.USER,
@@ -87,40 +87,40 @@ class ResourceHeadersExtractor private constructor(
             }
 
             return ResourceHeadersExtractor(
-                requestHeaders = requestHeaders,
-                responseHeaders = responseHeaders
+                allowedRequestHeaders = allowedRequestHeaders,
+                allowedResponseHeaders = allowedResponseHeaders
             )
         }
     }
 
     /**
      * Extracts allowed request and response headers and returns them as RUM resource attributes.
-     * @param requestHeaders the raw request headers (key to list of values).
-     * @param responseHeaders the raw response headers (key to list of values).
+     * @param rawRequestHeaders the raw request headers (key to list of values).
+     * @param rawResponseHeaders the raw response headers (key to list of values).
      * @param internalLogger logger for debug messages.
      * @return a map containing [RumAttributes.REQUEST_HEADERS] and [RumAttributes.RESPONSE_HEADERS]
      *   entries, or empty if no headers matched.
      */
     internal fun toResourceAttributes(
-        requestHeaders: Map<String, List<String>>,
-        responseHeaders: Map<String, List<String>>,
+        rawRequestHeaders: Map<String, List<String>>,
+        rawResponseHeaders: Map<String, List<String>>,
         internalLogger: InternalLogger
     ): Map<String, Any> {
-        val reqHeaders = extractHeaders(requestHeaders, this.requestHeaders, internalLogger)
-        val resHeaders = extractHeaders(responseHeaders, this.responseHeaders, internalLogger)
+        val extractedRequestHeaders = extractHeaders(rawRequestHeaders, allowedRequestHeaders, internalLogger)
+        val extractedResponseHeaders = extractHeaders(rawResponseHeaders, allowedResponseHeaders, internalLogger)
         return buildMap {
-            if (reqHeaders.isNotEmpty()) put(RumAttributes.REQUEST_HEADERS, reqHeaders)
-            if (resHeaders.isNotEmpty()) put(RumAttributes.RESPONSE_HEADERS, resHeaders)
+            if (extractedRequestHeaders.isNotEmpty()) put(RumAttributes.REQUEST_HEADERS, extractedRequestHeaders)
+            if (extractedResponseHeaders.isNotEmpty()) put(RumAttributes.RESPONSE_HEADERS, extractedResponseHeaders)
         }
     }
 
     private fun extractHeaders(
-        headers: Map<String, List<String>>,
+        rawHeaders: Map<String, List<String>>,
         allowedHeaders: List<String>,
         internalLogger: InternalLogger
     ): Map<String, String> {
-        if (headers.isEmpty()) return emptyMap()
-        val normalizedHeaders = headers.mapKeys { it.key.lowercase(Locale.US) }
+        if (rawHeaders.isEmpty() || allowedHeaders.isEmpty()) return emptyMap()
+        val normalizedHeaders = rawHeaders.mapKeys { it.key.lowercase(Locale.US) }
         val result = mutableMapOf<String, String>()
         var currentSize = 0
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/resource/ResourceHeadersExtractor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/resource/ResourceHeadersExtractor.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.rum.resource
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.internal.utils.truncateToUtf8ByteSize
 import com.datadog.android.rum.resource.ResourceHeadersExtractor.Companion.SECURITY_PATTERN
 import java.util.Locale
@@ -93,29 +94,24 @@ class ResourceHeadersExtractor private constructor(
     }
 
     /**
-     * Extracts the allowed request headers from the given [headers] map.
-     * @param headers the raw request headers (key to list of values).
+     * Extracts allowed request and response headers and returns them as RUM resource attributes.
+     * @param requestHeaders the raw request headers (key to list of values).
+     * @param responseHeaders the raw response headers (key to list of values).
      * @param internalLogger logger for debug messages.
-     * @return a map of allowed header names to their joined values.
+     * @return a map containing [RumAttributes.REQUEST_HEADERS] and [RumAttributes.RESPONSE_HEADERS]
+     *   entries, or empty if no headers matched.
      */
-    internal fun extractRequestHeaders(
-        headers: Map<String, List<String>>,
+    internal fun toResourceAttributes(
+        requestHeaders: Map<String, List<String>>,
+        responseHeaders: Map<String, List<String>>,
         internalLogger: InternalLogger
-    ): Map<String, String> {
-        return extractHeaders(headers, requestHeaders, internalLogger)
-    }
-
-    /**
-     * Extracts the allowed response headers from the given [headers] map.
-     * @param headers the raw response headers (key to list of values).
-     * @param internalLogger logger for debug messages.
-     * @return a map of allowed header names to their joined values.
-     */
-    internal fun extractResponseHeaders(
-        headers: Map<String, List<String>>,
-        internalLogger: InternalLogger
-    ): Map<String, String> {
-        return extractHeaders(headers, responseHeaders, internalLogger)
+    ): Map<String, Any> {
+        val reqHeaders = extractHeaders(requestHeaders, this.requestHeaders, internalLogger)
+        val resHeaders = extractHeaders(responseHeaders, this.responseHeaders, internalLogger)
+        return buildMap {
+            if (reqHeaders.isNotEmpty()) put(RumAttributes.REQUEST_HEADERS, reqHeaders)
+            if (resHeaders.isNotEmpty()) put(RumAttributes.RESPONSE_HEADERS, resHeaders)
+        }
     }
 
     private fun extractHeaders(
@@ -123,6 +119,7 @@ class ResourceHeadersExtractor private constructor(
         allowedHeaders: List<String>,
         internalLogger: InternalLogger
     ): Map<String, String> {
+        if (headers.isEmpty()) return emptyMap()
         val normalizedHeaders = headers.mapKeys { it.key.lowercase(Locale.US) }
         val result = mutableMapOf<String, String>()
         var currentSize = 0

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/configuration/RumNetworkInstrumentationConfigurationTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/configuration/RumNetworkInstrumentationConfigurationTest.kt
@@ -4,12 +4,12 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.rum.internal.net
+package com.datadog.android.rum.configuration
 
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType
 import com.datadog.android.rum.NoOpRumResourceAttributesProvider
 import com.datadog.android.rum.RumResourceAttributesProvider
-import com.datadog.android.rum.configuration.RumNetworkInstrumentationConfiguration
+import com.datadog.android.rum.resource.ResourceHeadersExtractor
 import com.datadog.android.rum.utils.forge.Configurator
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -31,7 +31,7 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal class RumInstrumentationConfigurationTest {
+internal class RumNetworkInstrumentationConfigurationTest {
 
     private lateinit var testedConfiguration: RumNetworkInstrumentationConfiguration
 
@@ -84,6 +84,40 @@ internal class RumInstrumentationConfigurationTest {
     }
 
     @Test
+    fun `M have null resourceHeadersExtractor by default W createInstrumentation()`() {
+        // When
+        val result = testedConfiguration.createInstrumentation(fakeInstrumentationName, fakeLibraryType)
+
+        // Then
+        assertThat(result.resourceHeadersExtractor).isNull()
+    }
+
+    @Test
+    fun `M set default extractor W trackResourceHeaders()`() {
+        // When
+        val result = testedConfiguration.trackResourceHeaders()
+            .createInstrumentation(fakeInstrumentationName, fakeLibraryType)
+
+        // Then
+        assertThat(result.resourceHeadersExtractor).isNotNull
+    }
+
+    @Test
+    fun `M set custom extractor W trackResourceHeaders(extractor)`() {
+        // Given
+        val customExtractor = ResourceHeadersExtractor.Builder(includeDefaults = false)
+            .captureHeaders("x-request-id")
+            .build()
+
+        // When
+        val result = testedConfiguration.trackResourceHeaders(customExtractor)
+            .createInstrumentation(fakeInstrumentationName, fakeLibraryType)
+
+        // Then
+        assertThat(result.resourceHeadersExtractor).isSameAs(customExtractor)
+    }
+
+    @Test
     fun `M return self W chaining builder methods()`(
         @StringForgery fakeSdkInstanceName: String
     ) {
@@ -91,6 +125,7 @@ internal class RumInstrumentationConfigurationTest {
         val result = testedConfiguration
             .setSdkInstanceName(fakeSdkInstanceName)
             .setRumResourceAttributesProvider(mockResourceAttributesProvider)
+            .trackResourceHeaders()
 
         // Then
         assertThat(result).isSameAs(testedConfiguration)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/net/RumNetworkInstrumentationTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/net/RumNetworkInstrumentationTest.kt
@@ -126,7 +126,8 @@ internal class RumNetworkInstrumentationTest {
             sdkInstanceName = null,
             networkInstrumentationName = fakeNetworkInstrumentationName,
             rumResourceAttributesProvider = mockRumResourceAttributesProvider,
-            libraryType = fakeLibraryType
+            libraryType = fakeLibraryType,
+            resourceHeadersExtractor = null
         )
     }
 
@@ -566,14 +567,75 @@ internal class RumNetworkInstrumentationTest {
                 capture()
             )
             @Suppress("UNCHECKED_CAST")
-            val reqHeaders = firstValue[RumAttributes.REQUEST_HEADERS] as? Map<String, String>
-            assertThat(reqHeaders).isNotNull
-            assertThat(reqHeaders).containsEntry(fakeHeaderName, fakeHeaderValue)
+            val extractedRequestHeaders = firstValue[RumAttributes.REQUEST_HEADERS] as? Map<String, String>
+            assertThat(extractedRequestHeaders).isNotNull
+            assertThat(extractedRequestHeaders).containsEntry(fakeHeaderName, fakeHeaderValue)
 
             @Suppress("UNCHECKED_CAST")
-            val resHeaders = firstValue[RumAttributes.RESPONSE_HEADERS] as? Map<String, String>
-            assertThat(resHeaders).isNotNull
-            assertThat(resHeaders).containsEntry(fakeResHeaderName, fakeResHeaderValue)
+            val extractedResponseHeaders = firstValue[RumAttributes.RESPONSE_HEADERS] as? Map<String, String>
+            assertThat(extractedResponseHeaders).isNotNull
+            assertThat(extractedResponseHeaders).containsEntry(fakeResHeaderName, fakeResHeaderValue)
+        }
+    }
+
+    @Test
+    fun `M prefer on-wire request headers W stopResource() { responseInfo has request }`(
+        @IntForgery(min = 200, max = 600) fakeStatusCode: Int,
+        @LongForgery(min = 0) fakeContentLength: Long,
+        forge: Forge
+    ) {
+        // Given
+        val fakeHeaderName = "x-request-id"
+        val fakeOriginalHeaderValue = forge.anAsciiString()
+        val fakeOnWireHeaderValue = forge.anAsciiString()
+
+        val extractor = ResourceHeadersExtractor.Builder(includeDefaults = false)
+            .captureHeaders(fakeHeaderName)
+            .build()
+
+        testedInstrumentation = RumNetworkInstrumentation(
+            sdkInstanceName = null,
+            networkInstrumentationName = fakeNetworkInstrumentationName,
+            rumResourceAttributesProvider = mockRumResourceAttributesProvider,
+            libraryType = fakeLibraryType,
+            resourceHeadersExtractor = extractor
+        )
+
+        fakeRequestInfo = fakeRequestInfo.copy(
+            headers = mapOf(fakeHeaderName to listOf(fakeOriginalHeaderValue))
+        )
+        val onWireRequestInfo = fakeRequestInfo.copy(
+            headers = mapOf(fakeHeaderName to listOf(fakeOnWireHeaderValue))
+        )
+        whenever(mockResponseInfo.request) doReturn onWireRequestInfo
+        whenever(mockResponseInfo.statusCode) doReturn fakeStatusCode
+        whenever(mockResponseInfo.contentLength) doReturn fakeContentLength
+        whenever(mockResponseInfo.contentType) doReturn null
+        whenever(mockResponseInfo.headers) doReturn emptyMap()
+        whenever(
+            mockRumResourceAttributesProvider.onProvideAttributes(
+                any<HttpRequestInfo>(),
+                anyOrNull<HttpResponseInfo>(),
+                anyOrNull()
+            )
+        ) doReturn emptyMap()
+
+        // When
+        testedInstrumentation.stopResource(fakeRequestInfo, mockResponseInfo)
+
+        // Then
+        argumentCaptor<Map<String, Any?>> {
+            verify(mockRumMonitor).stopResource(
+                any<ResourceId>(),
+                anyOrNull(),
+                anyOrNull(),
+                any<RumResourceKind>(),
+                capture()
+            )
+            @Suppress("UNCHECKED_CAST")
+            val extractedRequestHeaders = firstValue[RumAttributes.REQUEST_HEADERS] as? Map<String, String>
+            assertThat(extractedRequestHeaders).isNotNull
+            assertThat(extractedRequestHeaders).containsEntry(fakeHeaderName, fakeOnWireHeaderValue)
         }
     }
 
@@ -693,7 +755,8 @@ internal class RumNetworkInstrumentationTest {
             sdkInstanceName = null,
             networkInstrumentationName = fakeNetworkInstrumentationName,
             rumResourceAttributesProvider = mockRumResourceAttributesProvider,
-            libraryType = fakeLibraryType
+            libraryType = fakeLibraryType,
+            resourceHeadersExtractor = null
         )
 
         // When

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/net/RumNetworkInstrumentationTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/net/RumNetworkInstrumentationTest.kt
@@ -21,6 +21,7 @@ import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.internal.network.HttpSpec
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType
 import com.datadog.android.rum.GlobalRumMonitor
+import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.RumResourceAttributesProvider
@@ -28,6 +29,7 @@ import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.internal.monitor.AdvancedNetworkRumMonitor
+import com.datadog.android.rum.resource.ResourceHeadersExtractor
 import com.datadog.android.rum.resource.ResourceId
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
@@ -508,6 +510,106 @@ internal class RumNetworkInstrumentationTest {
             InternalLogger.Target.MAINTAINER,
             "Unable to instrument RUM resource: $fakeErrorMessage"
         )
+    }
+
+    @Test
+    fun `M include header attributes W stopResource() { trackResourceHeaders enabled }`(
+        @IntForgery(min = 200, max = 600) fakeStatusCode: Int,
+        @LongForgery(min = 0) fakeContentLength: Long,
+        forge: Forge
+    ) {
+        // Given
+        val fakeHeaderName = "x-request-id"
+        val fakeHeaderValue = forge.anAsciiString()
+        val fakeResHeaderName = "x-cache"
+        val fakeResHeaderValue = forge.anAsciiString()
+
+        val extractor = ResourceHeadersExtractor.Builder(includeDefaults = false)
+            .captureHeaders(fakeHeaderName, fakeResHeaderName)
+            .build()
+
+        testedInstrumentation = RumNetworkInstrumentation(
+            sdkInstanceName = null,
+            networkInstrumentationName = fakeNetworkInstrumentationName,
+            rumResourceAttributesProvider = mockRumResourceAttributesProvider,
+            libraryType = fakeLibraryType,
+            resourceHeadersExtractor = extractor
+        )
+
+        fakeRequestInfo = fakeRequestInfo.copy(
+            headers = mapOf(fakeHeaderName to listOf(fakeHeaderValue))
+        )
+        whenever(mockResponseInfo.statusCode) doReturn fakeStatusCode
+        whenever(mockResponseInfo.contentLength) doReturn fakeContentLength
+        whenever(mockResponseInfo.contentType) doReturn null
+        whenever(mockResponseInfo.headers) doReturn mapOf(
+            fakeResHeaderName to listOf(fakeResHeaderValue)
+        )
+        whenever(
+            mockRumResourceAttributesProvider.onProvideAttributes(
+                any<HttpRequestInfo>(),
+                anyOrNull<HttpResponseInfo>(),
+                anyOrNull()
+            )
+        ) doReturn emptyMap()
+
+        // When
+        testedInstrumentation.stopResource(fakeRequestInfo, mockResponseInfo)
+
+        // Then
+        argumentCaptor<Map<String, Any?>> {
+            verify(mockRumMonitor).stopResource(
+                any<ResourceId>(),
+                anyOrNull(),
+                anyOrNull(),
+                any<RumResourceKind>(),
+                capture()
+            )
+            @Suppress("UNCHECKED_CAST")
+            val reqHeaders = firstValue[RumAttributes.REQUEST_HEADERS] as? Map<String, String>
+            assertThat(reqHeaders).isNotNull
+            assertThat(reqHeaders).containsEntry(fakeHeaderName, fakeHeaderValue)
+
+            @Suppress("UNCHECKED_CAST")
+            val resHeaders = firstValue[RumAttributes.RESPONSE_HEADERS] as? Map<String, String>
+            assertThat(resHeaders).isNotNull
+            assertThat(resHeaders).containsEntry(fakeResHeaderName, fakeResHeaderValue)
+        }
+    }
+
+    @Test
+    fun `M not include header attributes W stopResource() { no trackResourceHeaders }`(
+        @IntForgery(min = 200, max = 600) fakeStatusCode: Int,
+        @LongForgery(min = 0) fakeContentLength: Long
+    ) {
+        // Given
+        whenever(mockResponseInfo.statusCode) doReturn fakeStatusCode
+        whenever(mockResponseInfo.contentLength) doReturn fakeContentLength
+        whenever(mockResponseInfo.contentType) doReturn null
+        whenever(mockResponseInfo.headers) doReturn emptyMap()
+        whenever(
+            mockRumResourceAttributesProvider.onProvideAttributes(
+                any<HttpRequestInfo>(),
+                anyOrNull<HttpResponseInfo>(),
+                anyOrNull()
+            )
+        ) doReturn emptyMap()
+
+        // When
+        testedInstrumentation.stopResource(fakeRequestInfo, mockResponseInfo)
+
+        // Then
+        argumentCaptor<Map<String, Any?>> {
+            verify(mockRumMonitor).stopResource(
+                any<ResourceId>(),
+                anyOrNull(),
+                anyOrNull(),
+                any<RumResourceKind>(),
+                capture()
+            )
+            assertThat(firstValue).doesNotContainKey(RumAttributes.REQUEST_HEADERS)
+            assertThat(firstValue).doesNotContainKey(RumAttributes.RESPONSE_HEADERS)
+        }
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/resource/ResourceHeadersExtractorBuilderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/resource/ResourceHeadersExtractorBuilderTest.kt
@@ -21,10 +21,10 @@ internal class ResourceHeadersExtractorBuilderTest {
         val extractor = ResourceHeadersExtractor.Builder().build()
 
         // Then
-        assertThat(extractor.requestHeaders).containsExactlyElementsOf(
+        assertThat(extractor.allowedRequestHeaders).containsExactlyElementsOf(
             DEFAULT_REQUEST_HEADERS
         )
-        assertThat(extractor.responseHeaders).containsExactlyElementsOf(
+        assertThat(extractor.allowedResponseHeaders).containsExactlyElementsOf(
             DEFAULT_RESPONSE_HEADERS
         )
     }
@@ -35,8 +35,8 @@ internal class ResourceHeadersExtractorBuilderTest {
         val extractor = ResourceHeadersExtractor.Builder(includeDefaults = false).build()
 
         // Then
-        assertThat(extractor.requestHeaders).isEmpty()
-        assertThat(extractor.responseHeaders).isEmpty()
+        assertThat(extractor.allowedRequestHeaders).isEmpty()
+        assertThat(extractor.allowedResponseHeaders).isEmpty()
     }
 
     @Test
@@ -50,8 +50,8 @@ internal class ResourceHeadersExtractorBuilderTest {
             .build()
 
         // Then
-        assertThat(extractor.requestHeaders).containsExactlyElementsOf(customHeaders.toList())
-        assertThat(extractor.responseHeaders).containsExactlyElementsOf(customHeaders.toList())
+        assertThat(extractor.allowedRequestHeaders).containsExactlyElementsOf(customHeaders.toList())
+        assertThat(extractor.allowedResponseHeaders).containsExactlyElementsOf(customHeaders.toList())
     }
 
     // endregion
@@ -85,8 +85,8 @@ internal class ResourceHeadersExtractorBuilderTest {
             .build()
 
         // Then
-        assertThat(extractor.requestHeaders).isEmpty()
-        assertThat(extractor.responseHeaders).isEmpty()
+        assertThat(extractor.allowedRequestHeaders).isEmpty()
+        assertThat(extractor.allowedResponseHeaders).isEmpty()
     }
 
     // endregion
@@ -104,8 +104,8 @@ internal class ResourceHeadersExtractorBuilderTest {
             .build()
 
         // Then
-        assertThat(extractor.requestHeaders).containsExactly("x-request-id", "x-correlation-id")
-        assertThat(extractor.responseHeaders).containsExactly("x-request-id", "x-correlation-id")
+        assertThat(extractor.allowedRequestHeaders).containsExactly("x-request-id", "x-correlation-id")
+        assertThat(extractor.allowedResponseHeaders).containsExactly("x-request-id", "x-correlation-id")
     }
 
     @Test
@@ -119,8 +119,8 @@ internal class ResourceHeadersExtractorBuilderTest {
             .build()
 
         // Then
-        assertThat(extractor.requestHeaders).containsExactly("x-request-id")
-        assertThat(extractor.responseHeaders).containsExactly("x-request-id")
+        assertThat(extractor.allowedRequestHeaders).containsExactly("x-request-id")
+        assertThat(extractor.allowedResponseHeaders).containsExactly("x-request-id")
     }
 
     @Test
@@ -135,9 +135,9 @@ internal class ResourceHeadersExtractorBuilderTest {
 
         // Then
         // content-type is a default, so it shouldn't appear twice
-        val contentTypeCount = extractor.requestHeaders.count { it == "content-type" }
+        val contentTypeCount = extractor.allowedRequestHeaders.count { it == "content-type" }
         assertThat(contentTypeCount).isEqualTo(1)
-        assertThat(extractor.requestHeaders).contains("x-request-id")
+        assertThat(extractor.allowedRequestHeaders).contains("x-request-id")
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/resource/ResourceHeadersExtractorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/resource/ResourceHeadersExtractorTest.kt
@@ -47,13 +47,13 @@ internal class ResourceHeadersExtractorTest {
         // Given
         val expectedMap = DEFAULT_REQUEST_HEADERS
             .associateWith { forge.anAsciiString() }
-        val requestHeaders = expectedMap.mapValues { listOf(it.value) }
+        val rawRequestHeaders = expectedMap.mapValues { listOf(it.value) }
 
         // When
-        val result = testedExtractor.toResourceAttributes(requestHeaders, emptyMap(), mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(rawRequestHeaders, emptyMap(), mockInternalLogger)
 
         // Then
-        assertThat(result.requestHeaders()).containsExactlyEntriesOf(expectedMap)
+        assertThat(result.extractedRequestHeaders()).containsExactlyEntriesOf(expectedMap)
     }
 
     @Test
@@ -61,13 +61,13 @@ internal class ResourceHeadersExtractorTest {
         // Given
         val expectedMap = DEFAULT_RESPONSE_HEADERS
             .associateWith { forge.anAsciiString() }
-        val responseHeaders = expectedMap.mapValues { listOf(it.value) }
+        val rawResponseHeaders = expectedMap.mapValues { listOf(it.value) }
 
         // When
-        val result = testedExtractor.toResourceAttributes(emptyMap(), responseHeaders, mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(emptyMap(), rawResponseHeaders, mockInternalLogger)
 
         // Then
-        assertThat(result.responseHeaders()).containsExactlyEntriesOf(expectedMap)
+        assertThat(result.extractedResponseHeaders()).containsExactlyEntriesOf(expectedMap)
     }
 
     @Test
@@ -75,13 +75,13 @@ internal class ResourceHeadersExtractorTest {
         // Given
         val headerName = forge.anElementFrom(DEFAULT_REQUEST_HEADERS)
         val fakeValue = forge.anAsciiString()
-        val requestHeaders = mapOf(headerName.uppercase(Locale.US) to listOf(fakeValue))
+        val rawRequestHeaders = mapOf(headerName.uppercase(Locale.US) to listOf(fakeValue))
 
         // When
-        val result = testedExtractor.toResourceAttributes(requestHeaders, emptyMap(), mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(rawRequestHeaders, emptyMap(), mockInternalLogger)
 
         // Then
-        assertThat(result.requestHeaders()).containsExactlyEntriesOf(
+        assertThat(result.extractedRequestHeaders()).containsExactlyEntriesOf(
             mapOf(headerName to fakeValue)
         )
     }
@@ -91,13 +91,13 @@ internal class ResourceHeadersExtractorTest {
         // Given
         val headerName = forge.anElementFrom(DEFAULT_RESPONSE_HEADERS)
         val fakeValues = forge.aList(forge.anInt(2, 5)) { anAsciiString() }
-        val responseHeaders = mapOf(headerName to fakeValues)
+        val rawResponseHeaders = mapOf(headerName to fakeValues)
 
         // When
-        val result = testedExtractor.toResourceAttributes(emptyMap(), responseHeaders, mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(emptyMap(), rawResponseHeaders, mockInternalLogger)
 
         // Then
-        assertThat(result.responseHeaders()).containsExactlyEntriesOf(
+        assertThat(result.extractedResponseHeaders()).containsExactlyEntriesOf(
             mapOf(headerName to fakeValues.joinToString(", "))
         )
     }
@@ -108,13 +108,13 @@ internal class ResourceHeadersExtractorTest {
         val configuredHeader = forge.anElementFrom(DEFAULT_REQUEST_HEADERS)
         val fakeValue = forge.anAsciiString()
         val nonConfiguredHeaders = forge.anHttpHeaderMap().mapValues { listOf(it.value) }
-        val requestHeaders = nonConfiguredHeaders + mapOf(configuredHeader to listOf(fakeValue))
+        val rawRequestHeaders = nonConfiguredHeaders + mapOf(configuredHeader to listOf(fakeValue))
 
         // When
-        val result = testedExtractor.toResourceAttributes(requestHeaders, emptyMap(), mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(rawRequestHeaders, emptyMap(), mockInternalLogger)
 
         // Then
-        assertThat(result.requestHeaders()).containsExactlyEntriesOf(
+        assertThat(result.extractedRequestHeaders()).containsExactlyEntriesOf(
             mapOf(configuredHeader to fakeValue)
         )
     }
@@ -131,15 +131,15 @@ internal class ResourceHeadersExtractorTest {
     @Test
     fun `M return empty map W toResourceAttributes() { no matching headers }`(forge: Forge) {
         // Given
-        val requestHeaders = mapOf(
+        val rawRequestHeaders = mapOf(
             "x-custom-${forge.anAlphabeticalString()}" to listOf(forge.anAsciiString())
         )
-        val responseHeaders = mapOf(
+        val rawResponseHeaders = mapOf(
             "x-custom-${forge.anAlphabeticalString()}" to listOf(forge.anAsciiString())
         )
 
         // When
-        val result = testedExtractor.toResourceAttributes(requestHeaders, responseHeaders, mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(rawRequestHeaders, rawResponseHeaders, mockInternalLogger)
 
         // Then
         assertThat(result).isEmpty()
@@ -154,13 +154,13 @@ internal class ResourceHeadersExtractorTest {
         // Given
         val headerName = forge.anElementFrom(DEFAULT_REQUEST_HEADERS)
         val longValue = forge.aStringMatching("[A-Za-z0-9]{200,300}")
-        val requestHeaders = mapOf(headerName to listOf(longValue))
+        val rawRequestHeaders = mapOf(headerName to listOf(longValue))
 
         // When
-        val result = testedExtractor.toResourceAttributes(requestHeaders, emptyMap(), mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(rawRequestHeaders, emptyMap(), mockInternalLogger)
 
         // Then
-        val value = checkNotNull(result.requestHeaders()[headerName])
+        val value = checkNotNull(result.extractedRequestHeaders()[headerName])
         assertThat(value.toByteArray(Charsets.UTF_8).size).isLessThanOrEqualTo(128)
     }
 
@@ -215,14 +215,13 @@ internal class ResourceHeadersExtractorTest {
             .build()
 
         // Build headers where each has a ~100 byte value (enough to exceed 2KB with ~20 headers)
-        val responseHeaders = (1..50).associate { "x-header-$it" to listOf("v".repeat(100)) }
+        val rawResponseHeaders = (1..50).associate { "x-header-$it" to listOf("v".repeat(100)) }
 
         // When
-        val result = testedExtractor.toResourceAttributes(emptyMap(), responseHeaders, mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(emptyMap(), rawResponseHeaders, mockInternalLogger)
 
         // Then
-        val resHeaders = result.responseHeaders()
-        val totalSize = resHeaders.entries.sumOf {
+        val totalSize = result.extractedResponseHeaders().entries.sumOf {
             it.key.length + 1 + it.value.toByteArray(Charsets.UTF_8).size
         }
         assertThat(totalSize).isLessThanOrEqualTo(HEADER_SIZE_LIMIT_BYTES)
@@ -237,13 +236,13 @@ internal class ResourceHeadersExtractorTest {
             .build()
 
         // Each header has a tiny value to avoid hitting 2KB limit first
-        val requestHeaders = headerNames.associateWith { listOf("v") }
+        val rawRequestHeaders = headerNames.associateWith { listOf("v") }
 
         // When
-        val result = testedExtractor.toResourceAttributes(requestHeaders, emptyMap(), mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(rawRequestHeaders, emptyMap(), mockInternalLogger)
 
         // Then
-        assertThat(result.requestHeaders().size).isLessThanOrEqualTo(100)
+        assertThat(result.extractedRequestHeaders().size).isLessThanOrEqualTo(100)
     }
 
     // endregion
@@ -255,31 +254,31 @@ internal class ResourceHeadersExtractorTest {
         // Given
         val fakeReqValue = forge.anAsciiString()
         val fakeResValue = forge.anAsciiString()
-        val requestHeaders = mapOf("content-type" to listOf(fakeReqValue))
-        val responseHeaders = mapOf("content-type" to listOf(fakeResValue))
+        val rawRequestHeaders = mapOf("content-type" to listOf(fakeReqValue))
+        val rawResponseHeaders = mapOf("content-type" to listOf(fakeResValue))
 
         // When
         val result = testedExtractor.toResourceAttributes(
-            requestHeaders,
-            responseHeaders,
+            rawRequestHeaders,
+            rawResponseHeaders,
             mockInternalLogger
         )
 
         // Then
-        assertThat(result.requestHeaders()).containsEntry("content-type", fakeReqValue)
-        assertThat(result.responseHeaders()).containsEntry("content-type", fakeResValue)
+        assertThat(result.extractedRequestHeaders()).containsEntry("content-type", fakeReqValue)
+        assertThat(result.extractedResponseHeaders()).containsEntry("content-type", fakeResValue)
     }
 
     @Test
     fun `M omit request headers key W toResourceAttributes() { no matching request headers }`(forge: Forge) {
         // Given
-        val requestHeaders = mapOf("x-unknown-header" to listOf(forge.anAsciiString()))
-        val responseHeaders = mapOf("content-type" to listOf(forge.anAsciiString()))
+        val rawRequestHeaders = mapOf("x-unknown-header" to listOf(forge.anAsciiString()))
+        val rawResponseHeaders = mapOf("content-type" to listOf(forge.anAsciiString()))
 
         // When
         val result = testedExtractor.toResourceAttributes(
-            requestHeaders,
-            responseHeaders,
+            rawRequestHeaders,
+            rawResponseHeaders,
             mockInternalLogger
         )
 
@@ -291,13 +290,13 @@ internal class ResourceHeadersExtractorTest {
     @Test
     fun `M omit response headers key W toResourceAttributes() { no matching response headers }`(forge: Forge) {
         // Given
-        val requestHeaders = mapOf("content-type" to listOf(forge.anAsciiString()))
-        val responseHeaders = mapOf("x-unknown-header" to listOf(forge.anAsciiString()))
+        val rawRequestHeaders = mapOf("content-type" to listOf(forge.anAsciiString()))
+        val rawResponseHeaders = mapOf("x-unknown-header" to listOf(forge.anAsciiString()))
 
         // When
         val result = testedExtractor.toResourceAttributes(
-            requestHeaders,
-            responseHeaders,
+            rawRequestHeaders,
+            rawResponseHeaders,
             mockInternalLogger
         )
 
@@ -310,12 +309,12 @@ internal class ResourceHeadersExtractorTest {
 
     // region Helpers
 
-    private fun Map<String, Any?>.requestHeaders(): Map<String, String> {
+    private fun Map<String, Any?>.extractedRequestHeaders(): Map<String, String> {
         @Suppress("UNCHECKED_CAST")
         return checkNotNull(this[RumAttributes.REQUEST_HEADERS] as? Map<String, String>)
     }
 
-    private fun Map<String, Any?>.responseHeaders(): Map<String, String> {
+    private fun Map<String, Any?>.extractedResponseHeaders(): Map<String, String> {
         @Suppress("UNCHECKED_CAST")
         return checkNotNull(this[RumAttributes.RESPONSE_HEADERS] as? Map<String, String>)
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/resource/ResourceHeadersExtractorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/resource/ResourceHeadersExtractorTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.rum.resource
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.internal.utils.truncateToUtf8ByteSize
 import com.datadog.android.rum.resource.ResourceHeadersExtractor.Companion.DEFAULT_REQUEST_HEADERS
 import com.datadog.android.rum.resource.ResourceHeadersExtractor.Companion.DEFAULT_RESPONSE_HEADERS
@@ -42,101 +43,103 @@ internal class ResourceHeadersExtractorTest {
     // region Extraction
 
     @Test
-    fun `M extract matching request headers W extractRequestHeaders()`(forge: Forge) {
+    fun `M extract matching request headers W toResourceAttributes()`(forge: Forge) {
         // Given
         val expectedMap = DEFAULT_REQUEST_HEADERS
             .associateWith { forge.anAsciiString() }
-        val headers = expectedMap.mapValues { listOf(it.value) }
+        val requestHeaders = expectedMap.mapValues { listOf(it.value) }
 
         // When
-        val result = testedExtractor.extractRequestHeaders(headers, mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(requestHeaders, emptyMap(), mockInternalLogger)
 
         // Then
-        assertThat(result).containsExactlyEntriesOf(expectedMap)
+        assertThat(result.requestHeaders()).containsExactlyEntriesOf(expectedMap)
     }
 
     @Test
-    fun `M extract matching response headers W extractResponseHeaders()`(forge: Forge) {
+    fun `M extract matching response headers W toResourceAttributes()`(forge: Forge) {
         // Given
         val expectedMap = DEFAULT_RESPONSE_HEADERS
             .associateWith { forge.anAsciiString() }
-        val headers = expectedMap.mapValues { listOf(it.value) }
+        val responseHeaders = expectedMap.mapValues { listOf(it.value) }
 
         // When
-        val result = testedExtractor.extractResponseHeaders(headers, mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(emptyMap(), responseHeaders, mockInternalLogger)
 
         // Then
-        assertThat(result).containsExactlyEntriesOf(expectedMap)
+        assertThat(result.responseHeaders()).containsExactlyEntriesOf(expectedMap)
     }
 
     @Test
-    fun `M normalize header keys to lowercase W extractRequestHeaders()`(forge: Forge) {
+    fun `M normalize header keys to lowercase W toResourceAttributes()`(forge: Forge) {
         // Given
         val headerName = forge.anElementFrom(DEFAULT_REQUEST_HEADERS)
         val fakeValue = forge.anAsciiString()
-        val headers = mapOf(headerName.uppercase(Locale.US) to listOf(fakeValue))
+        val requestHeaders = mapOf(headerName.uppercase(Locale.US) to listOf(fakeValue))
 
         // When
-        val result = testedExtractor.extractRequestHeaders(headers, mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(requestHeaders, emptyMap(), mockInternalLogger)
 
         // Then
-        assertThat(result).containsExactlyEntriesOf(
+        assertThat(result.requestHeaders()).containsExactlyEntriesOf(
             mapOf(headerName to fakeValue)
         )
     }
 
     @Test
-    fun `M join multi-value headers W extractResponseHeaders()`(forge: Forge) {
+    fun `M join multi-value headers W toResourceAttributes()`(forge: Forge) {
         // Given
         val headerName = forge.anElementFrom(DEFAULT_RESPONSE_HEADERS)
         val fakeValues = forge.aList(forge.anInt(2, 5)) { anAsciiString() }
-        val headers = mapOf(headerName to fakeValues)
+        val responseHeaders = mapOf(headerName to fakeValues)
 
         // When
-        val result = testedExtractor.extractResponseHeaders(headers, mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(emptyMap(), responseHeaders, mockInternalLogger)
 
         // Then
-        assertThat(result).containsExactlyEntriesOf(
+        assertThat(result.responseHeaders()).containsExactlyEntriesOf(
             mapOf(headerName to fakeValues.joinToString(", "))
         )
     }
 
     @Test
-    fun `M skip non-configured headers W extractRequestHeaders()`(forge: Forge) {
+    fun `M skip non-configured headers W toResourceAttributes()`(forge: Forge) {
         // Given
         val configuredHeader = forge.anElementFrom(DEFAULT_REQUEST_HEADERS)
         val fakeValue = forge.anAsciiString()
         val nonConfiguredHeaders = forge.anHttpHeaderMap().mapValues { listOf(it.value) }
-        val headers = nonConfiguredHeaders + mapOf(configuredHeader to listOf(fakeValue))
+        val requestHeaders = nonConfiguredHeaders + mapOf(configuredHeader to listOf(fakeValue))
 
         // When
-        val result = testedExtractor.extractRequestHeaders(headers, mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(requestHeaders, emptyMap(), mockInternalLogger)
 
         // Then
-        assertThat(result).containsExactlyEntriesOf(
+        assertThat(result.requestHeaders()).containsExactlyEntriesOf(
             mapOf(configuredHeader to fakeValue)
         )
     }
 
     @Test
-    fun `M return empty map W extractRequestHeaders() { empty input }`() {
+    fun `M return empty map W toResourceAttributes() { empty input }`() {
         // When
-        val result = testedExtractor.extractRequestHeaders(emptyMap(), mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(emptyMap(), emptyMap(), mockInternalLogger)
 
         // Then
         assertThat(result).isEmpty()
     }
 
     @Test
-    fun `M return empty map W extractResponseHeaders() { no matching headers }`(forge: Forge) {
+    fun `M return empty map W toResourceAttributes() { no matching headers }`(forge: Forge) {
         // Given
-        val headers = mapOf(
-            "x-custom-${forge.anAlphabeticalString()}" to
-                listOf(forge.anAsciiString())
+        val requestHeaders = mapOf(
+            "x-custom-${forge.anAlphabeticalString()}" to listOf(forge.anAsciiString())
+        )
+        val responseHeaders = mapOf(
+            "x-custom-${forge.anAlphabeticalString()}" to listOf(forge.anAsciiString())
         )
 
         // When
-        val result = testedExtractor.extractResponseHeaders(headers, mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(requestHeaders, responseHeaders, mockInternalLogger)
 
         // Then
         assertThat(result).isEmpty()
@@ -147,19 +150,17 @@ internal class ResourceHeadersExtractorTest {
     // region Truncation
 
     @Test
-    fun `M truncate value exceeding 128 bytes W extractRequestHeaders()`(forge: Forge) {
+    fun `M truncate value exceeding 128 bytes W toResourceAttributes()`(forge: Forge) {
         // Given
         val headerName = forge.anElementFrom(DEFAULT_REQUEST_HEADERS)
         val longValue = forge.aStringMatching("[A-Za-z0-9]{200,300}")
-        val headers = mapOf(
-            headerName to listOf(longValue)
-        )
+        val requestHeaders = mapOf(headerName to listOf(longValue))
 
         // When
-        val result = testedExtractor.extractRequestHeaders(headers, mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(requestHeaders, emptyMap(), mockInternalLogger)
 
         // Then
-        val value = checkNotNull(result[headerName])
+        val value = checkNotNull(result.requestHeaders()[headerName])
         assertThat(value.toByteArray(Charsets.UTF_8).size).isLessThanOrEqualTo(128)
     }
 
@@ -206,7 +207,7 @@ internal class ResourceHeadersExtractorTest {
     }
 
     @Test
-    fun `M enforce 2KB total limit W extractResponseHeaders()`() {
+    fun `M enforce 2KB total limit W toResourceAttributes()`() {
         // Given
         val headerNames = (1..50).map { "x-header-$it" }.toTypedArray()
         testedExtractor = ResourceHeadersExtractor.Builder(includeDefaults = false)
@@ -214,18 +215,21 @@ internal class ResourceHeadersExtractorTest {
             .build()
 
         // Build headers where each has a ~100 byte value (enough to exceed 2KB with ~20 headers)
-        val headers = (1..50).associate { "x-header-$it" to listOf("v".repeat(100)) }
+        val responseHeaders = (1..50).associate { "x-header-$it" to listOf("v".repeat(100)) }
 
         // When
-        val result = testedExtractor.extractResponseHeaders(headers, mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(emptyMap(), responseHeaders, mockInternalLogger)
 
         // Then
-        val totalSize = result.entries.sumOf { it.key.length + 1 + it.value.toByteArray(Charsets.UTF_8).size }
+        val resHeaders = result.responseHeaders()
+        val totalSize = resHeaders.entries.sumOf {
+            it.key.length + 1 + it.value.toByteArray(Charsets.UTF_8).size
+        }
         assertThat(totalSize).isLessThanOrEqualTo(HEADER_SIZE_LIMIT_BYTES)
     }
 
     @Test
-    fun `M stop at 100 headers max W extractRequestHeaders()`() {
+    fun `M stop at 100 headers max W toResourceAttributes()`() {
         // Given
         val headerNames = (1..150).map { "x-header-$it" }.toTypedArray()
         testedExtractor = ResourceHeadersExtractor.Builder(includeDefaults = false)
@@ -233,13 +237,87 @@ internal class ResourceHeadersExtractorTest {
             .build()
 
         // Each header has a tiny value to avoid hitting 2KB limit first
-        val headers = headerNames.associateWith { listOf("v") }
+        val requestHeaders = headerNames.associateWith { listOf("v") }
 
         // When
-        val result = testedExtractor.extractRequestHeaders(headers, mockInternalLogger)
+        val result = testedExtractor.toResourceAttributes(requestHeaders, emptyMap(), mockInternalLogger)
 
         // Then
-        assertThat(result.size).isLessThanOrEqualTo(100)
+        assertThat(result.requestHeaders().size).isLessThanOrEqualTo(100)
+    }
+
+    // endregion
+
+    // region toResourceAttributes - attribute keys
+
+    @Test
+    fun `M return both attribute keys W toResourceAttributes() { matching request and response }`(forge: Forge) {
+        // Given
+        val fakeReqValue = forge.anAsciiString()
+        val fakeResValue = forge.anAsciiString()
+        val requestHeaders = mapOf("content-type" to listOf(fakeReqValue))
+        val responseHeaders = mapOf("content-type" to listOf(fakeResValue))
+
+        // When
+        val result = testedExtractor.toResourceAttributes(
+            requestHeaders,
+            responseHeaders,
+            mockInternalLogger
+        )
+
+        // Then
+        assertThat(result.requestHeaders()).containsEntry("content-type", fakeReqValue)
+        assertThat(result.responseHeaders()).containsEntry("content-type", fakeResValue)
+    }
+
+    @Test
+    fun `M omit request headers key W toResourceAttributes() { no matching request headers }`(forge: Forge) {
+        // Given
+        val requestHeaders = mapOf("x-unknown-header" to listOf(forge.anAsciiString()))
+        val responseHeaders = mapOf("content-type" to listOf(forge.anAsciiString()))
+
+        // When
+        val result = testedExtractor.toResourceAttributes(
+            requestHeaders,
+            responseHeaders,
+            mockInternalLogger
+        )
+
+        // Then
+        assertThat(result).doesNotContainKey(RumAttributes.REQUEST_HEADERS)
+        assertThat(result).containsKey(RumAttributes.RESPONSE_HEADERS)
+    }
+
+    @Test
+    fun `M omit response headers key W toResourceAttributes() { no matching response headers }`(forge: Forge) {
+        // Given
+        val requestHeaders = mapOf("content-type" to listOf(forge.anAsciiString()))
+        val responseHeaders = mapOf("x-unknown-header" to listOf(forge.anAsciiString()))
+
+        // When
+        val result = testedExtractor.toResourceAttributes(
+            requestHeaders,
+            responseHeaders,
+            mockInternalLogger
+        )
+
+        // Then
+        assertThat(result).containsKey(RumAttributes.REQUEST_HEADERS)
+        assertThat(result).doesNotContainKey(RumAttributes.RESPONSE_HEADERS)
+    }
+
+    // endregion
+
+    // region Helpers
+
+    private fun Map<String, Any?>.requestHeaders(): Map<String, String> {
+        @Suppress("UNCHECKED_CAST")
+        return checkNotNull(this[RumAttributes.REQUEST_HEADERS] as? Map<String, String>)
+    }
+
+    private fun Map<String, Any?>.responseHeaders(): Map<String, String> {
+        @Suppress("UNCHECKED_CAST")
+        return checkNotNull(this[RumAttributes.RESPONSE_HEADERS] as? Map<String, String>)
     }
 
     // endregion

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -200,28 +200,6 @@ open class DatadogInterceptor internal constructor(
 
     // region Internal
 
-    private fun extractHeaderAttributes(
-        sdkCore: FeatureSdkCore,
-        response: Response
-    ): Map<String, Any?> {
-        val extractor = resourceHeadersExtractor ?: return emptyMap()
-        val reqHeaders = _RumInternalProxy.extractRequestHeaders(
-            extractor,
-            response.request.headers.toMultimap(),
-            sdkCore.internalLogger
-        )
-        val resHeaders = _RumInternalProxy.extractResponseHeaders(
-            extractor,
-            response.headers.toMultimap(),
-            sdkCore.internalLogger
-        )
-        return buildMap {
-            if (reqHeaders.isNotEmpty()) put(RumAttributes.REQUEST_HEADERS, reqHeaders)
-            if (resHeaders.isNotEmpty()) put(RumAttributes.RESPONSE_HEADERS, resHeaders)
-        }
-    }
-
-    @WorkerThread
     private fun handleResponse(
         sdkCore: FeatureSdkCore,
         request: Request,
@@ -254,7 +232,14 @@ open class DatadogInterceptor internal constructor(
             }
         }
 
-        val headerAttributes = extractHeaderAttributes(sdkCore, response)
+        val resourceHeaderAttributes = resourceHeadersExtractor?.let {
+            _RumInternalProxy.toResourceAttributes(
+                extractor = it,
+                requestHeaders = request.headers.toMultimap(),
+                responseHeaders = response.headers.toMultimap(),
+                internalLogger = sdkCore.internalLogger
+            )
+        } ?: emptyMap()
 
         @Suppress("DEPRECATION")
         (GlobalRumMonitor.get(sdkCore) as? AdvancedNetworkRumMonitor)?.stopResource(
@@ -262,7 +247,9 @@ open class DatadogInterceptor internal constructor(
             statusCode,
             getBodyLength(response, sdkCore.internalLogger),
             kind,
-            attributes + rumResourceAttributesProvider.onProvideAttributes(request, response, null) + headerAttributes
+            attributes +
+                rumResourceAttributesProvider.onProvideAttributes(request, response, null) +
+                resourceHeaderAttributes
         )
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -200,6 +200,7 @@ open class DatadogInterceptor internal constructor(
 
     // region Internal
 
+    @WorkerThread
     private fun handleResponse(
         sdkCore: FeatureSdkCore,
         request: Request,
@@ -235,8 +236,8 @@ open class DatadogInterceptor internal constructor(
         val resourceHeaderAttributes = resourceHeadersExtractor?.let {
             _RumInternalProxy.toResourceAttributes(
                 extractor = it,
-                requestHeaders = request.headers.toMultimap(),
-                responseHeaders = response.headers.toMultimap(),
+                rawRequestHeaders = response.request.headers.toMultimap(),
+                rawResponseHeaders = response.headers.toMultimap(),
                 internalLogger = sdkCore.internalLogger
             )
         } ?: emptyMap()
@@ -417,6 +418,8 @@ open class DatadogInterceptor internal constructor(
 
         /**
          * Enables capturing HTTP request and response headers in RUM Resource events.
+         *
+         * Sensitive headers matching the [ResourceHeadersExtractor.SECURITY_PATTERN] are automatically filtered out, even if specified in the [extractor].
          *
          * @param extractor the [ResourceHeadersExtractor] specifying which headers to capture.
          * Defaults to a configuration that captures common safe headers.

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -39,6 +39,7 @@ import com.datadog.android.rum.Rum
 import com.datadog.android.rum.RumConfiguration
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.configuration.RumNetworkInstrumentationConfiguration
+import com.datadog.android.rum.resource.ResourceHeadersExtractor
 import com.datadog.android.rum.tracking.NavigationViewTrackingStrategy
 import com.datadog.android.sample.account.AccountFragment
 import com.datadog.android.sample.data.db.LocalDataSource
@@ -102,7 +103,8 @@ class SampleApplication : Application() {
     @OptIn(ExperimentalRumApi::class, ExperimentalTraceApi::class)
     private val okHttpClient = OkHttpClient.Builder()
         .configureDatadogInstrumentation(
-            rumInstrumentationConfiguration = RumNetworkInstrumentationConfiguration(),
+            rumInstrumentationConfiguration = RumNetworkInstrumentationConfiguration()
+                .trackResourceHeaders(resourceHeadersExtractor),
             apmInstrumentationConfiguration = ApmNetworkInstrumentationConfiguration(tracedHosts)
         )
         .build()
@@ -495,6 +497,22 @@ class SampleApplication : Application() {
         init {
             System.loadLibrary("datadog-ndk-sample")
         }
+
+        internal val resourceHeadersExtractor = ResourceHeadersExtractor.Builder()
+            .captureHeaders(
+                "accept-ranges",
+                "content-disposition",
+                "server",
+                "user-agent",
+                "via",
+                "x-cache-hits",
+                "x-served-by",
+                "x-datadog-trace-id",
+                "x-datadog-parent-id",
+                "x-datadog-origin",
+                "traceparent"
+            )
+            .build()
 
         internal const val ATTR_IS_MAPPED = "is_mapped"
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/cronet/CronetImageFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/cronet/CronetImageFragment.kt
@@ -18,6 +18,7 @@ import com.datadog.android.cronet.configureDatadogInstrumentation
 import com.datadog.android.rum.ExperimentalRumApi
 import com.datadog.android.rum.configuration.RumNetworkInstrumentationConfiguration
 import com.datadog.android.sample.R
+import com.datadog.android.sample.SampleApplication
 import com.datadog.android.trace.ApmNetworkInstrumentationConfiguration
 import com.datadog.android.trace.ExperimentalTraceApi
 import org.chromium.net.CronetEngine
@@ -68,7 +69,8 @@ internal class CronetImageFragment : Fragment() {
             .enableQuic(true)
             .enableHttp2(true)
             .configureDatadogInstrumentation(
-                rumInstrumentationConfiguration = RumNetworkInstrumentationConfiguration(),
+                rumInstrumentationConfiguration = RumNetworkInstrumentationConfiguration()
+                    .trackResourceHeaders(SampleApplication.resourceHeadersExtractor),
                 apmInstrumentationConfiguration = ApmNetworkInstrumentationConfiguration(tracedHosts)
                     .setHeaderPropagationOnly()
             )


### PR DESCRIPTION
### What does this PR do?

- Add `trackResourceHeaders` api in `RumNetworkInstrumentationConfiguration`.
- Create `ResourceHeadersExtractor#toResourceAttributes` for better logic encapsulation and some cleanup.
- Instrument both Sample App's `okHttpClient` and `CronetEngine`, both tested and working well.

Example Cronet resource with headers from the sample app [here](https://mobile-integration.datadoghq.com/rum/sessions?query=%40type%3Aresource%20%40application.id%3A948d890c-c895-4060-a960-ac92c51db12d&agg_m=count&agg_m_source=base&agg_t=count&cols=&event=AwAAAZ2WuL01jqRTVAAAABhBWjJXdU5td0FBQ1BPV2xqMHdobjV3QUIAAAAkZjE5ZDk2YjgtZmQ1MC00ZmJhLWFjNzQtZDY0YjJhZTk3OWRlAAAA_w&fromUser=false&viz=stream&from_ts=1776350147017&to_ts=1776350447017&live=true)

### Motivation

We want to support tracking resource headers for all network libraries (OkHttp & Cronet), configured with the new instrumentation coming in #3180.

This is the Part 2 of this feature, after instrumenting for `OkHttp` in `DatadogInterceptor` #3204.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

