### PR TITLE
Reproduce RUMS-5469: TTID not emitted when launch Activity finishes before first draw

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImplTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImplTest.kt
@@ -230,6 +230,88 @@ internal class RumAppStartupDetectorImplTest {
         verifyNoMoreInteractions(listener)
     }
 
+    // region RUMS-5469 reproduction: second Activity invisible to startup detector
+
+    /**
+     * Reproduces RUMS-5469: In the interstitial-Activity pattern used by apps with a splash or
+     * authentication screen, AuthenticationActivity is created first (numberOfActivities == 1, so
+     * [RumAppStartupDetector.Listener.onAppStartupDetected] fires), but it calls finish() before
+     * its decor view draws. MainActivity is then created while AuthenticationActivity is still
+     * alive (numberOfActivities == 2), so [RumAppStartupDetectorImpl.onBeforeActivityCreated]
+     * does NOT call [RumAppStartupDetector.Listener.onAppStartupDetected] for MainActivity.
+     *
+     * Expected (correct) behaviour: when the first Activity finishes before producing a TTID, the
+     * detector should recognise the second Activity as the real launch target and notify the
+     * listener so that a TTID subscription can be set up for it.
+     *
+     * This test asserts the CORRECT behaviour (two calls to [onAppStartupDetected]) and therefore
+     * FAILS against the buggy code — proving that MainActivity is invisible to the startup
+     * detector.
+     */
+    @Test
+    fun `M detect second Activity as startup target W RumAppStartupDetector { interstitial Activity finishes before draw - RUMS-5469 }`(
+        forge: Forge,
+        @BoolForgery hasSavedInstanceStateBundle: Boolean,
+        @BoolForgery hasSavedInstanceStateBundle2: Boolean
+    ) {
+        // Given
+        val detector = createDetector()
+
+        currentTime += 3.seconds
+
+        // When — first Activity (AuthenticationActivity) is created: detection fires for it
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle
+        )
+
+        // AuthenticationActivity finishes before its view draws, but it is NOT yet destroyed
+        // when MainActivity is created — this is the race condition on fast emulators (API 34).
+        // Note: onActivityDestroyed is deliberately NOT called here.
+
+        val activity2 = mock<Activity>()
+        whenever(activity2.isChangingConfigurations) doReturn false
+
+        currentTime += 1.seconds
+
+        triggerBeforeCreated(
+            forge = forge,
+            detector = detector,
+            activity = activity2,
+            hasSavedInstanceStateBundle = hasSavedInstanceStateBundle2
+        )
+
+        // Then — the SDK should have called onAppStartupDetected for BOTH Activities so that
+        // TTID can be re-subscribed to the Activity that actually draws its first frame.
+        // In the buggy code, only ActivityA (AuthenticationActivity) triggers onAppStartupDetected
+        // because numberOfActivities == 2 when ActivityB (MainActivity) is pre-created.
+        // This assertion FAILS in the buggy code, proving MainActivity is invisible to the
+        // startup detector.
+        inOrder(listener) {
+            listener.verifyScenarioDetected(
+                RumStartupScenario.Cold(
+                    initialTime = Time(0, 0),
+                    hasSavedInstanceStateBundle = hasSavedInstanceStateBundle,
+                    activity = activity.wrapWeak(),
+                    appStartActivityOnCreateGapNs = 3.seconds.inWholeNanoseconds
+                )
+            )
+            // The second Activity should also be detected so that TTID can be tracked for it.
+            listener.verifyScenarioDetected(
+                RumStartupScenario.Cold(
+                    initialTime = Time(0, 0),
+                    hasSavedInstanceStateBundle = hasSavedInstanceStateBundle2,
+                    activity = activity2.wrapWeak(),
+                    appStartActivityOnCreateGapNs = 4.seconds.inWholeNanoseconds
+                )
+            )
+        }
+    }
+
+    // endregion
+
     @Test
     fun `M detect Cold only W RumAppStartupDetector {1st Cold, 1st activity stopped and another activity created}`(
         forge: Forge,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumFirstDrawTimeReporterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumFirstDrawTimeReporterTest.kt
@@ -256,6 +256,52 @@ class RumFirstDrawTimeReporterTest {
         }
     }
 
