### PR TITLE
RUM-15914: Drop word feature from operations APIs

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -124,9 +124,12 @@ interface com.datadog.android.rum.RumMonitor
   fun addViewLoadingTime(Boolean)
   fun addViewAttributes(Map<String, Any?>)
   fun removeViewAttributes(Collection<String>)
-  fun startFeatureOperation(String, String? = null, Map<String, Any?> = emptyMap())
-  fun succeedFeatureOperation(String, String? = null, Map<String, Any?> = emptyMap())
-  fun failFeatureOperation(String, String? = null, com.datadog.android.rum.featureoperations.FailureReason, Map<String, Any?> = emptyMap())
+  DEPRECATED fun startFeatureOperation(String, String? = null, Map<String, Any?> = emptyMap())
+  fun startOperation(String, String? = null, com.datadog.android.rum.operations.OperationOptions = OperationOptions.Empty, Map<String, Any?> = emptyMap())
+  DEPRECATED fun succeedFeatureOperation(String, String? = null, Map<String, Any?> = emptyMap())
+  fun succeedOperation(String, String? = null, Map<String, Any?> = emptyMap())
+  DEPRECATED fun failFeatureOperation(String, String? = null, com.datadog.android.rum.featureoperations.FailureReason, Map<String, Any?> = emptyMap())
+  fun failOperation(String, String? = null, com.datadog.android.rum.operations.FailureReason, Map<String, Any?> = emptyMap())
   fun reportAppFullyDisplayed()
   var debug: Boolean
   fun _getInternal(): _RumInternalProxy?
@@ -201,7 +204,7 @@ enum com.datadog.android.rum.configuration.VitalsUpdateFrequency
   - NEVER
 interface com.datadog.android.rum.event.ViewEventMapper : com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ViewEvent>
   override fun map(com.datadog.android.rum.model.ViewEvent): com.datadog.android.rum.model.ViewEvent
-enum com.datadog.android.rum.featureoperations.FailureReason
+DEPRECATED enum com.datadog.android.rum.featureoperations.FailureReason
   - ERROR
   - ABANDONED
   - OTHER
@@ -268,6 +271,12 @@ class com.datadog.android.rum.metric.networksettled.TimeBasedInitialResourceIden
   companion object 
 typealias RumVitalAppLaunchEvent = VitalAppLaunchEvent
 typealias RumVitalOperationStepEvent = VitalOperationStepEvent
