### PR TITLE
Make sure RumAppStartupDetector.destroy is called on main thread

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -224,6 +224,7 @@ class com.datadog.android.internal.thread.NamedRunnable : NamedExecutionUnit, Ru
   constructor(String, Runnable)
 class com.datadog.android.internal.thread.NamedCallable<V> : NamedExecutionUnit, java.util.concurrent.Callable<V>
   constructor(String, java.util.concurrent.Callable<V>)
+fun isMainThread(): Boolean
 class com.datadog.android.internal.time.DefaultTimeProvider : BaseTimeProvider
   override fun getServerTimestampMillis(): Long
   override fun getServerOffsetNanos(): Long

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -481,6 +481,10 @@ public final class com/datadog/android/internal/thread/NamedRunnable : com/datad
 	public fun run ()V
 }
 
+public final class com/datadog/android/internal/thread/ThreadUtilsKt {
+	public static final fun isMainThread ()Z
+}
+
 public abstract class com/datadog/android/internal/time/BaseTimeProvider : com/datadog/android/internal/time/TimeProvider {
 	public fun <init> ()V
 	public final fun getDeviceElapsedRealtimeMillis ()J

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/thread/ThreadUtils.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/thread/ThreadUtils.kt
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.thread
+
+import android.os.Looper
+
+// Returns if the current thread is the main thread
+fun isMainThread(): Boolean {
+    return Looper.myLooper() == Looper.getMainLooper()
+}

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/thread/ThreadUtils.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/thread/ThreadUtils.kt
@@ -8,7 +8,9 @@ package com.datadog.android.internal.thread
 
 import android.os.Looper
 
-// Returns if the current thread is the main thread
+/**
+ * @return true if the current thread is the main thread, false otherwise
+ */
 fun isMainThread(): Boolean {
     return Looper.myLooper() == Looper.getMainLooper()
 }

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/thread/ThreadUtilsTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/thread/ThreadUtilsTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.thread
+
+import android.os.Looper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.mock
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class ThreadUtilsTest {
+
+    @Test
+    fun `M return true W isMainThread() {current looper is main looper}`() {
+        // Given
+        val mockMainLooper = mock<Looper>()
+
+        Mockito.mockStatic(Looper::class.java).use { mockedLooper ->
+            // When
+            mockedLooper.`when`<Looper> { Looper.getMainLooper() }.thenReturn(mockMainLooper)
+            mockedLooper.`when`<Looper> { Looper.myLooper() }.thenReturn(mockMainLooper)
+
+            // Then
+            assertThat(isMainThread()).isTrue()
+        }
+    }
+
+    @Test
+    fun `M return false W isMainThread() {current looper is not main looper}`() {
+        // Given
+        val mockMainLooper = mock<Looper>()
+        val mockOtherLooper = mock<Looper>()
+
+        Mockito.mockStatic(Looper::class.java).use { mockedLooper ->
+            // When
+            mockedLooper.`when`<Looper> { Looper.getMainLooper() }.thenReturn(mockMainLooper)
+            mockedLooper.`when`<Looper> { Looper.myLooper() }.thenReturn(mockOtherLooper)
+
+            // Then
+            assertThat(isMainThread()).isFalse()
+        }
+    }
+
+    @Test
+    fun `M return false W isMainThread() {current looper is null}`() {
+        // Given
+        val mockMainLooper = mock<Looper>()
+
+        Mockito.mockStatic(Looper::class.java).use { mockedLooper ->
+            // When
+            mockedLooper.`when`<Looper> { Looper.getMainLooper() }.thenReturn(mockMainLooper)
+            mockedLooper.`when`<Looper> { Looper.myLooper() }.thenReturn(null)
+
+            // Then
+            assertThat(isMainThread()).isFalse()
+        }
+    }
+}

--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -72,6 +72,7 @@ datadog:
       - "android.os.LocaleList.get(kotlin.Int)"
       - "android.os.LocaleList.size()"
       - "android.os.Looper.getMainLooper()"
+      - "android.os.Looper.myLooper()"
       - "android.os.Looper.setMessageLogging(android.util.Printer?)"
       - "android.os.Process.getStartElapsedRealtime()"
       - "android.os.Process.getStartUptimeMillis()"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -137,7 +137,8 @@ internal class RumFeature(
     private val lateCrashReporterFactory: (InternalSdkCore) -> LateCrashReporter = {
         DatadogLateCrashReporter(it)
     },
-    private val buildSdkVersionProvider: BuildSdkVersionProvider = BuildSdkVersionProvider.DEFAULT
+    private val buildSdkVersionProvider: BuildSdkVersionProvider = BuildSdkVersionProvider.DEFAULT,
+    private val handler: Handler = Handler(Looper.getMainLooper())
 ) : StorageBackedFeature, FeatureEventReceiver {
 
     internal var dataWriter: DataWriter<Any> = NoOpDataWriter()
@@ -178,7 +179,7 @@ internal class RumFeature(
     internal var insightsCollector: InsightsCollector = NoOpInsightsCollector()
 
     private val lateCrashEventHandler by lazy { lateCrashReporterFactory(sdkCore as InternalSdkCore) }
-    private var rumAppStartupDetector: RumAppStartupDetector? = null
+    internal var rumAppStartupDetector: RumAppStartupDetector? = null
 
     // region Feature
 
@@ -355,7 +356,17 @@ internal class RumFeature(
 
         cleanupInfoProviders()
 
-        rumAppStartupDetector?.destroy()
+        val detector = rumAppStartupDetector
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            @Suppress("ThreadSafety") // just verified we are on the main thread
+            detector?.destroy()
+        } else {
+            handler.post {
+                @Suppress("ThreadSafety") // handler posts to the main looper
+                detector?.destroy()
+            }
+        }
+
         rumAppStartupDetector = null
 
         GlobalRumMonitor.unregister(sdkCore)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -36,6 +36,7 @@ import com.datadog.android.event.NoOpEventMapper
 import com.datadog.android.internal.flags.RumFlagEvaluationMessage
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
+import com.datadog.android.internal.thread.isMainThread
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumSessionListener
@@ -357,7 +358,7 @@ internal class RumFeature(
         cleanupInfoProviders()
 
         val detector = rumAppStartupDetector
-        if (Looper.myLooper() == Looper.getMainLooper()) {
+        if (isMainThread()) {
             @Suppress("ThreadSafety") // just verified we are on the main thread
             detector?.destroy()
         } else {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetector.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetector.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.rum.internal.startup
 
 import android.app.Application
+import androidx.annotation.UiThread
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.rum.internal.domain.Time
@@ -22,6 +23,7 @@ internal interface RumAppStartupDetector {
         fun onTTIDComputed(scenario: RumStartupScenario, durationNs: Long, wasForwarded: Boolean)
     }
 
+    @UiThread
     fun destroy()
 
     companion object {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -13,6 +13,7 @@ import android.app.ApplicationExitInfo
 import android.content.ContentResolver
 import android.content.Context
 import android.content.res.Resources
+import android.os.Handler
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.FeatureContextUpdateReceiver
 import com.datadog.android.api.storage.NoOpDataWriter
@@ -42,6 +43,7 @@ import com.datadog.android.rum.internal.domain.event.RumEventMapper
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.internal.monitor.NoOpAdvancedRumMonitor
+import com.datadog.android.rum.internal.startup.RumAppStartupDetector
 import com.datadog.android.rum.internal.thread.NoOpScheduledExecutorService
 import com.datadog.android.rum.internal.tracking.NoOpInteractionPredicate
 import com.datadog.android.rum.internal.tracking.NoOpUserActionTrackingStrategy
@@ -96,6 +98,7 @@ import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -1622,6 +1625,63 @@ internal class RumFeatureTest {
 
         // Then
         assertThat(testedFeature.initialized).isFalse()
+    }
+
+    @Test
+    fun `M destroy startup detector directly W onStop() {on main thread}`() {
+        // Given
+        val mockHandler: Handler = mock()
+        val mockDetector: RumAppStartupDetector = mock()
+        testedFeature = RumFeature(
+            mockSdkCore,
+            fakeApplicationId.toString(),
+            fakeConfiguration,
+            lateCrashReporterFactory = { mockLateCrashReporter },
+            handler = mockHandler
+        )
+        testedFeature.onInitialize(appContext.mockInstance)
+        testedFeature.rumAppStartupDetector = mockDetector
+
+        // When
+        testedFeature.onStop()
+
+        // Then
+        verify(mockDetector).destroy()
+        verifyNoInteractions(mockHandler)
+    }
+
+    @Test
+    fun `M post destroy to handler W onStop() {not on main thread}`() {
+        // Given
+        val mockHandler: Handler = mock()
+        whenever(mockHandler.post(any())) doAnswer {
+            it.getArgument(0, Runnable::class.java).run()
+            true
+        }
+
+        val mockDetector: RumAppStartupDetector = mock()
+        testedFeature = RumFeature(
+            mockSdkCore,
+            fakeApplicationId.toString(),
+            fakeConfiguration,
+            lateCrashReporterFactory = { mockLateCrashReporter },
+            handler = mockHandler
+        )
+        testedFeature.onInitialize(appContext.mockInstance)
+        testedFeature.rumAppStartupDetector = mockDetector
+
+        // When
+        Thread { testedFeature.onStop() }.apply {
+            start()
+            join()
+        }
+
+        // Then
+        inOrder(mockHandler, mockDetector) {
+            verify(mockHandler).post(any())
+            verify(mockDetector).destroy()
+            verifyNoMoreInteractions()
+        }
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

Addressing this comment https://github.com/DataDog/dd-sdk-android/pull/3373#discussion_r3091670749

**Observations:**
1. I tried to reproduce `CalledFromWrongThreadException` when calling `removeOnDrawListener` and `removeOnAttachStateChangeListener` on a background thread in a UI test, it doesn't crash. Nevertheless, looking at [ViewRootImpl](https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/view/ViewRootImpl.java?q=CalledFromWrongThreadException) code, it seems it requires main thread for a lot of its methods. So, I would say we should be extra careful when interacting with "view related things" from background threads.
2. `RumAppStartupDetectorImpl` by itself doesn't support calling `destroy` from non-main threads. All fields aren't volatile, there is no synchronization.

**Current PR:**
1. Adds `UiThread` annotation to `RumAppStartupDetector.destroy` to establish explicit contract for this class.
2. In `RumFeature.onStop` make sure `RumAppStartupDetector.destroy` is called from the main thread.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

