### PR TITLE
RUM-15423: Fix B3/B3multi propagation headers being silently dropped

### DIFF
--- a/features/dd-sdk-android-trace-api/api/apiSurface
+++ b/features/dd-sdk-android-trace-api/api/apiSurface
@@ -27,8 +27,10 @@ object com.datadog.android.trace.api.DatadogTracingConstants
     const val TRACE_RATE_LIMIT: String
     const val PARTIAL_FLUSH_MIN_SPANS: String
     const val TRACE_SAMPLE_RATE: String
-    const val PROPAGATION_STYLE_EXTRACT: String
-    const val PROPAGATION_STYLE_INJECT: String
+    DEPRECATED const val PROPAGATION_STYLE_EXTRACT: String
+    DEPRECATED const val PROPAGATION_STYLE_INJECT: String
+    const val TRACE_PROPAGATION_STYLE_EXTRACT: String
+    const val TRACE_PROPAGATION_STYLE_INJECT: String
     const val SERVICE_NAME: String
     const val SDK_V2_COMPATIBILITY_FLAG: String
     const val URL_AS_RESOURCE_NAME: String

--- a/features/dd-sdk-android-trace-api/api/dd-sdk-android-trace-api.api
+++ b/features/dd-sdk-android-trace-api/api/dd-sdk-android-trace-api.api
@@ -57,6 +57,8 @@ public final class com/datadog/android/trace/api/DatadogTracingConstants$TracerC
 	public static final field SERVICE_NAME Ljava/lang/String;
 	public static final field SPAN_TAGS Ljava/lang/String;
 	public static final field TAGS Ljava/lang/String;
+	public static final field TRACE_PROPAGATION_STYLE_EXTRACT Ljava/lang/String;
+	public static final field TRACE_PROPAGATION_STYLE_INJECT Ljava/lang/String;
 	public static final field TRACE_RATE_LIMIT Ljava/lang/String;
 	public static final field TRACE_SAMPLE_RATE Ljava/lang/String;
 	public static final field URL_AS_RESOURCE_NAME Ljava/lang/String;

