### PR TITLE
`timeseries` [4/6] RUM-13949 Add memory timeseries serializer and session factory

### DIFF
--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -548,7 +548,6 @@ datadog:
       - "java.util.concurrent.ExecutorService.shutdown()"
       - "java.util.concurrent.ExecutorService.shutdownNow()"
       - "java.util.concurrent.Executors.newSingleThreadExecutor()"
-      - "java.util.concurrent.Executors.newSingleThreadScheduledExecutor(java.util.concurrent.ThreadFactory?)"
       - "java.util.concurrent.LinkedBlockingDeque.constructor()"
       - "java.util.concurrent.LinkedBlockingQueue.constructor()"
       - "java.util.concurrent.LinkedBlockingQueue.toArray()"

--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -548,6 +548,7 @@ datadog:
       - "java.util.concurrent.ExecutorService.shutdown()"
       - "java.util.concurrent.ExecutorService.shutdownNow()"
       - "java.util.concurrent.Executors.newSingleThreadExecutor()"
+      - "java.util.concurrent.Executors.newSingleThreadScheduledExecutor(java.util.concurrent.ThreadFactory?)"
       - "java.util.concurrent.LinkedBlockingDeque.constructor()"
       - "java.util.concurrent.LinkedBlockingQueue.constructor()"
       - "java.util.concurrent.LinkedBlockingQueue.toArray()"

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -305,10 +305,11 @@ class com.datadog.android.rum.resource.RumResourceInputStream : java.io.InputStr
 interface com.datadog.android.rum.startup.AppStartupActivityPredicate
   fun shouldTrackStartup(android.app.Activity): Boolean
 class com.datadog.android.rum.timeseries.TimeseriesConfiguration
-  constructor(Int = DEFAULT_BUFFER_SIZE, Long = DEFAULT_INTERVAL_MS, Boolean = false)
-  val bufferSize: Int
-  val intervalMs: Long
-  val collectInBackground: Boolean
+  class Builder
+    fun setBufferSize(Int): Builder
+    fun setIntervalMs(Long): Builder
+    fun setCollectInBackground(Boolean): Builder
+    fun build(): TimeseriesConfiguration
   companion object 
     const val DEFAULT_BUFFER_SIZE: Int
     const val DEFAULT_INTERVAL_MS: Long

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -304,6 +304,14 @@ class com.datadog.android.rum.resource.RumResourceInputStream : java.io.InputStr
   override fun close()
 interface com.datadog.android.rum.startup.AppStartupActivityPredicate
   fun shouldTrackStartup(android.app.Activity): Boolean
+class com.datadog.android.rum.timeseries.TimeseriesConfiguration
+  constructor(Int = DEFAULT_BUFFER_SIZE, Long = DEFAULT_INTERVAL_MS, Boolean = false)
+  val bufferSize: Int
+  val intervalMs: Long
+  companion object 
+    const val DEFAULT_BUFFER_SIZE: Int
+    const val DEFAULT_INTERVAL_MS: Long
+    const val MIN_INTERVAL_MS: Long
 open class com.datadog.android.rum.tracking.AcceptAllActivities : ComponentPredicate<android.app.Activity>
   override fun accept(android.app.Activity): Boolean
   override fun getViewName(android.app.Activity): String?

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -308,6 +308,7 @@ class com.datadog.android.rum.timeseries.TimeseriesConfiguration
   constructor(Int = DEFAULT_BUFFER_SIZE, Long = DEFAULT_INTERVAL_MS, Boolean = false)
   val bufferSize: Int
   val intervalMs: Long
+  val collectInBackground: Boolean
   companion object 
     const val DEFAULT_BUFFER_SIZE: Int
     const val DEFAULT_INTERVAL_MS: Long

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -8637,6 +8637,24 @@ public abstract interface class com/datadog/android/rum/startup/AppStartupActivi
 	public abstract fun shouldTrackStartup (Landroid/app/Activity;)Z
 }
 
