### PR TITLE
Log task names for the observable queue dump in case of context executor usage

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -662,7 +662,7 @@ internal class CoreFeature(
             internalLogger,
             executorContext = "context",
             capacity = Int.MAX_VALUE,
-            notifyThreshold = 1024,
+            notifyThreshold = 2048,
             // just notify when reached
             onItemDropped = {},
             onThresholdReached = {},

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/thread/ObservableLinkedBlockingQueue.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/thread/ObservableLinkedBlockingQueue.kt
@@ -15,13 +15,17 @@ internal open class ObservableLinkedBlockingQueue<E : Any>(
     capacity: Int = Int.MAX_VALUE
 ) : LinkedBlockingQueue<E>(capacity) {
 
-    private val lastDumpTimestamp: AtomicLong = AtomicLong(0)
+    private val lastDumpTimestamp = AtomicLong(0)
 
     fun dumpQueue(currentTimestamp: Long): Map<String, Int>? {
         val last = lastDumpTimestamp.get()
         val timeSinceLastDump = currentTimestamp - last
         return if (timeSinceLastDump > DUMPING_TIME_INTERVAL_IN_MS) {
-            if (lastDumpTimestamp.compareAndSet(last, currentTimestamp)) {
+            // we may have unbounded queue which does only notification, so limit the size when we are making a copy,
+            // 2048 elements is more than enough to get an understanding
+            if (size <= MAX_SIZE_TO_DUMP &&
+                lastDumpTimestamp.compareAndSet(last, currentTimestamp)
+            ) {
                 buildDumpMap()
             } else {
                 null
@@ -43,5 +47,6 @@ internal open class ObservableLinkedBlockingQueue<E : Any>(
 
     companion object {
         private val DUMPING_TIME_INTERVAL_IN_MS = TimeUnit.SECONDS.toMillis(5)
+        internal const val MAX_SIZE_TO_DUMP = 2048
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/ConcurrencyExt.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/ConcurrencyExt.kt
@@ -8,6 +8,9 @@ package com.datadog.android.core.internal.utils
 
 import androidx.annotation.CheckResult
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.internal.thread.BackPressureExecutorService
+import com.datadog.android.core.internal.thread.ObservableLinkedBlockingQueue
+import com.datadog.android.internal.thread.NamedRunnable
 import com.datadog.android.lint.InternalApi
 import java.util.Locale
 import java.util.concurrent.Callable
@@ -19,6 +22,7 @@ import java.util.concurrent.Future
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
 internal const val ERROR_TASK_REJECTED = "Unable to schedule %s task on the executor"
@@ -39,8 +43,15 @@ fun Executor.executeSafe(
     runnable: Runnable
 ) {
     try {
+        // TODO RUM-16125 This approach doesn't work for `submit` calls
+        // not the cleanest approach, but the least invasive considering code changes scope
+        val wrappedRunnable = if (isWithNamedExecutionUnits && runnable !is NamedRunnable) {
+            NamedRunnable(operationName, runnable)
+        } else {
+            runnable
+        }
         @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
-        execute(runnable)
+        execute(wrappedRunnable)
     } catch (e: RejectedExecutionException) {
         internalLogger.log(
             InternalLogger.Level.ERROR,
@@ -182,3 +193,9 @@ fun <T> Future<T>?.getSafe(
         null
     }
 }
+
+private val Executor.isWithNamedExecutionUnits: Boolean
+    // BackPressureExecutorService is ThreadPoolExecutor + ObservableLinkedBlockingQueue anyway, but let's keep it
+    // in case it changes in the future
+    get() = (this is BackPressureExecutorService) ||
+        (this is ThreadPoolExecutor && queue is ObservableLinkedBlockingQueue)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/ObservableLinkedBlockingQueueTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/ObservableLinkedBlockingQueueTest.kt
@@ -110,4 +110,22 @@ class ObservableLinkedBlockingQueueTest {
         // Then
         assertThat(map).isEqualTo(expectedMap)
     }
+
+    @Test
+    fun `M skip dump W dumpQueue { size is over dump limit }`(
+        forge: Forge
+    ) {
+        // Given
+        val testedObservableLinkedBlockingQueue =
+            ObservableLinkedBlockingQueue<Runnable>(Int.MAX_VALUE)
+        repeat(ObservableLinkedBlockingQueue.MAX_SIZE_TO_DUMP + 1) {
+            testedObservableLinkedBlockingQueue.offer(mock<Runnable>())
+        }
+
+        // When
+        val map = testedObservableLinkedBlockingQueue.dumpQueue(forge.aPositiveLong())
+
+        // Then
+        assertThat(map).isNull()
+    }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/ConcurrencyExtTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/ConcurrencyExtTest.kt
@@ -7,6 +7,8 @@
 package com.datadog.android.core.internal.utils
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.internal.thread.BackPressureExecutorService
+import com.datadog.android.internal.thread.NamedRunnable
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import com.datadog.tools.unit.forge.aThrowable
@@ -23,6 +25,7 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
@@ -59,6 +62,44 @@ internal class ConcurrencyExtTest {
         // Given
         val service: ExecutorService = mock()
         val runnable: Runnable = mock()
+        doNothing().whenever(service).execute(runnable)
+
+        // When
+        service.executeSafe(name, mockInternalLogger, runnable)
+
+        // Then
+        verify(service).execute(runnable)
+    }
+
+    @Test
+    fun `M wrap task into named unit W executeSafe() { observable executor }`(
+        @StringForgery name: String
+    ) {
+        // Given
+        val service: BackPressureExecutorService = mock()
+        val runnable: Runnable = mock()
+        doNothing().whenever(service).execute(runnable)
+
+        // When
+        service.executeSafe(name, mockInternalLogger, runnable)
+
+        // Then
+        argumentCaptor<Runnable> {
+            verify(service).execute(capture())
+            assertThat(allValues).hasSize(1)
+            check(firstValue is NamedRunnable)
+            firstValue.run()
+            verify(runnable).run()
+        }
+    }
+
+    @Test
+    fun `M not wrap task into named unit W executeSafe() { observable executor, already named task }`(
+        @StringForgery name: String
+    ) {
+        // Given
+        val service: BackPressureExecutorService = mock()
+        val runnable: NamedRunnable = mock()
         doNothing().whenever(service).execute(runnable)
 
         // When
@@ -140,7 +181,7 @@ internal class ConcurrencyExtTest {
     }
 
     @Test
-    fun `M submit task W submitSafe() {runnable} `(
+    fun `M submit task W submitSafe() {runnable}`(
         @StringForgery name: String
     ) {
         // Given
@@ -183,7 +224,7 @@ internal class ConcurrencyExtTest {
     }
 
     @Test
-    fun `M submit task W submitSafe() {callable} `(
+    fun `M submit task W submitSafe() {callable}`(
         @StringForgery name: String
     ) {
         // Given

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -875,6 +875,8 @@ internal class DatadogRumMonitor(
                         val future = executorService.submitSafe(
                             "Rum event handling",
                             sdkCore.internalLogger,
+                            // TODO RUM-16125 Callable will get wrapped in another class, so we won't get it
+                            //  as-is when trying to make queue dump
                             NamedCallable("${event::class.simpleName}") {
                                 synchronized(rootScope) {
                                     handleEventWithMethodCallPerf(event, datadogContext, writeScope)


### PR DESCRIPTION
### What does this PR do?

Right now we are using `NamedRunnable` / `NamedCallable` only in RUM pipeline, meaning we don't have visibility for non-RUM queues.

This PR adds them to the generic ~~`submitSafe`~~ / `executeSafe` methods since they already carry `operationName`, so that we have more visibility when we hit backpressure.

We won't wrap task if it already implements `NamedRunnable` / `NamedCallable`.

On top of that, limit the size of the queue when we are doing the copy. Queue may be unbounded (doing only notifications, like in case of context queue), so if we have too many items there copy becomes very heavy.

Note: this approach doesn't work for `submit` calls, because task get wrapped into another classes there (namely `FutureTask` at least).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

