### PR TITLE
Use `SecureRandom` for Trace/Span ID generation, remove usage of `SecureRandom.getStrongInstance`

### DIFF
--- a/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/api/ConfigDefaults.java
+++ b/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/api/ConfigDefaults.java
@@ -172,7 +172,7 @@ public final class ConfigDefaults {
 
   static final boolean DEFAULT_TRACE_128_BIT_TRACEID_GENERATION_ENABLED = true;
   static final boolean DEFAULT_TRACE_128_BIT_TRACEID_LOGGING_ENABLED = false;
-  static final boolean DEFAULT_SECURE_RANDOM = false;
+  static final boolean DEFAULT_SECURE_RANDOM = true;
 
   public static final int DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH = 512;
 

--- a/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/api/IdGenerationStrategy.java
+++ b/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/api/IdGenerationStrategy.java
@@ -2,8 +2,6 @@ package com.datadog.trace.api;
 
 import static java.lang.Long.MAX_VALUE;
 
-import android.os.Build;
-
 import androidx.annotation.VisibleForTesting;
 
 import java.security.SecureRandom;
@@ -99,11 +97,7 @@ public abstract class IdGenerationStrategy {
     private final SecureRandom secureRandom;
 
     private static ThrowingSupplier<SecureRandom> getSecureRandomSupplier() {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        return SecureRandom::getInstanceStrong;
-      }else{
-        return SecureRandom::new;
-      }
+      return SecureRandom::new;
     }
 
     SRandom(boolean traceId128BitGenerationEnabled) {

--- a/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/CoreTracerTest.kt
+++ b/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/CoreTracerTest.kt
@@ -9,6 +9,7 @@ package com.datadog.trace.core
 import com.datadog.tools.unit.createInstance
 import com.datadog.tools.unit.getFieldValue
 import com.datadog.trace.api.Config
+import com.datadog.trace.api.IdGenerationStrategy
 import com.datadog.trace.api.config.TracerConfig
 import com.datadog.trace.api.sampling.PrioritySampling
 import com.datadog.trace.bootstrap.config.provider.ConfigProvider
@@ -180,6 +181,16 @@ internal class CoreTracerTest : DDCoreSpecification() {
 
         // Tear down
         tracer.close()
+    }
+
+    @Test
+    fun `M use secure random generation strategy W build()`() {
+        // When
+        val tracer = tracerBuilder().build()
+
+        // Then
+        val strategy: IdGenerationStrategy = tracer.getFieldValue("idGenerationStrategy")
+        assertThat(strategy.javaClass.simpleName).isEqualTo("SRandom")
     }
 
     companion object {


### PR DESCRIPTION
### What does this PR do?

This PR does the two things:

#### Use `SecureRandom` for `DatadogTracing`

It fixes the regression when we pulled `dd-trace-java`. In RUMM-233 + https://github.com/DataDog/dd-sdk-android/pull/141 we switched to `SecureRandom`, but during the latest pull of `dd-trace-java` we enabled its usage only for Otel, see

https://github.com/DataDog/dd-sdk-android/blob/e293f09f1c310307626e9fcb1fab3168d4699756/features/dd-sdk-android-trace-otel/src/main/kotlin/com/datadog/android/trace/opentelemetry/OtelTracerProvider.kt#L103

and later down the call chain

https://github.com/DataDog/dd-sdk-android/blob/e293f09f1c310307626e9fcb1fab3168d4699756/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/DatadogTracerBuilderAdapter.kt#L87

Small change in `Config.java` activates `SecureRandom` by default.

#### Remove `SecureRandom#getInstanceStrong` usage

[SecureRandom#getInstanceStrong()](https://developer.android.com/reference/java/security/SecureRandom#getInstanceStrong()) returns the generator which calls `/dev/random` and if there is not enough entropy any call to generate a random number will block until there is enough entropy.

Default constructor though is using `/dev/urandom` which doesn't block if there is not enough entropy. This is okay for our needs to generate ID. We are not using plain `Random` because it is using a timestamp as a seed, so span generated on two different devices at the same instant may have same ID.

The change is aligned with [iOS generator](https://github.com/DataDog/dd-sdk-ios/blob/feedabd640984c7f839ca0e191dc79ce05861a82/DatadogInternal/Sources/Models/Trace/TraceID.swift#L224), which is using [SystemRandomNumberGenerator
](https://developer.apple.com/documentation/swift/systemrandomnumbergenerator)

At least on Linux systems it also calls `/dev/urandom` and not `/dev/random`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

