### PR TITLE
Fix leakCanary for profilable builds

### DIFF
--- a/sample/kotlin/src/main/res/values/values.xml
+++ b/sample/kotlin/src/main/res/values/values.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+  ~ This product includes software developed at Datadog (https://www.datadoghq.com/).
+  ~ Copyright 2016-Present Datadog, Inc.
+  -->
+
+<resources>
+    <bool name="leak_canary_allow_in_non_debuggable_build">true</bool>
+</resources>


### PR DESCRIPTION
### What does this PR do?

Fixing the crash in LeakCanary when the sample app is run in "profiling" mode in Android Studio.

LeakCanary is added using `debugImplementation`, however here debug corresponds to the buildType and sourceSet. LeakCanary checks `android:debuggable` property in the manifest which is removed when you run profiling (checked the manifest).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

