### PR TITLE
Centralize PROFILER_IS_RUNNING key into internal module

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -1,3 +1,5 @@
+object com.datadog.android.internal.FeatureContextKeys
+  const val PROFILER_IS_RUNNING: String
 interface com.datadog.android.internal.attributes.LocalAttribute
   enum Key
     constructor(String)

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -1,3 +1,8 @@
+public final class com/datadog/android/internal/FeatureContextKeys {
+	public static final field INSTANCE Lcom/datadog/android/internal/FeatureContextKeys;
+	public static final field PROFILER_IS_RUNNING Ljava/lang/String;
+}
+
 public abstract interface class com/datadog/android/internal/attributes/LocalAttribute {
 }
 

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/FeatureContextKeys.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/FeatureContextKeys.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal
+
+/**
+ * Keys used to communicate profiling state via the features context.
+ */
+object FeatureContextKeys {
+    /**
+     * Indicates whether the profiler is currently running.
+     * Written by the profiling feature and read by RUM and debug widget consumers.
+     */
+    const val PROFILER_IS_RUNNING: String = "profiler_is_running"
+}

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
@@ -14,8 +14,8 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.internal.utils.scheduleSafe
 import com.datadog.android.core.sampling.RateBasedSampler
+import com.datadog.android.internal.FeatureContextKeys
 import com.datadog.android.internal.profiling.ProfilerEvent
