### PR TITLE
`timeseries` RUM-13949: Add timeseries JSON schemas and regenerate API surface

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -90,8 +90,6 @@ data class com.datadog.android.rum.RumConfiguration
     fun setSlowFramesConfiguration(com.datadog.android.rum.configuration.SlowFramesConfiguration?): Builder
     fun trackAnonymousUser(Boolean): Builder
     fun setAppStartupActivityPredicate(com.datadog.android.rum.startup.AppStartupActivityPredicate): Builder
-    fun enableTimeseries(com.datadog.android.rum.timeseries.TimeseriesConfiguration = TimeseriesConfiguration()): Builder
-    fun disableTimeseries(): Builder
     fun build(): RumConfiguration
 enum com.datadog.android.rum.RumErrorSource
   - NETWORK
@@ -306,14 +304,6 @@ class com.datadog.android.rum.resource.RumResourceInputStream : java.io.InputStr
   override fun close()
 interface com.datadog.android.rum.startup.AppStartupActivityPredicate
   fun shouldTrackStartup(android.app.Activity): Boolean
-class com.datadog.android.rum.timeseries.TimeseriesConfiguration
-  constructor(Int = DEFAULT_BUFFER_SIZE, Long = DEFAULT_INTERVAL_MS, Boolean = false)
-  val bufferSize: Int
-  val intervalMs: Long
-  companion object 
-    const val DEFAULT_BUFFER_SIZE: Int
-    const val DEFAULT_INTERVAL_MS: Long
-    const val MIN_INTERVAL_MS: Long
 open class com.datadog.android.rum.tracking.AcceptAllActivities : ComponentPredicate<android.app.Activity>
   override fun accept(android.app.Activity): Boolean
   override fun getViewName(android.app.Activity): String?

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -90,6 +90,8 @@ data class com.datadog.android.rum.RumConfiguration
     fun setSlowFramesConfiguration(com.datadog.android.rum.configuration.SlowFramesConfiguration?): Builder
     fun trackAnonymousUser(Boolean): Builder
     fun setAppStartupActivityPredicate(com.datadog.android.rum.startup.AppStartupActivityPredicate): Builder
+    fun enableTimeseries(com.datadog.android.rum.timeseries.TimeseriesConfiguration = TimeseriesConfiguration()): Builder
+    fun disableTimeseries(): Builder
     fun build(): RumConfiguration
 enum com.datadog.android.rum.RumErrorSource
   - NETWORK
@@ -304,6 +306,14 @@ class com.datadog.android.rum.resource.RumResourceInputStream : java.io.InputStr
   override fun close()
 interface com.datadog.android.rum.startup.AppStartupActivityPredicate
   fun shouldTrackStartup(android.app.Activity): Boolean
+class com.datadog.android.rum.timeseries.TimeseriesConfiguration
+  constructor(Int = DEFAULT_BUFFER_SIZE, Long = DEFAULT_INTERVAL_MS, Boolean = false)
+  val bufferSize: Int
+  val intervalMs: Long
+  companion object 
+    const val DEFAULT_BUFFER_SIZE: Int
+    const val DEFAULT_INTERVAL_MS: Long
+    const val MIN_INTERVAL_MS: Long
 open class com.datadog.android.rum.tracking.AcceptAllActivities : ComponentPredicate<android.app.Activity>
   override fun accept(android.app.Activity): Boolean
   override fun getViewName(android.app.Activity): String?
