### PR TITLE
Reproduce RUMS-5363: duplicate view registration causes duplicate resources

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
@@ -49,6 +49,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -437,6 +438,48 @@ internal class NavigationViewTrackingStrategyTest {
         testedStrategy.onActivityPaused(mockActivity)
 
         verifyNoInteractions(rumMonitor.mockInstance)
+    }
+
+    // region Reproduce RUMS-5363 - duplicate listener registration causes duplicate startView calls
+
+    @Test
+    fun `M register listener only once W startTracking called twice {RUMS-5363}`() {
+        // Given - activity has started so startTracking can proceed
+        testedStrategy.register(rumMonitor.mockSdkCore, mockActivity)
+        testedStrategy.onActivityStarted(mockActivity)
+
+        // When - startTracking is called a second time (e.g. dynamic nav setup)
+        testedStrategy.startTracking()
+
+        // Then - addOnDestinationChangedListener must be called exactly once.
+        // On pre-fix code this fails: the listener is added twice because startTracking()
+        // has no idempotency guard, so this assertion counts times(2) but we assert times(1).
+        verify(mockNavController, times(1)).addOnDestinationChangedListener(testedStrategy)
+    }
+
+    @Test
+    fun `M call startView once W onDestinationChanged after double startTracking {RUMS-5363}`() {
+        // Given - register the listener twice by calling startTracking twice
+        testedStrategy.register(rumMonitor.mockSdkCore, mockActivity)
+        testedStrategy.onActivityStarted(mockActivity)
+        // second call re-registers the same listener instance on the NavController
+        testedStrategy.startTracking()
+        whenever(mockPredicate.accept(mockNavDestination)) doReturn true
+
+        // When - NavController fires the destination-changed event; because the listener was
+        // registered twice, NavController iterates its list and calls onDestinationChanged twice.
+        // We simulate that double-dispatch here to prove the downstream effect.
+        testedStrategy.onDestinationChanged(mockNavController, mockNavDestination, null)
+        testedStrategy.onDestinationChanged(mockNavController, mockNavDestination, null)
+
+        // Then - startView must be called exactly once for the destination.
+        // On pre-fix code this fails: the double dispatch (caused by double registration) produces
+        // two startView calls for the same destination, resulting in duplicate resource events.
+        verify(rumMonitor.mockInstance, times(1)).startView(
+            mockNavDestination,
+            fakeDestinationName,
+            mapOf(ViewScopeInstrumentationType.FRAGMENT.key.toString() to ViewScopeInstrumentationType.FRAGMENT)
+        )
     }
 
     // endregion


### PR DESCRIPTION
## Reproduction for RUMS-5363

**Jira:** [RUMS-5363](https://datadoghq.atlassian.net/browse/RUMS-5363)

### Issue Summary
NavigationViewTrackingStrategy.startTracking() lacks an idempotency guard, allowing the NavController listener to be registered multiple times. This causes duplicate onDestinationChanged callbacks per navigation event, resulting in duplicate startView() calls and ultimately duplicate resource events.

### Root Cause Analysis
NavigationViewTrackingStrategy.startTracking() always calls navController.addOnDestinationChangedListener(this) without checking whether the listener is already registered, so calling startTracking() more than once registers the listener N times.

### Call Chain
NavigationViewTrackingStrategy.startTracking() called N times
→ navController.addOnDestinationChangedListener(this) called N times (no deduplication in NavController)
→ onDestinationChanged() called N times per navigation event
→ rumMonitor.startView() called N times
→ N RumViewScope instances created for same destination
→ Resources duplicated across N active view scopes

### What the Tests Prove
- Test 1: startTracking() called twice results in addOnDestinationChangedListener being called twice (should be once)
- Test 2: Double listener registration causes startView() to be called twice per navigation event (should be once)

---
*Generated by rum:tee-triage-insights*