### PR TITLE
Reproduce RUMS-4466: ANR thread stack duplicated causing inconsistent deobfuscation

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnableTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnableTest.kt
@@ -165,6 +165,55 @@ internal class ANRDetectorRunnableTest {
     }
 
     @Test
+    fun `M not include ANR thread stack in error threads W run() {ANR detected}`() {
+        // Reproduces RUMS-4466: ANRDetectorRunnable.reportAnr() stores anrException.loggableStackTrace()
+        // in allThreads[0].stack AND passes the same anrException as the throwable to addError().
+        // RumViewScope will later derive error.stack from throwable.loggableStackTrace(), making
+        // error.stack == error.threads[0].stack — causing inconsistent server-side deobfuscation.
+        // The fix should remove the ANR thread from error.threads so it is only represented via
+        // error.stack (through the throwable), ensuring the server deobfuscates it consistently.
+
+        // When
+        Thread(testedRunnable).start()
+        Thread.sleep(TEST_ANR_TEST_DELAY_MS)
+
+        // Then
+        Thread.sleep(TEST_ANR_THRESHOLD_MS)
+        argumentCaptor<Map<String, Any?>> {
+            val anrExceptionCaptor = argumentCaptor<Throwable>()
+            verify(rumMonitor.mockInstance).addError(
+                message = eq("Application Not Responding"),
+                source = eq(RumErrorSource.SOURCE),
+                throwable = anrExceptionCaptor.capture(),
+                attributes = capture()
+            )
+
+            @Suppress("UNCHECKED_CAST")
+            val allThreads = lastValue[RumAttributes.INTERNAL_ALL_THREADS] as List<ThreadDump>
+            val anrStackTrace = anrExceptionCaptor.lastValue.loggableStackTrace()
+
+            // The ANR thread's stack should NOT appear in error.threads because it is already
+            // represented via the throwable parameter (which becomes error.stack after deobfuscation).
+            // Including it in both causes inconsistent deobfuscation: error.stack gets deobfuscated
+            // by the server but error.threads[0].stack does not.
+            assertThat(allThreads.none { it.stack == anrStackTrace })
+                .overridingErrorMessage(
+                    "Expected ANR thread stack to NOT appear in error.threads " +
+                        "(it is already in error.stack via the throwable), " +
+                        "but allThreads contained a thread with the same stack as anrException.loggableStackTrace(). " +
+                        "This duplication causes inconsistent server-side deobfuscation (RUMS-4466)."
+                )
+                .isTrue()
+        }
+
+        argumentCaptor<Runnable> {
+            verify(mockHandler).post(capture())
+            testedRunnable.stop()
+            lastValue.run()
+        }
+    }
+
+    @Test
     fun `M not do anything W run() {handler returns false}`() {
         // Given
         whenever(mockHandler.post(any())) doReturn false

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -4801,6 +4801,83 @@ internal class RumViewScopeTest {
     }
 
     @Test
+    fun `M not duplicate ANR thread stack in error threads W handleEvent(AddError) {throwable is ANR}`(
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        forge: Forge
+    ) {
+        // Reproduces RUMS-4466: when ANRDetectorRunnable.reportAnr() fires, it calls addError() with
+        // both anrException as throwable AND allThreads[0] containing anrException.loggableStackTrace()
+        // as stack. RumViewScope emits an ErrorEvent where error.stack == error.threads[0].stack.
+        // The server deobfuscates error.stack but not error.threads, causing inconsistent prettification
+        // (fj class names remain in error.threads UI while error.stack shows the real class names).
+        // The fix should exclude the ANR thread from error.threads so it is only represented via
+        // error.stack (derived from the throwable), ensuring consistent server-side deobfuscation.
+
+        // Given
+        val anrThread = Thread.currentThread()
+        val anrException = ANRException(anrThread)
+        val anrStackTrace = anrException.loggableStackTrace()
+
+        // Simulate allThreads built by ANRDetectorRunnable: ANR thread's stack in threads[0]
+        val anrThreadDump = ThreadDump(
+            name = anrThread.name,
+            state = anrThread.state.name.lowercase(),
+            stack = anrStackTrace,
+            crashed = false
+        )
+        val otherThreadDump = ThreadDump(
+            name = "background-thread",
+            state = "waiting",
+            stack = "at com.example.BackgroundWorker.doWork(BackgroundWorker.java:42)",
+            crashed = false
+        )
+        val allThreads = listOf(anrThreadDump, otherThreadDump)
+
+        testedScope.activeActionScope = mockActionScope
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        fakeEvent = RumRawEvent.AddError(
+            message,
+            source,
+            throwable = anrException,
+            stacktrace = null,
+            isFatal = false,
+            threads = allThreads,
+            attributes = attributes
+        )
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        argumentCaptor<ErrorEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+
+            val errorEvent = firstValue
+            val errorStack = errorEvent.error.stack
+            val errorThreadStacks = errorEvent.error.threads?.map { it.stack } ?: emptyList()
+
+            // error.stack should be populated from the throwable
+            assertThat(errorStack).isNotNull
+            assertThat(errorStack).isEqualTo(anrStackTrace)
+
+            // The ANR thread's stack must NOT appear in error.threads.
+            // If it does, the server will see the same obfuscated frames in error.threads[0].stack
+            // that it deobfuscates in error.stack, producing an inconsistent UI (RUMS-4466).
+            assertThat(errorThreadStacks)
+                .overridingErrorMessage(
+                    "Expected error.threads to NOT contain the ANR thread's stack " +
+                        "(it is already represented in error.stack via the throwable). " +
+                        "Duplicate content in error.threads causes inconsistent server-side " +
+                        "deobfuscation: error.stack is prettified but error.threads is not (RUMS-4466). " +
+                        "Actual error.threads stacks: $errorThreadStacks"
+                )
+                .doesNotContain(anrStackTrace)
+        }
+        assertThat(result).isSameAs(testedScope)
+    }
+
+    @Test
     fun `M send event W handleEvent(AddError) on active view {throwable_message == blank}`(
         @StringForgery message: String,
         @Forgery source: RumErrorSource,


### PR DESCRIPTION
## Reproduction for RUMS-4466

**Jira:** [RUMS-4466](https://datadoghq.atlassian.net/browse/RUMS-4466)

### Issue Summary
ANRDetectorRunnable.reportAnr() adds the ANR thread's stack to both error.stack (via the throwable) and error.threads[0].stack (explicitly). The server deobfuscates error.stack but not error.threads, causing some fj class entries to appear as com.shift4.dblib while others remain obfuscated.

### Reproduction Tests
- 2 unit tests in 2 files:
  - ANRDetectorRunnableTest.kt: asserts ANR thread stack should NOT appear in error.threads
  - RumViewScopeTest.kt: asserts error.threads does not contain the same stack as the throwable

### Root Cause Analysis
ANRDetectorRunnable.reportAnr() creates allThreads[0] with stack = anrException.loggableStackTrace() and also passes anrException as the throwable to addError(). RumViewScope sets error.stack = throwable.loggableStackTrace() — identical to allThreads[0].stack. The resulting ErrorEvent has the same obfuscated frames in both fields. The backend deobfuscates error.stack (3 entries correctly mapped to com.shift4.dblib) but error.threads[0].stack remains obfuscated (same 3 frames = 4 undeobfuscated entries in the UI).

### Call Chain
ANRDetectorRunnable.reportAnr() → allThreads[0].stack = anrException.loggableStackTrace() → addError(ANR_MESSAGE, SOURCE, anrException, mapOf(INTERNAL_ALL_THREADS to allThreads)) → RumViewScope.handleEvent(AddError) → error.stack = throwable.loggableStackTrace() AND error.threads = event.threads → ErrorEvent with duplicate stacks → server deobfuscates error.stack but not error.threads → inconsistent prettification

---
*Generated by rum:tee-triage-insights*