### PR TITLE
RUM-16123: Move broadcast-receiver dispatch off the main thread to fix ANRs

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -203,7 +203,6 @@ internal class CoreFeature(
     internal lateinit var uploadExecutorService: ScheduledThreadPoolExecutor
     internal lateinit var persistenceExecutorService: FlushableExecutorService
     internal lateinit var contextExecutorService: ThreadPoolExecutor
-    internal lateinit var broadcastReceiverExecutorService: ExecutorService
     internal lateinit var backpressureStrategy: BackPressureStrategy
 
     internal var localDataEncryption: Encryption? = null
@@ -380,9 +379,6 @@ internal class CoreFeature(
         ioTasks.forEach {
             it.run()
         }
-
-        broadcastReceiverExecutorService.shutdown()
-        broadcastReceiverExecutorService.awaitTermination(DRAIN_WAIT_SECONDS, TimeUnit.SECONDS)
     }
 
     // region Internal
@@ -599,7 +595,7 @@ internal class CoreFeature(
         // System Info Provider
         systemInfoProvider = BroadcastReceiverSystemInfoProvider(
             internalLogger = internalLogger,
-            executorService = broadcastReceiverExecutorService
+            executorService = contextExecutorService
         )
         systemInfoProvider.register(appContext)
 
@@ -619,7 +615,7 @@ internal class CoreFeature(
         } else {
             BroadcastReceiverNetworkInfoProvider(
                 internalLogger = internalLogger,
-                executorService = broadcastReceiverExecutorService
+                executorService = contextExecutorService
             )
         }
         networkInfoProvider.register(appContext)
@@ -665,12 +661,6 @@ internal class CoreFeature(
         persistenceExecutorService = executorServiceFactory.create(
             internalLogger = internalLogger,
             executorContext = "storage",
-            backPressureStrategy = backpressureStrategy,
-            timeProvider = timeProvider
-        )
-        broadcastReceiverExecutorService = executorServiceFactory.create(
-            internalLogger = internalLogger,
-            executorContext = "broadcast-receiver",
             backPressureStrategy = backpressureStrategy,
             timeProvider = timeProvider
         )
@@ -723,13 +713,11 @@ internal class CoreFeature(
         uploadExecutorService.shutdownNow()
         contextExecutorService.shutdownNow()
         persistenceExecutorService.shutdownNow()
-        broadcastReceiverExecutorService.shutdownNow()
 
         try {
             uploadExecutorService.awaitTermination(1, TimeUnit.SECONDS)
             contextExecutorService.awaitTermination(1, TimeUnit.SECONDS)
             persistenceExecutorService.awaitTermination(1, TimeUnit.SECONDS)
-            broadcastReceiverExecutorService.awaitTermination(1, TimeUnit.SECONDS)
         } catch (e: InterruptedException) {
             try {
                 // Restore the interrupted status

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -203,6 +203,7 @@ internal class CoreFeature(
     internal lateinit var uploadExecutorService: ScheduledThreadPoolExecutor
     internal lateinit var persistenceExecutorService: FlushableExecutorService
     internal lateinit var contextExecutorService: ThreadPoolExecutor
+    internal lateinit var broadcastReceiverExecutorService: ExecutorService
     internal lateinit var backpressureStrategy: BackPressureStrategy
 
     internal var localDataEncryption: Encryption? = null
@@ -379,6 +380,9 @@ internal class CoreFeature(
         ioTasks.forEach {
             it.run()
         }
+
+        broadcastReceiverExecutorService.shutdown()
+        broadcastReceiverExecutorService.awaitTermination(DRAIN_WAIT_SECONDS, TimeUnit.SECONDS)
     }
 
     // region Internal
@@ -593,7 +597,10 @@ internal class CoreFeature(
         trackingConsentProvider = TrackingConsentProvider(consent)
 
         // System Info Provider
-        systemInfoProvider = BroadcastReceiverSystemInfoProvider(internalLogger = internalLogger)
+        systemInfoProvider = BroadcastReceiverSystemInfoProvider(
+            internalLogger = internalLogger,
+            executorService = broadcastReceiverExecutorService
+        )
         systemInfoProvider.register(appContext)
 
         // Network Info Provider
@@ -610,7 +617,10 @@ internal class CoreFeature(
         networkInfoProvider = if (buildSdkVersionProvider.isAtLeastN) {
             CallbackNetworkInfoProvider(internalLogger = internalLogger)
         } else {
-            BroadcastReceiverNetworkInfoProvider()
+            BroadcastReceiverNetworkInfoProvider(
+                internalLogger = internalLogger,
+                executorService = broadcastReceiverExecutorService
+            )
         }
         networkInfoProvider.register(appContext)
     }
@@ -655,6 +665,12 @@ internal class CoreFeature(
         persistenceExecutorService = executorServiceFactory.create(
             internalLogger = internalLogger,
             executorContext = "storage",
+            backPressureStrategy = backpressureStrategy,
+            timeProvider = timeProvider
+        )
+        broadcastReceiverExecutorService = executorServiceFactory.create(
+            internalLogger = internalLogger,
+            executorContext = "broadcast-receiver",
             backPressureStrategy = backpressureStrategy,
             timeProvider = timeProvider
         )
@@ -707,11 +723,13 @@ internal class CoreFeature(
         uploadExecutorService.shutdownNow()
         contextExecutorService.shutdownNow()
         persistenceExecutorService.shutdownNow()
+        broadcastReceiverExecutorService.shutdownNow()
 
         try {
             uploadExecutorService.awaitTermination(1, TimeUnit.SECONDS)
             contextExecutorService.awaitTermination(1, TimeUnit.SECONDS)
             persistenceExecutorService.awaitTermination(1, TimeUnit.SECONDS)
+            broadcastReceiverExecutorService.awaitTermination(1, TimeUnit.SECONDS)
         } catch (e: InterruptedException) {
             try {
                 // Restore the interrupted status

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
@@ -14,24 +14,36 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.net.ConnectivityManager
 import android.telephony.TelephonyManager
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.core.internal.receiver.ThreadSafeReceiver
+import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.internal.system.BuildSdkVersionProvider
+import java.util.concurrent.ExecutorService
 import android.net.NetworkInfo as AndroidNetworkInfo
 
 @Suppress("DEPRECATION")
 @SuppressLint("InlinedApi")
 internal class BroadcastReceiverNetworkInfoProvider(
+    private val internalLogger: InternalLogger,
+    private val executorService: ExecutorService,
     private val buildSdkVersionProvider: BuildSdkVersionProvider = BuildSdkVersionProvider.DEFAULT
 ) :
     ThreadSafeReceiver(),
     NetworkInfoProvider {
 
+    @Volatile
     private var networkInfo: NetworkInfo = NetworkInfo()
 
     // region BroadcastReceiver
 
     override fun onReceive(context: Context, intent: Intent?) {
+        executorService.executeSafe(HANDLE_INTENT_OPERATION_NAME, internalLogger) {
+            handleIntent(context)
+        }
+    }
+
+    private fun handleIntent(context: Context) {
         val connectivityMgr =
             context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
         val activeNetworkInfo = connectivityMgr?.activeNetworkInfo
@@ -45,9 +57,8 @@ internal class BroadcastReceiverNetworkInfoProvider(
 
     override fun register(context: Context) {
         val filter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
-        registerReceiver(context, filter).also {
-            onReceive(context, it)
-        }
+        registerReceiver(context, filter)
+        handleIntent(context)
     }
 
     override fun unregister(context: Context) {
@@ -142,6 +153,8 @@ internal class BroadcastReceiverNetworkInfoProvider(
     // endregion
 
     companion object {
+
+        private const val HANDLE_INTENT_OPERATION_NAME = "BroadcastReceiverNetworkInfoProvider.handleIntent"
 
         const val NETWORK_TYPE_LTE_CA = 19 // @Hide TelephonyManager.NETWORK_TYPE_LTE_CA,
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProvider.kt
@@ -24,6 +24,7 @@ internal class CallbackNetworkInfoProvider(
     ConnectivityManager.NetworkCallback(),
     NetworkInfoProvider {
 
+    @Volatile
     private var lastNetworkInfo: NetworkInfo = NetworkInfo()
 
     // region NetworkCallback

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
@@ -14,18 +14,28 @@ import android.os.BatteryManager
 import android.os.PowerManager
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.receiver.ThreadSafeReceiver
+import com.datadog.android.core.internal.utils.executeSafe
+import java.util.concurrent.ExecutorService
 import kotlin.math.roundToInt
 
 internal class BroadcastReceiverSystemInfoProvider(
-    private val internalLogger: InternalLogger
+    private val internalLogger: InternalLogger,
+    private val executorService: ExecutorService
 ) :
     ThreadSafeReceiver(), SystemInfoProvider {
 
+    @Volatile
     private var systemInfo: SystemInfo = SystemInfo()
 
     // region BroadcastReceiver
 
     override fun onReceive(context: Context, intent: Intent?) {
+        executorService.executeSafe(HANDLE_INTENT_OPERATION_NAME, internalLogger) {
+            handleIntent(context, intent)
+        }
+    }
+
+    private fun handleIntent(context: Context, intent: Intent?) {
         try {
             when (val action = intent?.action) {
                 Intent.ACTION_BATTERY_CHANGED -> {
@@ -82,7 +92,7 @@ internal class BroadcastReceiverSystemInfoProvider(
     private fun registerIntentFilter(context: Context, action: String) {
         val filter = IntentFilter()
         filter.addAction(action)
-        registerReceiver(context, filter)?.let { onReceive(context, it) }
+        registerReceiver(context, filter)?.let { handleIntent(context, it) }
     }
 
     private fun handleBatteryIntent(intent: Intent) {
@@ -119,6 +129,7 @@ internal class BroadcastReceiverSystemInfoProvider(
 
     companion object {
 
+        private const val HANDLE_INTENT_OPERATION_NAME = "BroadcastReceiverSystemInfoProvider.handleIntent"
         private const val DEFAULT_BATTERY_SCALE = 100
         private const val BATTERY_UNPLUGGED = -1
         private const val BATTERY_LEVEL_UNKNOWN = -1

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -92,7 +92,6 @@ import java.io.InputStream
 import java.net.Proxy
 import java.util.Locale
 import java.util.UUID
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledThreadPoolExecutor
@@ -1537,62 +1536,6 @@ internal class CoreFeatureTest {
         inOrder(mockContextExecutor) {
             verify(mockContextExecutor).shutdown()
             verify(mockContextExecutor).awaitTermination(10, TimeUnit.SECONDS)
-        }
-    }
-
-    @Test
-    fun `M create broadcastReceiverExecutorService W initialize()`() {
-        // When
-        testedFeature.initialize(
-            appContext.mockInstance,
-            fakeSdkInstanceId,
-            fakeConfig,
-            fakeConsent
-        )
-
-        // Then
-        assertThat(testedFeature.broadcastReceiverExecutorService).isNotNull()
-    }
-
-    @Test
-    fun `M shutdown broadcastReceiverExecutorService W stop()`() {
-        // Given
-        testedFeature.initialize(
-            appContext.mockInstance,
-            fakeSdkInstanceId,
-            fakeConfig,
-            fakeConsent
-        )
-        val mockBroadcastExecutor = mock<ExecutorService>()
-        testedFeature.broadcastReceiverExecutorService = mockBroadcastExecutor
-
-        // When
-        testedFeature.stop()
-
-        // Then
-        verify(mockBroadcastExecutor).shutdownNow()
-        verify(mockBroadcastExecutor).awaitTermination(1, TimeUnit.SECONDS)
-    }
-
-    @Test
-    fun `M shutdown with wait the broadcastReceiver executor W drainAndShutdownExecutors()`() {
-        // Given
-        testedFeature.initialize(
-            appContext.mockInstance,
-            fakeSdkInstanceId,
-            fakeConfig,
-            fakeConsent
-        )
-        val mockBroadcastExecutor = mock<ExecutorService>()
-        testedFeature.broadcastReceiverExecutorService = mockBroadcastExecutor
-
-        // When
-        testedFeature.drainAndShutdownExecutors()
-
-        // Then
-        inOrder(mockBroadcastExecutor) {
-            verify(mockBroadcastExecutor).shutdown()
-            verify(mockBroadcastExecutor).awaitTermination(CoreFeature.DRAIN_WAIT_SECONDS, TimeUnit.SECONDS)
         }
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -92,6 +92,7 @@ import java.io.InputStream
 import java.net.Proxy
 import java.util.Locale
 import java.util.UUID
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledThreadPoolExecutor
@@ -1536,6 +1537,62 @@ internal class CoreFeatureTest {
         inOrder(mockContextExecutor) {
             verify(mockContextExecutor).shutdown()
             verify(mockContextExecutor).awaitTermination(10, TimeUnit.SECONDS)
+        }
+    }
+
+    @Test
+    fun `M create broadcastReceiverExecutorService W initialize()`() {
+        // When
+        testedFeature.initialize(
+            appContext.mockInstance,
+            fakeSdkInstanceId,
+            fakeConfig,
+            fakeConsent
+        )
+
+        // Then
+        assertThat(testedFeature.broadcastReceiverExecutorService).isNotNull()
+    }
+
+    @Test
+    fun `M shutdown broadcastReceiverExecutorService W stop()`() {
+        // Given
+        testedFeature.initialize(
+            appContext.mockInstance,
+            fakeSdkInstanceId,
+            fakeConfig,
+            fakeConsent
+        )
+        val mockBroadcastExecutor = mock<ExecutorService>()
+        testedFeature.broadcastReceiverExecutorService = mockBroadcastExecutor
+
+        // When
+        testedFeature.stop()
+
+        // Then
+        verify(mockBroadcastExecutor).shutdownNow()
+        verify(mockBroadcastExecutor).awaitTermination(1, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun `M shutdown with wait the broadcastReceiver executor W drainAndShutdownExecutors()`() {
+        // Given
+        testedFeature.initialize(
+            appContext.mockInstance,
+            fakeSdkInstanceId,
+            fakeConfig,
+            fakeConsent
+        )
+        val mockBroadcastExecutor = mock<ExecutorService>()
+        testedFeature.broadcastReceiverExecutorService = mockBroadcastExecutor
+
+        // When
+        testedFeature.drainAndShutdownExecutors()
+
+        // Then
+        inOrder(mockBroadcastExecutor) {
+            verify(mockBroadcastExecutor).shutdown()
+            verify(mockBroadcastExecutor).awaitTermination(CoreFeature.DRAIN_WAIT_SECONDS, TimeUnit.SECONDS)
         }
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProviderTest.kt
@@ -12,8 +12,13 @@ import android.content.Context
 import android.content.Intent
 import android.net.ConnectivityManager
 import android.telephony.TelephonyManager
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.NetworkInfo
+import com.datadog.android.core.configuration.BackPressureMitigation
+import com.datadog.android.core.configuration.BackPressureStrategy
+import com.datadog.android.core.internal.thread.BackPressureExecutorService
 import com.datadog.android.internal.system.BuildSdkVersionProvider
+import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.utils.assertj.NetworkInfoAssert.Companion.assertThat
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
@@ -29,15 +34,20 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import java.util.stream.Stream
 import android.net.NetworkInfo as AndroidNetworkInfo
+import org.assertj.core.api.Assertions.assertThat as assertThatString
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -68,6 +78,12 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
     @Mock
     lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
 
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @Mock
+    lateinit var mockExecutorService: ExecutorService
+
     @BeforeEach
     fun `set up`() {
         whenever(mockContext.getSystemService(Context.CONNECTIVITY_SERVICE))
@@ -76,8 +92,15 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
             .doReturn(mockTelephonyManager)
         whenever(mockConnectivityManager.activeNetworkInfo) doReturn mockNetworkInfo
         whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn false
+        whenever(mockExecutorService.execute(any())) doAnswer {
+            it.getArgument<Runnable>(0).run()
+        }
 
-        testedProvider = BroadcastReceiverNetworkInfoProvider(mockBuildSdkVersionProvider)
+        testedProvider = BroadcastReceiverNetworkInfoProvider(
+            internalLogger = mockInternalLogger,
+            executorService = mockExecutorService,
+            buildSdkVersionProvider = mockBuildSdkVersionProvider
+        )
     }
 
     @Test
@@ -465,6 +488,46 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
             .hasCarrierName(null)
             .hasCarrierId(null)
             .hasCellularTechnology(null)
+    }
+
+    @Test
+    fun `M dispatch onReceive on background broadcast-receiver thread W onReceive() {real executor}`() {
+        // Given
+        val fakeBackPressureStrategy = BackPressureStrategy(
+            capacity = 128,
+            onThresholdReached = {},
+            onItemDropped = {},
+            backpressureMitigation = BackPressureMitigation.IGNORE_NEWEST
+        )
+        val realExecutor = BackPressureExecutorService(
+            logger = mockInternalLogger,
+            executorContext = "broadcast-receiver",
+            backpressureStrategy = fakeBackPressureStrategy,
+            timeProvider = DefaultTimeProvider()
+        )
+        val capturedThreadName = AtomicReference<String>()
+        val latch = CountDownLatch(1)
+
+        whenever(mockContext.getSystemService(Context.CONNECTIVITY_SERVICE)) doAnswer {
+            capturedThreadName.set(Thread.currentThread().name)
+            latch.countDown()
+            mockConnectivityManager
+        }
+
+        val provider = BroadcastReceiverNetworkInfoProvider(
+            internalLogger = mockInternalLogger,
+            executorService = realExecutor,
+            buildSdkVersionProvider = mockBuildSdkVersionProvider
+        )
+
+        // When
+        provider.onReceive(mockContext, mockIntent)
+        latch.await(3, TimeUnit.SECONDS)
+        realExecutor.shutdown()
+        realExecutor.awaitTermination(3, TimeUnit.SECONDS)
+
+        // Then
+        assertThatString(capturedThreadName.get()).startsWith("datadog-broadcast-receiver-thread-")
     }
 
     // region Internal

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProviderTest.kt
@@ -14,11 +14,7 @@ import android.net.ConnectivityManager
 import android.telephony.TelephonyManager
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.NetworkInfo
-import com.datadog.android.core.configuration.BackPressureMitigation
-import com.datadog.android.core.configuration.BackPressureStrategy
-import com.datadog.android.core.internal.thread.BackPressureExecutorService
 import com.datadog.android.internal.system.BuildSdkVersionProvider
-import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.utils.assertj.NetworkInfoAssert.Companion.assertThat
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
@@ -44,10 +40,8 @@ import org.mockito.quality.Strictness
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
 import java.util.stream.Stream
 import android.net.NetworkInfo as AndroidNetworkInfo
-import org.assertj.core.api.Assertions.assertThat as assertThatString
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -491,43 +485,12 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
     }
 
     @Test
-    fun `M dispatch onReceive on background broadcast-receiver thread W onReceive() {real executor}`() {
-        // Given
-        val fakeBackPressureStrategy = BackPressureStrategy(
-            capacity = 128,
-            onThresholdReached = {},
-            onItemDropped = {},
-            backpressureMitigation = BackPressureMitigation.IGNORE_NEWEST
-        )
-        val realExecutor = BackPressureExecutorService(
-            logger = mockInternalLogger,
-            executorContext = "broadcast-receiver",
-            backpressureStrategy = fakeBackPressureStrategy,
-            timeProvider = DefaultTimeProvider()
-        )
-        val capturedThreadName = AtomicReference<String>()
-        val latch = CountDownLatch(1)
-
-        whenever(mockContext.getSystemService(Context.CONNECTIVITY_SERVICE)) doAnswer {
-            capturedThreadName.set(Thread.currentThread().name)
-            latch.countDown()
-            mockConnectivityManager
-        }
-
-        val provider = BroadcastReceiverNetworkInfoProvider(
-            internalLogger = mockInternalLogger,
-            executorService = realExecutor,
-            buildSdkVersionProvider = mockBuildSdkVersionProvider
-        )
-
+    fun `M dispatch onReceive through executor W onReceive()`() {
         // When
-        provider.onReceive(mockContext, mockIntent)
-        latch.await(3, TimeUnit.SECONDS)
-        realExecutor.shutdown()
-        realExecutor.awaitTermination(3, TimeUnit.SECONDS)
+        testedProvider.onReceive(mockContext, mockIntent)
 
         // Then
-        assertThatString(capturedThreadName.get()).startsWith("datadog-broadcast-receiver-thread-")
+        verify(mockExecutorService).execute(any())
     }
 
     // region Internal

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProviderTest.kt
@@ -11,6 +11,10 @@ import android.content.Intent
 import android.os.BatteryManager
 import android.os.PowerManager
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.configuration.BackPressureMitigation
+import com.datadog.android.core.configuration.BackPressureStrategy
+import com.datadog.android.core.internal.thread.BackPressureExecutorService
+import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.utils.assertj.SystemInfoAssert.Companion.assertThat
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
@@ -43,8 +47,11 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.math.roundToInt
+import org.assertj.core.api.Assertions.assertThat as assertThatString
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -68,15 +75,23 @@ internal class BroadcastReceiverSystemInfoProviderTest {
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
+    @Mock
+    lateinit var mockExecutorService: ExecutorService
+
     @IntForgery
     var fakePluggedStatus: Int = 0
 
     @BeforeEach
     fun `set up`() {
         whenever(mockContext.getSystemService(Context.POWER_SERVICE)) doReturn mockPowerMgr
+        whenever(mockExecutorService.execute(any())) doAnswer {
+            it.getArgument<Runnable>(0).run()
+        }
 
-        testedProvider =
-            BroadcastReceiverSystemInfoProvider(mockInternalLogger)
+        testedProvider = BroadcastReceiverSystemInfoProvider(
+            internalLogger = mockInternalLogger,
+            executorService = mockExecutorService
+        )
     }
 
     @Test
@@ -471,6 +486,50 @@ internal class BroadcastReceiverSystemInfoProviderTest {
         assertDoesNotThrow {
             testedProvider.onReceive(mockContext, intent)
         }
+    }
+
+    @Test
+    fun `M dispatch onReceive on background broadcast-receiver thread W onReceive() {real executor}`() {
+        // Given
+        val fakeBackPressureStrategy = BackPressureStrategy(
+            capacity = 128,
+            onThresholdReached = {},
+            onItemDropped = {},
+            backpressureMitigation = BackPressureMitigation.IGNORE_NEWEST
+        )
+        val realExecutor = BackPressureExecutorService(
+            logger = mockInternalLogger,
+            executorContext = "broadcast-receiver",
+            backpressureStrategy = fakeBackPressureStrategy,
+            timeProvider = DefaultTimeProvider()
+        )
+        val capturedThreadName = AtomicReference<String>()
+        val latch = CountDownLatch(1)
+
+        val batteryIntent: Intent = mock()
+        whenever(batteryIntent.action) doReturn Intent.ACTION_BATTERY_CHANGED
+        whenever(batteryIntent.getIntExtra(any(), any())) doAnswer {
+            capturedThreadName.set(Thread.currentThread().name)
+            latch.countDown()
+            it.arguments[1] as Int
+        }
+        whenever(batteryIntent.getBooleanExtra(any(), any())) doAnswer {
+            it.arguments[1] as Boolean
+        }
+
+        val provider = BroadcastReceiverSystemInfoProvider(
+            internalLogger = mockInternalLogger,
+            executorService = realExecutor
+        )
+
+        // When
+        provider.onReceive(mockContext, batteryIntent)
+        latch.await(3, TimeUnit.SECONDS)
+        realExecutor.shutdown()
+        realExecutor.awaitTermination(3, TimeUnit.SECONDS)
+
+        // Then
+        assertThatString(capturedThreadName.get()).startsWith("datadog-broadcast-receiver-thread-")
     }
 
     // endregion

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProviderTest.kt
@@ -11,10 +11,6 @@ import android.content.Intent
 import android.os.BatteryManager
 import android.os.PowerManager
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.core.configuration.BackPressureMitigation
-import com.datadog.android.core.configuration.BackPressureStrategy
-import com.datadog.android.core.internal.thread.BackPressureExecutorService
-import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.utils.assertj.SystemInfoAssert.Companion.assertThat
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
@@ -49,9 +45,7 @@ import org.mockito.quality.Strictness
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
 import kotlin.math.roundToInt
-import org.assertj.core.api.Assertions.assertThat as assertThatString
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -489,47 +483,15 @@ internal class BroadcastReceiverSystemInfoProviderTest {
     }
 
     @Test
-    fun `M dispatch onReceive on background broadcast-receiver thread W onReceive() {real executor}`() {
+    fun `M dispatch onReceive through executor W onReceive()`() {
         // Given
-        val fakeBackPressureStrategy = BackPressureStrategy(
-            capacity = 128,
-            onThresholdReached = {},
-            onItemDropped = {},
-            backpressureMitigation = BackPressureMitigation.IGNORE_NEWEST
-        )
-        val realExecutor = BackPressureExecutorService(
-            logger = mockInternalLogger,
-            executorContext = "broadcast-receiver",
-            backpressureStrategy = fakeBackPressureStrategy,
-            timeProvider = DefaultTimeProvider()
-        )
-        val capturedThreadName = AtomicReference<String>()
-        val latch = CountDownLatch(1)
-
-        val batteryIntent: Intent = mock()
-        whenever(batteryIntent.action) doReturn Intent.ACTION_BATTERY_CHANGED
-        whenever(batteryIntent.getIntExtra(any(), any())) doAnswer {
-            capturedThreadName.set(Thread.currentThread().name)
-            latch.countDown()
-            it.arguments[1] as Int
-        }
-        whenever(batteryIntent.getBooleanExtra(any(), any())) doAnswer {
-            it.arguments[1] as Boolean
-        }
-
-        val provider = BroadcastReceiverSystemInfoProvider(
-            internalLogger = mockInternalLogger,
-            executorService = realExecutor
-        )
+        val intent: Intent = mock()
 
         // When
-        provider.onReceive(mockContext, batteryIntent)
-        latch.await(3, TimeUnit.SECONDS)
-        realExecutor.shutdown()
-        realExecutor.awaitTermination(3, TimeUnit.SECONDS)
+        testedProvider.onReceive(mockContext, intent)
 
         // Then
-        assertThatString(capturedThreadName.get()).startsWith("datadog-broadcast-receiver-thread-")
+        verify(mockExecutorService).execute(any())
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

Moves `BroadcastReceiverSystemInfoProvider.onReceive()` and `BroadcastReceiverNetworkInfoProvider.onReceive()` off the main thread by trampolining them through a new dedicated single-threaded `BackPressureExecutorService` (`broadcastReceiverExecutorService`) owned by `CoreFeature`. The initial sticky-seed path stays synchronous, so `Datadog.initialize()` still returns with system/network info populated. Adds `@Volatile` to `systemInfo`, `networkInfo`, and `lastNetworkInfo` for cross-thread visibility. `CallbackNetworkInfoProvider` (Android-N+) gets only `@Volatile` since its callbacks already dispatch off the main thread.

### Motivation

Fixes ANRs on the Android SDK. Root cause: `Context.registerReceiver(...)` without a `Handler` argument dispatches on the main thread by default. On low-end devices protected by PairIP (Google Play Integrity Code Transparency), each `onReceive` call incurred non-deterministic overhead from `com.pairip.VMRunner.invoke/executeVM`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)