### PR TITLE
RUM-15138: Ignore dropped local active span in RUM-to-APM path

### DIFF
--- a/features/dd-sdk-android-trace/api/apiSurface
+++ b/features/dd-sdk-android-trace/api/apiSurface
@@ -56,15 +56,21 @@ class com.datadog.android.trace.internal.ApmNetworkInstrumentation
   fun onResponseFailed(com.datadog.android.trace.internal.net.RequestTracingState, Throwable)
   fun removeTracingHeaders(com.datadog.android.api.instrumentation.network.HttpRequestInfoBuilder)
   fun reportInstrumentationError(() -> String)
+sealed class com.datadog.android.trace.internal.ParentContextSource
+  abstract val context: com.datadog.android.trace.api.span.DatadogSpanContext
+  class FromHeaders : ParentContextSource
+    constructor(com.datadog.android.trace.api.span.DatadogSpanContext)
+  class FromTag : ParentContextSource
+    constructor(com.datadog.android.trace.api.span.DatadogSpanContext)
 class com.datadog.android.trace.internal.DatadogPropagationHelper
   fun isExtractedContext(com.datadog.android.trace.api.span.DatadogSpanContext): Boolean
   fun setTraceContext(com.datadog.android.api.instrumentation.network.HttpRequestInfoBuilder, String, String, Int)
-  fun extractParentContext(com.datadog.android.trace.api.tracer.DatadogTracer, com.datadog.android.api.instrumentation.network.HttpRequestInfo): com.datadog.android.trace.api.span.DatadogSpanContext?
+  fun extractParentContext(com.datadog.android.trace.api.tracer.DatadogTracer, com.datadog.android.api.instrumentation.network.HttpRequestInfo): ParentContextSource?
   fun createExtractedContext(String, String, Int): com.datadog.android.trace.api.span.DatadogSpanContext
   fun propagateSampledHeaders(com.datadog.android.api.instrumentation.network.HttpRequestInfoBuilder, com.datadog.android.trace.api.tracer.DatadogTracer, com.datadog.android.trace.api.span.DatadogSpan, Set<com.datadog.android.trace.TracingHeaderType>)
   fun propagateNotSampledHeaders(com.datadog.android.api.instrumentation.network.HttpRequestInfoBuilder, com.datadog.android.trace.api.tracer.DatadogTracer, com.datadog.android.trace.api.span.DatadogSpan, Set<com.datadog.android.trace.TracingHeaderType>, com.datadog.android.trace.TraceContextInjection, String?)
   fun removeAllTracingHeaders(com.datadog.android.api.instrumentation.network.HttpRequestInfoBuilder)
-  fun extractSamplingDecision(com.datadog.android.api.instrumentation.network.HttpRequestInfo): Boolean?
+  fun extractSamplingDecision(com.datadog.android.api.instrumentation.network.HttpRequestInfo, Boolean = false): Boolean?
   companion object 
 class com.datadog.android.trace.internal.DatadogSpanIdConverter
   fun fromHex(String): Long

--- a/features/dd-sdk-android-trace/api/apiSurface
+++ b/features/dd-sdk-android-trace/api/apiSurface
@@ -91,6 +91,8 @@ object com.datadog.android.trace.internal._TraceInternalProxy
   fun mergeBaggage(String?, String): String
   fun createApmNetworkInstrumentation(String, com.datadog.android.trace.ApmNetworkInstrumentationConfiguration)
 fun com.datadog.android.core.sampling.Sampler<com.datadog.android.trace.api.span.DatadogSpan>.effectiveSampleRate(com.datadog.android.trace.api.span.DatadogSpan): Float?
+fun com.datadog.android.trace.api.span.DatadogSpanContext?.isDropped(): Boolean
+fun Int?.isDroppedPriority(): Boolean
 data class com.datadog.android.trace.internal.net.RequestTracingState
   constructor(com.datadog.android.api.instrumentation.network.HttpRequestInfoBuilder, Boolean = false, com.datadog.android.trace.api.span.DatadogSpan? = null, Float? = null)
   fun createRequestInfo(): com.datadog.android.api.instrumentation.network.HttpRequestInfo

