### PR TITLE
RUM-15138: Add cross-product sampling rebasing for RUM-to-APM correlation

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -450,6 +450,7 @@ object com.datadog.android.log.LogAttributes
   const val RUM_SESSION_ID: String
   const val RUM_VIEW_ID: String
   const val RUM_ACTION_ID: String
+  const val RUM_SESSION_SAMPLE_RATE: String
   const val SERVICE_NAME: String
   const val SOURCE: String
   const val STATUS: String

--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -449,6 +449,7 @@ object com.datadog.android.log.LogAttributes
   const val RUM_SESSION_ID: String
   const val RUM_VIEW_ID: String
   const val RUM_ACTION_ID: String
+  const val RUM_SESSION_SAMPLE_RATE: String
   const val SERVICE_NAME: String
   const val SOURCE: String
   const val STATUS: String

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -1083,6 +1083,7 @@ public final class com/datadog/android/log/LogAttributes {
 	public static final field RUM_ACTION_ID Ljava/lang/String;
 	public static final field RUM_APPLICATION_ID Ljava/lang/String;
 	public static final field RUM_SESSION_ID Ljava/lang/String;
+	public static final field RUM_SESSION_SAMPLE_RATE Ljava/lang/String;
 	public static final field RUM_VIEW_ID Ljava/lang/String;
 	public static final field SERVICE Ljava/lang/String;
 	public static final field SERVICE_NAME Ljava/lang/String;

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -1082,6 +1082,7 @@ public final class com/datadog/android/log/LogAttributes {
 	public static final field RUM_ACTION_ID Ljava/lang/String;
 	public static final field RUM_APPLICATION_ID Ljava/lang/String;
 	public static final field RUM_SESSION_ID Ljava/lang/String;
+	public static final field RUM_SESSION_SAMPLE_RATE Ljava/lang/String;
 	public static final field RUM_VIEW_ID Ljava/lang/String;
 	public static final field SERVICE Ljava/lang/String;
 	public static final field SERVICE_NAME Ljava/lang/String;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/log/LogAttributes.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/log/LogAttributes.kt
@@ -280,6 +280,13 @@ object LogAttributes {
     const val RUM_ACTION_ID: String = "user_action.id"
 
     /**
+     * The sample rate applied to the active RUM session. (Number)
+     * Used to propagate the session sample rate to other features (e.g. Tracing)
+     * for cross-product sampling correlation.
+     */
+    const val RUM_SESSION_SAMPLE_RATE: String = "session_sample_rate"
+
+    /**
      * The name of the application or service generating the log events. (String)
      * This value is filled automatically by the [Logger].
      * @see [Configuration.Builder.service]

--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -1136,6 +1136,7 @@ datadog:
       - "kotlin.Double.toInt()"
       - "kotlin.Double.toLong()"
       - "kotlin.Double.toULong()"
+      - "kotlin.Float.coerceAtMost(kotlin.Float)"
       - "kotlin.Float.coerceIn(kotlin.Float, kotlin.Float)"
       - "kotlin.Float.fromBits(kotlin.Int)"
       - "kotlin.Float.percent()"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumContext.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumContext.kt
@@ -25,7 +25,8 @@ internal data class RumContext(
     val syntheticsResultId: String? = null,
     val viewTimestamp: Long = 0L,
     val viewTimestampOffset: Long = 0L,
-    val hasReplay: Boolean = false
+    val hasReplay: Boolean = false,
+    val sessionSampleRate: Float = SAMPLE_ALL_RATE
 ) {
 
     fun toMap(): Map<String, Any?> {
@@ -44,7 +45,8 @@ internal data class RumContext(
             SYNTHETICS_RESULT_ID to syntheticsResultId,
             VIEW_TIMESTAMP to viewTimestamp,
             HAS_REPLAY to hasReplay,
-            VIEW_TIMESTAMP_OFFSET to viewTimestampOffset
+            VIEW_TIMESTAMP_OFFSET to viewTimestampOffset,
+            SESSION_SAMPLE_RATE to sessionSampleRate
         )
     }
 
@@ -69,6 +71,7 @@ internal data class RumContext(
         const val HAS_REPLAY = "view_has_replay"
         const val VIEW_TIMESTAMP = "view_timestamp"
         const val VIEW_TIMESTAMP_OFFSET = "view_timestamp_offset"
+        const val SESSION_SAMPLE_RATE = "session_sample_rate"
 
         fun fromFeatureContext(featureContext: Map<String, Any?>): RumContext {
             val applicationId = featureContext[APPLICATION_ID] as? String
@@ -90,6 +93,7 @@ internal data class RumContext(
             val hasReplay = featureContext[HAS_REPLAY] as? Boolean ?: false
             val viewTimestamp = featureContext[VIEW_TIMESTAMP] as? Long ?: 0L
             val viewTimestampOffset = featureContext[VIEW_TIMESTAMP_OFFSET] as? Long ?: 0L
+            val sampleRate = (featureContext[SESSION_SAMPLE_RATE] as? Number)?.toFloat() ?: SAMPLE_ALL_RATE
 
             return RumContext(
                 applicationId = applicationId ?: NULL_UUID,
@@ -106,7 +110,8 @@ internal data class RumContext(
                 syntheticsResultId = syntheticsResultId,
                 viewTimestamp = viewTimestamp,
                 viewTimestampOffset = viewTimestampOffset,
-                hasReplay = hasReplay
+                hasReplay = hasReplay,
+                sessionSampleRate = sampleRate
             )
         }
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -212,7 +212,8 @@ internal class RumSessionScope(
             sessionId = sessionId,
             sessionState = sessionState,
             sessionStartReason = startReason,
-            isSessionActive = isActive
+            isSessionActive = isActive,
+            sessionSampleRate = sessionSampleRate
         )
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/RumContextForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/RumContextForgeryFactory.kt
@@ -27,7 +27,8 @@ internal class RumContextForgeryFactory : ForgeryFactory<RumContext> {
             sessionStartReason = forge.aValueFrom(RumSessionScope.StartReason::class.java),
             viewType = forge.aValueFrom(RumViewType::class.java),
             syntheticsTestId = forge.aNullable { forge.anAlphaNumericalString() },
-            syntheticsResultId = forge.aNullable { forge.anAlphaNumericalString() }
+            syntheticsResultId = forge.aNullable { forge.anAlphaNumericalString() },
+            sessionSampleRate = forge.aFloat(min = 0f, max = 100f)
         )
     }
 }

--- a/features/dd-sdk-android-trace/api/apiSurface
+++ b/features/dd-sdk-android-trace/api/apiSurface
@@ -90,10 +90,10 @@ data class com.datadog.android.trace.internal.net.RequestTracingState
   fun createRequestInfo(): com.datadog.android.api.instrumentation.network.HttpRequestInfo
 fun RequestTracingState?.toAttributesMap(String, String, String): Map<String, Any?>
 class com.datadog.android.trace.internal.net.SessionRebasedSampler : com.datadog.android.core.sampling.Sampler<com.datadog.android.trace.api.span.DatadogSpan>, SpanAwareSampler
-  constructor(com.datadog.android.core.sampling.Sampler<com.datadog.android.trace.api.span.DatadogSpan>)
+  constructor(com.datadog.android.trace.DeterministicTraceSampler)
   override fun sample(com.datadog.android.trace.api.span.DatadogSpan): Boolean
-  override fun getSampleRate(): Float?
-  override fun getSampleRate(com.datadog.android.trace.api.span.DatadogSpan): Float?
+  override fun getSampleRate(): Float
+  override fun getSampleRate(com.datadog.android.trace.api.span.DatadogSpan): Float
 interface com.datadog.android.trace.internal.net.SpanAwareSampler
   fun getSampleRate(com.datadog.android.trace.api.span.DatadogSpan): Float?
 data class com.datadog.android.trace.internal.net.TraceContext

--- a/features/dd-sdk-android-trace/api/apiSurface
+++ b/features/dd-sdk-android-trace/api/apiSurface
@@ -84,10 +84,18 @@ object com.datadog.android.trace.internal._TraceInternalProxy
   fun activateSpan(com.datadog.android.trace.api.tracer.DatadogTracer, com.datadog.android.trace.api.span.DatadogSpan, Boolean): com.datadog.android.trace.api.scope.DatadogScope?
   fun mergeBaggage(String?, String): String
   fun createApmNetworkInstrumentation(String, com.datadog.android.trace.ApmNetworkInstrumentationConfiguration)
+fun com.datadog.android.core.sampling.Sampler<com.datadog.android.trace.api.span.DatadogSpan>.effectiveSampleRate(com.datadog.android.trace.api.span.DatadogSpan): Float?
 data class com.datadog.android.trace.internal.net.RequestTracingState
   constructor(com.datadog.android.api.instrumentation.network.HttpRequestInfoBuilder, Boolean = false, com.datadog.android.trace.api.span.DatadogSpan? = null, Float? = null)
   fun createRequestInfo(): com.datadog.android.api.instrumentation.network.HttpRequestInfo
 fun RequestTracingState?.toAttributesMap(String, String, String): Map<String, Any?>
+class com.datadog.android.trace.internal.net.SessionRebasedSampler : com.datadog.android.core.sampling.Sampler<com.datadog.android.trace.api.span.DatadogSpan>, SpanAwareSampler
+  constructor(com.datadog.android.core.sampling.Sampler<com.datadog.android.trace.api.span.DatadogSpan>)
+  override fun sample(com.datadog.android.trace.api.span.DatadogSpan): Boolean
+  override fun getSampleRate(): Float?
+  override fun getSampleRate(com.datadog.android.trace.api.span.DatadogSpan): Float?
+interface com.datadog.android.trace.internal.net.SpanAwareSampler
+  fun getSampleRate(com.datadog.android.trace.api.span.DatadogSpan): Float?
 data class com.datadog.android.trace.internal.net.TraceContext
   constructor(String, String, Int)
 fun <T> android.database.sqlite.SQLiteDatabase.transactionTraced(String, Boolean = true, com.datadog.android.trace.api.span.DatadogSpan.(android.database.sqlite.SQLiteDatabase) -> T): T

--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -156,6 +156,10 @@ public final class com/datadog/android/trace/internal/_TraceInternalProxy {
 	public final fun setTracingSamplingPriorityIfNecessary (Lcom/datadog/android/trace/api/span/DatadogSpanContext;)V
 }
 
+public final class com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExtKt {
+	public static final fun effectiveSampleRate (Lcom/datadog/android/core/sampling/Sampler;Lcom/datadog/android/trace/api/span/DatadogSpan;)Ljava/lang/Float;
+}
+
 public final class com/datadog/android/trace/internal/net/RequestTracingState {
 	public fun <init> (Lcom/datadog/android/api/instrumentation/network/HttpRequestInfoBuilder;ZLcom/datadog/android/trace/api/span/DatadogSpan;Ljava/lang/Float;)V
 	public synthetic fun <init> (Lcom/datadog/android/api/instrumentation/network/HttpRequestInfoBuilder;ZLcom/datadog/android/trace/api/span/DatadogSpan;Ljava/lang/Float;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -177,6 +181,18 @@ public final class com/datadog/android/trace/internal/net/RequestTracingState {
 
 public final class com/datadog/android/trace/internal/net/RequestTracingStateKt {
 	public static final fun toAttributesMap (Lcom/datadog/android/trace/internal/net/RequestTracingState;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/util/Map;
+}
+
+public final class com/datadog/android/trace/internal/net/SessionRebasedSampler : com/datadog/android/core/sampling/Sampler, com/datadog/android/trace/internal/net/SpanAwareSampler {
+	public fun <init> (Lcom/datadog/android/core/sampling/Sampler;)V
+	public fun getSampleRate ()Ljava/lang/Float;
+	public fun getSampleRate (Lcom/datadog/android/trace/api/span/DatadogSpan;)Ljava/lang/Float;
+	public fun sample (Lcom/datadog/android/trace/api/span/DatadogSpan;)Z
+	public synthetic fun sample (Ljava/lang/Object;)Z
+}
+
+public abstract interface class com/datadog/android/trace/internal/net/SpanAwareSampler {
+	public abstract fun getSampleRate (Lcom/datadog/android/trace/api/span/DatadogSpan;)Ljava/lang/Float;
 }
 
 public final class com/datadog/android/trace/internal/net/TraceContext {

--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -184,7 +184,7 @@ public final class com/datadog/android/trace/internal/net/RequestTracingStateKt 
 }
 
 public final class com/datadog/android/trace/internal/net/SessionRebasedSampler : com/datadog/android/core/sampling/Sampler, com/datadog/android/trace/internal/net/SpanAwareSampler {
-	public fun <init> (Lcom/datadog/android/core/sampling/Sampler;)V
+	public fun <init> (Lcom/datadog/android/trace/DeterministicTraceSampler;)V
 	public fun getSampleRate ()Ljava/lang/Float;
 	public fun getSampleRate (Lcom/datadog/android/trace/api/span/DatadogSpan;)Ljava/lang/Float;
 	public fun sample (Lcom/datadog/android/trace/api/span/DatadogSpan;)Z

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/ApmNetworkInstrumentationConfiguration.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/ApmNetworkInstrumentationConfiguration.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.trace.api.span.DatadogSpan
 import com.datadog.android.trace.api.tracer.DatadogTracer
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation
+import com.datadog.android.trace.internal.net.SessionRebasedSampler
 import com.datadog.android.trace.internal.net.TracerProvider
 
 /**
@@ -246,10 +247,16 @@ class ApmNetworkInstrumentationConfiguration internal constructor(
 
             val tracerProvider = TracerProvider(localTracerFactory, globalTracerProvider)
 
+            val effectiveSampler = if (headerPropagationOnly) {
+                SessionRebasedSampler(traceSampler)
+            } else {
+                traceSampler
+            }
+
             return ApmNetworkInstrumentation(
                 canSendSpan = !headerPropagationOnly,
                 traceOrigin = traceOrigin,
-                traceSampler = traceSampler,
+                traceSampler = effectiveSampler,
                 tracerProvider = tracerProvider,
                 sdkInstanceName = sdkInstanceName,
                 injectionType = traceContextInjection,

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/ApmNetworkInstrumentationConfiguration.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/ApmNetworkInstrumentationConfiguration.kt
@@ -119,6 +119,11 @@ class ApmNetworkInstrumentationConfiguration internal constructor(
      * Set the trace sample rate controlling the sampling of APM traces created for
      * auto-instrumented requests. If there is a parent trace attached to the network span created, then its
      * sampling decision will be used instead.
+     *
+     * When `headerPropagationOnly` is enabled, the effective trace sample rate is automatically combined with
+     * the active RUM session sample rate, ensuring the backend receives correct sampling metadata
+     * (`_dd.agent_psr` / `_dd.rule_psr`) for RUM-to-APM correlation.
+     *
      * @param sampleRate the sample rate to use (percentage between 0f and 100f, default is 100f).
      */
     fun setTraceSampleRate(@FloatRange(from = 0.0, to = 100.0) sampleRate: Float) = apply {
@@ -129,6 +134,11 @@ class ApmNetworkInstrumentationConfiguration internal constructor(
      * Set the trace sampler controlling the sampling of APM traces created for
      * auto-instrumented requests. If there is a parent trace attached to the network span created, then its
      * sampling decision will be used instead.
+     *
+     * Note: custom samplers passed here do not participate in cross-product rebasing with the RUM session
+     * sample rate (even when `headerPropagationOnly` is enabled). Use [setTraceSampleRate] if you need
+     * correlated sampling between RUM sessions and APM traces.
+     *
      * @param traceSampler the trace sampler controlling the sampling of APM traces.
      * By default it is a sampler accepting 100% of the traces.
      */
@@ -247,10 +257,11 @@ class ApmNetworkInstrumentationConfiguration internal constructor(
 
             val tracerProvider = TracerProvider(localTracerFactory, globalTracerProvider)
 
-            val effectiveSampler = if (headerPropagationOnly) {
-                SessionRebasedSampler(traceSampler)
+            val currentTraceSampler = traceSampler
+            val effectiveSampler = if (headerPropagationOnly && currentTraceSampler is DeterministicTraceSampler) {
+                SessionRebasedSampler(currentTraceSampler)
             } else {
-                traceSampler
+                currentTraceSampler
             }
 
             return ApmNetworkInstrumentation(

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ApmNetworkInstrumentation.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ApmNetworkInstrumentation.kt
@@ -32,6 +32,7 @@ import com.datadog.android.trace.internal.net.RequestTracingState
 import com.datadog.android.trace.internal.net.TracerProvider
 import com.datadog.android.trace.internal.net.applyPriority
 import com.datadog.android.trace.internal.net.buildSpan
+import com.datadog.android.trace.internal.net.effectiveSampleRate
 import com.datadog.android.trace.internal.net.finishRumAware
 import com.datadog.android.trace.internal.net.sample
 import java.net.HttpURLConnection
@@ -148,7 +149,7 @@ class ApmNetworkInstrumentation internal constructor(
         return RequestTracingState(
             span = span,
             isSampled = isSampled,
-            sampleRate = traceSampler.getSampleRate(),
+            sampleRate = traceSampler.effectiveSampleRate(span),
             requestInfoBuilder = tracedRequestInfoBuilder
         )
     }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/RumContextPropagator.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/RumContextPropagator.kt
@@ -62,6 +62,10 @@ class RumContextPropagator(private val sdkCoreProvider: () -> FeatureSdkCore?) {
                 instance.setTag(LogAttributes.RUM_SESSION_ID, rumContext["session_id"])
                 instance.setTag(LogAttributes.RUM_VIEW_ID, rumContext["view_id"])
                 instance.setTag(LogAttributes.RUM_ACTION_ID, rumContext["action_id"])
+                instance.setTag(
+                    LogAttributes.RUM_SESSION_SAMPLE_RATE,
+                    rumContext[LogAttributes.RUM_SESSION_SAMPLE_RATE]
+                )
                 instance.setTag(HttpCodec.RUM_KEY_USER_ID, datadogContext.userInfo.id)
                 instance.setTag(HttpCodec.RUM_KEY_ACCOUNT_ID, datadogContext.accountInfo?.id)
             }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExt.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExt.kt
@@ -9,6 +9,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.instrumentation.network.HttpRequestInfo
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.lint.InternalApi
 import com.datadog.android.trace.api.DatadogTracingConstants.PrioritySampling
 import com.datadog.android.trace.api.DatadogTracingConstants.Tags
 import com.datadog.android.trace.api.span.DatadogSpan
@@ -24,6 +25,19 @@ import java.util.Locale
 internal val FeatureSdkCore?.isRumEnabled: Boolean
     get() = this?.getFeature(Feature.RUM_FEATURE_NAME) != null
 
+/**
+ * Returns the effective sample rate for the given [span].
+ * If the sampler implements [SpanAwareSampler], the per-span rate is returned.
+ * Otherwise, the sampler's static rate is returned.
+ */
+@InternalApi
+fun Sampler<DatadogSpan>.effectiveSampleRate(span: DatadogSpan): Float? {
+    return when (this) {
+        is SpanAwareSampler -> getSampleRate(span)
+        else -> getSampleRate()
+    }
+}
+
 internal fun DatadogSpan.applyPriority(isSampled: Boolean, traceSampler: Sampler<DatadogSpan>) {
     val samplingPriority = if (isSampled) {
         PrioritySampling.SAMPLER_KEEP
@@ -35,7 +49,7 @@ internal fun DatadogSpan.applyPriority(isSampled: Boolean, traceSampler: Sampler
     if (spanContext.setSamplingPriority(samplingPriority)) {
         spanContext.setMetric(
             AGENT_PSR_ATTRIBUTE,
-            (traceSampler.getSampleRate() ?: ZERO_SAMPLE_RATE) / ALL_IN_SAMPLE_RATE
+            (traceSampler.effectiveSampleRate(this) ?: ZERO_SAMPLE_RATE) / ALL_IN_SAMPLE_RATE
         )
     }
 }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/SessionRebasedSampler.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/SessionRebasedSampler.kt
@@ -1,0 +1,72 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.internal.net
+
+import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.internal.sampling.DeterministicSampling
+import com.datadog.android.log.LogAttributes
+import com.datadog.android.trace.DeterministicTraceSampler
+import com.datadog.android.trace.api.span.DatadogSpan
+
+/**
+ * A [Sampler] decorator that rebases the trace sample rate against the RUM session sample rate.
+ *
+ * When the delegate is a [DeterministicTraceSampler] and the span carries a
+ * [LogAttributes.RUM_SESSION_SAMPLE_RATE] tag (injected by [com.datadog.android.trace.internal.RumContextPropagator]),
+ * the effective sample rate becomes `traceSampleRate * sessionSampleRate / 100`.
+ * This ensures that the combined probability of a trace being sampled within a sampled RUM session
+ * is correctly represented.
+ *
+ * For custom (non-[DeterministicTraceSampler]) delegates, the decorator passes through
+ * to the delegate without rebasing.
+ *
+ * @param delegate the underlying sampler to wrap.
+ */
+internal class SessionRebasedSampler(
+    private val delegate: Sampler<DatadogSpan>
+) : Sampler<DatadogSpan> {
+
+    override fun sample(item: DatadogSpan): Boolean {
+        if (delegate !is DeterministicTraceSampler) return delegate.sample(item)
+        val rawRate = delegate.getSampleRate()
+        val effectiveRate = computeEffectiveRate(item, rawRate)
+        return if (effectiveRate == rawRate) {
+            delegate.sample(item)
+        } else {
+            DeterministicTraceSampler(effectiveRate).sample(item)
+        }
+    }
+
+    override fun getSampleRate(): Float? = delegate.getSampleRate()
+
+    /**
+     * Returns the effective (rebased) sample rate for the given span.
+     * If the span has a `session_sample_rate` tag and the delegate is a [DeterministicTraceSampler],
+     * the rate is rebased. Otherwise, the raw delegate rate is returned.
+     */
+    internal fun getEffectiveSampleRate(item: DatadogSpan): Float {
+        val rawRate = delegate.getSampleRate() ?: SAMPLE_ALL_RATE
+        return if (delegate is DeterministicTraceSampler) {
+            computeEffectiveRate(item, rawRate)
+        } else {
+            rawRate
+        }
+    }
+
+    private fun computeEffectiveRate(item: DatadogSpan, rawRate: Float): Float {
+        val sessionRate = (item.context().tags[LogAttributes.RUM_SESSION_SAMPLE_RATE] as? Number)?.toFloat()
+        return if (sessionRate != null) {
+            DeterministicSampling.combinedSampleRate(sessionRate, rawRate)
+        } else {
+            rawRate
+        }
+    }
+
+    internal companion object {
+        internal const val SAMPLE_ALL_RATE = 100f
+    }
+}

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/SessionRebasedSampler.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/SessionRebasedSampler.kt
@@ -16,24 +16,24 @@ import com.datadog.android.trace.api.span.DatadogSpan
 /**
  * A [Sampler] decorator that rebases the trace sample rate against the RUM session sample rate.
  *
- * When the delegate is a [DeterministicTraceSampler] and the span carries a
- * [LogAttributes.RUM_SESSION_SAMPLE_RATE] tag (injected by [com.datadog.android.trace.internal.RumContextPropagator]),
- * the effective sample rate becomes `traceSampleRate * sessionSampleRate / 100`.
- * This ensures that the combined probability of a trace being sampled within a sampled RUM session
- * is correctly represented.
+ * When the span carries a [LogAttributes.RUM_SESSION_SAMPLE_RATE] tag (injected by
+ * [com.datadog.android.trace.internal.RumContextPropagator]), the effective sample rate becomes
+ * `traceSampleRate * sessionSampleRate / 100`. This ensures that the combined probability of a
+ * trace being sampled within a sampled RUM session is correctly represented.
  *
- * For custom (non-[DeterministicTraceSampler]) delegates, the decorator passes through
- * to the delegate without rebasing.
+ * Only [DeterministicTraceSampler] delegates participate in rebasing; this constraint is enforced
+ * at the construction sites, which only wrap the default trace sampler (or one set via
+ * `setTraceSampleRate`). Custom samplers passed via `setTraceSampler` are not wrapped and bypass
+ * rebasing entirely.
  *
- * @param delegate the underlying sampler to wrap.
+ * @param delegate the underlying [DeterministicTraceSampler] to wrap.
  */
 @InternalApi
 class SessionRebasedSampler(
-    private val delegate: Sampler<DatadogSpan>
+    private val delegate: DeterministicTraceSampler
 ) : Sampler<DatadogSpan>, SpanAwareSampler {
 
     override fun sample(item: DatadogSpan): Boolean {
-        if (delegate !is DeterministicTraceSampler) return delegate.sample(item)
         val rawRate = delegate.getSampleRate()
         val effectiveRate = computeEffectiveRate(item, rawRate)
         return if (effectiveRate == rawRate) {
@@ -43,10 +43,9 @@ class SessionRebasedSampler(
         }
     }
 
-    override fun getSampleRate(): Float? = delegate.getSampleRate()
+    override fun getSampleRate(): Float = delegate.getSampleRate()
 
-    override fun getSampleRate(span: DatadogSpan): Float? {
-        if (delegate !is DeterministicTraceSampler) return delegate.effectiveSampleRate(span)
+    override fun getSampleRate(span: DatadogSpan): Float {
         val rawRate = delegate.getSampleRate()
         return computeEffectiveRate(span, rawRate)
     }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/SessionRebasedSampler.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/SessionRebasedSampler.kt
@@ -8,6 +8,7 @@ package com.datadog.android.trace.internal.net
 
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.internal.sampling.DeterministicSampling
+import com.datadog.android.lint.InternalApi
 import com.datadog.android.log.LogAttributes
 import com.datadog.android.trace.DeterministicTraceSampler
 import com.datadog.android.trace.api.span.DatadogSpan
@@ -26,9 +27,10 @@ import com.datadog.android.trace.api.span.DatadogSpan
  *
  * @param delegate the underlying sampler to wrap.
  */
-internal class SessionRebasedSampler(
+@InternalApi
+class SessionRebasedSampler(
     private val delegate: Sampler<DatadogSpan>
-) : Sampler<DatadogSpan> {
+) : Sampler<DatadogSpan>, SpanAwareSampler {
 
     override fun sample(item: DatadogSpan): Boolean {
         if (delegate !is DeterministicTraceSampler) return delegate.sample(item)
@@ -43,18 +45,10 @@ internal class SessionRebasedSampler(
 
     override fun getSampleRate(): Float? = delegate.getSampleRate()
 
-    /**
-     * Returns the effective (rebased) sample rate for the given span.
-     * If the span has a `session_sample_rate` tag and the delegate is a [DeterministicTraceSampler],
-     * the rate is rebased. Otherwise, the raw delegate rate is returned.
-     */
-    internal fun getEffectiveSampleRate(item: DatadogSpan): Float {
-        val rawRate = delegate.getSampleRate() ?: SAMPLE_ALL_RATE
-        return if (delegate is DeterministicTraceSampler) {
-            computeEffectiveRate(item, rawRate)
-        } else {
-            rawRate
-        }
+    override fun getSampleRate(span: DatadogSpan): Float? {
+        if (delegate !is DeterministicTraceSampler) return delegate.effectiveSampleRate(span)
+        val rawRate = delegate.getSampleRate()
+        return computeEffectiveRate(span, rawRate)
     }
 
     private fun computeEffectiveRate(item: DatadogSpan, rawRate: Float): Float {
@@ -64,9 +58,5 @@ internal class SessionRebasedSampler(
         } else {
             rawRate
         }
-    }
-
-    internal companion object {
-        internal const val SAMPLE_ALL_RATE = 100f
     }
 }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/SpanAwareSampler.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/SpanAwareSampler.kt
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.internal.net
+
+import com.datadog.android.lint.InternalApi
+import com.datadog.android.trace.api.span.DatadogSpan
+
+/**
+ * A sampler that can provide a per-span sample rate.
+ *
+ * This extends the concept of [com.datadog.android.core.sampling.Sampler.getSampleRate] (no-arg)
+ * with a span-aware variant. It is used when the effective sample rate depends on span-level
+ * context (e.g., the RUM session sample rate tag for cross-product sampling rebasing).
+ */
+@InternalApi
+interface SpanAwareSampler {
+
+    /**
+     * Returns the effective sample rate for the given [span].
+     *
+     * @param span the span for which to compute the sample rate.
+     * @return the effective sample rate, or null if not available.
+     */
+    fun getSampleRate(span: DatadogSpan): Float?
+}

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/RumContextPropagatorTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/RumContextPropagatorTest.kt
@@ -24,6 +24,7 @@ import com.datadog.android.trace.internal.RumContextPropagator.Companion.injectR
 import com.datadog.android.trace.utils.RumContextTestsUtils.RUM_CONTEXT_ACTION_ID
 import com.datadog.android.trace.utils.RumContextTestsUtils.RUM_CONTEXT_APPLICATION_ID
 import com.datadog.android.trace.utils.RumContextTestsUtils.RUM_CONTEXT_SESSION_ID
+import com.datadog.android.trace.utils.RumContextTestsUtils.RUM_CONTEXT_SESSION_SAMPLE_RATE
 import com.datadog.android.trace.utils.RumContextTestsUtils.RUM_CONTEXT_VIEW_ID
 import com.datadog.android.trace.utils.RumContextTestsUtils.aDatadogContextWithRumContext
 import com.datadog.android.trace.utils.RumContextTestsUtils.aRumContext
@@ -293,6 +294,10 @@ class RumContextPropagatorTest {
         verify(span).setTag(LogAttributes.RUM_SESSION_ID, fakeRumContext[RUM_CONTEXT_SESSION_ID])
         verify(span).setTag(LogAttributes.RUM_VIEW_ID, fakeRumContext[RUM_CONTEXT_VIEW_ID])
         verify(span).setTag(LogAttributes.RUM_ACTION_ID, fakeRumContext[RUM_CONTEXT_ACTION_ID])
+        verify(span).setTag(
+            LogAttributes.RUM_SESSION_SAMPLE_RATE,
+            fakeRumContext[RUM_CONTEXT_SESSION_SAMPLE_RATE]
+        )
         verify(span).setTag(HttpCodec.RUM_KEY_ACCOUNT_ID, fakeDatadogContext.accountInfo?.id as? Any)
         verify(span).setTag(HttpCodec.RUM_KEY_USER_ID, fakeDatadogContext.userInfo.id as? Any)
         verify(span).setTag(DATADOG_INITIAL_CONTEXT, null as Any?)
@@ -317,6 +322,10 @@ class RumContextPropagatorTest {
         verify(span).setTag(LogAttributes.RUM_SESSION_ID, fakeRumContext[RUM_CONTEXT_SESSION_ID])
         verify(span).setTag(LogAttributes.RUM_VIEW_ID, fakeRumContext[RUM_CONTEXT_VIEW_ID])
         verify(span).setTag(LogAttributes.RUM_ACTION_ID, fakeRumContext[RUM_CONTEXT_ACTION_ID])
+        verify(span).setTag(
+            LogAttributes.RUM_SESSION_SAMPLE_RATE,
+            fakeRumContext[RUM_CONTEXT_SESSION_SAMPLE_RATE]
+        )
         verify(span).setTag(HttpCodec.RUM_KEY_ACCOUNT_ID, fakeDatadogContext.accountInfo?.id as? Any)
         verify(span).setTag(HttpCodec.RUM_KEY_USER_ID, fakeDatadogContext.userInfo.id as? Any)
         verify(span).setTag(DATADOG_INITIAL_CONTEXT, null as Any?)
@@ -339,6 +348,7 @@ class RumContextPropagatorTest {
         verify(span).setTag(LogAttributes.RUM_SESSION_ID, null as Any?)
         verify(span).setTag(LogAttributes.RUM_VIEW_ID, null as Any?)
         verify(span).setTag(LogAttributes.RUM_ACTION_ID, null as Any?)
+        verify(span).setTag(LogAttributes.RUM_SESSION_SAMPLE_RATE, null as Any?)
         verify(span).setTag(HttpCodec.RUM_KEY_ACCOUNT_ID, null as Any?)
         verify(span).setTag(HttpCodec.RUM_KEY_USER_ID, null as Any?)
         verify(span).setTag(DATADOG_INITIAL_CONTEXT, null as Any?)
@@ -362,6 +372,7 @@ class RumContextPropagatorTest {
         verify(span).setTag(LogAttributes.RUM_SESSION_ID, null as Any?)
         verify(span).setTag(LogAttributes.RUM_VIEW_ID, null as Any?)
         verify(span).setTag(LogAttributes.RUM_ACTION_ID, null as Any?)
+        verify(span).setTag(LogAttributes.RUM_SESSION_SAMPLE_RATE, null as Any?)
         verify(span).setTag(HttpCodec.RUM_KEY_ACCOUNT_ID, null as Any?)
         verify(span).setTag(HttpCodec.RUM_KEY_USER_ID, null as Any?)
         verify(span).setTag(DATADOG_INITIAL_CONTEXT, null as Any?)

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/CoreTraceWriterTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/CoreTraceWriterTest.kt
@@ -185,11 +185,11 @@ internal class CoreTraceWriterTest {
             allValues.forEach { span ->
                 verify(span).setTag(
                     LogAttributes.RUM_APPLICATION_ID,
-                    fakeRumContext[RUM_CONTEXT_APPLICATION_ID] as? Any?
+                    fakeRumContext[RUM_CONTEXT_APPLICATION_ID]
                 )
-                verify(span).setTag(LogAttributes.RUM_SESSION_ID, fakeRumContext[RUM_CONTEXT_SESSION_ID] as? Any?)
-                verify(span).setTag(LogAttributes.RUM_VIEW_ID, fakeRumContext[RUM_CONTEXT_VIEW_ID] as? Any?)
-                verify(span).setTag(LogAttributes.RUM_ACTION_ID, fakeRumContext[RUM_CONTEXT_ACTION_ID] as? Any?)
+                verify(span).setTag(LogAttributes.RUM_SESSION_ID, fakeRumContext[RUM_CONTEXT_SESSION_ID])
+                verify(span).setTag(LogAttributes.RUM_VIEW_ID, fakeRumContext[RUM_CONTEXT_VIEW_ID])
+                verify(span).setTag(LogAttributes.RUM_ACTION_ID, fakeRumContext[RUM_CONTEXT_ACTION_ID])
                 verify(span).setTag(RumContextPropagator.DATADOG_INITIAL_CONTEXT, null as Any?)
             }
         }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmInstrumentationConfigurationTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmInstrumentationConfigurationTest.kt
@@ -240,4 +240,33 @@ internal class ApmInstrumentationConfigurationTest {
         // Then
         assertThat(result.networkTracingScope).isEqualTo(fakeScope)
     }
+
+    @Test
+    fun `M wrap sampler in SessionRebasedSampler W createInstrumentation() { headerPropagationOnly }`(
+        @FloatForgery(min = 0f, max = 100f) fakeSampleRate: Float
+    ) {
+        // When
+        val result = testedBuilder
+            .setTraceSampleRate(fakeSampleRate)
+            .setHeaderPropagationOnly()
+            .createInstrumentation(fakeNetworkLibraryName)
+
+        // Then
+        assertThat(result.traceSampler).isInstanceOf(SessionRebasedSampler::class.java)
+        assertThat(result.traceSampler.getSampleRate()).isEqualTo(fakeSampleRate)
+    }
+
+    @Test
+    fun `M not wrap sampler W createInstrumentation() { not headerPropagationOnly }`(
+        @FloatForgery(min = 0f, max = 100f) fakeSampleRate: Float
+    ) {
+        // When
+        val result = testedBuilder
+            .setTraceSampleRate(fakeSampleRate)
+            .createInstrumentation(fakeNetworkLibraryName)
+
+        // Then
+        assertThat(result.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(result.traceSampler.getSampleRate()).isEqualTo(fakeSampleRate)
+    }
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/SessionRebasedSamplerTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/SessionRebasedSamplerTest.kt
@@ -1,0 +1,259 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.internal.net
+
+import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.log.LogAttributes
+import com.datadog.android.trace.DeterministicTraceSampler
+import com.datadog.android.trace.api.span.DatadogSpan
+import com.datadog.android.trace.api.span.DatadogSpanContext
+import com.datadog.android.trace.api.trace.DatadogTraceId
+import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.FloatForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class SessionRebasedSamplerTest {
+
+    // region sample()
+
+    @Test
+    fun `M use rebased rate W sample() { session_sample_rate tag present }`(forge: Forge) {
+        // Given
+        val fakeTraceRate = forge.aFloat(min = 0f, max = 100f)
+        val fakeSessionRate = forge.aFloat(min = 0f, max = 99.99f)
+        val expectedRate = fakeTraceRate * fakeSessionRate / 100f
+
+        val delegate = DeterministicTraceSampler(fakeTraceRate)
+        val testedSampler = SessionRebasedSampler(delegate)
+
+        val spans = createSpans(forge, sessionSampleRate = fakeSessionRate)
+
+        // When
+        val sampledCount = spans.count { testedSampler.sample(it) }
+
+        // Then
+        val expectedCount = spans.size * expectedRate / 100f
+        assertThat(sampledCount.toFloat()).isCloseTo(expectedCount, Offset.offset(spans.size * 0.1f))
+    }
+
+    @Test
+    fun `M use raw rate W sample() { session_sample_rate tag is 100 }`(forge: Forge) {
+        // Given
+        val fakeTraceRate = forge.aFloat(min = 0f, max = 100f)
+        val delegate = DeterministicTraceSampler(fakeTraceRate)
+        val testedSampler = SessionRebasedSampler(delegate)
+
+        val spans = createSpans(forge, sessionSampleRate = 100f)
+
+        // When
+        val sampledCount = spans.count { testedSampler.sample(it) }
+
+        // Then
+        val expectedCount = spans.size * fakeTraceRate / 100f
+        assertThat(sampledCount.toFloat()).isCloseTo(expectedCount, Offset.offset(spans.size * 0.1f))
+    }
+
+    @Test
+    fun `M use raw rate W sample() { session_sample_rate tag absent }`(forge: Forge) {
+        // Given
+        val fakeTraceRate = forge.aFloat(min = 0f, max = 100f)
+        val delegate = DeterministicTraceSampler(fakeTraceRate)
+        val testedSampler = SessionRebasedSampler(delegate)
+
+        val spans = createSpans(forge, sessionSampleRate = null)
+
+        // When
+        val sampledCount = spans.count { testedSampler.sample(it) }
+
+        // Then
+        val expectedCount = spans.size * fakeTraceRate / 100f
+        assertThat(sampledCount.toFloat()).isCloseTo(expectedCount, Offset.offset(spans.size * 0.1f))
+    }
+
+    @Test
+    fun `M sample none W sample() { session_sample_rate is 0 }`(forge: Forge) {
+        // Given
+        val fakeTraceRate = forge.aFloat(min = 1f, max = 100f)
+        val delegate = DeterministicTraceSampler(fakeTraceRate)
+        val testedSampler = SessionRebasedSampler(delegate)
+
+        val spans = createSpans(forge, sessionSampleRate = 0f)
+
+        // When
+        val sampledCount = spans.count { testedSampler.sample(it) }
+
+        // Then
+        assertThat(sampledCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `M sample nothing W sample() { session_sample_rate is negative }`(forge: Forge) {
+        // Given
+        val fakeTraceRate = forge.aFloat(min = 0f, max = 100f)
+        val delegate = DeterministicTraceSampler(fakeTraceRate)
+        val testedSampler = SessionRebasedSampler(delegate)
+
+        val fakeNegativeRate = -forge.aFloat(min = 1f, max = 100f)
+        val spans = createSpans(forge, sessionSampleRate = fakeNegativeRate)
+
+        // When
+        val sampledCount = spans.count { testedSampler.sample(it) }
+
+        // Then
+        assertThat(sampledCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `M delegate to custom sampler W sample() { delegate is not DeterministicTraceSampler }`(
+        forge: Forge
+    ) {
+        // Given
+        val mockDelegate = mock<Sampler<DatadogSpan>>()
+        whenever(mockDelegate.sample(org.mockito.kotlin.any())).thenReturn(true)
+        val testedSampler = SessionRebasedSampler(mockDelegate)
+
+        val span = createSpan(forge, sessionSampleRate = 50f)
+
+        // When
+        val result = testedSampler.sample(span)
+
+        // Then
+        assertThat(result).isTrue()
+        verify(mockDelegate).sample(span)
+    }
+
+    // endregion
+
+    // region getSampleRate()
+
+    @Test
+    fun `M return delegate raw rate W getSampleRate()`(
+        @FloatForgery(min = 0f, max = 100f) fakeTraceRate: Float
+    ) {
+        // Given
+        val delegate = DeterministicTraceSampler(fakeTraceRate)
+        val testedSampler = SessionRebasedSampler(delegate)
+
+        // When
+        val result = testedSampler.getSampleRate()
+
+        // Then
+        assertThat(result).isEqualTo(fakeTraceRate)
+    }
+
+    // endregion
+
+    // region getEffectiveSampleRate()
+
+    @Test
+    fun `M return rebased rate W getEffectiveSampleRate() { session tag present }`(
+        @FloatForgery(min = 0f, max = 100f) fakeTraceRate: Float,
+        @FloatForgery(min = 0f, max = 99.99f) fakeSessionRate: Float,
+        forge: Forge
+    ) {
+        // Given
+        val delegate = DeterministicTraceSampler(fakeTraceRate)
+        val testedSampler = SessionRebasedSampler(delegate)
+        val span = createSpan(forge, sessionSampleRate = fakeSessionRate)
+
+        val expectedRate = (fakeTraceRate * fakeSessionRate / 100f).coerceAtMost(100f)
+
+        // When
+        val result = testedSampler.getEffectiveSampleRate(span)
+
+        // Then
+        assertThat(result).isCloseTo(expectedRate, Offset.offset(0.001f))
+    }
+
+    @Test
+    fun `M return raw rate W getEffectiveSampleRate() { session tag absent }`(
+        @FloatForgery(min = 0f, max = 100f) fakeTraceRate: Float,
+        forge: Forge
+    ) {
+        // Given
+        val delegate = DeterministicTraceSampler(fakeTraceRate)
+        val testedSampler = SessionRebasedSampler(delegate)
+        val span = createSpan(forge, sessionSampleRate = null)
+
+        // When
+        val result = testedSampler.getEffectiveSampleRate(span)
+
+        // Then
+        assertThat(result).isEqualTo(fakeTraceRate)
+    }
+
+    @Test
+    fun `M return raw rate W getEffectiveSampleRate() { session tag is 100 }`(
+        @FloatForgery(min = 0f, max = 100f) fakeTraceRate: Float,
+        forge: Forge
+    ) {
+        // Given
+        val delegate = DeterministicTraceSampler(fakeTraceRate)
+        val testedSampler = SessionRebasedSampler(delegate)
+        val span = createSpan(forge, sessionSampleRate = 100f)
+
+        // When
+        val result = testedSampler.getEffectiveSampleRate(span)
+
+        // Then
+        assertThat(result).isEqualTo(fakeTraceRate)
+    }
+
+    // endregion
+
+    // region helpers
+
+    private fun createSpan(forge: Forge, sessionSampleRate: Float?): DatadogSpan {
+        val tags = buildMap<String, Any> {
+            if (sessionSampleRate != null) {
+                put(LogAttributes.RUM_SESSION_SAMPLE_RATE, sessionSampleRate)
+            }
+        }
+        val traceId = mock<DatadogTraceId> {
+            on { toLong() } doReturn forge.aLong()
+        }
+        val context = mock<DatadogSpanContext> {
+            on { this.traceId } doReturn traceId
+            on { this.tags } doReturn tags
+        }
+        return mock {
+            on { context() } doReturn context
+        }
+    }
+
+    private fun createSpans(
+        forge: Forge,
+        sessionSampleRate: Float?,
+        count: Int = forge.anInt(min = 256, max = 1024)
+    ): List<DatadogSpan> {
+        return forge.aList(count) {
+            createSpan(forge, sessionSampleRate)
+        }
+    }
+
+    // endregion
+}

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/SessionRebasedSamplerTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/SessionRebasedSamplerTest.kt
@@ -167,10 +167,10 @@ internal class SessionRebasedSamplerTest {
 
     // endregion
 
-    // region getEffectiveSampleRate()
+    // region getSampleRate(span)
 
     @Test
-    fun `M return rebased rate W getEffectiveSampleRate() { session tag present }`(
+    fun `M return rebased rate W getSampleRate(span) { session tag present }`(
         @FloatForgery(min = 0f, max = 100f) fakeTraceRate: Float,
         @FloatForgery(min = 0f, max = 99.99f) fakeSessionRate: Float,
         forge: Forge
@@ -183,14 +183,14 @@ internal class SessionRebasedSamplerTest {
         val expectedRate = (fakeTraceRate * fakeSessionRate / 100f).coerceAtMost(100f)
 
         // When
-        val result = testedSampler.getEffectiveSampleRate(span)
+        val result = testedSampler.getSampleRate(span)
 
         // Then
         assertThat(result).isCloseTo(expectedRate, Offset.offset(0.001f))
     }
 
     @Test
-    fun `M return raw rate W getEffectiveSampleRate() { session tag absent }`(
+    fun `M return raw rate W getSampleRate(span) { session tag absent }`(
         @FloatForgery(min = 0f, max = 100f) fakeTraceRate: Float,
         forge: Forge
     ) {
@@ -200,14 +200,14 @@ internal class SessionRebasedSamplerTest {
         val span = createSpan(forge, sessionSampleRate = null)
 
         // When
-        val result = testedSampler.getEffectiveSampleRate(span)
+        val result = testedSampler.getSampleRate(span)
 
         // Then
         assertThat(result).isEqualTo(fakeTraceRate)
     }
 
     @Test
-    fun `M return raw rate W getEffectiveSampleRate() { session tag is 100 }`(
+    fun `M return raw rate W getSampleRate(span) { session tag is 100 }`(
         @FloatForgery(min = 0f, max = 100f) fakeTraceRate: Float,
         forge: Forge
     ) {
@@ -217,15 +217,55 @@ internal class SessionRebasedSamplerTest {
         val span = createSpan(forge, sessionSampleRate = 100f)
 
         // When
-        val result = testedSampler.getEffectiveSampleRate(span)
+        val result = testedSampler.getSampleRate(span)
 
         // Then
-        assertThat(result).isEqualTo(fakeTraceRate)
+        assertThat(result).isCloseTo(fakeTraceRate, Offset.offset(0.001f))
+    }
+
+    @Test
+    fun `M return raw rate W getSampleRate(span) { custom sampler delegate }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeRawRate = forge.aFloat(min = 0f, max = 100f)
+        val mockDelegate = mock<Sampler<DatadogSpan>>()
+        whenever(mockDelegate.getSampleRate()).thenReturn(fakeRawRate)
+        val testedSampler = SessionRebasedSampler(mockDelegate)
+        val span = createSpan(forge, sessionSampleRate = 50f)
+
+        // When
+        val result = testedSampler.getSampleRate(span)
+
+        // Then
+        assertThat(result).isEqualTo(fakeRawRate)
+    }
+
+    @Test
+    fun `M return delegate per-span rate W getSampleRate(span) { delegate is SpanAwareSampler }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeStaticRate = forge.aFloat(min = 0f, max = 50f)
+        val fakePerSpanRate = forge.aFloat(min = 50.01f, max = 100f)
+        val stubDelegate = mock<SpanAwareDelegateSampler>()
+        whenever(stubDelegate.getSampleRate()).thenReturn(fakeStaticRate)
+        whenever(stubDelegate.getSampleRate(org.mockito.kotlin.any())).thenReturn(fakePerSpanRate)
+        val testedSampler = SessionRebasedSampler(stubDelegate)
+        val span = createSpan(forge, sessionSampleRate = 50f)
+
+        // When
+        val result = testedSampler.getSampleRate(span)
+
+        // Then
+        assertThat(result).isEqualTo(fakePerSpanRate)
     }
 
     // endregion
 
     // region helpers
+
+    internal interface SpanAwareDelegateSampler : Sampler<DatadogSpan>, SpanAwareSampler
 
     private fun createSpan(forge: Forge, sessionSampleRate: Float?): DatadogSpan {
         val tags = buildMap<String, Any> {

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/SessionRebasedSamplerTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/SessionRebasedSamplerTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.trace.internal.net
 
-import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.log.LogAttributes
 import com.datadog.android.trace.DeterministicTraceSampler
 import com.datadog.android.trace.api.span.DatadogSpan
@@ -26,8 +25,6 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 
 @Extensions(
@@ -127,25 +124,6 @@ internal class SessionRebasedSamplerTest {
         assertThat(sampledCount).isEqualTo(0)
     }
 
-    @Test
-    fun `M delegate to custom sampler W sample() { delegate is not DeterministicTraceSampler }`(
-        forge: Forge
-    ) {
-        // Given
-        val mockDelegate = mock<Sampler<DatadogSpan>>()
-        whenever(mockDelegate.sample(org.mockito.kotlin.any())).thenReturn(true)
-        val testedSampler = SessionRebasedSampler(mockDelegate)
-
-        val span = createSpan(forge, sessionSampleRate = 50f)
-
-        // When
-        val result = testedSampler.sample(span)
-
-        // Then
-        assertThat(result).isTrue()
-        verify(mockDelegate).sample(span)
-    }
-
     // endregion
 
     // region getSampleRate()
@@ -223,49 +201,9 @@ internal class SessionRebasedSamplerTest {
         assertThat(result).isCloseTo(fakeTraceRate, Offset.offset(0.001f))
     }
 
-    @Test
-    fun `M return raw rate W getSampleRate(span) { custom sampler delegate }`(
-        forge: Forge
-    ) {
-        // Given
-        val fakeRawRate = forge.aFloat(min = 0f, max = 100f)
-        val mockDelegate = mock<Sampler<DatadogSpan>>()
-        whenever(mockDelegate.getSampleRate()).thenReturn(fakeRawRate)
-        val testedSampler = SessionRebasedSampler(mockDelegate)
-        val span = createSpan(forge, sessionSampleRate = 50f)
-
-        // When
-        val result = testedSampler.getSampleRate(span)
-
-        // Then
-        assertThat(result).isEqualTo(fakeRawRate)
-    }
-
-    @Test
-    fun `M return delegate per-span rate W getSampleRate(span) { delegate is SpanAwareSampler }`(
-        forge: Forge
-    ) {
-        // Given
-        val fakeStaticRate = forge.aFloat(min = 0f, max = 50f)
-        val fakePerSpanRate = forge.aFloat(min = 50.01f, max = 100f)
-        val stubDelegate = mock<SpanAwareDelegateSampler>()
-        whenever(stubDelegate.getSampleRate()).thenReturn(fakeStaticRate)
-        whenever(stubDelegate.getSampleRate(org.mockito.kotlin.any())).thenReturn(fakePerSpanRate)
-        val testedSampler = SessionRebasedSampler(stubDelegate)
-        val span = createSpan(forge, sessionSampleRate = 50f)
-
-        // When
-        val result = testedSampler.getSampleRate(span)
-
-        // Then
-        assertThat(result).isEqualTo(fakePerSpanRate)
-    }
-
     // endregion
 
     // region helpers
-
-    internal interface SpanAwareDelegateSampler : Sampler<DatadogSpan>, SpanAwareSampler
 
     private fun createSpan(forge: Forge, sessionSampleRate: Float?): DatadogSpan {
         val tags = buildMap<String, Any> {

--- a/features/dd-sdk-android-trace/src/testFixtures/kotlin/com/datadog/android/trace/utils/RumContextTestsUtils.kt
+++ b/features/dd-sdk-android-trace/src/testFixtures/kotlin/com/datadog/android/trace/utils/RumContextTestsUtils.kt
@@ -18,6 +18,7 @@ object RumContextTestsUtils {
     const val RUM_CONTEXT_ACTION_ID = "action_id"
     const val RUM_CONTEXT_SESSION_ID = "session_id"
     const val RUM_CONTEXT_APPLICATION_ID = "application_id"
+    const val RUM_CONTEXT_SESSION_SAMPLE_RATE = "session_sample_rate"
 
     private const val HEX = 16
 
@@ -25,6 +26,7 @@ object RumContextTestsUtils {
         put(RUM_CONTEXT_VIEW_ID, getForgery<UUID>().toString())
         put(RUM_CONTEXT_ACTION_ID, getForgery<UUID>().toString())
         put(RUM_CONTEXT_APPLICATION_ID, getForgery<UUID>().toString())
+        put(RUM_CONTEXT_SESSION_SAMPLE_RATE, aFloat(min = 0f, max = 100f))
         sessionId?.let {
             put(
                 RUM_CONTEXT_SESSION_ID,

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -32,6 +32,7 @@ import com.datadog.android.rum._RumInternalProxy
 import com.datadog.android.rum.internal.monitor.AdvancedNetworkRumMonitor
 import com.datadog.android.rum.resource.ResourceHeadersExtractor
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
+import com.datadog.android.trace.DeterministicTraceSampler
 import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.api.span.DatadogSpan
@@ -409,12 +410,18 @@ open class DatadogInterceptor internal constructor(
          * Builds the [DatadogInterceptor].
          */
         override fun build(): DatadogInterceptor {
+            val currentTraceSampler = traceSampler
+            val effectiveTraceSampler = if (currentTraceSampler is DeterministicTraceSampler) {
+                SessionRebasedSampler(currentTraceSampler)
+            } else {
+                currentTraceSampler
+            }
             return DatadogInterceptor(
                 sdkInstanceName,
                 tracedHostsWithHeaderType,
                 tracedRequestListener,
                 rumResourceAttributesProvider,
-                SessionRebasedSampler(traceSampler),
+                effectiveTraceSampler,
                 traceContextInjection,
                 redacted404ResourceName,
                 localTracerFactory,

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -36,6 +36,8 @@ import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.api.span.DatadogSpan
 import com.datadog.android.trace.api.tracer.DatadogTracer
+import com.datadog.android.trace.internal.net.SessionRebasedSampler
+import com.datadog.android.trace.internal.net.effectiveSampleRate
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -248,7 +250,10 @@ open class DatadogInterceptor internal constructor(
             buildMap {
                 put(RumAttributes.TRACE_ID, span.context().traceId.toHexString())
                 put(RumAttributes.SPAN_ID, span.context().spanId.toString())
-                put(RumAttributes.RULE_PSR, (traceSampler.getSampleRate() ?: ZERO_SAMPLE_RATE) / ALL_IN_SAMPLE_RATE)
+                put(
+                    RumAttributes.RULE_PSR,
+                    (traceSampler.effectiveSampleRate(span) ?: ZERO_SAMPLE_RATE) / ALL_IN_SAMPLE_RATE
+                )
                 putAll(graphqlAttributes)
                 putAll(graphqlErrorAttributes)
             }
@@ -409,7 +414,7 @@ open class DatadogInterceptor internal constructor(
                 tracedHostsWithHeaderType,
                 tracedRequestListener,
                 rumResourceAttributesProvider,
-                traceSampler,
+                SessionRebasedSampler(traceSampler),
                 traceContextInjection,
                 redacted404ResourceName,
                 localTracerFactory,

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -34,6 +34,7 @@ import com.datadog.android.rum.internal.monitor.AdvancedNetworkRumMonitor
 import com.datadog.android.rum.internal.net.reportNetworkInstrumentationConfigured
 import com.datadog.android.rum.resource.ResourceHeadersExtractor
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
+import com.datadog.android.trace.DeterministicTraceSampler
 import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.api.span.DatadogSpan
@@ -395,12 +396,18 @@ open class DatadogInterceptor internal constructor(
          * Builds the [DatadogInterceptor].
          */
         override fun build(): DatadogInterceptor {
+            val currentTraceSampler = traceSampler
+            val effectiveTraceSampler = if (currentTraceSampler is DeterministicTraceSampler) {
+                SessionRebasedSampler(currentTraceSampler)
+            } else {
+                currentTraceSampler
+            }
             return DatadogInterceptor(
                 sdkInstanceName,
                 tracedHostsWithHeaderType,
                 tracedRequestListener,
                 rumResourceAttributesProvider,
-                SessionRebasedSampler(traceSampler),
+                effectiveTraceSampler,
                 traceContextInjection,
                 redacted404ResourceName,
                 localTracerFactory,

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -38,6 +38,8 @@ import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.api.span.DatadogSpan
 import com.datadog.android.trace.api.tracer.DatadogTracer
+import com.datadog.android.trace.internal.net.SessionRebasedSampler
+import com.datadog.android.trace.internal.net.effectiveSampleRate
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -225,7 +227,10 @@ open class DatadogInterceptor internal constructor(
             buildMap {
                 put(RumAttributes.TRACE_ID, span.context().traceId.toHexString())
                 put(RumAttributes.SPAN_ID, span.context().spanId.toString())
-                put(RumAttributes.RULE_PSR, (traceSampler.getSampleRate() ?: ZERO_SAMPLE_RATE) / ALL_IN_SAMPLE_RATE)
+                put(
+                    RumAttributes.RULE_PSR,
+                    (traceSampler.effectiveSampleRate(span) ?: ZERO_SAMPLE_RATE) / ALL_IN_SAMPLE_RATE
+                )
                 putAll(graphQLAttributes)
                 putAll(graphQLErrorAttributes)
             }
@@ -395,7 +400,7 @@ open class DatadogInterceptor internal constructor(
                 tracedHostsWithHeaderType,
                 tracedRequestListener,
                 rumResourceAttributesProvider,
-                traceSampler,
+                SessionRebasedSampler(traceSampler),
                 traceContextInjection,
                 redacted404ResourceName,
                 localTracerFactory,

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -38,6 +38,7 @@ import com.datadog.android.trace.internal.RumContextPropagator
 import com.datadog.android.trace.internal.RumContextPropagator.Companion.extractRumContext
 import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.trace.internal.net.TraceContext
+import com.datadog.android.trace.internal.net.effectiveSampleRate
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -260,7 +261,7 @@ internal constructor(
             if (spanContext.setSamplingPriority(samplingPriority)) {
                 spanContext.setMetric(
                     AGENT_PSR_ATTRIBUTE,
-                    (traceSampler.getSampleRate() ?: ZERO_SAMPLE_RATE) / ALL_IN_SAMPLE_RATE
+                    (traceSampler.effectiveSampleRate(span) ?: ZERO_SAMPLE_RATE) / ALL_IN_SAMPLE_RATE
                 )
             }
         }

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -805,6 +805,11 @@ internal constructor(
          * Set the trace sample rate controlling the sampling of APM traces created for
          * auto-instrumented requests. If there is a parent trace attached to the network span created, then its
          * sampling decision will be used instead.
+         *
+         * When used with [com.datadog.android.okhttp.DatadogInterceptor], the effective trace sample rate is
+         * automatically combined with the active RUM session sample rate, ensuring the backend receives correct
+         * sampling metadata (`_dd.agent_psr` / `_dd.rule_psr`) for RUM-to-APM correlation.
+         *
          * @param sampleRate the sample rate to use (percentage between 0f and 100f, default is 100f).
          */
         fun setTraceSampleRate(@FloatRange(from = 0.0, to = 100.0) sampleRate: Float): R {
@@ -816,6 +821,10 @@ internal constructor(
          * Set the trace sampler controlling the sampling of APM traces created for
          * auto-instrumented requests. If there is a parent trace attached to the network span created, then its
          * sampling decision will be used instead.
+         *
+         * Note: custom samplers passed here do not participate in cross-product rebasing with the RUM session
+         * sample rate. Use [setTraceSampleRate] if you need correlated sampling between RUM sessions and APM traces.
+         *
          * @param traceSampler the trace sampler controlling the sampling of APM traces.
          * By default it is a sampler accepting 100% of the traces.
          */

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorBuilderTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorBuilderTest.kt
@@ -13,10 +13,10 @@ import com.datadog.android.okhttp.trace.TracedRequestListener
 import com.datadog.android.rum.NoOpRumResourceAttributesProvider
 import com.datadog.android.rum.RumResourceAttributesProvider
 import com.datadog.android.rum.resource.ResourceHeadersExtractor
-import com.datadog.android.trace.DeterministicTraceSampler
 import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.api.span.DatadogSpan
+import com.datadog.android.trace.internal.net.SessionRebasedSampler
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.forge.BaseConfigurator
 import fr.xgouchet.elmyr.Forge
@@ -86,7 +86,7 @@ internal class DatadogInterceptorBuilderTest {
             interceptor.rumResourceAttributesProvider
         ).isInstanceOf(NoOpRumResourceAttributesProvider::class.java)
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
-        assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler).isInstanceOf(SessionRebasedSampler::class.java)
         assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
         assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
         assertThat(interceptor.localTracerFactory).isNotNull()
@@ -112,7 +112,7 @@ internal class DatadogInterceptorBuilderTest {
             interceptor.rumResourceAttributesProvider
         ).isInstanceOf(NoOpRumResourceAttributesProvider::class.java)
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
-        assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler).isInstanceOf(SessionRebasedSampler::class.java)
         assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
         assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
         assertThat(interceptor.localTracerFactory).isNotNull()
@@ -133,7 +133,7 @@ internal class DatadogInterceptorBuilderTest {
             interceptor.rumResourceAttributesProvider
         ).isInstanceOf(NoOpRumResourceAttributesProvider::class.java)
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
-        assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler).isInstanceOf(SessionRebasedSampler::class.java)
         assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
         assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
         assertThat(interceptor.localTracerFactory).isNotNull()
@@ -154,7 +154,7 @@ internal class DatadogInterceptorBuilderTest {
             interceptor.rumResourceAttributesProvider
         ).isInstanceOf(NoOpRumResourceAttributesProvider::class.java)
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
-        assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler).isInstanceOf(SessionRebasedSampler::class.java)
         assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
         assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
         assertThat(interceptor.localTracerFactory).isNotNull()
@@ -175,7 +175,7 @@ internal class DatadogInterceptorBuilderTest {
             interceptor.rumResourceAttributesProvider
         ).isInstanceOf(NoOpRumResourceAttributesProvider::class.java)
         assertThat(interceptor.tracedRequestListener).isSameAs(mockTracedRequestListener)
-        assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler).isInstanceOf(SessionRebasedSampler::class.java)
         assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
         assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
         assertThat(interceptor.localTracerFactory).isNotNull()
@@ -195,7 +195,7 @@ internal class DatadogInterceptorBuilderTest {
         check(interceptor.rumResourceAttributesProvider is RumResourceAttributesProviderCompatibilityAdapter)
         assertThat(interceptor.rumResourceAttributesProvider.delegate).isSameAs(mockRumResourceAttributesProvider)
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
-        assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler).isInstanceOf(SessionRebasedSampler::class.java)
         assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(100f)
         assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
         assertThat(interceptor.localTracerFactory).isNotNull()
@@ -218,7 +218,7 @@ internal class DatadogInterceptorBuilderTest {
             interceptor.rumResourceAttributesProvider
         ).isInstanceOf(NoOpRumResourceAttributesProvider::class.java)
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
-        assertThat(interceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(interceptor.traceSampler).isInstanceOf(SessionRebasedSampler::class.java)
         assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(fakeSampleRate)
         assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
         assertThat(interceptor.localTracerFactory).isNotNull()
@@ -239,7 +239,8 @@ internal class DatadogInterceptorBuilderTest {
             interceptor.rumResourceAttributesProvider
         ).isInstanceOf(NoOpRumResourceAttributesProvider::class.java)
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
-        assertThat(interceptor.traceSampler).isSameAs(mockSampler)
+        assertThat(interceptor.traceSampler).isInstanceOf(SessionRebasedSampler::class.java)
+        assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(mockSampler.getSampleRate())
         assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
         assertThat(interceptor.localTracerFactory).isNotNull()
     }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorBuilderTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorBuilderTest.kt
@@ -239,8 +239,7 @@ internal class DatadogInterceptorBuilderTest {
             interceptor.rumResourceAttributesProvider
         ).isInstanceOf(NoOpRumResourceAttributesProvider::class.java)
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
-        assertThat(interceptor.traceSampler).isInstanceOf(SessionRebasedSampler::class.java)
-        assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(mockSampler.getSampleRate())
+        assertThat(interceptor.traceSampler).isSameAs(mockSampler)
         assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
         assertThat(interceptor.localTracerFactory).isNotNull()
     }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -24,10 +24,10 @@ import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.resource.ResourceHeadersExtractor
 import com.datadog.android.rum.resource.ResourceId
-import com.datadog.android.trace.DeterministicTraceSampler
 import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.api.tracer.DatadogTracer
+import com.datadog.android.trace.internal.net.SessionRebasedSampler
 import com.datadog.android.utils.verifyLog
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.forge.BaseConfigurator
@@ -186,7 +186,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         assertThat(interceptor.tracedRequestListener)
             .isInstanceOf(NoOpTracedRequestListener::class.java)
         assertThat(interceptor.traceSampler)
-            .isInstanceOf(DeterministicTraceSampler::class.java)
+            .isInstanceOf(SessionRebasedSampler::class.java)
         assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(
             TracingInterceptor.DEFAULT_TRACE_SAMPLE_RATE
         )
@@ -214,7 +214,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         assertThat(interceptor.tracedRequestListener)
             .isInstanceOf(NoOpTracedRequestListener::class.java)
         assertThat(interceptor.traceSampler)
-            .isInstanceOf(DeterministicTraceSampler::class.java)
+            .isInstanceOf(SessionRebasedSampler::class.java)
         assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(
             TracingInterceptor.DEFAULT_TRACE_SAMPLE_RATE
         )

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -24,10 +24,10 @@ import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.resource.ResourceHeadersExtractor
 import com.datadog.android.rum.resource.ResourceId
-import com.datadog.android.trace.DeterministicTraceSampler
 import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.api.tracer.DatadogTracer
+import com.datadog.android.trace.internal.net.SessionRebasedSampler
 import com.datadog.android.utils.verifyLog
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.forge.BaseConfigurator
@@ -225,7 +225,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         assertThat(interceptor.tracedRequestListener)
             .isInstanceOf(NoOpTracedRequestListener::class.java)
         assertThat(interceptor.traceSampler)
-            .isInstanceOf(DeterministicTraceSampler::class.java)
+            .isInstanceOf(SessionRebasedSampler::class.java)
         assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(
             TracingInterceptor.DEFAULT_TRACE_SAMPLE_RATE
         )
@@ -253,7 +253,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         assertThat(interceptor.tracedRequestListener)
             .isInstanceOf(NoOpTracedRequestListener::class.java)
         assertThat(interceptor.traceSampler)
-            .isInstanceOf(DeterministicTraceSampler::class.java)
+            .isInstanceOf(SessionRebasedSampler::class.java)
         assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(
             TracingInterceptor.DEFAULT_TRACE_SAMPLE_RATE
         )


### PR DESCRIPTION
### What does this PR do?

Uses the rebased sample rate (`traceSampleRate * sessionSampleRate / 100`) when RUM-to-APM correlation requires it. A `SessionRebasedSampler` decorator wraps the trace sampler and adjusts the effective rate based on the RUM session sample rate tag on the span.

The rebasing is scoped exclusively to the RUM-to-APM path:
- `DatadogInterceptor` (OkHttp) wraps the sampler in `SessionRebasedSampler` at build time
- `ApmNetworkInstrumentationConfiguration` wraps when `headerPropagationOnly = true`
- `TracingInterceptor` (pure APM) and `headerPropagationOnly = false` use the raw trace rate unchanged
- HBS (head-based sampling) is preserved: parent span decisions propagate as before

### Motivation

When both RUM session sampling and trace sampling are active, the backend needs `_dd.agent_psr` / `_dd.rule_psr` to reflect the actual combined probability for correct statistical reweighting. Without rebasing, these metrics report only the trace rate, leading to incorrect trace counts on the platform.

### Additional Notes

- **API surface changes:** New `@InternalApi` types in `dd-sdk-android-trace`: `SessionRebasedSampler`, `SpanAwareSampler` interface, and `effectiveSampleRate()` extension. New `LogAttributes.RUM_SESSION_SAMPLE_RATE` constant in `dd-sdk-android-core`. All are internal-use types in `*.internal.*` packages.
- **`DeterministicTraceSampler` is NOT modified.** The decorator wraps it externally, avoiding changes to the open public class.
- **Custom samplers** (via `setTraceSampler()`) pass through without rebasing — the decorator only rebases `DeterministicTraceSampler` delegates.
- **Follow-up work (separate PR):** When a parent manual span is dropped by the Trace SDK, `DatadogInterceptor` should ignore it and create an independent trace so the RUM SDK can make its own sampling decision. Related iOS work: [dd-sdk-ios#2726](https://github.com/DataDog/dd-sdk-ios/pull/2726).

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)