### PR TITLE
RUM-15682: Support legacy okhttp network telemetry

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -210,6 +210,7 @@ sealed class com.datadog.android.internal.telemetry.InternalTelemetryEvent
       enum LibraryType
         - CRONET
         - OKHTTP
+        - LEGACY_OKHTTP
   object InterceptorInstantiated : InternalTelemetryEvent
 enum com.datadog.android.internal.telemetry.TracingHeaderType
   - DATADOG

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -376,6 +376,7 @@ public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent
 
 public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$NetworkInstrumentation$LibraryType : java/lang/Enum {
 	public static final field CRONET Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$NetworkInstrumentation$LibraryType;
+	public static final field LEGACY_OKHTTP Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$NetworkInstrumentation$LibraryType;
 	public static final field OKHTTP Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$NetworkInstrumentation$LibraryType;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$NetworkInstrumentation$LibraryType;
 	public static fun values ()[Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$NetworkInstrumentation$LibraryType;

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/telemetry/InternalTelemetryEvent.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/telemetry/InternalTelemetryEvent.kt
@@ -78,7 +78,8 @@ sealed class InternalTelemetryEvent {
         ) : ApiUsage(additionalProperties) {
             enum class LibraryType {
                 CRONET,
-                OKHTTP
+                OKHTTP,
+                LEGACY_OKHTTP
             }
         }
     }

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -3252,6 +3252,7 @@ data class com.datadog.android.telemetry.model.TelemetryUsageEvent
     constructor(kotlin.String)
     - CRONET
     - OKHTTP
+    - LEGACY_OKHTTP
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Type

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -9727,6 +9727,7 @@ public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Track
 public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Type : java/lang/Enum {
 	public static final field CRONET Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Type;
 	public static final field Companion Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Type$Companion;
+	public static final field LEGACY_OKHTTP Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Type;
 	public static final field OKHTTP Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Type;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Type;
 	public final fun toJson ()Lcom/google/gson/JsonElement;

--- a/features/dd-sdk-android-rum/src/main/json/telemetry/usage/mobile-features-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/telemetry/usage/mobile-features-schema.json
@@ -51,7 +51,7 @@
         "type": {
           "type": "string",
           "description": "The network instrumentation API used",
-          "enum": ["CRONET", "OKHTTP"]
+          "enum": ["CRONET", "OKHTTP", "LEGACY_OKHTTP"]
         }
       }
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -441,6 +441,9 @@ internal class TelemetryEventHandler(
 
                         InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType.OKHTTP ->
                             TelemetryUsageEvent.Type.OKHTTP
+
+                        InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType.LEGACY_OKHTTP ->
+                            TelemetryUsageEvent.Type.LEGACY_OKHTTP
                     }
                 )
             }

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -14,6 +14,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.okhttp.internal.RumResourceAttributesProviderCompatibilityAdapter
 import com.datadog.android.okhttp.internal.buildResourceId
 import com.datadog.android.okhttp.internal.graphql.OkHttpGraphQLAdapter
@@ -187,7 +188,12 @@ open class DatadogInterceptor internal constructor(
 
     override fun onSdkInstanceReady(sdkCore: InternalSdkCore) {
         super.onSdkInstanceReady(sdkCore)
-        (GlobalRumMonitor.get(sdkCore) as? AdvancedNetworkRumMonitor)?.notifyInterceptorInstantiated()
+        (GlobalRumMonitor.get(sdkCore) as? AdvancedNetworkRumMonitor)?.apply {
+            notifyInterceptorInstantiated()
+            reportNetworkingLibraryType(
+                InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType.LEGACY_OKHTTP
+            )
+        }
     }
 
     // endregion

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -10,8 +10,8 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.internal.network.GraphQLHeaders
-import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.network.HttpSpec
+import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.utils.toBase64
 import com.datadog.android.okhttp.trace.NoOpTracedRequestListener
 import com.datadog.android.okhttp.trace.TracingInterceptor

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -10,6 +10,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.internal.network.GraphQLHeaders
+import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.network.HttpSpec
 import com.datadog.android.internal.utils.toBase64
 import com.datadog.android.okhttp.trace.NoOpTracedRequestListener
@@ -145,6 +146,14 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         verify(rumMonitor.mockInstance).notifyInterceptorInstantiated()
+    }
+
+    @Test
+    fun `M report LEGACY_OKHTTP library type W onSdkInstanceReady()`() {
+        // Then
+        verify(rumMonitor.mockInstance).reportNetworkingLibraryType(
+            InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType.LEGACY_OKHTTP
+        )
     }
 
     @Test

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutRumTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutRumTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.okhttp
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
+import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.okhttp.internal.utils.forge.OkHttpConfigurator
 import com.datadog.android.okhttp.trace.TracingInterceptor
 import com.datadog.android.okhttp.trace.TracingInterceptorTest
@@ -101,6 +102,9 @@ internal class DatadogInterceptorWithoutRumTest : TracingInterceptorTest() {
 
         // Then
         verify(rumMonitor.mockInstance).notifyInterceptorInstantiated()
+        verify(rumMonitor.mockInstance).reportNetworkingLibraryType(
+            InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType.LEGACY_OKHTTP
+        )
         verifyNoMoreInteractions(rumMonitor.mockInstance)
         verifyNoInteractions(mockRumAttributesProvider)
     }
@@ -117,6 +121,9 @@ internal class DatadogInterceptorWithoutRumTest : TracingInterceptorTest() {
 
         // Then
         verify(rumMonitor.mockInstance).notifyInterceptorInstantiated()
+        verify(rumMonitor.mockInstance).reportNetworkingLibraryType(
+            InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType.LEGACY_OKHTTP
+        )
         verifyNoMoreInteractions(rumMonitor.mockInstance)
         verifyNoInteractions(mockRumAttributesProvider)
     }
@@ -136,6 +143,9 @@ internal class DatadogInterceptorWithoutRumTest : TracingInterceptorTest() {
 
         // Then
         verify(rumMonitor.mockInstance).notifyInterceptorInstantiated()
+        verify(rumMonitor.mockInstance).reportNetworkingLibraryType(
+            InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType.LEGACY_OKHTTP
+        )
         verifyNoMoreInteractions(rumMonitor.mockInstance)
         verifyNoInteractions(mockRumAttributesProvider)
     }


### PR DESCRIPTION
### What does this PR do?

Add `LEGACY_OKHTTP` to the `InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType` enum and to the `TelemetryUsageEvent` schema, and have `DatadogInterceptor.onSdkInstanceReady` report the legacy okhttp instrumentation type. Previously only `OKHTTP` (plugin-based) and `CRONET` were tracked.

### Motivation

Backend telemetry needs to distinguish apps still using the legacy `DatadogInterceptor` path from those that migrated to the new plugin-based okhttp instrumentation, so we can measure migration progress and make informed deprecation decisions.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)