### PR TITLE
Enforce schema character set on vital.name in Operation APIs

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -754,22 +754,38 @@ internal class DatadogRumMonitor(
         sdkCore.internalLogger.reportFeatureOperationApiUsage(ActionType.FAIL)
     }
 
-    private fun featureOperationArgumentsValid(name: String, operationKey: String?) = when {
-        name.isBlank() -> {
+    private fun featureOperationArgumentsValid(name: String, operationKey: String?): Boolean {
+        // Blank / empty names are rejected: the backend rejects them with
+        // its own non-empty precondition before evaluating the character-set
+        // regex, so drop client-side to match.
+        if (name.isBlank()) {
             sdkCore.internalLogger.logToUser(InternalLogger.Level.WARN) {
                 FO_ERROR_INVALID_NAME.format(Locale.US, name)
             }
-            false
+            return false
         }
 
-        operationKey?.isBlank() == true -> {
+        // Names that fail the backend's `[\w.@$-]*` character-set regex
+        // trigger a warning but the event is still emitted — the backend is
+        // the source of truth, so client-side drop would force a customer
+        // SDK bump if the rule is ever relaxed.
+        @Suppress(
+            "UnsafeThirdPartyFunctionCall"
+        ) // Regex is a compile-time constant; matches() cannot throw on a non-null input
+        val nameMatchesBackendPattern = VALID_OPERATION_NAME_REGEX.matches(name)
+        if (!nameMatchesBackendPattern) {
+            sdkCore.internalLogger.logToUser(InternalLogger.Level.WARN) {
+                FO_ERROR_INVALID_NAME_CHARACTERS.format(Locale.US, name)
+            }
+        }
+
+        val operationKeyIsBlank = operationKey?.isBlank() == true
+        if (operationKeyIsBlank) {
             sdkCore.internalLogger.logToUser(InternalLogger.Level.WARN) {
                 FO_ERROR_INVALID_OPERATION_KEY.format(Locale.US, operationKey)
             }
-            false
         }
-
-        else -> true
+        return !operationKeyIsBlank
     }
 
     // endregion
@@ -952,8 +968,27 @@ internal class DatadogRumMonitor(
         internal const val FO_ERROR_INVALID_NAME =
             "Feature operation name cannot be an empty or blank string but was \"%s\". Vital event won't be sent."
 
+        internal const val FO_ERROR_INVALID_NAME_CHARACTERS =
+            "Feature operation name \"%s\" does not match the backend-accepted " +
+                "pattern [\\w.@\$-]* (letters, digits, _ . @ \$ -). The vital event " +
+                "will still be sent and may be rejected by the backend."
+
         internal const val FO_ERROR_INVALID_OPERATION_KEY =
             "Feature operation key cannot be an empty or blank string but was \"%s\". Vital event won't be sent."
+
+        /**
+         * Mirrors the backend's server-side `vital.name` validation regex
+         * `[\w.@$-]*`. Names that do not match generate a developer warning
+         * but the event is still emitted — the backend is the single source
+         * of truth, so client-side drop would force a customer SDK bump if
+         * the policy is ever relaxed. `operationKey` is a separate parameter
+         * with its own validation.
+         *
+         * `\w` in `java.util.regex.Pattern` is ASCII-only (`[A-Za-z0-9_]`)
+         * unless `UNICODE_CHARACTER_CLASS` is set, which is what the backend
+         * regex assumes.
+         */
+        internal val VALID_OPERATION_NAME_REGEX = Regex("^[\\w.@\$-]*$")
 
         private fun InternalLogger.reportFeatureOperationApiUsage(actionType: ActionType) = logApiUsage {
             InternalTelemetryEvent.ApiUsage.AddOperationStepVital(actionType)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -805,22 +805,34 @@ internal class DatadogRumMonitor(
         sdkCore.internalLogger.reportOperationApiUsage(ActionType.FAIL)
     }
 
-    private fun operationArgumentsValid(name: String, operationKey: String?) = when {
-        name.isBlank() -> {
+    private fun operationArgumentsValid(name: String, operationKey: String?): Boolean {
+        // Blank / empty names are rejected: the backend rejects them with
+        // its own non-empty precondition before evaluating the character-set
+        // regex, so drop client-side to match.
+        if (name.isBlank()) {
             sdkCore.internalLogger.logToUser(InternalLogger.Level.WARN) {
                 OPERATION_ERROR_INVALID_NAME.format(Locale.US, name)
             }
-            false
+            return false
         }
 
-        operationKey?.isBlank() == true -> {
+        // Names that fail the backend's `[\w.@$-]*` character-set regex
+        // trigger a warning but the event is still emitted — the backend is
+        // the source of truth, so client-side drop would force a customer
+        // SDK bump if the rule is ever relaxed.
+        if (!name.matches(VALID_OPERATION_NAME_REGEX)) {
+            sdkCore.internalLogger.logToUser(InternalLogger.Level.WARN) {
+                OPERATION_ERROR_INVALID_NAME_CHARACTERS.format(Locale.US, name)
+            }
+        }
+
+        val operationKeyIsBlank = operationKey?.isBlank() == true
+        if (operationKeyIsBlank) {
             sdkCore.internalLogger.logToUser(InternalLogger.Level.WARN) {
                 OPERATION_ERROR_INVALID_OPERATION_KEY.format(Locale.US, operationKey)
             }
-            false
         }
-
-        else -> true
+        return !operationKeyIsBlank
     }
 
     // endregion
@@ -1005,8 +1017,27 @@ internal class DatadogRumMonitor(
         internal const val OPERATION_ERROR_INVALID_NAME =
             "Operation name cannot be an empty or blank string but was \"%s\". Vital event won't be sent."
 
+        internal const val OPERATION_ERROR_INVALID_NAME_CHARACTERS =
+            "Operation name \"%s\" does not match the backend-accepted " +
+                "pattern [\\w.@$-]* (letters, digits, _ . @ $ -). The vital event " +
+                "will still be sent and may be rejected by the backend."
+
         internal const val OPERATION_ERROR_INVALID_OPERATION_KEY =
             "Operation key cannot be an empty or blank string but was \"%s\". Vital event won't be sent."
+
+        /**
+         * Mirrors the backend's server-side `vital.name` validation regex
+         * `[\w.@$-]*`. Names that do not match generate a developer warning
+         * but the event is still emitted — the backend is the single source
+         * of truth, so client-side drop would force a customer SDK bump if
+         * the policy is ever relaxed. `operationKey` is a separate parameter
+         * with its own validation.
+         *
+         * `\w` in `java.util.regex.Pattern` is ASCII-only (`[A-Za-z0-9_]`)
+         * unless `UNICODE_CHARACTER_CLASS` is set, which is what the backend
+         * regex assumes.
+         */
+        internal val VALID_OPERATION_NAME_REGEX = Regex("^[\\w.@$-]*$")
 
         private fun InternalLogger.reportOperationApiUsage(actionType: ActionType) = logApiUsage {
             InternalTelemetryEvent.ApiUsage.AddOperationStepVital(actionType)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -826,13 +826,15 @@ internal class DatadogRumMonitor(
             }
         }
 
-        val operationKeyIsBlank = operationKey?.isBlank() == true
-        if (operationKeyIsBlank) {
+        // operationKey is optional: a blank value is malformed, but we warn
+        // and still emit on purpose — dropping the event would lose a
+        // diagnostic data point for good. (Blank `name` above stays a drop.)
+        if (operationKey?.isBlank() == true) {
             sdkCore.internalLogger.logToUser(InternalLogger.Level.WARN) {
                 OPERATION_ERROR_INVALID_OPERATION_KEY.format(Locale.US, operationKey)
             }
         }
-        return !operationKeyIsBlank
+        return true
     }
 
     // endregion
@@ -1023,7 +1025,8 @@ internal class DatadogRumMonitor(
                 "will still be sent and may be rejected by the backend."
 
         internal const val OPERATION_ERROR_INVALID_OPERATION_KEY =
-            "Operation key cannot be an empty or blank string but was \"%s\". Vital event won't be sent."
+            "Operation key cannot be an empty or blank string but was \"%s\". " +
+                "The vital event will still be sent."
 
         /**
          * Mirrors the backend's server-side `vital.name` validation regex

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -53,6 +53,7 @@ import com.datadog.android.rum.internal.instrumentation.insights.InsightsCollect
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor.Companion.FO_ERROR_INVALID_NAME
+import com.datadog.android.rum.internal.monitor.DatadogRumMonitor.Companion.FO_ERROR_INVALID_NAME_CHARACTERS
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor.Companion.FO_ERROR_INVALID_OPERATION_KEY
 import com.datadog.android.rum.internal.startup.RumAppStartupTelemetryReporter
 import com.datadog.android.rum.internal.vitals.VitalMonitor
@@ -96,6 +97,7 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.same
@@ -2980,6 +2982,105 @@ internal class DatadogRumMonitorTest {
 
         verifyNoInteractions(mockApplicationScope)
         verifyNoMoreInteractions(mockInternalLogger)
+    }
+
+    @OptIn(ExperimentalRumApi::class)
+    @Test
+    fun `M warn but still emit W startFeatureOperation { operation name contains invalid character }`() {
+        // vital.name is documented in _vital-common-schema.json as restricted to
+        // letters, digits, and - _ . @ $. Names outside that set are warned
+        // about but still emitted — the backend is the source of truth on the
+        // policy, so client-side drop would force a customer SDK bump if the
+        // rule were ever relaxed.
+        val invalidName = "user login"
+
+        assertMethodCallProducesValidEvent<RumRawEvent.StartFeatureOperation>(
+            whenCalled = {
+                testedMonitor.startFeatureOperation(invalidName, null, fakeAttributes)
+            },
+            then = { event ->
+                assertThat(event.name).isEqualTo(invalidName)
+            }
+        )
+
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            FO_ERROR_INVALID_NAME_CHARACTERS.format(Locale.US, invalidName)
+        )
+    }
+
+    @OptIn(ExperimentalRumApi::class)
+    @Test
+    fun `M warn but still emit W startFeatureOperation { operation name contains non-ASCII character }`() {
+        // Pins the ASCII-only semantics of Java Pattern's `\w` (no
+        // UNICODE_CHARACTER_CLASS flag). Non-ASCII letters must fail the
+        // character-set regex. If this test ever starts failing because
+        // "ログイン" is accepted, the regex has gained Unicode semantics — that
+        // would be a silent behavior change and is caught here.
+        val invalidName = "ログイン"
+
+        assertMethodCallProducesValidEvent<RumRawEvent.StartFeatureOperation>(
+            whenCalled = {
+                testedMonitor.startFeatureOperation(invalidName, null, fakeAttributes)
+            },
+            then = { event ->
+                assertThat(event.name).isEqualTo(invalidName)
+            }
+        )
+
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            FO_ERROR_INVALID_NAME_CHARACTERS.format(Locale.US, invalidName)
+        )
+    }
+
+    @OptIn(ExperimentalRumApi::class)
+    @Test
+    fun `M accept name W startFeatureOperation { name only uses schema-allowed characters }`() {
+        val validNames = listOf(
+            "login",
+            "step42",
+            "login-v2",
+            "user_login",
+            "login.v2",
+            "login@prod",
+            "login\$1",
+            "LoginV2",
+            "login-v2@1.0.0_step\$1"
+        )
+
+        validNames.forEach { validName ->
+            // When
+            testedMonitor.startFeatureOperation(validName, null, fakeAttributes)
+        }
+
+        // Then — no user-facing WARN was logged (character-set path never fired)
+        verify(mockInternalLogger, never()).log(
+            eq(InternalLogger.Level.WARN),
+            eq(InternalLogger.Target.USER),
+            any(),
+            isNull(),
+            any(),
+            isNull()
+        )
+    }
+
+    @OptIn(ExperimentalRumApi::class)
+    @Test
+    fun `M not restrict operationKey to name character set W startFeatureOperation`() {
+        // operation_key has no character-set restriction in the schema.
+        testedMonitor.startFeatureOperation("login", "session 42 / user foo", fakeAttributes)
+
+        verify(mockInternalLogger, never()).log(
+            eq(InternalLogger.Level.WARN),
+            eq(InternalLogger.Target.USER),
+            any(),
+            isNull(),
+            any(),
+            isNull()
+        )
     }
 
     @OptIn(ExperimentalRumApi::class)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -52,6 +52,7 @@ import com.datadog.android.rum.internal.instrumentation.insights.InsightsCollect
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor.Companion.OPERATION_ERROR_INVALID_NAME
+import com.datadog.android.rum.internal.monitor.DatadogRumMonitor.Companion.OPERATION_ERROR_INVALID_NAME_CHARACTERS
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor.Companion.OPERATION_ERROR_INVALID_OPERATION_KEY
 import com.datadog.android.rum.internal.startup.RumAppStartupTelemetryReporter
 import com.datadog.android.rum.internal.vitals.VitalMonitor
@@ -97,6 +98,7 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.same
@@ -3001,6 +3003,107 @@ internal class DatadogRumMonitorTest {
 
         verifyNoInteractions(mockApplicationScope)
         verifyNoMoreInteractions(mockInternalLogger)
+    }
+
+    @OptIn(ExperimentalRumApi::class)
+    @Test
+    fun `M warn but still emit W startOperation { operation name contains invalid character }`() {
+        // vital.name is documented in _vital-common-schema.json as restricted to
+        // letters, digits, and - _ . @ $. Names outside that set are warned
+        // about but still emitted — the backend is the source of truth on the
+        // policy, so client-side drop would force a customer SDK bump if the
+        // rule were ever relaxed.
+        val invalidName = "user login"
+        val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
+
+        assertMethodCallProducesValidEvent<RumRawEvent.StartOperation>(
+            whenCalled = {
+                testedMonitor.startOperation(invalidName, null, OperationOptions.Empty, attributes)
+            },
+            then = { event ->
+                assertThat(event.name).isEqualTo(invalidName)
+            }
+        )
+
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            OPERATION_ERROR_INVALID_NAME_CHARACTERS.format(Locale.US, invalidName)
+        )
+    }
+
+    @OptIn(ExperimentalRumApi::class)
+    @Test
+    fun `M warn but still emit W startOperation { operation name contains non-ASCII character }`() {
+        // Pins the ASCII-only semantics of Java Pattern's `\w` (no
+        // UNICODE_CHARACTER_CLASS flag). Non-ASCII letters must fail the
+        // character-set regex. If this test ever starts failing because
+        // "ログイン" is accepted, the regex has gained Unicode semantics — that
+        // would be a silent behavior change and is caught here.
+        val invalidName = "ログイン"
+        val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
+
+        assertMethodCallProducesValidEvent<RumRawEvent.StartOperation>(
+            whenCalled = {
+                testedMonitor.startOperation(invalidName, null, OperationOptions.Empty, attributes)
+            },
+            then = { event ->
+                assertThat(event.name).isEqualTo(invalidName)
+            }
+        )
+
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            OPERATION_ERROR_INVALID_NAME_CHARACTERS.format(Locale.US, invalidName)
+        )
+    }
+
+    @OptIn(ExperimentalRumApi::class)
+    @Test
+    fun `M accept name W startOperation { name only uses schema-allowed characters }`() {
+        val validNames = listOf(
+            "login",
+            "step42",
+            "login-v2",
+            "user_login",
+            "login.v2",
+            "login@prod",
+            "login$1",
+            "LoginV2",
+            "login-v2@1.0.0_step$1"
+        )
+
+        validNames.forEach { validName ->
+            // When
+            testedMonitor.startOperation(validName, null, OperationOptions.Empty, fakeAttributes)
+        }
+
+        // Then — no user-facing WARN was logged (character-set path never fired)
+        verify(mockInternalLogger, never()).log(
+            eq(InternalLogger.Level.WARN),
+            eq(InternalLogger.Target.USER),
+            any(),
+            isNull(),
+            any(),
+            isNull()
+        )
+    }
+
+    @OptIn(ExperimentalRumApi::class)
+    @Test
+    fun `M not restrict operationKey to name character set W startOperation`() {
+        // operation_key has no character-set restriction in the schema.
+        testedMonitor.startOperation("login", "session 42 / user foo", OperationOptions.Empty, fakeAttributes)
+
+        verify(mockInternalLogger, never()).log(
+            eq(InternalLogger.Level.WARN),
+            eq(InternalLogger.Target.USER),
+            any(),
+            isNull(),
+            any(),
+            isNull()
+        )
     }
 
     @OptIn(ExperimentalRumApi::class)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -3061,6 +3061,31 @@ internal class DatadogRumMonitorTest {
 
     @OptIn(ExperimentalRumApi::class)
     @Test
+    fun `M warn but still emit W startOperation { operation name contains emoji }`() {
+        // Like the non-ASCII case above, an emoji must fail the `[\w.@$-]*`
+        // regex. This additionally pins surrogate-pair / multi-byte handling
+        // (mirrors iOS PR #2864 / Browser PR #4525, spec test VAL-09).
+        val invalidName = "login🔐"
+        val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
+
+        assertMethodCallProducesValidEvent<RumRawEvent.StartOperation>(
+            whenCalled = {
+                testedMonitor.startOperation(invalidName, null, OperationOptions.Empty, attributes)
+            },
+            then = { event ->
+                assertThat(event.name).isEqualTo(invalidName)
+            }
+        )
+
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            OPERATION_ERROR_INVALID_NAME_CHARACTERS.format(Locale.US, invalidName)
+        )
+    }
+
+    @OptIn(ExperimentalRumApi::class)
+    @Test
     fun `M accept name W startOperation { name only uses schema-allowed characters }`() {
         val validNames = listOf(
             "login",
@@ -3108,22 +3133,32 @@ internal class DatadogRumMonitorTest {
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M log user message W startOperation { operation key is blank }`(
+    fun `M warn but still emit W startOperation { operation key is blank }`(
         @StringForgery name: String,
         @StringForgery(StringForgeryType.WHITESPACE) operationKey: String
     ) {
-        // When
-        testedMonitor.startOperation(name, operationKey, OperationOptions.Empty, fakeAttributes)
+        // operationKey is optional, so a blank / whitespace-only value is
+        // malformed but must NOT drop the event (v1.10 cross-SDK contract).
+        // The developer is warned and the event is still emitted.
+        val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
-        // Then
+        // When / Then — the event is still produced
+        assertMethodCallProducesValidEvent<RumRawEvent.StartOperation>(
+            whenCalled = {
+                testedMonitor.startOperation(name, operationKey, OperationOptions.Empty, attributes)
+            },
+            then = { event ->
+                assertThat(event.name).isEqualTo(name)
+                assertThat(event.operationKey).isEqualTo(operationKey)
+            }
+        )
+
+        // And — the developer is warned
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
             OPERATION_ERROR_INVALID_OPERATION_KEY.format(Locale.US, operationKey)
         )
-
-        verifyNoInteractions(mockApplicationScope)
-        verifyNoMoreInteractions(mockInternalLogger)
     }
 
     @OptIn(ExperimentalRumApi::class)
@@ -3147,22 +3182,32 @@ internal class DatadogRumMonitorTest {
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M log user message W succeedOperation { operation key is blank }`(
+    fun `M warn but still emit W succeedOperation { operation key is blank }`(
         @StringForgery name: String,
         @StringForgery(StringForgeryType.WHITESPACE) operationKey: String
     ) {
-        // When
-        testedMonitor.succeedOperation(name, operationKey, fakeAttributes)
+        // operationKey is optional, so a blank / whitespace-only value is
+        // malformed but must NOT drop the event (v1.10 cross-SDK contract).
+        val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
-        // Then
+        // When / Then — the event is still produced
+        assertMethodCallProducesValidEvent<RumRawEvent.StopOperation>(
+            whenCalled = {
+                testedMonitor.succeedOperation(name, operationKey, attributes)
+            },
+            then = { event ->
+                assertThat(event.name).isEqualTo(name)
+                assertThat(event.operationKey).isEqualTo(operationKey)
+                assertThat(event.failureReason).isNull()
+            }
+        )
+
+        // And — the developer is warned
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
             OPERATION_ERROR_INVALID_OPERATION_KEY.format(Locale.US, operationKey)
         )
-
-        verifyNoInteractions(mockApplicationScope)
-        verifyNoMoreInteractions(mockInternalLogger)
     }
 
     @OptIn(ExperimentalRumApi::class)
@@ -3189,25 +3234,34 @@ internal class DatadogRumMonitorTest {
 
     @OptIn(ExperimentalRumApi::class)
     @Test
-    fun `M log user message W failOperation { operation key is blank }`(
+    fun `M warn but still emit W failOperation { operation key is blank }`(
         @StringForgery name: String,
         @StringForgery(StringForgeryType.WHITESPACE) operationKey: String,
         forge: Forge
     ) {
+        // operationKey is optional, so a blank / whitespace-only value is
+        // malformed but must NOT drop the event (v1.10 cross-SDK contract).
         val failureReason = forge.aValueFrom(FailureReason::class.java)
+        val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
-        // When
-        testedMonitor.failOperation(name, operationKey, failureReason, fakeAttributes)
+        // When / Then — the event is still produced
+        assertMethodCallProducesValidEvent<RumRawEvent.StopOperation>(
+            whenCalled = {
+                testedMonitor.failOperation(name, operationKey, failureReason, attributes)
+            },
+            then = { event ->
+                assertThat(event.name).isEqualTo(name)
+                assertThat(event.operationKey).isEqualTo(operationKey)
+                assertThat(event.failureReason).isEqualTo(failureReason)
+            }
+        )
 
-        // Then
+        // And — the developer is warned
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
             OPERATION_ERROR_INVALID_OPERATION_KEY.format(Locale.US, operationKey)
         )
-
-        verifyNoInteractions(mockApplicationScope)
-        verifyNoMoreInteractions(mockInternalLogger)
     }
 
     private inline fun <reified T : RumRawEvent> assertMethodCallProducesValidEvent(


### PR DESCRIPTION
### What does this PR do?

Validates `vital.name` client-side in the Operation APIs (`startOperation` / `succeedOperation` / `failOperation`) against the backend's character-set regex `[\w.@$-]*`.

- Blank / whitespace-only name → dropped + `InternalLogger.Level.WARN`
- Name with characters outside `[\w.@$-]*` → `InternalLogger.Level.WARN`, event still emitted
- Valid name → silent emit
- `operationKey` has no schema character-set rule and is left untouched

### Motivation

The authoritative `_vital-common-schema.json` documents `vital.name` as restricted to letters, digits, and `- _ . @ $` — it is used as a facet path by the backend. Until now the Android SDK only checked for blank names; non-conforming values (e.g. `"user login"`) were silently shipped to intake, where they are rejected. Client-side validation gives developers immediate feedback at dev time.

Names that fail the character-set regex still emit because the backend is the source of truth on the policy — a client-side drop would force customers to bump the SDK if the server rule is ever relaxed.

### Additional Notes

- New symbols are `internal`: `VALID_OPERATION_NAME_REGEX` and `OPERATION_ERROR_INVALID_NAME_CHARACTERS`. No public API surface changes; `api/apiSurface` and `api/dd-sdk-android-rum.api` do not need to be regenerated.
- `java.util.regex.Pattern`'s default `\w` is ASCII-only (no `UNICODE_CHARACTER_CLASS` flag) — the non-ASCII test case `"ログイン"` pins this behavior against future drift.
- Part of a cross-SDK rollout (iOS, Browser, Roku, C++, Electron). See the cross-SDK RUM Operations reference spec v1.6 for the shared contract.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)