### PR TITLE
Fix GraphQL errors extraction for streaming responses

### DIFF
--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -14,6 +14,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.internal.network.HttpSpec
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.okhttp.internal.RumResourceAttributesProviderCompatibilityAdapter
 import com.datadog.android.okhttp.internal.buildResourceId
@@ -289,8 +290,8 @@ open class DatadogInterceptor internal constructor(
                 // manually rebuild the mimetype as `toString()` can also include the charsets
                 it.type + "/" + it.subtype
             }
-            val isStream = contentType in STREAM_CONTENT_TYPES
-            val isWebSocket = !response.header(WEBSOCKET_ACCEPT_HEADER, null).isNullOrBlank()
+            val isStream = HttpSpec.ContentType.isStream(contentType)
+            val isWebSocket = !response.header(HttpSpec.Header.WEBSOCKET_ACCEPT_HEADER, null).isNullOrBlank()
             if (body == null || isStream || isWebSocket) {
                 return null
             }
@@ -433,15 +434,6 @@ open class DatadogInterceptor internal constructor(
     // endregion
 
     internal companion object {
-        internal val STREAM_CONTENT_TYPES = setOf(
-            "text/event-stream",
-            "application/grpc",
-            "application/grpc+proto",
-            "application/grpc+json"
-        )
-
-        internal const val WEBSOCKET_ACCEPT_HEADER = "Sec-WebSocket-Accept"
-
         internal const val WARN_RUM_DISABLED =
             "You set up a DatadogInterceptor for %s, but RUM features are disabled. " +
                 "Make sure you initialized the Datadog SDK with a valid Application Id, " +

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapter.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapter.kt
@@ -9,6 +9,7 @@ package com.datadog.android.okhttp.internal.graphql
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.network.GraphQLHeaders
+import com.datadog.android.internal.network.HttpSpec
 import com.datadog.android.okhttp.internal.OkHttpRequestInfo
 import com.datadog.android.okhttp.internal.OkHttpResponseInfo
 import com.datadog.android.rum.RumAttributes
@@ -63,22 +64,31 @@ internal class OkHttpGraphQLAdapter(
         graphQLExtractor.extractGraphQLAttributes(OkHttpRequestInfo(request))
 
     @WorkerThread
+    @Suppress("ReturnCount")
     fun extractGraphQLErrorAttributes(
         response: Response,
         graphqlAttributes: Map<String, Any?>,
         internalLogger: InternalLogger
     ): Map<String, Any> {
         if (graphqlAttributes.isEmpty()) return emptyMap()
+        // Streaming responses surface GraphQL errors per-frame, not as a top-level `errors` array.
+        // Draining their bodies via peekBody().string() would block until the (potentially unbounded) body completes.
+        val body = response.body
+        val mimeType = body?.contentType()?.let { it.type + "/" + it.subtype }
+        val isStream = HttpSpec.ContentType.isStream(mimeType)
+        val isWebSocket = !response.header(HttpSpec.Header.WEBSOCKET_ACCEPT_HEADER, null).isNullOrBlank()
+        if (body == null || isStream || isWebSocket) return emptyMap()
+
         return try {
             val responseInfo = OkHttpResponseInfo(response, internalLogger)
 
             @Suppress("UnsafeThirdPartyFunctionCall") // exceptions are caught
-            val body = response
+            val bodyString = response
                 .peekBody(GraphQLExtractor.MAX_GRAPHQL_BODY_PEEK)
                 .string()
             graphQLExtractor.extractGraphQLErrors(
                 responseInfo.contentType,
-                body,
+                bodyString,
                 internalLogger
             )?.let {
                 mapOf(RumAttributes.GRAPHQL_ERRORS to it)

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -312,7 +312,9 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         // Given
-        val mimeType = forge.anElementFrom(DatadogInterceptor.STREAM_CONTENT_TYPES)
+        val mimeType = forge.anElementFrom(
+            HttpSpec.ContentType.values().filter(HttpSpec.ContentType::isStream)
+        )
         fakeMediaType = mimeType.toMediaType()
         stubChain(mockChain, statusCode)
         val expectedStartAttrs = emptyMap<String, Any?>()

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapterTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapterTest.kt
@@ -35,6 +35,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.io.IOException
@@ -273,6 +274,32 @@ internal class OkHttpGraphQLAdapterTest {
             any<Boolean>(),
             anyOrNull()
         )
+    }
+
+    @Test
+    fun `M return empty and skip extraction W extractGraphQLErrorAttributes() {streaming response}`(
+        @StringForgery fakeOpName: String,
+        @StringForgery fakeBody: String
+    ) {
+        // Given
+        val streamContentType = forge.anElementFrom(
+            HttpSpec.ContentType.values().filter(HttpSpec.ContentType::isStream)
+        )
+        val request = Request.Builder()
+            .url("https://example.com/graphql")
+            .build()
+
+        val response = forge.anOkHttpResponse(request, 200) {
+            body(fakeBody.toResponseBody(streamContentType.toMediaType()))
+        }
+        val graphqlAttributes = mapOf<String, Any?>(RumAttributes.GRAPHQL_OPERATION_NAME to fakeOpName)
+
+        // When
+        val result = testedHelper.extractGraphQLErrorAttributes(response, graphqlAttributes, mockInternalLogger)
+
+        // Then
+        assertThat(result).isEmpty()
+        verify(mockGraphQLExtractor, never()).extractGraphQLErrors(any(), any(), any())
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

Fixes `OkHttpGraphQLAdapter#extractGraphQLErrorAttributes` so it returns early if there is a streaming response. Otherwise, `peekBody` might deadlock as described in the issue below. This is exactly the same mechanism used inside `DatadogInterceptor#getBodyLength`.

### Motivation

#3407 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