@@ -1724,6 +1734,154 @@ data class com.datadog.android.rum.model.ResourceEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): OperationType
+data class com.datadog.android.rum.model.RumTimeseriesCpuEvent
+  constructor(Dd, Application, Session, Source, kotlin.Long, kotlin.String? = null, kotlin.String? = null, Timeseries)
+  val type: kotlin.String
+  fun toJson(): com.google.gson.JsonElement
+  companion object 
+    fun fromJson(kotlin.String): RumTimeseriesCpuEvent
+    fun fromJsonObject(com.google.gson.JsonObject): RumTimeseriesCpuEvent
+  class Dd
+    val formatVersion: kotlin.Long
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Dd
+      fun fromJsonObject(com.google.gson.JsonObject): Dd
+  data class Application
+    constructor(kotlin.String)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Application
+      fun fromJsonObject(com.google.gson.JsonObject): Application
+  data class Session
+    constructor(kotlin.String, Type)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Session
+      fun fromJsonObject(com.google.gson.JsonObject): Session
+  data class Timeseries
+    constructor(kotlin.String, Schema, kotlin.Long, kotlin.Long, kotlin.collections.List<Data>)
+    val name: kotlin.String
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Timeseries
+      fun fromJsonObject(com.google.gson.JsonObject): Timeseries
+  data class Data
+    constructor(kotlin.Long, DataPoint)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Data
+      fun fromJsonObject(com.google.gson.JsonObject): Data
+  data class DataPoint
+    constructor(kotlin.Number)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): DataPoint
+      fun fromJsonObject(com.google.gson.JsonObject): DataPoint
+  enum Source
+    constructor(kotlin.String)
+    - ANDROID
+    - IOS
+    - BROWSER
+    - FLUTTER
+    - REACT_NATIVE
+    - ROKU
+    - UNITY
+    - KOTLIN_MULTIPLATFORM
+    - ELECTRON
+    - RUM_CPP
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Source
+  enum Type
+    constructor(kotlin.String)
+    - USER
+    - SYNTHETICS
+    - CI_TEST
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Type
+  enum Schema
+    constructor(kotlin.String)
+    - OBJECT
+    - DELTA_SCALAR
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Schema
+data class com.datadog.android.rum.model.RumTimeseriesMemoryEvent
+  constructor(Dd, Application, Session, Source, kotlin.Long, kotlin.String? = null, kotlin.String? = null, Timeseries)
+  val type: kotlin.String
+  fun toJson(): com.google.gson.JsonElement
+  companion object 
+    fun fromJson(kotlin.String): RumTimeseriesMemoryEvent
+    fun fromJsonObject(com.google.gson.JsonObject): RumTimeseriesMemoryEvent
+  class Dd
+    val formatVersion: kotlin.Long
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Dd
+      fun fromJsonObject(com.google.gson.JsonObject): Dd
+  data class Application
+    constructor(kotlin.String)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Application
+      fun fromJsonObject(com.google.gson.JsonObject): Application
+  data class Session
+    constructor(kotlin.String, Type)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Session
+      fun fromJsonObject(com.google.gson.JsonObject): Session
+  data class Timeseries
+    constructor(kotlin.String, Schema, kotlin.Long, kotlin.Long, kotlin.collections.List<Data>)
+    val name: kotlin.String
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Timeseries
+      fun fromJsonObject(com.google.gson.JsonObject): Timeseries
+  data class Data
+    constructor(kotlin.Long, DataPoint)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Data
+      fun fromJsonObject(com.google.gson.JsonObject): Data
+  data class DataPoint
+    constructor(kotlin.Number, kotlin.Number)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): DataPoint
+      fun fromJsonObject(com.google.gson.JsonObject): DataPoint
+  enum Source
+    constructor(kotlin.String)
+    - ANDROID
+    - IOS
+    - BROWSER
+    - FLUTTER
+    - REACT_NATIVE
+    - ROKU
+    - UNITY
+    - KOTLIN_MULTIPLATFORM
+    - ELECTRON
+    - RUM_CPP
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Source
+  enum Type
+    constructor(kotlin.String)
+    - USER
+    - SYNTHETICS
+    - CI_TEST
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Type
+  enum Schema
+    constructor(kotlin.String)
+    - OBJECT
+    - DELTA_OBJECT
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Schema
 data class com.datadog.android.rum.model.ViewEvent
   constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ViewEventSession, ViewEventSource? = null, ViewEventView, Usr? = null, Account? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Container? = null, Context? = null, Privacy? = null)
   val type: kotlin.String

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -1724,13 +1724,13 @@ data class com.datadog.android.rum.model.ResourceEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): OperationType
-data class com.datadog.android.rum.model.RumTimeseriesCpuEvent
+data class com.datadog.android.rum.model.TimeseriesCpuEvent
   constructor(Dd, Application, Session, Source, kotlin.Long, kotlin.String? = null, kotlin.String? = null, Timeseries)
   val type: kotlin.String
   fun toJson(): com.google.gson.JsonElement
   companion object 
-    fun fromJson(kotlin.String): RumTimeseriesCpuEvent
-    fun fromJsonObject(com.google.gson.JsonObject): RumTimeseriesCpuEvent
+    fun fromJson(kotlin.String): TimeseriesCpuEvent
+    fun fromJsonObject(com.google.gson.JsonObject): TimeseriesCpuEvent
   class Dd
     val formatVersion: kotlin.Long
     fun toJson(): com.google.gson.JsonElement
@@ -1798,13 +1798,13 @@ data class com.datadog.android.rum.model.RumTimeseriesCpuEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Schema
-data class com.datadog.android.rum.model.RumTimeseriesMemoryEvent
+data class com.datadog.android.rum.model.TimeseriesMemoryEvent
   constructor(Dd, Application, Session, Source, kotlin.Long, kotlin.String? = null, kotlin.String? = null, Timeseries)
   val type: kotlin.String
   fun toJson(): com.google.gson.JsonElement
   companion object 
