### PR TITLE
RUM-15287: pause/resume on foreground/background with grace period

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
@@ -12,13 +12,16 @@ import androidx.annotation.RequiresApi
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.core.internal.utils.scheduleSafe
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.internal.FeatureContextKeys
+import com.datadog.android.internal.time.TimeProvider
 import java.util.Locale
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
+import kotlin.math.max
 import kotlin.random.Random
 
 @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
@@ -27,6 +30,7 @@ internal class ContinuousProfilingScheduler(
     private val appContext: Context,
     private val profiler: Profiler,
     private val sdkCore: FeatureSdkCore,
+    private val timeProvider: TimeProvider,
     private val sampleRate: Float,
     private val onActiveWindowStarted: () -> Unit = {}
 ) {
@@ -43,6 +47,18 @@ internal class ContinuousProfilingScheduler(
 
     @Volatile
     internal var isActive: Boolean = false
+
+    @Volatile
+    internal var state: State = State.IDLE
+
+    @Volatile
+    private var cooldownWindowEndMs: Long = 0L
+
+    @Volatile
+    private var activeWindowEndMs: Long = 0L
+
+    @Volatile
+    private var remainingCooldownMs: Long = 0L
 
     private val schedulerExecutor: ScheduledExecutorService = profiler.scheduledExecutorService
 
@@ -69,6 +85,7 @@ internal class ContinuousProfilingScheduler(
         isScheduling = false
         logToUser { LOG_STOPPED }
         pendingFuture?.cancel(false)
+        state = State.IDLE
         isActive = false
     }
 
@@ -86,11 +103,106 @@ internal class ContinuousProfilingScheduler(
         rumSessionSampled = sessionSampled
     }
 
+    /**
+     * Called by [ProfilingLifecycleCallback] when the app moves to the background.
+     *
+     * During an active profiling window, a 10-second grace period is started so brief
+     * interruptions (notification shade, quick-settings) do not truncate the session.
+     * During a cooldown, the timer is paused and resumed on foreground with the remaining time.
+     */
+    fun onBackground() {
+        schedulerExecutor.executeSafe(OPERATION_ON_BACKGROUND, sdkCore.internalLogger) {
+            if (!isScheduling) return@executeSafe
+            when (state) {
+                State.ACTIVE -> {
+                    pendingFuture?.cancel(false)
+                    pendingFuture = schedulerExecutor.scheduleSafe(
+                        operationName = OPERATION_GRACE_PERIOD,
+                        delay = BACKGROUND_GRACE_PERIOD_MS,
+                        unit = TimeUnit.MILLISECONDS,
+                        internalLogger = sdkCore.internalLogger,
+                        runnable = ::onGracePeriodExpired
+                    )
+                    state = State.GRACE_PERIOD
+                    val remaining = max(0L, activeWindowEndMs - timeProvider.getDeviceTimestampMillis())
+                    logToUser { LOG_BACKGROUND_GRACE_PERIOD.format(Locale.US, remaining) }
+                }
+
+                State.COOLDOWN -> {
+                    remainingCooldownMs =
+                        max(0L, cooldownWindowEndMs - timeProvider.getDeviceTimestampMillis())
+                    pendingFuture?.cancel(false)
+                    state = State.PAUSED_COOLDOWN
+                    logToUser {
+                        LOG_BACKGROUND_COOLDOWN_PAUSED.format(
+                            Locale.US,
+                            remainingCooldownMs
+                        )
+                    }
+                }
+
+                else -> {
+                    /* IDLE / GRACE_PERIOD / PAUSED_* — ignore */
+                }
+            }
+        }
+    }
+
+    /**
+     * Called by [ProfilingLifecycleCallback] when the app returns to the foreground.
+     *
+     * - [State.GRACE_PERIOD]: cancel the grace timer; resume the active window for its remaining time.
+     * - [State.PAUSED_COOLDOWN]: resume the cooldown with the remaining time.
+     * - [State.PAUSED_AFTER_GRACE]: start a fresh jittered cooldown.
+     */
+    fun onForeground() {
+        schedulerExecutor.executeSafe(OPERATION_ON_FOREGROUND, sdkCore.internalLogger) {
+            if (!isScheduling) return@executeSafe
+            when (state) {
+                State.GRACE_PERIOD -> {
+                    pendingFuture?.cancel(false)
+                    val remaining = max(0L, activeWindowEndMs - timeProvider.getDeviceTimestampMillis())
+                    scheduleActiveWindowEnd(remaining)
+                    state = State.ACTIVE
+                    logToUser { LOG_FOREGROUND_RESUMED_ACTIVE }
+                }
+
+                State.PAUSED_COOLDOWN -> {
+                    scheduleCooldown(remainingCooldownMs)
+                    logToUser {
+                        LOG_FOREGROUND_RESUMED_COOLDOWN.format(
+                            Locale.US,
+                            remainingCooldownMs
+                        )
+                    }
+                }
+
+                State.PAUSED_AFTER_GRACE -> {
+                    scheduleCooldown(jitter(CONTINUOUS_COOLDOWN_DURATION_MS))
+                    logToUser { LOG_FOREGROUND_AFTER_GRACE }
+                }
+
+                else -> {
+                    /* IDLE / ACTIVE / COOLDOWN — ignore (rapid flicker) */
+                }
+            }
+        }
+    }
+
+    private fun onGracePeriodExpired() {
+        state = State.PAUSED_AFTER_GRACE
+        isActive = false
+        profiler.stop(sdkCore.name)
+        logToUser { LOG_GRACE_PERIOD_EXPIRED }
+    }
+
     private fun scheduleNextCycle() {
         val activeMs = jitter(CONTINUOUS_WINDOW_DURATION_MS)
         if (rumSessionSampled) {
             onActiveWindowStarted()
             isActive = true
+            activeWindowEndMs = timeProvider.getDeviceTimestampMillis() + activeMs
+            state = State.ACTIVE
             logToUser { LOG_ACTIVE_WINDOW_STARTED.format(Locale.US, activeMs) }
             profiler.start(
                 appContext = appContext,
@@ -104,13 +216,18 @@ internal class ContinuousProfilingScheduler(
             }
         } else {
             logToUser { LOG_ACTIVE_WINDOW_SKIPPED }
+            // Skipped windows behave like cooldown for lifecycle purposes.
+            state = State.COOLDOWN
         }
 
-        // If the active window is skipped due to RUM session,
-        // next cooldown window still needs to be scheduled.
+        scheduleActiveWindowEnd(activeMs)
+    }
+
+    private fun scheduleActiveWindowEnd(delayMs: Long) {
+        cooldownWindowEndMs = timeProvider.getDeviceTimestampMillis() + delayMs
         pendingFuture = schedulerExecutor.scheduleSafe(
             operationName = OPERATION_ACTIVE_WINDOW_END,
-            delay = activeMs,
+            delay = delayMs,
             unit = TimeUnit.MILLISECONDS,
             internalLogger = sdkCore.internalLogger,
             runnable = {
@@ -122,6 +239,8 @@ internal class ContinuousProfilingScheduler(
     }
 
     private fun scheduleCooldown(cooldownMs: Long) {
+        state = State.COOLDOWN
+        cooldownWindowEndMs = timeProvider.getDeviceTimestampMillis() + cooldownMs
         pendingFuture = schedulerExecutor.scheduleSafe(
             operationName = OPERATION_COOLDOWN_END,
             delay = cooldownMs,
@@ -145,6 +264,47 @@ internal class ContinuousProfilingScheduler(
         )
     }
 
+    internal enum class State {
+        /**
+         * Continuous profiler has not started, or it's sampled out. No timer is running.
+         */
+        IDLE,
+
+        /**
+         * Between active windows. The cooldown timer is running in the foreground and will fire
+         * [scheduleNextCycle] when it expires. Backgrounding here transitions to [PAUSED_COOLDOWN].
+         */
+        COOLDOWN,
+
+        /**
+         * Profiler is currently running its active window. Backgrounding here transitions to
+         * [GRACE_PERIOD]. The active-window-end timer fires when the window completes and
+         * schedules the next cooldown.
+         */
+        ACTIVE,
+
+        /**
+         * Was [ACTIVE]; app moved to background. The grace timer is running. Foregrounding
+         * within the grace period returns to [ACTIVE] for the active window's remaining time.
+         * If the grace timer expires first, transitions to [PAUSED_AFTER_GRACE] and the
+         * profiler is stopped.
+         */
+        GRACE_PERIOD,
+
+        /**
+         * Was [COOLDOWN]; app is in background. The cooldown timer was cancelled and the
+         * remaining time is saved in [remainingCooldownMs]. Foregrounding resumes [COOLDOWN]
+         * with that remainder.
+         */
+        PAUSED_COOLDOWN,
+
+        /**
+         * Grace period expired while still in background. The profiler has been stopped and
+         * no timer is running. Foregrounding starts a fresh jittered [COOLDOWN].
+         */
+        PAUSED_AFTER_GRACE
+    }
+
     companion object {
         // Base active window duration: 1 minute (±20% jitter applied per cycle).
         internal const val CONTINUOUS_WINDOW_DURATION_MS = 60_000L
@@ -152,11 +312,17 @@ internal class ContinuousProfilingScheduler(
         // Base cooldown duration: 1 minute (±20% jitter applied per cycle).
         internal const val CONTINUOUS_COOLDOWN_DURATION_MS = 60_000L
 
+        // Grace period before stopping an active session when app moves to background.
+        internal const val BACKGROUND_GRACE_PERIOD_MS = 10_000L
+
         // Fraction of base duration used as jitter range (±20%).
         private const val JITTER_FACTOR = 0.20
 
         private const val OPERATION_ACTIVE_WINDOW_END = "continuous_profiling_active_window"
         private const val OPERATION_COOLDOWN_END = "continuous_profiling_cooldown"
+        private const val OPERATION_GRACE_PERIOD = "continuous_profiling_grace_period"
+        private const val OPERATION_ON_BACKGROUND = "continuous_profiling_on_background"
+        private const val OPERATION_ON_FOREGROUND = "continuous_profiling_on_foreground"
 
         internal const val LOG_DISABLED =
             "Continuous profiling disabled (not sampled in at rate=%s)."
@@ -174,5 +340,17 @@ internal class ContinuousProfilingScheduler(
             "Continuous profiling active window skipped (RUM session not sampled); cooldown still scheduled."
         internal const val LOG_ACTIVE_WINDOW_ENDED =
             "Continuous profiling active window ended; cooling down for %sms."
+        internal const val LOG_BACKGROUND_GRACE_PERIOD =
+            "App backgrounded during active window; grace period started (%sms remaining in active window)."
+        internal const val LOG_BACKGROUND_COOLDOWN_PAUSED =
+            "App backgrounded during cooldown; cooldown paused (%sms remaining)."
+        internal const val LOG_FOREGROUND_RESUMED_ACTIVE =
+            "App foregrounded; active window resumed."
+        internal const val LOG_FOREGROUND_RESUMED_COOLDOWN =
+            "App foregrounded; cooldown resumed (%sms remaining)."
+        internal const val LOG_FOREGROUND_AFTER_GRACE =
+            "App foregrounded after grace period expired; starting cooldown."
+        internal const val LOG_GRACE_PERIOD_EXPIRED =
+            "Grace period expired; profiler stopped."
     }
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.profiling.internal
 
+import android.app.Application
 import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -17,8 +18,10 @@ import com.datadog.android.api.feature.StorageBackedFeature
 import com.datadog.android.api.net.RequestFactory
 import com.datadog.android.api.storage.FeatureStorageConfiguration
 import com.datadog.android.internal.FeatureContextKeys
+import com.datadog.android.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.internal.profiling.ProfilerEvent
 import com.datadog.android.internal.rum.RumSessionRenewedEvent
+import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.profiling.ExperimentalProfilingApi
 import com.datadog.android.profiling.ProfilingConfiguration
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
@@ -53,6 +56,8 @@ internal class ProfilingFeature(
     @Volatile
     private var continuousProfilingScheduler: ContinuousProfilingScheduler? = null
 
+    private var processLifecycleMonitor: ProcessLifecycleMonitor? = null
+
     override val requestFactory: RequestFactory = ProfilingRequestFactory(
         customEndpointUrl = configuration.customEndpointUrl,
         internalLogger = sdkCore.internalLogger
@@ -82,18 +87,30 @@ internal class ProfilingFeature(
         }
         dataWriter = createDataWriter(sdkCore)
 
-        continuousProfilingScheduler = ContinuousProfilingScheduler(
+        val scheduler = ContinuousProfilingScheduler(
             appContext = appContext,
             profiler = profiler,
             sdkCore = sdkCore,
+            timeProvider = DefaultTimeProvider(),
             sampleRate = configuration.continuousSampleRate,
             onActiveWindowStarted = pendingRumEvents::clear
         ).apply {
             start(launchProfilingActive = profiler.isRunning(sdkCore.name))
         }
+        continuousProfilingScheduler = scheduler
+
+        if (appContext is Application) {
+            processLifecycleMonitor = ProcessLifecycleMonitor(ProfilingLifecycleCallback(scheduler)).apply {
+                appContext.registerActivityLifecycleCallbacks(this)
+            }
+        }
     }
 
     override fun onStop() {
+        processLifecycleMonitor?.let { monitor ->
+            (appContext as? Application)?.unregisterActivityLifecycleCallbacks(monitor)
+        }
+        processLifecycleMonitor = null
         continuousProfilingScheduler?.stop()
         profiler.apply {
             stop(sdkCore.name)

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingLifecycleCallback.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingLifecycleCallback.kt
@@ -1,0 +1,40 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling.internal
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.datadog.android.internal.lifecycle.ProcessLifecycleMonitor
+
+/**
+ * Bridges process-level [ProcessLifecycleMonitor.Callback] events into
+ * [ContinuousProfilingScheduler.onForeground] / [ContinuousProfilingScheduler.onBackground].
+ *
+ * Reusing [ProcessLifecycleMonitor] keeps profiling aligned with the foreground/background
+ * state observed by the rest of the SDK (uploaders, batch metrics).
+ */
+@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+internal class ProfilingLifecycleCallback(
+    private val scheduler: ContinuousProfilingScheduler
+) : ProcessLifecycleMonitor.Callback {
+
+    override fun onStarted() {
+        scheduler.onForeground()
+    }
+
+    override fun onResumed() {
+        // NO - OP
+    }
+
+    override fun onStopped() {
+        scheduler.onBackground()
+    }
+
+    override fun onPaused() {
+        // NO - OP
+    }
+}

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -25,6 +25,10 @@ import com.datadog.android.profiling.internal.ProfilingStartReason
 import com.datadog.android.profiling.internal.ProfilingStorage
 import com.datadog.android.profiling.internal.ProfilingWriter
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
+import com.datadog.android.profiling.utils.config.MainLooperTestConfiguration
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -55,7 +59,8 @@ import java.util.concurrent.ScheduledExecutorService
 @OptIn(ExperimentalProfilingApi::class)
 @Extensions(
     ExtendWith(MockitoExtension::class),
-    ExtendWith(ForgeExtension::class)
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
@@ -800,5 +805,15 @@ internal class ProfilingFeatureTest {
         assertThat(argumentCaptor.firstValue.invoke())
             .isEqualTo("Profiling feature received an event of unsupported type=${String::class.java.canonicalName}.")
         verify(mockProfiler, never()).stop(fakeInstanceName)
+    }
+
+    companion object {
+        private val mainLooper = MainLooperTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(mainLooper)
+        }
     }
 }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
@@ -18,6 +18,10 @@ import com.datadog.android.profiling.internal.ProfilingFeature
 import com.datadog.android.profiling.internal.ProfilingStartReason
 import com.datadog.android.profiling.internal.ProfilingStorage
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
+import com.datadog.android.profiling.utils.config.MainLooperTestConfiguration
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -42,7 +46,8 @@ import java.util.concurrent.ExecutorService
 @OptIn(ExperimentalProfilingApi::class)
 @Extensions(
     ExtendWith(MockitoExtension::class),
-    ExtendWith(ForgeExtension::class)
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
@@ -203,5 +208,15 @@ class ProfilingTest {
     private fun resetProfilerField() {
         Profiling.profiler = NoOpProfiler()
         Profiling.isProfilerInitialized.set(false)
+    }
+
+    companion object {
+        private val mainLooper = MainLooperTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(mainLooper)
+        }
     }
 }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ContinuousProfilingSchedulerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ContinuousProfilingSchedulerTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.profiling.internal
 import android.app.Application
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.profiling.forge.Configurator
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -23,9 +24,11 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -62,6 +65,9 @@ internal class ContinuousProfilingSchedulerTest {
     @Mock
     private lateinit var mockFuture: ScheduledFuture<Any>
 
+    @Mock
+    private lateinit var mockTimeProvider: TimeProvider
+
     private var activeWindowStartedCount = 0
 
     private val fakeInstanceName = "test-sdk-instance"
@@ -79,11 +85,26 @@ internal class ContinuousProfilingSchedulerTest {
             )
         ) doReturn mockFuture
 
+        // Make submit() execute the runnable immediately (synchronous for testing).
+        whenever(mockSchedulerExecutor.submit(any<Runnable>())) doAnswer { invocation ->
+            (invocation.getArgument<Runnable>(0)).run()
+            @Suppress("UNCHECKED_CAST")
+            mockFuture
+        }
+
+        // Make execute() run the runnable immediately so executeSafe-dispatched
+        // lifecycle callbacks (onBackground/onForeground) execute synchronously.
+        doAnswer { invocation ->
+            (invocation.getArgument<Runnable>(0)).run()
+            null
+        }.whenever(mockSchedulerExecutor).execute(any<Runnable>())
+
         activeWindowStartedCount = 0
         testedScheduler = ContinuousProfilingScheduler(
             profiler = mockProfiler,
             appContext = mockApplication,
             sdkCore = mockSdkCore,
+            timeProvider = mockTimeProvider,
             sampleRate = 100f,
             onActiveWindowStarted = { activeWindowStartedCount++ }
         )
@@ -159,6 +180,7 @@ internal class ContinuousProfilingSchedulerTest {
             profiler = mockProfiler,
             appContext = mockApplication,
             sdkCore = mockSdkCore,
+            timeProvider = mockTimeProvider,
             sampleRate = 0f
         )
 
@@ -176,6 +198,7 @@ internal class ContinuousProfilingSchedulerTest {
             profiler = mockProfiler,
             appContext = mockApplication,
             sdkCore = mockSdkCore,
+            timeProvider = mockTimeProvider,
             sampleRate = 0f
         )
 
@@ -197,6 +220,7 @@ internal class ContinuousProfilingSchedulerTest {
             profiler = mockProfiler,
             appContext = mockApplication,
             sdkCore = mockSdkCore,
+            timeProvider = mockTimeProvider,
             sampleRate = 0f
         )
         testedScheduler.start(launchProfilingActive = false)
@@ -372,12 +396,225 @@ internal class ContinuousProfilingSchedulerTest {
         verify(mockFuture).cancel(false)
     }
 
+    @Test
+    fun `M cancel grace period future W stop() {grace period running}`() {
+        // Given
+        openActiveWindow()
+        testedScheduler.onBackground()
+
+        // When
+        testedScheduler.stop()
+
+        // Then
+        verify(mockFuture, atLeastOnce()).cancel(false)
+    }
+
     // endregion
 
+    // region lifecycle — onBackground / onForeground
+
     @Test
-    fun `M invoke onActiveWindowStarted callback W each new active window starts`() {
+    fun `M start grace period timer W onBackground() {active window running}`() {
         // Given
-        testedScheduler.onRumSessionRenewed(sessionSampled = true)
+        openActiveWindow()
+        val delayCaptor = argumentCaptor<Long>()
+        whenever(
+            mockSchedulerExecutor.schedule(any<Runnable>(), delayCaptor.capture(), any<TimeUnit>())
+        ) doReturn mockFuture
+
+        // When
+        testedScheduler.onBackground()
+
+        // Then
+        assertThat(delayCaptor.lastValue)
+            .isEqualTo(ContinuousProfilingScheduler.BACKGROUND_GRACE_PERIOD_MS)
+    }
+
+    @Test
+    fun `M cancel active window timer W onBackground() {active window running}`() {
+        // Given
+        openActiveWindow()
+
+        // When
+        testedScheduler.onBackground()
+
+        // Then
+        verify(mockFuture).cancel(false)
+    }
+
+    @Test
+    fun `M NOT stop profiler W onBackground() {active window running}`() {
+        // Given
+        openActiveWindow()
+
+        // When
+        testedScheduler.onBackground()
+
+        // Then
+        verify(mockProfiler, never()).stop(any())
+    }
+
+    @Test
+    fun `M resume active window W onForeground() {grace period not expired}`() {
+        // Given
+        openActiveWindow()
+        testedScheduler.onBackground()
+
+        // When
+        testedScheduler.onForeground()
+
+        // Then
+        assertThat(testedScheduler.state).isEqualTo(ContinuousProfilingScheduler.State.ACTIVE)
+        verify(mockProfiler, never()).start(any(), any(), any(), any(), eq(0))
+    }
+
+    @Test
+    fun `M stop profiler W grace period expires`() {
+        // Given
+        openActiveWindow()
+        testedScheduler.onBackground()
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(mockSchedulerExecutor, atLeastOnce()).schedule(
+            runnableCaptor.capture(),
+            any(),
+            any()
+        )
+
+        // When
+        runnableCaptor.lastValue.run()
+
+        // Then
+        verify(mockProfiler).stop(fakeInstanceName)
+    }
+
+    @Test
+    fun `M start cooldown W onForeground() {after grace period expired}`() {
+        // Given
+        openActiveWindow()
+        testedScheduler.onBackground()
+        val runnableCaptor = argumentCaptor<Runnable>()
+        verify(mockSchedulerExecutor, atLeastOnce()).schedule(
+            runnableCaptor.capture(),
+            any(),
+            any()
+        )
+        runnableCaptor.lastValue.run() // expire grace period
+        val delayCaptor = argumentCaptor<Long>()
+        whenever(
+            mockSchedulerExecutor.schedule(any<Runnable>(), delayCaptor.capture(), any<TimeUnit>())
+        ) doReturn mockFuture
+
+        // When
+        testedScheduler.onForeground()
+
+        // Then
+        val cooldownBase = ContinuousProfilingScheduler.CONTINUOUS_COOLDOWN_DURATION_MS
+        assertThat(delayCaptor.lastValue)
+            .isBetween((cooldownBase * 0.8).toLong(), (cooldownBase * 1.2).toLong())
+    }
+
+    @Test
+    fun `M pause cooldown timer W onBackground() {cooldown running}`() {
+        // Given
+        testedScheduler.start(launchProfilingActive = true)
+        testedScheduler.onAppLaunchProfilingComplete()
+
+        // When
+        testedScheduler.onBackground()
+
+        // Then
+        verify(mockFuture).cancel(false)
+    }
+
+    @Test
+    fun `M resume cooldown with remaining time W onForeground() {paused cooldown}`() {
+        // Given
+        testedScheduler.start(launchProfilingActive = true)
+        testedScheduler.onAppLaunchProfilingComplete()
+        testedScheduler.onBackground()
+
+        // When
+        testedScheduler.onForeground()
+
+        // Then
+        assertThat(testedScheduler.state).isEqualTo(ContinuousProfilingScheduler.State.COOLDOWN)
+    }
+
+    @Test
+    fun `M do nothing W onBackground() {scheduler not started}`() {
+        // When
+        testedScheduler.onBackground()
+
+        // Then
+        verify(mockProfiler, never()).stop(any())
+        verify(mockFuture, never()).cancel(any())
+    }
+
+    @Test
+    fun `M do nothing W onForeground() {scheduler not started}`() {
+        // When
+        testedScheduler.onForeground()
+
+        // Then
+        verify(mockProfiler, never()).start(any(), any(), any(), any(), any())
+        verify(mockSchedulerExecutor, never()).schedule(any<Runnable>(), any(), any())
+    }
+
+    @Test
+    fun `M ignore second background W onBackground() {already in grace period}`() {
+        // Given
+        openActiveWindow()
+        testedScheduler.onBackground() // → GRACE_PERIOD
+
+        // When
+        testedScheduler.onBackground()
+
+        // Then
+        assertThat(testedScheduler.state).isEqualTo(ContinuousProfilingScheduler.State.GRACE_PERIOD)
+        verify(mockFuture, times(1)).cancel(false)
+    }
+
+    @Test
+    fun `M ignore foreground W onForeground() {state is ACTIVE}`() {
+        // Given
+        openActiveWindow()
+
+        // When
+        testedScheduler.onForeground()
+
+        // Then
+        assertThat(testedScheduler.state).isEqualTo(ContinuousProfilingScheduler.State.ACTIVE)
+    }
+
+    @Test
+    fun `M ignore foreground W onForeground() {state is COOLDOWN}`() {
+        // Given
+        testedScheduler.start(launchProfilingActive = false)
+        check(testedScheduler.state == ContinuousProfilingScheduler.State.COOLDOWN)
+
+        // When
+        testedScheduler.onForeground()
+
+        // Then
+        assertThat(testedScheduler.state).isEqualTo(ContinuousProfilingScheduler.State.COOLDOWN)
+    }
+
+    @Test
+    fun `M re-enter grace period W onBackground() {after foreground resumed active window}`() {
+        // Given
+        openActiveWindow()
+        testedScheduler.onBackground() // ACTIVE → GRACE_PERIOD
+        testedScheduler.onForeground() // GRACE_PERIOD → ACTIVE
+
+        // When
+        testedScheduler.onBackground() // ACTIVE → GRACE_PERIOD again
+
+        // Then
+        assertThat(testedScheduler.state).isEqualTo(ContinuousProfilingScheduler.State.GRACE_PERIOD)
+    }
+
+    private fun openActiveWindow() {
+        testedScheduler.rumSessionSampled = true
         testedScheduler.start(launchProfilingActive = true)
         val runnableCaptor = argumentCaptor<Runnable>()
         testedScheduler.onAppLaunchProfilingComplete()

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingLifecycleCallbackTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingLifecycleCallbackTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling.internal
+
+import com.datadog.android.profiling.forge.Configurator
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class ProfilingLifecycleCallbackTest {
+
+    private lateinit var testedCallback: ProfilingLifecycleCallback
+
+    @Mock
+    private lateinit var mockScheduler: ContinuousProfilingScheduler
+
+    @BeforeEach
+    fun `set up`() {
+        testedCallback = ProfilingLifecycleCallback(mockScheduler)
+    }
+
+    @Test
+    fun `M call onForeground W onStarted()`() {
+        // When
+        testedCallback.onStarted()
+
+        // Then
+        verify(mockScheduler).onForeground()
+    }
+
+    @Test
+    fun `M call onBackground W onStopped()`() {
+        // When
+        testedCallback.onStopped()
+
+        // Then
+        verify(mockScheduler).onBackground()
+    }
+
+    @Test
+    fun `M do nothing W onResumed()`() {
+        // When
+        testedCallback.onResumed()
+
+        // Then
+        verifyNoInteractions(mockScheduler)
+    }
+
+    @Test
+    fun `M do nothing W onPaused()`() {
+        // When
+        testedCallback.onPaused()
+
+        // Then
+        verifyNoInteractions(mockScheduler)
+    }
+}

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/utils/config/MainLooperTestConfiguration.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/utils/config/MainLooperTestConfiguration.kt
@@ -1,0 +1,36 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling.utils.config
+
+import android.os.Looper
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import com.datadog.tools.unit.getStaticValue
+import com.datadog.tools.unit.setStaticValue
+import fr.xgouchet.elmyr.Forge
+
+internal class MainLooperTestConfiguration : TestConfiguration {
+
+    override fun setUp(forge: Forge) {
+        val mainLooper = Looper.getMainLooper()
+        if (mainLooper == null) {
+            try {
+                @Suppress("DEPRECATION")
+                Looper.prepareMainLooper()
+            } catch (e: IllegalStateException) {
+                // main looper already prepared
+            }
+        }
+        checkNotNull(Looper.getMainLooper())
+    }
+
+    override fun tearDown(forge: Forge) {
+        Looper::class.java.setStaticValue("sMainLooper", null)
+        Looper::class.java.getStaticValue<Looper, ThreadLocal<Looper>>("sThreadLocal").set(null)
+
+        check(Looper.getMainLooper() == null)
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Adds lifecycle-aware pause/resume to the continuous profiler — profiling pauses when the app goes to background (after a grace period)  and resumes on foreground. Introduces `ProfilingLifecycleObserver`, extends `ContinuousProfilingScheduler `with the grace-period logic.    

### Motivation

RUM-15287


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

