### PR TITLE
Expose trace as api dependency in okhttp module

### DIFF
--- a/integrations/dd-sdk-android-okhttp/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation(project(":dd-sdk-android-internal"))
     implementation(project(":features:dd-sdk-android-rum"))
     implementation(project(":features:dd-sdk-android-trace"))
+    api(project(":features:dd-sdk-android-trace-api"))
     // Generate NoOp implementations
     ksp(project(":tools:noopfactory"))
 

--- a/integrations/dd-sdk-android-okhttp/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp/build.gradle.kts
@@ -50,8 +50,9 @@ dependencies {
     implementation(libs.androidXAnnotation)
     implementation(project(":dd-sdk-android-internal"))
     implementation(project(":features:dd-sdk-android-rum"))
-    implementation(project(":features:dd-sdk-android-trace"))
-    api(project(":features:dd-sdk-android-trace-api"))
+    // TODO RUM-15626: Move TraceContextInjection to dd-sdk-android-trace-api module,
+    //  then replace api(dd-sdk-android-trace) with api(dd-sdk-android-trace-api).
+    api(project(":features:dd-sdk-android-trace"))
     // Generate NoOp implementations
     ksp(project(":tools:noopfactory"))
 


### PR DESCRIPTION
### What does this PR do?

  Exposes `dd-sdk-android-trace` as an `api` dependency of `dd-sdk-android-okhttp`, fixing the following Kotlin compiler warning in consumer modules that don't independently depend on `dd-sdk-android-trace` (namely `dd-sdk android-glide` and `sample/tv`):                                                                                                                                                                                                                                         
  > Cannot access class 'DatadogSpan' in the expression type. This may be forbidden soon.                                                                                                                                                
  > Check the module classpath for missing or conflicting dependencies.

The warning is triggered when calling `TracingInterceptor.BaseBuilder#setTraceSampler(Sampler<DatadogSpan>)`, since `DatadogSpan` (from `trace-api`) was only reachable transitively through `implementation(dd-sdk-android-trace)`, which Gradle hides from consumers' compile classpath.                                                                           

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

