### PR TITLE
Migrate ProcessLifecycleMonitor from core to internal

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -28,7 +28,6 @@ import com.datadog.android.core.configuration.BatchSize
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.core.internal.lifecycle.ProcessLifecycleCallback
-import com.datadog.android.core.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.core.internal.logger.SdkInternalLogger
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.time.DefaultAppStartTimeProvider
@@ -39,6 +38,7 @@ import com.datadog.android.core.internal.utils.scheduleSafe
 import com.datadog.android.core.internal.utils.submitSafe
 import com.datadog.android.core.thread.FlushableExecutorService
 import com.datadog.android.error.internal.CrashReportsFeature
+import com.datadog.android.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.time.TimeProvider

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -30,7 +30,6 @@ import com.datadog.android.core.internal.data.upload.DefaultUploadSchedulerStrat
 import com.datadog.android.core.internal.data.upload.NoOpDataUploader
 import com.datadog.android.core.internal.data.upload.NoOpUploadScheduler
 import com.datadog.android.core.internal.data.upload.UploadScheduler
-import com.datadog.android.core.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.core.internal.metrics.BatchMetricsDispatcher
 import com.datadog.android.core.internal.metrics.MetricsDispatcher
 import com.datadog.android.core.internal.metrics.NoOpMetricsDispatcher
@@ -55,6 +54,7 @@ import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.core.internal.utils.getSafe
 import com.datadog.android.core.internal.utils.submitSafe
 import com.datadog.android.core.persistence.PersistenceStrategy
+import com.datadog.android.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.internal.profiler.BenchmarkSdkUploads
 import com.datadog.android.internal.profiler.GlobalBenchmark
 import com.datadog.android.privacy.TrackingConsentProviderCallback

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallback.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallback.kt
@@ -11,6 +11,7 @@ import androidx.work.WorkManager
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.utils.cancelUploadWorker
 import com.datadog.android.core.internal.utils.triggerUploadWorker
+import com.datadog.android.internal.lifecycle.ProcessLifecycleMonitor
 import java.lang.ref.Reference
 import java.lang.ref.WeakReference
 
