### PR TITLE
RUM-16092: Atomically write NDK crash logs + catch `NumberFormatException`

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/ndk/internal/NdkCrashLog.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/ndk/internal/NdkCrashLog.kt
@@ -42,7 +42,7 @@ internal data class NdkCrashLog(
         internal const val STACKTRACE_KEY_NAME = "stacktrace"
 
         @Suppress("UnsafeThirdPartyFunctionCall")
-        @Throws(JsonParseException::class, IllegalStateException::class)
+        @Throws(JsonParseException::class, IllegalStateException::class, NumberFormatException::class)
         internal fun fromJson(jsonString: String): NdkCrashLog {
             val jsonObject = JsonParser.parseString(jsonString).asJsonObject
             return NdkCrashLog(

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/ndk/internal/NdkCrashLogDeserializer.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/ndk/internal/NdkCrashLogDeserializer.kt
@@ -34,6 +34,14 @@ internal class NdkCrashLogDeserializer(
                 e
             )
             null
+        } catch (e: NumberFormatException) {
+            internalLogger.log(
+                InternalLogger.Level.ERROR,
+                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                { DESERIALIZE_ERROR_MESSAGE_FORMAT.format(Locale.US, model) },
+                e
+            )
+            null
         }
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/ndk/internal/NdkCrashLogDeserializerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/ndk/internal/NdkCrashLogDeserializerTest.kt
@@ -61,4 +61,22 @@ internal class NdkCrashLogDeserializerTest {
         // THEN
         assertThat(deserializedEvent).isNull()
     }
+
+    @Test
+    fun `M return null W deserialize { numeric field has non-numeric value }`(
+        @Forgery fakeNdkCrashLog: NdkCrashLog
+    ) {
+        // GIVEN
+        val corruptedJson = fakeNdkCrashLog.toJson()
+            .replace(
+                "\"${NdkCrashLog.TIMESTAMP_KEY_NAME}\":${fakeNdkCrashLog.timestamp}",
+                "\"${NdkCrashLog.TIMESTAMP_KEY_NAME}\":\"\""
+            )
+
+        // WHEN
+        val deserializedEvent = testedDeserializer.deserialize(corruptedJson)
+
+        // THEN
+        assertThat(deserializedEvent).isNull()
+    }
 }

--- a/features/dd-sdk-android-ndk/src/androidTest/kotlin/com/datadog/android/ndk/NdkTests.kt
+++ b/features/dd-sdk-android-ndk/src/androidTest/kotlin/com/datadog/android/ndk/NdkTests.kt
@@ -17,8 +17,13 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
+import java.io.File
+import java.io.IOException
 import java.nio.charset.Charset
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
 
 @RunWith(AndroidJUnit4::class)
 class NdkTests {
@@ -73,10 +78,12 @@ class NdkTests {
         // we need to give time to native part to write the file
         // otherwise we will get into race condition issues
         ConditionWatcher {
-            // assert the log file
-            val listFiles = temporaryFolder.root.listFiles()
-            val inputStream = listFiles?.first()?.inputStream()
-            inputStream?.use {
+            // The atomic write+rename in the native writer must leave exactly one file
+            // named "crash_log" — no stray "crash_log.tmp" should linger.
+            val listFiles = temporaryFolder.root.listFiles().orEmpty()
+            Assertions.assertThat(listFiles).hasSize(1)
+            Assertions.assertThat(listFiles[0].name).isEqualTo("crash_log")
+            listFiles[0].inputStream().use {
                 val jsonString = String(it.readBytes(), Charset.forName("utf-8"))
                 val jsonObject = JsonParser.parseString(jsonString).asJsonObject
                 assertThat(jsonObject).hasField("signal", fakeSignal)
@@ -96,6 +103,65 @@ class NdkTests {
             }
             true
         }.doWait(timeoutMs = 5000)
+    }
+
+    @Test
+    fun crashLogFile_isNeverObservablyTorn_whileBeingWritten() {
+        // Seed the destination with a known-good JSON so the reader always has a valid baseline.
+        // With the atomic rename in the native writer, crash_log content must always be either
+        // this seed or a fully-formed JSON — never empty and never starting with a non-'{' byte.
+        val storage = temporaryFolder.root
+        val crashLog = File(storage, "crash_log")
+        crashLog.writeText(
+            """{"signal":0,"timestamp":0,"signal_name":"seed","message":"seed",""" +
+                """"stacktrace":"seed","time_since_app_start_ms":0}"""
+        )
+
+        initNdkErrorHandler(storage.absolutePath)
+        updateTrackingConsent(1)
+        updateAppStartTime(System.currentTimeMillis() - 1000)
+
+        val stop = AtomicBoolean(false)
+        val tornObservations = AtomicInteger(0)
+        val totalReads = AtomicInteger(0)
+
+        val reader = thread(name = "crash-log-reader", isDaemon = true) {
+            while (!stop.get()) {
+                try {
+                    val bytes = crashLog.readBytes()
+                    totalReads.incrementAndGet()
+                    if (bytes.isEmpty() || bytes[0] != '{'.code.toByte()) {
+                        tornObservations.incrementAndGet()
+                    }
+                } catch (@Suppress("SwallowedException") e: IOException) {
+                    // A missing or unreadable file mid-write counts as a torn observation.
+                    tornObservations.incrementAndGet()
+                }
+            }
+        }
+
+        // Let the reader warm up before triggering the write.
+        Thread.sleep(20)
+
+        simulateSignalInterception(
+            forge.aPositiveInt(true),
+            "sig",
+            "msg",
+            "stack"
+        )
+
+        // Let the write settle so the reader observes the post-rename state too.
+        Thread.sleep(100)
+        stop.set(true)
+        reader.join(2000)
+
+        Assertions.assertThat(tornObservations.get())
+            .withFailMessage(
+                "Reader observed %d torn states of crash_log out of %d reads",
+                tornObservations.get(),
+                totalReads.get()
+            )
+            .isZero()
     }
 
     @Test

--- a/features/dd-sdk-android-ndk/src/androidTest/kotlin/com/datadog/android/ndk/NdkTests.kt
+++ b/features/dd-sdk-android-ndk/src/androidTest/kotlin/com/datadog/android/ndk/NdkTests.kt
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith
 import java.io.File
 import java.io.IOException
 import java.nio.charset.Charset
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -122,10 +123,12 @@ class NdkTests {
         updateAppStartTime(System.currentTimeMillis() - 1000)
 
         val stop = AtomicBoolean(false)
+        val readerStarted = CountDownLatch(1)
         val tornObservations = AtomicInteger(0)
         val totalReads = AtomicInteger(0)
 
         val reader = thread(name = "crash-log-reader", isDaemon = true) {
+            readerStarted.countDown()
             while (!stop.get()) {
                 try {
                     val bytes = crashLog.readBytes()
@@ -140,18 +143,23 @@ class NdkTests {
             }
         }
 
-        // Let the reader warm up before triggering the write.
-        Thread.sleep(20)
+        // Block until the reader thread has actually entered its loop.
+        Assertions.assertThat(readerStarted.await(2, TimeUnit.SECONDS)).isTrue
 
+        val fakeSignalName = forge.anAlphabeticalString()
         simulateSignalInterception(
             forge.aPositiveInt(true),
-            "sig",
+            fakeSignalName,
             "msg",
             "stack"
         )
 
-        // Let the write settle so the reader observes the post-rename state too.
-        Thread.sleep(100)
+        // Wait until the new payload is visible on disk before stopping the reader,
+        // so the reader has a chance to observe both pre- and post-rename states.
+        ConditionWatcher {
+            crashLog.readText(Charsets.UTF_8).contains("\"signal_name\":\"$fakeSignalName\"")
+        }.doWait(timeoutMs = 5000)
+
         stop.set(true)
         reader.join(2000)
 

--- a/features/dd-sdk-android-ndk/src/main/cpp/datadog-ndk.cpp
+++ b/features/dd-sdk-android-ndk/src/main/cpp/datadog-ndk.cpp
@@ -96,7 +96,7 @@ void write_crash_report(int signum,
     }
 
     // serialize the log
-    const string file_path = main_context.storage_dir.append("/").append(crash_log_filename);
+    const string file_path = main_context.storage_dir + "/" + crash_log_filename;
     const uint64_t timestamp = time_since_epoch();
     const std::string serialized_log = serialize_crash_report(signum, timestamp, signal_name, error_message, error_stacktrace);
 

--- a/features/dd-sdk-android-ndk/src/main/cpp/datadog-ndk.cpp
+++ b/features/dd-sdk-android-ndk/src/main/cpp/datadog-ndk.cpp
@@ -6,10 +6,13 @@
 
 #include "datadog-ndk.h"
 
-#include <fstream>
+#include <cerrno>
+#include <cstdio>
+#include <fcntl.h>
 #include <jni.h>
 #include <pthread.h>
 #include <string>
+#include <unistd.h>
 
 #include "android/log.h"
 #include "datetime-utils.h"
@@ -97,13 +100,34 @@ void write_crash_report(int signum,
     const uint64_t timestamp = time_since_epoch();
     const std::string serialized_log = serialize_crash_report(signum, timestamp, signal_name, error_message, error_stacktrace);
 
-    // write the log in the crash log file
-    ofstream logs_file_output_stream(file_path.c_str(),
-                                     ofstream::out | ofstream::trunc);
-    if (logs_file_output_stream.is_open()) {
-        logs_file_output_stream << serialized_log.c_str();
+    // Atomic write+fsync via temp file: avoids torn/zero-filled crash logs when the
+    // process dies between buffer flush and disk flush.
+    const std::string tmp_path = file_path + ".tmp";
+    const int fd = ::open(tmp_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd >= 0) {
+        const char *data = serialized_log.data();
+        size_t remaining = serialized_log.size();
+        bool write_ok = true;
+        while (remaining > 0) {
+            const ssize_t written = ::write(fd, data, remaining);
+            if (written < 0) {
+                if (errno == EINTR) continue;
+                write_ok = false;
+                break;
+            }
+            data += written;
+            remaining -= static_cast<size_t>(written);
+        }
+        if (write_ok) {
+            ::fsync(fd);
+        }
+        ::close(fd);
+        if (write_ok) {
+            ::rename(tmp_path.c_str(), file_path.c_str());
+        } else {
+            ::unlink(tmp_path.c_str());
+        }
     }
-    logs_file_output_stream.close();
     pthread_mutex_unlock(&handler_mutex);
 }
 


### PR DESCRIPTION
### What does this PR do?

- Switch `write_crash_report` to an atomic write + `fsync` + `rename` pattern, so the NDK `crash_log` file on disk is never observable as zero-filled or torn when the process dies between the buffered write and the kerne's writeback (root cause of the `NumberFormatException`).
- Add a `catch (e: NumberFormatException)` in `NdkCrashLogDeserializer` so corrupt files are handled gracefully.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