-import com.datadog.android.profiling.internal.ProfilingFeature.Companion.PROFILER_IS_RUNNING
 import java.util.Locale
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ScheduledExecutorService
@@ -127,7 +127,7 @@ internal class ContinuousProfilingScheduler(
                 durationMs = activeMs.toInt()
             )
             sdkCore.updateFeatureContext(Feature.PROFILING_FEATURE_NAME) { context ->
-                context[PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
+                context[FeatureContextKeys.PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
             }
         } else {
             logToUser { LOG_ACTIVE_WINDOW_SKIPPED }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -16,6 +16,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.feature.StorageBackedFeature
 import com.datadog.android.api.net.RequestFactory
 import com.datadog.android.api.storage.FeatureStorageConfiguration
+import com.datadog.android.internal.FeatureContextKeys
 import com.datadog.android.internal.profiling.ProfilerEvent
 import com.datadog.android.internal.rum.RumSessionRenewedEvent
 import com.datadog.android.profiling.ExperimentalProfilingApi
@@ -68,7 +69,7 @@ internal class ProfilingFeature(
         ProfilingStorage.addProfilingFlag(appContext, sdkCore.name)
         sdkCore.setEventReceiver(name, this)
         sdkCore.updateFeatureContext(Feature.PROFILING_FEATURE_NAME) { context ->
-            context[PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
+            context[FeatureContextKeys.PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
         }
         dataWriter = createDataWriter(sdkCore)
 
@@ -119,7 +120,7 @@ internal class ProfilingFeature(
         perfettoResult = result
         tryWriteProfilingEvent()
         sdkCore.updateFeatureContext(Feature.PROFILING_FEATURE_NAME) { context ->
-            context[PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
+            context[FeatureContextKeys.PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
         }
     }
 
@@ -132,7 +133,7 @@ internal class ProfilingFeature(
             continuousProfilingScheduler?.onActiveWindowEnded()
         }
         sdkCore.updateFeatureContext(Feature.PROFILING_FEATURE_NAME) { context ->
-            context[PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
+            context[FeatureContextKeys.PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
         }
     }
 
@@ -210,6 +211,5 @@ internal class ProfilingFeature(
     companion object {
         private const val UNSUPPORTED_EVENT_TYPE =
             "Profiling feature received an event of unsupported type=%s."
-        internal const val PROFILER_IS_RUNNING = "profiler_is_running"
     }
 }

--- a/features/dd-sdk-android-rum-debug-widget/src/main/kotlin/com/datadog/android/insights/internal/DefaultInsightsCollector.kt
+++ b/features/dd-sdk-android-rum-debug-widget/src/main/kotlin/com/datadog/android/insights/internal/DefaultInsightsCollector.kt
@@ -15,6 +15,7 @@ import com.datadog.android.insights.internal.domain.TimelineEvent
 import com.datadog.android.insights.internal.extensions.Mb
 import com.datadog.android.insights.internal.extensions.round
 import com.datadog.android.insights.internal.platform.Platform
+import com.datadog.android.internal.FeatureContextKeys
 import com.datadog.android.internal.collections.EvictingQueue
 import com.datadog.android.rum.internal.instrumentation.insights.InsightsCollector
 import com.datadog.android.rum.internal.instrumentation.insights.InsightsUpdatesListener
@@ -143,7 +144,7 @@ internal class DefaultInsightsCollector internal constructor(
 
     override fun onContextUpdate(featureName: String, context: Map<String, Any?>) {
         if (featureName == Feature.PROFILING_FEATURE_NAME) {
-            val running = context[PROFILER_IS_RUNNING] as? Boolean ?: false
+            val running = context[FeatureContextKeys.PROFILER_IS_RUNNING] as? Boolean ?: false
             handler.post {
                 isProfilingRunning = running
                 updatesListeners.forEach(InsightsUpdatesListener::onDataUpdated)
@@ -196,8 +197,5 @@ internal class DefaultInsightsCollector internal constructor(
         internal const val PRECISION = 2
         internal const val GC_COUNT = "art.gc.gc-count"
         internal const val ONE_SECOND_NS = 1_000_000_000L
-
-        // Contract key; must match ProfilingFeature.PROFILER_IS_RUNNING in dd-sdk-android-profiling.
-        private const val PROFILER_IS_RUNNING = "profiler_is_running"
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -16,6 +16,7 @@ import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
+import com.datadog.android.internal.FeatureContextKeys
 import com.datadog.android.internal.attributes.LocalAttribute
 import com.datadog.android.internal.attributes.ViewScopeInstrumentationType
 import com.datadog.android.internal.profiling.ProfilerEvent
@@ -1691,7 +1692,7 @@ internal open class RumViewScope(
         val profilingFeature = sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)
         return profilingFeature?.let {
             datadogContext.featuresContext[Feature.PROFILING_FEATURE_NAME]?.get(
-                PROFILER_IS_RUNNING
+                FeatureContextKeys.PROFILER_IS_RUNNING
             ) == true
         } ?: false
     }
@@ -1707,8 +1708,6 @@ internal open class RumViewScope(
     // endregion
 
     companion object {
-
-        private const val PROFILER_IS_RUNNING = "profiler_is_running"
 
         internal val ONE_SECOND_NS = TimeUnit.SECONDS.toNanos(1)
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManager.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManager.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.internal.FeatureContextKeys
 import com.datadog.android.internal.profiling.ProfilerEvent
 import com.datadog.android.internal.profiling.ProfilingRumContext
 import com.datadog.android.rum.internal.domain.RumContext
@@ -288,13 +289,11 @@ internal class RumSessionScopeStartupManagerImpl(
 
     private fun DatadogContext.getProfilingStatus(): VitalAppLaunchEvent.ProfilingStatus? {
         val isProfilerRunning = featuresContext[Feature.PROFILING_FEATURE_NAME]
-            ?.get(PROFILER_IS_RUNNING)
+            ?.get(FeatureContextKeys.PROFILER_IS_RUNNING)
         return if (isProfilerRunning == true) VitalAppLaunchEvent.ProfilingStatus.RUNNING else null
     }
 
     companion object {
-        private const val PROFILER_IS_RUNNING = "profiler_is_running"
-
         internal const val REPORT_APP_FULLY_DISPLAYED_CALLED_TOO_EARLY_MESSAGE =
             "RumMonitor.reportAppFullyDisplayed was called before the application launch was detected, ignoring it."
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -19,6 +19,8 @@ import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.feature.event.ThreadDump
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
+import com.datadog.android.internal.FeatureContextKeys
+import com.datadog.android.internal.FeatureContextKeys.PROFILER_IS_RUNNING
 import com.datadog.android.internal.profiling.ProfilerEvent
 import com.datadog.android.internal.profiling.ProfilingRumContext
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
@@ -5580,7 +5582,7 @@ internal class RumViewScopeTest {
         fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
         val datadogContext = fakeDatadogContext.copy(
             featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
-                put(Feature.PROFILING_FEATURE_NAME, mapOf("profiler_is_running" to true))
+                put(Feature.PROFILING_FEATURE_NAME, mapOf(FeatureContextKeys.PROFILER_IS_RUNNING to true))
             }
         )
 
@@ -5604,7 +5606,7 @@ internal class RumViewScopeTest {
         fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
         val datadogContext = fakeDatadogContext.copy(
             featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
-                put(Feature.PROFILING_FEATURE_NAME, mapOf("profiler_is_running" to false))
+                put(Feature.PROFILING_FEATURE_NAME, mapOf(PROFILER_IS_RUNNING to false))
             }
         )
 
@@ -5671,7 +5673,7 @@ internal class RumViewScopeTest {
         )
         val datadogContext = fakeDatadogContext.copy(
             featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
-                put(Feature.PROFILING_FEATURE_NAME, mapOf("profiler_is_running" to true))
+                put(Feature.PROFILING_FEATURE_NAME, mapOf(FeatureContextKeys.PROFILER_IS_RUNNING to true))
             }
         )
 
@@ -5707,7 +5709,7 @@ internal class RumViewScopeTest {
         )
         val datadogContext = fakeDatadogContext.copy(
             featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
-                put(Feature.PROFILING_FEATURE_NAME, mapOf("profiler_is_running" to false))
+                put(Feature.PROFILING_FEATURE_NAME, mapOf(PROFILER_IS_RUNNING to false))
             }
         )
 
@@ -5743,7 +5745,7 @@ internal class RumViewScopeTest {
         )
         val datadogContext = fakeDatadogContext.copy(
             featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
-                put(Feature.PROFILING_FEATURE_NAME, mapOf("profiler_is_running" to true))
+                put(Feature.PROFILING_FEATURE_NAME, mapOf(FeatureContextKeys.PROFILER_IS_RUNNING to true))
             }
         )
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManagerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManagerTest.kt
@@ -17,6 +17,7 @@ import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.internal.FeatureContextKeys
 import com.datadog.android.internal.profiling.ProfilerEvent
 import com.datadog.android.internal.profiling.ProfilingRumContext
 import com.datadog.android.rum.RumSessionType
@@ -174,7 +175,7 @@ internal class RumSessionScopeStartupManagerTest {
             featuresContext = fakeDatadogContext.featuresContext.let {
                 if (forge.aBool()) {
                     it.toMutableMap().apply {
-                        put(Feature.PROFILING_FEATURE_NAME, mapOf("profiler_is_running" to true))
+                        put(Feature.PROFILING_FEATURE_NAME, mapOf(FeatureContextKeys.PROFILER_IS_RUNNING to true))
                     }
                 } else {
                     it


### PR DESCRIPTION
### What does this PR do?

`PROFILER_IS_RUNNING` was used in a lot of place with duplicated definition, this PR centralizes it into `dd-sdk-android-internal` module to reuse.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