--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -112,8 +112,9 @@ public final class com/datadog/android/trace/internal/ApmNetworkInstrumentation 
 public final class com/datadog/android/trace/internal/DatadogPropagationHelper {
 	public static final field Companion Lcom/datadog/android/trace/internal/DatadogPropagationHelper$Companion;
 	public final fun createExtractedContext (Ljava/lang/String;Ljava/lang/String;I)Lcom/datadog/android/trace/api/span/DatadogSpanContext;
-	public final fun extractParentContext (Lcom/datadog/android/trace/api/tracer/DatadogTracer;Lcom/datadog/android/api/instrumentation/network/HttpRequestInfo;)Lcom/datadog/android/trace/api/span/DatadogSpanContext;
-	public final fun extractSamplingDecision (Lcom/datadog/android/api/instrumentation/network/HttpRequestInfo;)Ljava/lang/Boolean;
+	public final fun extractParentContext (Lcom/datadog/android/trace/api/tracer/DatadogTracer;Lcom/datadog/android/api/instrumentation/network/HttpRequestInfo;)Lcom/datadog/android/trace/internal/ParentContextSource;
+	public final fun extractSamplingDecision (Lcom/datadog/android/api/instrumentation/network/HttpRequestInfo;Z)Ljava/lang/Boolean;
+	public static synthetic fun extractSamplingDecision$default (Lcom/datadog/android/trace/internal/DatadogPropagationHelper;Lcom/datadog/android/api/instrumentation/network/HttpRequestInfo;ZILjava/lang/Object;)Ljava/lang/Boolean;
 	public final fun isExtractedContext (Lcom/datadog/android/trace/api/span/DatadogSpanContext;)Z
 	public final fun propagateNotSampledHeaders (Lcom/datadog/android/api/instrumentation/network/HttpRequestInfoBuilder;Lcom/datadog/android/trace/api/tracer/DatadogTracer;Lcom/datadog/android/trace/api/span/DatadogSpan;Ljava/util/Set;Lcom/datadog/android/trace/TraceContextInjection;Ljava/lang/String;)Lcom/datadog/android/api/instrumentation/network/HttpRequestInfoBuilder;
 	public final fun propagateSampledHeaders (Lcom/datadog/android/api/instrumentation/network/HttpRequestInfoBuilder;Lcom/datadog/android/trace/api/tracer/DatadogTracer;Lcom/datadog/android/trace/api/span/DatadogSpan;Ljava/util/Set;)Lcom/datadog/android/api/instrumentation/network/HttpRequestInfoBuilder;
@@ -131,6 +132,20 @@ public final class com/datadog/android/trace/internal/DatadogSpanIdConverter {
 
 public final class com/datadog/android/trace/internal/DatadogTraceExtKt {
 	public static final fun fromHex (Lcom/datadog/android/trace/api/trace/DatadogTraceId$Companion;Ljava/lang/String;)Lcom/datadog/android/trace/api/trace/DatadogTraceId;
+}
+
+public abstract class com/datadog/android/trace/internal/ParentContextSource {
+	public abstract fun getContext ()Lcom/datadog/android/trace/api/span/DatadogSpanContext;
+}
+
+public final class com/datadog/android/trace/internal/ParentContextSource$FromHeaders : com/datadog/android/trace/internal/ParentContextSource {
+	public fun <init> (Lcom/datadog/android/trace/api/span/DatadogSpanContext;)V
+	public fun getContext ()Lcom/datadog/android/trace/api/span/DatadogSpanContext;
+}
+
+public final class com/datadog/android/trace/internal/ParentContextSource$FromTag : com/datadog/android/trace/internal/ParentContextSource {
+	public fun <init> (Lcom/datadog/android/trace/api/span/DatadogSpanContext;)V
+	public fun getContext ()Lcom/datadog/android/trace/api/span/DatadogSpanContext;
 }
 
 public final class com/datadog/android/trace/internal/RumContextPropagator {

--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -173,6 +173,8 @@ public final class com/datadog/android/trace/internal/_TraceInternalProxy {
 
 public final class com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExtKt {
 	public static final fun effectiveSampleRate (Lcom/datadog/android/core/sampling/Sampler;Lcom/datadog/android/trace/api/span/DatadogSpan;)Ljava/lang/Float;
+	public static final fun isDropped (Lcom/datadog/android/trace/api/span/DatadogSpanContext;)Z
+	public static final fun isDroppedPriority (Ljava/lang/Integer;)Z
 }
 
 public final class com/datadog/android/trace/internal/net/RequestTracingState {

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ApmNetworkInstrumentation.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ApmNetworkInstrumentation.kt
@@ -128,7 +128,7 @@ class ApmNetworkInstrumentation internal constructor(
             return RequestTracingState(requestInfoBuilder)
         }
 
-        val span = tracer.buildSpan(request, networkingLibraryName, traceOrigin)
+        val span = tracer.buildSpan(request, networkingLibraryName, traceOrigin, ignoreDroppedParent = !canSendSpan)
         val isSampled = span.isSampled(request)
         if (span.isRootSpan) {
             span.applyPriority(isSampled, traceSampler)

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ApmNetworkInstrumentation.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ApmNetworkInstrumentation.kt
@@ -226,7 +226,7 @@ class ApmNetworkInstrumentation internal constructor(
 
     private fun DatadogSpan.isSampled(request: HttpRequestInfo): Boolean =
         extractRumContext(rumContextPropagator, block = true)
-            .sample(request, traceSampler)
+            .sample(request, traceSampler, ignoreLocalDroppedParent = !canSendSpan)
 
     private fun RequestTracingState.onRequestIntercepted(
         response: HttpResponseInfo?,

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ApmNetworkInstrumentation.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ApmNetworkInstrumentation.kt
@@ -128,7 +128,12 @@ class ApmNetworkInstrumentation internal constructor(
             return RequestTracingState(requestInfoBuilder)
         }
 
-        val span = tracer.buildSpan(request, networkingLibraryName, traceOrigin, ignoreDroppedParent = !canSendSpan)
+        val span = tracer.buildSpan(
+            request,
+            networkingLibraryName,
+            traceOrigin,
+            ignoreLocalDroppedParent = !canSendSpan
+        )
         val isSampled = span.isSampled(request)
         if (span.isRootSpan) {
             span.applyPriority(isSampled, traceSampler)

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/DatadogPropagationHelper.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/DatadogPropagationHelper.kt
@@ -16,12 +16,33 @@ import com.datadog.android.trace.api.span.DatadogSpan
 import com.datadog.android.trace.api.span.DatadogSpanContext
 import com.datadog.android.trace.api.tracer.DatadogTracer
 import com.datadog.android.trace.internal.net.TraceContext
+import com.datadog.android.trace.internal.net.isDroppedPriority
 import com.datadog.trace.api.DDSpanId
 import com.datadog.trace.api.DDTraceId
 import com.datadog.trace.core.propagation.B3HttpCodec
 import com.datadog.trace.core.propagation.DatadogHttpCodec
 import com.datadog.trace.core.propagation.ExtractedContext
 import com.datadog.trace.core.propagation.W3CHttpCodec
+
+/**
+ * For internal usage only.
+ * Represents the origin of a parent context extracted for a network request.
+ *
+ * Distinguishing the source allows callers to apply different policies — e.g. ignoring a dropped
+ * tag-attached parent (explicit developer intent) while always honoring a header-propagated
+ * parent (upstream service intent, required for head-based sampling).
+ */
+@InternalApi
+sealed class ParentContextSource {
+    /** The parent [DatadogSpanContext]. */
+    abstract val context: DatadogSpanContext
+
+    /** Parent context parsed from inbound trace propagation headers (Datadog, W3C, B3). */
+    class FromHeaders(override val context: DatadogSpanContext) : ParentContextSource()
+
+    /** Parent context derived from a request tag ([DatadogSpan] or [TraceContext]). */
+    class FromTag(override val context: DatadogSpanContext) : ParentContextSource()
+}
 
 /**
  * For internal usage only.
@@ -66,14 +87,15 @@ class DatadogPropagationHelper internal constructor() {
     }
 
     /**
-     * Extracts the parent span context from the request.
+     * Extracts the parent span context from the request along with its source.
      * Checks both the request tags and headers for trace context information.
      *
      * @param tracer the tracer to use for context extraction.
      * @param request the HTTP request info to extract context from.
-     * @return the extracted parent context, or null if none found.
+     * @return a [ParentContextSource] indicating whether the parent came from headers or from a
+     *   request tag, or null if no parent context was found.
      */
-    fun extractParentContext(tracer: DatadogTracer, request: HttpRequestInfo): DatadogSpanContext? {
+    fun extractParentContext(tracer: DatadogTracer, request: HttpRequestInfo): ParentContextSource? {
         val tagContext = extractTraceContext(request)
 
         val headerContext: DatadogSpanContext? = tracer.propagate().extract(request) { carrier, classifier ->
@@ -85,10 +107,12 @@ class DatadogPropagationHelper internal constructor() {
             for ((key, value) in headers) classifier(key, value)
         }
 
-        return if (headerContext != null && isExtractedContext(headerContext)) {
-            headerContext
-        } else {
-            tagContext
+        return when {
+            headerContext != null && isExtractedContext(headerContext) ->
+                ParentContextSource.FromHeaders(headerContext)
+            tagContext != null ->
+                ParentContextSource.FromTag(tagContext)
+            else -> null
         }
     }
 
@@ -256,10 +280,20 @@ class DatadogPropagationHelper internal constructor() {
      * Extracts the sampling decision from the request.
      * Checks headers and tags for existing sampling decisions.
      *
+     * Header sampling priority (Datadog / B3 / W3C) is always authoritative when present, since
+     * it represents upstream service intent and must be preserved for head-based sampling.
+     *
      * @param request the HTTP request info to extract sampling decision from.
+     * @param ignoreLocalDroppedParent when true, tag-attached parents (DatadogSpan tag or
+     *   TraceContext tag) that resolve to a DROP sampling priority are treated as having no
+     *   decision (returns null), so the caller can defer to its own sampler. This mirrors the
+     *   parent-context policy applied by buildSpan() on the RUM path.
      * @return true if sampled, false if not sampled, null if no decision found.
      */
-    fun extractSamplingDecision(request: HttpRequestInfo): Boolean? {
+    fun extractSamplingDecision(
+        request: HttpRequestInfo,
+        ignoreLocalDroppedParent: Boolean = false
+    ): Boolean? {
         val datadogSpan = request.tag(DatadogSpan::class.java)
         val headerSamplingPriority = extractSamplingDecisionFromHeader(request)
         val openTelemetrySpanSamplingPriority = request.tag(TraceContext::class.java)?.samplingPriority
@@ -269,12 +303,25 @@ class DatadogPropagationHelper internal constructor() {
 
             datadogSpan != null -> {
                 _TraceInternalProxy.setTracingSamplingPriorityIfNecessary(datadogSpan.context())
-                datadogSpan.context().samplingPriority > 0
+                val priority = datadogSpan.context().samplingPriority
+                if (ignoreLocalDroppedParent && priority.isDroppedPriority()) {
+                    null
+                } else {
+                    priority > 0
+                }
             }
 
             openTelemetrySpanSamplingPriority == PrioritySampling.UNSET -> null
 
-            else -> openTelemetrySpanSamplingPriority?.let { samplingPriority -> samplingPriority > 0 }
+            openTelemetrySpanSamplingPriority != null -> {
+                if (ignoreLocalDroppedParent && openTelemetrySpanSamplingPriority.isDroppedPriority()) {
+                    null
+                } else {
+                    openTelemetrySpanSamplingPriority > 0
+                }
+            }
+
+            else -> null
         }
     }
 

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExt.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExt.kt
@@ -13,6 +13,7 @@ import com.datadog.android.lint.InternalApi
 import com.datadog.android.trace.api.DatadogTracingConstants.PrioritySampling
 import com.datadog.android.trace.api.DatadogTracingConstants.Tags
 import com.datadog.android.trace.api.span.DatadogSpan
+import com.datadog.android.trace.api.span.DatadogSpanContext
 import com.datadog.android.trace.api.tracer.DatadogTracer
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation.Companion.AGENT_PSR_ATTRIBUTE
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation.Companion.ALL_IN_SAMPLE_RATE
@@ -74,14 +75,22 @@ internal fun DatadogSpan.finishRumAware(isSampled: Boolean, canSendSpan: Boolean
 internal fun DatadogTracer.buildSpan(
     request: HttpRequestInfo,
     networkInstrumentationName: String,
-    traceOrigin: String?
+    traceOrigin: String?,
+    ignoreDroppedParent: Boolean
 ): DatadogSpan {
     val parentContext = propagationHelper.extractParentContext(this, request)
+    val shouldIgnoreParent = ignoreDroppedParent && isParentDropped(this, parentContext)
 
-    val span = buildSpan(SPAN_NAME.format(Locale.US, networkInstrumentationName))
+    val builder = buildSpan(SPAN_NAME.format(Locale.US, networkInstrumentationName))
         .withOrigin(traceOrigin)
-        .withParentContext(parentContext)
-        .start()
+
+    if (shouldIgnoreParent) {
+        builder.ignoreActiveSpan()
+    } else {
+        builder.withParentContext(parentContext)
+    }
+
+    val span = builder.start()
 
     span.resourceName = request.url.substringBefore(URL_QUERY_PARAMS_BLOCK_SEPARATOR)
     span.setTag(Tags.KEY_HTTP_URL, request.url)
@@ -89,4 +98,11 @@ internal fun DatadogTracer.buildSpan(
     span.setTag(Tags.KEY_SPAN_KIND, Tags.VALUE_SPAN_KIND_CLIENT)
 
     return span
+}
+
+private fun isParentDropped(tracer: DatadogTracer, explicitParent: DatadogSpanContext?): Boolean {
+    // Only consult the local active span. Explicit parents (request tags or propagated
+    // headers) represent developer intent and must be honored regardless of priority.
+    val priority = if (explicitParent != null) null else tracer.activeSpan()?.samplingPriority
+    return priority == PrioritySampling.SAMPLER_DROP || priority == PrioritySampling.USER_DROP
 }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExt.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExt.kt
@@ -20,6 +20,7 @@ import com.datadog.android.trace.internal.ApmNetworkInstrumentation.Companion.AL
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation.Companion.SPAN_NAME
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation.Companion.URL_QUERY_PARAMS_BLOCK_SEPARATOR
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation.Companion.ZERO_SAMPLE_RATE
+import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.trace.internal._TraceInternalProxy.propagationHelper
 import java.util.Locale
 
@@ -103,6 +104,10 @@ internal fun DatadogTracer.buildSpan(
 private fun isParentDropped(tracer: DatadogTracer, explicitParent: DatadogSpanContext?): Boolean {
     // Only consult the local active span. Explicit parents (request tags or propagated
     // headers) represent developer intent and must be honored regardless of priority.
-    val priority = if (explicitParent != null) null else tracer.activeSpan()?.samplingPriority
+    val activeContext = if (explicitParent != null) null else tracer.activeSpan()?.context()
+    // Force resolution of the active span's sampling priority — a manual span backed
+    // by a PendingTrace can read UNSET until the sampler commits at inject time.
+    activeContext?.let { _TraceInternalProxy.setTracingSamplingPriorityIfNecessary(it) }
+    val priority = activeContext?.samplingPriority
     return priority == PrioritySampling.SAMPLER_DROP || priority == PrioritySampling.USER_DROP
 }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExt.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExt.kt
@@ -119,10 +119,20 @@ internal fun DatadogTracer.buildSpan(
     return span
 }
 
-internal fun DatadogSpanContext?.isDropped(): Boolean {
+/**
+ * Returns true if this context's sampling priority is a dropped trace (SAMPLER_DROP or USER_DROP).
+ * `@InternalApi` so `DatadogInterceptor` can share this; revert to `internal` once `DatadogInterceptor` is removed.
+ */
+@InternalApi
+fun DatadogSpanContext?.isDropped(): Boolean {
     val priority = this?.samplingPriority
     return priority.isDroppedPriority()
 }
 
-internal fun Int?.isDroppedPriority(): Boolean =
+/**
+ * Returns true if this sampling priority value is a dropped trace (SAMPLER_DROP or USER_DROP).
+ * `@InternalApi` so `DatadogInterceptor` can share this; revert to `internal` once `DatadogInterceptor` is removed.
+ */
+@InternalApi
+fun Int?.isDroppedPriority(): Boolean =
     this == PrioritySampling.SAMPLER_DROP || this == PrioritySampling.USER_DROP

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExt.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExt.kt
@@ -20,6 +20,7 @@ import com.datadog.android.trace.internal.ApmNetworkInstrumentation.Companion.AL
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation.Companion.SPAN_NAME
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation.Companion.URL_QUERY_PARAMS_BLOCK_SEPARATOR
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation.Companion.ZERO_SAMPLE_RATE
+import com.datadog.android.trace.internal.ParentContextSource
 import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.trace.internal._TraceInternalProxy.propagationHelper
 import java.util.Locale
@@ -56,12 +57,17 @@ internal fun DatadogSpan.applyPriority(isSampled: Boolean, traceSampler: Sampler
     }
 }
 
-internal fun DatadogSpan.sample(request: HttpRequestInfo, traceSampler: Sampler<DatadogSpan>): Boolean {
+internal fun DatadogSpan.sample(
+    request: HttpRequestInfo,
+    traceSampler: Sampler<DatadogSpan>,
+    ignoreLocalDroppedParent: Boolean
+): Boolean {
     val samplingPriority = samplingPriority
     return if (samplingPriority != null) {
         samplingPriority > 0
     } else {
-        propagationHelper.extractSamplingDecision(request) ?: traceSampler.sample(this)
+        propagationHelper.extractSamplingDecision(request, ignoreLocalDroppedParent)
+            ?: traceSampler.sample(this)
     }
 }
 
@@ -79,14 +85,20 @@ internal fun DatadogTracer.buildSpan(
     traceOrigin: String?,
     ignoreLocalDroppedParent: Boolean
 ): DatadogSpan {
-    val parentContext = propagationHelper.extractParentContext(this, request)
-    // Only consult the local active span. Explicit parents (request tags or propagated
-    // headers) represent developer intent and must be honored regardless of priority.
-    val activeSpanContext = if (parentContext == null) activeSpan()?.context() else null
-    // Force resolution of the active span's sampling priority — a manual span backed
-    // by a PendingTrace can read UNSET until the sampler commits at inject time.
-    activeSpanContext?.let { _TraceInternalProxy.setTracingSamplingPriorityIfNecessary(it) }
-    val shouldIgnoreLocalDroppedParent = ignoreLocalDroppedParent && activeSpanContext.isDropped()
+    val extractedParent = propagationHelper.extractParentContext(this, request)
+    val parentContext = extractedParent?.context
+    // Local sources we can ignore when dropped: tag-attached parent (developer intent) and
+    // active span on this thread. Header-propagated parents are always honored to preserve
+    // head-based sampling of upstream propagation.
+    val localParentContext = when (extractedParent) {
+        is ParentContextSource.FromTag -> extractedParent.context
+        is ParentContextSource.FromHeaders -> null
+        null -> activeSpan()?.context()
+    }
+    // Force resolution of the local parent's sampling priority — a manual span backed by a
+    // PendingTrace can read UNSET until the sampler commits at inject time.
+    localParentContext?.let { _TraceInternalProxy.setTracingSamplingPriorityIfNecessary(it) }
+    val shouldIgnoreLocalDroppedParent = ignoreLocalDroppedParent && localParentContext.isDropped()
 
     val builder = buildSpan(SPAN_NAME.format(Locale.US, networkInstrumentationName))
         .withOrigin(traceOrigin)
@@ -107,7 +119,10 @@ internal fun DatadogTracer.buildSpan(
     return span
 }
 
-private fun DatadogSpanContext?.isDropped(): Boolean {
+internal fun DatadogSpanContext?.isDropped(): Boolean {
     val priority = this?.samplingPriority
-    return priority == PrioritySampling.SAMPLER_DROP || priority == PrioritySampling.USER_DROP
+    return priority.isDroppedPriority()
 }
+
+internal fun Int?.isDroppedPriority(): Boolean =
+    this == PrioritySampling.SAMPLER_DROP || this == PrioritySampling.USER_DROP

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExt.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExt.kt
@@ -77,15 +77,21 @@ internal fun DatadogTracer.buildSpan(
     request: HttpRequestInfo,
     networkInstrumentationName: String,
     traceOrigin: String?,
-    ignoreDroppedParent: Boolean
+    ignoreLocalDroppedParent: Boolean
 ): DatadogSpan {
     val parentContext = propagationHelper.extractParentContext(this, request)
-    val shouldIgnoreParent = ignoreDroppedParent && isParentDropped(this, parentContext)
+    // Only consult the local active span. Explicit parents (request tags or propagated
+    // headers) represent developer intent and must be honored regardless of priority.
+    val activeSpanContext = if (parentContext == null) activeSpan()?.context() else null
+    // Force resolution of the active span's sampling priority — a manual span backed
+    // by a PendingTrace can read UNSET until the sampler commits at inject time.
+    activeSpanContext?.let { _TraceInternalProxy.setTracingSamplingPriorityIfNecessary(it) }
+    val shouldIgnoreLocalDroppedParent = ignoreLocalDroppedParent && activeSpanContext.isDropped()
 
     val builder = buildSpan(SPAN_NAME.format(Locale.US, networkInstrumentationName))
         .withOrigin(traceOrigin)
 
-    if (shouldIgnoreParent) {
+    if (shouldIgnoreLocalDroppedParent) {
         builder.ignoreActiveSpan()
     } else {
         builder.withParentContext(parentContext)
@@ -101,13 +107,7 @@ internal fun DatadogTracer.buildSpan(
     return span
 }
 
-private fun isParentDropped(tracer: DatadogTracer, explicitParent: DatadogSpanContext?): Boolean {
-    // Only consult the local active span. Explicit parents (request tags or propagated
-    // headers) represent developer intent and must be honored regardless of priority.
-    val activeContext = if (explicitParent != null) null else tracer.activeSpan()?.context()
-    // Force resolution of the active span's sampling priority — a manual span backed
-    // by a PendingTrace can read UNSET until the sampler commits at inject time.
-    activeContext?.let { _TraceInternalProxy.setTracingSamplingPriorityIfNecessary(it) }
-    val priority = activeContext?.samplingPriority
+private fun DatadogSpanContext?.isDropped(): Boolean {
+    val priority = this?.samplingPriority
     return priority == PrioritySampling.SAMPLER_DROP || priority == PrioritySampling.USER_DROP
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/DatadogPropagationHelperTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/DatadogPropagationHelperTest.kt
@@ -204,7 +204,8 @@ internal class DatadogPropagationHelperTest {
         val result = testedHelper.extractParentContext(mockTracer, mockRequest)
 
         // Then
-        assertThat(result).isSameAs(mockSpanContext)
+        assertThat(result).isInstanceOf(ParentContextSource.FromTag::class.java)
+        assertThat(result?.context).isSameAs(mockSpanContext)
     }
 
     @Test
@@ -232,7 +233,8 @@ internal class DatadogPropagationHelperTest {
         val result = testedHelper.extractParentContext(mockTracer, mockRequest)
 
         // Then
-        assertThat(result).isSameAs(extractedSpanContext)
+        assertThat(result).isInstanceOf(ParentContextSource.FromHeaders::class.java)
+        assertThat(result?.context).isSameAs(extractedSpanContext)
     }
 
     @Test
@@ -253,7 +255,8 @@ internal class DatadogPropagationHelperTest {
         val result = testedHelper.extractParentContext(mockTracer, mockRequest)
 
         // Then
-        assertThat(result).isSameAs(mockSpanContext)
+        assertThat(result).isInstanceOf(ParentContextSource.FromTag::class.java)
+        assertThat(result?.context).isSameAs(mockSpanContext)
     }
 
     @Test
@@ -275,9 +278,10 @@ internal class DatadogPropagationHelperTest {
         val result = testedHelper.extractParentContext(mockTracer, mockRequest)
 
         // Then
-        assertThat(result).isNotNull
-        assertThat(result!!.traceId.toHexString()).isEqualTo(fakeTraceId)
-        assertThat(result.samplingPriority).isEqualTo(fakeSamplingPriority)
+        assertThat(result).isInstanceOf(ParentContextSource.FromTag::class.java)
+        assertThat(result?.context).isNotNull
+        assertThat(result!!.context.traceId.toHexString()).isEqualTo(fakeTraceId)
+        assertThat(result.context.samplingPriority).isEqualTo(fakeSamplingPriority)
     }
 
     @Test
@@ -601,6 +605,105 @@ internal class DatadogPropagationHelperTest {
         // Then
         assertThat(result).isFalse()
     }
+
+    // region ignoreLocalDroppedParent
+
+    @Test
+    fun `M return null W extractSamplingDecision() {ignoreLocalDroppedParent, DatadogSpan tag SAMPLER_DROP}`() {
+        // Given - on the RUM path, a dropped local tag parent must not lock the request to dropped.
+        // Returning null defers the decision to the caller's sampler so RUM can sample independently.
+        whenever(mockSpanContext.samplingPriority) doReturn PrioritySampling.SAMPLER_DROP
+        val mockRequest = createMockRequestWithTags(datadogSpan = mockSpan)
+
+        // When
+        val result = testedHelper.extractSamplingDecision(mockRequest, ignoreLocalDroppedParent = true)
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M return null W extractSamplingDecision() {ignoreLocalDroppedParent, DatadogSpan tag USER_DROP}`() {
+        // Given
+        whenever(mockSpanContext.samplingPriority) doReturn PrioritySampling.USER_DROP
+        val mockRequest = createMockRequestWithTags(datadogSpan = mockSpan)
+
+        // When
+        val result = testedHelper.extractSamplingDecision(mockRequest, ignoreLocalDroppedParent = true)
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M return true W extractSamplingDecision() {ignoreLocalDroppedParent, DatadogSpan tag KEEP}`() {
+        // Given - the ignore flag must not change behavior for KEEP parents; they are still honored.
+        whenever(mockSpanContext.samplingPriority) doReturn PrioritySampling.SAMPLER_KEEP
+        val mockRequest = createMockRequestWithTags(datadogSpan = mockSpan)
+
+        // When
+        val result = testedHelper.extractSamplingDecision(mockRequest, ignoreLocalDroppedParent = true)
+
+        // Then
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `M return null W extractSamplingDecision() {ignoreLocalDroppedParent, TraceContext tag SAMPLER_DROP}`() {
+        // Given - TraceContext tag (OTel interop) is also local developer intent; same policy applies.
+        val traceContext = TraceContext("traceId", "spanId", PrioritySampling.SAMPLER_DROP)
+        val mockRequest = createMockRequestWithTags(traceContext = traceContext)
+
+        // When
+        val result = testedHelper.extractSamplingDecision(mockRequest, ignoreLocalDroppedParent = true)
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M return null W extractSamplingDecision() {ignoreLocalDroppedParent, TraceContext tag USER_DROP}`() {
+        // Given
+        val traceContext = TraceContext("traceId", "spanId", PrioritySampling.USER_DROP)
+        val mockRequest = createMockRequestWithTags(traceContext = traceContext)
+
+        // When
+        val result = testedHelper.extractSamplingDecision(mockRequest, ignoreLocalDroppedParent = true)
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M return true W extractSamplingDecision() {ignoreLocalDroppedParent, TraceContext tag KEEP}`() {
+        // Given
+        val traceContext = TraceContext("traceId", "spanId", PrioritySampling.USER_KEEP)
+        val mockRequest = createMockRequestWithTags(traceContext = traceContext)
+
+        // When
+        val result = testedHelper.extractSamplingDecision(mockRequest, ignoreLocalDroppedParent = true)
+
+        // Then
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `M honor header W extractSamplingDecision() {ignoreLocalDroppedParent, header DROP, tag DROP}`() {
+        // Given - header sampling priority is always authoritative; the ignore flag must not affect it.
+        val headers = mapOf(
+            DatadogHttpCodec.SAMPLING_PRIORITY_KEY to listOf(PrioritySampling.SAMPLER_DROP.toString())
+        )
+        whenever(mockSpanContext.samplingPriority) doReturn PrioritySampling.SAMPLER_DROP
+        val mockRequest = createMockRequestWithTags(headers = headers, datadogSpan = mockSpan)
+
+        // When
+        val result = testedHelper.extractSamplingDecision(mockRequest, ignoreLocalDroppedParent = true)
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    // endregion
 
     @Test
     fun `M call tracer inject W propagateSampledHeaders()`() {

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationTest.kt
@@ -324,6 +324,46 @@ internal class ApmNetworkInstrumentationTest {
     }
 
     @Test
+    fun `M honor parent W onRequest() {canSendSpan=false, extracted parent DROP}`() {
+        // Given - extracted parent context with DROP priority. Explicit parents (header- or
+        // tag-propagated) represent developer/upstream intent and must be honored as-is.
+        testedInstrumentation = createInstrumentation(canSendSpan = false)
+        val parentSpanContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
+        }
+        whenever(mockPropagationHelper.extractParentContext(mockTracer, mockRequestInfo)) doReturn parentSpanContext
+
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
+            // When
+            testedInstrumentation.onRequest(mockRequestInfo)
+
+            // Then
+            verify(mockSpanBuilder).withParentContext(parentSpanContext)
+            verify(mockSpanBuilder, never()).ignoreActiveSpan()
+        }
+    }
+
+    @Test
+    fun `M use parent W onRequest() {canSendSpan=false, parent context resolves to KEEP}`() {
+        // Given - parent context returns SAMPLER_KEEP, simulating the post-resolution state
+        // after setTracingSamplingPriorityIfNecessary forces the lazy sampling decision.
+        testedInstrumentation = createInstrumentation(canSendSpan = false)
+        val parentSpanContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP
+        }
+        whenever(mockPropagationHelper.extractParentContext(mockTracer, mockRequestInfo)) doReturn parentSpanContext
+
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
+            // When
+            testedInstrumentation.onRequest(mockRequestInfo)
+
+            // Then
+            verify(mockSpanBuilder).withParentContext(parentSpanContext)
+            verify(mockSpanBuilder, never()).ignoreActiveSpan()
+        }
+    }
+
+    @Test
     fun `M return RequestTraceState without span W onRequest() {tracer not available}`() {
         // Given
         whenever(mockTracerProvider.provideTracer(any(), any(), any())) doReturn null

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationTest.kt
@@ -23,6 +23,7 @@ import com.datadog.android.trace.ApmNetworkTracingScope
 import com.datadog.android.trace.NetworkTracedRequestListener
 import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
+import com.datadog.android.trace.api.DatadogTracingConstants
 import com.datadog.android.trace.api.DatadogTracingConstants.Tags
 import com.datadog.android.trace.api.span.DatadogSpan
 import com.datadog.android.trace.api.span.DatadogSpanBuilder
@@ -167,6 +168,7 @@ internal class ApmNetworkInstrumentationTest {
         mockSpanBuilder = mock {
             on { withOrigin(anyOrNull()) } doAnswer { mockSpanBuilder }
             on { withParentContext(anyOrNull()) } doAnswer { mockSpanBuilder }
+            on { ignoreActiveSpan() } doAnswer { mockSpanBuilder }
             on { start() } doReturn mockSpan
         }
         whenever(mockTracer.buildSpan(any())) doReturn mockSpanBuilder
@@ -274,6 +276,50 @@ internal class ApmNetworkInstrumentationTest {
             // Then
             assertThat(result.span).isNotNull()
             assertThat(result.isSampled).isTrue()
+        }
+    }
+
+    @Test
+    fun `M use parent context W onRequest() {canSendSpan=false, parent sampling UNSET}`() {
+        // Given
+        testedInstrumentation = createInstrumentation(canSendSpan = false)
+        val parentSpanContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.UNSET
+        }
+        whenever(mockPropagationHelper.extractParentContext(mockTracer, mockRequestInfo)) doReturn parentSpanContext
+
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
+            // When
+            testedInstrumentation.onRequest(mockRequestInfo)
+
+            // Then
+            verify(mockSpanBuilder).withParentContext(parentSpanContext)
+            verify(mockSpanBuilder, never()).ignoreActiveSpan()
+        }
+    }
+
+    @Test
+    fun `M honor explicit parent W onRequest() {canSendSpan=false, active span DROP, extracted parent KEEP}`() {
+        // Given - an explicit extracted parent (KEEP) takes precedence over a dropped
+        // local active span. The active span's drop status must not leak into the
+        // sampling decision for a request that has its own parent context.
+        testedInstrumentation = createInstrumentation(canSendSpan = false)
+        val droppedActiveSpan: DatadogSpan = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
+        }
+        whenever(mockTracer.activeSpan()) doReturn droppedActiveSpan
+        val parentSpanContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP
+        }
+        whenever(mockPropagationHelper.extractParentContext(mockTracer, mockRequestInfo)) doReturn parentSpanContext
+
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
+            // When
+            testedInstrumentation.onRequest(mockRequestInfo)
+
+            // Then
+            verify(mockSpanBuilder).withParentContext(parentSpanContext)
+            verify(mockSpanBuilder, never()).ignoreActiveSpan()
         }
     }
 

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationTest.kt
@@ -32,6 +32,7 @@ import com.datadog.android.trace.api.tracer.DatadogTracer
 import com.datadog.android.trace.api.withMockPropagationHelper
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation
 import com.datadog.android.trace.internal.DatadogPropagationHelper
+import com.datadog.android.trace.internal.ParentContextSource
 import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
@@ -194,7 +195,7 @@ internal class ApmNetworkInstrumentationTest {
         }
 
         // Set up mock propagation helper to return null for sampling decision (falls through to sampler)
-        whenever(mockPropagationHelper.extractSamplingDecision(any())) doReturn null
+        whenever(mockPropagationHelper.extractSamplingDecision(any(), any())) doReturn null
 
         testedInstrumentation = createInstrumentation()
     }
@@ -280,13 +281,14 @@ internal class ApmNetworkInstrumentationTest {
     }
 
     @Test
-    fun `M use parent context W onRequest() {canSendSpan=false, parent sampling UNSET}`() {
+    fun `M use parent context W onRequest() {canSendSpan=false, header parent sampling UNSET}`() {
         // Given
         testedInstrumentation = createInstrumentation(canSendSpan = false)
         val parentSpanContext: DatadogSpanContext = mock {
             on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.UNSET
         }
-        whenever(mockPropagationHelper.extractParentContext(mockTracer, mockRequestInfo)) doReturn parentSpanContext
+        whenever(mockPropagationHelper.extractParentContext(mockTracer, mockRequestInfo)) doReturn
+            ParentContextSource.FromHeaders(parentSpanContext)
 
         _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
@@ -299,10 +301,10 @@ internal class ApmNetworkInstrumentationTest {
     }
 
     @Test
-    fun `M honor explicit parent W onRequest() {canSendSpan=false, active span DROP, extracted parent KEEP}`() {
-        // Given - an explicit extracted parent (KEEP) takes precedence over a dropped
-        // local active span. The active span's drop status must not leak into the
-        // sampling decision for a request that has its own parent context.
+    fun `M honor explicit parent W onRequest() {canSendSpan=false, active span DROP, header parent KEEP}`() {
+        // Given - an explicit header-propagated parent (KEEP) takes precedence over a dropped
+        // local active span. The active span's drop status must not leak into the sampling
+        // decision for a request that has its own parent context.
         testedInstrumentation = createInstrumentation(canSendSpan = false)
         val droppedActiveSpan: DatadogSpan = mock {
             on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
@@ -311,7 +313,8 @@ internal class ApmNetworkInstrumentationTest {
         val parentSpanContext: DatadogSpanContext = mock {
             on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP
         }
-        whenever(mockPropagationHelper.extractParentContext(mockTracer, mockRequestInfo)) doReturn parentSpanContext
+        whenever(mockPropagationHelper.extractParentContext(mockTracer, mockRequestInfo)) doReturn
+            ParentContextSource.FromHeaders(parentSpanContext)
 
         _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
@@ -324,14 +327,16 @@ internal class ApmNetworkInstrumentationTest {
     }
 
     @Test
-    fun `M honor parent W onRequest() {canSendSpan=false, extracted parent DROP}`() {
-        // Given - extracted parent context with DROP priority. Explicit parents (header- or
-        // tag-propagated) represent developer/upstream intent and must be honored as-is.
+    fun `M honor parent W onRequest() {canSendSpan=false, header parent DROP}`() {
+        // Given - header-propagated parent with DROP priority. Header parents represent
+        // upstream service intent and must be honored regardless of priority to preserve
+        // head-based sampling of distributed traces.
         testedInstrumentation = createInstrumentation(canSendSpan = false)
         val parentSpanContext: DatadogSpanContext = mock {
             on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
         }
-        whenever(mockPropagationHelper.extractParentContext(mockTracer, mockRequestInfo)) doReturn parentSpanContext
+        whenever(mockPropagationHelper.extractParentContext(mockTracer, mockRequestInfo)) doReturn
+            ParentContextSource.FromHeaders(parentSpanContext)
 
         _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
@@ -344,14 +349,15 @@ internal class ApmNetworkInstrumentationTest {
     }
 
     @Test
-    fun `M use parent W onRequest() {canSendSpan=false, parent context resolves to KEEP}`() {
-        // Given - parent context returns SAMPLER_KEEP, simulating the post-resolution state
-        // after setTracingSamplingPriorityIfNecessary forces the lazy sampling decision.
+    fun `M use parent W onRequest() {canSendSpan=false, header parent context resolves to KEEP}`() {
+        // Given - header-propagated parent returns SAMPLER_KEEP, simulating the post-resolution
+        // state after setTracingSamplingPriorityIfNecessary forces the lazy sampling decision.
         testedInstrumentation = createInstrumentation(canSendSpan = false)
         val parentSpanContext: DatadogSpanContext = mock {
             on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP
         }
-        whenever(mockPropagationHelper.extractParentContext(mockTracer, mockRequestInfo)) doReturn parentSpanContext
+        whenever(mockPropagationHelper.extractParentContext(mockTracer, mockRequestInfo)) doReturn
+            ParentContextSource.FromHeaders(parentSpanContext)
 
         _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
             // When
@@ -360,6 +366,145 @@ internal class ApmNetworkInstrumentationTest {
             // Then
             verify(mockSpanBuilder).withParentContext(parentSpanContext)
             verify(mockSpanBuilder, never()).ignoreActiveSpan()
+        }
+    }
+
+    @Test
+    fun `M ignore parent W onRequest() {canSendSpan=false, tag parent DROP}`() {
+        // Given - a developer-attached parent (via Request.Builder.parentSpan or
+        // addRequestAnnotation) with DROP priority. On the RUM path, this should be ignored
+        // so RUM can make its own sampling decision.
+        testedInstrumentation = createInstrumentation(canSendSpan = false)
+        val droppedTagContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
+        }
+        whenever(mockPropagationHelper.extractParentContext(mockTracer, mockRequestInfo)) doReturn
+            ParentContextSource.FromTag(droppedTagContext)
+
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
+            // When
+            testedInstrumentation.onRequest(mockRequestInfo)
+
+            // Then
+            verify(mockSpanBuilder).ignoreActiveSpan()
+            verify(mockSpanBuilder, never()).withParentContext(any())
+        }
+    }
+
+    @Test
+    fun `M honor parent W onRequest() {canSendSpan=false, tag parent KEEP}`() {
+        // Given - tag-attached parent with KEEP priority is honored on the RUM path.
+        testedInstrumentation = createInstrumentation(canSendSpan = false)
+        val tagContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP
+        }
+        whenever(mockPropagationHelper.extractParentContext(mockTracer, mockRequestInfo)) doReturn
+            ParentContextSource.FromTag(tagContext)
+
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
+            // When
+            testedInstrumentation.onRequest(mockRequestInfo)
+
+            // Then
+            verify(mockSpanBuilder).withParentContext(tagContext)
+            verify(mockSpanBuilder, never()).ignoreActiveSpan()
+        }
+    }
+
+    @Test
+    fun `M honor parent W onRequest() {canSendSpan=true, tag parent DROP}`() {
+        // Given - on the pure-APM path (canSendSpan=true), tag parents are honored even when
+        // dropped. This preserves head-based sampling for the APM-only path.
+        testedInstrumentation = createInstrumentation(canSendSpan = true)
+        val droppedTagContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
+        }
+        whenever(mockPropagationHelper.extractParentContext(mockTracer, mockRequestInfo)) doReturn
+            ParentContextSource.FromTag(droppedTagContext)
+
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
+            // When
+            testedInstrumentation.onRequest(mockRequestInfo)
+
+            // Then
+            verify(mockSpanBuilder).withParentContext(droppedTagContext)
+            verify(mockSpanBuilder, never()).ignoreActiveSpan()
+        }
+    }
+
+    @Test
+    fun `M extract sampling decision with ignoreLocalDroppedParent=true W onRequest() {canSendSpan=false}`() {
+        // Given - on the RUM path, the dropped-local-parent policy must be threaded to the
+        // sampling-decision layer so it stays consistent with buildSpan().
+        testedInstrumentation = createInstrumentation(canSendSpan = false)
+
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
+            // When
+            testedInstrumentation.onRequest(mockRequestInfo)
+
+            // Then
+            verify(mockPropagationHelper).extractSamplingDecision(mockRequestInfo, true)
+        }
+    }
+
+    @Test
+    fun `M extract sampling decision with ignoreLocalDroppedParent=false W onRequest() {canSendSpan=true}`() {
+        // Given - APM-only path keeps the legacy behavior; dropped local parents lock sampling.
+        testedInstrumentation = createInstrumentation(canSendSpan = true)
+
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
+            // When
+            testedInstrumentation.onRequest(mockRequestInfo)
+
+            // Then
+            verify(mockPropagationHelper).extractSamplingDecision(mockRequestInfo, false)
+        }
+    }
+
+    @Test
+    fun `M defer to sampler W onRequest() {canSendSpan=false, tag parent DROP, helper returns null}`() {
+        // Given - on the RUM path with a dropped tag parent, the sampling-decision layer is
+        // expected to return null (defer to sampler). The trace sampler then decides
+        // independently and the result is reflected in RequestTracingState.isSampled.
+        testedInstrumentation = createInstrumentation(canSendSpan = false)
+        val droppedTagContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
+        }
+        whenever(mockPropagationHelper.extractParentContext(mockTracer, mockRequestInfo)) doReturn
+            ParentContextSource.FromTag(droppedTagContext)
+        whenever(mockPropagationHelper.extractSamplingDecision(mockRequestInfo, true)) doReturn null
+        whenever(mockTraceSampler.sample(mockSpan)) doReturn true
+
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
+            // When
+            val result = checkNotNull(testedInstrumentation.onRequest(mockRequestInfo))
+
+            // Then
+            verify(mockTraceSampler).sample(mockSpan)
+            assertThat(result.isSampled).isTrue()
+        }
+    }
+
+    @Test
+    fun `M honor header W onRequest() {canSendSpan=false, header DROP, tag DROP}`() {
+        // Given - header sampling priority remains authoritative on the RUM path. Even when
+        // the local tag parent would have been ignored, an inbound DROP header still locks
+        // the request to dropped to preserve head-based sampling of distributed traces.
+        testedInstrumentation = createInstrumentation(canSendSpan = false)
+        val droppedTagContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
+        }
+        whenever(mockPropagationHelper.extractParentContext(mockTracer, mockRequestInfo)) doReturn
+            ParentContextSource.FromTag(droppedTagContext)
+        whenever(mockPropagationHelper.extractSamplingDecision(mockRequestInfo, true)) doReturn false
+
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
+            // When
+            val result = checkNotNull(testedInstrumentation.onRequest(mockRequestInfo))
+
+            // Then
+            verify(mockTraceSampler, never()).sample(mockSpan)
+            assertThat(result.isSampled).isFalse()
         }
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -345,12 +345,19 @@ internal constructor(
 
     private fun buildSpan(tracer: DatadogTracer, request: Request): DatadogSpan {
         val parentContext = extractParentContext(tracer, request)
+        val shouldIgnoreParent = !canSendSpan() && isParentDropped(tracer, parentContext)
         val url = request.url.toString()
 
-        val span = tracer.buildSpan(SPAN_NAME)
+        val builder = tracer.buildSpan(SPAN_NAME)
             .withOrigin(traceOrigin)
-            .withParentContext(parentContext)
-            .start()
+
+        if (shouldIgnoreParent) {
+            builder.ignoreActiveSpan()
+        } else {
+            builder.withParentContext(parentContext)
+        }
+
+        val span = builder.start()
 
         span.resourceName = url.substringBefore(URL_QUERY_PARAMS_BLOCK_SEPARATOR)
         span.setTag(Tags.KEY_HTTP_URL, url)
@@ -358,6 +365,13 @@ internal constructor(
         span.setTag(Tags.KEY_SPAN_KIND, Tags.VALUE_SPAN_KIND_CLIENT)
 
         return span
+    }
+
+    private fun isParentDropped(tracer: DatadogTracer, explicitParent: DatadogSpanContext?): Boolean {
+        // Only consult the local active span. Explicit parents (request tags or propagated
+        // headers) represent developer intent and must be honored regardless of priority.
+        val priority = if (explicitParent != null) null else tracer.activeSpan()?.samplingPriority
+        return priority == PrioritySampling.SAMPLER_DROP || priority == PrioritySampling.USER_DROP
     }
 
     private fun extractSamplingDecision(request: Request): Boolean? {

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -370,7 +370,11 @@ internal constructor(
     private fun isParentDropped(tracer: DatadogTracer, explicitParent: DatadogSpanContext?): Boolean {
         // Only consult the local active span. Explicit parents (request tags or propagated
         // headers) represent developer intent and must be honored regardless of priority.
-        val priority = if (explicitParent != null) null else tracer.activeSpan()?.samplingPriority
+        val activeContext = if (explicitParent != null) null else tracer.activeSpan()?.context()
+        // Force resolution of the active span's sampling priority — a manual span backed
+        // by a PendingTrace can read UNSET until the sampler commits at inject time.
+        activeContext?.let { _TraceInternalProxy.setTracingSamplingPriorityIfNecessary(it) }
+        val priority = activeContext?.samplingPriority
         return priority == PrioritySampling.SAMPLER_DROP || priority == PrioritySampling.USER_DROP
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -40,6 +40,8 @@ import com.datadog.android.trace.internal.RumContextPropagator.Companion.extract
 import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.trace.internal.net.TraceContext
 import com.datadog.android.trace.internal.net.effectiveSampleRate
+import com.datadog.android.trace.internal.net.isDropped
+import com.datadog.android.trace.internal.net.isDroppedPriority
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -380,14 +382,6 @@ internal constructor(
 
         return span
     }
-
-    private fun DatadogSpanContext?.isDropped(): Boolean {
-        val priority = this?.samplingPriority
-        return priority.isDroppedPriority()
-    }
-
-    private fun Int?.isDroppedPriority(): Boolean =
-        this == PrioritySampling.SAMPLER_DROP || this == PrioritySampling.USER_DROP
 
     private fun extractSamplingDecision(
         request: Request,

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -34,6 +34,7 @@ import com.datadog.android.trace.api.DatadogTracingConstants.Tags
 import com.datadog.android.trace.api.span.DatadogSpan
 import com.datadog.android.trace.api.span.DatadogSpanContext
 import com.datadog.android.trace.api.tracer.DatadogTracer
+import com.datadog.android.trace.internal.ParentContextSource
 import com.datadog.android.trace.internal.RumContextPropagator
 import com.datadog.android.trace.internal.RumContextPropagator.Companion.extractRumContext
 import com.datadog.android.trace.internal._TraceInternalProxy
@@ -248,7 +249,8 @@ internal constructor(
         tracer: DatadogTracer
     ): Response {
         val span = buildSpan(tracer, request)
-        val isSampled = span.extractRumContext(rumContextPropagator, block = true).sample(request)
+        val isSampled = span.extractRumContext(rumContextPropagator, block = true)
+            .sample(request, ignoreLocalDroppedParent = !canSendSpan())
 
         if (span.isRootSpan) {
             val samplingPriority = if (isSampled) {
@@ -344,14 +346,20 @@ internal constructor(
     }
 
     private fun buildSpan(tracer: DatadogTracer, request: Request): DatadogSpan {
-        val parentContext = extractParentContext(tracer, request)
-        // Only consult the local active span. Explicit parents (request tags or propagated
-        // headers) represent developer intent and must be honored regardless of priority.
-        val activeSpanContext = if (parentContext == null) tracer.activeSpan()?.context() else null
-        // Force resolution of the active span's sampling priority — a manual span backed
-        // by a PendingTrace can read UNSET until the sampler commits at inject time.
-        activeSpanContext?.let { _TraceInternalProxy.setTracingSamplingPriorityIfNecessary(it) }
-        val shouldIgnoreLocalDroppedParent = !canSendSpan() && activeSpanContext.isDropped()
+        val extractedParent = extractParentContext(tracer, request)
+        val parentContext = extractedParent?.context
+        // Local sources we can ignore when dropped: tag-attached parent (developer intent) and
+        // active span on this thread. Header-propagated parents are always honored to preserve
+        // head-based sampling of upstream propagation.
+        val localParentContext = when (extractedParent) {
+            is ParentContextSource.FromTag -> extractedParent.context
+            is ParentContextSource.FromHeaders -> null
+            null -> tracer.activeSpan()?.context()
+        }
+        // Force resolution of the local parent's sampling priority — a manual span backed by a
+        // PendingTrace can read UNSET until the sampler commits at inject time.
+        localParentContext?.let { _TraceInternalProxy.setTracingSamplingPriorityIfNecessary(it) }
+        val shouldIgnoreLocalDroppedParent = !canSendSpan() && localParentContext.isDropped()
         val url = request.url.toString()
 
         val builder = tracer.buildSpan(SPAN_NAME)
@@ -375,10 +383,16 @@ internal constructor(
 
     private fun DatadogSpanContext?.isDropped(): Boolean {
         val priority = this?.samplingPriority
-        return priority == PrioritySampling.SAMPLER_DROP || priority == PrioritySampling.USER_DROP
+        return priority.isDroppedPriority()
     }
 
-    private fun extractSamplingDecision(request: Request): Boolean? {
+    private fun Int?.isDroppedPriority(): Boolean =
+        this == PrioritySampling.SAMPLER_DROP || this == PrioritySampling.USER_DROP
+
+    private fun extractSamplingDecision(
+        request: Request,
+        ignoreLocalDroppedParent: Boolean
+    ): Boolean? {
         val headerSamplingPriority = extractSamplingDecisionFromHeader(request)
         val datadogSpan = request.tag(DatadogSpan::class.java)
         val openTelemetrySpanSamplingPriority = request.getTraceContextTag()?.samplingPriority
@@ -387,10 +401,22 @@ internal constructor(
             headerSamplingPriority != null -> headerSamplingPriority
             datadogSpan != null -> {
                 _TraceInternalProxy.setTracingSamplingPriorityIfNecessary(datadogSpan.context())
-                datadogSpan.context().samplingPriority > 0
+                val priority = datadogSpan.context().samplingPriority
+                if (ignoreLocalDroppedParent && priority.isDroppedPriority()) {
+                    null
+                } else {
+                    priority > 0
+                }
             }
             openTelemetrySpanSamplingPriority == PrioritySampling.UNSET -> null
-            else -> openTelemetrySpanSamplingPriority?.let { samplingPriority -> samplingPriority > 0 }
+            openTelemetrySpanSamplingPriority != null -> {
+                if (ignoreLocalDroppedParent && openTelemetrySpanSamplingPriority.isDroppedPriority()) {
+                    null
+                } else {
+                    openTelemetrySpanSamplingPriority > 0
+                }
+            }
+            else -> null
         }
     }
 
@@ -448,7 +474,7 @@ internal constructor(
         return null
     }
 
-    private fun extractParentContext(tracer: DatadogTracer, request: Request): DatadogSpanContext? {
+    private fun extractParentContext(tracer: DatadogTracer, request: Request): ParentContextSource? {
         val tagContext = request.tag(DatadogSpan::class.java)?.context() ?: extractTraceContext(request)
 
         val headerContext: DatadogSpanContext? = tracer.propagate().extract(request) { carrier, classifier ->
@@ -460,10 +486,12 @@ internal constructor(
             for ((key, value) in headers) classifier(key, value)
         }
 
-        return if (headerContext != null && _TraceInternalProxy.propagationHelper.isExtractedContext(headerContext)) {
-            headerContext
-        } else {
-            tagContext
+        return when {
+            headerContext != null && _TraceInternalProxy.propagationHelper.isExtractedContext(headerContext) ->
+                ParentContextSource.FromHeaders(headerContext)
+            tagContext != null ->
+                ParentContextSource.FromTag(tagContext)
+            else -> null
         }
     }
 
@@ -721,12 +749,12 @@ internal constructor(
         }
     }
 
-    private fun DatadogSpan.sample(request: Request): Boolean {
+    private fun DatadogSpan.sample(request: Request, ignoreLocalDroppedParent: Boolean): Boolean {
         val samplingPriority = samplingPriority
         return if (samplingPriority != null) {
             samplingPriority > 0
         } else {
-            extractSamplingDecision(request) ?: traceSampler.sample(this)
+            extractSamplingDecision(request, ignoreLocalDroppedParent) ?: traceSampler.sample(this)
         }
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -345,13 +345,19 @@ internal constructor(
 
     private fun buildSpan(tracer: DatadogTracer, request: Request): DatadogSpan {
         val parentContext = extractParentContext(tracer, request)
-        val shouldIgnoreParent = !canSendSpan() && isParentDropped(tracer, parentContext)
+        // Only consult the local active span. Explicit parents (request tags or propagated
+        // headers) represent developer intent and must be honored regardless of priority.
+        val activeSpanContext = if (parentContext == null) tracer.activeSpan()?.context() else null
+        // Force resolution of the active span's sampling priority — a manual span backed
+        // by a PendingTrace can read UNSET until the sampler commits at inject time.
+        activeSpanContext?.let { _TraceInternalProxy.setTracingSamplingPriorityIfNecessary(it) }
+        val shouldIgnoreLocalDroppedParent = !canSendSpan() && activeSpanContext.isDropped()
         val url = request.url.toString()
 
         val builder = tracer.buildSpan(SPAN_NAME)
             .withOrigin(traceOrigin)
 
-        if (shouldIgnoreParent) {
+        if (shouldIgnoreLocalDroppedParent) {
             builder.ignoreActiveSpan()
         } else {
             builder.withParentContext(parentContext)
@@ -367,14 +373,8 @@ internal constructor(
         return span
     }
 
-    private fun isParentDropped(tracer: DatadogTracer, explicitParent: DatadogSpanContext?): Boolean {
-        // Only consult the local active span. Explicit parents (request tags or propagated
-        // headers) represent developer intent and must be honored regardless of priority.
-        val activeContext = if (explicitParent != null) null else tracer.activeSpan()?.context()
-        // Force resolution of the active span's sampling priority — a manual span backed
-        // by a PendingTrace can read UNSET until the sampler commits at inject time.
-        activeContext?.let { _TraceInternalProxy.setTracingSamplingPriorityIfNecessary(it) }
-        val priority = activeContext?.samplingPriority
+    private fun DatadogSpanContext?.isDropped(): Boolean {
+        val priority = this?.samplingPriority
         return priority == PrioritySampling.SAMPLER_DROP || priority == PrioritySampling.USER_DROP
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
@@ -530,7 +530,9 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
-        val parentSpanContext: DatadogSpanContext = mock()
+        val parentSpanContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP
+        }
         whenever(mockSpanBuilder.withParentContext(any<DatadogSpanContext>())) doReturn mockSpanBuilder
         whenever(mockPropagation.extract(any<Request>(), any())) doReturn parentSpanContext
         whenever(mockPropagationHelper.isExtractedContext(parentSpanContext)) doReturn true

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
@@ -590,7 +590,9 @@ internal open class TracingInterceptorNotSendingSpanTest {
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
-        val parentSpanContext: DatadogSpanContext = mock()
+        val parentSpanContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP
+        }
         whenever(mockPropagation.extract(any<Request>(), any())) doReturn parentSpanContext
         whenever(mockPropagationHelper.isExtractedContext(parentSpanContext)) doReturn true
         whenever(mockSpanBuilder.withParentContext(any<DatadogSpanContext>())) doReturn mockSpanBuilder
@@ -1279,6 +1281,148 @@ internal open class TracingInterceptorNotSendingSpanTest {
         verify(mockLocalTracer, times(2)).buildSpan(TracingInterceptor.SPAN_NAME)
         assertThat(called).isEqualTo(1)
     }
+
+    // region Ignore dropped parent
+
+    @Test
+    fun `M ignore dropped parent W intercept() { active span dropped }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given
+        val droppedActiveSpan = forge.newSpanMock(
+            samplingPriority = DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
+        )
+        whenever(mockTracer.activeSpan()) doReturn droppedActiveSpan
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        verify(mockSpanBuilder).ignoreActiveSpan()
+        verify(mockSpanBuilder, never()).withParentContext(any())
+    }
+
+    @Test
+    fun `M use parent context W intercept() { active span sampled }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given
+        val sampledActiveSpan = forge.newSpanMock(
+            samplingPriority = DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP
+        )
+        whenever(mockTracer.activeSpan()) doReturn sampledActiveSpan
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        verify(mockSpanBuilder, never()).ignoreActiveSpan()
+        verify(mockSpanBuilder).withParentContext(null as DatadogSpanContext?)
+    }
+
+    @Test
+    fun `M use parent context W intercept() { active span UNSET }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given
+        val activeSpanWithoutDecision = forge.newSpanMock(
+            samplingPriority = DatadogTracingConstants.PrioritySampling.UNSET
+        )
+        whenever(mockTracer.activeSpan()) doReturn activeSpanWithoutDecision
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        verify(mockSpanBuilder, never()).ignoreActiveSpan()
+        verify(mockSpanBuilder).withParentContext(null as DatadogSpanContext?)
+    }
+
+    @Test
+    fun `M use extracted parent context W intercept() { parent sampling UNSET }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given
+        val parentSpanContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.UNSET
+        }
+        whenever(mockPropagation.extract(any<Request>(), any())) doReturn parentSpanContext
+        whenever(mockPropagationHelper.isExtractedContext(parentSpanContext)) doReturn true
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
+            testedInterceptor.intercept(mockChain)
+        }
+
+        // Then
+        verify(mockSpanBuilder, never()).ignoreActiveSpan()
+        verify(mockSpanBuilder).withParentContext(parentSpanContext)
+    }
+
+    @Test
+    fun `M honor parent W intercept() { extracted header parent DROP }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given - extracted parent context with DROP priority simulates an upstream
+        // service that propagated `x-datadog-sampling-priority: 0` (or W3C `00`, B3 `0`).
+        // The inbound caller explicitly asked for this trace context; we must honor
+        // it regardless of priority to preserve distributed-trace continuity.
+        val parentSpanContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
+        }
+        whenever(mockPropagation.extract(any<Request>(), any())) doReturn parentSpanContext
+        whenever(mockPropagationHelper.isExtractedContext(parentSpanContext)) doReturn true
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
+            testedInterceptor.intercept(mockChain)
+        }
+
+        // Then
+        verify(mockSpanBuilder, never()).ignoreActiveSpan()
+        verify(mockSpanBuilder).withParentContext(parentSpanContext)
+    }
+
+    @Test
+    fun `M honor explicit parent W intercept() { active span DROP, extracted parent KEEP }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given - an explicit extracted parent (KEEP) takes precedence over a dropped
+        // local active span. The active span's drop status must not leak into the
+        // sampling decision for a request that has its own parent context.
+        val droppedActiveSpan = forge.newSpanMock(
+            samplingPriority = DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
+        )
+        whenever(mockTracer.activeSpan()) doReturn droppedActiveSpan
+        val parentSpanContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP
+        }
+        whenever(mockPropagation.extract(any<Request>(), any())) doReturn parentSpanContext
+        whenever(mockPropagationHelper.isExtractedContext(parentSpanContext)) doReturn true
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
+            testedInterceptor.intercept(mockChain)
+        }
+
+        // Then
+        verify(mockSpanBuilder, never()).ignoreActiveSpan()
+        verify(mockSpanBuilder).withParentContext(parentSpanContext)
+    }
+
+    // endregion
 
     // region Internal
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
@@ -1289,7 +1289,11 @@ internal open class TracingInterceptorNotSendingSpanTest {
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         // Given
+        val droppedContext: DatadogSpanContext = forge.newSpanContextMock(
+            samplingPriority = DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
+        )
         val droppedActiveSpan = forge.newSpanMock(
+            context = droppedContext,
             samplingPriority = DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
         )
         whenever(mockTracer.activeSpan()) doReturn droppedActiveSpan
@@ -1309,7 +1313,11 @@ internal open class TracingInterceptorNotSendingSpanTest {
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         // Given
+        val sampledContext: DatadogSpanContext = forge.newSpanContextMock(
+            samplingPriority = DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP
+        )
         val sampledActiveSpan = forge.newSpanMock(
+            context = sampledContext,
             samplingPriority = DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP
         )
         whenever(mockTracer.activeSpan()) doReturn sampledActiveSpan
@@ -1329,7 +1337,11 @@ internal open class TracingInterceptorNotSendingSpanTest {
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         // Given
+        val unsetContext: DatadogSpanContext = forge.newSpanContextMock(
+            samplingPriority = DatadogTracingConstants.PrioritySampling.UNSET
+        )
         val activeSpanWithoutDecision = forge.newSpanMock(
+            context = unsetContext,
             samplingPriority = DatadogTracingConstants.PrioritySampling.UNSET
         )
         whenever(mockTracer.activeSpan()) doReturn activeSpanWithoutDecision
@@ -1420,6 +1432,58 @@ internal open class TracingInterceptorNotSendingSpanTest {
         // Then
         verify(mockSpanBuilder, never()).ignoreActiveSpan()
         verify(mockSpanBuilder).withParentContext(parentSpanContext)
+    }
+
+    @Test
+    fun `M ignore parent W intercept() { active span context resolves to DROP }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given - span.samplingPriority is null (UNSET at span level), but the context
+        // returns SAMPLER_DROP, simulating the post-resolution state after
+        // setTracingSamplingPriorityIfNecessary forces the lazy sampling decision.
+        val mockContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
+        }
+        val activeSpan = mock<DatadogSpan> {
+            on { context() } doReturn mockContext
+            on { samplingPriority } doReturn null
+        }
+        whenever(mockTracer.activeSpan()) doReturn activeSpan
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        verify(mockSpanBuilder).ignoreActiveSpan()
+        verify(mockSpanBuilder, never()).withParentContext(any())
+    }
+
+    @Test
+    fun `M use parent W intercept() { active span context resolves to KEEP }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given - span.samplingPriority is null (UNSET at span level), but the context
+        // returns SAMPLER_KEEP, simulating the post-resolution state after
+        // setTracingSamplingPriorityIfNecessary forces the lazy sampling decision.
+        val mockContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP
+        }
+        val activeSpan = mock<DatadogSpan> {
+            on { context() } doReturn mockContext
+            on { samplingPriority } doReturn null
+        }
+        whenever(mockTracer.activeSpan()) doReturn activeSpan
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        verify(mockSpanBuilder, never()).ignoreActiveSpan()
+        verify(mockSpanBuilder).withParentContext(null as DatadogSpanContext?)
     }
 
     // endregion

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
@@ -28,6 +28,7 @@ import com.datadog.android.trace.api.tracer.DatadogTracer
 import com.datadog.android.trace.api.withMockPropagationHelper
 import com.datadog.android.trace.internal.DatadogPropagationHelper
 import com.datadog.android.trace.internal._TraceInternalProxy
+import com.datadog.android.trace.internal.net.TraceContext
 import com.datadog.android.utils.verifyLog
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -1561,14 +1562,14 @@ internal open class TracingInterceptorNotSendingSpanTest {
     ) {
         // Given - TraceContext tag (OTel interop) DROP is also treated as local developer
         // intent on the RUM path; the sampler must be consulted.
-        val traceContext = com.datadog.android.trace.internal.net.TraceContext(
+        val traceContext = TraceContext(
             fakeTraceId,
             fakeSpanId,
             DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
         )
         fakeRequest = forgeRequest {
             it.tag(
-                com.datadog.android.trace.internal.net.TraceContext::class.java,
+                TraceContext::class.java,
                 traceContext
             )
         }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
@@ -1486,6 +1486,103 @@ internal open class TracingInterceptorNotSendingSpanTest {
         verify(mockSpanBuilder).withParentContext(null as DatadogSpanContext?)
     }
 
+    @Test
+    fun `M ignore parent W intercept() { Request DatadogSpan tag DROP, RUM path }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given - a developer-attached parent (via Request.Builder.parentSpan) with DROP
+        // priority. On the RUM path (canSendSpan() == false in this suite), this should be
+        // ignored so RUM can make its own sampling decision.
+        val droppedTagContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
+        }
+        val droppedSpan: DatadogSpan = forge.newSpanMock(droppedTagContext)
+        fakeRequest = forgeRequest { it.tag(DatadogSpan::class.java, droppedSpan) }
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        verify(mockSpanBuilder).ignoreActiveSpan()
+        verify(mockSpanBuilder, never()).withParentContext(any())
+    }
+
+    @Test
+    fun `M honor parent W intercept() { Request DatadogSpan tag KEEP, RUM path }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given - tag-attached parent with KEEP priority is honored on the RUM path.
+        val tagContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_KEEP
+        }
+        val keptSpan: DatadogSpan = forge.newSpanMock(tagContext)
+        fakeRequest = forgeRequest { it.tag(DatadogSpan::class.java, keptSpan) }
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        verify(mockSpanBuilder).withParentContext(tagContext)
+        verify(mockSpanBuilder, never()).ignoreActiveSpan()
+    }
+
+    @Test
+    fun `M defer to sampler W intercept() { Request DatadogSpan tag DROP, RUM path }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given - on the RUM path, a dropped tag parent must not lock the request to dropped
+        // via extractSamplingDecision; the trace sampler must be consulted instead so RUM can
+        // make its own sampling decision.
+        val droppedTagContext: DatadogSpanContext = mock {
+            on { samplingPriority } doReturn DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
+        }
+        val droppedSpan: DatadogSpan = forge.newSpanMock(droppedTagContext)
+        fakeRequest = forgeRequest { it.tag(DatadogSpan::class.java, droppedSpan) }
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        verify(mockTraceSampler).sample(mockSpan)
+    }
+
+    @Test
+    fun `M defer to sampler W intercept() { Request TraceContext tag DROP, RUM path }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int,
+        @StringForgery(regex = "[a-f0-9]{32}") fakeTraceId: String,
+        @StringForgery(regex = "[a-f0-9]{16}") fakeSpanId: String
+    ) {
+        // Given - TraceContext tag (OTel interop) DROP is also treated as local developer
+        // intent on the RUM path; the sampler must be consulted.
+        val traceContext = com.datadog.android.trace.internal.net.TraceContext(
+            fakeTraceId,
+            fakeSpanId,
+            DatadogTracingConstants.PrioritySampling.SAMPLER_DROP
+        )
+        fakeRequest = forgeRequest {
+            it.tag(
+                com.datadog.android.trace.internal.net.TraceContext::class.java,
+                traceContext
+            )
+        }
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        verify(mockTraceSampler).sample(mockSpan)
+    }
+
     // endregion
 
     // region Internal

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
@@ -1653,6 +1653,30 @@ internal open class TracingInterceptorTest {
         )
     }
 
+    // region HBS with dropped parent (APM path)
+
+    @Test
+    fun `M use parent context W intercept() { active span dropped, APM path }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given
+        val droppedActiveSpan = forge.newSpanMock(
+            samplingPriority = PrioritySampling.SAMPLER_DROP
+        )
+        whenever(mockTracer.activeSpan()) doReturn droppedActiveSpan
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        verify(mockSpanBuilder, never()).ignoreActiveSpan()
+        verify(mockSpanBuilder).withParentContext(null as DatadogSpanContext?)
+    }
+
+    // endregion
+
     // region Internal
 
     internal fun stubChain(chain: Interceptor.Chain, statusCode: Int = forge.anInt(min = 200, max = 600)) {

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
@@ -694,6 +694,54 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
+    fun `M honor parent W intercept() { Request DatadogSpan tag DROP, APM path }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given - on the pure-APM path (canSendSpan() == true), tag-attached parents are
+        // honored even when dropped. This preserves head-based sampling for the
+        // APM-only path. The dropped-parent ignore logic only applies to the RUM-to-APM path
+        // (DatadogInterceptor), not the standalone TracingInterceptor.
+        val droppedTagContext: DatadogSpanContext = forge.newSpanContextMock<DatadogSpanContext>(
+            samplingPriority = PrioritySampling.SAMPLER_DROP
+        )
+        val droppedSpan: DatadogSpan = forge.newSpanMock(droppedTagContext)
+        whenever(mockSpanBuilder.withParentContext(droppedTagContext)) doReturn mockSpanBuilder
+        fakeRequest = forgeRequest { it.tag(DatadogSpan::class.java, droppedSpan) }
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        verify(mockSpanBuilder).withParentContext(droppedTagContext)
+        verify(mockSpanBuilder, never()).ignoreActiveSpan()
+    }
+
+    @Test
+    fun `M not consult sampler W intercept() { Request DatadogSpan tag DROP, APM path }`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given - regression guard: on the APM path, a dropped tag parent still locks the
+        // request to dropped via extractSamplingDecision; the trace sampler must NOT be
+        // consulted. This preserves head-based sampling for the APM-only path.
+        val droppedTagContext: DatadogSpanContext = forge.newSpanContextMock<DatadogSpanContext>(
+            samplingPriority = PrioritySampling.SAMPLER_DROP
+        )
+        val droppedSpan: DatadogSpan = forge.newSpanMock(droppedTagContext)
+        whenever(mockSpanBuilder.withParentContext(droppedTagContext)) doReturn mockSpanBuilder
+        fakeRequest = forgeRequest { it.tag(DatadogSpan::class.java, droppedSpan) }
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        verify(mockTraceSampler, never()).sample(mockSpan)
+    }
+
+    @Test
     fun `M inject tracing header W intercept() for request with parent TraceContext`(
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTestsExt.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTestsExt.kt
@@ -102,5 +102,6 @@ internal fun Forge.newSpanBuilderMock(
     on { withOrigin(anyOrNull()) } doReturn it
     on { withParentContext(context) } doReturn it
     on { withParentContext(null as DatadogSpanContext?) } doReturn it
+    on { ignoreActiveSpan() } doReturn it
     on { start() } doReturn localSpan
 }


### PR DESCRIPTION
### What does this PR do?

When a local manual span (created via the Trace SDK) is active but has been dropped by the trace sampler, the RUM-to-APM path (DatadogInterceptor / `headerPropagationOnly=true`) now ignores it and creates an independent trace with its own sampling decision. This prevents the Trace SDK's drop decision from killing RUM-APM correlation for network requests where the RUM SDK would have sampled the trace.

The fix only affects the case where the dropped parent is a **local active span with no explicit parent context**. Explicit parent contexts — set via `Request.Builder().parentSpan(...)`, request tags, or inbound trace propagation headers (Datadog, W3C, B3) — are always honored regardless of their sampling priority. This preserves distributed-trace continuity when an upstream service or developer code has explicitly chosen a parent.

### Motivation

When a customer creates a manual span via the Trace SDK that gets dropped (e.g., 5% trace rate), and then makes a network request through DatadogInterceptor, HBS previously propagated the drop — the RUM resource lost all trace correlation. The customer configured the RUM SDK to sample at a higher rate, but the Trace SDK's lower rate overrode it. This change lets the RUM SDK make its own independent sampling decision in that scenario, while still honoring any explicit parent the developer or upstream service has propagated.

### Behavior matrix (RUM path only — `canSendSpan()=false`)

| Parent source | Priority | Behavior |
|---|---|---|
| Local active span (`tracer.activeSpan()`) | `SAMPLER_DROP` / `USER_DROP` | Ignore parent, start fresh trace (new behavior) |
| Local active span | `SAMPLER_KEEP` / `USER_KEEP` / `UNSET` | Honor parent (unchanged) |
| Request tag (`Request.Builder().parentSpan(...)`) | any | Honor parent (unchanged) |
| Inbound trace headers (Datadog / W3C / B3) | any, including drop | Honor parent (unchanged) |

The `TracingInterceptor` APM-only path (`canSendSpan()=true`) is unaffected — HBS still propagates dropped parents as before.

### Implementation Notes

- **Mechanism**: `TracingInterceptor.buildSpan()` and `ApmNetworkInstrumentationExt.buildSpan()` call `isParentDropped()`, which inspects **only** the local active span when no explicit parent context is present. When that active span resolves to `SAMPLER_DROP` or `USER_DROP`, `ignoreActiveSpan()` is called on the span builder, creating a root span with a fresh trace ID.
- **Lazy sampling resolution**: A manual span backed by a `PendingTrace` can carry `UNSET` priority until propagation / inject runs the sampler. Without forcing resolution, the check would treat such a span as not-dropped, attach the network span as a child, and then watch the APM sampler propagate a `DROP` at inject time — exactly the scenario this code is meant to prevent. `isParentDropped` calls `_TraceInternalProxy.setTracingSamplingPriorityIfNecessary` on the active span's context before reading its priority. This is the same forcing mechanism already used in `extractSamplingDecision` and during inject; it is idempotent (CAS-guarded) and produces the exact decision the trace would have received later.
- **No API surface changes** — both `isParentDropped` helpers are `private`.
- **Depends on PR #3402** (cross-product sampling rebasing) — the `SessionRebasedSampler` from that PR is what makes the independent sampling decision meaningful.
- **Related iOS work**: [dd-sdk-ios#2726](https://github.com/DataDog/dd-sdk-ios/pull/2726).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)
