### PR TITLE
Fix evaluation intake endpoint path

### DIFF
--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationsFeature.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EvaluationsFeature.kt
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Flags Evaluations sub-feature class, registered by FlagsFeature.
  *
  * This feature handles aggregation and storage of flag evaluation events,
- * separate from exposure logging. Events are uploaded to /api/v2/flagevaluations.
+ * separate from exposure logging. Events are uploaded to /api/v2/flagevaluation.
  */
 internal class EvaluationsFeature(
     private val sdkCore: FeatureSdkCore,

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/net/EvaluationsRequestFactory.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/net/EvaluationsRequestFactory.kt
@@ -19,7 +19,7 @@ import java.util.UUID
  * Factory for creating requests to the EVP intake endpoint for evaluation logging.
  *
  * Request format:
- * - Endpoint: /api/v2/flagevaluations
+ * - Endpoint: /api/v2/flagevaluation
  * - Content-Type: text/plain
  * - Payload: NDJSON (newline-delimited JSON) of FlagEvaluation events
  *
@@ -72,7 +72,7 @@ internal class EvaluationsRequestFactory(
     )
 
     private companion object {
-        private const val EVALUATION_ENDPOINT = "/api/v2/flagevaluations"
+        private const val EVALUATION_ENDPOINT = "/api/v2/flagevaluation"
         private val PAYLOAD_SEPARATOR = "\n".toByteArray(Charsets.UTF_8)
     }
 }

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/net/EvaluationsRequestFactoryTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/net/EvaluationsRequestFactoryTest.kt
@@ -60,7 +60,7 @@ internal class EvaluationsRequestFactoryTest {
 
         // Then
         requireNotNull(request)
-        assertThat(request.url).isEqualTo("${fakeDatadogContext.site.intakeEndpoint}/api/v2/flagevaluations")
+        assertThat(request.url).isEqualTo("${fakeDatadogContext.site.intakeEndpoint}/api/v2/flagevaluation")
         assertThat(request.contentType).isEqualTo(RequestFactory.CONTENT_TYPE_TEXT_UTF8)
         assertThat(request.headers.minus(RequestFactory.HEADER_REQUEST_ID)).isEqualTo(
             mapOf(


### PR DESCRIPTION
## What

Fix the evaluation intake endpoint path from `/api/v2/flagevaluations` (plural) to `/api/v2/flagevaluation` (singular).

## Motivation

The plural form caused 404s because the backend track is defined as `flagevaluation` (singular). This matches the endpoint used by browser-sdk and Unity SDK.

## Additional Notes

Changed the constant in `EvaluationsRequestFactory`, updated the corresponding test assertion, and fixed stale KDoc comments in both `EvaluationsRequestFactory` and `EvaluationsFeature`.