### PR TITLE
Sync Detekt configs with a `static-analysis` template version

### DIFF
--- a/local_ci.sh
+++ b/local_ci.sh
@@ -48,6 +48,90 @@ done
 # exit on errors
 set -e
 
+# Syncs detekt-common.yml and detekt-public-api.yml from dd-source into config/ at the
+# revision pinned by ci/pipelines/default-pipeline.yml. The dd-source repo is restored
+# to its prior state afterwards so switching branches there can't affect our checks.
+sync_detekt_configs() {
+  local config_dir="config"
+  local pipeline_file="ci/pipelines/default-pipeline.yml"
+  local stamp_file="$config_dir/detekt_dd-source_config.stamp"
+  local detekt_common_config="$config_dir/detekt-common.yml"
+  local detekt_public_api_config="$config_dir/detekt-public-api.yml"
+
+  mkdir -p "$config_dir"
+
+  local version
+  version=$(grep -oE 'gitlab-templates\.ddbuild\.io/mobile/v[0-9]+-[0-9a-f]+/static-analysis\.yml' "$pipeline_file" \
+    | head -1 \
+    | sed -E 's|.*/mobile/(v[0-9]+-[0-9a-f]+)/.*|\1|')
+
+  if [ -z "$version" ]; then
+    echo "  Could not extract dd-source detekt template version from $pipeline_file"
+    exit 1
+  fi
+
+  # Template tag format: vXXXX-${CI_COMMIT_SHA:0:8}
+  local sha="${version##*-}"
+
+  local current=""
+  if [ -f "$stamp_file" ]; then
+    current=$(cat "$stamp_file")
+  fi
+
+  if [ "$current" = "$version" ] && [ -f "$detekt_common_config" ] && [ -f "$detekt_public_api_config" ]; then
+    echo "  Detekt configs already at $version"
+    return 0
+  fi
+
+  echo "  Detekt configs out of date (have '${current:-none}', want '$version'); syncing from dd-source"
+
+  if [ -z "$DD_SOURCE" ]; then
+    echo "  DD_SOURCE not set. Please set it to your local dd-source checkout."
+    echo "  E.g.: export DD_SOURCE=/Volumes/Dev/ci/dd-source"
+    exit 1
+  fi
+  if [ ! -d "$DD_SOURCE/.git" ]; then
+    echo "  DD_SOURCE ($DD_SOURCE) is not a git repository"
+    exit 1
+  fi
+
+  local sdk_dir
+  sdk_dir=$(pwd)
+
+  (
+    cd "$DD_SOURCE"
+
+    orig_ref=$(git symbolic-ref --short -q HEAD || git rev-parse HEAD)
+    stashed=0
+
+    restore_dd_source() {
+      git checkout --quiet "$orig_ref" 2>/dev/null || true
+      if [ "$stashed" = "1" ]; then
+        git stash pop --quiet 2>/dev/null \
+          || echo "  Warning: could not restore stash in $DD_SOURCE; check 'git stash list'"
+      fi
+    }
+    trap restore_dd_source EXIT
+
+    if ! git diff --quiet || ! git diff --cached --quiet || [ -n "$(git ls-files --others --exclude-standard)" ]; then
+      git stash push -u -m "dd-sdk-android-detekt-sync" > /dev/null
+      stashed=1
+    fi
+
+    git fetch --quiet origin main
+    if ! git checkout --quiet "$sha" 2>/dev/null; then
+      echo "  Could not check out $sha in $DD_SOURCE — make sure dd-source main is up to date"
+      exit 1
+    fi
+
+    cp "domains/mobile/config/android/gitlab/detekt/detekt-common.yml" "$sdk_dir/$detekt_common_config"
+    cp "domains/mobile/config/android/gitlab/detekt/detekt-public-api.yml" "$sdk_dir/$detekt_public_api_config"
+  )
+
+  echo "$version" > "$stamp_file"
+  echo "  Detekt configs synced to $version"
+}
+
 if [[ $SETUP == 1 ]]; then
   echo "-- SETUP"
 
@@ -111,21 +195,14 @@ if [[ $ANALYSIS == 1 ]]; then
   fi
 
   echo "---- Detekt"
-  if [ -z "$DD_SOURCE" ]; then
-    echo "Can't run shared Detekt, missing dd_source repository path."
-    echo "Please set the path to your local dd_source repository in the DD_SOURCE environment variable."
-    echo "E.g.: "
-    echo "$ export DD_SOURCE=/Volumes/Dev/ci/dd-source"
-    exit 1
-  else
-    echo "Using Detekt rules from $DD_SOURCE folder"
-  fi
+  echo "------ Sync Detekt configs from dd-source"
+  sync_detekt_configs
 
   echo "------ Detekt common rules"
-  detekt --parallel --config "$DD_SOURCE/domains/mobile/config/android/gitlab/detekt/detekt-common.yml"
+  detekt --parallel --config "config/detekt-common.yml"
 
   echo "------ Detekt public API rules"
-  detekt --parallel --config "$DD_SOURCE/domains/mobile/config/android/gitlab/detekt/detekt-public-api.yml"
+  detekt --parallel --config "config/detekt-public-api.yml"
 
   if [[ $COMPILE == 1 ]]; then
     # Assemble is required to get generated classes type resolution


### PR DESCRIPTION
### What does this PR do?

It is quite painful to get the right version of the Detekt Common and Public API config when working with `dd-source` in parallel, so this change does the following:

* reads template version from CI pipeline definition
* checks if it matches the version in the `.stamp` file of `config` folder
* if it matches, and both config files are there (also in `config` folder), then run Detekt check
* if version is different, then checkout `dd-source` at the right version and copy the necessary configs, restore `dd-source` back.

The code is 100% AI-generated, I'm not that big Bash/Git expert.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

