### PR TITLE
RUM-15137: Don't run Java API generation task on CI for non-release builds

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/ApiSurfacePlugin.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/ApiSurfacePlugin.kt
@@ -37,8 +37,7 @@ class ApiSurfacePlugin : Plugin<Project> {
             }
         target.tasks
             .register<CheckApiSurfaceTask>(TASK_CHECK_API_SURFACE) {
-                this.kotlinSurfaceFile.set(kotlinSurfaceFile)
-                dependsOn(TASK_GEN_KOTLIN_API_SURFACE)
+                this.kotlinSurfaceFile.set(generateApiSurfaceTask.flatMap { it.surfaceFile })
                 if (target.plugins.hasPlugin(GEN_JAVA_API_LAYOUT_PLUGIN)) {
                     this.javaSurfaceFile.set(javaSurfaceFile)
                     dependsOn(TASK_GEN_JAVA_API_SURFACE)
@@ -73,7 +72,16 @@ class ApiSurfacePlugin : Plugin<Project> {
             // Java API generation task does a clean-up of all files in the output
             // folder, so let it run first
             if (target.plugins.hasPlugin(GEN_JAVA_API_LAYOUT_PLUGIN)) {
-                finalizedBy(TASK_GEN_JAVA_API_SURFACE)
+                val isCi = target.providers.environmentVariable("CI").isPresent
+                if (isCi) {
+                    // Java API generation wires to the release build type, so we can afford triggering compilation
+                    // of release type locally when we run debug compilation, but we would like to avoid it on CI
+                    if (name == "compileReleaseKotlin") {
+                        finalizedBy(TASK_GEN_JAVA_API_SURFACE)
+                    }
+                } else {
+                    finalizedBy(TASK_GEN_JAVA_API_SURFACE)
+                }
             }
             finalizedBy(generateApiSurfaceTask)
         }


### PR DESCRIPTION
### What does this PR do?

We are using [binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator) plugin to generate Java API surface in addition to the KotlinAPI surface (made by ourselves).

The problem is that it is [running](https://github.com/DataDog/dd-sdk-android/blob/develop/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/ApiSurfacePlugin.kt#L69-L79) on any compilation, but it has a strong dependency on the [release compilation](https://github.com/Kotlin/binary-compatibility-validator/blob/31dafe4fb93646fa044d4b612b334b82b3978c20/src/main/kotlin/BinaryCompatibilityValidatorPlugin.kt#L134-L136), meaning that if we run debug variant compilation, we will also then trigger release variant compilation for our library modules.

This PR keeps having Java API surface generation for non-CI executions (we want it to be updated on the local changes), but for CI it is strictly wired to the release compilation.

```shell
➜  dd-sdk-android ✗ ./gradlew :dd-sdk-android-internal:compileDebugKotlin --dry-run | grep Release
:dd-sdk-android-internal:preReleaseBuild SKIPPED
:dd-sdk-android-internal:generateReleaseResValues SKIPPED
:dd-sdk-android-internal:generateReleaseResources SKIPPED
:dd-sdk-android-internal:packageReleaseResources SKIPPED
:dd-sdk-android-internal:processReleaseNavigationResources SKIPPED
:dd-sdk-android-internal:parseReleaseLocalResources SKIPPED
:dd-sdk-android-internal:generateReleaseRFile SKIPPED
:dd-sdk-android-internal:kspReleaseKotlin SKIPPED
:dd-sdk-android-internal:compileReleaseKotlin SKIPPED
:dd-sdk-android-internal:javaPreCompileRelease SKIPPED
:dd-sdk-android-internal:compileReleaseJavaWithJavac SKIPPED
➜  dd-sdk-android ✗ CI=true ./gradlew :dd-sdk-android-internal:compileDebugKotlin --dry-run | grep Release
// nothing printed
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

