### PR TITLE
RUM-15352: Replace GraphQL chain wrapper with request tag

### DIFF
--- a/detekt_custom_unsafe_calls.yml
+++ b/detekt_custom_unsafe_calls.yml
@@ -231,6 +231,7 @@ datadog:
       - "okhttp3.Request.Builder.build():java.lang.IllegalStateException"
       - "okhttp3.Request.Builder.post(okhttp3.RequestBody):java.lang.NullPointerException,java.lang.IllegalArgumentException"
       - "okhttp3.Request.Builder.method(kotlin.String, okhttp3.RequestBody?):java.lang.NullPointerException,java.lang.IllegalArgumentException"
+      - "okhttp3.Request.Builder.tag(java.lang.Class, com.datadog.android.okhttp.internal.graphql.GraphQLAttributes?):java.lang.ClassCastException"
       - "okhttp3.Request.Builder.tag(java.lang.Class, com.datadog.android.okhttp.TraceContext?):java.lang.ClassCastException"
       - "okhttp3.Request.Builder.url(kotlin.String):java.lang.NullPointerException,java.lang.IllegalArgumentException"
       - "okhttp3.RequestBody.writeTo(okio.BufferedSink):java.io.IOException"

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -123,7 +123,7 @@ open class DatadogInterceptor internal constructor(
             .apply {
                 @Suppress("UnsafeThirdPartyFunctionCall") // ClassCastException can't happen here.
                 tag(UUID::class.java, UUID.randomUUID())
-                okHttpGraphQLAdapter.stripHeadersAndTag(originalRequest, this)
+                okHttpGraphQLAdapter.convertHeadersToTag(originalRequest, this)
             }
             .safeBuild() ?: originalRequest
 

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -118,13 +118,14 @@ open class DatadogInterceptor internal constructor(
         val sdkCore = sdkCoreReference.get() as? FeatureSdkCore
         val rumFeature = sdkCore?.getFeature(Feature.RUM_FEATURE_NAME)
 
-        val request = chain.request()
-            .newBuilder()
+        val originalRequest = chain.request()
+        val request = originalRequest.newBuilder()
             .apply {
                 @Suppress("UnsafeThirdPartyFunctionCall") // ClassCastException can't happen here.
                 tag(UUID::class.java, UUID.randomUUID())
+                okHttpGraphQLAdapter.stripHeadersAndTag(originalRequest, this)
             }
-            .safeBuild() ?: chain.request()
+            .safeBuild() ?: originalRequest
 
         if (rumFeature != null) {
             val url = request.url.toString()
@@ -147,10 +148,7 @@ open class DatadogInterceptor internal constructor(
             )
         }
 
-        val internalLogger = (sdkCore?.internalLogger ?: InternalLogger.UNBOUND)
-        val localChain = okHttpGraphQLAdapter.wrapChainWithoutDDHeaders(internalLogger, chain)
-
-        return doIntercept(localChain, request)
+        return doIntercept(chain, request)
     }
 
     // endregion
@@ -218,18 +216,18 @@ open class DatadogInterceptor internal constructor(
         val attributes = if (!isSampled || span == null) {
             emptyMap<String, Any?>()
         } else {
-            val graphqlAttributes = okHttpGraphQLAdapter.extractGraphQLAttributes(request)
-            val graphqlErrorAttributes = okHttpGraphQLAdapter.extractGraphQLErrorAttributes(
+            val graphQLAttributes = okHttpGraphQLAdapter.readGraphQLAttributesFromTag(request)
+            val graphQLErrorAttributes = okHttpGraphQLAdapter.extractGraphQLErrorAttributes(
                 response,
-                graphqlAttributes,
+                graphQLAttributes,
                 sdkCore.internalLogger
             )
             buildMap {
                 put(RumAttributes.TRACE_ID, span.context().traceId.toHexString())
                 put(RumAttributes.SPAN_ID, span.context().spanId.toString())
                 put(RumAttributes.RULE_PSR, (traceSampler.getSampleRate() ?: ZERO_SAMPLE_RATE) / ALL_IN_SAMPLE_RATE)
-                putAll(graphqlAttributes)
-                putAll(graphqlErrorAttributes)
+                putAll(graphQLAttributes)
+                putAll(graphQLErrorAttributes)
             }
         }
 

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapter.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapter.kt
@@ -21,7 +21,7 @@ internal class OkHttpGraphQLAdapter(
     private val graphQLExtractor: GraphQLExtractor = GraphQLExtractor()
 ) {
 
-    fun stripHeadersAndTag(request: Request, builder: Request.Builder) {
+    fun convertHeadersToTag(request: Request, builder: Request.Builder) {
         val attributes = graphQLExtractor.extractGraphQLAttributes(OkHttpRequestInfo(request))
         if (attributes.isEmpty()) return
 

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapter.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapter.kt
@@ -14,63 +14,33 @@ import com.datadog.android.okhttp.internal.OkHttpRequestInfo
 import com.datadog.android.okhttp.internal.OkHttpResponseInfo
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.internal.net.GraphQLExtractor
-import okhttp3.Headers
-import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
-import java.io.IOException
 
 internal class OkHttpGraphQLAdapter(
     private val graphQLExtractor: GraphQLExtractor = GraphQLExtractor()
 ) {
 
-    fun wrapChainWithoutDDHeaders(
-        internalLogger: InternalLogger,
-        originalChain: Interceptor.Chain
-    ): Interceptor.Chain {
-        return if (hasGraphQLHeaders(originalChain.request().headers)) {
-            object : Interceptor.Chain by originalChain {
-                override fun proceed(request: Request): Response {
-                    return try {
-                        val cleanedRequest = request.newBuilder().apply {
-                            removeGraphQLHeaders(this)
-                        }.build()
-                        return originalChain.proceed(cleanedRequest)
-                    } catch (e: IllegalStateException) {
-                        internalLogger.log(
-                            level = InternalLogger.Level.WARN,
-                            target = InternalLogger.Target.MAINTAINER,
-                            messageBuilder = { ERROR_FAILED_BUILD_REQUEST },
-                            throwable = e
-                        )
-                        originalChain.proceed(request) // fallback to the original request
-                    } catch (e: IOException) {
-                        internalLogger.log(
-                            level = InternalLogger.Level.WARN,
-                            target = InternalLogger.Target.MAINTAINER,
-                            messageBuilder = { ERROR_FAILED_BUILD_REQUEST },
-                            throwable = e
-                        )
-                        originalChain.proceed(request) // fallback to the original request
-                    }
-                }
-            }
-        } else {
-            originalChain
-        }
+    fun stripHeadersAndTag(request: Request, builder: Request.Builder) {
+        val attributes = graphQLExtractor.extractGraphQLAttributes(OkHttpRequestInfo(request))
+        if (attributes.isEmpty()) return
+
+        GraphQLHeaders.values().forEach { builder.removeHeader(it.headerValue) }
+        @Suppress("UnsafeThirdPartyFunctionCall") // ClassCastException can't happen here.
+        builder.tag(GraphQLAttributes::class.java, GraphQLAttributes(attributes))
     }
 
-    fun extractGraphQLAttributes(request: Request): Map<String, Any?> =
-        graphQLExtractor.extractGraphQLAttributes(OkHttpRequestInfo(request))
+    fun readGraphQLAttributesFromTag(request: Request): Map<String, Any?> =
+        request.tag(GraphQLAttributes::class.java)?.attributes.orEmpty()
 
     @WorkerThread
     @Suppress("ReturnCount")
     fun extractGraphQLErrorAttributes(
         response: Response,
-        graphqlAttributes: Map<String, Any?>,
+        graphQLAttributes: Map<String, Any?>,
         internalLogger: InternalLogger
     ): Map<String, Any> {
-        if (graphqlAttributes.isEmpty()) return emptyMap()
+        if (graphQLAttributes.isEmpty()) return emptyMap()
         // Streaming responses surface GraphQL errors per-frame, not as a top-level `errors` array.
         // Draining their bodies via peekBody().string() would block until the (potentially unbounded) body completes.
         val body = response.body
@@ -104,18 +74,12 @@ internal class OkHttpGraphQLAdapter(
         }
     }
 
-    internal fun hasGraphQLHeaders(headers: Headers): Boolean =
-        GraphQLHeaders.values().any { headers[it.headerValue] != null }
-
-    private fun removeGraphQLHeaders(requestBuilder: Request.Builder) {
-        GraphQLHeaders.values().forEach { requestBuilder.removeHeader(it.headerValue) }
-    }
-
     internal companion object {
-        internal const val ERROR_FAILED_BUILD_REQUEST =
-            "Failed to build interceptor chain after removing DD headers. Falling back to original chain."
-
         internal const val ERROR_PEEK_BODY_GRAPHQL =
             "Failed to peek response body for GraphQL errors."
     }
 }
+
+internal data class GraphQLAttributes(
+    val attributes: Map<String, Any?>
+)

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapterTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapterTest.kt
@@ -9,7 +9,6 @@ package com.datadog.android.okhttp.internal.graphql
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.network.GraphQLHeaders
 import com.datadog.android.internal.network.HttpSpec
-import com.datadog.android.internal.utils.toBase64
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.internal.net.GraphQLExtractor
 import com.datadog.android.tests.elmyr.anOkHttpResponse
@@ -32,7 +31,6 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
@@ -65,114 +63,90 @@ internal class OkHttpGraphQLAdapterTest {
         testedHelper = OkHttpGraphQLAdapter(mockGraphQLExtractor)
     }
 
-    // region wrapChainWithoutDDHeaders
+    // region stripHeadersAndTag
 
     @Test
-    fun `M strip GraphQL headers W wrapChainWithoutDDHeaders() {with DD headers}`(
-        @StringForgery fakeGraphQLName: String,
-        @StringForgery fakeUserAgent: String
+    fun `M strip DD headers and attach tag W stripHeadersAndTag() {graphql request}`(
+        @StringForgery fakeOperationName: String
     ) {
         // Given
+        val attrs = mapOf<String, Any?>(RumAttributes.GRAPHQL_OPERATION_NAME to fakeOperationName)
+        whenever(mockGraphQLExtractor.extractGraphQLAttributes(any())) doReturn attrs
+
         val request = Request.Builder()
             .url("https://example.com/graphql")
-            .addHeader("User-Agent", fakeUserAgent)
-            .addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeGraphQLName.toBase64())
+            .header(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, "encoded-name")
+            .header(GraphQLHeaders.DD_GRAPHQL_TYPE_HEADER.headerValue, "encoded-type")
+            .header(GraphQLHeaders.DD_GRAPHQL_VARIABLES_HEADER.headerValue, "encoded-vars")
+            .header(GraphQLHeaders.DD_GRAPHQL_PAYLOAD_HEADER.headerValue, "encoded-payload")
+            .header("User-Agent", "test-agent")
             .build()
-        val response = forge.anOkHttpResponse(request, 200) {
-            body("""{"data":{}}""".toResponseBody(HttpSpec.ContentType.APPLICATION_JSON.toMediaType()))
+        val builder = request.newBuilder()
+
+        // When
+        testedHelper.stripHeadersAndTag(request, builder)
+        val result = builder.build()
+
+        // Then
+        GraphQLHeaders.values().forEach {
+            assertThat(result.header(it.headerValue)).isNull()
         }
-        whenever(mockChain.request()) doReturn request
-        whenever(mockChain.proceed(any())) doReturn response
-
-        // When
-        val wrappedChain = testedHelper.wrapChainWithoutDDHeaders(mockInternalLogger, mockChain)
-        wrappedChain.proceed(request)
-
-        // Then
-        val requestCaptor = argumentCaptor<Request>()
-        verify(mockChain).proceed(requestCaptor.capture())
-        val cleanedRequest = requestCaptor.firstValue
-        assertThat(cleanedRequest.headers[GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue]).isNull()
-        assertThat(cleanedRequest.headers["User-Agent"]).isEqualTo(fakeUserAgent)
+        assertThat(result.header("User-Agent")).isEqualTo("test-agent")
+        assertThat(result.tag(GraphQLAttributes::class.java)).isEqualTo(GraphQLAttributes(attrs))
     }
 
     @Test
-    fun `M return original chain W wrapChainWithoutDDHeaders() {without DD headers}`(
-        @StringForgery fakeUserAgent: String
-    ) {
+    fun `M not modify builder W stripHeadersAndTag() {empty attributes}`() {
         // Given
-        val request = Request.Builder()
-            .url("https://example.com/graphql")
-            .addHeader("User-Agent", fakeUserAgent)
-            .build()
+        whenever(mockGraphQLExtractor.extractGraphQLAttributes(any())) doReturn emptyMap()
 
-        whenever(mockChain.request()) doReturn request
+        val request = Request.Builder()
+            .url("https://example.com/api")
+            .header("User-Agent", "test-agent")
+            .build()
+        val builder = request.newBuilder()
 
         // When
-        val wrappedChain = testedHelper.wrapChainWithoutDDHeaders(mockInternalLogger, mockChain)
+        testedHelper.stripHeadersAndTag(request, builder)
+        val result = builder.build()
 
         // Then
-        assertThat(wrappedChain).isSameAs(mockChain)
+        assertThat(result.header("User-Agent")).isEqualTo("test-agent")
+        assertThat(result.tag(GraphQLAttributes::class.java)).isNull()
     }
 
     // endregion
 
-    // region hasGraphQLHeaders
+    // region readGraphQLAttributesFromTag
 
     @Test
-    fun `M return true W hasGraphQLHeaders() {with any GraphQL header}`(
-        @StringForgery fakeValue: String
+    fun `M return tagged attributes W readGraphQLAttributesFromTag() {tag present}`(
+        @StringForgery fakeOperationName: String
     ) {
         // Given
+        val attrs = mapOf<String, Any?>(RumAttributes.GRAPHQL_OPERATION_NAME to fakeOperationName)
         val request = Request.Builder()
             .url("https://example.com/graphql")
-            .addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeValue)
+            .tag(GraphQLAttributes::class.java, GraphQLAttributes(attrs))
             .build()
 
         // When
-        val result = testedHelper.hasGraphQLHeaders(request.headers)
+        val result = testedHelper.readGraphQLAttributesFromTag(request)
 
         // Then
-        assertThat(result).isTrue()
+        assertThat(result).isEqualTo(attrs)
     }
 
     @Test
-    fun `M return false W hasGraphQLHeaders() {without GraphQL headers}`() {
+    fun `M return empty map W readGraphQLAttributesFromTag() {no tag}`() {
         // Given
-        val request = Request.Builder()
-            .url("https://example.com/graphql")
-            .addHeader("User-Agent", "test")
-            .build()
+        val request = Request.Builder().url("https://example.com/api").build()
 
         // When
-        val result = testedHelper.hasGraphQLHeaders(request.headers)
+        val result = testedHelper.readGraphQLAttributesFromTag(request)
 
         // Then
-        assertThat(result).isFalse()
-    }
-
-    // endregion
-
-    // region extractGraphQLAttributes
-
-    @Test
-    fun `M delegate to graphQLExtractor W extractGraphQLAttributes()`(
-        @StringForgery fakeGraphQLName: String
-    ) {
-        // Given
-        val request = Request.Builder()
-            .url("https://example.com/graphql")
-            .addHeader(GraphQLHeaders.DD_GRAPHQL_NAME_HEADER.headerValue, fakeGraphQLName.toBase64())
-            .build()
-        val expectedAttributes = mapOf("key" to "value")
-        whenever(mockGraphQLExtractor.extractGraphQLAttributes(any())) doReturn expectedAttributes
-
-        // When
-        val result = testedHelper.extractGraphQLAttributes(request)
-
-        // Then
-        assertThat(result).isEqualTo(expectedAttributes)
-        verify(mockGraphQLExtractor).extractGraphQLAttributes(any())
+        assertThat(result).isEmpty()
     }
 
     // endregion

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapterTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/graphql/OkHttpGraphQLAdapterTest.kt
@@ -63,10 +63,10 @@ internal class OkHttpGraphQLAdapterTest {
         testedHelper = OkHttpGraphQLAdapter(mockGraphQLExtractor)
     }
 
-    // region stripHeadersAndTag
+    // region convertHeadersToTag
 
     @Test
-    fun `M strip DD headers and attach tag W stripHeadersAndTag() {graphql request}`(
+    fun `M strip DD headers and attach tag W convertHeadersToTag() {graphql request}`(
         @StringForgery fakeOperationName: String
     ) {
         // Given
@@ -84,7 +84,7 @@ internal class OkHttpGraphQLAdapterTest {
         val builder = request.newBuilder()
 
         // When
-        testedHelper.stripHeadersAndTag(request, builder)
+        testedHelper.convertHeadersToTag(request, builder)
         val result = builder.build()
 
         // Then
@@ -96,7 +96,7 @@ internal class OkHttpGraphQLAdapterTest {
     }
 
     @Test
-    fun `M not modify builder W stripHeadersAndTag() {empty attributes}`() {
+    fun `M not modify builder W convertHeadersToTag() {empty attributes}`() {
         // Given
         whenever(mockGraphQLExtractor.extractGraphQLAttributes(any())) doReturn emptyMap()
 
@@ -107,7 +107,7 @@ internal class OkHttpGraphQLAdapterTest {
         val builder = request.newBuilder()
 
         // When
-        testedHelper.stripHeadersAndTag(request, builder)
+        testedHelper.convertHeadersToTag(request, builder)
         val result = builder.build()
 
         // Then


### PR DESCRIPTION
### What does this PR do?

Replace the existing logic of `wrapChainWithoutDDHeaders` with strip-and-tag step at `DatadogInterceptor.interceptor()`.
Now GraphQL attributes travel though the pipeline in a `Request.tag()`.

### Motivation

The previous logic was unpredictably modifying the request flow and could cause issues in complex interception pipelines. Also as tags are in-memory only, they cannot be serialized and leak to the network.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

