### PR TITLE
RUM-15269: Fix DefaultAppStartTimeProvider guard to handle result > createTimeNs

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/time/DefaultAppStartTimeProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/time/DefaultAppStartTimeProvider.kt
@@ -23,16 +23,27 @@ internal class DefaultAppStartTimeProvider(
             buildSdkVersionProvider.isAtLeastN -> {
                 val timeProvider = timeProviderFactory()
                 val diffMs = timeProvider.getDeviceElapsedRealtimeMillis() - Process.getStartElapsedRealtime()
-                val result = timeProvider.getDeviceElapsedTimeNanos() - TimeUnit.MILLISECONDS.toNanos(diffMs)
+                val computedAppStartTimeNs =
+                    timeProvider.getDeviceElapsedTimeNanos() - TimeUnit.MILLISECONDS.toNanos(diffMs)
+                val contentProviderCreateTimeNs = DdRumContentProvider.createTimeNs
+                val isAfterContentProviderInit = computedAppStartTimeNs > contentProviderCreateTimeNs
+                val isTooFarBeforeContentProviderInit =
+                    contentProviderCreateTimeNs - computedAppStartTimeNs >
+                        PROCESS_START_TO_CP_START_DIFF_THRESHOLD_NS
 
                 /**
                  * Occasionally [Process.getStartElapsedRealtime] returns buggy values. We filter them and fall back
                  * to the time of creation of [DdRumContentProvider].
+                 * Two directions are guarded:
+                 * - computedAppStartTimeNs > createTimeNs: app start appears to be after content provider init,
+                 * which is impossible.
+                 * - computedAppStartTimeNs is more than the threshold before createTimeNs: app start appears
+                 * unreasonably far in the past.
                  */
-                if (DdRumContentProvider.createTimeNs - result > PROCESS_START_TO_CP_START_DIFF_THRESHOLD_NS) {
-                    DdRumContentProvider.createTimeNs
+                if (isAfterContentProviderInit || isTooFarBeforeContentProviderInit) {
+                    contentProviderCreateTimeNs
                 } else {
-                    result
+                    computedAppStartTimeNs
                 }
             }
             else -> DdRumContentProvider.createTimeNs

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/time/DefaultAppStartTimeProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/time/DefaultAppStartTimeProviderTest.kt
@@ -86,6 +86,29 @@ class DefaultAppStartTimeProviderTest {
     }
 
     @Test
+    fun `M fall back to DdRumContentProvider W appStartTime { N+ result is greater than createTimeNs }`(
+        @LongForgery(min = 2L) fakeComputedAppStartTimeNs: Long
+    ) {
+        // GIVEN
+        whenever(mockBuildSdkVersionProvider.isAtLeastN) doReturn true
+        val diffMs = stubAndGetElapsedRealtimeMs() - Process.getStartElapsedRealtime()
+        val fakeCurrentTimeNs = fakeComputedAppStartTimeNs + TimeUnit.MILLISECONDS.toNanos(diffMs)
+        whenever(mockTimeProvider.getDeviceElapsedTimeNanos()) doReturn fakeCurrentTimeNs
+
+        val computedAppStartTimeNs = fakeCurrentTimeNs - TimeUnit.MILLISECONDS.toNanos(diffMs)
+        // Set createTimeNs strictly before computedAppStartTimeNs, simulating a buggy
+        // getStartElapsedRealtime()
+        // that makes the computed app start time appear to be after the content provider was created.
+        DdRumContentProvider.createTimeNs = computedAppStartTimeNs - 1L
+
+        // WHEN
+        val providedStartTime = testedProvider.appStartTimeNs
+
+        // THEN
+        assertThat(providedStartTime).isEqualTo(DdRumContentProvider.createTimeNs)
+    }
+
+    @Test
     fun `M return content provider load time W appStartTime { Legacy }`() {
         // GIVEN
         whenever(mockBuildSdkVersionProvider.isAtLeastN) doReturn false
@@ -101,13 +124,18 @@ class DefaultAppStartTimeProviderTest {
     @Test
     fun `M return app uptime W appUptimeNs`(
         @LongForgery(min = 1000000L) fakeStartTimeNs: Long,
-        @LongForgery(min = 1000L, max = 100000L) fakeUptimeNs: Long
+        @LongForgery(min = 1000L, max = 100000L) fakeUptimeNs: Long,
+        forge: Forge
     ) {
         // Given
         whenever(mockBuildSdkVersionProvider.isAtLeastN) doReturn true
 
-        val diffMs = stubAndGetElapsedRealtimeMs() - Process.getStartElapsedRealtime()
-        val fakeCurrentTimeNs = fakeStartTimeNs + TimeUnit.MILLISECONDS.toNanos(diffMs)
+        val fakeCurrentTimeNs = computeCurrentTimeNsForStartTime(fakeStartTimeNs)
+        // Set createTimeNs strictly above result so the guard does not fire, but the two values
+        // are distinguishable — if the guard did fire, appStartTimeNs would differ from result
+        // and the uptime assertion would fail.
+        DdRumContentProvider.createTimeNs = fakeCurrentTimeNs +
+            forge.aLong(min = 1L, max = DefaultAppStartTimeProvider.PROCESS_START_TO_CP_START_DIFF_THRESHOLD_NS)
 
         whenever(mockTimeProvider.getDeviceElapsedTimeNanos())
             .doReturn(fakeCurrentTimeNs)
@@ -132,8 +160,8 @@ class DefaultAppStartTimeProviderTest {
     ) {
         // Given
         whenever(mockBuildSdkVersionProvider.isAtLeastN) doReturn true
-        val diffMs = stubAndGetElapsedRealtimeMs() - Process.getStartElapsedRealtime()
-        val fakeCurrentTimeNs = fakeStartTimeNs + TimeUnit.MILLISECONDS.toNanos(diffMs)
+        val fakeCurrentTimeNs = computeCurrentTimeNsForStartTime(fakeStartTimeNs)
+        DdRumContentProvider.createTimeNs = fakeCurrentTimeNs
 
         whenever(mockTimeProvider.getDeviceElapsedTimeNanos())
             .doReturn(fakeCurrentTimeNs)
@@ -186,8 +214,8 @@ class DefaultAppStartTimeProviderTest {
     ) {
         // Given
         whenever(mockBuildSdkVersionProvider.isAtLeastN) doReturn true
-        val diffMs = stubAndGetElapsedRealtimeMs() - Process.getStartElapsedRealtime()
-        val fakeCurrentTimeNs = fakeStartTimeNs + TimeUnit.MILLISECONDS.toNanos(diffMs)
+        val fakeCurrentTimeNs = computeCurrentTimeNsForStartTime(fakeStartTimeNs)
+        DdRumContentProvider.createTimeNs = fakeCurrentTimeNs
 
         whenever(mockTimeProvider.getDeviceElapsedTimeNanos())
             .doReturn(fakeCurrentTimeNs)
@@ -212,5 +240,10 @@ class DefaultAppStartTimeProviderTest {
         val elapsedRealtimeMs = SystemClock.elapsedRealtime()
         whenever(mockTimeProvider.getDeviceElapsedRealtimeMillis()) doReturn elapsedRealtimeMs
         return elapsedRealtimeMs
+    }
+
+    private fun computeCurrentTimeNsForStartTime(fakeStartTimeNs: Long): Long {
+        val diffMs = stubAndGetElapsedRealtimeMs() - Process.getStartElapsedRealtime()
+        return fakeStartTimeNs + TimeUnit.MILLISECONDS.toNanos(diffMs)
     }
 }


### PR DESCRIPTION
### What does this PR do?

Extends the fallback guard in `DefaultAppStartTimeProvider` to also handle the case where the computed `appStartTimeNs` is greater than `DdRumContentProvider.createTimeNs`, which is an impossible value since the process always starts before the content provider initialises. Adds a unit test covering this direction, and updates existing uptime tests to set `createTimeNs` consistently with the production invariant.

### Motivation

The CI integration test `mustReturnTheCorrectAppStartTime_when_appStartTimeNs` failed with a `java.lang.AssertionError`. The full assertion message was truncated in the CI log, so we cannot confirm the exact values involved, but I think the root cause is a buggy value returned by `Process.getStartElapsedRealtime()`.

This API is known to occasionally return wrong values on API 28+ (confirmed in RUM-13082 and documented in [this article](https://dev.to/pyricau/android-vitals-when-did-my-app-start-24p4)). I think that when it returns a value larger than the current `elapsedRealtime()`, `diffMs` goes negative and `result` exceeds `System.nanoTime()`.

The existing guard only caught the case where `result` was too far in the past:
```kotlin
// Before — only catches one direction
if (DdRumContentProvider.createTimeNs - result > THRESHOLD)
```

When `result > createTimeNs`, this expression is negative and the guard silently passes the invalid value through.

### Additional context — BOOTTIME vs MONOTONIC clock mismatch

While investigating the failure we also noticed a separate structural issue in the formula:

```kotlin
val diffMs = getDeviceElapsedRealtimeMillis() - Process.getStartElapsedRealtime()
val result  = getDeviceElapsedTimeNanos() - TimeUnit.MILLISECONDS.toNanos(diffMs)
```

This mixes two different Android clocks:
- `getDeviceElapsedRealtimeMillis()` → `SystemClock.elapsedRealtime()` — `CLOCK_BOOTTIME`, advances during device sleep
- `getDeviceElapsedTimeNanos()` → `System.nanoTime()` — `CLOCK_MONOTONIC`, does not advance during sleep

On a device that sleeps after the process starts, `CLOCK_BOOTTIME` accumulates more time than `CLOCK_MONOTONIC`, inflating `diffMs` and making `result` too small. Since `appStartTimeNs` feeds RUM startup duration, TTID, fatal crash `timeSinceAppStartNs`, and NDK crash timestamps, a wrong value here silently corrupts multiple RUM and crash metrics. This is not addressed by this PR. A proper fix would require `Process.getStartUptimeMillis()` (available from API 33) to keep the computation in the MONOTONIC domain throughout.

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)