--- a/features/dd-sdk-android-trace-api/src/main/kotlin/com/datadog/android/trace/api/DatadogTracingConstants.kt
+++ b/features/dd-sdk-android-trace-api/src/main/kotlin/com/datadog/android/trace/api/DatadogTracingConstants.kt
@@ -134,10 +134,24 @@ object DatadogTracingConstants {
         const val TRACE_SAMPLE_RATE: String = "trace.sample.rate"
 
         /**Constant used to specify the propagation style for extracting context headers during distributed tracing. */
+        @Deprecated(
+            "Use TRACE_PROPAGATION_STYLE_EXTRACT instead.",
+            replaceWith = ReplaceWith("TRACE_PROPAGATION_STYLE_EXTRACT")
+        )
         const val PROPAGATION_STYLE_EXTRACT: String = "propagation.style.extract"
 
         /** Defines the property key for configuring the propagation style during the injection phase. */
+        @Deprecated(
+            "Use TRACE_PROPAGATION_STYLE_INJECT instead.",
+            replaceWith = ReplaceWith("TRACE_PROPAGATION_STYLE_INJECT")
+        )
         const val PROPAGATION_STYLE_INJECT: String = "propagation.style.inject"
+
+        /** Constant used to specify the propagation style for extracting context headers during distributed tracing. */
+        const val TRACE_PROPAGATION_STYLE_EXTRACT: String = "trace.propagation.style.extract"
+
+        /** Defines the property key for configuring the propagation style during the injection phase. */
+        const val TRACE_PROPAGATION_STYLE_INJECT: String = "trace.propagation.style.inject"
 
         /**
          * A constant key used to retrieve or set the service name configuration

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/DatadogTracerBuilderAdapter.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/DatadogTracerBuilderAdapter.kt
@@ -99,8 +99,8 @@ internal class DatadogTracerBuilderAdapter(
         val properties = Properties()
 
         val propagationStyles = tracingHeadersTypes.joinToString(",")
-        properties.setProperty(TracerConfig.PROPAGATION_STYLE_EXTRACT, propagationStyles)
-        properties.setProperty(TracerConfig.PROPAGATION_STYLE_INJECT, propagationStyles)
+        properties.setProperty(TracerConfig.TRACE_PROPAGATION_STYLE_EXTRACT, propagationStyles)
+        properties.setProperty(TracerConfig.TRACE_PROPAGATION_STYLE_INJECT, propagationStyles)
         properties.setProperty(TracerConfig.SERVICE_NAME, serviceName)
         properties.setProperty(TracerConfig.TRACE_RATE_LIMIT, traceRateLimit.toString())
         properties.setProperty(TracerConfig.PARTIAL_FLUSH_MIN_SPANS, partialFlushMinSpans.toString())

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/DatadogTracerBuilderAdapter.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/DatadogTracerBuilderAdapter.kt
@@ -98,7 +98,7 @@ internal class DatadogTracerBuilderAdapter(
     internal fun properties(): Properties {
         val properties = Properties()
 
-        val propagationStyles = tracingHeadersTypes.joinToString(",")
+        val propagationStyles = tracingHeadersTypes.joinToString(",") { it.toPropagationStyle() }
         properties.setProperty(TracerConfig.TRACE_PROPAGATION_STYLE_EXTRACT, propagationStyles)
         properties.setProperty(TracerConfig.TRACE_PROPAGATION_STYLE_INJECT, propagationStyles)
         properties.setProperty(TracerConfig.SERVICE_NAME, serviceName)
@@ -124,5 +124,13 @@ internal class DatadogTracerBuilderAdapter(
         internal const val DEFAULT_SAMPLE_RATE = 100.0
         internal const val DEFAULT_PARTIAL_MIN_FLUSH = 5
         internal const val DEFAULT_URL_AS_RESOURCE_NAME = false
+
+        internal fun TracingHeaderType.toPropagationStyle(): String = when (this) {
+            // dd-trace-java code (TracePropagationStyle.valueOfDisplayName)
+            // treats "B3" as an alias for B3MULTI, not B3 single header.
+            // We must pass this explicitly to get the correct single-header injector.
+            TracingHeaderType.B3 -> "B3SINGLE"
+            else -> name
+        }
     }
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/DatadogTracerBuilderAdapterTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/DatadogTracerBuilderAdapterTest.kt
@@ -69,8 +69,8 @@ class DatadogTracerBuilderAdapterTest {
     fun `M return default properties W properties() {no method called}`() {
         // Given
         val expected = Properties()
-        expected.setProperty(TracerConfig.PROPAGATION_STYLE_EXTRACT, EXPECTED_DEFAULT_PROPAGATION)
-        expected.setProperty(TracerConfig.PROPAGATION_STYLE_INJECT, EXPECTED_DEFAULT_PROPAGATION)
+        expected.setProperty(TracerConfig.TRACE_PROPAGATION_STYLE_EXTRACT, EXPECTED_DEFAULT_PROPAGATION)
+        expected.setProperty(TracerConfig.TRACE_PROPAGATION_STYLE_INJECT, EXPECTED_DEFAULT_PROPAGATION)
         expected.setProperty(TracerConfig.SERVICE_NAME, fakeServiceName)
         expected.setProperty(TracerConfig.TRACE_RATE_LIMIT, Int.MAX_VALUE.toString())
         expected.setProperty(
@@ -106,8 +106,8 @@ class DatadogTracerBuilderAdapterTest {
         )
 
         val expected = Properties().apply {
-            setProperty(TracerConfig.PROPAGATION_STYLE_EXTRACT, fakeHeaderType.toString())
-            setProperty(TracerConfig.PROPAGATION_STYLE_INJECT, fakeHeaderType.toString())
+            setProperty(TracerConfig.TRACE_PROPAGATION_STYLE_EXTRACT, fakeHeaderType.toString())
+            setProperty(TracerConfig.TRACE_PROPAGATION_STYLE_INJECT, fakeHeaderType.toString())
             setProperty(TracerConfig.SERVICE_NAME, fakeServiceName)
             setProperty(TracerConfig.TRACE_RATE_LIMIT, fakeTraceLimit.toString())
             setProperty(TracerConfig.TRACE_SAMPLE_RATE, (fakeSampleRate / 100.0).toString())

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/DatadogTracerBuilderAdapterTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/DatadogTracerBuilderAdapterTest.kt
@@ -9,6 +9,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.api.DatadogTracingConstants.TracerConfig
 import com.datadog.android.trace.internal.DatadogTracerBuilderAdapter.Companion.DEFAULT_URL_AS_RESOURCE_NAME
+import com.datadog.android.trace.internal.DatadogTracerBuilderAdapter.Companion.toPropagationStyle
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.trace.api.DD128bTraceId
 import com.datadog.trace.api.DD64bTraceId
@@ -106,8 +107,8 @@ class DatadogTracerBuilderAdapterTest {
         )
 
         val expected = Properties().apply {
-            setProperty(TracerConfig.TRACE_PROPAGATION_STYLE_EXTRACT, fakeHeaderType.toString())
-            setProperty(TracerConfig.TRACE_PROPAGATION_STYLE_INJECT, fakeHeaderType.toString())
+            setProperty(TracerConfig.TRACE_PROPAGATION_STYLE_EXTRACT, fakeHeaderType.toPropagationStyle())
+            setProperty(TracerConfig.TRACE_PROPAGATION_STYLE_INJECT, fakeHeaderType.toPropagationStyle())
             setProperty(TracerConfig.SERVICE_NAME, fakeServiceName)
             setProperty(TracerConfig.TRACE_RATE_LIMIT, fakeTraceLimit.toString())
             setProperty(TracerConfig.TRACE_SAMPLE_RATE, (fakeSampleRate / 100.0).toString())

--- a/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/TracingHeaderTypePropagationTest.kt
+++ b/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/TracingHeaderTypePropagationTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.android.okhttp
+
+import com.datadog.android.Datadog
+import com.datadog.android.api.SdkCore
+import com.datadog.android.core.stub.StubSDKCore
+import com.datadog.android.okhttp.tests.elmyr.OkHttpConfigurator
+import com.datadog.android.okhttp.trace.TracingInterceptor
+import com.datadog.android.trace.DatadogTracing
+import com.datadog.android.trace.GlobalDatadogTracer
+import com.datadog.android.trace.Trace
+import com.datadog.android.trace.TraceConfiguration
+import com.datadog.android.trace.TraceContextInjection
+import com.datadog.android.trace.TracingHeaderType
+import com.datadog.tools.unit.getFieldValue
+import com.datadog.tools.unit.getStaticValue
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(ExtendWith(ForgeExtension::class))
+@ForgeConfiguration(OkHttpConfigurator::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TracingHeaderTypePropagationTest {
+
+    private lateinit var stubSdkCore: StubSDKCore
+    private lateinit var mockServer: MockWebServer
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        stubSdkCore = StubSDKCore(forge)
+        val registry: Any = Datadog::class.java.getStaticValue("registry")
+        val instances: MutableMap<String, SdkCore> = registry.getFieldValue("instances")
+        instances += stubSdkCore.name to stubSdkCore
+
+        mockServer = MockWebServer()
+
+        Trace.enable(TraceConfiguration.Builder().build(), stubSdkCore)
+    }
+
+    @AfterEach
+    fun `tear down`() {
+        GlobalDatadogTracer.clear()
+        Datadog.stopInstance(stubSdkCore.name)
+        mockServer.shutdown()
+    }
+
+    @Test
+    fun `M inject B3 single header W call is made { B3 configured }`() {
+        verifyHeadersInjected(
+            TracingHeaderType.B3,
+            HEADER_B3
+        )
+    }
+
+    @Test
+    fun `M inject B3Multi headers W call is made { B3MULTI configured }`() {
+        verifyHeadersInjected(
+            TracingHeaderType.B3MULTI,
+            HEADER_B3_TRACE_ID,
+            HEADER_B3_SPAN_ID,
+            HEADER_B3_SAMPLED
+        )
+    }
+
+    @Test
+    fun `M inject Datadog headers W call is made { DATADOG configured }`() {
+        verifyHeadersInjected(
+            TracingHeaderType.DATADOG,
+            HEADER_DD_TRACE_ID,
+            HEADER_DD_PARENT_ID,
+            HEADER_DD_SAMPLING_PRIORITY
+        )
+    }
+
+    @Test
+    fun `M inject TraceContext headers W call is made { TRACECONTEXT configured }`() {
+        verifyHeadersInjected(
+            TracingHeaderType.TRACECONTEXT,
+            HEADER_TRACEPARENT,
+            HEADER_TRACESTATE
+        )
+    }
+
+    // region utilities
+
+    private fun verifyHeadersInjected(
+        headerType: TracingHeaderType,
+        vararg expectedHeaders: String
+    ) {
+        // Given
+        mockServer.enqueue(MockResponse())
+        mockServer.start()
+        val tracer = DatadogTracing.newTracerBuilder(stubSdkCore)
+            .withTracingHeadersTypes(setOf(headerType))
+            .withSampleRate(100.0)
+            .build()
+        GlobalDatadogTracer.registerIfAbsent(tracer)
+        val client = OkHttpClient.Builder()
+            .addInterceptor(
+                TracingInterceptor.Builder(mapOf(mockServer.hostName to setOf(headerType)))
+                    .setTraceContextInjection(TraceContextInjection.ALL)
+                    .setSdkInstanceName(stubSdkCore.name)
+                    .build()
+            )
+            .build()
+
+        // When
+        client.newCall(Request.Builder().url(mockServer.url("/")).build()).execute()
+
+        // Then
+        val recordedRequest = mockServer.takeRequest()
+        expectedHeaders.forEach { header ->
+            assertThat(recordedRequest.getHeader(header)).isNotEmpty()
+        }
+    }
+
+    // endregion
+
+    companion object {
+        // B3 Single header
+        private const val HEADER_B3 = "b3"
+
+        // B3 Multi headers
+        private const val HEADER_B3_TRACE_ID = "X-B3-TraceId"
+        private const val HEADER_B3_SPAN_ID = "X-B3-SpanId"
+        private const val HEADER_B3_SAMPLED = "X-B3-Sampled"
+
+        // Datadog headers
+        private const val HEADER_DD_TRACE_ID = "x-datadog-trace-id"
+        private const val HEADER_DD_PARENT_ID = "x-datadog-parent-id"
+        private const val HEADER_DD_SAMPLING_PRIORITY = "x-datadog-sampling-priority"
+
+        // W3C TraceContext headers
+        private const val HEADER_TRACEPARENT = "traceparent"
+        private const val HEADER_TRACESTATE = "tracestate"
+    }
+}


### PR DESCRIPTION
### What does this PR do?

- Create new `TRACE_PROPAGATION_STYLE_EXTRACT ` & `TRACE_PROPAGATION_STYLE_INJECT ` properties in `DatadogTracingConstants.kt`.
- Deprecate incorrect and old `PROPAGATION_STYLE_EXTRACT` & `PROPAGATION_STYLE_INJECT` that are now unused.
- Map `B3` type to `B3SINGLE` as expected in `dd-trace-java` [TracePropagationStyle](https://github.com/DataDog/dd-trace-java/blob/aa7c70f2e7ca07ce82b920508a5481830508662c/dd-trace-api/src/main/java/datadog/trace/api/TracePropagationStyle.java#L33-L37). Otherwise, it would be silently converted to `B3MULTI`.
- Add tests for all `TracingHeaderType` in `TracingHeaderTypePropagationTest.kt`.

After some set up in `SampleApplication`'s `GlobalDatadogTracer`, `DatadogInterceptor` and `TracingInterceptor`, and using these new constants, we can see the headers are now used and captured with `trackResourceHeaders`:

**B3 (Single)**
<img width="494" height="143" alt="image" src="https://github.com/user-attachments/assets/7798d001-4a84-4511-aa1d-4bc16b87fc02" />

**B3Multi**
<img width="838" height="392" alt="image" src="https://github.com/user-attachments/assets/e4796822-4402-43f6-af72-2a3ef8d6b90f" />

### Motivation

RUM-15423: `DatadogTracerBuilderAdapter` was writing properties with keys `propagation.style.inject/extract`, but `Config.java` reads `trace.propagation.style.inject/extract` [here](https://github.com/DataDog/dd-sdk-android/blob/142528735e9a028fb01386a6d98264296ee257f2/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/api/Config.java#L877-L887), causing a mismatch and fallback to default Datadog + TraceContext.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