+public final class com/datadog/android/rum/timeseries/TimeseriesConfiguration {
+	public static final field Companion Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration$Companion;
+	public static final field DEFAULT_BUFFER_SIZE I
+	public static final field DEFAULT_INTERVAL_MS J
+	public static final field MIN_INTERVAL_MS J
+	public fun <init> ()V
+	public fun <init> (I)V
+	public fun <init> (IJ)V
+	public fun <init> (IJZ)V
+	public synthetic fun <init> (IJZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getBufferSize ()I
+	public final fun getCollectInBackground ()Z
+	public final fun getIntervalMs ()J
+}
+
+public final class com/datadog/android/rum/timeseries/TimeseriesConfiguration$Companion {
+}
+
 public class com/datadog/android/rum/tracking/AcceptAllActivities : com/datadog/android/rum/tracking/ComponentPredicate {
 	public fun <init> ()V
 	public fun accept (Landroid/app/Activity;)Z

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -8642,14 +8642,14 @@ public final class com/datadog/android/rum/timeseries/TimeseriesConfiguration {
 	public static final field DEFAULT_BUFFER_SIZE I
 	public static final field DEFAULT_INTERVAL_MS J
 	public static final field MIN_INTERVAL_MS J
+}
+
+public final class com/datadog/android/rum/timeseries/TimeseriesConfiguration$Builder {
 	public fun <init> ()V
-	public fun <init> (I)V
-	public fun <init> (IJ)V
-	public fun <init> (IJZ)V
-	public synthetic fun <init> (IJZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getBufferSize ()I
-	public final fun getCollectInBackground ()Z
-	public final fun getIntervalMs ()J
+	public final fun build ()Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration;
+	public final fun setBufferSize (I)Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration$Builder;
+	public final fun setCollectInBackground (Z)Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration$Builder;
+	public final fun setIntervalMs (J)Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration$Builder;
 }
 
 public final class com/datadog/android/rum/timeseries/TimeseriesConfiguration$Companion {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/serializer/MemoryEventSerializer.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/serializer/MemoryEventSerializer.kt
@@ -16,6 +16,7 @@ import com.datadog.android.rum.internal.toTimeseriesMemorySessionType
 import com.datadog.android.rum.model.TimeseriesMemoryEvent
 import com.google.gson.JsonObject
 import java.util.UUID
+import kotlin.math.pow
 
 internal class MemoryEventSerializer(
     private val sessionId: String,
@@ -23,7 +24,8 @@ internal class MemoryEventSerializer(
     private val sessionType: RumSessionType,
     private val totalRamBytes: Long,
     private val timeProvider: TimeProvider,
-    private val useDeltaCompression: Boolean = false
+    private val useDeltaCompression: Boolean = false,
+    private val precision: Int = DeltaCompression.PRECISION
 ) : JsonSerializer<Double> {
 
     override fun serialize(dataPoints: List<DataPoint<Double>>): JsonObject? {
@@ -75,18 +77,19 @@ internal class MemoryEventSerializer(
     private fun encodeDelta(data: List<TimeseriesMemoryEvent.Data>): JsonObject? {
         if (data.size <= 1) return null
 
+        val scale = 10.0.pow(precision.toDouble()).toLong()
         val ts = data.mapToDeltaCompressed { it.timestamp }
 
         val memoryMaxArray = data.mapToDeltaCompressed {
-            roundToLongSafely(it.dataPoint.memoryMax.toDouble())
+            roundToLongSafely(it.dataPoint.memoryMax.toDouble(), scale = scale)
         }
 
         val memoryPercentArray = data.mapToDeltaCompressed {
-            roundToLongSafely(it.dataPoint.memoryPercent.toDouble())
+            roundToLongSafely(it.dataPoint.memoryPercent.toDouble(), scale = scale)
         }
 
         return JsonObject().apply {
-            addProperty("precision", DeltaCompression.PRECISION)
+            addProperty("precision", precision)
             addProperty("resolution", RESOLUTION_NS)
             add("ts", ts)
             add("memory_max", memoryMaxArray)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/serializer/MemoryEventSerializer.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/serializer/MemoryEventSerializer.kt
@@ -1,0 +1,99 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.timeseries.serializer
+
+import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.rum.RumSessionType
+import com.datadog.android.rum.internal.timeseries.DataPoint
+import com.datadog.android.rum.internal.timeseries.DeltaCompression
+import com.datadog.android.rum.internal.timeseries.DeltaCompression.mapToDeltaCompressed
+import com.datadog.android.rum.internal.timeseries.DeltaCompression.roundToLongSafely
+import com.datadog.android.rum.internal.toTimeseriesMemorySessionType
+import com.datadog.android.rum.model.TimeseriesMemoryEvent
+import com.google.gson.JsonObject
+import java.util.UUID
+
+internal class MemoryEventSerializer(
+    private val sessionId: String,
+    private val applicationId: String,
+    private val sessionType: RumSessionType,
+    private val totalRamBytes: Long,
+    private val timeProvider: TimeProvider,
+    private val useDeltaCompression: Boolean = false
+) : JsonSerializer<Double> {
+
+    override fun serialize(dataPoints: List<DataPoint<Double>>): JsonObject? {
+        if (totalRamBytes <= 0L || dataPoints.isEmpty()) return null
+        val data = dataPoints.map { sample ->
+            val memoryPercent = sample.value / totalRamBytes * PERCENT_FACTOR
+            TimeseriesMemoryEvent.Data(
+                timestamp = sample.timestampNs,
+                dataPoint = TimeseriesMemoryEvent.DataPoint(sample.value, memoryPercent)
+            )
+        }
+        val start = data.firstOrNull()?.timestamp ?: 0L
+        val end = data.lastOrNull()?.timestamp ?: 0L
+        val deltaEncoded = if (useDeltaCompression) encodeDelta(data) else null
+        val schema = if (deltaEncoded != null) {
+            TimeseriesMemoryEvent.Schema.DELTA_OBJECT
+        } else {
+            TimeseriesMemoryEvent.Schema.OBJECT
+        }
+        val json = TimeseriesMemoryEvent(
+            dd = TimeseriesMemoryEvent.Dd(),
+            application = TimeseriesMemoryEvent.Application(id = applicationId),
+            session = TimeseriesMemoryEvent.Session(
+                id = sessionId,
+                type = sessionType.toTimeseriesMemorySessionType()
+            ),
+            source = TimeseriesMemoryEvent.Source.ANDROID,
+            date = timeProvider.getDeviceTimestampMillis(),
+            service = null,
+            version = null,
+            timeseries = TimeseriesMemoryEvent.Timeseries(
+                id = UUID.randomUUID().toString(),
+                schema = schema,
+                start = start,
+                end = end,
+                data = data
+            )
+        ).toJson() as JsonObject
+        if (deltaEncoded != null) {
+            val timeseriesJson = json.getAsJsonObject("timeseries")
+            timeseriesJson.remove("data")
+            timeseriesJson.add("data", deltaEncoded)
+        }
+        return json
+    }
+
+    private fun encodeDelta(data: List<TimeseriesMemoryEvent.Data>): JsonObject? {
+        if (data.size <= 1) return null
+
+        val ts = data.mapToDeltaCompressed { it.timestamp }
+
+        val memoryMaxArray = data.mapToDeltaCompressed {
+            roundToLongSafely(it.dataPoint.memoryMax.toDouble())
+        }
+
+        val memoryPercentArray = data.mapToDeltaCompressed {
+            roundToLongSafely(it.dataPoint.memoryPercent.toDouble())
+        }
+
+        return JsonObject().apply {
+            addProperty("precision", DeltaCompression.PRECISION)
+            addProperty("resolution", RESOLUTION_NS)
+            add("ts", ts)
+            add("memory_max", memoryMaxArray)
+            add("memory_percent", memoryPercentArray)
+        }
+    }
+
+    companion object {
+        private const val PERCENT_FACTOR = 100.0
+        private const val RESOLUTION_NS = "ns"
+    }
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/serializer/MemoryEventSerializer.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/serializer/MemoryEventSerializer.kt
@@ -61,11 +61,13 @@ internal class MemoryEventSerializer(
                 end = end,
                 data = data
             )
-        ).toJson() as JsonObject
+        ).toJson() as? JsonObject
+
         if (deltaEncoded != null) {
-            val timeseriesJson = json.getAsJsonObject("timeseries")
-            timeseriesJson.remove("data")
-            timeseriesJson.add("data", deltaEncoded)
+            json?.getAsJsonObject("timeseries")?.apply {
+                remove("data")
+                add("data", deltaEncoded)
+            }
         }
         return json
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfiguration.kt
@@ -1,0 +1,55 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.android.rum.timeseries
+
+import com.datadog.android.rum.ExperimentalRumApi
+import com.datadog.android.rum.timeseries.TimeseriesConfiguration.Companion.DEFAULT_BUFFER_SIZE
+import com.datadog.android.rum.timeseries.TimeseriesConfiguration.Companion.DEFAULT_INTERVAL_MS
+import com.datadog.android.rum.timeseries.TimeseriesConfiguration.Companion.MIN_INTERVAL_MS
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+
+/**
+ * Configuration for memory and CPU timeseries collection.
+ *
+ * @param bufferSize Number of samples accumulated per pipeline before sending a batch event.
+ *                   Must be > 0; out-of-range values fall back to [DEFAULT_BUFFER_SIZE].
+ *                   Defaults to [DEFAULT_BUFFER_SIZE] (≈30 seconds at the default 1 s interval).
+ * @param intervalMs Sampling interval in milliseconds. Must be ≥ [MIN_INTERVAL_MS];
+ *                   out-of-range values fall back to [DEFAULT_INTERVAL_MS].
+ *                   Defaults to [DEFAULT_INTERVAL_MS].
+ * @param collectInBackground Whether to keep sampling timeseries when the app is in background.
+ *                            Defaults to `false`.
+ */
+
+class TimeseriesConfiguration
+@JvmOverloads @ExperimentalRumApi
+constructor(
+    bufferSize: Int = DEFAULT_BUFFER_SIZE,
+    intervalMs: Long = DEFAULT_INTERVAL_MS,
+    val collectInBackground: Boolean = false
+) {
+    val bufferSize: Int = if (bufferSize > 0) bufferSize else DEFAULT_BUFFER_SIZE
+    val intervalMs: Long = if (intervalMs >= MIN_INTERVAL_MS) intervalMs else DEFAULT_INTERVAL_MS
+
+    internal val executorFactory: () -> ScheduledExecutorService = {
+        Executors.newSingleThreadScheduledExecutor { runnable ->
+            @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
+            Thread(runnable, "datadog-timeseries").apply { isDaemon = true }
+        }
+    }
+
+    companion object {
+        /** Default number of samples to accumulate before emitting a timeseries event. */
+        const val DEFAULT_BUFFER_SIZE: Int = 30
+
+        /** Default sampling interval in milliseconds. */
+        const val DEFAULT_INTERVAL_MS: Long = 1000L
+
+        /** Minimum allowed sampling interval in milliseconds. */
+        const val MIN_INTERVAL_MS: Long = 100L
+    }
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfiguration.kt
@@ -7,33 +7,65 @@ package com.datadog.android.rum.timeseries
 
 import androidx.annotation.IntRange
 import com.datadog.android.rum.ExperimentalRumApi
-import com.datadog.android.rum.timeseries.TimeseriesConfiguration.Companion.DEFAULT_BUFFER_SIZE
-import com.datadog.android.rum.timeseries.TimeseriesConfiguration.Companion.DEFAULT_INTERVAL_MS
-import com.datadog.android.rum.timeseries.TimeseriesConfiguration.Companion.MIN_INTERVAL_MS
 
 /**
  * Configuration for memory and CPU timeseries collection.
  *
- * @param bufferSize Number of samples accumulated per pipeline before sending a batch event.
- *                   Must be > 0; out-of-range values fall back to [DEFAULT_BUFFER_SIZE].
- *                   Defaults to [DEFAULT_BUFFER_SIZE] (≈30 seconds at the default 1 s interval).
- * @param intervalMs Sampling interval in milliseconds. Must be ≥ [MIN_INTERVAL_MS];
- *                   out-of-range values fall back to [DEFAULT_INTERVAL_MS].
- *                   Defaults to [DEFAULT_INTERVAL_MS].
- * @param collectInBackground Whether to keep sampling timeseries when the app is in background.
- *                            Defaults to `false`.
+ * Use [Builder] to create an instance.
  */
-
-class TimeseriesConfiguration
-@JvmOverloads @ExperimentalRumApi
-constructor(
-    @IntRange(from = 1, to = Int.MAX_VALUE.toLong()) bufferSize: Int = DEFAULT_BUFFER_SIZE,
-    @IntRange(from = MIN_INTERVAL_MS, to = Long.MAX_VALUE) intervalMs: Long = DEFAULT_INTERVAL_MS,
-    collectInBackground: Boolean = false
+class TimeseriesConfiguration internal constructor(
+    internal val bufferSize: Int,
+    internal val intervalMs: Long,
+    internal val collectInBackground: Boolean
 ) {
-    val bufferSize: Int = if (bufferSize > 0) bufferSize else DEFAULT_BUFFER_SIZE
-    val intervalMs: Long = if (intervalMs >= MIN_INTERVAL_MS) intervalMs else DEFAULT_INTERVAL_MS
-    val collectInBackground: Boolean = collectInBackground
+
+    /**
+     * A Builder for [TimeseriesConfiguration].
+     */
+    @ExperimentalRumApi
+    class Builder {
+
+        private var bufferSize: Int = DEFAULT_BUFFER_SIZE
+        private var intervalMs: Long = DEFAULT_INTERVAL_MS
+        private var collectInBackground: Boolean = false
+
+        /**
+         * Sets the number of samples accumulated per pipeline before sending a batch event.
+         * Must be > 0; out-of-range values fall back to [DEFAULT_BUFFER_SIZE].
+         * Defaults to [DEFAULT_BUFFER_SIZE] (≈30 seconds at the default 1 s interval).
+         */
+        fun setBufferSize(
+            @IntRange(from = 1, to = Int.MAX_VALUE.toLong()) bufferSize: Int
+        ): Builder = apply {
+            this.bufferSize = if (bufferSize > 0) bufferSize else DEFAULT_BUFFER_SIZE
+        }
+
+        /**
+         * Sets the sampling interval in milliseconds.
+         * Must be ≥ [MIN_INTERVAL_MS]; out-of-range values fall back to [DEFAULT_INTERVAL_MS].
+         * Defaults to [DEFAULT_INTERVAL_MS].
+         */
+        fun setIntervalMs(
+            @IntRange(from = MIN_INTERVAL_MS, to = Long.MAX_VALUE) intervalMs: Long
+        ): Builder = apply {
+            this.intervalMs = if (intervalMs >= MIN_INTERVAL_MS) intervalMs else DEFAULT_INTERVAL_MS
+        }
+
+        /**
+         * Sets whether to keep sampling timeseries when the app is in background.
+         * Defaults to `false`.
+         */
+        fun setCollectInBackground(collectInBackground: Boolean): Builder = apply {
+            this.collectInBackground = collectInBackground
+        }
+
+        /** Builds a [TimeseriesConfiguration] from the current builder state. */
+        fun build(): TimeseriesConfiguration = TimeseriesConfiguration(
+            bufferSize = bufferSize,
+            intervalMs = intervalMs,
+            collectInBackground = collectInBackground
+        )
+    }
 
     companion object {
         /** Default number of samples to accumulate before emitting a timeseries event. */

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfiguration.kt
@@ -5,12 +5,11 @@
  */
 package com.datadog.android.rum.timeseries
 
+import androidx.annotation.IntRange
 import com.datadog.android.rum.ExperimentalRumApi
 import com.datadog.android.rum.timeseries.TimeseriesConfiguration.Companion.DEFAULT_BUFFER_SIZE
 import com.datadog.android.rum.timeseries.TimeseriesConfiguration.Companion.DEFAULT_INTERVAL_MS
 import com.datadog.android.rum.timeseries.TimeseriesConfiguration.Companion.MIN_INTERVAL_MS
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
 
 /**
  * Configuration for memory and CPU timeseries collection.
@@ -28,19 +27,13 @@ import java.util.concurrent.ScheduledExecutorService
 class TimeseriesConfiguration
 @JvmOverloads @ExperimentalRumApi
 constructor(
-    bufferSize: Int = DEFAULT_BUFFER_SIZE,
-    intervalMs: Long = DEFAULT_INTERVAL_MS,
-    val collectInBackground: Boolean = false
+    @IntRange(from = 1, to = Int.MAX_VALUE.toLong()) bufferSize: Int = DEFAULT_BUFFER_SIZE,
+    @IntRange(from = MIN_INTERVAL_MS, to = Long.MAX_VALUE) intervalMs: Long = DEFAULT_INTERVAL_MS,
+    collectInBackground: Boolean = false
 ) {
     val bufferSize: Int = if (bufferSize > 0) bufferSize else DEFAULT_BUFFER_SIZE
     val intervalMs: Long = if (intervalMs >= MIN_INTERVAL_MS) intervalMs else DEFAULT_INTERVAL_MS
-
-    internal val executorFactory: () -> ScheduledExecutorService = {
-        Executors.newSingleThreadScheduledExecutor { runnable ->
-            @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
-            Thread(runnable, "datadog-timeseries").apply { isDaemon = true }
-        }
-    }
+    val collectInBackground: Boolean = collectInBackground
 
     companion object {
         /** Default number of samples to accumulate before emitting a timeseries event. */

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/serializer/MemoryEventSerializerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/serializer/MemoryEventSerializerTest.kt
@@ -21,6 +21,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Offset
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
@@ -129,14 +130,15 @@ internal class MemoryEventSerializerTest {
         )
 
         // When
-        val json = testedSerializer().serialize(samples) ?: error(NON_NULL_JSON_ERROR)
+        val result = testedSerializer().serialize(samples)
 
         // Then
+        val json = checkNotNull(result)
         val timeseries = json.getAsJsonObject(KEY_TIMESERIES)
         assertThat(timeseries.get(KEY_SCHEMA).asString).isEqualTo(VALUE_SCHEMA_OBJECT)
         assertThat(timeseries.get(KEY_START).asLong).isEqualTo(fakeTs)
         assertThat(timeseries.get(KEY_END).asLong).isEqualTo(fakeTs + 1L)
-        UUID.fromString(timeseries.get(KEY_ID).asString)
+        assertDoesNotThrow { UUID.fromString(timeseries.get(KEY_ID).asString) }
 
         val parsed = TimeseriesMemoryEvent.fromJsonObject(json)
         assertThat(parsed.timeseries.data).hasSize(2)
@@ -152,11 +154,11 @@ internal class MemoryEventSerializerTest {
         @LongForgery(min = 1L) fakeTs: Long
     ) {
         // When
-        val json = testedSerializer(sessionType = RumSessionType.SYNTHETICS)
+        val result = testedSerializer(sessionType = RumSessionType.SYNTHETICS)
             .serialize(listOf(DataPoint(fakeTs, fakeMemory), DataPoint(fakeTs + 1L, fakeMemory)))
-            ?: error(NON_NULL_JSON_ERROR)
 
         // Then
+        val json = checkNotNull(result)
         assertThat(json.getAsJsonObject(KEY_SESSION).get(KEY_TYPE).asString).isEqualTo(VALUE_TYPE_SYNTHETICS)
     }
 
@@ -179,9 +181,10 @@ internal class MemoryEventSerializerTest {
         )
 
         // When
-        val json = testedSerializer(useDeltaCompression = true).serialize(samples) ?: error(NON_NULL_JSON_ERROR)
+        val result = testedSerializer(useDeltaCompression = true).serialize(samples)
 
         // Then
+        val json = checkNotNull(result)
         val timeseries = json.getAsJsonObject(KEY_TIMESERIES)
         assertThat(timeseries.get(KEY_SCHEMA).asString).isEqualTo(VALUE_SCHEMA_DELTA_OBJECT)
         val data = timeseries.get(KEY_DATA).asJsonObject
@@ -214,11 +217,11 @@ internal class MemoryEventSerializerTest {
         @LongForgery(min = 1L) fakeTs: Long
     ) {
         // When
-        val json = testedSerializer(useDeltaCompression = true)
+        val result = testedSerializer(useDeltaCompression = true)
             .serialize(listOf(DataPoint(fakeTs, fakeMemory)))
-            ?: error(NON_NULL_JSON_ERROR)
 
         // Then
+        val json = checkNotNull(result)
         val timeseries = json.getAsJsonObject(KEY_TIMESERIES)
         assertThat(timeseries.get(KEY_SCHEMA).asString).isEqualTo(VALUE_SCHEMA_OBJECT)
         assertThat(timeseries.get(KEY_DATA).isJsonArray).isTrue()
@@ -248,7 +251,5 @@ internal class MemoryEventSerializerTest {
         private const val VALUE_SCHEMA_DELTA_OBJECT: String = "delta-object"
         private const val VALUE_TYPE_SYNTHETICS: String = "synthetics"
         private const val VALUE_RESOLUTION_NS: String = "ns"
-
-        private const val NON_NULL_JSON_ERROR: String = "expected non-null json"
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/serializer/MemoryEventSerializerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/serializer/MemoryEventSerializerTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.rum.internal.timeseries.DataPoint
 import com.datadog.android.rum.model.TimeseriesMemoryEvent
 import com.datadog.android.rum.utils.forge.Configurator
 import fr.xgouchet.elmyr.annotation.DoubleForgery
+import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -29,6 +30,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.util.UUID
+import kotlin.math.pow
 import kotlin.math.roundToLong
 
 @Extensions(
@@ -54,24 +56,35 @@ internal class MemoryEventSerializerTest {
     @LongForgery(min = 1L)
     var fakeNowMs: Long = 0L
 
+    @IntForgery(min = 2, max = 9)
+    var fakePrecision: Int = 0
+
+    val fakeScale: Long get() = 10.0.pow(fakePrecision.toDouble()).toLong()
+
     @BeforeEach
     fun `set up`() {
         whenever(mockTimeProvider.getDeviceTimestampMillis()) doReturn fakeNowMs
     }
 
+    private fun testedSerializer(
+        useDeltaCompression: Boolean = false,
+        sessionType: RumSessionType = RumSessionType.USER,
+        totalRamBytes: Long = fakeTotalRamBytes,
+        precision: Int = fakePrecision
+    ) = MemoryEventSerializer(
+        sessionId = fakeSessionId,
+        applicationId = fakeApplicationId,
+        sessionType = sessionType,
+        totalRamBytes = totalRamBytes,
+        timeProvider = mockTimeProvider,
+        useDeltaCompression = useDeltaCompression,
+        precision = precision
+    )
+
     @Test
     fun `M return null W serialize() { empty input }`() {
-        // Given
-        val testedSerializer = MemoryEventSerializer(
-            sessionId = fakeSessionId,
-            applicationId = fakeApplicationId,
-            sessionType = RumSessionType.USER,
-            totalRamBytes = fakeTotalRamBytes,
-            timeProvider = mockTimeProvider
-        )
-
         // When
-        val result = testedSerializer.serialize(emptyList())
+        val result = testedSerializer().serialize(emptyList())
 
         // Then
         assertThat(result).isNull()
@@ -82,17 +95,9 @@ internal class MemoryEventSerializerTest {
         @DoubleForgery(min = 1.0) fakeMemory: Double,
         @LongForgery(min = 1L) fakeTs: Long
     ) {
-        // Given
-        val testedSerializer = MemoryEventSerializer(
-            sessionId = fakeSessionId,
-            applicationId = fakeApplicationId,
-            sessionType = RumSessionType.USER,
-            totalRamBytes = 0L,
-            timeProvider = mockTimeProvider
-        )
-
         // When
-        val result = testedSerializer.serialize(listOf(DataPoint(fakeTs, fakeMemory)))
+        val result = testedSerializer(totalRamBytes = 0L)
+            .serialize(listOf(DataPoint(fakeTs, fakeMemory)))
 
         // Then
         assertThat(result).isNull()
@@ -104,17 +109,9 @@ internal class MemoryEventSerializerTest {
         @DoubleForgery(min = 1.0) fakeMemory: Double,
         @LongForgery(min = 1L) fakeTs: Long
     ) {
-        // Given
-        val testedSerializer = MemoryEventSerializer(
-            sessionId = fakeSessionId,
-            applicationId = fakeApplicationId,
-            sessionType = RumSessionType.USER,
-            totalRamBytes = fakeNegativeRam,
-            timeProvider = mockTimeProvider
-        )
-
         // When
-        val result = testedSerializer.serialize(listOf(DataPoint(fakeTs, fakeMemory)))
+        val result = testedSerializer(totalRamBytes = fakeNegativeRam)
+            .serialize(listOf(DataPoint(fakeTs, fakeMemory)))
 
         // Then
         assertThat(result).isNull()
@@ -126,21 +123,13 @@ internal class MemoryEventSerializerTest {
         @LongForgery(min = 1L) fakeTs: Long
     ) {
         // Given
-        val testedSerializer = MemoryEventSerializer(
-            sessionId = fakeSessionId,
-            applicationId = fakeApplicationId,
-            sessionType = RumSessionType.USER,
-            totalRamBytes = fakeTotalRamBytes,
-            timeProvider = mockTimeProvider,
-            useDeltaCompression = false
-        )
         val samples = listOf(
             DataPoint(fakeTs, fakeMemory),
             DataPoint(fakeTs + 1L, fakeMemory + 1.0)
         )
 
         // When
-        val json = testedSerializer.serialize(samples) ?: error(NON_NULL_JSON_ERROR)
+        val json = testedSerializer().serialize(samples) ?: error(NON_NULL_JSON_ERROR)
 
         // Then
         val timeseries = json.getAsJsonObject(KEY_TIMESERIES)
@@ -162,19 +151,10 @@ internal class MemoryEventSerializerTest {
         @DoubleForgery(min = 1.0) fakeMemory: Double,
         @LongForgery(min = 1L) fakeTs: Long
     ) {
-        // Given
-        val testedSerializer = MemoryEventSerializer(
-            sessionId = fakeSessionId,
-            applicationId = fakeApplicationId,
-            sessionType = RumSessionType.SYNTHETICS,
-            totalRamBytes = fakeTotalRamBytes,
-            timeProvider = mockTimeProvider
-        )
-
         // When
-        val json = testedSerializer.serialize(
-            listOf(DataPoint(fakeTs, fakeMemory), DataPoint(fakeTs + 1L, fakeMemory))
-        ) ?: error(NON_NULL_JSON_ERROR)
+        val json = testedSerializer(sessionType = RumSessionType.SYNTHETICS)
+            .serialize(listOf(DataPoint(fakeTs, fakeMemory), DataPoint(fakeTs + 1L, fakeMemory)))
+            ?: error(NON_NULL_JSON_ERROR)
 
         // Then
         assertThat(json.getAsJsonObject(KEY_SESSION).get(KEY_TYPE).asString).isEqualTo(VALUE_TYPE_SYNTHETICS)
@@ -189,15 +169,6 @@ internal class MemoryEventSerializerTest {
         @LongForgery(min = 1L, max = 1_000L) fakeTimestampStep: Long
     ) {
         // Given
-        val testedSerializer = MemoryEventSerializer(
-            sessionId = fakeSessionId,
-            applicationId = fakeApplicationId,
-            sessionType = RumSessionType.USER,
-            totalRamBytes = fakeTotalRamBytes,
-            timeProvider = mockTimeProvider,
-            useDeltaCompression = true
-        )
-
         val fakeTs2 = fakeTs1 + fakeTimestampStep
         val fakeTs3 = fakeTs2 + fakeTimestampStep
 
@@ -208,13 +179,13 @@ internal class MemoryEventSerializerTest {
         )
 
         // When
-        val json = testedSerializer.serialize(samples) ?: error(NON_NULL_JSON_ERROR)
+        val json = testedSerializer(useDeltaCompression = true).serialize(samples) ?: error(NON_NULL_JSON_ERROR)
 
         // Then
         val timeseries = json.getAsJsonObject(KEY_TIMESERIES)
         assertThat(timeseries.get(KEY_SCHEMA).asString).isEqualTo(VALUE_SCHEMA_DELTA_OBJECT)
         val data = timeseries.get(KEY_DATA).asJsonObject
-        assertThat(data.get(KEY_PRECISION).asInt).isEqualTo(EXPECTED_PRECISION)
+        assertThat(data.get(KEY_PRECISION).asInt).isEqualTo(fakePrecision)
         assertThat(data.get(KEY_RESOLUTION).asString).isEqualTo(VALUE_RESOLUTION_NS)
 
         val tsArray = data.get(KEY_TS).asJsonArray
@@ -224,9 +195,9 @@ internal class MemoryEventSerializerTest {
 
         val maxArr = data.get(KEY_MEMORY_MAX).asJsonArray
         val pctArr = data.get(KEY_MEMORY_PERCENT).asJsonArray
-        val scaledMax = listOf(fakeMem1, fakeMem2, fakeMem3).map { (it * SCALE).roundToLong() }
+        val scaledMax = listOf(fakeMem1, fakeMem2, fakeMem3).map { (it * fakeScale).roundToLong() }
         val scaledPct = listOf(fakeMem1, fakeMem2, fakeMem3)
-            .map { (it / fakeTotalRamBytes * PERCENT_FACTOR * SCALE).roundToLong() }
+            .map { (it / fakeTotalRamBytes * PERCENT_FACTOR * fakeScale).roundToLong() }
 
         assertThat(maxArr[0].asLong).isEqualTo(scaledMax[0])
         assertThat(maxArr[1].asLong).isEqualTo(scaledMax[1] - scaledMax[0])
@@ -242,18 +213,9 @@ internal class MemoryEventSerializerTest {
         @DoubleForgery(min = 1.0) fakeMemory: Double,
         @LongForgery(min = 1L) fakeTs: Long
     ) {
-        // Given
-        val testedSerializer = MemoryEventSerializer(
-            sessionId = fakeSessionId,
-            applicationId = fakeApplicationId,
-            sessionType = RumSessionType.USER,
-            totalRamBytes = fakeTotalRamBytes,
-            timeProvider = mockTimeProvider,
-            useDeltaCompression = true
-        )
-
         // When
-        val json = testedSerializer.serialize(listOf(DataPoint(fakeTs, fakeMemory)))
+        val json = testedSerializer(useDeltaCompression = true)
+            .serialize(listOf(DataPoint(fakeTs, fakeMemory)))
             ?: error(NON_NULL_JSON_ERROR)
 
         // Then
@@ -263,9 +225,7 @@ internal class MemoryEventSerializerTest {
     }
 
     private companion object {
-        private const val SCALE: Long = 10_000L
         private const val PERCENT_FACTOR: Double = 100.0
-        private const val EXPECTED_PRECISION: Int = 4
         private const val MEMORY_OFFSET: Double = 0.0001
 
         // JSON keys

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/serializer/MemoryEventSerializerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/serializer/MemoryEventSerializerTest.kt
@@ -1,0 +1,294 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.timeseries.serializer
+
+import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.rum.RumSessionType
+import com.datadog.android.rum.internal.timeseries.DataPoint
+import com.datadog.android.rum.model.TimeseriesMemoryEvent
+import com.datadog.android.rum.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.DoubleForgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import java.util.UUID
+import kotlin.math.roundToLong
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class MemoryEventSerializerTest {
+
+    @Mock
+    lateinit var mockTimeProvider: TimeProvider
+
+    @StringForgery
+    lateinit var fakeSessionId: String
+
+    @StringForgery
+    lateinit var fakeApplicationId: String
+
+    @LongForgery(min = 1_000_000_000L, max = 16_000_000_000L)
+    var fakeTotalRamBytes: Long = 0L
+
+    @LongForgery(min = 1L)
+    var fakeNowMs: Long = 0L
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(mockTimeProvider.getDeviceTimestampMillis()) doReturn fakeNowMs
+    }
+
+    @Test
+    fun `M return null W serialize() { empty input }`() {
+        // Given
+        val testedSerializer = MemoryEventSerializer(
+            sessionId = fakeSessionId,
+            applicationId = fakeApplicationId,
+            sessionType = RumSessionType.USER,
+            totalRamBytes = fakeTotalRamBytes,
+            timeProvider = mockTimeProvider
+        )
+
+        // When
+        val result = testedSerializer.serialize(emptyList())
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M return null W serialize() { totalRamBytes is zero }`(
+        @DoubleForgery(min = 1.0) fakeMemory: Double,
+        @LongForgery(min = 1L) fakeTs: Long
+    ) {
+        // Given
+        val testedSerializer = MemoryEventSerializer(
+            sessionId = fakeSessionId,
+            applicationId = fakeApplicationId,
+            sessionType = RumSessionType.USER,
+            totalRamBytes = 0L,
+            timeProvider = mockTimeProvider
+        )
+
+        // When
+        val result = testedSerializer.serialize(listOf(DataPoint(fakeTs, fakeMemory)))
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M return null W serialize() { totalRamBytes is negative }`(
+        @LongForgery(max = -1L) fakeNegativeRam: Long,
+        @DoubleForgery(min = 1.0) fakeMemory: Double,
+        @LongForgery(min = 1L) fakeTs: Long
+    ) {
+        // Given
+        val testedSerializer = MemoryEventSerializer(
+            sessionId = fakeSessionId,
+            applicationId = fakeApplicationId,
+            sessionType = RumSessionType.USER,
+            totalRamBytes = fakeNegativeRam,
+            timeProvider = mockTimeProvider
+        )
+
+        // When
+        val result = testedSerializer.serialize(listOf(DataPoint(fakeTs, fakeMemory)))
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M produce object schema W serialize() { compression off }`(
+        @DoubleForgery(min = 1.0) fakeMemory: Double,
+        @LongForgery(min = 1L) fakeTs: Long
+    ) {
+        // Given
+        val testedSerializer = MemoryEventSerializer(
+            sessionId = fakeSessionId,
+            applicationId = fakeApplicationId,
+            sessionType = RumSessionType.USER,
+            totalRamBytes = fakeTotalRamBytes,
+            timeProvider = mockTimeProvider,
+            useDeltaCompression = false
+        )
+        val samples = listOf(
+            DataPoint(fakeTs, fakeMemory),
+            DataPoint(fakeTs + 1L, fakeMemory + 1.0)
+        )
+
+        // When
+        val json = testedSerializer.serialize(samples) ?: error(NON_NULL_JSON_ERROR)
+
+        // Then
+        val timeseries = json.getAsJsonObject(KEY_TIMESERIES)
+        assertThat(timeseries.get(KEY_SCHEMA).asString).isEqualTo(VALUE_SCHEMA_OBJECT)
+        assertThat(timeseries.get(KEY_START).asLong).isEqualTo(fakeTs)
+        assertThat(timeseries.get(KEY_END).asLong).isEqualTo(fakeTs + 1L)
+        UUID.fromString(timeseries.get(KEY_ID).asString)
+
+        val parsed = TimeseriesMemoryEvent.fromJsonObject(json)
+        assertThat(parsed.timeseries.data).hasSize(2)
+        val first = parsed.timeseries.data.first().dataPoint
+        assertThat(first.memoryMax.toDouble()).isCloseTo(fakeMemory, Offset.offset(MEMORY_OFFSET))
+        assertThat(first.memoryPercent.toDouble())
+            .isCloseTo(fakeMemory / fakeTotalRamBytes * PERCENT_FACTOR, Offset.offset(MEMORY_OFFSET))
+    }
+
+    @Test
+    fun `M map session type W serialize() { synthetics }`(
+        @DoubleForgery(min = 1.0) fakeMemory: Double,
+        @LongForgery(min = 1L) fakeTs: Long
+    ) {
+        // Given
+        val testedSerializer = MemoryEventSerializer(
+            sessionId = fakeSessionId,
+            applicationId = fakeApplicationId,
+            sessionType = RumSessionType.SYNTHETICS,
+            totalRamBytes = fakeTotalRamBytes,
+            timeProvider = mockTimeProvider
+        )
+
+        // When
+        val json = testedSerializer.serialize(
+            listOf(DataPoint(fakeTs, fakeMemory), DataPoint(fakeTs + 1L, fakeMemory))
+        ) ?: error(NON_NULL_JSON_ERROR)
+
+        // Then
+        assertThat(json.getAsJsonObject(KEY_SESSION).get(KEY_TYPE).asString).isEqualTo(VALUE_TYPE_SYNTHETICS)
+    }
+
+    @Test
+    fun `M produce delta-object schema W serialize() { compression on, multi-sample }`(
+        @DoubleForgery(min = 1.0, max = 1_000_000.0) fakeMem1: Double,
+        @DoubleForgery(min = 1.0, max = 1_000_000.0) fakeMem2: Double,
+        @DoubleForgery(min = 1.0, max = 1_000_000.0) fakeMem3: Double,
+        @LongForgery(min = 1L, max = 1_000_000L) fakeTs1: Long,
+        @LongForgery(min = 1L, max = 1_000L) fakeTimestampStep: Long
+    ) {
+        // Given
+        val testedSerializer = MemoryEventSerializer(
+            sessionId = fakeSessionId,
+            applicationId = fakeApplicationId,
+            sessionType = RumSessionType.USER,
+            totalRamBytes = fakeTotalRamBytes,
+            timeProvider = mockTimeProvider,
+            useDeltaCompression = true
+        )
+
+        val fakeTs2 = fakeTs1 + fakeTimestampStep
+        val fakeTs3 = fakeTs2 + fakeTimestampStep
+
+        val samples = listOf(
+            DataPoint(fakeTs1, fakeMem1),
+            DataPoint(fakeTs2, fakeMem2),
+            DataPoint(fakeTs3, fakeMem3)
+        )
+
+        // When
+        val json = testedSerializer.serialize(samples) ?: error(NON_NULL_JSON_ERROR)
+
+        // Then
+        val timeseries = json.getAsJsonObject(KEY_TIMESERIES)
+        assertThat(timeseries.get(KEY_SCHEMA).asString).isEqualTo(VALUE_SCHEMA_DELTA_OBJECT)
+        val data = timeseries.get(KEY_DATA).asJsonObject
+        assertThat(data.get(KEY_PRECISION).asInt).isEqualTo(EXPECTED_PRECISION)
+        assertThat(data.get(KEY_RESOLUTION).asString).isEqualTo(VALUE_RESOLUTION_NS)
+
+        val tsArray = data.get(KEY_TS).asJsonArray
+        assertThat(tsArray[0].asLong).isEqualTo(fakeTs1)
+        assertThat(tsArray[1].asLong).isEqualTo(fakeTimestampStep)
+        assertThat(tsArray[2].asLong).isEqualTo(fakeTimestampStep)
+
+        val maxArr = data.get(KEY_MEMORY_MAX).asJsonArray
+        val pctArr = data.get(KEY_MEMORY_PERCENT).asJsonArray
+        val scaledMax = listOf(fakeMem1, fakeMem2, fakeMem3).map { (it * SCALE).roundToLong() }
+        val scaledPct = listOf(fakeMem1, fakeMem2, fakeMem3)
+            .map { (it / fakeTotalRamBytes * PERCENT_FACTOR * SCALE).roundToLong() }
+
+        assertThat(maxArr[0].asLong).isEqualTo(scaledMax[0])
+        assertThat(maxArr[1].asLong).isEqualTo(scaledMax[1] - scaledMax[0])
+        assertThat(maxArr[2].asLong).isEqualTo(scaledMax[2] - scaledMax[1])
+
+        assertThat(pctArr[0].asLong).isEqualTo(scaledPct[0])
+        assertThat(pctArr[1].asLong).isEqualTo(scaledPct[1] - scaledPct[0])
+        assertThat(pctArr[2].asLong).isEqualTo(scaledPct[2] - scaledPct[1])
+    }
+
+    @Test
+    fun `M fall back to object schema W serialize() { compression on, single sample }`(
+        @DoubleForgery(min = 1.0) fakeMemory: Double,
+        @LongForgery(min = 1L) fakeTs: Long
+    ) {
+        // Given
+        val testedSerializer = MemoryEventSerializer(
+            sessionId = fakeSessionId,
+            applicationId = fakeApplicationId,
+            sessionType = RumSessionType.USER,
+            totalRamBytes = fakeTotalRamBytes,
+            timeProvider = mockTimeProvider,
+            useDeltaCompression = true
+        )
+
+        // When
+        val json = testedSerializer.serialize(listOf(DataPoint(fakeTs, fakeMemory)))
+            ?: error(NON_NULL_JSON_ERROR)
+
+        // Then
+        val timeseries = json.getAsJsonObject(KEY_TIMESERIES)
+        assertThat(timeseries.get(KEY_SCHEMA).asString).isEqualTo(VALUE_SCHEMA_OBJECT)
+        assertThat(timeseries.get(KEY_DATA).isJsonArray).isTrue()
+    }
+
+    private companion object {
+        private const val SCALE: Long = 10_000L
+        private const val PERCENT_FACTOR: Double = 100.0
+        private const val EXPECTED_PRECISION: Int = 4
+        private const val MEMORY_OFFSET: Double = 0.0001
+
+        // JSON keys
+        private const val KEY_TIMESERIES: String = "timeseries"
+        private const val KEY_SCHEMA: String = "schema"
+        private const val KEY_DATA: String = "data"
+        private const val KEY_SESSION: String = "session"
+        private const val KEY_TYPE: String = "type"
+        private const val KEY_ID: String = "id"
+        private const val KEY_START: String = "start"
+        private const val KEY_END: String = "end"
+        private const val KEY_PRECISION: String = "precision"
+        private const val KEY_RESOLUTION: String = "resolution"
+        private const val KEY_TS: String = "ts"
+        private const val KEY_MEMORY_MAX: String = "memory_max"
+        private const val KEY_MEMORY_PERCENT: String = "memory_percent"
+
+        // JSON values
+        private const val VALUE_SCHEMA_OBJECT: String = "object"
+        private const val VALUE_SCHEMA_DELTA_OBJECT: String = "delta-object"
+        private const val VALUE_TYPE_SYNTHETICS: String = "synthetics"
+        private const val VALUE_RESOLUTION_NS: String = "ns"
+
+        private const val NON_NULL_JSON_ERROR: String = "expected non-null json"
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfigurationTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfigurationTest.kt
@@ -9,51 +9,9 @@ package com.datadog.android.rum.timeseries
 import com.datadog.android.rum.ExperimentalRumApi
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalRumApi::class)
 internal class TimeseriesConfigurationTest {
-
-    @Test
-    fun `M create thread named datadog-timeseries W executorFactory()`() {
-        // Given
-        val config = TimeseriesConfiguration()
-        val executor = config.executorFactory()
-        val capturedName = arrayOfNulls<String>(1)
-        val latch = CountDownLatch(1)
-
-        // When
-        executor.submit {
-            capturedName[0] = Thread.currentThread().name
-            latch.countDown()
-        }
-        latch.await(5, TimeUnit.SECONDS)
-        executor.shutdownNow()
-
-        // Then
-        assertThat(capturedName[0]).isEqualTo("datadog-timeseries")
-    }
-
-    @Test
-    fun `M create daemon thread W executorFactory()`() {
-        // Given
-        val config = TimeseriesConfiguration()
-        val executor = config.executorFactory()
-        val capturedDaemon = booleanArrayOf(false)
-        val latch = CountDownLatch(1)
-
-        // When
-        executor.submit {
-            capturedDaemon[0] = Thread.currentThread().isDaemon
-            latch.countDown()
-        }
-        latch.await(5, TimeUnit.SECONDS)
-        executor.shutdownNow()
-
-        // Then
-        assertThat(capturedDaemon[0]).isTrue()
-    }
 
     @Test
     fun `M use defaults W constructed with no args`() {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfigurationTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfigurationTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.timeseries
+
+import com.datadog.android.rum.ExperimentalRumApi
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@OptIn(ExperimentalRumApi::class)
+internal class TimeseriesConfigurationTest {
+
+    @Test
+    fun `M create thread named datadog-timeseries W executorFactory()`() {
+        // Given
+        val config = TimeseriesConfiguration()
+        val executor = config.executorFactory()
+        val capturedName = arrayOfNulls<String>(1)
+        val latch = CountDownLatch(1)
+
+        // When
+        executor.submit {
+            capturedName[0] = Thread.currentThread().name
+            latch.countDown()
+        }
+        latch.await(5, TimeUnit.SECONDS)
+        executor.shutdownNow()
+
+        // Then
+        assertThat(capturedName[0]).isEqualTo("datadog-timeseries")
+    }
+
+    @Test
+    fun `M create daemon thread W executorFactory()`() {
+        // Given
+        val config = TimeseriesConfiguration()
+        val executor = config.executorFactory()
+        val capturedDaemon = booleanArrayOf(false)
+        val latch = CountDownLatch(1)
+
+        // When
+        executor.submit {
+            capturedDaemon[0] = Thread.currentThread().isDaemon
+            latch.countDown()
+        }
+        latch.await(5, TimeUnit.SECONDS)
+        executor.shutdownNow()
+
+        // Then
+        assertThat(capturedDaemon[0]).isTrue()
+    }
+
+    @Test
+    fun `M use defaults W constructed with no args`() {
+        // When
+        val config = TimeseriesConfiguration()
+
+        // Then
+        assertThat(config.bufferSize).isEqualTo(TimeseriesConfiguration.DEFAULT_BUFFER_SIZE)
+        assertThat(config.intervalMs).isEqualTo(TimeseriesConfiguration.DEFAULT_INTERVAL_MS)
+    }
+
+    @Test
+    fun `M use default bufferSize W constructed with non-positive bufferSize`() {
+        // When
+        val configZero = TimeseriesConfiguration(bufferSize = 0)
+        val configNegative = TimeseriesConfiguration(bufferSize = -1)
+
+        // Then
+        assertThat(configZero.bufferSize).isEqualTo(TimeseriesConfiguration.DEFAULT_BUFFER_SIZE)
+        assertThat(configNegative.bufferSize).isEqualTo(TimeseriesConfiguration.DEFAULT_BUFFER_SIZE)
+    }
+
+    @Test
+    fun `M use default intervalMs W constructed with intervalMs below minimum`() {
+        // When
+        val configBelowMin = TimeseriesConfiguration(intervalMs = TimeseriesConfiguration.MIN_INTERVAL_MS - 1)
+        val configZero = TimeseriesConfiguration(intervalMs = 0L)
+
+        // Then
+        assertThat(configBelowMin.intervalMs).isEqualTo(TimeseriesConfiguration.DEFAULT_INTERVAL_MS)
+        assertThat(configZero.intervalMs).isEqualTo(TimeseriesConfiguration.DEFAULT_INTERVAL_MS)
+    }
+
+    @Test
+    fun `M store provided values W constructed with valid args`() {
+        // Given
+        val fakeBufferSize = 10
+        val fakeIntervalMs = 500L
+
+        // When
+        val config = TimeseriesConfiguration(bufferSize = fakeBufferSize, intervalMs = fakeIntervalMs)
+
+        // Then
+        assertThat(config.bufferSize).isEqualTo(fakeBufferSize)
+        assertThat(config.intervalMs).isEqualTo(fakeIntervalMs)
+    }
+
+    @Test
+    fun `M default collectInBackground to false W constructed with no args`() {
+        // When
+        val config = TimeseriesConfiguration()
+
+        // Then
+        assertThat(config.collectInBackground).isFalse()
+    }
+
+    @Test
+    fun `M store collectInBackground W constructed with collectInBackground = true`() {
+        // When
+        val config = TimeseriesConfiguration(collectInBackground = true)
+
+        // Then
+        assertThat(config.collectInBackground).isTrue()
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfigurationTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfigurationTest.kt
@@ -14,9 +14,9 @@ import org.junit.jupiter.api.Test
 internal class TimeseriesConfigurationTest {
 
     @Test
-    fun `M use defaults W constructed with no args`() {
+    fun `M use defaults W built with no args`() {
         // When
-        val config = TimeseriesConfiguration()
+        val config = TimeseriesConfiguration.Builder().build()
 
         // Then
         assertThat(config.bufferSize).isEqualTo(TimeseriesConfiguration.DEFAULT_BUFFER_SIZE)
@@ -24,10 +24,10 @@ internal class TimeseriesConfigurationTest {
     }
 
     @Test
-    fun `M use default bufferSize W constructed with non-positive bufferSize`() {
+    fun `M use default bufferSize W setBufferSize with non-positive value`() {
         // When
-        val configZero = TimeseriesConfiguration(bufferSize = 0)
-        val configNegative = TimeseriesConfiguration(bufferSize = -1)
+        val configZero = TimeseriesConfiguration.Builder().setBufferSize(0).build()
+        val configNegative = TimeseriesConfiguration.Builder().setBufferSize(-1).build()
 
         // Then
         assertThat(configZero.bufferSize).isEqualTo(TimeseriesConfiguration.DEFAULT_BUFFER_SIZE)
@@ -35,10 +35,12 @@ internal class TimeseriesConfigurationTest {
     }
 
     @Test
-    fun `M use default intervalMs W constructed with intervalMs below minimum`() {
+    fun `M use default intervalMs W setIntervalMs below minimum`() {
         // When
-        val configBelowMin = TimeseriesConfiguration(intervalMs = TimeseriesConfiguration.MIN_INTERVAL_MS - 1)
-        val configZero = TimeseriesConfiguration(intervalMs = 0L)
+        val configBelowMin = TimeseriesConfiguration.Builder()
+            .setIntervalMs(TimeseriesConfiguration.MIN_INTERVAL_MS - 1)
+            .build()
+        val configZero = TimeseriesConfiguration.Builder().setIntervalMs(0L).build()
 
         // Then
         assertThat(configBelowMin.intervalMs).isEqualTo(TimeseriesConfiguration.DEFAULT_INTERVAL_MS)
@@ -46,13 +48,16 @@ internal class TimeseriesConfigurationTest {
     }
 
     @Test
-    fun `M store provided values W constructed with valid args`() {
+    fun `M store provided values W built with valid args`() {
         // Given
         val fakeBufferSize = 10
         val fakeIntervalMs = 500L
 
         // When
-        val config = TimeseriesConfiguration(bufferSize = fakeBufferSize, intervalMs = fakeIntervalMs)
+        val config = TimeseriesConfiguration.Builder()
+            .setBufferSize(fakeBufferSize)
+            .setIntervalMs(fakeIntervalMs)
+            .build()
 
         // Then
         assertThat(config.bufferSize).isEqualTo(fakeBufferSize)
@@ -60,18 +65,18 @@ internal class TimeseriesConfigurationTest {
     }
 
     @Test
-    fun `M default collectInBackground to false W constructed with no args`() {
+    fun `M default collectInBackground to false W built with no args`() {
         // When
-        val config = TimeseriesConfiguration()
+        val config = TimeseriesConfiguration.Builder().build()
 
         // Then
         assertThat(config.collectInBackground).isFalse()
     }
 
     @Test
-    fun `M store collectInBackground W constructed with collectInBackground = true`() {
+    fun `M store collectInBackground W setCollectInBackground true`() {
         // When
-        val config = TimeseriesConfiguration(collectInBackground = true)
+        val config = TimeseriesConfiguration.Builder().setCollectInBackground(true).build()
 
         // Then
         assertThat(config.collectInBackground).isTrue()


### PR DESCRIPTION
### What does this PR do?

Adds `MemoryEventSerializer`, which converts a batch of memory `DataPoint`s (heap + native RSS) into a `RumTimeseriesMemoryEvent` JSON object. Introduces `TimeseriesConfiguration` as the public `@ExperimentalRumApi` configuration class (sampling intervals, batch size, background collection flag). Completes the pipeline with `RumSessionScopeTimeseriesFactory`, which wires CPU and memory readers, serializers, and the `TimeseriesConfiguration` together to create fully configured `RumSessionScopeTimeseries` instances for each new session.

### Motivation

Completes the two metric types and provides the factory needed to tie the pipeline to the RUM session lifecycle.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

