### PR TITLE
Change location of Play SDK console verification token in the published lib

### DIFF
--- a/dd-sdk-android-internal/build.gradle.kts
+++ b/dd-sdk-android-internal/build.gradle.kts
@@ -47,6 +47,14 @@ android {
     testFixtures {
         enable = true
     }
+
+    libraryVariants.all {
+        packageLibraryProvider.configure {
+            from("src/main/resources") {
+                include("META-INF/**/verification.properties")
+            }
+        }
+    }
 }
 
 dependencies {

--- a/features/dd-sdk-android-session-replay-compose/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-compose/build.gradle.kts
@@ -47,6 +47,14 @@ android {
     buildFeatures {
         compose = true
     }
+
+    libraryVariants.all {
+        packageLibraryProvider.configure {
+            from("src/main/resources") {
+                include("META-INF/**/verification.properties")
+            }
+        }
+    }
 }
 
 dependencies {

--- a/features/dd-sdk-android-session-replay-material/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-material/build.gradle.kts
@@ -42,6 +42,14 @@ android {
     }
 
     namespace = "com.datadog.android.sessionreplay.material"
+
+    libraryVariants.all {
+        packageLibraryProvider.configure {
+            from("src/main/resources") {
+                include("META-INF/**/verification.properties")
+            }
+        }
+    }
 }
 
 dependencies {

--- a/features/dd-sdk-android-trace-api/build.gradle.kts
+++ b/features/dd-sdk-android-trace-api/build.gradle.kts
@@ -41,6 +41,14 @@ plugins {
 
 android {
     namespace = "com.datadog.android.trace.api"
+
+    libraryVariants.all {
+        packageLibraryProvider.configure {
+            from("src/main/resources") {
+                include("META-INF/**/verification.properties")
+            }
+        }
+    }
 }
 
 dependencies {

--- a/features/dd-sdk-android-trace-internal/build.gradle.kts
+++ b/features/dd-sdk-android-trace-internal/build.gradle.kts
@@ -40,6 +40,14 @@ plugins {
 
 android {
     namespace = "com.datadog.android.trace.internal"
+
+    libraryVariants.all {
+        packageLibraryProvider.configure {
+            from("src/main/resources") {
+                include("META-INF/**/verification.properties")
+            }
+        }
+    }
 }
 
 dependencies {

--- a/features/dd-sdk-android-trace-otel/build.gradle.kts
+++ b/features/dd-sdk-android-trace-otel/build.gradle.kts
@@ -51,6 +51,14 @@ android {
         )
     }
     namespace = "com.datadog.android.trace.opentelemetry"
+
+    libraryVariants.all {
+        packageLibraryProvider.configure {
+            from("src/main/resources") {
+                include("META-INF/**/verification.properties")
+            }
+        }
+    }
 }
 
 dependencies {

--- a/integrations/dd-sdk-android-apollo/build.gradle.kts
+++ b/integrations/dd-sdk-android-apollo/build.gradle.kts
@@ -35,6 +35,14 @@ plugins {
 
 android {
     namespace = "com.datadog.android.apollo"
+
+    libraryVariants.all {
+        packageLibraryProvider.configure {
+            from("src/main/resources") {
+                include("META-INF/**/verification.properties")
+            }
+        }
+    }
 }
 
 dependencies {

--- a/integrations/dd-sdk-android-coil/build.gradle.kts
+++ b/integrations/dd-sdk-android-coil/build.gradle.kts
@@ -38,6 +38,14 @@ plugins {
 
 android {
     namespace = "com.datadog.android.coil"
+
+    libraryVariants.all {
+        packageLibraryProvider.configure {
+            from("src/main/resources") {
+                include("META-INF/**/verification.properties")
+            }
+        }
+    }
 }
 
 dependencies {

--- a/integrations/dd-sdk-android-compose/build.gradle.kts
+++ b/integrations/dd-sdk-android-compose/build.gradle.kts
@@ -46,6 +46,14 @@ android {
     buildFeatures {
         compose = true
     }
+
+    libraryVariants.all {
+        packageLibraryProvider.configure {
+            from("src/main/resources") {
+                include("META-INF/**/verification.properties")
+            }
+        }
+    }
 }
 
 dependencies {

--- a/integrations/dd-sdk-android-glide/build.gradle.kts
+++ b/integrations/dd-sdk-android-glide/build.gradle.kts
@@ -38,6 +38,14 @@ plugins {
 
 android {
     namespace = "com.datadog.android.glide"
+
+    libraryVariants.all {
+        packageLibraryProvider.configure {
+            from("src/main/resources") {
+                include("META-INF/**/verification.properties")
+            }
+        }
+    }
 }
 
 dependencies {

--- a/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
@@ -37,6 +37,14 @@ plugins {
 
 android {
     namespace = "com.datadog.android.rum.coroutines"
+
+    libraryVariants.all {
+        packageLibraryProvider.configure {
+            from("src/main/resources") {
+                include("META-INF/**/verification.properties")
+            }
+        }
+    }
 }
 
 dependencies {

--- a/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
@@ -37,6 +37,14 @@ plugins {
 
 android {
     namespace = "com.datadog.android.trace.coroutines"
+
+    libraryVariants.all {
+        packageLibraryProvider.configure {
+            from("src/main/resources") {
+                include("META-INF/**/verification.properties")
+            }
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
### What does this PR do?

Follow-up for https://github.com/DataDog/dd-sdk-android/pull/3217, because the verification didn't work.

Right now `verification.properties` is in `xxx.aar/classes.jar/META-INF`, so with this change it will be in `xxx.aar/META-INF` instead.

Verification instructions simply say:

```
Unzip this file in your SDK's parent folder. Make sure the file verification.properties is located inside src/main/resources/META-INF/com/datadoghq/dd-sdk-android-glide

Build your SDK and ensure that the verification file is included in your binary
```

We followed them, it didn't work, so trying something else. `Help` link on the Play SDK console website doesn't work anyway.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