-    fun fromJson(kotlin.String): RumTimeseriesMemoryEvent
-    fun fromJsonObject(com.google.gson.JsonObject): RumTimeseriesMemoryEvent
+    fun fromJson(kotlin.String): TimeseriesMemoryEvent
+    fun fromJsonObject(com.google.gson.JsonObject): TimeseriesMemoryEvent
   class Dd
     val formatVersion: kotlin.Long
     fun toJson(): com.google.gson.JsonElement

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -105,7 +105,11 @@ public final class com/datadog/android/rum/RumConfiguration$Builder {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun build ()Lcom/datadog/android/rum/RumConfiguration;
 	public final fun collectAccessibility (Z)Lcom/datadog/android/rum/RumConfiguration$Builder;
+	public final fun disableTimeseries ()Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun disableUserInteractionTracking ()Lcom/datadog/android/rum/RumConfiguration$Builder;
+	public final fun enableTimeseries ()Lcom/datadog/android/rum/RumConfiguration$Builder;
+	public final fun enableTimeseries (Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration;)Lcom/datadog/android/rum/RumConfiguration$Builder;
+	public static synthetic fun enableTimeseries$default (Lcom/datadog/android/rum/RumConfiguration$Builder;Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration;ILjava/lang/Object;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setActionEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setAppStartupActivityPredicate (Lcom/datadog/android/rum/startup/AppStartupActivityPredicate;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setErrorEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
@@ -4896,6 +4900,436 @@ public final class com/datadog/android/rum/model/ResourceEvent$Worker$Companion 
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ResourceEvent$Worker;
 }
 
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent {
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Companion;
+	public fun <init> (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;
+	public final fun component2 ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;
+	public final fun component3 ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;
+	public final fun component4 ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+	public final fun component5 ()J
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;
+	public final fun copy (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent;
+	public final fun getApplication ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;
+	public final fun getDate ()J
+	public final fun getDd ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;
+	public final fun getService ()Ljava/lang/String;
+	public final fun getSession ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;
+	public final fun getSource ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+	public final fun getTimeseries ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getVersion ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Application {
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;
+	public final fun getId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Application$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Data {
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Data$Companion;
+	public fun <init> (JLcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;)V
+	public final fun component1 ()J
+	public final fun component2 ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;
+	public final fun copy (JLcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Data;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Data;JLcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Data;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Data;
+	public final fun getDataPoint ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;
+	public final fun getTimestamp ()J
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Data$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Data;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Data;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint {
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint$Companion;
+	public fun <init> (Ljava/lang/Number;)V
+	public final fun component1 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/Number;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;
+	public final fun getCpuUsage ()Ljava/lang/Number;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd {
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd$Companion;
+	public fun <init> ()V
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;
+	public final fun getFormatVersion ()J
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema$Companion;
+	public static final field DELTA_SCALAR Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;
+	public static final field OBJECT Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;
+	public static fun values ()[Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Session {
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session$Companion;
+	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getType ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Session$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Source : java/lang/Enum {
+	public static final field ANDROID Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+	public static final field BROWSER Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source$Companion;
+	public static final field ELECTRON Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+	public static final field FLUTTER Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+	public static final field IOS Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+	public static final field KOTLIN_MULTIPLATFORM Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+	public static final field REACT_NATIVE Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+	public static final field ROKU Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+	public static final field RUM_CPP Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+	public static final field UNITY Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+	public static fun values ()[Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Source$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries {
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries$Companion;
+	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;JJLjava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;JJLjava/util/List;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;JJLjava/util/List;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;
+	public final fun getData ()Ljava/util/List;
+	public final fun getEnd ()J
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSchema ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;
+	public final fun getStart ()J
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Type : java/lang/Enum {
+	public static final field CI_TEST Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type$Companion;
+	public static final field SYNTHETICS Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
+	public static final field USER Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
+	public static fun values ()[Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Type$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent {
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Companion;
+	public fun <init> (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;
+	public final fun component2 ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;
+	public final fun component3 ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;
+	public final fun component4 ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+	public final fun component5 ()J
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;
+	public final fun copy (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent;
+	public final fun getApplication ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;
+	public final fun getDate ()J
+	public final fun getDd ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;
+	public final fun getService ()Ljava/lang/String;
+	public final fun getSession ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;
+	public final fun getSource ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+	public final fun getTimeseries ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getVersion ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application {
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;
+	public final fun getId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data {
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data$Companion;
+	public fun <init> (JLcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;)V
+	public final fun component1 ()J
+	public final fun component2 ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;
+	public final fun copy (JLcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data;JLcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data;
+	public final fun getDataPoint ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;
+	public final fun getTimestamp ()J
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint {
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint$Companion;
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;)V
+	public final fun component1 ()Ljava/lang/Number;
+	public final fun component2 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;
+	public final fun getMemoryMax ()Ljava/lang/Number;
+	public final fun getMemoryPercent ()Ljava/lang/Number;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd {
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd$Companion;
+	public fun <init> ()V
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;
+	public final fun getFormatVersion ()J
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema$Companion;
+	public static final field DELTA_OBJECT Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;
+	public static final field OBJECT Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;
+	public static fun values ()[Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session {
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session$Companion;
+	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getType ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source : java/lang/Enum {
+	public static final field ANDROID Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+	public static final field BROWSER Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source$Companion;
+	public static final field ELECTRON Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+	public static final field FLUTTER Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+	public static final field IOS Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+	public static final field KOTLIN_MULTIPLATFORM Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+	public static final field REACT_NATIVE Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+	public static final field ROKU Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+	public static final field RUM_CPP Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+	public static final field UNITY Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+	public static fun values ()[Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries {
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries$Companion;
+	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;JJLjava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;JJLjava/util/List;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;JJLjava/util/List;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;
+	public final fun getData ()Ljava/util/List;
+	public final fun getEnd ()J
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSchema ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;
+	public final fun getStart ()J
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type : java/lang/Enum {
+	public static final field CI_TEST Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
+	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type$Companion;
+	public static final field SYNTHETICS Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
+	public static final field USER Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
+	public static fun values ()[Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
+}
+
+public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
+}
+
 public final class com/datadog/android/rum/model/ViewEvent {
 	public static final field Companion Lcom/datadog/android/rum/model/ViewEvent$Companion;
 	public fun <init> (JLcom/datadog/android/rum/model/ViewEvent$Application;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/ViewEvent$ViewEventSession;Lcom/datadog/android/rum/model/ViewEvent$ViewEventSource;Lcom/datadog/android/rum/model/ViewEvent$ViewEventView;Lcom/datadog/android/rum/model/ViewEvent$Usr;Lcom/datadog/android/rum/model/ViewEvent$Account;Lcom/datadog/android/rum/model/ViewEvent$Connectivity;Lcom/datadog/android/rum/model/ViewEvent$Display;Lcom/datadog/android/rum/model/ViewEvent$Synthetics;Lcom/datadog/android/rum/model/ViewEvent$CiTest;Lcom/datadog/android/rum/model/ViewEvent$Os;Lcom/datadog/android/rum/model/ViewEvent$Device;Lcom/datadog/android/rum/model/ViewEvent$Dd;Lcom/datadog/android/rum/model/ViewEvent$Context;Lcom/datadog/android/rum/model/ViewEvent$Container;Lcom/datadog/android/rum/model/ViewEvent$Context;Lcom/datadog/android/rum/model/ViewEvent$Privacy;)V
@@ -8197,6 +8631,24 @@ public final class com/datadog/android/rum/resource/RumResourceInputStream : jav
 
 public abstract interface class com/datadog/android/rum/startup/AppStartupActivityPredicate {
 	public abstract fun shouldTrackStartup (Landroid/app/Activity;)Z
+}
+
+public final class com/datadog/android/rum/timeseries/TimeseriesConfiguration {
+	public static final field Companion Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration$Companion;
+	public static final field DEFAULT_BUFFER_SIZE I
+	public static final field DEFAULT_INTERVAL_MS J
+	public static final field MIN_INTERVAL_MS J
+	public fun <init> ()V
+	public fun <init> (I)V
+	public fun <init> (IJ)V
+	public fun <init> (IJZ)V
+	public synthetic fun <init> (IJZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getBufferSize ()I
+	public final fun getCollectInBackground ()Z
+	public final fun getIntervalMs ()J
+}
+
+public final class com/datadog/android/rum/timeseries/TimeseriesConfiguration$Companion {
 }
 
 public class com/datadog/android/rum/tracking/AcceptAllActivities : com/datadog/android/rum/tracking/ComponentPredicate {

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -105,11 +105,7 @@ public final class com/datadog/android/rum/RumConfiguration$Builder {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun build ()Lcom/datadog/android/rum/RumConfiguration;
 	public final fun collectAccessibility (Z)Lcom/datadog/android/rum/RumConfiguration$Builder;
-	public final fun disableTimeseries ()Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun disableUserInteractionTracking ()Lcom/datadog/android/rum/RumConfiguration$Builder;
-	public final fun enableTimeseries ()Lcom/datadog/android/rum/RumConfiguration$Builder;
-	public final fun enableTimeseries (Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration;)Lcom/datadog/android/rum/RumConfiguration$Builder;
-	public static synthetic fun enableTimeseries$default (Lcom/datadog/android/rum/RumConfiguration$Builder;Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration;ILjava/lang/Object;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setActionEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setAppStartupActivityPredicate (Lcom/datadog/android/rum/startup/AppStartupActivityPredicate;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setErrorEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
@@ -8631,24 +8627,6 @@ public final class com/datadog/android/rum/resource/RumResourceInputStream : jav
 
 public abstract interface class com/datadog/android/rum/startup/AppStartupActivityPredicate {
 	public abstract fun shouldTrackStartup (Landroid/app/Activity;)Z
-}
-
-public final class com/datadog/android/rum/timeseries/TimeseriesConfiguration {
-	public static final field Companion Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration$Companion;
-	public static final field DEFAULT_BUFFER_SIZE I
-	public static final field DEFAULT_INTERVAL_MS J
-	public static final field MIN_INTERVAL_MS J
-	public fun <init> ()V
-	public fun <init> (I)V
-	public fun <init> (IJ)V
-	public fun <init> (IJZ)V
-	public synthetic fun <init> (IJZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getBufferSize ()I
-	public final fun getCollectInBackground ()Z
-	public final fun getIntervalMs ()J
-}
-
-public final class com/datadog/android/rum/timeseries/TimeseriesConfiguration$Companion {
 }
 
 public class com/datadog/android/rum/tracking/AcceptAllActivities : com/datadog/android/rum/tracking/ComponentPredicate {

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -4896,30 +4896,30 @@ public final class com/datadog/android/rum/model/ResourceEvent$Worker$Companion 
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ResourceEvent$Worker;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent {
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Companion;
-	public fun <init> (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;)V
-	public synthetic fun <init> (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;
-	public final fun component2 ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;
-	public final fun component3 ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;
-	public final fun component4 ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent {
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Companion;
+	public fun <init> (Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Dd;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Application;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Session;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Timeseries;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Dd;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Application;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Session;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Timeseries;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Dd;
+	public final fun component2 ()Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Application;
+	public final fun component3 ()Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Session;
+	public final fun component4 ()Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
 	public final fun component5 ()J
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;
-	public final fun copy (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent;
+	public final fun component8 ()Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Timeseries;
+	public final fun copy (Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Dd;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Application;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Session;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Timeseries;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/TimeseriesCpuEvent;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Dd;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Application;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Session;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Timeseries;ILjava/lang/Object;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent;
-	public final fun getApplication ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent;
+	public final fun getApplication ()Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Application;
 	public final fun getDate ()J
-	public final fun getDd ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;
+	public final fun getDd ()Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Dd;
 	public final fun getService ()Ljava/lang/String;
-	public final fun getSession ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;
-	public final fun getSource ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
-	public final fun getTimeseries ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;
+	public final fun getSession ()Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Session;
+	public final fun getSource ()Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
+	public final fun getTimeseries ()Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Timeseries;
 	public final fun getType ()Ljava/lang/String;
 	public final fun getVersion ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -4927,213 +4927,213 @@ public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Application {
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application$Companion;
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Application {
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Application$Companion;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;
+	public final fun copy (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Application;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Application;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Application;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Application;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Application;
 	public final fun getId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Application$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Application;
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Application$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Application;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Application;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent;
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Data {
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Data$Companion;
-	public fun <init> (JLcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;)V
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Data {
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Data$Companion;
+	public fun <init> (JLcom/datadog/android/rum/model/TimeseriesCpuEvent$DataPoint;)V
 	public final fun component1 ()J
-	public final fun component2 ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;
-	public final fun copy (JLcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Data;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Data;JLcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Data;
+	public final fun component2 ()Lcom/datadog/android/rum/model/TimeseriesCpuEvent$DataPoint;
+	public final fun copy (JLcom/datadog/android/rum/model/TimeseriesCpuEvent$DataPoint;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Data;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Data;JLcom/datadog/android/rum/model/TimeseriesCpuEvent$DataPoint;ILjava/lang/Object;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Data;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Data;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Data;
-	public final fun getDataPoint ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Data;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Data;
+	public final fun getDataPoint ()Lcom/datadog/android/rum/model/TimeseriesCpuEvent$DataPoint;
 	public final fun getTimestamp ()J
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Data$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Data;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Data;
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Data$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Data;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Data;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint {
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint$Companion;
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$DataPoint {
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesCpuEvent$DataPoint$Companion;
 	public fun <init> (Ljava/lang/Number;)V
 	public final fun component1 ()Ljava/lang/Number;
-	public final fun copy (Ljava/lang/Number;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;
+	public final fun copy (Ljava/lang/Number;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$DataPoint;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/TimeseriesCpuEvent$DataPoint;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$DataPoint;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$DataPoint;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$DataPoint;
 	public final fun getCpuUsage ()Ljava/lang/Number;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$DataPoint;
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$DataPoint$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$DataPoint;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$DataPoint;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd {
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd$Companion;
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Dd {
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Dd$Companion;
 	public fun <init> ()V
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Dd;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Dd;
 	public final fun getFormatVersion ()J
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Dd;
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Dd$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Dd;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Dd;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema : java/lang/Enum {
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema$Companion;
-	public static final field DELTA_SCALAR Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;
-	public static final field OBJECT Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Schema : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Schema$Companion;
+	public static final field DELTA_SCALAR Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Schema;
+	public static final field OBJECT Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Schema;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Schema;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
-	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;
-	public static fun values ()[Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Schema;
+	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Schema;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Schema$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Schema;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Session {
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session$Companion;
-	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;)V
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Session {
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Session$Companion;
+	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Type;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
-	public final fun copy (Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;
+	public final fun component2 ()Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Type;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Type;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Session;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Session;Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Type;ILjava/lang/Object;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Session;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Session;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Session;
 	public final fun getId ()Ljava/lang/String;
-	public final fun getType ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
+	public final fun getType ()Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Type;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Session$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Session;
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Session$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Session;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Session;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Source : java/lang/Enum {
-	public static final field ANDROID Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
-	public static final field BROWSER Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source$Companion;
-	public static final field ELECTRON Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
-	public static final field FLUTTER Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
-	public static final field IOS Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
-	public static final field KOTLIN_MULTIPLATFORM Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
-	public static final field REACT_NATIVE Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
-	public static final field ROKU Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
-	public static final field RUM_CPP Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
-	public static final field UNITY Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Source : java/lang/Enum {
+	public static final field ANDROID Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
+	public static final field BROWSER Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source$Companion;
+	public static final field ELECTRON Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
+	public static final field FLUTTER Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
+	public static final field IOS Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
+	public static final field KOTLIN_MULTIPLATFORM Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
+	public static final field REACT_NATIVE Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
+	public static final field ROKU Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
+	public static final field RUM_CPP Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
+	public static final field UNITY Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
-	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
-	public static fun values ()[Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
+	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Source$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Source;
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Source$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries {
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries$Companion;
-	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;JJLjava/util/List;)V
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Timeseries {
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Timeseries$Companion;
+	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Schema;JJLjava/util/List;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;
+	public final fun component2 ()Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Schema;
 	public final fun component3 ()J
 	public final fun component4 ()J
 	public final fun component5 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;JJLjava/util/List;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;JJLjava/util/List;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Schema;JJLjava/util/List;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Timeseries;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Timeseries;Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Schema;JJLjava/util/List;ILjava/lang/Object;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Timeseries;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Timeseries;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Timeseries;
 	public final fun getData ()Ljava/util/List;
 	public final fun getEnd ()J
 	public final fun getId ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
-	public final fun getSchema ()Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Schema;
+	public final fun getSchema ()Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Schema;
 	public final fun getStart ()J
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Timeseries;
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Timeseries$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Timeseries;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Timeseries;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Type : java/lang/Enum {
-	public static final field CI_TEST Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type$Companion;
-	public static final field SYNTHETICS Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
-	public static final field USER Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Type : java/lang/Enum {
+	public static final field CI_TEST Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Type;
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Type$Companion;
+	public static final field SYNTHETICS Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Type;
+	public static final field USER Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Type;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Type;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
-	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
-	public static fun values ()[Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Type;
+	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Type;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesCpuEvent$Type$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesCpuEvent$Type;
+public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Type$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Type;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent {
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Companion;
-	public fun <init> (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;)V
-	public synthetic fun <init> (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;
-	public final fun component2 ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;
-	public final fun component3 ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;
-	public final fun component4 ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent {
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Companion;
+	public fun <init> (Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Dd;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Application;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Session;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Timeseries;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Dd;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Application;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Session;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Timeseries;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Dd;
+	public final fun component2 ()Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Application;
+	public final fun component3 ()Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Session;
+	public final fun component4 ()Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
 	public final fun component5 ()J
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Ljava/lang/String;
-	public final fun component8 ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;
-	public final fun copy (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent;
+	public final fun component8 ()Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Timeseries;
+	public final fun copy (Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Dd;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Application;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Session;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Timeseries;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/TimeseriesMemoryEvent;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Dd;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Application;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Session;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;JLjava/lang/String;Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Timeseries;ILjava/lang/Object;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent;
-	public final fun getApplication ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent;
+	public final fun getApplication ()Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Application;
 	public final fun getDate ()J
-	public final fun getDd ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;
+	public final fun getDd ()Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Dd;
 	public final fun getService ()Ljava/lang/String;
-	public final fun getSession ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;
-	public final fun getSource ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
-	public final fun getTimeseries ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;
+	public final fun getSession ()Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Session;
+	public final fun getSource ()Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
+	public final fun getTimeseries ()Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Timeseries;
 	public final fun getType ()Ljava/lang/String;
 	public final fun getVersion ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -5141,63 +5141,63 @@ public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application {
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application$Companion;
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Application {
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Application$Companion;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;
+	public final fun copy (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Application;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Application;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Application;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Application;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Application;
 	public final fun getId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Application;
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Application$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Application;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Application;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent;
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data {
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data$Companion;
-	public fun <init> (JLcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;)V
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Data {
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Data$Companion;
+	public fun <init> (JLcom/datadog/android/rum/model/TimeseriesMemoryEvent$DataPoint;)V
 	public final fun component1 ()J
-	public final fun component2 ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;
-	public final fun copy (JLcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data;JLcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data;
+	public final fun component2 ()Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$DataPoint;
+	public final fun copy (JLcom/datadog/android/rum/model/TimeseriesMemoryEvent$DataPoint;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Data;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Data;JLcom/datadog/android/rum/model/TimeseriesMemoryEvent$DataPoint;ILjava/lang/Object;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Data;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data;
-	public final fun getDataPoint ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Data;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Data;
+	public final fun getDataPoint ()Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$DataPoint;
 	public final fun getTimestamp ()J
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Data;
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Data$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Data;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Data;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint {
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint$Companion;
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$DataPoint {
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$DataPoint$Companion;
 	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;)V
 	public final fun component1 ()Ljava/lang/Number;
 	public final fun component2 ()Ljava/lang/Number;
-	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$DataPoint;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$DataPoint;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$DataPoint;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$DataPoint;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$DataPoint;
 	public final fun getMemoryMax ()Ljava/lang/Number;
 	public final fun getMemoryPercent ()Ljava/lang/Number;
 	public fun hashCode ()I
@@ -5205,125 +5205,125 @@ public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPo
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$DataPoint;
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$DataPoint$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$DataPoint;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$DataPoint;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd {
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd$Companion;
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Dd {
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Dd$Companion;
 	public fun <init> ()V
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Dd;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Dd;
 	public final fun getFormatVersion ()J
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Dd;
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Dd$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Dd;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Dd;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema : java/lang/Enum {
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema$Companion;
-	public static final field DELTA_OBJECT Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;
-	public static final field OBJECT Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Schema : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Schema$Companion;
+	public static final field DELTA_OBJECT Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Schema;
+	public static final field OBJECT Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Schema;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Schema;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
-	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;
-	public static fun values ()[Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Schema;
+	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Schema;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Schema$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Schema;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session {
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session$Companion;
-	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;)V
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Session {
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Session$Companion;
+	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Type;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
-	public final fun copy (Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;
+	public final fun component2 ()Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Type;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Type;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Session;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Session;Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Type;ILjava/lang/Object;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Session;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Session;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Session;
 	public final fun getId ()Ljava/lang/String;
-	public final fun getType ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
+	public final fun getType ()Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Type;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Session;
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Session$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Session;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Session;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source : java/lang/Enum {
-	public static final field ANDROID Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
-	public static final field BROWSER Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source$Companion;
-	public static final field ELECTRON Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
-	public static final field FLUTTER Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
-	public static final field IOS Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
-	public static final field KOTLIN_MULTIPLATFORM Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
-	public static final field REACT_NATIVE Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
-	public static final field ROKU Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
-	public static final field RUM_CPP Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
-	public static final field UNITY Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Source : java/lang/Enum {
+	public static final field ANDROID Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
+	public static final field BROWSER Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source$Companion;
+	public static final field ELECTRON Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
+	public static final field FLUTTER Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
+	public static final field IOS Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
+	public static final field KOTLIN_MULTIPLATFORM Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
+	public static final field REACT_NATIVE Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
+	public static final field ROKU Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
+	public static final field RUM_CPP Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
+	public static final field UNITY Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
-	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
-	public static fun values ()[Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
+	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Source;
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Source$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries {
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries$Companion;
-	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;JJLjava/util/List;)V
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Timeseries {
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Timeseries$Companion;
+	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Schema;JJLjava/util/List;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;
+	public final fun component2 ()Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Schema;
 	public final fun component3 ()J
 	public final fun component4 ()J
 	public final fun component5 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;JJLjava/util/List;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;Ljava/lang/String;Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;JJLjava/util/List;ILjava/lang/Object;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Schema;JJLjava/util/List;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Timeseries;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Timeseries;Ljava/lang/String;Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Schema;JJLjava/util/List;ILjava/lang/Object;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Timeseries;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Timeseries;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Timeseries;
 	public final fun getData ()Ljava/util/List;
 	public final fun getEnd ()J
 	public final fun getId ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
-	public final fun getSchema ()Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Schema;
+	public final fun getSchema ()Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Schema;
 	public final fun getStart ()J
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Timeseries;
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Timeseries$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Timeseries;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Timeseries;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type : java/lang/Enum {
-	public static final field CI_TEST Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
-	public static final field Companion Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type$Companion;
-	public static final field SYNTHETICS Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
-	public static final field USER Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Type : java/lang/Enum {
+	public static final field CI_TEST Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Type;
+	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Type$Companion;
+	public static final field SYNTHETICS Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Type;
+	public static final field USER Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Type;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Type;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
-	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
-	public static fun values ()[Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Type;
+	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Type;
 }
 
-public final class com/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/RumTimeseriesMemoryEvent$Type;
+public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Type$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Type;
 }
 
 public final class com/datadog/android/rum/model/ViewEvent {

--- a/features/dd-sdk-android-rum/generate_rum_models.gradle.kts
+++ b/features/dd-sdk-android-rum/generate_rum_models.gradle.kts
@@ -28,6 +28,8 @@ createJsonModelsGenerationTask("generateRumModelsFromJson") {
         "view-schema.json" to "ViewEvent",
         "long_task-schema.json" to "LongTaskEvent",
         "vital-app-launch-schema.json" to "VitalAppLaunchEvent",
-        "vital-operation-step-schema.json" to "VitalOperationStepEvent"
+        "vital-operation-step-schema.json" to "VitalOperationStepEvent",
+        "timeseries-memory-schema.json" to "RumTimeseriesMemoryEvent",
+        "timeseries-cpu-schema.json" to "RumTimeseriesCpuEvent"
     )
 }

--- a/features/dd-sdk-android-rum/generate_rum_models.gradle.kts
+++ b/features/dd-sdk-android-rum/generate_rum_models.gradle.kts
@@ -29,7 +29,7 @@ createJsonModelsGenerationTask("generateRumModelsFromJson") {
         "long_task-schema.json" to "LongTaskEvent",
         "vital-app-launch-schema.json" to "VitalAppLaunchEvent",
         "vital-operation-step-schema.json" to "VitalOperationStepEvent",
-        "timeseries-memory-schema.json" to "RumTimeseriesMemoryEvent",
-        "timeseries-cpu-schema.json" to "RumTimeseriesCpuEvent"
+        "timeseries-memory-schema.json" to "TimeseriesMemoryEvent",
+        "timeseries-cpu-schema.json" to "TimeseriesCpuEvent"
     )
 }

--- a/features/dd-sdk-android-rum/src/main/json/rum/timeseries-cpu-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/timeseries-cpu-schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/timeseries-cpu-schema.json",
+  "title": "RumTimeseriesCpuEvent",
+  "type": "object",
+  "description": "Schema for a CPU timeseries event.",
+  "required": ["_dd", "application", "date", "session", "source", "timeseries", "type"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "RUM event type",
+      "const": "timeseries",
+      "readOnly": true
+    },
+    "_dd": {
+      "type": "object",
+      "description": "Internal properties",
+      "required": ["format_version"],
+      "properties": {
+        "format_version": {
+          "type": "integer",
+          "const": 2,
+          "description": "Version of the RUM event format",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "application": {
+      "type": "object",
+      "description": "Application properties",
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "UUID of the application",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "session": {
+      "type": "object",
+      "description": "Session properties",
+      "required": ["id", "type"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "UUID of the session",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the session",
+          "enum": ["user", "synthetics", "ci_test"],
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "source": {
+      "type": "string",
+      "description": "The source of this event",
+      "enum": [
+        "android",
+        "ios",
+        "browser",
+        "flutter",
+        "react-native",
+        "roku",
+        "unity",
+        "kotlin-multiplatform",
+        "electron",
+        "rum-cpp"
+      ],
+      "readOnly": true
+    },
+    "date": {
+      "type": "integer",
+      "description": "Start of the event in ms from epoch",
+      "minimum": 0,
+      "readOnly": true
+    },
+    "service": {
+      "type": "string",
+      "description": "The service name for this application"
+    },
+    "version": {
+      "type": "string",
+      "description": "The version for this application"
+    },
+    "timeseries": {
+      "type": "object",
+      "description": "CPU timeseries properties",
+      "required": ["id", "name", "schema", "start", "end", "data"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "UUID of the timeseries batch",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name identifying the timeseries metric",
+          "const": "cpu",
+          "readOnly": true
+        },
+        "schema": {
+          "type": "string",
+          "description": "Wire-shape discriminator for the data field",
+          "enum": ["object", "delta-scalar"],
+          "readOnly": true
+        },
+        "start": {
+          "type": "integer",
+          "description": "Timestamp of the first sample in nanoseconds from epoch",
+          "readOnly": true
+        },
+        "end": {
+          "type": "integer",
+          "description": "Timestamp of the last sample in nanoseconds from epoch",
+          "readOnly": true
+        },
+        "data": {
+          "type": "array",
+          "description": "Array of CPU data points",
+          "items": {
+            "type": "object",
+            "description": "A single CPU data point",
+            "required": ["timestamp", "data_point"],
+            "properties": {
+              "timestamp": {
+                "type": "integer",
+                "description": "Sample timestamp in nanoseconds from epoch",
+                "readOnly": true
+              },
+              "data_point": {
+                "type": "object",
+                "description": "CPU measurements for this sample",
+                "required": ["cpu_usage"],
+                "properties": {
+                  "cpu_usage": {
+                    "type": "number",
+                    "description": "CPU usage as a percentage (0.0 to 100.0)",
+                    "readOnly": true
+                  }
+                },
+                "readOnly": true
+              }
+            },
+            "readOnly": true
+          },
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    }
+  }
+}

--- a/features/dd-sdk-android-rum/src/main/json/rum/timeseries-memory-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/timeseries-memory-schema.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "rum/timeseries-memory-schema.json",
+  "title": "RumTimeseriesMemoryEvent",
+  "type": "object",
+  "description": "Schema for a memory timeseries event.",
+  "required": ["_dd", "application", "date", "session", "source", "timeseries", "type"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "RUM event type",
+      "const": "timeseries",
+      "readOnly": true
+    },
+    "_dd": {
+      "type": "object",
+      "description": "Internal properties",
+      "required": ["format_version"],
+      "properties": {
+        "format_version": {
+          "type": "integer",
+          "const": 2,
+          "description": "Version of the RUM event format",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "application": {
+      "type": "object",
+      "description": "Application properties",
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "UUID of the application",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "session": {
+      "type": "object",
+      "description": "Session properties",
+      "required": ["id", "type"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "UUID of the session",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the session",
+          "enum": ["user", "synthetics", "ci_test"],
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    },
+    "source": {
+      "type": "string",
+      "description": "The source of this event",
+      "enum": [
+        "android",
+        "ios",
+        "browser",
+        "flutter",
+        "react-native",
+        "roku",
+        "unity",
+        "kotlin-multiplatform",
+        "electron",
+        "rum-cpp"
+      ],
+      "readOnly": true
+    },
+    "date": {
+      "type": "integer",
+      "description": "Start of the event in ms from epoch",
+      "minimum": 0,
+      "readOnly": true
+    },
+    "service": {
+      "type": "string",
+      "description": "The service name for this application"
+    },
+    "version": {
+      "type": "string",
+      "description": "The version for this application"
+    },
+    "timeseries": {
+      "type": "object",
+      "description": "Memory timeseries properties",
+      "required": ["id", "name", "schema", "start", "end", "data"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "UUID of the timeseries batch",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name identifying the timeseries metric",
+          "const": "memory",
+          "readOnly": true
+        },
+        "schema": {
+          "type": "string",
+          "description": "Wire-shape discriminator for the data field",
+          "enum": ["object", "delta-object"],
+          "readOnly": true
+        },
+        "start": {
+          "type": "integer",
+          "description": "Timestamp of the first sample in nanoseconds from epoch",
+          "readOnly": true
+        },
+        "end": {
+          "type": "integer",
+          "description": "Timestamp of the last sample in nanoseconds from epoch",
+          "readOnly": true
+        },
+        "data": {
+          "type": "array",
+          "description": "Array of memory data points",
+          "items": {
+            "type": "object",
+            "description": "A single memory data point",
+            "required": ["timestamp", "data_point"],
+            "properties": {
+              "timestamp": {
+                "type": "integer",
+                "description": "Sample timestamp in nanoseconds from epoch",
+                "readOnly": true
+              },
+              "data_point": {
+                "type": "object",
+                "description": "Memory measurements for this sample",
+                "required": ["memory_max", "memory_percent"],
+                "properties": {
+                  "memory_max": {
+                    "type": "number",
+                    "description": "Physical memory footprint of the process in bytes",
+                    "readOnly": true
+                  },
+                  "memory_percent": {
+                    "type": "number",
+                    "description": "Memory footprint as a percentage of total device RAM",
+                    "readOnly": true
+                  }
+                },
+                "readOnly": true
+              }
+            },
+            "readOnly": true
+          },
+          "readOnly": true
+        }
+      },
+      "readOnly": true
+    }
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Adds JSON schemas for the CPU and memory timeseries event types (`timeseries-cpu-schema.json`, `timeseries-memory-schema.json`), registers them in the model-generation Gradle task, and updates the generated `api/apiSurface` and `api/dd-sdk-android-rum.api` files to reflect the new `RumTimeseriesCpuEvent`, `RumTimeseriesMemoryEvent`, and `TimeseriesConfiguration` public surface.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

