### PR TITLE
RUMS-5893: Fix NPE when SeekBar thumb is null

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapper.kt
@@ -82,12 +82,13 @@ internal open class SeekBarWireframeMapper(
         screenDensity: Float,
         thumbColor: Int
     ): MobileSegment.Wireframe? {
+        val thumb = view.thumb ?: return null
         val thumbId = viewIdentifierResolver.resolveChildUniqueIdentifier(view, THUMB_KEY_NAME)
             ?: return null
         val backgroundColor = colorStringFormatter.formatColorAndAlphaAsHexString(thumbColor, OPAQUE_ALPHA_VALUE)
 
-        val thumbWidth = view.thumb.bounds.width().densityNormalized(screenDensity).toLong()
-        val thumbHeight = view.thumb.bounds.height().densityNormalized(screenDensity).toLong()
+        val thumbWidth = thumb.bounds.width().densityNormalized(screenDensity).toLong()
+        val thumbHeight = thumb.bounds.height().densityNormalized(screenDensity).toLong()
         return MobileSegment.Wireframe.ShapeWireframe(
             id = thumbId,
             x = (trackBounds.x + (trackBounds.width * normalizedProgress).toLong() - (thumbWidth / 2)),

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapper.kt
@@ -82,24 +82,24 @@ internal open class SeekBarWireframeMapper(
         screenDensity: Float,
         thumbColor: Int
     ): MobileSegment.Wireframe? {
-        val thumbId = viewIdentifierResolver.resolveChildUniqueIdentifier(view, THUMB_KEY_NAME)
-            ?: return null
+        val thumb = view.thumb ?: return null
         val backgroundColor = colorStringFormatter.formatColorAndAlphaAsHexString(thumbColor, OPAQUE_ALPHA_VALUE)
-
-        val thumbWidth = view.thumb.bounds.width().densityNormalized(screenDensity).toLong()
-        val thumbHeight = view.thumb.bounds.height().densityNormalized(screenDensity).toLong()
-        return MobileSegment.Wireframe.ShapeWireframe(
-            id = thumbId,
-            x = (trackBounds.x + (trackBounds.width * normalizedProgress).toLong() - (thumbWidth / 2)),
-            y = trackBounds.y + (trackHeight / 2) - (thumbHeight / 2),
-            width = thumbWidth,
-            height = thumbHeight,
-            shapeStyle = MobileSegment.ShapeStyle(
-                backgroundColor = backgroundColor,
-                opacity = view.alpha,
-                cornerRadius = max(thumbWidth / 2, thumbHeight / 2)
+        val thumbWidth = thumb.bounds.width().densityNormalized(screenDensity).toLong()
+        val thumbHeight = thumb.bounds.height().densityNormalized(screenDensity).toLong()
+        return viewIdentifierResolver.resolveChildUniqueIdentifier(view, THUMB_KEY_NAME)?.let { thumbId ->
+            MobileSegment.Wireframe.ShapeWireframe(
+                id = thumbId,
+                x = (trackBounds.x + (trackBounds.width * normalizedProgress).toLong() - (thumbWidth / 2)),
+                y = trackBounds.y + (trackHeight / 2) - (thumbHeight / 2),
+                width = thumbWidth,
+                height = thumbHeight,
+                shapeStyle = MobileSegment.ShapeStyle(
+                    backgroundColor = backgroundColor,
+                    opacity = view.alpha,
+                    cornerRadius = max(thumbWidth / 2, thumbHeight / 2)
+                )
             )
-        )
+        }
     }
 
     companion object {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapperTest.kt
@@ -145,6 +145,28 @@ internal class SeekBarWireframeMapperTest : AbstractWireframeMapperTest<SeekBar,
     }
 
     @Test
+    fun `M return partial wireframes W map {null thumb, Android O+}`() {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastO) doReturn true
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
+        prepareMockSeekBar()
+        whenever(mockMappedView.thumb) doReturn null
+
+        // When
+        val wireframes = testedWireframeMapper.map(
+            mockMappedView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
+
+        // Then
+        assertThat(wireframes).hasSize(2)
+        assertThatBoundsAreCloseEnough(wireframes[0], expectedNonActiveTrackWireframe)
+        assertThatBoundsAreCloseEnough(wireframes[1], expectedActiveTrackWireframe)
+    }
+
+    @Test
     fun `M return partial wireframes W map {invalid active track id, Android O+}`() {
         // Given
         whenever(mockBuildSdkVersionProvider.isAtLeastO) doReturn true


### PR DESCRIPTION
<!-- dd-meta {"pullId":"abaa8f9d-8d82-40d6-8fc6-a3faf71cc05b","source":"chat","resourceId":"c9a5bbd9-a2b0-41fb-8a3b-c1895d89dddf","workflowId":"3c6fa8de-0453-4d01-b8e2-374cfa0f10bb","codeChangeId":"3c6fa8de-0453-4d01-b8e2-374cfa0f10bb","sourceType":"action_platform_workflows"} -->
### What does this PR do?

Workflow Automation • [View in Workflow Automation](https://app.datadoghq.com/workflow/299cdab5-cab7-494a-9ebd-5e1feacd7258)

Fixes a crash in Session Replay seek bar mapping when `SeekBar.thumb` is null by safely skipping thumb wireframe creation. Adds a unit test to verify we still return track wireframes when the thumb is missing.

### Motivation

Some `SeekBar` instances can have a null thumb drawable. The existing mapper unconditionally accessed `view.thumb.bounds`, which could throw a `NullPointerException` during recording.

### Changes

- Added a null guard in `SeekBarWireframeMapper.buildThumbWireframe()` to return early when `view.thumb` is null.
- Reused the resolved non-null thumb instance for bounds access.
- Added `SeekBarWireframeMapperTest` coverage for the `{null thumb, Android O+}` case, asserting mapping returns only active/non-active track wireframes.

### Testing

- Ran `ktlint --format --reporter=json` on changed Kotlin files via the lint tool (no issues).
- Attempted to run `./gradlew :features:dd-sdk-android-session-replay:testDebugUnitTest --tests "*SeekBarWireframeMapperTest"` but execution is blocked in this sandbox because Gradle wrapper download failed with `java.net.NoRouteToHostException`.

### Additional Notes

This change is intentionally scoped to the Session Replay module and does not alter privacy behavior or public APIs.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/c9a5bbd9-a2b0-41fb-8a3b-c1895d89dddf)

Comment @datadog to request changes