@@ -18,8 +19,7 @@ internal class ProcessLifecycleCallback(
     appContext: Context,
     internal val instanceName: String,
     private val internalLogger: InternalLogger
-) :
-    ProcessLifecycleMonitor.Callback {
+) : ProcessLifecycleMonitor.Callback {
 
     internal val contextWeakRef: Reference<Context> = WeakReference(appContext)
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
@@ -9,11 +9,11 @@ package com.datadog.android.core.internal.metrics
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.core.internal.configuration.DataUploadConfiguration
-import com.datadog.android.core.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.advanced.FeatureFileOrchestrator
 import com.datadog.android.core.internal.persistence.file.existsSafe
 import com.datadog.android.core.internal.persistence.file.lengthSafe
+import com.datadog.android.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.privacy.TrackingConsent
 import java.io.File

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
@@ -20,12 +20,12 @@ import com.datadog.android.core.internal.NoOpContextProvider
 import com.datadog.android.core.internal.SdkFeature
 import com.datadog.android.core.internal.account.MutableAccountInfoProvider
 import com.datadog.android.core.internal.lifecycle.ProcessLifecycleCallback
-import com.datadog.android.core.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.privacy.ConsentProvider
 import com.datadog.android.core.internal.user.MutableUserInfoProvider
 import com.datadog.android.core.thread.FlushableExecutorService
+import com.datadog.android.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.tests.stub.StubTimeProvider
 import com.datadog.android.internal.time.TimeProvider

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -29,7 +29,6 @@ import com.datadog.android.core.internal.data.upload.DefaultUploadSchedulerStrat
 import com.datadog.android.core.internal.data.upload.NoOpDataUploader
 import com.datadog.android.core.internal.data.upload.NoOpUploadScheduler
 import com.datadog.android.core.internal.data.upload.UploadScheduler
-import com.datadog.android.core.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.core.internal.metrics.BatchMetricsDispatcher
 import com.datadog.android.core.internal.metrics.BatchMetricsDispatcher.Companion.TRACK_KEY
 import com.datadog.android.core.internal.metrics.NoOpMetricsDispatcher
@@ -42,6 +41,7 @@ import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.NoOpFileOrchestrator
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileOrchestrator
 import com.datadog.android.core.persistence.PersistenceStrategy
+import com.datadog.android.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.internal.profiler.BenchmarkMeter
 import com.datadog.android.internal.profiler.BenchmarkSdkUploads
 import com.datadog.android.privacy.TrackingConsent

--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -60,6 +60,24 @@ class com.datadog.android.internal.data.SharedPreferencesStorage : PreferencesSt
   override fun clear()
 data class com.datadog.android.internal.flags.RumFlagEvaluationMessage
   constructor(String, Any)
+class com.datadog.android.internal.lifecycle.ProcessLifecycleMonitor : android.app.Application.ActivityLifecycleCallbacks
+  constructor(Callback)
+  val activitiesResumedCounter: java.util.concurrent.atomic.AtomicInteger
+  val activitiesStartedCounter: java.util.concurrent.atomic.AtomicInteger
+  val wasPaused: java.util.concurrent.atomic.AtomicBoolean
+  val wasStopped: java.util.concurrent.atomic.AtomicBoolean
+  override fun onActivityPaused(android.app.Activity)
+  override fun onActivityStarted(android.app.Activity)
+  override fun onActivityDestroyed(android.app.Activity)
+  override fun onActivitySaveInstanceState(android.app.Activity, android.os.Bundle)
+  override fun onActivityStopped(android.app.Activity)
+  override fun onActivityCreated(android.app.Activity, android.os.Bundle?)
+  override fun onActivityResumed(android.app.Activity)
+  interface Callback
+    fun onStarted()
+    fun onResumed()
+    fun onStopped()
+    fun onPaused()
 enum com.datadog.android.internal.network.GraphQLHeaders
   constructor(String)
   - DD_GRAPHQL_NAME_HEADER

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -123,6 +123,29 @@ public final class com/datadog/android/internal/flags/RumFlagEvaluationMessage {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/datadog/android/internal/lifecycle/ProcessLifecycleMonitor : android/app/Application$ActivityLifecycleCallbacks {
+	public fun <init> (Lcom/datadog/android/internal/lifecycle/ProcessLifecycleMonitor$Callback;)V
+	public final fun getActivitiesResumedCounter ()Ljava/util/concurrent/atomic/AtomicInteger;
+	public final fun getActivitiesStartedCounter ()Ljava/util/concurrent/atomic/AtomicInteger;
+	public final fun getCallback ()Lcom/datadog/android/internal/lifecycle/ProcessLifecycleMonitor$Callback;
+	public final fun getWasPaused ()Ljava/util/concurrent/atomic/AtomicBoolean;
+	public final fun getWasStopped ()Ljava/util/concurrent/atomic/AtomicBoolean;
+	public fun onActivityCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
+	public fun onActivityDestroyed (Landroid/app/Activity;)V
+	public fun onActivityPaused (Landroid/app/Activity;)V
+	public fun onActivityResumed (Landroid/app/Activity;)V
+	public fun onActivitySaveInstanceState (Landroid/app/Activity;Landroid/os/Bundle;)V
+	public fun onActivityStarted (Landroid/app/Activity;)V
+	public fun onActivityStopped (Landroid/app/Activity;)V
+}
+
+public abstract interface class com/datadog/android/internal/lifecycle/ProcessLifecycleMonitor$Callback {
+	public abstract fun onPaused ()V
+	public abstract fun onResumed ()V
+	public abstract fun onStarted ()V
+	public abstract fun onStopped ()V
+}
+
 public final class com/datadog/android/internal/network/GraphQLHeaders : java/lang/Enum {
 	public static final field DD_GRAPHQL_NAME_HEADER Lcom/datadog/android/internal/network/GraphQLHeaders;
 	public static final field DD_GRAPHQL_PAYLOAD_HEADER Lcom/datadog/android/internal/network/GraphQLHeaders;

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/lifecycle/ProcessLifecycleMonitor.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/lifecycle/ProcessLifecycleMonitor.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.core.internal.lifecycle
+package com.datadog.android.internal.lifecycle
 
 import android.app.Activity
 import android.app.Application
@@ -13,14 +13,28 @@ import androidx.annotation.MainThread
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
-internal class ProcessLifecycleMonitor(val callback: Callback) :
+/**
+ * Monitors the app process lifecycle by tracking [android.app.Activity] starts and stops,
+ * and delivers single process-level [Callback] events when the app enters or leaves the foreground.
+ *
+ * @param callback the receiver for process-level lifecycle events.
+ */
+class ProcessLifecycleMonitor(val callback: Callback) :
     Application.ActivityLifecycleCallbacks {
 
-    val activitiesResumedCounter = AtomicInteger(0)
-    val activitiesStartedCounter = AtomicInteger(0)
-    val wasPaused = AtomicBoolean(true)
-    val wasStopped = AtomicBoolean(true)
+    /** Number of activities currently in the resumed state. */
+    val activitiesResumedCounter: AtomicInteger = AtomicInteger(0)
 
+    /** Number of activities currently in the started (visible) state. */
+    val activitiesStartedCounter: AtomicInteger = AtomicInteger(0)
+
+    /** Whether the process was last observed in the paused state. */
+    val wasPaused: AtomicBoolean = AtomicBoolean(true)
+
+    /** Whether the process was last observed in the stopped state. */
+    val wasStopped: AtomicBoolean = AtomicBoolean(true)
+
+    /** @inheritDoc */
     @MainThread
     override fun onActivityPaused(activity: Activity) {
         if (activitiesResumedCounter.decrementAndGet() == 0 &&
@@ -31,6 +45,7 @@ internal class ProcessLifecycleMonitor(val callback: Callback) :
         }
     }
 
+    /** @inheritDoc */
     @MainThread
     override fun onActivityStarted(activity: Activity) {
         if (activitiesStartedCounter.incrementAndGet() == 1 &&
@@ -41,16 +56,19 @@ internal class ProcessLifecycleMonitor(val callback: Callback) :
         }
     }
 
+    /** @inheritDoc */
     @MainThread
     override fun onActivityDestroyed(activity: Activity) {
         //  NO-OP
     }
 
+    /** @inheritDoc */
     @MainThread
     override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
         //  NO-OP
     }
 
+    /** @inheritDoc */
     @MainThread
     override fun onActivityStopped(activity: Activity) {
         if (activitiesStartedCounter.decrementAndGet() == 0 && wasPaused.get()) {
@@ -60,11 +78,13 @@ internal class ProcessLifecycleMonitor(val callback: Callback) :
         }
     }
 
+    /** @inheritDoc */
     @MainThread
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
         //  NO-OP
     }
 
+    /** @inheritDoc */
     @MainThread
     override fun onActivityResumed(activity: Activity) {
         if (activitiesResumedCounter.incrementAndGet() == 1 &&
@@ -74,13 +94,23 @@ internal class ProcessLifecycleMonitor(val callback: Callback) :
         }
     }
 
-    internal interface Callback {
+    /**
+     * Receives process-level lifecycle events from [ProcessLifecycleMonitor].
+     * Each method is called at most once per foreground/background transition,
+     * regardless of how many activities are involved.
+     */
+    interface Callback {
+
+        /** Called when the app process enters the foreground (first activity started). */
         fun onStarted()
 
+        /** Called when the app process is fully resumed (first activity resumed). */
         fun onResumed()
 
+        /** Called when the app process leaves the foreground (last activity stopped). */
         fun onStopped()
 
+        /** Called when the app process is fully paused (last activity paused). */
         fun onPaused()
     }
 }

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/lifecycle/ProcessLifecycleMonitorTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/lifecycle/ProcessLifecycleMonitorTest.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.core.internal.lifecycle
+package com.datadog.android.internal.lifecycle
 
 import android.app.Activity
 import org.junit.jupiter.api.BeforeEach


### PR DESCRIPTION
### What does this PR do?

Migrate `ProcessLifecycleMonitor` from `dd-sdk-android-core` to `dd-sdk-android-internal` so that it can be used by other modules while keeping it not public to users. 

### Motivation

Continuous Profiling needs to reuse this class to track the application lifecycle when it goes to the background or foreground.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

