### PR TITLE
Add request to HttpResponseInfo.kt

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -177,7 +177,7 @@ interface com.datadog.android.api.instrumentation.network.HttpResponseInfo
   val headers: Map<String, List<String>>
   val contentType: String?
   val contentLength: Long?
-  val request: HttpRequestInfo
+  val request: HttpRequestInfo?
 interface com.datadog.android.api.instrumentation.network.MutableHttpRequestInfo
   fun newBuilder(): HttpRequestInfoBuilder
 data class com.datadog.android.api.net.Request

--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -177,6 +177,7 @@ interface com.datadog.android.api.instrumentation.network.HttpResponseInfo
   val headers: Map<String, List<String>>
   val contentType: String?
   val contentLength: Long?
+  val request: HttpRequestInfo
 interface com.datadog.android.api.instrumentation.network.MutableHttpRequestInfo
   fun newBuilder(): HttpRequestInfoBuilder
 data class com.datadog.android.api.net.Request

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -499,6 +499,7 @@ public abstract interface class com/datadog/android/api/instrumentation/network/
 	public abstract fun getContentLength ()Ljava/lang/Long;
 	public abstract fun getContentType ()Ljava/lang/String;
 	public abstract fun getHeaders ()Ljava/util/Map;
+	public abstract fun getRequest ()Lcom/datadog/android/api/instrumentation/network/HttpRequestInfo;
 	public abstract fun getStatusCode ()I
 	public abstract fun getUrl ()Ljava/lang/String;
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/instrumentation/network/HttpResponseInfo.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/instrumentation/network/HttpResponseInfo.kt
@@ -38,4 +38,9 @@ interface HttpResponseInfo {
      */
     @get:WorkerThread
     val contentLength: Long?
+
+    /**
+     * Represents the HTTP request associated with the response.
+     */
+    val request: HttpRequestInfo
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/instrumentation/network/HttpResponseInfo.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/instrumentation/network/HttpResponseInfo.kt
@@ -40,7 +40,7 @@ interface HttpResponseInfo {
     val contentLength: Long?
 
     /**
-     * Represents the HTTP request associated with the response.
+     * Represents the HTTP request associated with the response, or null when not available.
      */
-    val request: HttpRequestInfo
+    val request: HttpRequestInfo?
 }

--- a/integrations/dd-sdk-android-cronet/src/main/kotlin/com/datadog/android/cronet/internal/CronetHttpResponseInfo.kt
+++ b/integrations/dd-sdk-android-cronet/src/main/kotlin/com/datadog/android/cronet/internal/CronetHttpResponseInfo.kt
@@ -5,12 +5,14 @@
  */
 package com.datadog.android.cronet.internal
 
+import com.datadog.android.api.instrumentation.network.HttpRequestInfo
 import com.datadog.android.api.instrumentation.network.HttpResponseInfo
 import com.datadog.android.internal.network.HttpSpec
 import org.chromium.net.UrlResponseInfo
 
 internal data class CronetHttpResponseInfo(
-    private val response: UrlResponseInfo
+    private val response: UrlResponseInfo,
+    override val request: HttpRequestInfo
 ) : HttpResponseInfo {
 
     override val url: String get() = response.url
@@ -35,7 +37,7 @@ internal data class CronetHttpResponseInfo(
         get() {
             /*
              *  Content-Length is expected to be declared once or in case of multiple repetitions should have same value.
-             *  Otherwise it's assumed that Content-Length is invalid
+             *  Otherwise, it's assumed that Content-Length is invalid
              *  according to  https://www.rfc-editor.org/rfc/rfc9110.pdf, page 63:
              *
              * Likewise, a sender forward a message with a Content-Length header field value that does not match the ABNF

--- a/integrations/dd-sdk-android-cronet/src/main/kotlin/com/datadog/android/cronet/internal/CronetHttpResponseInfo.kt
+++ b/integrations/dd-sdk-android-cronet/src/main/kotlin/com/datadog/android/cronet/internal/CronetHttpResponseInfo.kt
@@ -5,14 +5,13 @@
  */
 package com.datadog.android.cronet.internal
 
-import com.datadog.android.api.instrumentation.network.HttpRequestInfo
 import com.datadog.android.api.instrumentation.network.HttpResponseInfo
 import com.datadog.android.internal.network.HttpSpec
 import org.chromium.net.UrlResponseInfo
 
 internal data class CronetHttpResponseInfo(
     private val response: UrlResponseInfo,
-    override val request: HttpRequestInfo
+    override val request: CronetHttpRequestInfo?
 ) : HttpResponseInfo {
 
     override val url: String get() = response.url

--- a/integrations/dd-sdk-android-cronet/src/main/kotlin/com/datadog/android/cronet/internal/CronetRequestCallback.kt
+++ b/integrations/dd-sdk-android-cronet/src/main/kotlin/com/datadog/android/cronet/internal/CronetRequestCallback.kt
@@ -102,7 +102,13 @@ internal class CronetRequestCallback(
     ) = delegate.onReadCompleted(request, info, byteBuffer)
 
     private fun finishSuccessRequestTracing(response: UrlResponseInfo?) {
-        val responseInfo = response?.let { CronetHttpResponseInfo(it) }
+        val requestInfo = apmTracingStateHolder.get()?.createRequestInfo()
+            ?: distributedTracingStateHolder.get()?.createRequestInfo()
+        val responseInfo = if (response != null && requestInfo != null) {
+            CronetHttpResponseInfo(response, requestInfo)
+        } else {
+            null
+        }
 
         apmTracingStateHolder.getAndSet(null)?.let { apmTracingState ->
             if (responseInfo != null) {

--- a/integrations/dd-sdk-android-cronet/src/main/kotlin/com/datadog/android/cronet/internal/CronetRequestCallback.kt
+++ b/integrations/dd-sdk-android-cronet/src/main/kotlin/com/datadog/android/cronet/internal/CronetRequestCallback.kt
@@ -102,25 +102,25 @@ internal class CronetRequestCallback(
     ) = delegate.onReadCompleted(request, info, byteBuffer)
 
     private fun finishSuccessRequestTracing(response: UrlResponseInfo?) {
-        val requestInfo = apmTracingStateHolder.get()?.createRequestInfo()
-            ?: distributedTracingStateHolder.get()?.createRequestInfo()
-        val responseInfo = if (response != null && requestInfo != null) {
-            CronetHttpResponseInfo(response, requestInfo)
-        } else {
-            null
-        }
-
         apmTracingStateHolder.getAndSet(null)?.let { apmTracingState ->
-            if (responseInfo != null) {
-                apmNetworkInstrumentation?.onResponseSucceeded(apmTracingState, responseInfo)
+            if (response != null) {
+                val requestInfo = apmTracingState.createRequestInfo() as? CronetHttpRequestInfo
+                apmNetworkInstrumentation?.onResponseSucceeded(
+                    apmTracingState,
+                    CronetHttpResponseInfo(response, requestInfo)
+                )
             }
         } ?: apmNetworkInstrumentation?.reportInstrumentationError {
             "Request tracing state not found for ${response?.url}. Instrumentation may be broken."
         }
 
         distributedTracingStateHolder.getAndSet(null)?.let { distributedTracingState ->
-            if (responseInfo != null) {
-                distributedTracingInstrumentation?.onResponseSucceeded(distributedTracingState, responseInfo)
+            if (response != null) {
+                val requestInfo = distributedTracingState.createRequestInfo() as? CronetHttpRequestInfo
+                distributedTracingInstrumentation?.onResponseSucceeded(
+                    distributedTracingState,
+                    CronetHttpResponseInfo(response, requestInfo)
+                )
             }
         }
     }

--- a/integrations/dd-sdk-android-cronet/src/main/kotlin/com/datadog/android/cronet/internal/CronetRequestFinishedInfoListener.kt
+++ b/integrations/dd-sdk-android-cronet/src/main/kotlin/com/datadog/android/cronet/internal/CronetRequestFinishedInfoListener.kt
@@ -53,7 +53,7 @@ internal class CronetRequestFinishedInfoListener(
             }
 
             RequestFinishedInfo.SUCCEEDED -> {
-                val responseInfo = finishedInfo.responseInfo?.let { CronetHttpResponseInfo(it) }
+                val responseInfo = finishedInfo.responseInfo?.let { CronetHttpResponseInfo(it, requestInfo) }
 
                 if (responseInfo == null) {
                     rumNetworkInstrumentation.stopResourceWithError(

--- a/integrations/dd-sdk-android-cronet/src/main/kotlin/com/datadog/android/cronet/internal/CronetRequestFinishedInfoListener.kt
+++ b/integrations/dd-sdk-android-cronet/src/main/kotlin/com/datadog/android/cronet/internal/CronetRequestFinishedInfoListener.kt
@@ -6,7 +6,6 @@
 package com.datadog.android.cronet.internal
 
 import androidx.annotation.WorkerThread
-import com.datadog.android.api.instrumentation.network.HttpRequestInfo
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.internal.net.RumNetworkInstrumentation
@@ -25,7 +24,7 @@ internal class CronetRequestFinishedInfoListener(
 
     @WorkerThread
     override fun onRequestFinished(finishedInfo: RequestFinishedInfo) {
-        val requestInfo = finishedInfo.annotations?.filterIsInstance<HttpRequestInfo>()?.firstOrNull()
+        val requestInfo = finishedInfo.annotations?.filterIsInstance<CronetHttpRequestInfo>()?.firstOrNull()
         val distributingTracingState = finishedInfo.annotations?.filterIsInstance<RequestTracingState>()?.firstOrNull()
         if (requestInfo == null) {
             rumNetworkInstrumentation.reportInstrumentationError {

--- a/integrations/dd-sdk-android-cronet/src/test/kotlin/com/datadog/android/cronet/internal/CronetRequestCallbackTest.kt
+++ b/integrations/dd-sdk-android-cronet/src/test/kotlin/com/datadog/android/cronet/internal/CronetRequestCallbackTest.kt
@@ -388,6 +388,7 @@ internal class CronetRequestCallbackTest {
         // Given
         val mockDistributedTracingState: RequestTracingState = mock()
         whenever(mockDistributedTracingInstrumentation.onRequest(fakeRequestInfo)) doReturn mockDistributedTracingState
+        whenever(mockDistributedTracingState.createRequestInfo()) doReturn mockMutableRequestInfo
         testedCallback.onRequestStarted(fakeRequestInfo)
 
         // When
@@ -476,6 +477,7 @@ internal class CronetRequestCallbackTest {
         // Given
         val mockDistributedTracingState: RequestTracingState = mock()
         whenever(mockDistributedTracingInstrumentation.onRequest(fakeRequestInfo)) doReturn mockDistributedTracingState
+        whenever(mockDistributedTracingState.createRequestInfo()) doReturn mockMutableRequestInfo
         testedCallback.onRequestStarted(fakeRequestInfo)
 
         // When

--- a/integrations/dd-sdk-android-cronet/src/test/kotlin/com/datadog/android/cronet/internal/CronetRequestCallbackTest.kt
+++ b/integrations/dd-sdk-android-cronet/src/test/kotlin/com/datadog/android/cronet/internal/CronetRequestCallbackTest.kt
@@ -388,7 +388,6 @@ internal class CronetRequestCallbackTest {
         // Given
         val mockDistributedTracingState: RequestTracingState = mock()
         whenever(mockDistributedTracingInstrumentation.onRequest(fakeRequestInfo)) doReturn mockDistributedTracingState
-        whenever(mockDistributedTracingState.createRequestInfo()) doReturn mockMutableRequestInfo
         testedCallback.onRequestStarted(fakeRequestInfo)
 
         // When
@@ -477,7 +476,6 @@ internal class CronetRequestCallbackTest {
         // Given
         val mockDistributedTracingState: RequestTracingState = mock()
         whenever(mockDistributedTracingInstrumentation.onRequest(fakeRequestInfo)) doReturn mockDistributedTracingState
-        whenever(mockDistributedTracingState.createRequestInfo()) doReturn mockMutableRequestInfo
         testedCallback.onRequestStarted(fakeRequestInfo)
 
         // When

--- a/integrations/dd-sdk-android-cronet/src/test/kotlin/com/datadog/android/cronet/internal/CronetRequestFinishedInfoListenerTest.kt
+++ b/integrations/dd-sdk-android-cronet/src/test/kotlin/com/datadog/android/cronet/internal/CronetRequestFinishedInfoListenerTest.kt
@@ -5,7 +5,6 @@
  */
 package com.datadog.android.cronet.internal
 
-import com.datadog.android.api.instrumentation.network.HttpRequestInfo
 import com.datadog.android.cronet.internal.CronetRequestFinishedInfoListener.Companion.minus
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.internal.net.RumNetworkInstrumentation
@@ -54,8 +53,8 @@ internal class CronetRequestFinishedInfoListenerTest {
     @Mock
     private lateinit var mockResponseInfo: UrlResponseInfo
 
-    @Forgery
-    private lateinit var fakeRequestInfo: HttpRequestInfo
+    @Mock
+    private lateinit var fakeRequestInfo: CronetHttpRequestInfo
 
     private lateinit var testedListener: CronetRequestFinishedInfoListener
 

--- a/integrations/dd-sdk-android-cronet/src/test/kotlin/com/datadog/android/cronet/internal/CronetRequestFinishedInfoListenerTest.kt
+++ b/integrations/dd-sdk-android-cronet/src/test/kotlin/com/datadog/android/cronet/internal/CronetRequestFinishedInfoListenerTest.kt
@@ -136,7 +136,7 @@ internal class CronetRequestFinishedInfoListenerTest {
         // Then
         verify(mockRumNetworkInstrumentation).stopResource(
             requestInfo = fakeRequestInfo,
-            responseInfo = CronetHttpResponseInfo(mockResponseInfo)
+            responseInfo = CronetHttpResponseInfo(mockResponseInfo, fakeRequestInfo)
         )
     }
 

--- a/integrations/dd-sdk-android-cronet/src/test/kotlin/com/datadog/android/cronet/internal/CronetResponseInfoTest.kt
+++ b/integrations/dd-sdk-android-cronet/src/test/kotlin/com/datadog/android/cronet/internal/CronetResponseInfoTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.cronet.internal
 
-import com.datadog.android.api.instrumentation.network.HttpRequestInfo
 import com.datadog.android.internal.network.HttpSpec
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.forge.exhaustiveAttributes
@@ -40,7 +39,7 @@ internal class CronetResponseInfoTest {
     lateinit var mockUrlResponseInfo: UrlResponseInfo
 
     @Mock
-    lateinit var mockRequestInfo: HttpRequestInfo
+    lateinit var mockRequestInfo: CronetHttpRequestInfo
 
     lateinit var fakeHeaders: Map<String, List<String>>
 
@@ -132,6 +131,18 @@ internal class CronetResponseInfoTest {
 
         // Then
         assertThat(result).isSameAs(mockRequestInfo)
+    }
+
+    @Test
+    fun `M return null W request property { null request }`() {
+        // Given
+        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo, null)
+
+        // When
+        val result = responseInfo.request
+
+        // Then
+        assertThat(result).isNull()
     }
 
     @Test

--- a/integrations/dd-sdk-android-cronet/src/test/kotlin/com/datadog/android/cronet/internal/CronetResponseInfoTest.kt
+++ b/integrations/dd-sdk-android-cronet/src/test/kotlin/com/datadog/android/cronet/internal/CronetResponseInfoTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.cronet.internal
 
-import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.instrumentation.network.HttpRequestInfo
 import com.datadog.android.internal.network.HttpSpec
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.forge.exhaustiveAttributes
@@ -40,7 +40,7 @@ internal class CronetResponseInfoTest {
     lateinit var mockUrlResponseInfo: UrlResponseInfo
 
     @Mock
-    lateinit var mockInternalLogger: InternalLogger
+    lateinit var mockRequestInfo: HttpRequestInfo
 
     lateinit var fakeHeaders: Map<String, List<String>>
 
@@ -55,7 +55,7 @@ internal class CronetResponseInfoTest {
     ) {
         // Given
         whenever(mockUrlResponseInfo.url).thenReturn(fakeUrl)
-        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo)
+        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo, mockRequestInfo)
 
         // When
         val result = responseInfo.url
@@ -70,7 +70,7 @@ internal class CronetResponseInfoTest {
     ) {
         // Given
         whenever(mockUrlResponseInfo.httpStatusCode).thenReturn(fakeStatusCode)
-        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo)
+        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo, mockRequestInfo)
 
         // When
         val result = responseInfo.statusCode
@@ -84,7 +84,7 @@ internal class CronetResponseInfoTest {
         // Given
 
         whenever(mockUrlResponseInfo.allHeaders).thenReturn(fakeHeaders)
-        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo)
+        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo, mockRequestInfo)
 
         // When
         val result = responseInfo.headers
@@ -100,7 +100,7 @@ internal class CronetResponseInfoTest {
         // Given
         val fakeHeaders = fakeHeaders + mapOf(HttpSpec.Header.CONTENT_TYPE to listOf(fakeContentType))
         whenever(mockUrlResponseInfo.allHeaders).thenReturn(fakeHeaders)
-        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo)
+        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo, mockRequestInfo)
 
         // When
         val result = responseInfo.contentType
@@ -113,7 +113,7 @@ internal class CronetResponseInfoTest {
     fun `M return null W contentType property { no content type header }`() {
         // Given
         whenever(mockUrlResponseInfo.allHeaders).thenReturn(emptyMap())
-        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo)
+        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo, mockRequestInfo)
 
         // When
         val result = responseInfo.contentType
@@ -123,13 +123,25 @@ internal class CronetResponseInfoTest {
     }
 
     @Test
+    fun `M return request W request property`() {
+        // Given
+        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo, mockRequestInfo)
+
+        // When
+        val result = responseInfo.request
+
+        // Then
+        assertThat(result).isSameAs(mockRequestInfo)
+    }
+
+    @Test
     fun `M return content length from header W computeContentLength() { header present }`(
         @LongForgery(min = 1) fakeContentLength: Long
     ) {
         // Given
         val fakeHeaders = fakeHeaders + mapOf(HttpSpec.Header.CONTENT_LENGTH to listOf(fakeContentLength.toString()))
         whenever(mockUrlResponseInfo.allHeaders).thenReturn(fakeHeaders)
-        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo)
+        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo, mockRequestInfo)
 
         // When
         val result = responseInfo.contentLength
@@ -145,7 +157,7 @@ internal class CronetResponseInfoTest {
         // Given
         whenever(mockUrlResponseInfo.allHeaders).thenReturn(emptyMap())
         whenever(mockUrlResponseInfo.receivedByteCount).thenReturn(fakeByteCount)
-        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo)
+        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo, mockRequestInfo)
 
         // When
         val result = responseInfo.contentLength
@@ -159,7 +171,7 @@ internal class CronetResponseInfoTest {
         // Given
         whenever(mockUrlResponseInfo.allHeaders).thenReturn(emptyMap())
         whenever(mockUrlResponseInfo.receivedByteCount).thenReturn(0L)
-        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo)
+        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo, mockRequestInfo)
 
         // When
         val result = responseInfo.contentLength
@@ -173,7 +185,7 @@ internal class CronetResponseInfoTest {
         // Given
         whenever(mockUrlResponseInfo.allHeaders).thenReturn(emptyMap())
         whenever(mockUrlResponseInfo.receivedByteCount).thenReturn(-1L)
-        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo)
+        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo, mockRequestInfo)
 
         // When
         val result = responseInfo.contentLength
@@ -192,7 +204,7 @@ internal class CronetResponseInfoTest {
         )
         whenever(mockUrlResponseInfo.allHeaders).thenReturn(fakeHeaders)
         whenever(mockUrlResponseInfo.receivedByteCount).thenReturn(100L)
-        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo)
+        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo, mockRequestInfo)
 
         // When
         val result = responseInfo.contentLength
@@ -210,7 +222,7 @@ internal class CronetResponseInfoTest {
         val fakeHeaders = fakeHeaders + mapOf(HttpSpec.Header.CONTENT_LENGTH to listOf(fakeHeaderLength.toString()))
         whenever(mockUrlResponseInfo.allHeaders).thenReturn(fakeHeaders)
         whenever(mockUrlResponseInfo.receivedByteCount).thenReturn(fakeByteCount)
-        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo)
+        val responseInfo = CronetHttpResponseInfo(mockUrlResponseInfo, mockRequestInfo)
 
         // When
         val result = responseInfo.contentLength

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/OkHttpResponseInfo.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/OkHttpResponseInfo.kt
@@ -7,6 +7,7 @@ package com.datadog.android.okhttp.internal
 
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.instrumentation.network.HttpRequestInfo
 import com.datadog.android.api.instrumentation.network.HttpResponseInfo
 import okhttp3.Response
 import okhttp3.ResponseBody
@@ -64,6 +65,8 @@ internal class OkHttpResponseInfo(
             )
             null
         }
+
+    override val request: HttpRequestInfo get() = OkHttpRequestInfo(originalResponse.request)
 
     internal companion object {
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/OkHttpResponseInfoTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/OkHttpResponseInfoTest.kt
@@ -91,6 +91,20 @@ internal class OkHttpResponseInfoTest {
     }
 
     @Test
+    fun `M delegate W request property`() {
+        // Given
+        val mockRequest = mock<Request>()
+        val mockResponse = mock<Response> { on { request } doReturn mockRequest }
+
+        // When
+        val result = OkHttpResponseInfo(mockResponse, mockInternalLogger).request
+
+        // Then
+        assertThat(result).isInstanceOf(OkHttpRequestInfo::class.java)
+        assertThat(result.toOkHttpRequest()).isSameAs(mockRequest)
+    }
+
+    @Test
     fun `M delegate W contentType property { content type header present }`(
         @StringForgery fakeContentType: String,
         @StringForgery fakeContentSubType: String


### PR DESCRIPTION
### What does this PR do?

Add a `request` property to `HttpResponseInfo`.

### Motivation

Needed by #3338 to extract headers from the actual on-wire request, which contains all the headers after the chains.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

