### PR TITLE
RUM-15544: DatadogTracingToolkit.kt -> _TraceInternalProxy

### DIFF
--- a/features/dd-sdk-android-trace-otel/src/main/java/com/datadog/opentelemetry/trace/OtelExtractedContext.java
+++ b/features/dd-sdk-android-trace-otel/src/main/java/com/datadog/opentelemetry/trace/OtelExtractedContext.java
@@ -14,7 +14,7 @@ import com.datadog.android.trace.api.DatadogTracingConstants;
 import com.datadog.android.trace.api.span.DatadogSpanContext;
 import com.datadog.android.trace.api.trace.DatadogTraceId;
 import com.datadog.android.trace.internal.DatadogTraceExtKt;
-import com.datadog.android.trace.internal.DatadogTracingToolkit;
+import com.datadog.android.trace.internal._TraceInternalProxy;
 
 import java.util.Collections;
 import java.util.Locale;
@@ -31,7 +31,7 @@ public class OtelExtractedContext implements DatadogSpanContext {
 
     private OtelExtractedContext(SpanContext context) {
         traceId = DatadogTraceExtKt.fromHex(DatadogTraceId.Companion, context.getTraceId());
-        spanId = DatadogTracingToolkit.spanIdConverter.fromHex(context.getSpanId());
+        spanId = _TraceInternalProxy.spanIdConverter.fromHex(context.getSpanId());
         prioritySampling = context.isSampled()
                 ? DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP
                 : DatadogTracingConstants.PrioritySampling.UNSET;

--- a/features/dd-sdk-android-trace-otel/src/main/java/com/datadog/opentelemetry/trace/OtelSpan.java
+++ b/features/dd-sdk-android-trace-otel/src/main/java/com/datadog/opentelemetry/trace/OtelSpan.java
@@ -21,7 +21,7 @@ import com.datadog.android.trace.api.scope.DatadogScope;
 import com.datadog.android.trace.api.span.DatadogSpan;
 import com.datadog.android.trace.api.span.DatadogSpanContext;
 import com.datadog.android.trace.api.tracer.DatadogTracer;
-import com.datadog.android.trace.internal.DatadogTracingToolkit;
+import com.datadog.android.trace.internal._TraceInternalProxy;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -115,7 +115,7 @@ public class OtelSpan implements Span {
   public Span recordException(Throwable exception, Attributes additionalAttributes) {
     if (this.recording) {
       // Store exception as span tags as span events are not supported yet
-      DatadogTracingToolkit.addThrowable(delegate, exception, DatadogTracingConstants.ErrorPriorities.UNSET);
+      _TraceInternalProxy.addThrowable(delegate, exception, DatadogTracingConstants.ErrorPriorities.UNSET);
     }
     return this;
   }
@@ -153,7 +153,7 @@ public class OtelSpan implements Span {
   }
 
   public DatadogScope activate() {
-    return DatadogTracingToolkit.activateSpan(agentTracer, this.delegate, DEFAULT_ASYNC_PROPAGATING);
+    return _TraceInternalProxy.activateSpan(agentTracer, this.delegate, DEFAULT_ASYNC_PROPAGATING);
   }
 
   public DatadogSpan getDatadogSpan() {

--- a/features/dd-sdk-android-trace-otel/src/main/java/com/datadog/opentelemetry/trace/OtelSpanContext.java
+++ b/features/dd-sdk-android-trace-otel/src/main/java/com/datadog/opentelemetry/trace/OtelSpanContext.java
@@ -10,7 +10,7 @@ import androidx.annotation.VisibleForTesting;
 
 import com.datadog.android.trace.api.span.DatadogSpan;
 import com.datadog.android.trace.api.span.DatadogSpanContext;
-import com.datadog.android.trace.internal.DatadogTracingToolkit;
+import com.datadog.android.trace.internal._TraceInternalProxy;
 
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
@@ -55,7 +55,7 @@ public class OtelSpanContext implements SpanContext {
   @Override
   public String getSpanId() {
     if (this.spanId == null) {
-      this.spanId = DatadogTracingToolkit.spanIdConverter.toHexStringPadded(this.delegate.getSpanId());
+      this.spanId = _TraceInternalProxy.spanIdConverter.toHexStringPadded(this.delegate.getSpanId());
     }
     return this.spanId;
   }

--- a/features/dd-sdk-android-trace-otel/src/main/java/com/datadog/opentelemetry/trace/OtelSpanLink.java
+++ b/features/dd-sdk-android-trace-otel/src/main/java/com/datadog/opentelemetry/trace/OtelSpanLink.java
@@ -13,7 +13,7 @@ import androidx.annotation.Nullable;
 import com.datadog.android.trace.api.span.DatadogSpanLink;
 import com.datadog.android.trace.api.trace.DatadogTraceId;
 import com.datadog.android.trace.internal.DatadogTraceExtKt;
-import com.datadog.android.trace.internal.DatadogTracingToolkit;
+import com.datadog.android.trace.internal._TraceInternalProxy;
 import com.datadog.opentelemetry.context.propagation.TraceStateHelper;
 
 import java.util.Collections;
@@ -37,7 +37,7 @@ public class OtelSpanLink implements DatadogSpanLink {
 
   public OtelSpanLink(SpanContext spanContext, Attributes attributes) {
     traceId = DatadogTraceExtKt.fromHex(DatadogTraceId.Companion, spanContext.getTraceId());
-    spanId = DatadogTracingToolkit.spanIdConverter.fromHex(spanContext.getSpanId());
+    spanId = _TraceInternalProxy.spanIdConverter.fromHex(spanContext.getSpanId());
     sampled = spanContext.isSampled();
     traceState = TraceStateHelper.encodeHeader(spanContext.getTraceState());
     this.attributes = convertAttributes(attributes);

--- a/features/dd-sdk-android-trace-otel/src/main/kotlin/com/datadog/android/trace/opentelemetry/OtelTracerProvider.kt
+++ b/features/dd-sdk-android-trace-otel/src/main/kotlin/com/datadog/android/trace/opentelemetry/OtelTracerProvider.kt
@@ -17,8 +17,8 @@ import com.datadog.android.trace.DatadogTracing
 import com.datadog.android.trace.InternalCoreWriterProvider
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.api.tracer.DatadogTracer
-import com.datadog.android.trace.internal.DatadogTracingToolkit
-import com.datadog.android.trace.internal.DatadogTracingToolkit.setTraceId128BitGenerationEnabled
+import com.datadog.android.trace.internal._TraceInternalProxy
+import com.datadog.android.trace.internal._TraceInternalProxy.setTraceId128BitGenerationEnabled
 import com.datadog.android.trace.opentelemetry.internal.DatadogContextStorageWrapper
 import com.datadog.android.trace.opentelemetry.internal.executeIfJavaFunctionPackageExists
 import com.datadog.opentelemetry.trace.OtelTracerBuilder
@@ -151,7 +151,7 @@ class OtelTracerProvider internal constructor(
         private fun createDatadogTracer(): DatadogTracer {
             val datadogTracer = builderDelegate
                 .withServiceName(serviceName)
-                .also(DatadogTracingToolkit::setSdkV2Compatible)
+                .also(_TraceInternalProxy::setSdkV2Compatible)
                 .build()
 
             return datadogTracer

--- a/features/dd-sdk-android-trace-otel/src/test/kotlin/com/datadog/opentelemetry/trace/OtelSpanTest.kt
+++ b/features/dd-sdk-android-trace-otel/src/test/kotlin/com/datadog/opentelemetry/trace/OtelSpanTest.kt
@@ -10,7 +10,7 @@ import com.datadog.android.trace.api.DatadogTracingConstants.DEFAULT_ASYNC_PROPA
 import com.datadog.android.trace.api.DatadogTracingConstants.ErrorPriorities
 import com.datadog.android.trace.api.span.DatadogSpan
 import com.datadog.android.trace.api.tracer.DatadogTracer
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.trace.opentelemetry.utils.forge.Configurator
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -213,12 +213,12 @@ internal class OtelSpanTest {
     fun `M delegate to AgentSpan W recordException`(@Forgery fakeThrowable: Throwable) {
         // Given
         val mockAttributes: Attributes = mock()
-        Mockito.mockStatic(DatadogTracingToolkit::class.java).use { mockedStatic ->
+        Mockito.mockStatic(_TraceInternalProxy::class.java).use { mockedStatic ->
             // When
             testedSpan.recordException(fakeThrowable, mockAttributes)
             // Then
             mockedStatic.verify {
-                DatadogTracingToolkit.addThrowable(
+                _TraceInternalProxy.addThrowable(
                     mockAgentSpan,
                     fakeThrowable,
                     ErrorPriorities.UNSET
@@ -233,7 +233,7 @@ internal class OtelSpanTest {
         // Given
         testedSpan.end()
         val mockAttributes: Attributes = mock()
-        Mockito.mockStatic(DatadogTracingToolkit::class.java).use { mockedStatic ->
+        Mockito.mockStatic(_TraceInternalProxy::class.java).use { mockedStatic ->
             // When
             testedSpan.recordException(fakeThrowable, mockAttributes)
 
@@ -248,12 +248,12 @@ internal class OtelSpanTest {
 
     @Test
     fun `M delegate to AgentSpan W activate`() {
-        Mockito.mockStatic(DatadogTracingToolkit::class.java).use { mockedStatic ->
+        Mockito.mockStatic(_TraceInternalProxy::class.java).use { mockedStatic ->
             // When
             testedSpan.activate()
             // Then
             mockedStatic.verify {
-                DatadogTracingToolkit.activateSpan(
+                _TraceInternalProxy.activateSpan(
                     mockAgentTracer,
                     mockAgentSpan,
                     DEFAULT_ASYNC_PROPAGATING

--- a/features/dd-sdk-android-trace/api/apiSurface
+++ b/features/dd-sdk-android-trace/api/apiSurface
@@ -70,7 +70,11 @@ class com.datadog.android.trace.internal.DatadogSpanIdConverter
   fun fromHex(String): Long
   fun toHexStringPadded(Long): String
 fun com.datadog.android.trace.api.trace.DatadogTraceId.Companion.fromHex(String): com.datadog.android.trace.api.trace.DatadogTraceId
-object com.datadog.android.trace.internal.DatadogTracingToolkit
+class com.datadog.android.trace.internal.RumContextPropagator
+  constructor(() -> com.datadog.android.api.feature.FeatureSdkCore?)
+  companion object 
+    fun com.datadog.android.trace.api.span.DatadogSpan.extractRumContext(RumContextPropagator, Boolean = false)
+object com.datadog.android.trace.internal._TraceInternalProxy
   val spanIdConverter: DatadogSpanIdConverter
   var propagationHelper: DatadogPropagationHelper
   fun setTracingSamplingPriorityIfNecessary(com.datadog.android.trace.api.span.DatadogSpanContext)
@@ -80,10 +84,6 @@ object com.datadog.android.trace.internal.DatadogTracingToolkit
   fun activateSpan(com.datadog.android.trace.api.tracer.DatadogTracer, com.datadog.android.trace.api.span.DatadogSpan, Boolean): com.datadog.android.trace.api.scope.DatadogScope?
   fun mergeBaggage(String?, String): String
   fun createApmNetworkInstrumentation(String, com.datadog.android.trace.ApmNetworkInstrumentationConfiguration)
-class com.datadog.android.trace.internal.RumContextPropagator
-  constructor(() -> com.datadog.android.api.feature.FeatureSdkCore?)
-  companion object 
-    fun com.datadog.android.trace.api.span.DatadogSpan.extractRumContext(RumContextPropagator, Boolean = false)
 data class com.datadog.android.trace.internal.net.RequestTracingState
   constructor(com.datadog.android.api.instrumentation.network.HttpRequestInfoBuilder, Boolean = false, com.datadog.android.trace.api.span.DatadogSpan? = null, Float? = null)
   fun createRequestInfo(): com.datadog.android.api.instrumentation.network.HttpRequestInfo

--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -133,8 +133,18 @@ public final class com/datadog/android/trace/internal/DatadogTraceExtKt {
 	public static final fun fromHex (Lcom/datadog/android/trace/api/trace/DatadogTraceId$Companion;Ljava/lang/String;)Lcom/datadog/android/trace/api/trace/DatadogTraceId;
 }
 
-public final class com/datadog/android/trace/internal/DatadogTracingToolkit {
-	public static final field INSTANCE Lcom/datadog/android/trace/internal/DatadogTracingToolkit;
+public final class com/datadog/android/trace/internal/RumContextPropagator {
+	public static final field Companion Lcom/datadog/android/trace/internal/RumContextPropagator$Companion;
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+}
+
+public final class com/datadog/android/trace/internal/RumContextPropagator$Companion {
+	public final fun extractRumContext (Lcom/datadog/android/trace/api/span/DatadogSpan;Lcom/datadog/android/trace/internal/RumContextPropagator;Z)Lcom/datadog/android/trace/api/span/DatadogSpan;
+	public static synthetic fun extractRumContext$default (Lcom/datadog/android/trace/internal/RumContextPropagator$Companion;Lcom/datadog/android/trace/api/span/DatadogSpan;Lcom/datadog/android/trace/internal/RumContextPropagator;ZILjava/lang/Object;)Lcom/datadog/android/trace/api/span/DatadogSpan;
+}
+
+public final class com/datadog/android/trace/internal/_TraceInternalProxy {
+	public static final field INSTANCE Lcom/datadog/android/trace/internal/_TraceInternalProxy;
 	public static final field spanIdConverter Lcom/datadog/android/trace/internal/DatadogSpanIdConverter;
 	public static final fun activateSpan (Lcom/datadog/android/trace/api/tracer/DatadogTracer;Lcom/datadog/android/trace/api/span/DatadogSpan;Z)Lcom/datadog/android/trace/api/scope/DatadogScope;
 	public static final fun addThrowable (Lcom/datadog/android/trace/api/span/DatadogSpan;Ljava/lang/Throwable;B)V
@@ -144,16 +154,6 @@ public final class com/datadog/android/trace/internal/DatadogTracingToolkit {
 	public final fun setSdkV2Compatible (Lcom/datadog/android/trace/api/tracer/DatadogTracerBuilder;)Lcom/datadog/android/trace/api/tracer/DatadogTracerBuilder;
 	public final fun setTraceId128BitGenerationEnabled (Lcom/datadog/android/trace/api/tracer/DatadogTracerBuilder;)Lcom/datadog/android/trace/api/tracer/DatadogTracerBuilder;
 	public final fun setTracingSamplingPriorityIfNecessary (Lcom/datadog/android/trace/api/span/DatadogSpanContext;)V
-}
-
-public final class com/datadog/android/trace/internal/RumContextPropagator {
-	public static final field Companion Lcom/datadog/android/trace/internal/RumContextPropagator$Companion;
-	public fun <init> (Lkotlin/jvm/functions/Function0;)V
-}
-
-public final class com/datadog/android/trace/internal/RumContextPropagator$Companion {
-	public final fun extractRumContext (Lcom/datadog/android/trace/api/span/DatadogSpan;Lcom/datadog/android/trace/internal/RumContextPropagator;Z)Lcom/datadog/android/trace/api/span/DatadogSpan;
-	public static synthetic fun extractRumContext$default (Lcom/datadog/android/trace/internal/RumContextPropagator$Companion;Lcom/datadog/android/trace/api/span/DatadogSpan;Lcom/datadog/android/trace/internal/RumContextPropagator;ZILjava/lang/Object;)Lcom/datadog/android/trace/api/span/DatadogSpan;
 }
 
 public final class com/datadog/android/trace/internal/net/RequestTracingState {

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/DatadogTracing.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/DatadogTracing.kt
@@ -14,7 +14,7 @@ import com.datadog.android.trace.api.tracer.DatadogTracerBuilder
 import com.datadog.android.trace.api.tracer.NoOpDatadogTracerBuilder
 import com.datadog.android.trace.internal.DatadogSpanWriterWrapper
 import com.datadog.android.trace.internal.DatadogTracerBuilderAdapter
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.trace.common.writer.NoOpWriter
 import com.datadog.trace.core.CoreTracer
 
@@ -35,8 +35,8 @@ object DatadogTracing {
      */
     @JvmStatic
     fun newTracerBuilder(sdkCore: SdkCore = Datadog.getInstance()): DatadogTracerBuilder = when {
-        DatadogTracingToolkit.testBuilderProvider != null -> {
-            DatadogTracingToolkit.testBuilderProvider as DatadogTracerBuilder
+        _TraceInternalProxy.testBuilderProvider != null -> {
+            _TraceInternalProxy.testBuilderProvider as DatadogTracerBuilder
         }
         sdkCore !is FeatureSdkCore -> {
             NoOpDatadogTracerBuilder()

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ApmNetworkInstrumentation.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ApmNetworkInstrumentation.kt
@@ -26,8 +26,8 @@ import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.api.DatadogTracingConstants
 import com.datadog.android.trace.api.span.DatadogSpan
 import com.datadog.android.trace.api.tracer.DatadogTracer
-import com.datadog.android.trace.internal.DatadogTracingToolkit.propagationHelper
 import com.datadog.android.trace.internal.RumContextPropagator.Companion.extractRumContext
+import com.datadog.android.trace.internal._TraceInternalProxy.propagationHelper
 import com.datadog.android.trace.internal.net.RequestTracingState
 import com.datadog.android.trace.internal.net.TracerProvider
 import com.datadog.android.trace.internal.net.applyPriority

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/DatadogPropagationHelper.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/DatadogPropagationHelper.kt
@@ -172,7 +172,7 @@ class DatadogPropagationHelper internal constructor() {
 
                 W3CHttpCodec.BAGGAGE_KEY -> carrier.replaceHeader(
                     key,
-                    DatadogTracingToolkit.mergeBaggage(
+                    _TraceInternalProxy.mergeBaggage(
                         carrier.resolveExistingBaggageHeaderValue(),
                         value
                     )
@@ -268,7 +268,7 @@ class DatadogPropagationHelper internal constructor() {
             headerSamplingPriority != null -> headerSamplingPriority
 
             datadogSpan != null -> {
-                DatadogTracingToolkit.setTracingSamplingPriorityIfNecessary(datadogSpan.context())
+                _TraceInternalProxy.setTracingSamplingPriorityIfNecessary(datadogSpan.context())
                 datadogSpan.context().samplingPriority > 0
             }
 
@@ -413,7 +413,7 @@ class DatadogPropagationHelper internal constructor() {
             build()
                 .headers[W3CHttpCodec.BAGGAGE_KEY].orEmpty()
                 .reduce { acc, header ->
-                    DatadogTracingToolkit.mergeBaggage(acc, header)
+                    _TraceInternalProxy.mergeBaggage(acc, header)
                 }
         } catch (_: UnsupportedOperationException) {
             // Header values collection is empty

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/_TraceInternalProxy.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/_TraceInternalProxy.kt
@@ -20,7 +20,8 @@ import com.datadog.trace.core.propagation.Baggage
  * Provides implementation for specific interfaces to dependent modules
  */
 @InternalApi
-object DatadogTracingToolkit {
+@Suppress("ClassName")
+object _TraceInternalProxy {
     /**
      * Provides a mechanism for converting Datadog span IDs between decimal and hexadecimal representations.
      *

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExt.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExt.kt
@@ -18,7 +18,7 @@ import com.datadog.android.trace.internal.ApmNetworkInstrumentation.Companion.AL
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation.Companion.SPAN_NAME
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation.Companion.URL_QUERY_PARAMS_BLOCK_SEPARATOR
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation.Companion.ZERO_SAMPLE_RATE
-import com.datadog.android.trace.internal.DatadogTracingToolkit.propagationHelper
+import com.datadog.android.trace.internal._TraceInternalProxy.propagationHelper
 import java.util.Locale
 
 internal val FeatureSdkCore?.isRumEnabled: Boolean

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/TraceInternalProxyTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/TraceInternalProxyTest.kt
@@ -28,7 +28,7 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal class DatadogTracingToolkitTest {
+internal class TraceInternalProxyTest {
 
     private lateinit var fakeTracedHosts: Map<String, Set<TracingHeaderType>>
 
@@ -50,7 +50,7 @@ internal class DatadogTracingToolkitTest {
         val builder = ApmNetworkInstrumentationConfiguration(fakeTracedHosts)
 
         // When
-        val result: ApmNetworkInstrumentation = DatadogTracingToolkit.createApmNetworkInstrumentation(
+        val result: ApmNetworkInstrumentation = _TraceInternalProxy.createApmNetworkInstrumentation(
             fakeInstrumentationName,
             builder
         )
@@ -73,7 +73,7 @@ internal class DatadogTracingToolkitTest {
 
         // When
         val result: ApmNetworkInstrumentation =
-            DatadogTracingToolkit.createApmNetworkInstrumentation(
+            _TraceInternalProxy.createApmNetworkInstrumentation(
                 fakeInstrumentationName,
                 builder
             )

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationTest.kt
@@ -31,7 +31,7 @@ import com.datadog.android.trace.api.tracer.DatadogTracer
 import com.datadog.android.trace.api.withMockPropagationHelper
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation
 import com.datadog.android.trace.internal.DatadogPropagationHelper
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.Forge
@@ -207,7 +207,7 @@ internal class ApmNetworkInstrumentationTest {
     @Test
     fun `M return RequestTraceState with span W onRequest() {traceable first party url}`() {
         // Given
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             val result = checkNotNull(testedInstrumentation.onRequest(mockRequestInfo))
 
@@ -221,7 +221,7 @@ internal class ApmNetworkInstrumentationTest {
     @Test
     fun `M set span resource name W onRequest()`() {
         // Given
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onRequest(mockRequestInfo)
 
@@ -233,7 +233,7 @@ internal class ApmNetworkInstrumentationTest {
     @Test
     fun `M set span tags W onRequest()`() {
         // Given
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onRequest(mockRequestInfo)
 
@@ -250,7 +250,7 @@ internal class ApmNetworkInstrumentationTest {
         whenever(mockLocalFirstPartyHostResolver.isFirstPartyUrl(fakeUrl)) doReturn false
         whenever(mockSdkCore.firstPartyHostResolver.isFirstPartyUrl(fakeUrl)) doReturn false
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             val result = checkNotNull(testedInstrumentation.onRequest(mockRequestInfo))
 
@@ -267,7 +267,7 @@ internal class ApmNetworkInstrumentationTest {
             networkTracingScope = ApmNetworkTracingScope.EXCLUDE_INTERNAL_REDIRECTS
         )
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             val result = checkNotNull(testedInstrumentation.onRequest(mockRequestInfo))
 
@@ -282,7 +282,7 @@ internal class ApmNetworkInstrumentationTest {
         // Given
         whenever(mockTracerProvider.provideTracer(any(), any(), any())) doReturn null
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             val result = checkNotNull(testedInstrumentation.onRequest(mockRequestInfo))
 
@@ -297,7 +297,7 @@ internal class ApmNetworkInstrumentationTest {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)) doReturn false
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             val result = checkNotNull(testedInstrumentation.onRequest(mockRequestInfo))
 
@@ -310,7 +310,7 @@ internal class ApmNetworkInstrumentationTest {
     @Test
     fun `M propagate sampled headers W onRequest() {sampled}`() {
         // Given
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onRequest(mockRequestInfo)
 
@@ -329,7 +329,7 @@ internal class ApmNetworkInstrumentationTest {
         // Given
         whenever(mockTraceSampler.sample(mockSpan)) doReturn false
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onRequest(mockRequestInfo)
 
@@ -353,7 +353,7 @@ internal class ApmNetworkInstrumentationTest {
         whenever(mockSdkCore.firstPartyHostResolver) doReturn mockGlobalResolver
         whenever(mockGlobalResolver.headerTypesForUrl(fakeUrl)) doReturn setOf(TracingHeaderType.TRACECONTEXT)
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onRequest(mockRequestInfo)
 
@@ -375,7 +375,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState()
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseSucceeded(traceState, mockResponseInfo)
 
@@ -394,7 +394,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState()
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseSucceeded(traceState, mockResponseInfo)
 
@@ -413,7 +413,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState()
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseSucceeded(traceState, mockResponseInfo)
 
@@ -429,7 +429,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState()
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseSucceeded(traceState, mockResponseInfo)
 
@@ -447,7 +447,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState()
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseSucceeded(traceState, mockResponseInfo)
 
@@ -466,7 +466,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState(isSampled = fakeIsSampled)
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseSucceeded(traceState, mockResponseInfo)
 
@@ -491,7 +491,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState(isSampled = fakeIsSampled)
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseSucceeded(traceState, mockResponseInfo)
 
@@ -511,7 +511,7 @@ internal class ApmNetworkInstrumentationTest {
         // Given
         val traceState = createTraceState()
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseFailed(traceState, fakeThrowable)
 
@@ -529,7 +529,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState()
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseFailed(traceState, fakeThrowable)
 
@@ -548,7 +548,7 @@ internal class ApmNetworkInstrumentationTest {
         // Given
         val traceState = createTraceState(isSampled = fakeIsSampled)
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseFailed(traceState, fakeThrowable)
 
@@ -569,7 +569,7 @@ internal class ApmNetworkInstrumentationTest {
         // Given
         val traceState = createTraceState(isSampled = false)
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseFailed(traceState, fakeThrowable)
 
@@ -591,7 +591,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState(isSampled = fakeIsSampled)
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseFailed(traceState, fakeThrowable)
 
@@ -616,7 +616,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState()
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseSucceeded(traceState, mockResponseInfo)
 
@@ -635,7 +635,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState()
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseSucceeded(traceState, mockResponseInfo)
 
@@ -656,7 +656,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState()
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseSucceeded(traceState, mockResponseInfo)
 
@@ -677,7 +677,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState()
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseFailed(traceState, fakeThrowable)
 
@@ -694,7 +694,7 @@ internal class ApmNetworkInstrumentationTest {
         // Given - canSendSpan=true is set in setUp
         val traceState = createTraceState()
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseFailed(traceState, fakeThrowable)
 
@@ -714,7 +714,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState()
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseFailed(traceState, fakeThrowable)
 
@@ -733,7 +733,7 @@ internal class ApmNetworkInstrumentationTest {
         // Given
         datadogRegistryClearMethod.invoke(datadogRegistryField.get(null))
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             val result = checkNotNull(testedInstrumentation.onRequest(mockRequestInfo))
 
@@ -755,7 +755,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState(isSampled = fakeIsSampled)
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseSucceeded(traceState, mockResponseInfo)
 
@@ -774,7 +774,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState(isSampled = fakeIsSampled)
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseFailed(traceState, fakeThrowable)
 
@@ -793,7 +793,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState()
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseSucceeded(traceState, mockResponseInfo)
 
@@ -816,7 +816,7 @@ internal class ApmNetworkInstrumentationTest {
 
         val traceState = createTraceState()
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.onResponseFailed(traceState, fakeThrowable)
 
@@ -914,7 +914,7 @@ internal class ApmNetworkInstrumentationTest {
     @Test
     fun `M delegate to propagation helper W removeTracingHeaders()`() {
         // Given
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             testedInstrumentation.removeTracingHeaders(mockRequestBuilder)
 

--- a/features/dd-sdk-android-trace/src/testFixtures/kotlin/com/datadog/android/trace/api/DatadogTracingTestExt.kt
+++ b/features/dd-sdk-android-trace/src/testFixtures/kotlin/com/datadog/android/trace/api/DatadogTracingTestExt.kt
@@ -18,7 +18,7 @@ import com.datadog.android.trace.internal.DatadogSpanContextAdapter
 import com.datadog.android.trace.internal.DatadogTraceIdAdapter
 import com.datadog.android.trace.internal.DatadogTracerAdapter
 import com.datadog.android.trace.internal.DatadogTracerBuilderAdapter
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.trace.api.DDTraceId
 import com.datadog.trace.core.CoreTracer
 import com.datadog.trace.core.DDSpanContext
@@ -47,17 +47,17 @@ fun DatadogSpan.forceSamplingDecision() {
     (this as DatadogSpanAdapter).delegate.forceSamplingDecision()
 }
 
-fun DatadogTracingToolkit.setTracingAdapterBuilderMock(mock: DatadogTracerBuilder?) {
+fun _TraceInternalProxy.setTracingAdapterBuilderMock(mock: DatadogTracerBuilder?) {
     testBuilderProvider = mock
 }
 
-fun DatadogTracingToolkit.clear() {
+fun _TraceInternalProxy.clear() {
     setTracingAdapterBuilderMock(null)
 }
 
-fun DatadogTracingToolkit.withMockPropagationHelper(
+fun _TraceInternalProxy.withMockPropagationHelper(
     mockHelper: DatadogPropagationHelper,
-    block: DatadogTracingToolkit.() -> Unit
+    block: _TraceInternalProxy.() -> Unit
 ) {
     val helper = propagationHelper
     try {

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/trace/SpanExt.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/trace/SpanExt.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.sdk.integration.trace
 
 import com.datadog.android.trace.api.span.DatadogSpan
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 
 /**
  * Returns the span's least significant trace id in hex format (the last 64 bits from the 128 bits trace id)
@@ -27,5 +27,5 @@ fun DatadogSpan.mostSignificant64BitsTraceId(): String {
  * Returns the span's spanId in hex format.
  */
 fun DatadogSpan.spanIdAsHexString(): String {
-    return DatadogTracingToolkit.spanIdConverter.toHexStringPadded(context().spanId)
+    return _TraceInternalProxy.spanIdConverter.toHexStringPadded(context().spanId)
 }

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/trace/TracesTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/trace/TracesTest.kt
@@ -17,7 +17,7 @@ import com.datadog.android.sdk.rules.MockServerActivityTestRule
 import com.datadog.android.sdk.utils.isLogsUrl
 import com.datadog.android.sdk.utils.isTracesUrl
 import com.datadog.android.trace.api.span.DatadogSpan
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.tools.unit.assertj.JsonObjectAssert.Companion.assertThat
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
@@ -124,7 +124,7 @@ internal abstract class TracesTest {
             .hasField(
                 PARENT_ID_KEY,
                 span.parentSpanId?.let {
-                    DatadogTracingToolkit.spanIdConverter.toHexStringPadded(it)
+                    _TraceInternalProxy.spanIdConverter.toHexStringPadded(it)
                 }
                     ?: throw AssertionError("No parentId provided from $span")
             )

--- a/integrations/dd-sdk-android-cronet/src/main/kotlin/com/datadog/android/cronet/CronetIntegrationPlugin.kt
+++ b/integrations/dd-sdk-android-cronet/src/main/kotlin/com/datadog/android/cronet/CronetIntegrationPlugin.kt
@@ -19,7 +19,7 @@ import com.datadog.android.trace.ApmNetworkInstrumentationConfiguration
 import com.datadog.android.trace.ApmNetworkTracingScope
 import com.datadog.android.trace.ExperimentalTraceApi
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 import org.chromium.net.CronetEngine
 import java.util.concurrent.Executor
 import java.util.concurrent.SynchronousQueue
@@ -129,7 +129,7 @@ class CronetIntegrationPlugin internal constructor(
         private fun ApmNetworkInstrumentationConfiguration.createDistributedTracingInstrumentation(
             rumInstrumentationExists: Boolean
         ): ApmNetworkInstrumentation? = if (rumInstrumentationExists) {
-            DatadogTracingToolkit.createApmNetworkInstrumentation(
+            _TraceInternalProxy.createApmNetworkInstrumentation(
                 CRONET_NETWORK_INSTRUMENTATION_NAME,
                 copy()
                     .setHeaderPropagationOnly()
@@ -143,7 +143,7 @@ class CronetIntegrationPlugin internal constructor(
         private fun ApmNetworkInstrumentationConfiguration.createApmInstrumentation(
             rumInstrumentationExists: Boolean
         ): ApmNetworkInstrumentation? = if (!isHeaderPropagationOnly() || !rumInstrumentationExists) {
-            DatadogTracingToolkit.createApmNetworkInstrumentation(
+            _TraceInternalProxy.createApmNetworkInstrumentation(
                 CRONET_NETWORK_INSTRUMENTATION_NAME,
                 this
             )

--- a/integrations/dd-sdk-android-okhttp-otel/src/main/kotlin/com/datadog/android/okhttp/otel/OkHttpExt.kt
+++ b/integrations/dd-sdk-android-okhttp-otel/src/main/kotlin/com/datadog/android/okhttp/otel/OkHttpExt.kt
@@ -8,7 +8,7 @@ package com.datadog.android.okhttp.otel
 
 import com.datadog.android.okhttp.internal.OkHttpRequestInfoBuilder
 import com.datadog.android.trace.api.DatadogTracingConstants
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.opentelemetry.trace.OtelSpan
 import io.opentelemetry.api.trace.Span
 import okhttp3.Request
@@ -23,15 +23,15 @@ fun Request.Builder.addParentSpan(span: Span): Request.Builder = apply {
     // we need to trigger sampling decision at this point, because we are doing context propagation out of OpenTelemetry
     val builder = OkHttpRequestInfoBuilder(this)
     if (span is OtelSpan) {
-        DatadogTracingToolkit.setTracingSamplingPriorityIfNecessary(span.datadogSpanContext)
-        DatadogTracingToolkit.propagationHelper.setTraceContext(
+        _TraceInternalProxy.setTracingSamplingPriorityIfNecessary(span.datadogSpanContext)
+        _TraceInternalProxy.propagationHelper.setTraceContext(
             builder,
             span.spanContext.traceId,
             span.spanContext.spanId,
             span.datadogSpanContext.samplingPriority
         )
     } else {
-        DatadogTracingToolkit.propagationHelper.setTraceContext(
+        _TraceInternalProxy.propagationHelper.setTraceContext(
             builder,
             span.spanContext.traceId,
             span.spanContext.spanId,

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/OkHttpIntegrationPlugin.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/OkHttpIntegrationPlugin.kt
@@ -23,7 +23,7 @@ import com.datadog.android.trace.ApmNetworkInstrumentationConfiguration
 import com.datadog.android.trace.ApmNetworkTracingScope
 import com.datadog.android.trace.ExperimentalTraceApi
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 import okhttp3.EventListener
 import okhttp3.OkHttpClient
 
@@ -168,7 +168,7 @@ class OkHttpIntegrationPlugin internal constructor(
         private fun ApmNetworkInstrumentationConfiguration.createApmInstrumentation(
             rumInstrumentationExists: Boolean
         ) = if (!isHeaderPropagationOnly() || !rumInstrumentationExists) {
-            DatadogTracingToolkit.createApmNetworkInstrumentation(
+            _TraceInternalProxy.createApmNetworkInstrumentation(
                 OKHTTP_NETWORK_INSTRUMENTATION_NAME,
                 this
             )
@@ -179,7 +179,7 @@ class OkHttpIntegrationPlugin internal constructor(
         private fun ApmNetworkInstrumentationConfiguration.createDistributedTracingInstrumentation(
             rumInstrumentationExists: Boolean
         ) = if (rumInstrumentationExists) {
-            DatadogTracingToolkit.createApmNetworkInstrumentation(
+            _TraceInternalProxy.createApmNetworkInstrumentation(
                 OKHTTP_NETWORK_INSTRUMENTATION_NAME,
                 configuration = copy()
                     .setHeaderPropagationOnly()

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -34,9 +34,9 @@ import com.datadog.android.trace.api.DatadogTracingConstants.Tags
 import com.datadog.android.trace.api.span.DatadogSpan
 import com.datadog.android.trace.api.span.DatadogSpanContext
 import com.datadog.android.trace.api.tracer.DatadogTracer
-import com.datadog.android.trace.internal.DatadogTracingToolkit
 import com.datadog.android.trace.internal.RumContextPropagator
 import com.datadog.android.trace.internal.RumContextPropagator.Companion.extractRumContext
+import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.trace.internal.net.TraceContext
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -367,7 +367,7 @@ internal constructor(
         return when {
             headerSamplingPriority != null -> headerSamplingPriority
             datadogSpan != null -> {
-                DatadogTracingToolkit.setTracingSamplingPriorityIfNecessary(datadogSpan.context())
+                _TraceInternalProxy.setTracingSamplingPriorityIfNecessary(datadogSpan.context())
                 datadogSpan.context().samplingPriority > 0
             }
             openTelemetrySpanSamplingPriority == PrioritySampling.UNSET -> null
@@ -441,7 +441,7 @@ internal constructor(
             for ((key, value) in headers) classifier(key, value)
         }
 
-        return if (headerContext != null && DatadogTracingToolkit.propagationHelper.isExtractedContext(headerContext)) {
+        return if (headerContext != null && _TraceInternalProxy.propagationHelper.isExtractedContext(headerContext)) {
             headerContext
         } else {
             tagContext
@@ -450,7 +450,7 @@ internal constructor(
 
     private fun extractTraceContext(request: Request): DatadogSpanContext? =
         request.getTraceContextTag()?.let {
-            DatadogTracingToolkit.propagationHelper.createExtractedContext(
+            _TraceInternalProxy.propagationHelper.createExtractedContext(
                 it.traceId,
                 it.spanId,
                 it.samplingPriority
@@ -623,7 +623,7 @@ internal constructor(
 
                     W3C_BAGGAGE_KEY -> carrier.replaceHeader(
                         key,
-                        DatadogTracingToolkit.mergeBaggage(
+                        _TraceInternalProxy.mergeBaggage(
                             resolveExistingBaggageHeaderValue(carrier),
                             value
                         )

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorContextInjectionSampledTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorContextInjectionSampledTest.kt
@@ -28,7 +28,7 @@ import com.datadog.android.trace.api.trace.DatadogTraceId
 import com.datadog.android.trace.api.tracer.DatadogTracer
 import com.datadog.android.trace.api.withMockPropagationHelper
 import com.datadog.android.trace.internal.DatadogPropagationHelper
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.trace.internal.fromHex
 import com.datadog.android.trace.internal.net.TraceContext
 import com.datadog.android.utils.verifyLog
@@ -488,7 +488,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
     ) {
         // Given
         val fakeExpectedTraceId = DatadogTraceId.fromHex(fakeTraceContext.traceId)
-        val fakeExpectedSpanId = DatadogTracingToolkit.spanIdConverter.fromHex(fakeTraceContext.spanId)
+        val fakeExpectedSpanId = _TraceInternalProxy.spanIdConverter.fromHex(fakeTraceContext.spanId)
         val fakeExtractedContext = forge.newSpanContextMock<DatadogSpanContext>(
             fakeExpectedTraceId,
             fakeExpectedSpanId
@@ -500,7 +500,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
         whenever(mockSpanBuilder.withParentContext(any<DatadogSpanContext>())) doReturn mockSpanBuilder
         whenever(mockPropagationHelper.createExtractedContext(any(), any(), any())).thenReturn(fakeExtractedContext)
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             val response = testedInterceptor.intercept(mockChain)
 
@@ -597,7 +597,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
         stubChain(mockChain, statusCode)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             val response = testedInterceptor.intercept(mockChain)
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
@@ -26,7 +26,7 @@ import com.datadog.android.trace.api.trace.DatadogTraceId
 import com.datadog.android.trace.api.tracer.DatadogTracer
 import com.datadog.android.trace.api.withMockPropagationHelper
 import com.datadog.android.trace.internal.DatadogPropagationHelper
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.utils.verifyLog
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -539,7 +539,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(fakeUrl.toHttpUrl())
         stubChain(mockChain, statusCode)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             val response = testedInterceptor.intercept(mockChain)
 
             assertThat(response).isSameAs(fakeResponse)

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
@@ -27,7 +27,7 @@ import com.datadog.android.trace.api.trace.DatadogTraceId
 import com.datadog.android.trace.api.tracer.DatadogTracer
 import com.datadog.android.trace.api.withMockPropagationHelper
 import com.datadog.android.trace.internal.DatadogPropagationHelper
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.utils.verifyLog
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -625,7 +625,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         stubChain(mockChain, statusCode)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             val response = testedInterceptor.intercept(mockChain)
 
             assertThat(response).isSameAs(fakeResponse)

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
@@ -27,7 +27,7 @@ import com.datadog.android.trace.api.trace.DatadogTraceId
 import com.datadog.android.trace.api.tracer.DatadogTracer
 import com.datadog.android.trace.api.withMockPropagationHelper
 import com.datadog.android.trace.internal.DatadogPropagationHelper
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.utils.verifyLog
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -600,7 +600,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         stubChain(mockChain, statusCode)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             val response = testedInterceptor.intercept(mockChain)
 
             assertThat(response).isSameAs(fakeResponse)

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
@@ -34,7 +34,7 @@ import com.datadog.android.trace.api.trace.DatadogTraceId
 import com.datadog.android.trace.api.tracer.DatadogTracer
 import com.datadog.android.trace.api.withMockPropagationHelper
 import com.datadog.android.trace.internal.DatadogPropagationHelper
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.trace.internal.fromHex
 import com.datadog.android.trace.internal.net.TraceContext
 import com.datadog.android.utils.verifyLog
@@ -703,7 +703,7 @@ internal open class TracingInterceptorTest {
         // Given
 
         val fakeExpectedTraceId = DatadogTraceId.fromHex(fakeTraceContext.traceId)
-        val fakeExpectedSpanId = DatadogTracingToolkit.spanIdConverter.fromHex(fakeTraceContext.spanId)
+        val fakeExpectedSpanId = _TraceInternalProxy.spanIdConverter.fromHex(fakeTraceContext.spanId)
         val fakeExtractedContext = forge.newSpanContextMock<DatadogSpanContext>(
             fakeExpectedTraceId,
             fakeExpectedSpanId
@@ -715,7 +715,7 @@ internal open class TracingInterceptorTest {
         stubChain(mockChain, statusCode)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             val response = testedInterceptor.intercept(mockChain)
 
@@ -815,7 +815,7 @@ internal open class TracingInterceptorTest {
         stubChain(mockChain, statusCode)
         mockPropagation.wheneverInjectThenValueToHeaders(key, value)
 
-        DatadogTracingToolkit.withMockPropagationHelper(mockPropagationHelper) {
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
             val response = testedInterceptor.intercept(mockChain)
 

--- a/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/HeadBasedSamplingTest.kt
+++ b/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/HeadBasedSamplingTest.kt
@@ -28,7 +28,7 @@ import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.api.DatadogTracingConstants
 import com.datadog.android.trace.api.span.DatadogSpan
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.trace.opentelemetry.OtelTracerProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.getFieldValue
@@ -1129,11 +1129,11 @@ class HeadBasedSamplingTest {
     private fun String.toTags(): Map<String, String> = split(",")
         .associate { it.split("=").let { it[0] to it[1] } }
 
-    private fun String.toHexPaddedFromHexString(): String = with(DatadogTracingToolkit.spanIdConverter) {
+    private fun String.toHexPaddedFromHexString(): String = with(_TraceInternalProxy.spanIdConverter) {
         toHexStringPadded(fromHex(this@toHexPaddedFromHexString))
     }
 
-    private fun String.toHexPaddedFromDecimalString(): String = with(DatadogTracingToolkit.spanIdConverter) {
+    private fun String.toHexPaddedFromDecimalString(): String = with(_TraceInternalProxy.spanIdConverter) {
         toHexStringPadded(this@toHexPaddedFromDecimalString.toLong())
     }
 

--- a/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/SpanExtIntegrationTest.kt
+++ b/reliability/single-fit/okhttp/src/test/kotlin/com/datadog/android/okhttp/SpanExtIntegrationTest.kt
@@ -18,7 +18,7 @@ import com.datadog.android.trace.Trace
 import com.datadog.android.trace.TraceConfiguration
 import com.datadog.android.trace.api.replace
 import com.datadog.android.trace.api.span.DatadogSpan
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.trace.withinSpan
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.getFieldValue
@@ -62,7 +62,7 @@ class SpanExtIntegrationTest {
 
     private fun JsonArray.getObject(index: Int) = get(index).asJsonObject
     private fun StubEvent.asJson(): JsonObject = JsonParser.parseString(eventData).asJsonObject
-    private fun DatadogSpan.getSpanId(): String = DatadogTracingToolkit.spanIdConverter
+    private fun DatadogSpan.getSpanId(): String = _TraceInternalProxy.spanIdConverter
         .toHexStringPadded(context().spanId)
     private fun registerTracer(
         sampleRate: Double? = null,

--- a/reliability/single-fit/trace/src/test/kotlin/com/datadog/android/trace/integration/api/SpanExt.kt
+++ b/reliability/single-fit/trace/src/test/kotlin/com/datadog/android/trace/integration/api/SpanExt.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.trace.integration.api
 
 import com.datadog.android.trace.api.span.DatadogSpan
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 
 /**
  * Returns the span's least significant trace id in hex format (the last 64 bits from the 128 bits trace id)
@@ -29,5 +29,5 @@ fun DatadogSpan.mostSignificant64BitsTraceId(): String {
  * which doesn't match what we send in our events
  */
 fun DatadogSpan.spanIdAsHexString(): String {
-    return DatadogTracingToolkit.spanIdConverter.toHexStringPadded(context().spanId)
+    return _TraceInternalProxy.spanIdConverter.toHexStringPadded(context().spanId)
 }

--- a/reliability/single-fit/trace/src/test/kotlin/com/datadog/android/trace/integration/api/UtilitiesTest.kt
+++ b/reliability/single-fit/trace/src/test/kotlin/com/datadog/android/trace/integration/api/UtilitiesTest.kt
@@ -17,7 +17,7 @@ import com.datadog.android.trace.Trace
 import com.datadog.android.trace.TraceConfiguration
 import com.datadog.android.trace.api.clear
 import com.datadog.android.trace.integration.tests.elmyr.TraceIntegrationForgeConfigurator
-import com.datadog.android.trace.internal.DatadogTracingToolkit
+import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.trace.withinSpan
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.google.gson.JsonObject
@@ -60,7 +60,7 @@ class UtilitiesTest {
 
     @AfterEach
     fun `tear down`() {
-        DatadogTracingToolkit.clear()
+        _TraceInternalProxy.clear()
         GlobalDatadogTracer.clear()
     }
 
@@ -146,7 +146,7 @@ class UtilitiesTest {
         assertThat(event0.getString("spans[0].meta._dd.p.id")).isEqualTo(mostSignificantTraceId)
         assertThat(
             event0.getString("spans[0].span_id")
-        ).isEqualTo(DatadogTracingToolkit.spanIdConverter.toHexStringPadded(spanId))
+        ).isEqualTo(_TraceInternalProxy.spanIdConverter.toHexStringPadded(spanId))
         assertThat(event0.getString("spans[0].service")).isEqualTo(stubSdkCore.getDatadogContext().service)
         assertThat(event0.getString("spans[0].meta.version")).isEqualTo(stubSdkCore.getDatadogContext().version)
         assertThat(event0.getString("spans[0].meta._dd.source")).isEqualTo(stubSdkCore.getDatadogContext().source)
@@ -251,7 +251,7 @@ class UtilitiesTest {
         assertThat(
             event0.getString("spans[0].span_id")
         ).isEqualTo(
-            DatadogTracingToolkit.spanIdConverter.toHexStringPadded(spanId)
+            _TraceInternalProxy.spanIdConverter.toHexStringPadded(spanId)
         )
         assertThat(event0.getString("spans[0].service")).isEqualTo(stubSdkCore.getDatadogContext().service)
         assertThat(event0.getString("spans[0].meta.version")).isEqualTo(stubSdkCore.getDatadogContext().version)


### PR DESCRIPTION
### What does this PR do?

Renaming `DatadogTracingToolkit.kt` to `_TraceInternalProxy` in order to make it consistent with existing `_RumInternalProxy` and `InternalProxy` classes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