+enum com.datadog.android.rum.operations.FailureReason
+  - ERROR
+  - ABANDONED
+  - OTHER
+sealed class com.datadog.android.rum.operations.OperationOptions
+  object Empty : OperationOptions
 fun android.content.Context.getAssetAsRumResource(String, Int = AssetManager.ACCESS_STREAMING, com.datadog.android.api.SdkCore = Datadog.getInstance()): java.io.InputStream
 fun android.content.Context.getRawResAsRumResource(Int, com.datadog.android.api.SdkCore = Datadog.getInstance()): java.io.InputStream
 fun java.io.InputStream.asRumResource(String, com.datadog.android.api.SdkCore = Datadog.getInstance()): java.io.InputStream

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -163,6 +163,7 @@ public abstract interface class com/datadog/android/rum/RumMonitor {
 	public abstract fun addViewLoadingTime (Z)V
 	public abstract fun clearAttributes ()V
 	public abstract fun failFeatureOperation (Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/featureoperations/FailureReason;Ljava/util/Map;)V
+	public abstract fun failOperation (Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/operations/FailureReason;Ljava/util/Map;)V
 	public abstract fun getAttributes ()Ljava/util/Map;
 	public abstract fun getCurrentSessionId (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun getDebug ()Z
@@ -172,6 +173,7 @@ public abstract interface class com/datadog/android/rum/RumMonitor {
 	public abstract fun setDebug (Z)V
 	public abstract fun startAction (Lcom/datadog/android/rum/RumActionType;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun startFeatureOperation (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun startOperation (Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/operations/OperationOptions;Ljava/util/Map;)V
 	public abstract fun startResource (Ljava/lang/String;Lcom/datadog/android/rum/RumResourceMethod;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun startView (Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun stopAction (Lcom/datadog/android/rum/RumActionType;Ljava/lang/String;Ljava/util/Map;)V
@@ -181,6 +183,7 @@ public abstract interface class com/datadog/android/rum/RumMonitor {
 	public abstract fun stopSession ()V
 	public abstract fun stopView (Ljava/lang/Object;Ljava/util/Map;)V
 	public abstract fun succeedFeatureOperation (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun succeedOperation (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 }
 
 public final class com/datadog/android/rum/RumMonitor$DefaultImpls {
@@ -188,8 +191,10 @@ public final class com/datadog/android/rum/RumMonitor$DefaultImpls {
 	public static synthetic fun addError$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun addErrorWithStacktrace$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun failFeatureOperation$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/featureoperations/FailureReason;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun failOperation$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/operations/FailureReason;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun startAction$default (Lcom/datadog/android/rum/RumMonitor;Lcom/datadog/android/rum/RumActionType;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun startFeatureOperation$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun startOperation$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/operations/OperationOptions;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun startResource$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Lcom/datadog/android/rum/RumResourceMethod;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun startView$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun stopAction$default (Lcom/datadog/android/rum/RumMonitor;Lcom/datadog/android/rum/RumActionType;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
@@ -198,6 +203,7 @@ public final class com/datadog/android/rum/RumMonitor$DefaultImpls {
 	public static synthetic fun stopResourceWithError$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun stopView$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/Object;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun succeedFeatureOperation$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun succeedOperation$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 }
 
 public final class com/datadog/android/rum/RumPerformanceMetric : java/lang/Enum {
@@ -8111,6 +8117,21 @@ public final class com/datadog/android/rum/model/VitalOperationStepEvent$VitalOp
 public final class com/datadog/android/rum/model/VitalOperationStepEvent$VitalOperationStepEventView$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$VitalOperationStepEventView;
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$VitalOperationStepEventView;
+}
+
+public final class com/datadog/android/rum/operations/FailureReason : java/lang/Enum {
+	public static final field ABANDONED Lcom/datadog/android/rum/operations/FailureReason;
+	public static final field ERROR Lcom/datadog/android/rum/operations/FailureReason;
+	public static final field OTHER Lcom/datadog/android/rum/operations/FailureReason;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/operations/FailureReason;
+	public static fun values ()[Lcom/datadog/android/rum/operations/FailureReason;
+}
+
+public abstract class com/datadog/android/rum/operations/OperationOptions {
+}
+
+public final class com/datadog/android/rum/operations/OperationOptions$Empty : com/datadog/android/rum/operations/OperationOptions {
+	public static final field INSTANCE Lcom/datadog/android/rum/operations/OperationOptions$Empty;
 }
 
 public final class com/datadog/android/rum/resource/ContextExtKt {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -4,12 +4,16 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.datadog.android.rum
 
 import android.app.Activity
 import androidx.fragment.app.Fragment
-import com.datadog.android.rum.featureoperations.FailureReason
+import com.datadog.android.rum.operations.FailureReason
+import com.datadog.android.rum.operations.OperationOptions
 import com.datadog.tools.annotation.NoOpImplementation
+import com.datadog.android.rum.featureoperations.FailureReason as DeprecatedFailureReason
 
 /**
  *  A class enabling Datadog RUM features.
@@ -335,8 +339,28 @@ interface RumMonitor {
      * For example, multiple network requests (photo or file uploads) for the same URL.
      * @param attributes additional custom attributes to attach to the feature operation.
      */
-    @ExperimentalRumApi
+    @Deprecated(
+        message = "Use startOperation instead.",
+        replaceWith = ReplaceWith("startOperation(name, operationKey, attributes)")
+    )
     fun startFeatureOperation(name: String, operationKey: String? = null, attributes: Map<String, Any?> = emptyMap())
+
+    /**
+     * Starts the [name] operation.
+     *
+     * @param name the name of the operation.
+     * @param operationKey optional operation key. Allows to track multiple operations of the same [name].
+     * For example, multiple network requests (photo or file uploads) for the same URL.
+     * @param options options to attach to this operation.
+     * @param attributes additional custom attributes to attach to the operation.
+     */
+    @ExperimentalRumApi
+    fun startOperation(
+        name: String,
+        operationKey: String? = null,
+        options: OperationOptions = OperationOptions.Empty,
+        attributes: Map<String, Any?> = emptyMap()
+    )
 
     /**
      * Finishes the [name] feature operation with successful status.
@@ -348,8 +372,24 @@ interface RumMonitor {
      * @param attributes additional custom attributes to attach to the feature operation. Can be
      * used to add some result data produced as the result of the operation.
      */
-    @ExperimentalRumApi
+    @Deprecated(
+        message = "Use succeedOperation instead.",
+        replaceWith = ReplaceWith("succeedOperation(name, operationKey, attributes)")
+    )
     fun succeedFeatureOperation(name: String, operationKey: String? = null, attributes: Map<String, Any?> = emptyMap())
+
+    /**
+     * Finishes the [name] operation with successful status.
+     *
+     * @param name the name of the operation.
+     * @param operationKey optional operation key identifying a specific operation
+     * instance from the list of operations of the same [name]. Should be provided if [operationKey] was
+     * provided during [startOperation] invocation.
+     * @param attributes additional custom attributes to attach to the operation. Can be
+     * used to add some result data produced as the result of the operation.
+     */
+    @ExperimentalRumApi
+    fun succeedOperation(name: String, operationKey: String? = null, attributes: Map<String, Any?> = emptyMap())
 
     /**
      * Finishes the [name] feature operation with failure status.
@@ -362,8 +402,31 @@ interface RumMonitor {
      * @param attributes additional custom attributes to attach to the feature operation. Can be
      * used to add some result data produced as the result of the operation.
      */
-    @ExperimentalRumApi
+    @Deprecated(
+        message = "Use failOperation instead.",
+        replaceWith = ReplaceWith("failOperation(name, operationKey, failureReason, attributes)")
+    )
     fun failFeatureOperation(
+        name: String,
+        operationKey: String? = null,
+        // when removing this remove @Suppress("DEPRECATION") also at the file level (for the import)
+        @Suppress("DEPRECATION") failureReason: DeprecatedFailureReason,
+        attributes: Map<String, Any?> = emptyMap()
+    )
+
+    /**
+     * Finishes the [name] operation with failure status.
+     *
+     * @param name the name of the operation.
+     * @param operationKey optional operation key identifying a specific operation
+     * instance from the list of operations of the same [name]. Should be provided if [operationKey] was
+     * provided during [startOperation] invocation.
+     * @param failureReason the reason for the operation failure.
+     * @param attributes additional custom attributes to attach to the operation. Can be
+     * used to add some result data produced as the result of the operation.
+     */
+    @ExperimentalRumApi
+    fun failOperation(
         name: String,
         operationKey: String? = null,
         failureReason: FailureReason,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
@@ -14,7 +14,6 @@ import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
-import com.datadog.android.rum.featureoperations.FailureReason
 import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.internal.startup.RumStartupScenario
@@ -25,6 +24,7 @@ import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.rum.model.VitalAppLaunchEvent
 import com.datadog.android.rum.model.VitalOperationStepEvent
+import com.datadog.android.rum.operations.FailureReason
 import java.util.Locale
 
 // region Resource.Method conversion
@@ -715,7 +715,7 @@ internal fun RumSessionScope.StartReason.toLongTaskSessionPrecondition(): LongTa
 
 // endregion
 
-// region FeatureOperation
+// region Operation
 
 internal fun RumSessionScope.StartReason.toVitalOperationStepSessionPrecondition():
     VitalOperationStepEvent.SessionPrecondition {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -13,13 +13,13 @@ import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
-import com.datadog.android.rum.featureoperations.FailureReason
 import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.internal.startup.RumStartupScenario
 import com.datadog.android.rum.internal.startup.RumTTIDInfo
 import com.datadog.android.rum.model.ActionEvent
+import com.datadog.android.rum.operations.FailureReason
 
 internal sealed class RumRawEvent {
 
@@ -255,14 +255,14 @@ internal sealed class RumRawEvent {
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 
-    internal data class StartFeatureOperation(
+    internal data class StartOperation(
         val name: String,
         val operationKey: String?,
         val attributes: Map<String, Any?>,
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 
-    internal data class StopFeatureOperation(
+    internal data class StopOperation(
         val name: String,
         val operationKey: String?,
         val attributes: Map<String, Any?>,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -433,8 +433,8 @@ internal class RumViewManagerScope(
             RumRawEvent.AddError::class.java,
             RumRawEvent.StartAction::class.java,
             RumRawEvent.StartResource::class.java,
-            RumRawEvent.StartFeatureOperation::class.java,
-            RumRawEvent.StopFeatureOperation::class.java
+            RumRawEvent.StartOperation::class.java,
+            RumRawEvent.StopOperation::class.java
         )
 
         internal val silentOrphanEventTypes = arrayOf<Class<*>>(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -240,8 +240,8 @@ internal open class RumViewScope(
             is RumRawEvent.AddViewAttributes -> onAddViewAttributes(event)
             is RumRawEvent.RemoveViewAttributes -> onRemoveViewAttributes(event)
 
-            is RumRawEvent.StartFeatureOperation -> onStartFeatureOperation(event, datadogContext, writeScope, writer)
-            is RumRawEvent.StopFeatureOperation -> onStopFeatureOperation(event, datadogContext, writeScope, writer)
+            is RumRawEvent.StartOperation -> onStartOperation(event, datadogContext, writeScope, writer)
+            is RumRawEvent.StopOperation -> onStopOperation(event, datadogContext, writeScope, writer)
 
             else -> delegateEventToChildren(event, datadogContext, writeScope, writer)
         }
@@ -256,8 +256,8 @@ internal open class RumViewScope(
         }
     }
 
-    private fun onStartFeatureOperation(
-        event: RumRawEvent.StartFeatureOperation,
+    private fun onStartOperation(
+        event: RumRawEvent.StartOperation,
         datadogContext: DatadogContext,
         writeScope: EventWriteScope,
         writer: DataWriter<Any>
@@ -278,8 +278,8 @@ internal open class RumViewScope(
         sendViewUpdate(event, datadogContext, writeScope, writer)
     }
 
-    private fun onStopFeatureOperation(
-        event: RumRawEvent.StopFeatureOperation,
+    private fun onStopOperation(
+        event: RumRawEvent.StopOperation,
         datadogContext: DatadogContext,
         writeScope: EventWriteScope,
         writer: DataWriter<Any>

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -4,6 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.datadog.android.rum.internal.monitor
 
 import android.app.Activity
@@ -40,7 +42,6 @@ import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum._RumInternalProxy
-import com.datadog.android.rum.featureoperations.FailureReason
 import com.datadog.android.rum.internal.CombinedRumSessionListener
 import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.RumFeature
@@ -66,6 +67,8 @@ import com.datadog.android.rum.internal.startup.RumTTIDInfo
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.metric.interactiontonextview.LastInteractionIdentifier
 import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
+import com.datadog.android.rum.operations.FailureReason
+import com.datadog.android.rum.operations.OperationOptions
 import com.datadog.android.rum.resource.ResourceId
 import com.datadog.android.telemetry.internal.TelemetryEventHandler
 import java.util.Locale
@@ -75,6 +78,7 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import com.datadog.android.rum.featureoperations.FailureReason as DeprecatedFailureReason
 
 @Suppress("LongParameterList", "LargeClass", "TooManyFunctions")
 internal class DatadogRumMonitor(
@@ -690,14 +694,25 @@ internal class DatadogRumMonitor(
 
     // endregion
 
-    // region Feature Operations
+    // region Operations
+
+    @OptIn(ExperimentalRumApi::class)
+    @Deprecated("Use startOperation instead.", replaceWith = ReplaceWith("startOperation"))
+    override fun startFeatureOperation(name: String, operationKey: String?, attributes: Map<String, Any?>) {
+        startOperation(name, operationKey, OperationOptions.Empty, attributes)
+    }
 
     @ExperimentalRumApi
-    override fun startFeatureOperation(name: String, operationKey: String?, attributes: Map<String, Any?>) {
-        if (!featureOperationArgumentsValid(name, operationKey)) return
+    override fun startOperation(
+        name: String,
+        operationKey: String?,
+        options: OperationOptions,
+        attributes: Map<String, Any?>
+    ) {
+        if (!operationArgumentsValid(name, operationKey)) return
 
         handleEvent(
-            RumRawEvent.StartFeatureOperation(
+            RumRawEvent.StartOperation(
                 name,
                 operationKey,
                 attributes.toMap(),
@@ -705,17 +720,27 @@ internal class DatadogRumMonitor(
             )
         )
         sdkCore.internalLogger.logToUser(InternalLogger.Level.DEBUG) {
-            "Feature Operation `$name` (operationKey `$operationKey`) started."
+            "Operation `$name` (operationKey `$operationKey`) started."
         }
-        sdkCore.internalLogger.reportFeatureOperationApiUsage(ActionType.START)
+        sdkCore.internalLogger.reportOperationApiUsage(ActionType.START)
+    }
+
+    @OptIn(ExperimentalRumApi::class)
+    @Deprecated("Use succeedOperation instead.", replaceWith = ReplaceWith("succeedOperation"))
+    override fun succeedFeatureOperation(name: String, operationKey: String?, attributes: Map<String, Any?>) {
+        succeedOperation(name, operationKey, attributes)
     }
 
     @ExperimentalRumApi
-    override fun succeedFeatureOperation(name: String, operationKey: String?, attributes: Map<String, Any?>) {
-        if (!featureOperationArgumentsValid(name, operationKey)) return
+    override fun succeedOperation(
+        name: String,
+        operationKey: String?,
+        attributes: Map<String, Any?>
+    ) {
+        if (!operationArgumentsValid(name, operationKey)) return
 
         handleEvent(
-            RumRawEvent.StopFeatureOperation(
+            RumRawEvent.StopOperation(
                 name,
                 operationKey,
                 attributes.toMap(),
@@ -724,22 +749,40 @@ internal class DatadogRumMonitor(
             )
         )
         sdkCore.internalLogger.logToUser(InternalLogger.Level.DEBUG) {
-            "Feature Operation `$name` (operationKey `$operationKey`) successfully ended."
+            "Operation `$name` (operationKey `$operationKey`) successfully ended."
         }
-        sdkCore.internalLogger.reportFeatureOperationApiUsage(ActionType.SUCCEED)
+        sdkCore.internalLogger.reportOperationApiUsage(ActionType.SUCCEED)
+    }
+
+    @OptIn(ExperimentalRumApi::class)
+    @Deprecated("Use failOperation instead.", replaceWith = ReplaceWith("failOperation"))
+    override fun failFeatureOperation(
+        name: String,
+        operationKey: String?,
+        // when removing this remove @Suppress("DEPRECATION") also at the file level (for the import)
+        @Suppress("DEPRECATION") failureReason: DeprecatedFailureReason,
+        attributes: Map<String, Any?>
+    ) {
+        @Suppress("DEPRECATION")
+        val newFailureReason = when (failureReason) {
+            DeprecatedFailureReason.ERROR -> FailureReason.ERROR
+            DeprecatedFailureReason.ABANDONED -> FailureReason.ABANDONED
+            DeprecatedFailureReason.OTHER -> FailureReason.OTHER
+        }
+        failOperation(name, operationKey, newFailureReason, attributes)
     }
 
     @ExperimentalRumApi
-    override fun failFeatureOperation(
+    override fun failOperation(
         name: String,
         operationKey: String?,
         failureReason: FailureReason,
         attributes: Map<String, Any?>
     ) {
-        if (!featureOperationArgumentsValid(name, operationKey)) return
+        if (!operationArgumentsValid(name, operationKey)) return
 
         handleEvent(
-            RumRawEvent.StopFeatureOperation(
+            RumRawEvent.StopOperation(
                 name,
                 operationKey,
                 attributes.toMap(),
@@ -748,23 +791,23 @@ internal class DatadogRumMonitor(
             )
         )
         sdkCore.internalLogger.logToUser(InternalLogger.Level.DEBUG) {
-            "Feature Operation `$name` (operationKey `$operationKey`) unsuccessfully ended" +
+            "Operation `$name` (operationKey `$operationKey`) unsuccessfully ended" +
                 " with the following failure reason: $failureReason."
         }
-        sdkCore.internalLogger.reportFeatureOperationApiUsage(ActionType.FAIL)
+        sdkCore.internalLogger.reportOperationApiUsage(ActionType.FAIL)
     }
 
-    private fun featureOperationArgumentsValid(name: String, operationKey: String?) = when {
+    private fun operationArgumentsValid(name: String, operationKey: String?) = when {
         name.isBlank() -> {
             sdkCore.internalLogger.logToUser(InternalLogger.Level.WARN) {
-                FO_ERROR_INVALID_NAME.format(Locale.US, name)
+                OPERATION_ERROR_INVALID_NAME.format(Locale.US, name)
             }
             false
         }
 
         operationKey?.isBlank() == true -> {
             sdkCore.internalLogger.logToUser(InternalLogger.Level.WARN) {
-                FO_ERROR_INVALID_OPERATION_KEY.format(Locale.US, operationKey)
+                OPERATION_ERROR_INVALID_OPERATION_KEY.format(Locale.US, operationKey)
             }
             false
         }
@@ -949,13 +992,13 @@ internal class DatadogRumMonitor(
         internal const val CANNOT_WRITE_CRASH_WRITE_CONTEXT_IS_NOT_AVAILABLE =
             "Cannot write JVM crash, because write context is not available."
 
-        internal const val FO_ERROR_INVALID_NAME =
-            "Feature operation name cannot be an empty or blank string but was \"%s\". Vital event won't be sent."
+        internal const val OPERATION_ERROR_INVALID_NAME =
+            "Operation name cannot be an empty or blank string but was \"%s\". Vital event won't be sent."
 
-        internal const val FO_ERROR_INVALID_OPERATION_KEY =
-            "Feature operation key cannot be an empty or blank string but was \"%s\". Vital event won't be sent."
+        internal const val OPERATION_ERROR_INVALID_OPERATION_KEY =
+            "Operation key cannot be an empty or blank string but was \"%s\". Vital event won't be sent."
 
-        private fun InternalLogger.reportFeatureOperationApiUsage(actionType: ActionType) = logApiUsage {
+        private fun InternalLogger.reportOperationApiUsage(actionType: ActionType) = logApiUsage {
             InternalTelemetryEvent.ApiUsage.AddOperationStepVital(actionType)
         }
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/operations/FailureReason.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/operations/FailureReason.kt
@@ -3,18 +3,11 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2016-Present Datadog, Inc.
  */
-package com.datadog.android.rum.featureoperations
+package com.datadog.android.rum.operations
 
 /**
- * Represents the possible reasons for a failed feature operation.
+ * Represents the possible reasons for a failed operation.
  */
-@Deprecated(
-    "Use com.datadog.android.rum.operations.FailureReason instead",
-    replaceWith = ReplaceWith(
-        expression = "FailureReason",
-        imports = ["com.datadog.android.rum.operations.FailureReason"]
-    )
-)
 enum class FailureReason {
     /**
      * Represents a failure caused by an error during execution.

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/operations/OperationOptions.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/operations/OperationOptions.kt
@@ -1,0 +1,17 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.operations
+
+/**
+ * Options to attach to the operation.
+ */
+sealed class OperationOptions {
+    /**
+     * No options.
+     */
+    object Empty : OperationOptions()
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/VitalOperationPropertiesAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/VitalOperationPropertiesAssert.kt
@@ -6,16 +6,16 @@
 
 package com.datadog.android.rum.assertj
 
-import com.datadog.android.rum.featureoperations.FailureReason
 import com.datadog.android.rum.internal.domain.scope.toSchemaFailureReason
 import com.datadog.android.rum.model.VitalOperationStepEvent
+import com.datadog.android.rum.operations.FailureReason
 import org.assertj.core.api.AbstractObjectAssert
 import org.assertj.core.api.Assertions.assertThat
 
-internal class VitalFeatureOperationPropertiesAssert(actual: VitalOperationStepEvent.Vital) :
-    AbstractObjectAssert<VitalFeatureOperationPropertiesAssert, VitalOperationStepEvent.Vital>(
+internal class VitalOperationPropertiesAssert(actual: VitalOperationStepEvent.Vital) :
+    AbstractObjectAssert<VitalOperationPropertiesAssert, VitalOperationStepEvent.Vital>(
         actual,
-        VitalFeatureOperationPropertiesAssert::class.java
+        VitalOperationPropertiesAssert::class.java
     ) {
 
     fun hasVitalName(expected: String) = apply {
@@ -61,7 +61,6 @@ internal class VitalFeatureOperationPropertiesAssert(actual: VitalOperationStepE
     companion object {
         internal fun assertThat(
             actual: VitalOperationStepEvent.Vital
-        ): VitalFeatureOperationPropertiesAssert =
-            VitalFeatureOperationPropertiesAssert(actual)
+        ): VitalOperationPropertiesAssert = VitalOperationPropertiesAssert(actual)
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
@@ -10,9 +10,9 @@ import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
-import com.datadog.android.rum.featureoperations.FailureReason
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.model.ActionEvent
+import com.datadog.android.rum.operations.FailureReason
 import com.datadog.tools.unit.forge.aThrowable
 import com.datadog.tools.unit.forge.exhaustiveAttributes
 import fr.xgouchet.elmyr.Forge
@@ -79,16 +79,16 @@ internal fun Forge.stopResourceEvent(): RumRawEvent.StopResource {
     )
 }
 
-internal fun Forge.startFeatureOperationEvent(): RumRawEvent.StartFeatureOperation {
-    return RumRawEvent.StartFeatureOperation(
+internal fun Forge.startOperationEvent(): RumRawEvent.StartOperation {
+    return RumRawEvent.StartOperation(
         name = anAlphabeticalString(),
         operationKey = aNullable { anAlphabeticalString() },
         attributes = exhaustiveAttributes()
     )
 }
 
-internal fun Forge.stopFeatureOperationEvent(): RumRawEvent.StopFeatureOperation {
-    return RumRawEvent.StopFeatureOperation(
+internal fun Forge.stopOperationEvent(): RumRawEvent.StopOperation {
+    return RumRawEvent.StopOperation(
         name = anAlphabeticalString(),
         operationKey = aNullable { anAlphabeticalString() },
         failureReason = aNullable { aValueFrom(FailureReason::class.java) },
@@ -200,8 +200,8 @@ internal fun Forge.validBackgroundEvent(): RumRawEvent {
             { startActionEvent() },
             { addErrorEvent() },
             { startResourceEvent() },
-            { startFeatureOperationEvent() },
-            { stopFeatureOperationEvent() }
+            { startOperationEvent() },
+            { stopOperationEvent() }
         )
     ).invoke()
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -31,8 +31,7 @@ import com.datadog.android.rum.assertj.ErrorEventAssert.Companion.assertThat
 import com.datadog.android.rum.assertj.LongTaskEventAssert.Companion.assertThat
 import com.datadog.android.rum.assertj.ViewEventAssert.Companion.assertThat
 import com.datadog.android.rum.assertj.VitalEventAssert
-import com.datadog.android.rum.assertj.VitalFeatureOperationPropertiesAssert
-import com.datadog.android.rum.featureoperations.FailureReason
+import com.datadog.android.rum.assertj.VitalOperationPropertiesAssert
 import com.datadog.android.rum.internal.FeaturesContextResolver
 import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.anr.ANRException
@@ -72,6 +71,7 @@ import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.rum.model.VitalOperationStepEvent
+import com.datadog.android.rum.operations.FailureReason
 import com.datadog.android.rum.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.android.utils.verifyApiUsage
@@ -8746,17 +8746,17 @@ internal class RumViewScopeTest {
 
     // endregion
 
-    // region Feature Operations
+    // region Operations
 
     @Test
-    fun `M do nothing if view is stopped W handleEvent { StartFeatureOperation }`(
+    fun `M do nothing if view is stopped W handleEvent { StartOperation }`(
         @StringForgery key: String,
         @StringForgery name: String,
         @LongForgery(min = 0) duration: Long,
         forge: Forge
     ) {
         // Given
-        val event = RumRawEvent.StartFeatureOperation(
+        val event = RumRawEvent.StartOperation(
             name,
             attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys),
             operationKey = forge.aNullable { key },
@@ -8773,14 +8773,14 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M do nothing if view is stopped W handleEvent { StopFeatureOperation }`(
+    fun `M do nothing if view is stopped W handleEvent { StopOperation }`(
         @StringForgery key: String,
         @StringForgery name: String,
         @LongForgery(min = 0) duration: Long,
         forge: Forge
     ) {
         // Given
-        val event = RumRawEvent.StopFeatureOperation(
+        val event = RumRawEvent.StopOperation(
             name,
             attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys),
             operationKey = forge.aNullable { key },
@@ -8797,7 +8797,7 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M send view update W handleEvent { StartFeatureOperation }`(
+    fun `M send view update W handleEvent { StartOperation }`(
         @StringForgery key: String,
         @StringForgery name: String,
         @LongForgery(min = 0) duration: Long,
@@ -8805,7 +8805,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
-        val event = RumRawEvent.StartFeatureOperation(
+        val event = RumRawEvent.StartOperation(
             name,
             attributes = attributes,
             operationKey = forge.aNullable { key },
@@ -8826,7 +8826,7 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M send view update W handleEvent { StopFeatureOperation }`(
+    fun `M send view update W handleEvent { StopOperation }`(
         @StringForgery key: String,
         @StringForgery name: String,
         @LongForgery(min = 0) duration: Long,
@@ -8834,7 +8834,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
-        val event = RumRawEvent.StopFeatureOperation(
+        val event = RumRawEvent.StopOperation(
             name,
             attributes = attributes,
             operationKey = forge.aNullable { key },
@@ -8856,7 +8856,7 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M send VitalEvent W handleEvent { StartFeatureOperation }`(
+    fun `M send VitalEvent W handleEvent { StartOperation }`(
         @StringForgery key: String,
         @StringForgery fakeName: String,
         @LongForgery(min = 0) fakeDuration: Long,
@@ -8865,7 +8865,7 @@ internal class RumViewScopeTest {
         // Given
         val fakeOperationKey = forge.aNullable { key }
         val (attributes, expectedAttributes) = withAttributesCheckingMergeWithViewAttributes(forge)
-        val event = RumRawEvent.StartFeatureOperation(
+        val event = RumRawEvent.StartOperation(
             fakeName,
             operationKey = fakeOperationKey,
             attributes = attributes,
@@ -8916,9 +8916,9 @@ internal class RumViewScopeTest {
                 .hasServiceName(fakeDatadogContext.service)
                 .hasDDTags(buildDDTagsString(fakeDatadogContext))
 
-            val featureOperationsProps = lastValue.vital
+            val operationsProps = lastValue.vital
 
-            VitalFeatureOperationPropertiesAssert.assertThat(featureOperationsProps)
+            VitalOperationPropertiesAssert.assertThat(operationsProps)
                 .hasVitalName(fakeName)
                 .hasVitalOperationalKey(fakeOperationKey)
                 .hasVitalStepType(VitalOperationStepEvent.StepType.START)
@@ -8927,7 +8927,7 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M send event with synthetics info W handleEvent(VitalEvent) { StartFeatureOperation }`(
+    fun `M send event with synthetics info W handleEvent(VitalEvent) { StartOperation }`(
         @StringForgery fakeTestId: String,
         @StringForgery fakeResultId: String,
         forge: Forge
@@ -8937,7 +8937,7 @@ internal class RumViewScopeTest {
         val fakeDuration: Long = forge.aLong(min = 0)
         val fakeOperationKey = forge.aNullable { forge.anAlphabeticalString() }
         val (attributes, expectedAttributes) = withAttributesCheckingMergeWithViewAttributes(forge)
-        val event = RumRawEvent.StartFeatureOperation(
+        val event = RumRawEvent.StartOperation(
             fakeName,
             operationKey = fakeOperationKey,
             attributes = attributes,
@@ -8991,9 +8991,9 @@ internal class RumViewScopeTest {
                 .hasServiceName(fakeDatadogContext.service)
                 .hasDDTags(buildDDTagsString(fakeDatadogContext))
 
-            val featureOperationsProps = lastValue.vital
+            val operationsProps = lastValue.vital
 
-            VitalFeatureOperationPropertiesAssert.assertThat(featureOperationsProps)
+            VitalOperationPropertiesAssert.assertThat(operationsProps)
                 .hasVitalName(fakeName)
                 .hasVitalOperationalKey(fakeOperationKey)
                 .hasVitalStepType(VitalOperationStepEvent.StepType.START)
@@ -9002,7 +9002,7 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M send VitalEvent W handleEvent { StopFeatureOperation, succeed }`(
+    fun `M send VitalEvent W handleEvent { StopOperation, succeed }`(
         @StringForgery key: String,
         @StringForgery fakeName: String,
         @LongForgery(min = 0) fakeDuration: Long,
@@ -9011,7 +9011,7 @@ internal class RumViewScopeTest {
         // Given
         val fakeOperationKey = forge.aNullable { key }
         val (attributes, expectedAttributes) = withAttributesCheckingMergeWithViewAttributes(forge)
-        val event = RumRawEvent.StopFeatureOperation(
+        val event = RumRawEvent.StopOperation(
             fakeName,
             operationKey = fakeOperationKey,
             attributes = attributes,
@@ -9063,9 +9063,9 @@ internal class RumViewScopeTest {
                 .hasServiceName(fakeDatadogContext.service)
                 .hasDDTags(buildDDTagsString(fakeDatadogContext))
 
-            val featureOperationsProps = lastValue.vital
+            val operationsProps = lastValue.vital
 
-            VitalFeatureOperationPropertiesAssert.assertThat(featureOperationsProps)
+            VitalOperationPropertiesAssert.assertThat(operationsProps)
                 .hasVitalName(fakeName)
                 .hasVitalOperationalKey(fakeOperationKey)
                 .hasVitalStepType(VitalOperationStepEvent.StepType.END)
@@ -9074,7 +9074,7 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M send event with synthetics info W handleEvent(VitalEvent) { StopFeatureOperation, succeed }`(
+    fun `M send event with synthetics info W handleEvent(VitalEvent) { StopOperation, succeed }`(
         @StringForgery fakeTestId: String,
         @StringForgery fakeResultId: String,
         forge: Forge
@@ -9084,7 +9084,7 @@ internal class RumViewScopeTest {
         val fakeDuration: Long = forge.aLong(min = 0)
         val fakeOperationKey = forge.aNullable { forge.anAlphabeticalString() }
         val (attributes, expectedAttributes) = withAttributesCheckingMergeWithViewAttributes(forge)
-        val event = RumRawEvent.StopFeatureOperation(
+        val event = RumRawEvent.StopOperation(
             fakeName,
             operationKey = fakeOperationKey,
             attributes = attributes,
@@ -9138,9 +9138,9 @@ internal class RumViewScopeTest {
                 .hasServiceName(fakeDatadogContext.service)
                 .hasDDTags(buildDDTagsString(fakeDatadogContext))
 
-            val featureOperationsProps = lastValue.vital
+            val operationsProps = lastValue.vital
 
-            VitalFeatureOperationPropertiesAssert.assertThat(featureOperationsProps)
+            VitalOperationPropertiesAssert.assertThat(operationsProps)
                 .hasVitalName(fakeName)
                 .hasVitalOperationalKey(fakeOperationKey)
                 .hasVitalStepType(VitalOperationStepEvent.StepType.END)
@@ -9149,7 +9149,7 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M send VitalEvent W handleEvent { StopFeatureOperation, failed }`(
+    fun `M send VitalEvent W handleEvent { StopOperation, failed }`(
         @StringForgery key: String,
         @StringForgery fakeName: String,
         @LongForgery(min = 0) fakeDuration: Long,
@@ -9159,7 +9159,7 @@ internal class RumViewScopeTest {
         val fakeOperationKey = forge.aNullable { key }
         val (attributes, expectedAttributes) = withAttributesCheckingMergeWithViewAttributes(forge)
         val failureReason = forge.aValueFrom(FailureReason::class.java)
-        val event = RumRawEvent.StopFeatureOperation(
+        val event = RumRawEvent.StopOperation(
             fakeName,
             operationKey = fakeOperationKey,
             attributes = attributes,
@@ -9211,9 +9211,9 @@ internal class RumViewScopeTest {
                 .hasServiceName(fakeDatadogContext.service)
                 .hasDDTags(buildDDTagsString(fakeDatadogContext))
 
-            val featureOperationsProps = lastValue.vital
+            val operationsProps = lastValue.vital
 
-            VitalFeatureOperationPropertiesAssert.assertThat(featureOperationsProps)
+            VitalOperationPropertiesAssert.assertThat(operationsProps)
                 .hasVitalName(fakeName)
                 .hasVitalOperationalKey(fakeOperationKey)
                 .hasVitalStepType(VitalOperationStepEvent.StepType.END)
@@ -9222,7 +9222,7 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `M send event with synthetics info W handleEvent(VitalEvent) { StopFeatureOperation, failed }`(
+    fun `M send event with synthetics info W handleEvent(VitalEvent) { StopOperation, failed }`(
         @StringForgery fakeTestId: String,
         @StringForgery fakeResultId: String,
         forge: Forge
@@ -9233,7 +9233,7 @@ internal class RumViewScopeTest {
         val fakeOperationKey = forge.aNullable { forge.anAlphabeticalString() }
         val (attributes, expectedAttributes) = withAttributesCheckingMergeWithViewAttributes(forge)
         val failureReason = forge.aValueFrom(FailureReason::class.java)
-        val event = RumRawEvent.StopFeatureOperation(
+        val event = RumRawEvent.StopOperation(
             fakeName,
             operationKey = fakeOperationKey,
             attributes = attributes,
@@ -9288,9 +9288,9 @@ internal class RumViewScopeTest {
                 .hasServiceName(fakeDatadogContext.service)
                 .hasDDTags(buildDDTagsString(fakeDatadogContext))
 
-            val featureOperationsProps = lastValue.vital
+            val operationsProps = lastValue.vital
 
-            VitalFeatureOperationPropertiesAssert.assertThat(featureOperationsProps)
+            VitalOperationPropertiesAssert.assertThat(operationsProps)
                 .hasVitalName(fakeName)
                 .hasVitalOperationalKey(fakeOperationKey)
                 .hasVitalStepType(VitalOperationStepEvent.StepType.END)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -32,7 +32,6 @@ import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.RumSessionType
-import com.datadog.android.rum.featureoperations.FailureReason
 import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.debug.RumDebugListener
@@ -52,13 +51,15 @@ import com.datadog.android.rum.internal.domain.state.ViewUIPerformanceReport
 import com.datadog.android.rum.internal.instrumentation.insights.InsightsCollector
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
-import com.datadog.android.rum.internal.monitor.DatadogRumMonitor.Companion.FO_ERROR_INVALID_NAME
-import com.datadog.android.rum.internal.monitor.DatadogRumMonitor.Companion.FO_ERROR_INVALID_OPERATION_KEY
+import com.datadog.android.rum.internal.monitor.DatadogRumMonitor.Companion.OPERATION_ERROR_INVALID_NAME
+import com.datadog.android.rum.internal.monitor.DatadogRumMonitor.Companion.OPERATION_ERROR_INVALID_OPERATION_KEY
 import com.datadog.android.rum.internal.startup.RumAppStartupTelemetryReporter
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.metric.interactiontonextview.LastInteractionIdentifier
 import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
 import com.datadog.android.rum.model.ActionEvent
+import com.datadog.android.rum.operations.FailureReason
+import com.datadog.android.rum.operations.OperationOptions
 import com.datadog.android.rum.resource.ResourceId
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.android.telemetry.internal.TelemetryEventHandler
@@ -2760,7 +2761,7 @@ internal class DatadogRumMonitorTest {
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M produce StartFeatureOperation event W startFeatureOperation`(
+    fun `M produce StartOperation event W startOperation`(
         @StringForgery key: String,
         @StringForgery name: String,
         forge: Forge
@@ -2768,9 +2769,9 @@ internal class DatadogRumMonitorTest {
         val operationKey = forge.aNullable { key }
         val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
-        assertMethodCallProducesValidEvent<RumRawEvent.StartFeatureOperation>(
+        assertMethodCallProducesValidEvent<RumRawEvent.StartOperation>(
             whenCalled = {
-                testedMonitor.startFeatureOperation(name, operationKey, attributes)
+                testedMonitor.startOperation(name, operationKey, OperationOptions.Empty, attributes)
             },
             then = { event ->
                 assertThat(event.name).isEqualTo(name)
@@ -2783,7 +2784,7 @@ internal class DatadogRumMonitorTest {
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M produce StopFeatureOperation event W succeedFeatureOperation { successful }`(
+    fun `M produce StopOperation event W succeedOperation { successful }`(
         @StringForgery key: String,
         @StringForgery name: String,
         forge: Forge
@@ -2791,9 +2792,9 @@ internal class DatadogRumMonitorTest {
         val operationKey = forge.aNullable { key }
         val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
-        assertMethodCallProducesValidEvent<RumRawEvent.StopFeatureOperation>(
+        assertMethodCallProducesValidEvent<RumRawEvent.StopOperation>(
             whenCalled = {
-                testedMonitor.succeedFeatureOperation(name, operationKey, attributes)
+                testedMonitor.succeedOperation(name, operationKey, attributes)
             },
             then = { event ->
                 assertThat(event.name).isEqualTo(name)
@@ -2807,7 +2808,7 @@ internal class DatadogRumMonitorTest {
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M produce StopFeatureOperation event W failFeatureOperation { failed }`(
+    fun `M produce StopOperation event W failOperation { failed }`(
         @StringForgery key: String,
         @StringForgery name: String,
         forge: Forge
@@ -2816,9 +2817,9 @@ internal class DatadogRumMonitorTest {
         val failureReason = forge.aValueFrom(FailureReason::class.java)
         val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
-        assertMethodCallProducesValidEvent<RumRawEvent.StopFeatureOperation>(
+        assertMethodCallProducesValidEvent<RumRawEvent.StopOperation>(
             whenCalled = {
-                testedMonitor.failFeatureOperation(name, operationKey, failureReason, attributes)
+                testedMonitor.failOperation(name, operationKey, failureReason, attributes)
             },
             then = { event ->
                 assertThat(event.name).isEqualTo(name)
@@ -2832,7 +2833,7 @@ internal class DatadogRumMonitorTest {
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M log user message W startFeatureOperation`(
+    fun `M log user message W startOperation`(
         @StringForgery key: String,
         @StringForgery name: String,
         forge: Forge
@@ -2842,19 +2843,19 @@ internal class DatadogRumMonitorTest {
         val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         // When
-        testedMonitor.startFeatureOperation(name, operationKey, attributes)
+        testedMonitor.startOperation(name, operationKey, OperationOptions.Empty, attributes)
 
         // Then
         mockInternalLogger.verifyLog(
             InternalLogger.Level.DEBUG,
             InternalLogger.Target.USER,
-            "Feature Operation `$name` (operationKey `$operationKey`) started."
+            "Operation `$name` (operationKey `$operationKey`) started."
         )
     }
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M log user message W succeedFeatureOperation`(
+    fun `M log user message W succeedOperation`(
         @StringForgery key: String,
         @StringForgery name: String,
         forge: Forge
@@ -2863,19 +2864,19 @@ internal class DatadogRumMonitorTest {
         val operationKey = forge.aNullable { key }
 
         // When
-        testedMonitor.succeedFeatureOperation(name, operationKey, fakeAttributes)
+        testedMonitor.succeedOperation(name, operationKey, fakeAttributes)
 
         // Then
         mockInternalLogger.verifyLog(
             InternalLogger.Level.DEBUG,
             InternalLogger.Target.USER,
-            "Feature Operation `$name` (operationKey `$operationKey`) successfully ended."
+            "Operation `$name` (operationKey `$operationKey`) successfully ended."
         )
     }
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M log user message W failFeatureOperation`(
+    fun `M log user message W failOperation`(
         @StringForgery key: String,
         @StringForgery name: String,
         forge: Forge
@@ -2885,20 +2886,20 @@ internal class DatadogRumMonitorTest {
         val failureReason = forge.aValueFrom(FailureReason::class.java)
 
         // When
-        testedMonitor.failFeatureOperation(name, operationKey, failureReason, fakeAttributes)
+        testedMonitor.failOperation(name, operationKey, failureReason, fakeAttributes)
 
         // Then
         mockInternalLogger.verifyLog(
             InternalLogger.Level.DEBUG,
             InternalLogger.Target.USER,
-            "Feature Operation `$name` (operationKey `$operationKey`) unsuccessfully " +
+            "Operation `$name` (operationKey `$operationKey`) unsuccessfully " +
                 "ended with the following failure reason: $failureReason."
         )
     }
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M log telemetry message W startFeatureOperation`(
+    fun `M log telemetry message W startOperation`(
         @StringForgery key: String,
         @StringForgery name: String,
         forge: Forge
@@ -2907,7 +2908,7 @@ internal class DatadogRumMonitorTest {
         val operationKey = forge.aNullable { key }
 
         // When
-        testedMonitor.startFeatureOperation(name, operationKey, fakeAttributes)
+        testedMonitor.startOperation(name, operationKey, OperationOptions.Empty, fakeAttributes)
 
         // Then
         mockInternalLogger.verifyApiUsage(
@@ -2920,7 +2921,7 @@ internal class DatadogRumMonitorTest {
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M log telemetry message W succeedFeatureOperation`(
+    fun `M log telemetry message W succeedOperation`(
         @StringForgery key: String,
         @StringForgery name: String,
         forge: Forge
@@ -2929,7 +2930,7 @@ internal class DatadogRumMonitorTest {
         val operationKey = forge.aNullable { key }
 
         // When
-        testedMonitor.succeedFeatureOperation(name, operationKey, fakeAttributes)
+        testedMonitor.succeedOperation(name, operationKey, fakeAttributes)
 
         // Then
         mockInternalLogger.verifyApiUsage(
@@ -2942,7 +2943,7 @@ internal class DatadogRumMonitorTest {
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M log telemetry message W failFeatureOperation`(
+    fun `M log telemetry message W failOperation`(
         @StringForgery key: String,
         @StringForgery name: String,
         forge: Forge
@@ -2952,7 +2953,7 @@ internal class DatadogRumMonitorTest {
         val failureReason = forge.aValueFrom(FailureReason::class.java)
 
         // When
-        testedMonitor.failFeatureOperation(name, operationKey, failureReason, fakeAttributes)
+        testedMonitor.failOperation(name, operationKey, failureReason, fakeAttributes)
 
         // Then
         mockInternalLogger.verifyApiUsage(
@@ -2965,17 +2966,17 @@ internal class DatadogRumMonitorTest {
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M log user message W startFeatureOperation { operation name is blank }`(
+    fun `M log user message W startOperation { operation name is blank }`(
         @StringForgery(StringForgeryType.WHITESPACE) name: String
     ) {
         // When
-        testedMonitor.startFeatureOperation(name, null, fakeAttributes)
+        testedMonitor.startOperation(name, null, OperationOptions.Empty, fakeAttributes)
 
         // Then
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
-            FO_ERROR_INVALID_NAME.format(Locale.US, name)
+            OPERATION_ERROR_INVALID_NAME.format(Locale.US, name)
         )
 
         verifyNoInteractions(mockApplicationScope)
@@ -2984,18 +2985,18 @@ internal class DatadogRumMonitorTest {
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M log user message W startFeatureOperation { operation key is blank }`(
+    fun `M log user message W startOperation { operation key is blank }`(
         @StringForgery name: String,
         @StringForgery(StringForgeryType.WHITESPACE) operationKey: String
     ) {
         // When
-        testedMonitor.startFeatureOperation(name, operationKey, fakeAttributes)
+        testedMonitor.startOperation(name, operationKey, OperationOptions.Empty, fakeAttributes)
 
         // Then
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
-            FO_ERROR_INVALID_OPERATION_KEY.format(Locale.US, operationKey)
+            OPERATION_ERROR_INVALID_OPERATION_KEY.format(Locale.US, operationKey)
         )
 
         verifyNoInteractions(mockApplicationScope)
@@ -3004,17 +3005,17 @@ internal class DatadogRumMonitorTest {
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M log user message W succeedFeatureOperation { operation name is blank }`(
+    fun `M log user message W succeedOperation { operation name is blank }`(
         @StringForgery(StringForgeryType.WHITESPACE) name: String
     ) {
         // When
-        testedMonitor.succeedFeatureOperation(name, null, fakeAttributes)
+        testedMonitor.succeedOperation(name, null, fakeAttributes)
 
         // Then
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
-            FO_ERROR_INVALID_NAME.format(Locale.US, name)
+            OPERATION_ERROR_INVALID_NAME.format(Locale.US, name)
         )
 
         verifyNoInteractions(mockApplicationScope)
@@ -3023,18 +3024,18 @@ internal class DatadogRumMonitorTest {
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M log user message W succeedFeatureOperation { operation key is blank }`(
+    fun `M log user message W succeedOperation { operation key is blank }`(
         @StringForgery name: String,
         @StringForgery(StringForgeryType.WHITESPACE) operationKey: String
     ) {
         // When
-        testedMonitor.succeedFeatureOperation(name, operationKey, fakeAttributes)
+        testedMonitor.succeedOperation(name, operationKey, fakeAttributes)
 
         // Then
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
-            FO_ERROR_INVALID_OPERATION_KEY.format(Locale.US, operationKey)
+            OPERATION_ERROR_INVALID_OPERATION_KEY.format(Locale.US, operationKey)
         )
 
         verifyNoInteractions(mockApplicationScope)
@@ -3043,20 +3044,20 @@ internal class DatadogRumMonitorTest {
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M log user message W failFeatureOperation { operation name is blank }`(
+    fun `M log user message W failOperation { operation name is blank }`(
         @StringForgery(StringForgeryType.WHITESPACE) name: String,
         forge: Forge
     ) {
         val failureReason = forge.aValueFrom(FailureReason::class.java)
 
         // When
-        testedMonitor.failFeatureOperation(name, null, failureReason, fakeAttributes)
+        testedMonitor.failOperation(name, null, failureReason, fakeAttributes)
 
         // Then
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
-            FO_ERROR_INVALID_NAME.format(Locale.US, name)
+            OPERATION_ERROR_INVALID_NAME.format(Locale.US, name)
         )
 
         verifyNoInteractions(mockApplicationScope)
@@ -3065,7 +3066,7 @@ internal class DatadogRumMonitorTest {
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M log user message W failFeatureOperation { operation key is blank }`(
+    fun `M log user message W failOperation { operation key is blank }`(
         @StringForgery name: String,
         @StringForgery(StringForgeryType.WHITESPACE) operationKey: String,
         forge: Forge
@@ -3073,13 +3074,13 @@ internal class DatadogRumMonitorTest {
         val failureReason = forge.aValueFrom(FailureReason::class.java)
 
         // When
-        testedMonitor.failFeatureOperation(name, operationKey, failureReason, fakeAttributes)
+        testedMonitor.failOperation(name, operationKey, failureReason, fakeAttributes)
 
         // Then
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
-            FO_ERROR_INVALID_OPERATION_KEY.format(Locale.US, operationKey)
+            OPERATION_ERROR_INVALID_OPERATION_KEY.format(Locale.US, operationKey)
         )
 
         verifyNoInteractions(mockApplicationScope)

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/vitals/VitalsFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/vitals/VitalsFragment.kt
@@ -15,7 +15,7 @@ import android.widget.CompoundButton
 import android.widget.ProgressBar
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProviders
-import com.datadog.android.rum.featureoperations.FailureReason
+import com.datadog.android.rum.operations.FailureReason
 import com.datadog.android.sample.R
 import com.google.android.material.textfield.TextInputEditText
 
@@ -45,15 +45,15 @@ internal class VitalsFragment :
         rootView.findViewById<CheckBox>(R.id.vital_slow_frame_rate).setOnCheckedChangeListener(this)
         rootView.findViewById<CheckBox>(R.id.vital_memory).setOnCheckedChangeListener(this)
         rootView.findViewById<CheckBox>(R.id.vital_stress_test).setOnCheckedChangeListener(this)
-        rootView.findViewById<Button>(R.id.fo_start).setOnClickListener(this)
-        rootView.findViewById<Button>(R.id.fo_stop_successfully).setOnClickListener(this)
-        rootView.findViewById<Button>(R.id.fo_stop_unsuccessfully).setOnClickListener(this)
+        rootView.findViewById<Button>(R.id.operation_start).setOnClickListener(this)
+        rootView.findViewById<Button>(R.id.operation_stop_successfully).setOnClickListener(this)
+        rootView.findViewById<Button>(R.id.operation_stop_unsuccessfully).setOnClickListener(this)
 
         badView = rootView.findViewById(R.id.vital_slow_view)
         progressView = rootView.findViewById(R.id.progress)
 
-        operationName = rootView.findViewById(R.id.fo_name_edit_text)
-        operationKey = rootView.findViewById(R.id.fo_operation_key_edit_text)
+        operationName = rootView.findViewById(R.id.operation_name_edit_text)
+        operationKey = rootView.findViewById(R.id.operation_key_edit_text)
         return rootView
     }
 
@@ -81,17 +81,17 @@ internal class VitalsFragment :
         when (v.id) {
             R.id.vital_long_task -> viewModel.runLongTask()
             R.id.vital_frozen_frame -> viewModel.runFrozenFrame()
-            R.id.fo_start -> viewModel.startFeatureOperation(
+            R.id.operation_start -> viewModel.startOperation(
                 operationName.text.toString(),
                 operationKey
             )
 
-            R.id.fo_stop_successfully -> viewModel.stopFeatureOperation(
+            R.id.operation_stop_successfully -> viewModel.stopOperation(
                 operationName.text.toString(),
                 operationKey
             )
 
-            R.id.fo_stop_unsuccessfully -> viewModel.stopFeatureOperation(
+            R.id.operation_stop_unsuccessfully -> viewModel.stopOperation(
                 operationName.text.toString(),
                 operationKey,
                 FailureReason.ERROR

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/vitals/VitalsViewModel.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/vitals/VitalsViewModel.kt
@@ -13,7 +13,7 @@ import androidx.lifecycle.ViewModel
 import com.datadog.android.rum.ExperimentalRumApi
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumActionType
-import com.datadog.android.rum.featureoperations.FailureReason
+import com.datadog.android.rum.operations.FailureReason
 import timber.log.Timber
 import java.security.SecureRandom
 
@@ -141,16 +141,16 @@ internal class VitalsViewModel : ViewModel() {
     }
 
     @OptIn(ExperimentalRumApi::class)
-    fun startFeatureOperation(name: String, operationKey: String?) {
-        GlobalRumMonitor.get().startFeatureOperation(name, operationKey)
+    fun startOperation(name: String, operationKey: String?) {
+        GlobalRumMonitor.get().startOperation(name, operationKey)
     }
 
     @OptIn(ExperimentalRumApi::class)
-    fun stopFeatureOperation(name: String, operationKey: String?, reason: FailureReason? = null) {
+    fun stopOperation(name: String, operationKey: String?, reason: FailureReason? = null) {
         if (reason != null) {
-            GlobalRumMonitor.get().failFeatureOperation(name, operationKey, reason)
+            GlobalRumMonitor.get().failOperation(name, operationKey, reason)
         } else {
-            GlobalRumMonitor.get().succeedFeatureOperation(name, operationKey)
+            GlobalRumMonitor.get().succeedOperation(name, operationKey)
         }
     }
 }

--- a/sample/kotlin/src/main/res/layout/fragment_vitals.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_vitals.xml
@@ -143,77 +143,77 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="24dp"
-        app:dv_text="@string/divider_feature_operations"
+        app:dv_text="@string/divider_operations"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/vital_slow_view" />
 
     <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/fo_name"
+        android:id="@+id/operation_name"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        app:layout_constraintEnd_toStartOf="@id/fo_operation_key"
+        app:layout_constraintEnd_toStartOf="@id/operation_key"
         app:layout_constraintHorizontal_chainStyle="spread"
         app:layout_constraintHorizontal_weight="1"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/divider">
 
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/fo_name_edit_text"
+            android:id="@+id/operation_name_edit_text"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:hint="@string/text_feature_operation_name_hint"
-            android:text="@string/text_feature_operation_name" />
+            android:hint="@string/text_operation_name_hint"
+            android:text="@string/text_operation_name" />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/fo_operation_key"
+        android:id="@+id/operation_key"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_weight="1"
-        app:layout_constraintStart_toEndOf="@id/fo_name"
-        app:layout_constraintTop_toTopOf="@id/fo_name">
+        app:layout_constraintStart_toEndOf="@id/operation_name"
+        app:layout_constraintTop_toTopOf="@id/operation_name">
 
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/fo_operation_key_edit_text"
+            android:id="@+id/operation_key_edit_text"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:hint="@string/text_feature_operation_key_hint" />
+            android:hint="@string/text_operation_key_hint" />
 
     </com.google.android.material.textfield.TextInputLayout>
 
     <Button
-        android:id="@+id/fo_start"
+        android:id="@+id/operation_start"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        android:text="@string/button_fo_start"
-        app:layout_constraintEnd_toStartOf="@id/fo_stop_successfully"
+        android:text="@string/button_operation_start"
+        app:layout_constraintEnd_toStartOf="@id/operation_stop_successfully"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/fo_name" />
+        app:layout_constraintTop_toBottomOf="@id/operation_name" />
 
     <Button
-        android:id="@+id/fo_stop_successfully"
+        android:id="@+id/operation_stop_successfully"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="4dp"
         android:layout_marginEnd="4dp"
-        android:text="@string/button_fo_stop_successfully"
-        app:layout_constraintEnd_toStartOf="@id/fo_stop_unsuccessfully"
-        app:layout_constraintStart_toEndOf="@id/fo_start"
-        app:layout_constraintTop_toTopOf="@id/fo_start" />
+        android:text="@string/button_operation_stop_successfully"
+        app:layout_constraintEnd_toStartOf="@id/operation_stop_unsuccessfully"
+        app:layout_constraintStart_toEndOf="@id/operation_start"
+        app:layout_constraintTop_toTopOf="@id/operation_start" />
 
     <Button
-        android:id="@+id/fo_stop_unsuccessfully"
+        android:id="@+id/operation_stop_unsuccessfully"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="@string/button_fo_stop_unsuccessfully"
+        android:text="@string/button_operation_stop_unsuccessfully"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/fo_stop_successfully"
-        app:layout_constraintTop_toTopOf="@id/fo_start" />
+        app:layout_constraintStart_toEndOf="@id/operation_stop_successfully"
+        app:layout_constraintTop_toTopOf="@id/operation_start" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/kotlin/src/main/res/values/strings.xml
+++ b/sample/kotlin/src/main/res/values/strings.xml
@@ -73,14 +73,14 @@
     <string name="button_high_cpu_usage">High CPU usage</string>
     <string name="button_high_memory_usage">High RAM usage</string>
     <string name="button_stress_test_events">Stress Test Events</string>
-    <string name="button_fo_start">Start</string>
-    <string name="button_fo_stop_successfully">Success</string>
-    <string name="button_fo_stop_unsuccessfully">Fail</string>
-    <string name="divider_feature_operations">Feature Operations</string>
+    <string name="button_operation_start">Start</string>
+    <string name="button_operation_stop_successfully">Success</string>
+    <string name="button_operation_stop_unsuccessfully">Fail</string>
+    <string name="divider_operations">Operations</string>
     <string name="divider_performance_degradation">Performance degradation</string>
-    <string name="text_feature_operation_name">Test</string>
-    <string name="text_feature_operation_name_hint">Operation name</string>
-    <string name="text_feature_operation_key_hint">Operation key</string>
+    <string name="text_operation_name">Test</string>
+    <string name="text_operation_name_hint">Operation name</string>
+    <string name="text_operation_key_hint">Operation key</string>
 
     <string name="group_image_loader">Image Loader</string>
     <string name="group_data_source">Data Source</string>

--- a/tools/noopfactory/src/main/kotlin/com/datadog/tools/noopfactory/NoOpFactorySymbolProcessor.kt
+++ b/tools/noopfactory/src/main/kotlin/com/datadog/tools/noopfactory/NoOpFactorySymbolProcessor.kt
@@ -8,6 +8,7 @@ package com.datadog.tools.noopfactory
 
 import com.datadog.tools.annotation.NoOpImplementation
 import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.getAllSuperTypes
 import com.google.devtools.ksp.getAnnotationsByType
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Dependencies
@@ -119,6 +120,15 @@ class NoOpFactorySymbolProcessor(
             .addAnnotation(
                 AnnotationSpec.builder(Suppress::class)
                     .addMember("%S", "ktlint")
+                    .apply {
+                        interfaceDeclaration.getAllSuperTypes()
+                            .map { it.declaration.containingFile }
+                            .let { it.plus(declarationSourceFile) }
+                            .filterNotNull()
+                            .flatMap { it.getAnnotationsByType(Suppress::class).flatMap { it.names.toList() } }
+                            .toSet()
+                            .forEach { addMember("%S", it) }
+                    }
                     .build()
             )
             .addType(typeSpec)


### PR DESCRIPTION
### What does this PR do?

Change similar to https://github.com/DataDog/dd-sdk-ios/pull/2802: we are changing the wording `feature operations` -> `operations`.

This PR deprecates feature-related symbol names, they should be removed in v4.

Also adding `OperationOptions` parameter, which will be used later for profiling.

cc @simaoseica-dd @Valpertui 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

