### PR TITLE
RUM-16241: Support model generation from JSON schema when array is top-level element

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/GenerateJsonSchemaTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/GenerateJsonSchemaTask.kt
@@ -128,8 +128,8 @@ abstract class GenerateJsonSchemaTask : DefaultTask() {
         val reader = JsonSchemaReader(inputNameMapping.get(), logger)
         val generator = FileGenerator(outputDir, targetPackageName.get(), logger)
         files.forEach {
-            val type = reader.readSchema(it)
-            generator.generate(type)
+            val root = reader.readSchema(it)
+            generator.generate(root.definition, root.name)
         }
     }
 

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReader.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReader.kt
@@ -24,7 +24,7 @@ class JsonSchemaReader(
 
     // region JsonSchemaReader
 
-    fun readSchema(schemaFile: File): TypeDefinition {
+    fun readSchema(schemaFile: File): RootSchema {
         logger.info("Reading schema ${schemaFile.name}")
         val schema = loadSchema(schemaFile)
         currentFile = schemaFile
@@ -33,7 +33,16 @@ class JsonSchemaReader(
         val typeName = (customName ?: schema.title ?: fileName).toCamelCase()
 
         val rawType = transform(schema, typeName, schemaFile)
-        return sanitize(rawType)
+        val sanitized = sanitize(rawType)
+        // For Class/OneOfClass roots, prefer the type's resolved `name` — it may have been picked up
+        // from a referenced schema's `title` (e.g. when the root is a bare `$ref`) and that's the
+        // expected file name. For types without an embedded name (Array), fall back to typeName.
+        val rootName = when (sanitized) {
+            is TypeDefinition.Class -> sanitized.name
+            is TypeDefinition.OneOfClass -> sanitized.name
+            else -> typeName
+        }
+        return RootSchema(rootName, sanitized)
     }
 
     // endregion
@@ -404,22 +413,33 @@ class JsonSchemaReader(
     }
 
     private fun sanitize(type: TypeDefinition): TypeDefinition {
-        if (type is TypeDefinition.Class) {
-            val names = type.getChildrenTypeNames().distinct().sortedBy { it.first }
-            val duplicates = mutableSetOf<String>()
-
-            names.forEachIndexed { i, n ->
-                if (i > 0) {
-                    if (n.first == names[i - 1].first) {
-                        duplicates.add(n.first)
-                    }
+        return when (type) {
+            is TypeDefinition.Class -> sanitizeClass(type)
+            is TypeDefinition.Array -> {
+                val items = type.items
+                if (items is TypeDefinition.Class) {
+                    type.copy(items = sanitizeClass(items))
+                } else {
+                    type
                 }
             }
-
-            return type.renameRecursive(duplicates, "")
-        } else {
-            return type
+            else -> type
         }
+    }
+
+    private fun sanitizeClass(type: TypeDefinition.Class): TypeDefinition.Class {
+        val names = type.getChildrenTypeNames().distinct().sortedBy { it.first }
+        val duplicates = mutableSetOf<String>()
+
+        names.forEachIndexed { i, n ->
+            if (i > 0) {
+                if (n.first == names[i - 1].first) {
+                    duplicates.add(n.first)
+                }
+            }
+        }
+
+        return type.renameRecursive(duplicates, "") as TypeDefinition.Class
     }
     // endregion
 

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/RootSchema.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/RootSchema.kt
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.jsonschema
+
+/**
+ * The root type read from a JSON schema, paired with the name to use when emitting the Kotlin file.
+ *
+ * The name is external metadata (derived from `inputNameMapping`, the schema's `title`, or the file
+ * name) and is not part of the schema [TypeDefinition] itself. This allows top-level schemas whose
+ * type doesn't carry a name (e.g. [TypeDefinition.Array]) to still be emitted with a chosen class
+ * name.
+ */
+data class RootSchema(
+    val name: String,
+    val definition: TypeDefinition
+)

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/generator/ArrayWrapperClassGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/generator/ArrayWrapperClassGenerator.kt
@@ -1,0 +1,185 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.jsonschema.generator
+
+import com.datadog.gradle.plugin.jsonschema.TypeDefinition
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.LIST
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.SET
+import com.squareup.kotlinpoet.STRING
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.jvm.throws
+
+/**
+ * Generates a wrapper Kotlin class for a JSON schema whose root type is an array. The wrapper holds
+ * the array as a single `items` property and serializes/deserializes directly as a JSON array, not
+ * an object. The array items must be a single object type ([TypeDefinition.Class]); other item
+ * shapes (oneOf/anyOf, primitives) are not supported as top-level arrays.
+ */
+class ArrayWrapperClassGenerator(
+    packageName: String,
+    knownTypes: MutableSet<KotlinTypeWrapper>
+) : TypeSpecGenerator<TypeDefinition.Array>(
+    packageName,
+    knownTypes
+) {
+
+    override fun generate(
+        definition: TypeDefinition.Array,
+        rootTypeName: String
+    ): TypeSpec.Builder {
+        val itemsClass = definition.items
+        check(itemsClass is TypeDefinition.Class) {
+            "Top-level array schema must have items of a single object type, " +
+                "but got ${itemsClass::class.simpleName}. " +
+                "Multiple item types (oneOf/anyOf/primitives) are not supported as top-level arrays."
+        }
+
+        // Registers the items class as a known nested type so FileGenerator's
+        // nested-class loop emits it inside the wrapper.
+        val itemTypeName = itemsClass.asKotlinTypeName(rootTypeName)
+        val collectionTypeName = if (definition.uniqueItems) {
+            SET.parameterizedBy(itemTypeName)
+        } else {
+            LIST.parameterizedBy(itemTypeName)
+        }
+
+        val typeBuilder = TypeSpec.classBuilder(rootTypeName)
+            .addModifiers(KModifier.DATA)
+
+        if (definition.description.isNotBlank()) {
+            typeBuilder.addKdoc(definition.description + "\n")
+        }
+
+        typeBuilder.primaryConstructor(
+            FunSpec.constructorBuilder()
+                .addParameter(ParameterSpec.builder(PROPERTY_ITEMS, collectionTypeName).build())
+                .build()
+        )
+        typeBuilder.addProperty(
+            PropertySpec.builder(PROPERTY_ITEMS, collectionTypeName)
+                .mutable(false)
+                .initializer(PROPERTY_ITEMS)
+                .build()
+        )
+
+        typeBuilder.addFunction(generateToJson())
+        typeBuilder.addType(generateCompanion(definition, rootTypeName))
+
+        return typeBuilder
+    }
+
+    private fun generateToJson(): FunSpec {
+        return FunSpec.builder(Identifier.FUN_TO_JSON)
+            .returns(ClassNameRef.JsonElement)
+            .addStatement(
+                "val %L = %T(%L.size)",
+                Identifier.PARAM_JSON_ARRAY,
+                ClassNameRef.JsonArray,
+                PROPERTY_ITEMS
+            )
+            .addStatement(
+                "%L.forEach { %L.add(it.%L()) }",
+                PROPERTY_ITEMS,
+                Identifier.PARAM_JSON_ARRAY,
+                Identifier.FUN_TO_JSON
+            )
+            .addStatement("return %L", Identifier.PARAM_JSON_ARRAY)
+            .build()
+    }
+
+    private fun generateCompanion(
+        definition: TypeDefinition.Array,
+        rootTypeName: String
+    ): TypeSpec {
+        return TypeSpec.companionObjectBuilder()
+            .addFunction(generateFromJsonString(rootTypeName))
+            .addFunction(generateFromJsonElement(definition, rootTypeName))
+            .build()
+    }
+
+    private fun generateFromJsonString(rootTypeName: String): FunSpec {
+        val returnType = ClassName.bestGuess(rootTypeName)
+        val funBuilder = FunSpec.builder(Identifier.FUN_FROM_JSON)
+            .addAnnotation(AnnotationSpec.builder(JvmStatic::class).build())
+            .returns(returnType)
+
+        funBuilder.throws(ClassNameRef.JsonParseException)
+        funBuilder.addParameter(Identifier.PARAM_JSON_STR, STRING)
+
+        funBuilder.wrapInDeserializerTryCatch(returnType, STRING_DESERIALIZER_EXCEPTIONS) {
+            addStatement(
+                "val %L = %T.parseString(%L).asJsonArray",
+                Identifier.PARAM_JSON_ARRAY,
+                ClassNameRef.JsonParser,
+                Identifier.PARAM_JSON_STR
+            )
+            addStatement(
+                "return %L(%L)",
+                Identifier.FUN_FROM_JSON_ELEMENT,
+                Identifier.PARAM_JSON_ARRAY
+            )
+        }
+
+        return funBuilder.build()
+    }
+
+    private fun generateFromJsonElement(
+        definition: TypeDefinition.Array,
+        rootTypeName: String
+    ): FunSpec {
+        val returnType = ClassName.bestGuess(rootTypeName)
+        val itemTypeName = definition.items.asKotlinTypeName(rootTypeName)
+        val collectionClass = if (definition.uniqueItems) {
+            ClassNameRef.MutableSet
+        } else {
+            ClassNameRef.MutableList
+        }
+
+        val funBuilder = FunSpec.builder(Identifier.FUN_FROM_JSON_ELEMENT)
+            .addAnnotation(AnnotationSpec.builder(JvmStatic::class).build())
+            .returns(returnType)
+
+        funBuilder.throws(ClassNameRef.JsonParseException)
+        funBuilder.addParameter(Identifier.PARAM_JSON_ELEMENT, ClassNameRef.JsonElement)
+
+        funBuilder.wrapInDeserializerTryCatch(returnType, ELEMENT_DESERIALIZER_EXCEPTIONS) {
+            addStatement(
+                "val %L = %L.asJsonArray",
+                Identifier.PARAM_JSON_ARRAY,
+                Identifier.PARAM_JSON_ELEMENT
+            )
+            addStatement(
+                "val %L = %T(%L.size())",
+                Identifier.PARAM_COLLECTION,
+                collectionClass.parameterizedBy(itemTypeName),
+                Identifier.PARAM_JSON_ARRAY
+            )
+            beginControlFlow("%L.forEach", Identifier.PARAM_JSON_ARRAY)
+            addStatement(
+                "%L.add(%T.%L(it.asJsonObject))",
+                Identifier.PARAM_COLLECTION,
+                itemTypeName,
+                Identifier.FUN_FROM_JSON_OBJ
+            )
+            endControlFlow()
+            addStatement("return %L(%L)", rootTypeName, Identifier.PARAM_COLLECTION)
+        }
+
+        return funBuilder.build()
+    }
+
+    companion object {
+        private const val PROPERTY_ITEMS = "items"
+    }
+}

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/generator/ClassJsonElementDeserializerGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/generator/ClassJsonElementDeserializerGenerator.kt
@@ -34,22 +34,10 @@ class ClassJsonElementDeserializerGenerator(
 
         funBuilder.throws(ClassNameRef.JsonParseException)
         funBuilder.addParameter(Identifier.PARAM_JSON_OBJ, ClassNameRef.JsonObject)
-        funBuilder.beginControlFlow("try")
 
-        funBuilder.appendDeserializerFunctionBlock(definition, rootTypeName)
-
-        caughtExceptions.forEach {
-            funBuilder.nextControlFlow(
-                "catch (%L: %T)",
-                Identifier.CAUGHT_EXCEPTION,
-                it
-            )
-            funBuilder.addStatement("throw %T(", ClassNameRef.JsonParseException)
-            funBuilder.addStatement("    \"$PARSE_ERROR_MSG %T\",", returnType)
-            funBuilder.addStatement("    %L", Identifier.CAUGHT_EXCEPTION)
-            funBuilder.addStatement(")")
+        funBuilder.wrapInDeserializerTryCatch(returnType, ELEMENT_DESERIALIZER_EXCEPTIONS) {
+            appendDeserializerFunctionBlock(definition, rootTypeName)
         }
-        funBuilder.endControlFlow()
 
         return funBuilder.build()
     }
@@ -366,14 +354,4 @@ class ClassJsonElementDeserializerGenerator(
     }
 
     // endregion
-
-    companion object {
-        private const val PARSE_ERROR_MSG = "Unable to parse json into type"
-
-        private val caughtExceptions = arrayOf(
-            ClassNameRef.IllegalStateException,
-            ClassNameRef.NumberFormatException,
-            ClassNameRef.NullPointerException
-        )
-    }
 }

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/generator/ClassStringDeserializerGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/generator/ClassStringDeserializerGenerator.kt
@@ -29,37 +29,17 @@ class ClassStringDeserializerGenerator(
 
         funBuilder.throws(ClassNameRef.JsonParseException)
         funBuilder.addParameter(Identifier.PARAM_JSON_STR, STRING)
-        funBuilder.beginControlFlow("try")
 
-        funBuilder.addStatement(
-            "val %L = %T.parseString(%L).asJsonObject",
-            Identifier.PARAM_JSON_OBJ,
-            ClassNameRef.JsonParser,
-            Identifier.PARAM_JSON_STR
-        )
-        funBuilder.addStatement("return %L(%L)", Identifier.FUN_FROM_JSON_OBJ, Identifier.PARAM_JSON_OBJ)
-
-        caughtExceptions.forEach {
-            funBuilder.nextControlFlow(
-                "catch (%L: %T)",
-                Identifier.CAUGHT_EXCEPTION,
-                it
+        funBuilder.wrapInDeserializerTryCatch(returnType, STRING_DESERIALIZER_EXCEPTIONS) {
+            addStatement(
+                "val %L = %T.parseString(%L).asJsonObject",
+                Identifier.PARAM_JSON_OBJ,
+                ClassNameRef.JsonParser,
+                Identifier.PARAM_JSON_STR
             )
-            funBuilder.addStatement("throw %T(", ClassNameRef.JsonParseException)
-            funBuilder.addStatement("    \"$PARSE_ERROR_MSG %T\",", returnType)
-            funBuilder.addStatement("    %L", Identifier.CAUGHT_EXCEPTION)
-            funBuilder.addStatement(")")
+            addStatement("return %L(%L)", Identifier.FUN_FROM_JSON_OBJ, Identifier.PARAM_JSON_OBJ)
         }
-        funBuilder.endControlFlow()
 
         return funBuilder.build()
-    }
-
-    companion object {
-        private const val PARSE_ERROR_MSG = "Unable to parse json into type"
-
-        private val caughtExceptions = arrayOf(
-            ClassNameRef.IllegalStateException
-        )
     }
 }

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/generator/DeserializerHelpers.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/generator/DeserializerHelpers.kt
@@ -1,0 +1,47 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.jsonschema.generator
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FunSpec
+
+internal const val PARSE_ERROR_MSG = "Unable to parse json into type"
+
+internal val STRING_DESERIALIZER_EXCEPTIONS = arrayOf(
+    ClassNameRef.IllegalStateException
+)
+
+internal val ELEMENT_DESERIALIZER_EXCEPTIONS = arrayOf(
+    ClassNameRef.IllegalStateException,
+    ClassNameRef.NumberFormatException,
+    ClassNameRef.NullPointerException
+)
+
+/**
+ * Wraps [body] in a `try` block followed by one `catch` block per entry in [caughtExceptions].
+ * Each catch rethrows as a `JsonParseException` referencing [returnType] and chaining the cause.
+ */
+internal fun FunSpec.Builder.wrapInDeserializerTryCatch(
+    returnType: ClassName,
+    caughtExceptions: Array<ClassName>,
+    body: FunSpec.Builder.() -> Unit
+) {
+    beginControlFlow("try")
+    body()
+    caughtExceptions.forEach { exception ->
+        nextControlFlow(
+            "catch (%L: %T)",
+            Identifier.CAUGHT_EXCEPTION,
+            exception
+        )
+        addStatement("throw %T(", ClassNameRef.JsonParseException)
+        addStatement("    \"$PARSE_ERROR_MSG %T\",", returnType)
+        addStatement("    %L", Identifier.CAUGHT_EXCEPTION)
+        addStatement(")")
+    }
+    endControlFlow()
+}

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/generator/FileGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/generator/FileGenerator.kt
@@ -24,6 +24,7 @@ class FileGenerator(
     private val classGenerator = ClassGenerator(packageName, knownTypes)
     private val enumGenerator = EnumClassGenerator(packageName, knownTypes)
     private val oneOfPrimitiveOptionGenerator = OneOfPrimitiveOptionGenerator(packageName)
+    private val arrayWrapperClassGenerator = ArrayWrapperClassGenerator(packageName, knownTypes)
 
     private val multiClassGenerator = MultiClassGenerator(
         classGenerator = classGenerator,
@@ -35,12 +36,15 @@ class FileGenerator(
     // region FileGenerator
 
     /**
-     * Generate a Kotlin file based on the input schema file
+     * Generate a Kotlin file based on the input schema file.
+     *
+     * @param definition the root [TypeDefinition] read from the schema
+     * @param rootTypeName the name to give the generated top-level Kotlin type
      */
-    fun generate(typeDefinition: TypeDefinition) {
-        logger.info("Generating class for type $typeDefinition with package name $packageName")
+    fun generate(definition: TypeDefinition, rootTypeName: String) {
+        logger.info("Generating class $rootTypeName for type $definition with package name $packageName")
         knownTypes.clear()
-        generateFile(typeDefinition)
+        generateFile(definition, rootTypeName)
     }
 
     // endregion
@@ -58,13 +62,7 @@ class FileGenerator(
     /**
      *  Generate a Kotlin file based on the root schema definition
      */
-    private fun generateFile(definition: TypeDefinition) {
-        val rootTypeName = when (definition) {
-            is TypeDefinition.Class -> definition.name
-            is TypeDefinition.OneOfClass -> definition.name
-            else -> error("Top level type $definition is not supported")
-        }
-
+    private fun generateFile(definition: TypeDefinition, rootTypeName: String) {
         val fileBuilder = FileSpec.builder(packageName, rootTypeName)
 
         knownTypes.add(
@@ -107,6 +105,7 @@ class FileGenerator(
             is TypeDefinition.Class -> classGenerator.generate(definition, rootTypeName)
             is TypeDefinition.Enum -> enumGenerator.generate(definition, rootTypeName)
             is TypeDefinition.OneOfClass -> multiClassGenerator.generate(definition, rootTypeName)
+            is TypeDefinition.Array -> arrayWrapperClassGenerator.generate(definition, rootTypeName)
             else -> throw IllegalArgumentException("Can't generate a file for type $definition")
         }
     }

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReaderTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReaderTest.kt
@@ -17,6 +17,7 @@ import java.io.File
 @RunWith(Parameterized::class)
 class JsonSchemaReaderTest(
     internal val inputSchema: String,
+    internal val expectedName: String,
     internal val outputType: TypeDefinition
 ) {
 
@@ -39,13 +40,14 @@ class JsonSchemaReaderTest(
             NoOpLogger()
         )
 
-        val generatedType = testedReader.readSchema(File(inputPath))
+        val generatedRoot = testedReader.readSchema(File(inputPath))
 
-        assertThat(generatedType)
+        val expectedRoot = RootSchema(expectedName, outputType)
+        assertThat(generatedRoot)
             .overridingErrorMessage(
-                "Expected definition:\n$outputType\nbut was:\n$generatedType"
+                "Expected root schema:\n$expectedRoot\nbut was:\n$generatedRoot"
             )
-            .isEqualTo(outputType)
+            .isEqualTo(expectedRoot)
     }
 
     companion object {
@@ -53,43 +55,45 @@ class JsonSchemaReaderTest(
         @Parameterized.Parameters(name = "{index}: {0}")
         fun data(): Collection<Array<Any>> {
             return listOf(
-                arrayOf("arrays", Article),
-                arrayOf("one_of", Animal),
-                arrayOf("defaults_with_optionals", Bike),
-                arrayOf("nested", Book),
-                arrayOf("additional_props", Comment),
-                arrayOf("additional_props_any", Company),
-                arrayOf("additional_props_merged", AdditionalPropsMerged),
-                arrayOf("additional_props_single_merge", AdditionalPropsSingleMerge),
-                arrayOf("definition_name_conflict", Conflict),
-                arrayOf("root_schema_with_no_type", Country),
-                arrayOf("definition", Customer),
-                arrayOf("definition_with_id", Customer),
-                arrayOf("nested_enum", DateTime),
-                arrayOf("external_description", Delivery),
-                arrayOf("types", Demo),
-                arrayOf("external_description_complex_path", Employee),
-                arrayOf("top_level_definition", Foo),
-                arrayOf("one_of_ref", Household),
-                arrayOf("enum_number", Jacket),
-                arrayOf("constant", Location),
-                arrayOf("read_only", Message),
-                arrayOf("enum_array", Order),
-                arrayOf("description", Opus),
-                arrayOf("one_of_complex", Paper),
-                arrayOf("minimal", Person),
-                arrayOf("required", Product),
-                arrayOf("external_nested_description", Shipping),
-                arrayOf("external_nested_description_properties", Shipping),
-                arrayOf("enum", Style),
-                arrayOf("all_of", User),
-                arrayOf("all_of_merged", UserMerged),
-                arrayOf("constant_number", Version),
-                arrayOf("sets", Video),
-                arrayOf("one_of_nested", WeirdCombo),
-                arrayOf("required_for_other_all_of", RequiredForOtherAllOf),
-                arrayOf("path_array_with_integer", PathArrayWithInteger),
-                arrayOf("path_array_with_number", PathArrayWithNumber)
+                arrayOf("arrays", "Article", Article),
+                arrayOf("one_of", "Animal", Animal),
+                arrayOf("defaults_with_optionals", "Bike", Bike),
+                arrayOf("nested", "Book", Book),
+                arrayOf("additional_props", "Comment", Comment),
+                arrayOf("additional_props_any", "Company", Company),
+                arrayOf("additional_props_merged", "AdditionalPropsMerged", AdditionalPropsMerged),
+                arrayOf("additional_props_single_merge", "AdditionalPropsSingleMerge", AdditionalPropsSingleMerge),
+                arrayOf("definition_name_conflict", "Conflict", Conflict),
+                arrayOf("root_schema_with_no_type", "Country", Country),
+                arrayOf("definition", "Customer", Customer),
+                arrayOf("definition_with_id", "Customer", Customer),
+                arrayOf("nested_enum", "DateTime", DateTime),
+                arrayOf("external_description", "Delivery", Delivery),
+                arrayOf("types", "Demo", Demo),
+                arrayOf("external_description_complex_path", "Employee", Employee),
+                arrayOf("top_level_definition", "Foo", Foo),
+                arrayOf("one_of_ref", "Household", Household),
+                arrayOf("enum_number", "Jacket", Jacket),
+                arrayOf("constant", "Location", Location),
+                arrayOf("read_only", "Message", Message),
+                arrayOf("enum_array", "Order", Order),
+                arrayOf("description", "Opus", Opus),
+                arrayOf("one_of_complex", "Paper", Paper),
+                arrayOf("minimal", "Person", Person),
+                arrayOf("required", "Product", Product),
+                arrayOf("external_nested_description", "Shipping", Shipping),
+                arrayOf("external_nested_description_properties", "Shipping", Shipping),
+                arrayOf("enum", "Style", Style),
+                arrayOf("all_of", "User", User),
+                arrayOf("all_of_merged", "UserMerged", UserMerged),
+                arrayOf("constant_number", "Version", Version),
+                arrayOf("sets", "Video", Video),
+                arrayOf("one_of_nested", "WeirdCombo", WeirdCombo),
+                arrayOf("required_for_other_all_of", "RequiredForOtherAllOf", RequiredForOtherAllOf),
+                arrayOf("path_array_with_integer", "PathArrayWithInteger", PathArrayWithInteger),
+                arrayOf("path_array_with_number", "PathArrayWithNumber", PathArrayWithNumber),
+                arrayOf("top_level_array", "Tasks", Tasks),
+                arrayOf("top_level_unique_array", "TagSet", TagSet)
             )
         }
     }

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/TestDefinitions.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/TestDefinitions.kt
@@ -1112,3 +1112,54 @@ val PathArrayWithNumber = TypeDefinition.Class(
     ),
     required = setOf("path")
 )
+
+val TagSet = TypeDefinition.Array(
+    items = TypeDefinition.Class(
+        name = "Tag",
+        properties = listOf(
+            TypeProperty(
+                name = "name",
+                type = TypeDefinition.Primitive(JsonPrimitiveType.STRING),
+                readOnly = true
+            )
+        ),
+        required = setOf("name")
+    ),
+    uniqueItems = true
+)
+
+val Tasks = TypeDefinition.Array(
+    items = TypeDefinition.Class(
+        name = "Task",
+        properties = listOf(
+            TypeProperty(
+                name = "id",
+                type = TypeDefinition.Primitive(
+                    type = JsonPrimitiveType.STRING,
+                    description = "Task identifier."
+                ),
+                readOnly = true
+            ),
+            TypeProperty(
+                name = "title",
+                type = TypeDefinition.Primitive(
+                    type = JsonPrimitiveType.STRING,
+                    description = "Human-readable task title."
+                ),
+                readOnly = true
+            ),
+            TypeProperty(
+                name = "priority",
+                type = TypeDefinition.Primitive(
+                    type = JsonPrimitiveType.INTEGER,
+                    description = "Optional priority."
+                ),
+                readOnly = true
+            )
+        ),
+        required = setOf("id", "title"),
+        description = "A single task."
+    ),
+    uniqueItems = false,
+    description = "A flat list of tasks."
+)

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/generator/FileGeneratorTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/generator/FileGeneratorTest.kt
@@ -32,6 +32,8 @@ import com.datadog.gradle.plugin.jsonschema.Person
 import com.datadog.gradle.plugin.jsonschema.Product
 import com.datadog.gradle.plugin.jsonschema.Shipping
 import com.datadog.gradle.plugin.jsonschema.Style
+import com.datadog.gradle.plugin.jsonschema.TagSet
+import com.datadog.gradle.plugin.jsonschema.Tasks
 import com.datadog.gradle.plugin.jsonschema.TypeDefinition
 import com.datadog.gradle.plugin.jsonschema.User
 import com.datadog.gradle.plugin.jsonschema.UserMerged
@@ -65,7 +67,7 @@ class FileGeneratorTest(
         val outputPath = clazz.getResource("/output/$outputFile.kt").file
         val testedGenerator = FileGenerator(tempDir, "com.example.model", NoOpLogger())
 
-        testedGenerator.generate(inputType)
+        testedGenerator.generate(inputType, outputFile)
 
         val generatedFile = Files.find(
             Paths.get(tempDir.toURI()),
@@ -132,7 +134,9 @@ class FileGeneratorTest(
                 arrayOf(Video, "Video"),
                 arrayOf(WeirdCombo, "WeirdCombo"),
                 arrayOf(PathArrayWithInteger, "PathArrayWithInteger"),
-                arrayOf(PathArrayWithNumber, "PathArrayWithNumber")
+                arrayOf(PathArrayWithNumber, "PathArrayWithNumber"),
+                arrayOf(Tasks, "Tasks"),
+                arrayOf(TagSet, "TagSet")
             )
         }
     }

--- a/buildSrc/src/test/kotlin/com/example/model/TagSet.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/TagSet.kt
@@ -1,0 +1,119 @@
+package com.example.model
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonParseException
+import com.google.gson.JsonParser
+import java.lang.IllegalStateException
+import java.lang.NullPointerException
+import java.lang.NumberFormatException
+import kotlin.String
+import kotlin.collections.HashSet
+import kotlin.collections.Set
+import kotlin.jvm.JvmStatic
+import kotlin.jvm.Throws
+
+public data class TagSet(
+    public val items: Set<Tag>,
+) {
+    public fun toJson(): JsonElement {
+        val jsonArray = JsonArray(items.size)
+        items.forEach { jsonArray.add(it.toJson()) }
+        return jsonArray
+    }
+
+    public companion object {
+        @JvmStatic
+        @Throws(JsonParseException::class)
+        public fun fromJson(jsonString: String): TagSet {
+            try {
+                val jsonArray = JsonParser.parseString(jsonString).asJsonArray
+                return fromJsonElement(jsonArray)
+            } catch (e: IllegalStateException) {
+                throw JsonParseException(
+                    "Unable to parse json into type TagSet",
+                    e
+                )
+            }
+        }
+
+        @JvmStatic
+        @Throws(JsonParseException::class)
+        public fun fromJsonElement(jsonElement: JsonElement): TagSet {
+            try {
+                val jsonArray = jsonElement.asJsonArray
+                val collection = HashSet<Tag>(jsonArray.size())
+                jsonArray.forEach {
+                    collection.add(Tag.fromJsonObject(it.asJsonObject))
+                }
+                return TagSet(collection)
+            } catch (e: IllegalStateException) {
+                throw JsonParseException(
+                    "Unable to parse json into type TagSet",
+                    e
+                )
+            } catch (e: NumberFormatException) {
+                throw JsonParseException(
+                    "Unable to parse json into type TagSet",
+                    e
+                )
+            } catch (e: NullPointerException) {
+                throw JsonParseException(
+                    "Unable to parse json into type TagSet",
+                    e
+                )
+            }
+        }
+    }
+
+    public data class Tag(
+        public val name: String,
+    ) {
+        public fun toJson(): JsonElement {
+            val json = JsonObject()
+            json.addProperty("name", name)
+            return json
+        }
+
+        public companion object {
+            @JvmStatic
+            @Throws(JsonParseException::class)
+            public fun fromJson(jsonString: String): Tag {
+                try {
+                    val jsonObject = JsonParser.parseString(jsonString).asJsonObject
+                    return fromJsonObject(jsonObject)
+                } catch (e: IllegalStateException) {
+                    throw JsonParseException(
+                        "Unable to parse json into type Tag",
+                        e
+                    )
+                }
+            }
+
+            @JvmStatic
+            @Throws(JsonParseException::class)
+            public fun fromJsonObject(jsonObject: JsonObject): Tag {
+                try {
+                    val name = jsonObject.get("name").asString
+                    return Tag(name)
+                } catch (e: IllegalStateException) {
+                    throw JsonParseException(
+                        "Unable to parse json into type Tag",
+                        e
+                    )
+                } catch (e: NumberFormatException) {
+                    throw JsonParseException(
+                        "Unable to parse json into type Tag",
+                        e
+                    )
+                } catch (e: NullPointerException) {
+                    throw JsonParseException(
+                        "Unable to parse json into type Tag",
+                        e
+                    )
+                }
+            }
+        }
+    }
+}

--- a/buildSrc/src/test/kotlin/com/example/model/Tasks.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Tasks.kt
@@ -1,0 +1,137 @@
+package com.example.model
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonParseException
+import com.google.gson.JsonParser
+import java.lang.IllegalStateException
+import java.lang.NullPointerException
+import java.lang.NumberFormatException
+import kotlin.Long
+import kotlin.String
+import kotlin.collections.ArrayList
+import kotlin.collections.List
+import kotlin.jvm.JvmStatic
+import kotlin.jvm.Throws
+
+/**
+ * A flat list of tasks.
+ */
+public data class Tasks(
+    public val items: List<Task>,
+) {
+    public fun toJson(): JsonElement {
+        val jsonArray = JsonArray(items.size)
+        items.forEach { jsonArray.add(it.toJson()) }
+        return jsonArray
+    }
+
+    public companion object {
+        @JvmStatic
+        @Throws(JsonParseException::class)
+        public fun fromJson(jsonString: String): Tasks {
+            try {
+                val jsonArray = JsonParser.parseString(jsonString).asJsonArray
+                return fromJsonElement(jsonArray)
+            } catch (e: IllegalStateException) {
+                throw JsonParseException(
+                    "Unable to parse json into type Tasks",
+                    e
+                )
+            }
+        }
+
+        @JvmStatic
+        @Throws(JsonParseException::class)
+        public fun fromJsonElement(jsonElement: JsonElement): Tasks {
+            try {
+                val jsonArray = jsonElement.asJsonArray
+                val collection = ArrayList<Task>(jsonArray.size())
+                jsonArray.forEach {
+                    collection.add(Task.fromJsonObject(it.asJsonObject))
+                }
+                return Tasks(collection)
+            } catch (e: IllegalStateException) {
+                throw JsonParseException(
+                    "Unable to parse json into type Tasks",
+                    e
+                )
+            } catch (e: NumberFormatException) {
+                throw JsonParseException(
+                    "Unable to parse json into type Tasks",
+                    e
+                )
+            } catch (e: NullPointerException) {
+                throw JsonParseException(
+                    "Unable to parse json into type Tasks",
+                    e
+                )
+            }
+        }
+    }
+
+    /**
+     * A single task.
+     * @param id Task identifier.
+     * @param title Human-readable task title.
+     * @param priority Optional priority.
+     */
+    public data class Task(
+        public val id: String,
+        public val title: String,
+        public val priority: Long? = null,
+    ) {
+        public fun toJson(): JsonElement {
+            val json = JsonObject()
+            json.addProperty("id", id)
+            json.addProperty("title", title)
+            priority?.let { priorityNonNull ->
+                json.addProperty("priority", priorityNonNull)
+            }
+            return json
+        }
+
+        public companion object {
+            @JvmStatic
+            @Throws(JsonParseException::class)
+            public fun fromJson(jsonString: String): Task {
+                try {
+                    val jsonObject = JsonParser.parseString(jsonString).asJsonObject
+                    return fromJsonObject(jsonObject)
+                } catch (e: IllegalStateException) {
+                    throw JsonParseException(
+                        "Unable to parse json into type Task",
+                        e
+                    )
+                }
+            }
+
+            @JvmStatic
+            @Throws(JsonParseException::class)
+            public fun fromJsonObject(jsonObject: JsonObject): Task {
+                try {
+                    val id = jsonObject.get("id").asString
+                    val title = jsonObject.get("title").asString
+                    val priority = jsonObject.get("priority")?.asLong
+                    return Task(id, title, priority)
+                } catch (e: IllegalStateException) {
+                    throw JsonParseException(
+                        "Unable to parse json into type Task",
+                        e
+                    )
+                } catch (e: NumberFormatException) {
+                    throw JsonParseException(
+                        "Unable to parse json into type Task",
+                        e
+                    )
+                } catch (e: NullPointerException) {
+                    throw JsonParseException(
+                        "Unable to parse json into type Task",
+                        e
+                    )
+                }
+            }
+        }
+    }
+}

--- a/buildSrc/src/test/resources/input/top_level_array.json
+++ b/buildSrc/src/test/resources/input/top_level_array.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Tasks",
+  "description": "A flat list of tasks.",
+  "type": "array",
+  "items": {
+    "$ref": "#/definitions/Task"
+  },
+  "definitions": {
+    "Task": {
+      "type": "object",
+      "description": "A single task.",
+      "required": ["id", "title"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Task identifier.",
+          "readOnly": true
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable task title.",
+          "readOnly": true
+        },
+        "priority": {
+          "type": "integer",
+          "description": "Optional priority.",
+          "readOnly": true
+        }
+      }
+    }
+  }
+}

--- a/buildSrc/src/test/resources/input/top_level_unique_array.json
+++ b/buildSrc/src/test/resources/input/top_level_unique_array.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "TagSet",
+  "type": "array",
+  "uniqueItems": true,
+  "items": {
+    "$ref": "#/definitions/Tag"
+  },
+  "definitions": {
+    "Tag": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "readOnly": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds support of handling array as top-level element of the type definition. It is different from just `Array`, because we need to have a wrapper class to no deal with adding JSON items to the array manually.

The goal is to support schema in https://github.com/DataDog/rum-events-format/pull/387.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