+    // region RUMS-5469 reproduction: TTID not emitted when launch Activity finishes before first draw
+
+    /**
+     * Reproduces RUMS-5469: When the launch Activity (e.g. AuthenticationActivity) calls finish()
+     * before its decor view completes a single draw pass, the [View.OnAttachStateChangeListener]
+     * registered in [RumFirstDrawTimeReporterImpl.onDecorViewReady] receives
+     * [View.OnAttachStateChangeListener.onViewDetachedFromWindow] instead of
+     * [View.OnAttachStateChangeListener.onViewAttachedToWindow]. The current implementation has an
+     * empty body for [View.OnAttachStateChangeListener.onViewDetachedFromWindow] — there is no
+     * fallback and [RumFirstDrawTimeReporter.Callback.onFirstFrameDrawn] is never called, so the
+     * TTID event is silently dropped.
+     *
+     * Expected (correct) behaviour: the SDK should handle the detach-before-draw case gracefully,
+     * e.g. by invoking the callback with a best-effort timestamp so that TTID is still emitted.
+     *
+     * This test asserts the CORRECT behaviour and therefore FAILS against the buggy code, proving
+     * the bug exists.
+     */
+    @Test
+    fun `M call onFirstFrameDrawn W subscribeToFirstFrameDrawn { decorView detaches before first draw - RUMS-5469 }`() {
+        // Given — decor view is not yet attached (fast-finishing interstitial Activity)
+        whenever(window.peekDecorView()) doReturn decorView
+        whenever(decorView.isAttachedToWindow) doReturn false
+
+        currentTime += 1.seconds
+
+        // When
+        reporter.subscribeToFirstFrameDrawn(activity, callback)
+
+        // Capture the OnAttachStateChangeListener that was registered on the decor view
+        val attachListenerCaptor = argumentCaptor<View.OnAttachStateChangeListener>()
+        org.mockito.kotlin.verify(decorView).addOnAttachStateChangeListener(attachListenerCaptor.capture())
+        val attachListener = attachListenerCaptor.firstValue
+
+        // Simulate the Activity finishing before the first draw — onViewDetachedFromWindow fires
+        // without onViewAttachedToWindow ever being called (the no-op bug path)
+        attachListener.onViewDetachedFromWindow(decorView)
+
+        // Then — the SDK should have invoked the callback with a fallback timestamp so that
+        // a TTID event is still emitted. In the buggy code onViewDetachedFromWindow is an empty
+        // body, so this assertion FAILS — proving the missing fallback.
+        org.mockito.kotlin.verify(callback).onFirstFrameDrawn(org.mockito.kotlin.any())
+    }
+
+    // endregion
+
     @Test
     fun `M call internalLogger W addOnDrawListener { if it throws IllegalStateException }`() {
         // Given

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManagerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManagerTest.kt
@@ -554,6 +554,66 @@ internal class RumSessionScopeStartupManagerTest {
         verifyNoMoreInteractions(mockInternalLogger)
     }
 
+    // region RUMS-5469 reproduction: TTFD dropped when TTID never arrives
+
+    /**
+     * Reproduces RUMS-5469: When the launch Activity (e.g. AuthenticationActivity) finishes
+     * before its first draw on emulators (API 34), the first-draw callback is never invoked and
+     * [RumSessionScopeStartupManager.onTTIDEvent] is never called. If the app calls
+     * [com.datadog.android.rum.RumMonitor.reportAppFullyDisplayed] in a subsequent Activity
+     * (MainActivity), [RumSessionScopeStartupManager.onTTFDEvent] fires with
+     * [ttidReportedForScenario] == false. The current code logs a warning and returns early
+     * WITHOUT writing the TTFD event; because TTID also never arrives, the TTFD is permanently
+     * lost.
+     *
+     * Expected (correct) behaviour: when [reportAppFullyDisplayed] is called and TTID has not yet
+     * been reported, the SDK should still emit a TTFD event using the TTFD timestamp directly
+     * (treating TTFD time as the app-fully-displayed duration) rather than silently dropping it.
+     *
+     * This test asserts the CORRECT behaviour (a TTFD event IS written) and therefore FAILS
+     * against the buggy code — proving that TTFD is silently lost in the emulator scenario.
+     */
+    @ParameterizedTest
+    @MethodSource("testScenarios")
+    fun `M write TTFD event W onTTFDEvent { TTID never arrives due to interstitial Activity - RUMS-5469 }`(
+        scenario: RumStartupScenario,
+        forge: Forge
+    ) {
+        // Given — simulate the RUMS-5469 scenario: startup was detected and TTFD was requested,
+        // but TTID never arrived because the first Activity's view detached before drawing.
+        manager.onAppStartEvent(RumRawEvent.AppStartEvent(scenario = scenario))
+
+        val ttfdEvent = forge.createTTFDEvent(scenario.initialTime)
+
+        // When — app calls reportAppFullyDisplayed (e.g. in MainActivity) while TTID has not
+        // been received yet (because the interstitial Activity's view detached before drawing)
+        manager.onTTFDEvent(
+            event = ttfdEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter,
+            rumContext = rumContext,
+            customAttributes = fakeParentAttributes
+        )
+
+        // Simulate that TTID NEVER arrives (the bug: onViewDetachedFromWindow is a no-op).
+        // No call to manager.onTTIDEvent(...) here.
+
+        // Then — the SDK should still write a TTFD event so that the user's
+        // reportAppFullyDisplayed() call is not silently ignored.
+        // In the buggy code this assertion FAILS because onTTFDEvent returns early after logging
+        // the REPORT_APP_FULLY_DISPLAYED_CALLED_BEFORE_TTID_MESSAGE warning without writing
+        // anything.
+        argumentCaptor<VitalAppLaunchEvent> {
+            org.mockito.kotlin.verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue.vital).apply {
+                hasAppLaunchMetric(VitalAppLaunchEvent.AppLaunchMetric.TTFD)
+            }
+        }
+    }
+
+    // endregion
+
     @ParameterizedTest
     @MethodSource("testScenarios")
     fun `M report TTID as TTFD W onTTIDEvent { onTTFDEvent called before onTTIDEvent }`(


### PR DESCRIPTION
## Summary

Reproduces RUMS-5469: Android TTID not emitted on emulators (API 34) when an interstitial
Activity (e.g. AuthenticationActivity) calls finish() before its decor view completes a
single draw pass.

- **Test 1** (`RumFirstDrawTimeReporterTest`): Asserts that when the decor view detaches from
  the window before `onViewAttachedToWindow` fires, `onFirstFrameDrawn` is still called with
  a fallback timestamp. FAILS in buggy code because `onViewDetachedFromWindow` is an empty
  body with no fallback.

- **Test 2** (`RumAppStartupDetectorImplTest`): Asserts that when a second Activity is created
  while the first is still alive (interstitial pattern), `onAppStartupDetected` is called for
  both Activities so that TTID can be tracked for the one that actually draws. FAILS in buggy
  code because `onBeforeActivityCreated` only fires when `numberOfActivities == 1`.

- **Test 3** (`RumSessionScopeStartupManagerTest`): Asserts that when `reportAppFullyDisplayed`
  is called and TTID was never received (because the first Activity's view detached before
  drawing), a TTFD event is still written. FAILS in buggy code because `onTTFDEvent` returns
  early with a warning and never writes anything when TTID has not yet been reported.

## Test plan

- [ ] Run `./gradlew :features:dd-sdk-android-rum:test` — all three new tests should FAIL
  against the current code, confirming the bug exists
- [ ] Verify no existing tests are broken by the new test additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
