### PR TITLE
Pass resource headers on network errors

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/net/RumNetworkInstrumentation.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/net/RumNetworkInstrumentation.kt
@@ -130,13 +130,18 @@ class RumNetworkInstrumentation internal constructor(
      * @param throwable the error that occurred
      */
     fun stopResourceWithError(requestInfo: HttpRequestInfo, throwable: Throwable) = ifRumEnabled { sdkCore ->
+        val resourceHeaderAttributes = resourceHeadersExtractor?.toResourceAttributes(
+            rawRequestHeaders = requestInfo.headers,
+            rawResponseHeaders = emptyMap(),
+            internalLogger = sdkCore.internalLogger
+        ) ?: emptyMap()
         sdkCore.networkMonitor?.stopResourceWithError(
             buildResourceId(requestInfo, generateUuid = false),
             null,
             ERROR_MSG_FORMAT.format(Locale.US, networkInstrumentationName, requestInfo.method, requestInfo.url),
             RumErrorSource.NETWORK,
             throwable,
-            rumResourceAttributesProvider.onProvideAttributes(requestInfo, null, throwable)
+            rumResourceAttributesProvider.onProvideAttributes(requestInfo, null, throwable) + resourceHeaderAttributes
         )
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/net/RumNetworkInstrumentationTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/net/RumNetworkInstrumentationTest.kt
@@ -499,6 +499,60 @@ internal class RumNetworkInstrumentationTest {
     }
 
     @Test
+    fun `M include request header attributes W stopResourceWithError() { trackResourceHeaders enabled }`(
+        @Forgery fakeThrowable: Throwable,
+        forge: Forge
+    ) {
+        // Given
+        val fakeHeaderName = "x-request-id"
+        val fakeHeaderValue = forge.anAsciiString()
+        val fakeResponseHeaderName = "x-cache"
+
+        val extractor = ResourceHeadersExtractor.Builder(includeDefaults = false)
+            .captureHeaders(fakeHeaderName, fakeResponseHeaderName)
+            .build()
+
+        testedInstrumentation = RumNetworkInstrumentation(
+            sdkInstanceName = null,
+            networkInstrumentationName = fakeNetworkInstrumentationName,
+            rumResourceAttributesProvider = mockRumResourceAttributesProvider,
+            libraryType = fakeLibraryType,
+            resourceHeadersExtractor = extractor
+        )
+
+        fakeRequestInfo = fakeRequestInfo.copy(
+            headers = mapOf(fakeHeaderName to listOf(fakeHeaderValue))
+        )
+        whenever(
+            mockRumResourceAttributesProvider.onProvideAttributes(
+                any<HttpRequestInfo>(),
+                anyOrNull<HttpResponseInfo>(),
+                anyOrNull()
+            )
+        ) doReturn emptyMap()
+
+        // When
+        testedInstrumentation.stopResourceWithError(fakeRequestInfo, fakeThrowable)
+
+        // Then
+        argumentCaptor<Map<String, Any?>> {
+            verify(mockRumMonitor).stopResourceWithError(
+                any<ResourceId>(),
+                anyOrNull(),
+                any<String>(),
+                any<RumErrorSource>(),
+                any<Throwable>(),
+                capture()
+            )
+            @Suppress("UNCHECKED_CAST")
+            val extractedRequestHeaders = firstValue[RumAttributes.REQUEST_HEADERS] as? Map<String, String>
+            assertThat(extractedRequestHeaders).isNotNull
+            assertThat(extractedRequestHeaders).containsEntry(fakeHeaderName, fakeHeaderValue)
+            assertThat(firstValue).doesNotContainKey(RumAttributes.RESPONSE_HEADERS)
+        }
+    }
+
+    @Test
     fun `M log warning W reportInstrumentationError()`(
         @StringForgery fakeErrorMessage: String
     ) {

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -263,7 +263,7 @@ open class DatadogInterceptor internal constructor(
     }
 
     private fun handleThrowable(
-        sdkCore: SdkCore,
+        sdkCore: FeatureSdkCore,
         request: Request,
         throwable: Throwable
     ) {
@@ -271,6 +271,14 @@ open class DatadogInterceptor internal constructor(
         val requestId = request.buildResourceId(generateUuid = false)
         val method = request.method
         val url = request.url.toString()
+        val resourceHeaderAttributes = resourceHeadersExtractor?.let {
+            _RumInternalProxy.toResourceAttributes(
+                extractor = it,
+                rawRequestHeaders = request.headers.toMultimap(),
+                rawResponseHeaders = emptyMap(),
+                internalLogger = sdkCore.internalLogger
+            )
+        } ?: emptyMap()
         @Suppress("DEPRECATION")
         (GlobalRumMonitor.get(sdkCore) as? AdvancedNetworkRumMonitor)?.stopResourceWithError(
             requestId,
@@ -278,7 +286,7 @@ open class DatadogInterceptor internal constructor(
             ERROR_MSG_FORMAT.format(Locale.US, method, url),
             RumErrorSource.NETWORK,
             throwable,
-            rumResourceAttributesProvider.onProvideAttributes(request, null, throwable)
+            rumResourceAttributesProvider.onProvideAttributes(request, null, throwable) + resourceHeaderAttributes
         )
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -1333,6 +1333,43 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
     }
 
     @Test
+    fun `M include request header attributes in stopResourceWithError W intercept() { trackResourceHeaders enabled }`(
+        @Forgery throwable: Throwable
+    ) {
+        // Given
+        resourceHeadersExtractor = ResourceHeadersExtractor.Builder(includeDefaults = false)
+            .captureHeaders("x-request-id", "x-cache")
+            .build()
+
+        testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
+
+        fakeRequest = forgeRequest { it.addHeader("X-Request-Id", "abc-123") }
+        whenever(mockChain.request()) doReturn fakeRequest
+        whenever(mockChain.proceed(any())) doThrow throwable
+
+        // When
+        assertThrows<Throwable>(throwable.message.orEmpty()) {
+            testedInterceptor.intercept(mockChain)
+        }
+
+        // Then
+        val attrsCaptor = argumentCaptor<Map<String, Any?>>()
+        verify(rumMonitor.mockInstance).stopResourceWithError(
+            any<ResourceId>(),
+            anyOrNull(),
+            any<String>(),
+            any<RumErrorSource>(),
+            any<Throwable>(),
+            attrsCaptor.capture()
+        )
+        @Suppress("UNCHECKED_CAST")
+        val reqHeaders = attrsCaptor.firstValue[RumAttributes.REQUEST_HEADERS] as? Map<String, String>
+        assertThat(reqHeaders).isNotNull
+        assertThat(reqHeaders).containsEntry("x-request-id", "abc-123")
+        assertThat(attrsCaptor.firstValue).doesNotContainKey(RumAttributes.RESPONSE_HEADERS)
+    }
+
+    @Test
     fun `M header attributes override provider attributes W intercept() { conflicting keys }`(
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {


### PR DESCRIPTION
### What does this PR do?

- Pass resource headers on `RumNetworkInstrumentation#stopResourceWithError` and `DatadogInterceptor#handleThrowable`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

