### PR TITLE
RUM-15344 Pt.1: Add ProfilingAnrDetectedEvent in internal module

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -169,8 +169,12 @@ sealed class com.datadog.android.internal.profiling.ProfilerEvent
     constructor(String, Long, Long, ProfilingRumContext)
   data class RumLongTaskEvent : ProfilerEvent
     constructor(String, Long, Long, ProfilingRumContext)
+data class com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
+  constructor(Long, List<StackTraceElement>, List<ProfilingThreadDump>)
 data class com.datadog.android.internal.profiling.ProfilingRumContext
   constructor(String, String, String?, String?)
+data class com.datadog.android.internal.profiling.ProfilingThreadDump
+  constructor(String, String, String, Boolean)
 data class com.datadog.android.internal.rum.RumSessionRenewedEvent
   constructor(String, Boolean)
 object com.datadog.android.internal.sampling.DeterministicSampling

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -334,6 +334,21 @@ public final class com/datadog/android/internal/profiling/ProfilerEvent$TTIDNotT
 	public static final field INSTANCE Lcom/datadog/android/internal/profiling/ProfilerEvent$TTIDNotTracked;
 }
 
+public final class com/datadog/android/internal/profiling/ProfilingAnrDetectedEvent {
+	public fun <init> (JLjava/util/List;Ljava/util/List;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (JLjava/util/List;Ljava/util/List;)Lcom/datadog/android/internal/profiling/ProfilingAnrDetectedEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/ProfilingAnrDetectedEvent;JLjava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/datadog/android/internal/profiling/ProfilingAnrDetectedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllThreads ()Ljava/util/List;
+	public final fun getAnrThreadStack ()Ljava/util/List;
+	public final fun getDetectedAtMs ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/datadog/android/internal/profiling/ProfilingRumContext {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -347,6 +362,23 @@ public final class com/datadog/android/internal/profiling/ProfilingRumContext {
 	public final fun getSessionId ()Ljava/lang/String;
 	public final fun getViewId ()Ljava/lang/String;
 	public final fun getViewName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/internal/profiling/ProfilingThreadDump {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Lcom/datadog/android/internal/profiling/ProfilingThreadDump;
+	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/ProfilingThreadDump;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lcom/datadog/android/internal/profiling/ProfilingThreadDump;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCrashed ()Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getStack ()Ljava/lang/String;
+	public final fun getState ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilingAnrDetectedEvent.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilingAnrDetectedEvent.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.profiling
+
+/**
+ * Sent by the profiling feature to the RUM feature when ProfilingManager
+ * notifies us of an ANR via the trigger-based capture API.
+ *
+ * @param detectedAtMs Timestamp (device clock, millis since epoch) when the
+ *   profiling feature handled the ANR trigger callback.
+ * @param anrThreadStack Stack trace of the thread that triggered the ANR
+ *   (in practice the main looper thread) at capture time. Used as the
+ *   synthesized `ANRException` stack trace on the RUM side.
+ * @param allThreads Per-thread dump for every other live thread (ANR thread excluded).
+ */
+data class ProfilingAnrDetectedEvent(
+    val detectedAtMs: Long,
+    val anrThreadStack: List<StackTraceElement>,
+    val allThreads: List<ProfilingThreadDump>
+)

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilingThreadDump.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilingThreadDump.kt
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.profiling
+
+/**
+ * Thread snapshot used within [ProfilingAnrDetectedEvent].
+ *
+ * Defined here (in `dd-sdk-android-internal`) so that [ProfilingAnrDetectedEvent] can live
+ * in this module without creating a circular dependency on `dd-sdk-android-core`.
+ *
+ * @param name Thread name.
+ * @param state Thread state string (e.g. `Thread.State.name.lowercase()`).
+ * @param stack Serialized stack trace (lines joined with newline).
+ * @param crashed Whether this thread was the one that triggered the ANR.
+ */
+data class ProfilingThreadDump(
+    val name: String,
+    val state: String,
+    val stack: String,
+    val crashed: Boolean
+)

--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilingAnrDetectedEventForgeryFactory.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilingAnrDetectedEventForgeryFactory.kt
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.tests.elmyr
+
+import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
+import com.datadog.android.internal.profiling.ProfilingThreadDump
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+class ProfilingAnrDetectedEventForgeryFactory : ForgeryFactory<ProfilingAnrDetectedEvent> {
+    override fun getForgery(forge: Forge): ProfilingAnrDetectedEvent {
+        return ProfilingAnrDetectedEvent(
+            detectedAtMs = forge.aLong(min = 1L),
+            anrThreadStack = forge.aList {
+                StackTraceElement(
+                    forge.anAlphabeticalString(),
+                    forge.anAlphabeticalString(),
+                    forge.aNullable { anAlphabeticalString() + if (forge.aBool()) ".java" else ".kt" },
+                    forge.anInt(min = -2)
+                )
+            },
+            allThreads = forge.aList { getForgery<ProfilingThreadDump>() }
+        )
+    }
+}

--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilingThreadDumpForgeryFactory.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilingThreadDumpForgeryFactory.kt
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.tests.elmyr
+
+import com.datadog.android.internal.profiling.ProfilingThreadDump
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+class ProfilingThreadDumpForgeryFactory : ForgeryFactory<ProfilingThreadDump> {
+    override fun getForgery(forge: Forge): ProfilingThreadDump {
+        return ProfilingThreadDump(
+            name = forge.anAlphaNumericalString(),
+            state = forge.aValueFrom(Thread.State::class.java).name.lowercase(),
+            crashed = forge.aBool(),
+            stack = forge.aList {
+                StackTraceElement(
+                    forge.anAlphabeticalString(),
+                    forge.anAlphabeticalString(),
+                    forge.aNullable { anAlphabeticalString() + if (forge.aBool()) ".java" else ".kt" },
+                    forge.anInt(min = -2)
+                )
+            }.joinToString(separator = "\n") { "at $it" }
+        )
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds `ProfilingAnrDetectedEvent` into internal module to prepare for the ANR capturing in Profiling feature

### Motivation

RUM-15344

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

