### PR TITLE
RUM-3862 Report carrier info on Android API 24+

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -144,9 +144,7 @@ internal class CoreFeature(
     internal class OkHttpCallFactory(factory: () -> OkHttpClient) : Call.Factory {
         val okhttpClient by lazy(factory)
 
-        override fun newCall(request: Request): Call {
-            return okhttpClient.newCall(request)
-        }
+        override fun newCall(request: Request): Call = okhttpClient.newCall(request)
     }
 
     internal val initialized = AtomicBoolean(false)
@@ -247,12 +245,7 @@ internal class CoreFeature(
             }
         }
 
-    fun initialize(
-        appContext: Context,
-        sdkInstanceId: String,
-        configuration: Configuration,
-        consent: TrackingConsent
-    ) {
+    fun initialize(appContext: Context, sdkInstanceId: String, configuration: Configuration, consent: TrackingConsent) {
         if (initialized.get()) {
             return
         }
@@ -322,31 +315,23 @@ internal class CoreFeature(
         }
     }
 
-    fun buildFilePersistenceConfig(): FilePersistenceConfig {
-        return FilePersistenceConfig(
-            recentDelayMs = batchSize.windowDurationMs
-        )
-    }
+    fun buildFilePersistenceConfig(): FilePersistenceConfig = FilePersistenceConfig(
+        recentDelayMs = batchSize.windowDurationMs
+    )
 
-    fun createExecutorService(executorContext: String): ExecutorService {
-        return executorServiceFactory.create(internalLogger, executorContext, backpressureStrategy, timeProvider)
-    }
+    fun createExecutorService(executorContext: String): ExecutorService =
+        executorServiceFactory.create(internalLogger, executorContext, backpressureStrategy, timeProvider)
 
-    fun createScheduledExecutorService(executorContext: String): ScheduledExecutorService {
-        return scheduledExecutorServiceFactory.create(internalLogger, executorContext, backpressureStrategy)
-    }
+    fun createScheduledExecutorService(executorContext: String): ScheduledExecutorService =
+        scheduledExecutorServiceFactory.create(internalLogger, executorContext, backpressureStrategy)
 
-    fun createOkHttpCallFactory(block: OkHttpClient.Builder.() -> Unit): Call.Factory {
-        return object : Call.Factory {
-            // Create a new client that shares pools with the base client
-            private val client = lazySharedOkHttpClient.newBuilder()
-                .apply(block)
-                .build()
+    fun createOkHttpCallFactory(block: OkHttpClient.Builder.() -> Unit): Call.Factory = object : Call.Factory {
+        // Create a new client that shares pools with the base client
+        private val client = lazySharedOkHttpClient.newBuilder()
+            .apply(block)
+            .build()
 
-            override fun newCall(request: Request): Call {
-                return client.newCall(request)
-            }
-        }
+        override fun newCall(request: Request): Call = client.newCall(request)
     }
 
     @Throws(UnsupportedOperationException::class, InterruptedException::class)
@@ -529,49 +514,45 @@ internal class CoreFeature(
         contextRef = WeakReference(appContext)
     }
 
-    private fun getPackageInfo(appContext: Context): PackageInfo? {
-        return try {
-            val packageName = appContext.packageName
-            with(appContext.packageManager) {
-                if (buildSdkVersionProvider.isAtLeastTiramisu) {
-                    getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0))
-                } else {
-                    getPackageInfo(packageName, 0)
-                }
+    private fun getPackageInfo(appContext: Context): PackageInfo? = try {
+        val packageName = appContext.packageName
+        with(appContext.packageManager) {
+            if (buildSdkVersionProvider.isAtLeastTiramisu) {
+                getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0))
+            } else {
+                getPackageInfo(packageName, 0)
             }
-        } catch (e: PackageManager.NameNotFoundException) {
+        }
+    } catch (e: PackageManager.NameNotFoundException) {
+        internalLogger.log(
+            InternalLogger.Level.ERROR,
+            InternalLogger.Target.USER,
+            { "Unable to read your application's version name" },
+            e
+        )
+        null
+    }
+
+    private fun readBuildId(context: Context): String? = with(context.assets) {
+        try {
+            open(BUILD_ID_FILE_NAME).bufferedReader().use {
+                it.readText().trim()
+            }
+        } catch (@Suppress("SwallowedException") e: FileNotFoundException) {
+            internalLogger.log(
+                InternalLogger.Level.INFO,
+                InternalLogger.Target.USER,
+                { BUILD_ID_IS_MISSING_INFO_MESSAGE }
+            )
+            null
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
-                InternalLogger.Target.USER,
-                { "Unable to read your application's version name" },
+                targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+                { BUILD_ID_READ_ERROR },
                 e
             )
             null
-        }
-    }
-
-    private fun readBuildId(context: Context): String? {
-        return with(context.assets) {
-            try {
-                open(BUILD_ID_FILE_NAME).bufferedReader().use {
-                    it.readText().trim()
-                }
-            } catch (@Suppress("SwallowedException") e: FileNotFoundException) {
-                internalLogger.log(
-                    InternalLogger.Level.INFO,
-                    InternalLogger.Target.USER,
-                    { BUILD_ID_IS_MISSING_INFO_MESSAGE }
-                )
-                null
-            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-                internalLogger.log(
-                    InternalLogger.Level.ERROR,
-                    targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-                    { BUILD_ID_READ_ERROR },
-                    e
-                )
-                null
-            }
         }
     }
 
@@ -585,10 +566,7 @@ internal class CoreFeature(
         customUploadSchedulerStrategy = configuration.uploadSchedulerStrategy
     }
 
-    private fun setupInfoProviders(
-        appContext: Context,
-        consent: TrackingConsent
-    ) {
+    private fun setupInfoProviders(appContext: Context, consent: TrackingConsent) {
         // Tracking Consent Provider
         trackingConsentProvider = TrackingConsentProvider(consent)
 
@@ -611,11 +589,15 @@ internal class CoreFeature(
 
     private fun setupNetworkInfoProviders(appContext: Context) {
         networkInfoProvider = if (buildSdkVersionProvider.isAtLeastN) {
-            CallbackNetworkInfoProvider(internalLogger = internalLogger)
+            CallbackNetworkInfoProvider(
+                internalLogger = internalLogger,
+                buildSdkVersionProvider = buildSdkVersionProvider
+            )
         } else {
             BroadcastReceiverNetworkInfoProvider(
                 internalLogger = internalLogger,
-                executorService = contextExecutorService
+                executorService = contextExecutorService,
+                buildSdkVersionProvider = buildSdkVersionProvider
             )
         }
         networkInfoProvider.register(appContext)

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -245,7 +245,12 @@ internal class CoreFeature(
             }
         }
 
-    fun initialize(appContext: Context, sdkInstanceId: String, configuration: Configuration, consent: TrackingConsent) {
+    fun initialize(
+        appContext: Context,
+        sdkInstanceId: String,
+        configuration: Configuration,
+        consent: TrackingConsent
+    ) {
         if (initialized.get()) {
             return
         }
@@ -315,23 +320,31 @@ internal class CoreFeature(
         }
     }
 
-    fun buildFilePersistenceConfig(): FilePersistenceConfig = FilePersistenceConfig(
-        recentDelayMs = batchSize.windowDurationMs
-    )
+    fun buildFilePersistenceConfig(): FilePersistenceConfig {
+        return FilePersistenceConfig(
+            recentDelayMs = batchSize.windowDurationMs
+        )
+    }
 
-    fun createExecutorService(executorContext: String): ExecutorService =
-        executorServiceFactory.create(internalLogger, executorContext, backpressureStrategy, timeProvider)
+    fun createExecutorService(executorContext: String): ExecutorService {
+        return executorServiceFactory.create(internalLogger, executorContext, backpressureStrategy, timeProvider)
+    }
 
-    fun createScheduledExecutorService(executorContext: String): ScheduledExecutorService =
-        scheduledExecutorServiceFactory.create(internalLogger, executorContext, backpressureStrategy)
+    fun createScheduledExecutorService(executorContext: String): ScheduledExecutorService {
+        return scheduledExecutorServiceFactory.create(internalLogger, executorContext, backpressureStrategy)
+    }
 
-    fun createOkHttpCallFactory(block: OkHttpClient.Builder.() -> Unit): Call.Factory = object : Call.Factory {
-        // Create a new client that shares pools with the base client
-        private val client = lazySharedOkHttpClient.newBuilder()
-            .apply(block)
-            .build()
+    fun createOkHttpCallFactory(block: OkHttpClient.Builder.() -> Unit): Call.Factory {
+        return object : Call.Factory {
+            // Create a new client that shares pools with the base client
+            private val client = lazySharedOkHttpClient.newBuilder()
+                .apply(block)
+                .build()
 
-        override fun newCall(request: Request): Call = client.newCall(request)
+            override fun newCall(request: Request): Call {
+                return client.newCall(request)
+            }
+        }
     }
 
     @Throws(UnsupportedOperationException::class, InterruptedException::class)
@@ -514,45 +527,49 @@ internal class CoreFeature(
         contextRef = WeakReference(appContext)
     }
 
-    private fun getPackageInfo(appContext: Context): PackageInfo? = try {
-        val packageName = appContext.packageName
-        with(appContext.packageManager) {
-            if (buildSdkVersionProvider.isAtLeastTiramisu) {
-                getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0))
-            } else {
-                getPackageInfo(packageName, 0)
+    private fun getPackageInfo(appContext: Context): PackageInfo? {
+        return try {
+            val packageName = appContext.packageName
+            with(appContext.packageManager) {
+                if (buildSdkVersionProvider.isAtLeastTiramisu) {
+                    getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0))
+                } else {
+                    getPackageInfo(packageName, 0)
+                }
             }
-        }
-    } catch (e: PackageManager.NameNotFoundException) {
-        internalLogger.log(
-            InternalLogger.Level.ERROR,
-            InternalLogger.Target.USER,
-            { "Unable to read your application's version name" },
-            e
-        )
-        null
-    }
-
-    private fun readBuildId(context: Context): String? = with(context.assets) {
-        try {
-            open(BUILD_ID_FILE_NAME).bufferedReader().use {
-                it.readText().trim()
-            }
-        } catch (@Suppress("SwallowedException") e: FileNotFoundException) {
-            internalLogger.log(
-                InternalLogger.Level.INFO,
-                InternalLogger.Target.USER,
-                { BUILD_ID_IS_MISSING_INFO_MESSAGE }
-            )
-            null
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        } catch (e: PackageManager.NameNotFoundException) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
-                targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-                { BUILD_ID_READ_ERROR },
+                InternalLogger.Target.USER,
+                { "Unable to read your application's version name" },
                 e
             )
             null
+        }
+    }
+
+    private fun readBuildId(context: Context): String? {
+        return with(context.assets) {
+            try {
+                open(BUILD_ID_FILE_NAME).bufferedReader().use {
+                    it.readText().trim()
+                }
+            } catch (@Suppress("SwallowedException") e: FileNotFoundException) {
+                internalLogger.log(
+                    InternalLogger.Level.INFO,
+                    InternalLogger.Target.USER,
+                    { BUILD_ID_IS_MISSING_INFO_MESSAGE }
+                )
+                null
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                internalLogger.log(
+                    InternalLogger.Level.ERROR,
+                    targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+                    { BUILD_ID_READ_ERROR },
+                    e
+                )
+                null
+            }
         }
     }
 
@@ -566,7 +583,10 @@ internal class CoreFeature(
         customUploadSchedulerStrategy = configuration.uploadSchedulerStrategy
     }
 
-    private fun setupInfoProviders(appContext: Context, consent: TrackingConsent) {
+    private fun setupInfoProviders(
+        appContext: Context,
+        consent: TrackingConsent
+    ) {
         // Tracking Consent Provider
         trackingConsentProvider = TrackingConsentProvider(consent)
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
@@ -64,14 +64,19 @@ internal class BroadcastReceiverNetworkInfoProvider(
         unregisterReceiver(context)
     }
 
-    override fun getLatestNetworkInfo(): NetworkInfo = networkInfo
+    override fun getLatestNetworkInfo(): NetworkInfo {
+        return networkInfo
+    }
 
     // endregion
 
     // region Internal
 
-    private fun buildNetworkInfo(context: Context, activeNetworkInfo: AndroidNetworkInfo?): NetworkInfo =
-        if (activeNetworkInfo == null || !activeNetworkInfo.isConnected) {
+    private fun buildNetworkInfo(
+        context: Context,
+        activeNetworkInfo: AndroidNetworkInfo?
+    ): NetworkInfo {
+        return if (activeNetworkInfo == null || !activeNetworkInfo.isConnected) {
             NetworkInfo(
                 NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED
             )
@@ -94,6 +99,7 @@ internal class BroadcastReceiverNetworkInfoProvider(
                 NetworkInfo.Connectivity.NETWORK_OTHER
             )
         }
+    }
 
     private fun buildMobileNetworkInfo(carrierInfoResolver: CarrierInfoResolver?, subtype: Int): NetworkInfo {
         val connectivity = when (subtype) {
@@ -113,28 +119,30 @@ internal class BroadcastReceiverNetworkInfoProvider(
         )
     }
 
-    private fun getCellularTechnology(subtype: Int): String? = when (subtype) {
-        TelephonyManager.NETWORK_TYPE_GPRS -> "GPRS"
-        TelephonyManager.NETWORK_TYPE_EDGE -> "Edge"
-        TelephonyManager.NETWORK_TYPE_CDMA -> "CDMA"
-        TelephonyManager.NETWORK_TYPE_1xRTT -> "CDMA1x"
-        TelephonyManager.NETWORK_TYPE_IDEN -> "iDen"
-        TelephonyManager.NETWORK_TYPE_GSM -> "GSM"
-        TelephonyManager.NETWORK_TYPE_UMTS -> "UMTS"
-        TelephonyManager.NETWORK_TYPE_EVDO_0 -> "CDMAEVDORev0"
-        TelephonyManager.NETWORK_TYPE_EVDO_A -> "CDMAEVDORevA"
-        TelephonyManager.NETWORK_TYPE_EVDO_B -> "CDMAEVDORevB"
-        TelephonyManager.NETWORK_TYPE_HSDPA -> "HSDPA"
-        TelephonyManager.NETWORK_TYPE_HSUPA -> "HSUPA"
-        TelephonyManager.NETWORK_TYPE_HSPA -> "HSPA"
-        TelephonyManager.NETWORK_TYPE_EHRPD -> "eHRPD"
-        TelephonyManager.NETWORK_TYPE_HSPAP -> "HSPA+"
-        TelephonyManager.NETWORK_TYPE_TD_SCDMA -> "TD_SCDMA"
-        TelephonyManager.NETWORK_TYPE_LTE -> "LTE"
-        TelephonyManager.NETWORK_TYPE_IWLAN -> "IWLAN"
-        NETWORK_TYPE_LTE_CA -> "LTE_CA"
-        TelephonyManager.NETWORK_TYPE_NR -> "New Radio"
-        else -> null
+    private fun getCellularTechnology(subtype: Int): String? {
+        return when (subtype) {
+            TelephonyManager.NETWORK_TYPE_GPRS -> "GPRS"
+            TelephonyManager.NETWORK_TYPE_EDGE -> "Edge"
+            TelephonyManager.NETWORK_TYPE_CDMA -> "CDMA"
+            TelephonyManager.NETWORK_TYPE_1xRTT -> "CDMA1x"
+            TelephonyManager.NETWORK_TYPE_IDEN -> "iDen"
+            TelephonyManager.NETWORK_TYPE_GSM -> "GSM"
+            TelephonyManager.NETWORK_TYPE_UMTS -> "UMTS"
+            TelephonyManager.NETWORK_TYPE_EVDO_0 -> "CDMAEVDORev0"
+            TelephonyManager.NETWORK_TYPE_EVDO_A -> "CDMAEVDORevA"
+            TelephonyManager.NETWORK_TYPE_EVDO_B -> "CDMAEVDORevB"
+            TelephonyManager.NETWORK_TYPE_HSDPA -> "HSDPA"
+            TelephonyManager.NETWORK_TYPE_HSUPA -> "HSUPA"
+            TelephonyManager.NETWORK_TYPE_HSPA -> "HSPA"
+            TelephonyManager.NETWORK_TYPE_EHRPD -> "eHRPD"
+            TelephonyManager.NETWORK_TYPE_HSPAP -> "HSPA+"
+            TelephonyManager.NETWORK_TYPE_TD_SCDMA -> "TD_SCDMA"
+            TelephonyManager.NETWORK_TYPE_LTE -> "LTE"
+            TelephonyManager.NETWORK_TYPE_IWLAN -> "IWLAN"
+            NETWORK_TYPE_LTE_CA -> "LTE_CA"
+            TelephonyManager.NETWORK_TYPE_NR -> "New Radio"
+            else -> null
+        }
     }
 
     // endregion

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
@@ -28,8 +28,7 @@ internal class BroadcastReceiverNetworkInfoProvider(
     private val internalLogger: InternalLogger,
     private val executorService: ExecutorService,
     private val buildSdkVersionProvider: BuildSdkVersionProvider = BuildSdkVersionProvider.DEFAULT
-) :
-    ThreadSafeReceiver(),
+) : ThreadSafeReceiver(),
     NetworkInfoProvider {
 
     @Volatile
@@ -65,19 +64,14 @@ internal class BroadcastReceiverNetworkInfoProvider(
         unregisterReceiver(context)
     }
 
-    override fun getLatestNetworkInfo(): NetworkInfo {
-        return networkInfo
-    }
+    override fun getLatestNetworkInfo(): NetworkInfo = networkInfo
 
     // endregion
 
     // region Internal
 
-    private fun buildNetworkInfo(
-        context: Context,
-        activeNetworkInfo: AndroidNetworkInfo?
-    ): NetworkInfo {
-        return if (activeNetworkInfo == null || !activeNetworkInfo.isConnected) {
+    private fun buildNetworkInfo(context: Context, activeNetworkInfo: AndroidNetworkInfo?): NetworkInfo =
+        if (activeNetworkInfo == null || !activeNetworkInfo.isConnected) {
             NetworkInfo(
                 NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED
             )
@@ -90,15 +84,18 @@ internal class BroadcastReceiverNetworkInfoProvider(
                 NetworkInfo.Connectivity.NETWORK_ETHERNET
             )
         } else if (activeNetworkInfo.type in knownMobileTypes) {
-            buildMobileNetworkInfo(context, activeNetworkInfo.subtype)
+            val telephonyManager = context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
+            val carrierInfoResolver = telephonyManager?.let {
+                CarrierInfoResolver(it, internalLogger, buildSdkVersionProvider)
+            }
+            buildMobileNetworkInfo(carrierInfoResolver, activeNetworkInfo.subtype)
         } else {
             NetworkInfo(
                 NetworkInfo.Connectivity.NETWORK_OTHER
             )
         }
-    }
 
-    private fun buildMobileNetworkInfo(context: Context, subtype: Int): NetworkInfo {
+    private fun buildMobileNetworkInfo(carrierInfoResolver: CarrierInfoResolver?, subtype: Int): NetworkInfo {
         val connectivity = when (subtype) {
             in known2GSubtypes -> NetworkInfo.Connectivity.NETWORK_2G
             in known3GSubtypes -> NetworkInfo.Connectivity.NETWORK_3G
@@ -108,46 +105,36 @@ internal class BroadcastReceiverNetworkInfoProvider(
         }
         val cellularTechnology = getCellularTechnology(subtype)
 
-        return if (buildSdkVersionProvider.isAtLeastP) {
-            val telephonyMgr =
-                context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
-            val carrierName = telephonyMgr?.simCarrierIdName ?: UNKNOWN_CARRIER_NAME
-            val carrierId = telephonyMgr?.simCarrierId?.toLong()
-            NetworkInfo(
-                connectivity,
-                carrierName.toString(),
-                carrierId,
-                cellularTechnology = cellularTechnology
-            )
-        } else {
-            NetworkInfo(connectivity, cellularTechnology = cellularTechnology)
-        }
+        return NetworkInfo(
+            connectivity,
+            carrierName = carrierInfoResolver?.carrierName,
+            carrierId = carrierInfoResolver?.carrierId,
+            cellularTechnology = cellularTechnology
+        )
     }
 
-    private fun getCellularTechnology(subtype: Int): String? {
-        return when (subtype) {
-            TelephonyManager.NETWORK_TYPE_GPRS -> "GPRS"
-            TelephonyManager.NETWORK_TYPE_EDGE -> "Edge"
-            TelephonyManager.NETWORK_TYPE_CDMA -> "CDMA"
-            TelephonyManager.NETWORK_TYPE_1xRTT -> "CDMA1x"
-            TelephonyManager.NETWORK_TYPE_IDEN -> "iDen"
-            TelephonyManager.NETWORK_TYPE_GSM -> "GSM"
-            TelephonyManager.NETWORK_TYPE_UMTS -> "UMTS"
-            TelephonyManager.NETWORK_TYPE_EVDO_0 -> "CDMAEVDORev0"
-            TelephonyManager.NETWORK_TYPE_EVDO_A -> "CDMAEVDORevA"
-            TelephonyManager.NETWORK_TYPE_EVDO_B -> "CDMAEVDORevB"
-            TelephonyManager.NETWORK_TYPE_HSDPA -> "HSDPA"
-            TelephonyManager.NETWORK_TYPE_HSUPA -> "HSUPA"
-            TelephonyManager.NETWORK_TYPE_HSPA -> "HSPA"
-            TelephonyManager.NETWORK_TYPE_EHRPD -> "eHRPD"
-            TelephonyManager.NETWORK_TYPE_HSPAP -> "HSPA+"
-            TelephonyManager.NETWORK_TYPE_TD_SCDMA -> "TD_SCDMA"
-            TelephonyManager.NETWORK_TYPE_LTE -> "LTE"
-            TelephonyManager.NETWORK_TYPE_IWLAN -> "IWLAN"
-            NETWORK_TYPE_LTE_CA -> "LTE_CA"
-            TelephonyManager.NETWORK_TYPE_NR -> "New Radio"
-            else -> null
-        }
+    private fun getCellularTechnology(subtype: Int): String? = when (subtype) {
+        TelephonyManager.NETWORK_TYPE_GPRS -> "GPRS"
+        TelephonyManager.NETWORK_TYPE_EDGE -> "Edge"
+        TelephonyManager.NETWORK_TYPE_CDMA -> "CDMA"
+        TelephonyManager.NETWORK_TYPE_1xRTT -> "CDMA1x"
+        TelephonyManager.NETWORK_TYPE_IDEN -> "iDen"
+        TelephonyManager.NETWORK_TYPE_GSM -> "GSM"
+        TelephonyManager.NETWORK_TYPE_UMTS -> "UMTS"
+        TelephonyManager.NETWORK_TYPE_EVDO_0 -> "CDMAEVDORev0"
+        TelephonyManager.NETWORK_TYPE_EVDO_A -> "CDMAEVDORevA"
+        TelephonyManager.NETWORK_TYPE_EVDO_B -> "CDMAEVDORevB"
+        TelephonyManager.NETWORK_TYPE_HSDPA -> "HSDPA"
+        TelephonyManager.NETWORK_TYPE_HSUPA -> "HSUPA"
+        TelephonyManager.NETWORK_TYPE_HSPA -> "HSPA"
+        TelephonyManager.NETWORK_TYPE_EHRPD -> "eHRPD"
+        TelephonyManager.NETWORK_TYPE_HSPAP -> "HSPA+"
+        TelephonyManager.NETWORK_TYPE_TD_SCDMA -> "TD_SCDMA"
+        TelephonyManager.NETWORK_TYPE_LTE -> "LTE"
+        TelephonyManager.NETWORK_TYPE_IWLAN -> "IWLAN"
+        NETWORK_TYPE_LTE_CA -> "LTE_CA"
+        TelephonyManager.NETWORK_TYPE_NR -> "New Radio"
+        else -> null
     }
 
     // endregion
@@ -197,7 +184,5 @@ internal class BroadcastReceiverNetworkInfoProvider(
         private val known5GSubtypes = setOf(
             TelephonyManager.NETWORK_TYPE_NR
         )
-
-        private const val UNKNOWN_CARRIER_NAME = "Unknown Carrier Name"
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProvider.kt
@@ -139,37 +139,42 @@ internal class CallbackNetworkInfoProvider(
         }
     }
 
-    override fun getLatestNetworkInfo(): NetworkInfo = lastNetworkInfo
+    override fun getLatestNetworkInfo(): NetworkInfo {
+        return lastNetworkInfo
+    }
 
     // endregion
 
     // region Internal
 
-    private fun resolveUpBandwidth(networkCapabilities: NetworkCapabilities): Long? =
-        if (networkCapabilities.linkUpstreamBandwidthKbps > 0) {
+    private fun resolveUpBandwidth(networkCapabilities: NetworkCapabilities): Long? {
+        return if (networkCapabilities.linkUpstreamBandwidthKbps > 0) {
             networkCapabilities.linkUpstreamBandwidthKbps.toLong()
         } else {
             null
         }
+    }
 
-    private fun resolveDownBandwidth(networkCapabilities: NetworkCapabilities): Long? =
-        if (networkCapabilities.linkDownstreamBandwidthKbps > 0) {
+    private fun resolveDownBandwidth(networkCapabilities: NetworkCapabilities): Long? {
+        return if (networkCapabilities.linkDownstreamBandwidthKbps > 0) {
             networkCapabilities.linkDownstreamBandwidthKbps.toLong()
         } else {
             null
         }
+    }
 
-    private fun resolveStrength(networkCapabilities: NetworkCapabilities): Long? =
-        if (buildSdkVersionProvider.isAtLeastQ &&
+    private fun resolveStrength(networkCapabilities: NetworkCapabilities): Long? {
+        return if (buildSdkVersionProvider.isAtLeastQ &&
             networkCapabilities.signalStrength != NetworkCapabilities.SIGNAL_STRENGTH_UNSPECIFIED
         ) {
             networkCapabilities.signalStrength.toLong()
         } else {
             null
         }
+    }
 
-    private fun getNetworkType(networkCapabilities: NetworkCapabilities): NetworkInfo.Connectivity =
-        if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+    private fun getNetworkType(networkCapabilities: NetworkCapabilities): NetworkInfo.Connectivity {
+        return if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
             NetworkInfo.Connectivity.NETWORK_WIFI
         } else if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
             NetworkInfo.Connectivity.NETWORK_ETHERNET
@@ -180,6 +185,7 @@ internal class CallbackNetworkInfoProvider(
         } else {
             NetworkInfo.Connectivity.NETWORK_OTHER
         }
+    }
 
     // endregion
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProvider.kt
@@ -11,6 +11,7 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.os.Build
+import android.telephony.TelephonyManager
 import androidx.annotation.RequiresApi
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.NetworkInfo
@@ -20,19 +21,24 @@ import com.datadog.android.internal.system.BuildSdkVersionProvider
 internal class CallbackNetworkInfoProvider(
     private val buildSdkVersionProvider: BuildSdkVersionProvider = BuildSdkVersionProvider.DEFAULT,
     private val internalLogger: InternalLogger
-) :
-    ConnectivityManager.NetworkCallback(),
+) : ConnectivityManager.NetworkCallback(),
     NetworkInfoProvider {
 
     @Volatile
     private var lastNetworkInfo: NetworkInfo = NetworkInfo()
 
+    @Volatile
+    private var carrierInfoResolver: CarrierInfoResolver? = null
+
     // region NetworkCallback
 
     override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
         super.onCapabilitiesChanged(network, networkCapabilities)
+        val isCellular = networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
         lastNetworkInfo = NetworkInfo(
             connectivity = getNetworkType(networkCapabilities),
+            carrierName = if (isCellular) carrierInfoResolver?.carrierName else null,
+            carrierId = if (isCellular) carrierInfoResolver?.carrierId else null,
             upKbps = resolveUpBandwidth(networkCapabilities),
             downKbps = resolveDownBandwidth(networkCapabilities),
             strength = resolveStrength(networkCapabilities)
@@ -50,6 +56,8 @@ internal class CallbackNetworkInfoProvider(
 
     @Suppress("TooGenericExceptionCaught")
     override fun register(context: Context) {
+        carrierInfoResolver = (context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager)
+            ?.let { CarrierInfoResolver(it, internalLogger, buildSdkVersionProvider) }
         val systemService = context.getSystemService(Context.CONNECTIVITY_SERVICE)
         val connMgr = systemService as? ConnectivityManager
 
@@ -95,6 +103,7 @@ internal class CallbackNetworkInfoProvider(
 
     @Suppress("TooGenericExceptionCaught")
     override fun unregister(context: Context) {
+        carrierInfoResolver = null
         val systemService = context.getSystemService(Context.CONNECTIVITY_SERVICE)
         val connMgr = systemService as? ConnectivityManager
 
@@ -130,42 +139,37 @@ internal class CallbackNetworkInfoProvider(
         }
     }
 
-    override fun getLatestNetworkInfo(): NetworkInfo {
-        return lastNetworkInfo
-    }
+    override fun getLatestNetworkInfo(): NetworkInfo = lastNetworkInfo
 
     // endregion
 
     // region Internal
 
-    private fun resolveUpBandwidth(networkCapabilities: NetworkCapabilities): Long? {
-        return if (networkCapabilities.linkUpstreamBandwidthKbps > 0) {
+    private fun resolveUpBandwidth(networkCapabilities: NetworkCapabilities): Long? =
+        if (networkCapabilities.linkUpstreamBandwidthKbps > 0) {
             networkCapabilities.linkUpstreamBandwidthKbps.toLong()
         } else {
             null
         }
-    }
 
-    private fun resolveDownBandwidth(networkCapabilities: NetworkCapabilities): Long? {
-        return if (networkCapabilities.linkDownstreamBandwidthKbps > 0) {
+    private fun resolveDownBandwidth(networkCapabilities: NetworkCapabilities): Long? =
+        if (networkCapabilities.linkDownstreamBandwidthKbps > 0) {
             networkCapabilities.linkDownstreamBandwidthKbps.toLong()
         } else {
             null
         }
-    }
 
-    private fun resolveStrength(networkCapabilities: NetworkCapabilities): Long? {
-        return if (buildSdkVersionProvider.isAtLeastQ &&
+    private fun resolveStrength(networkCapabilities: NetworkCapabilities): Long? =
+        if (buildSdkVersionProvider.isAtLeastQ &&
             networkCapabilities.signalStrength != NetworkCapabilities.SIGNAL_STRENGTH_UNSPECIFIED
         ) {
             networkCapabilities.signalStrength.toLong()
         } else {
             null
         }
-    }
 
-    private fun getNetworkType(networkCapabilities: NetworkCapabilities): NetworkInfo.Connectivity {
-        return if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+    private fun getNetworkType(networkCapabilities: NetworkCapabilities): NetworkInfo.Connectivity =
+        if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
             NetworkInfo.Connectivity.NETWORK_WIFI
         } else if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
             NetworkInfo.Connectivity.NETWORK_ETHERNET
@@ -176,7 +180,6 @@ internal class CallbackNetworkInfoProvider(
         } else {
             NetworkInfo.Connectivity.NETWORK_OTHER
         }
-    }
 
     // endregion
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/CarrierInfoResolver.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/CarrierInfoResolver.kt
@@ -1,0 +1,62 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.android.core.internal.net.info
+
+import android.telephony.TelephonyManager
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.internal.system.BuildSdkVersionProvider
+
+internal class CarrierInfoResolver(
+    private val telephonyManager: TelephonyManager,
+    private val internalLogger: InternalLogger,
+    private val sdkVersionProvider: BuildSdkVersionProvider = BuildSdkVersionProvider.DEFAULT
+) {
+
+    val carrierId: Long?
+        get() = telephonyManager.resolveCarrierId()
+
+    val carrierName: String?
+        get() = telephonyManager.resolveCarrierName()
+
+    private fun TelephonyManager.resolveCarrierName(): String? = try {
+        if (sdkVersionProvider.isAtLeastP) {
+            simCarrierIdName?.toString()
+        } else {
+            networkOperatorName?.takeIf {
+                it.isNotEmpty()
+            }
+        }
+    } catch (@Suppress("TooGenericExceptionCaught") e: RuntimeException) {
+        internalLogger.log(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            { ERROR_CARRIER_NAME },
+            e
+        )
+        null
+    }
+
+    private fun TelephonyManager.resolveCarrierId(): Long? = try {
+        if (sdkVersionProvider.isAtLeastP) {
+            simCarrierId.takeIf { it != TelephonyManager.UNKNOWN_CARRIER_ID }?.toLong()
+        } else {
+            networkOperator?.takeIf { it.isNotEmpty() }?.toLongOrNull()
+        }
+    } catch (@Suppress("TooGenericExceptionCaught") e: RuntimeException) {
+        internalLogger.log(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            { ERROR_CARRIER_ID },
+            e
+        )
+        null
+    }
+
+    internal companion object {
+        internal const val ERROR_CARRIER_ID = "Failed to resolve carrier id information from TelephonyManager."
+        internal const val ERROR_CARRIER_NAME = "Failed to resolve carrier name information from TelephonyManager."
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProviderTest.kt
@@ -14,7 +14,6 @@ import android.net.ConnectivityManager
 import android.telephony.TelephonyManager
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.NetworkInfo
-import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.utils.assertj.NetworkInfoAssert.Companion.assertThat
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
@@ -70,9 +69,6 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
     lateinit var mockIntent: Intent
 
     @Mock
-    lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
-
-    @Mock
     lateinit var mockInternalLogger: InternalLogger
 
     @Mock
@@ -85,15 +81,13 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
         whenever(mockContext.getSystemService(Context.TELEPHONY_SERVICE))
             .doReturn(mockTelephonyManager)
         whenever(mockConnectivityManager.activeNetworkInfo) doReturn mockNetworkInfo
-        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn false
         whenever(mockExecutorService.execute(any())) doAnswer {
             it.getArgument<Runnable>(0).run()
         }
 
         testedProvider = BroadcastReceiverNetworkInfoProvider(
             internalLogger = mockInternalLogger,
-            executorService = mockExecutorService,
-            buildSdkVersionProvider = mockBuildSdkVersionProvider
+            executorService = mockExecutorService
         )
     }
 
@@ -227,40 +221,13 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
     @MethodSource("2gSubtypeToMobileTypes")
     fun `connected to mobile 2G`(subtype: NetworkType, mobileType: MobileType, forge: Forge) {
         val carrierName = forge.anAlphabeticalString()
-        val carrierId = forge.aPositiveInt(strict = true)
+        val carrierId = forge.anInt(min = 10_000, max = 999_999).toString()
         stubNetworkInfo(mobileType.id, subtype.id)
         stubTelephonyManager(carrierName, carrierId)
         testedProvider.onReceive(mockContext, mockIntent)
 
         val networkInfo = testedProvider.getLatestNetworkInfo()
 
-        assertThat(networkInfo)
-            .hasConnectivity(NetworkInfo.Connectivity.NETWORK_2G)
-            .hasCarrierName(null)
-            .hasCarrierId(null)
-            .hasCellularTechnology(mobileSubtypeNames[subtype.id])
-    }
-
-    @ParameterizedTest
-    @MethodSource("2gSubtypeToMobileTypes")
-    fun `connected to mobile 2G API 28+`(
-        subtype: NetworkType,
-        mobileType: MobileType,
-        forge: Forge
-    ) {
-        // GIVEN
-        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
-
-        val carrierName = forge.anAlphabeticalString()
-        val carrierId = forge.aPositiveInt(strict = true)
-        stubNetworkInfo(mobileType.id, subtype.id)
-        stubTelephonyManager(carrierName, carrierId)
-        testedProvider.onReceive(mockContext, mockIntent)
-
-        // WHEN
-        val networkInfo = testedProvider.getLatestNetworkInfo()
-
-        // THEN
         assertThat(networkInfo)
             .hasConnectivity(NetworkInfo.Connectivity.NETWORK_2G)
             .hasCarrierName(carrierName)
@@ -272,40 +239,13 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
     @MethodSource("3gSubtypeToMobileTypes")
     fun `connected to mobile 3G`(subtype: NetworkType, mobileType: MobileType, forge: Forge) {
         val carrierName = forge.anAlphabeticalString()
-        val carrierId = forge.aPositiveInt(strict = true)
+        val carrierId = forge.anInt(min = 10_000, max = 999_999).toString()
         stubNetworkInfo(mobileType.id, subtype.id)
         stubTelephonyManager(carrierName, carrierId)
         testedProvider.onReceive(mockContext, mockIntent)
 
         val networkInfo = testedProvider.getLatestNetworkInfo()
 
-        assertThat(networkInfo)
-            .hasConnectivity(NetworkInfo.Connectivity.NETWORK_3G)
-            .hasCarrierName(null)
-            .hasCarrierId(null)
-            .hasCellularTechnology(mobileSubtypeNames[subtype.id])
-    }
-
-    @ParameterizedTest
-    @MethodSource("3gSubtypeToMobileTypes")
-    fun `connected to mobile 3G API 28+`(
-        subtype: NetworkType,
-        mobileType: MobileType,
-        forge: Forge
-    ) {
-        // GIVEN
-        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
-
-        val carrierName = forge.anAlphabeticalString()
-        val carrierId = forge.aPositiveInt(strict = true)
-        stubNetworkInfo(mobileType.id, subtype.id)
-        stubTelephonyManager(carrierName, carrierId)
-        testedProvider.onReceive(mockContext, mockIntent)
-
-        // WHEN
-        val networkInfo = testedProvider.getLatestNetworkInfo()
-
-        // THEN
         assertThat(networkInfo)
             .hasConnectivity(NetworkInfo.Connectivity.NETWORK_3G)
             .hasCarrierName(carrierName)
@@ -317,40 +257,13 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
     @MethodSource("4gSubtypeToMobileTypes")
     fun `connected to mobile 4G`(subtype: NetworkType, mobileType: MobileType, forge: Forge) {
         val carrierName = forge.anAlphabeticalString()
-        val carrierId = forge.aPositiveInt(strict = true)
+        val carrierId = forge.anInt(min = 10_000, max = 999_999).toString()
         stubNetworkInfo(mobileType.id, subtype.id)
         stubTelephonyManager(carrierName, carrierId)
         testedProvider.onReceive(mockContext, mockIntent)
 
         val networkInfo = testedProvider.getLatestNetworkInfo()
 
-        assertThat(networkInfo)
-            .hasConnectivity(NetworkInfo.Connectivity.NETWORK_4G)
-            .hasCarrierName(null)
-            .hasCarrierId(null)
-            .hasCellularTechnology(mobileSubtypeNames[subtype.id])
-    }
-
-    @ParameterizedTest
-    @MethodSource("4gSubtypeToMobileTypes")
-    fun `connected to mobile 4G API 28+`(
-        subtype: NetworkType,
-        mobileType: MobileType,
-        forge: Forge
-    ) {
-        // GIVEN
-        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
-
-        val carrierName = forge.anAlphabeticalString()
-        val carrierId = forge.aPositiveInt(strict = true)
-        stubNetworkInfo(mobileType.id, subtype.id)
-        stubTelephonyManager(carrierName, carrierId)
-        testedProvider.onReceive(mockContext, mockIntent)
-
-        // WHEN
-        val networkInfo = testedProvider.getLatestNetworkInfo()
-
-        // THEN
         assertThat(networkInfo)
             .hasConnectivity(NetworkInfo.Connectivity.NETWORK_4G)
             .hasCarrierName(carrierName)
@@ -362,40 +275,13 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
     @MethodSource("5gSubtypeToMobileTypes")
     fun `connected to mobile 5G`(subtype: NetworkType, mobileType: MobileType, forge: Forge) {
         val carrierName = forge.anAlphabeticalString()
-        val carrierId = forge.aPositiveInt(strict = true)
+        val carrierId = forge.anInt(min = 10_000, max = 999_999).toString()
         stubNetworkInfo(mobileType.id, subtype.id)
         stubTelephonyManager(carrierName, carrierId)
         testedProvider.onReceive(mockContext, mockIntent)
 
         val networkInfo = testedProvider.getLatestNetworkInfo()
 
-        assertThat(networkInfo)
-            .hasConnectivity(NetworkInfo.Connectivity.NETWORK_5G)
-            .hasCarrierName(null)
-            .hasCarrierId(null)
-            .hasCellularTechnology(mobileSubtypeNames[subtype.id])
-    }
-
-    @ParameterizedTest
-    @MethodSource("5gSubtypeToMobileTypes")
-    fun `connected to mobile 5G API 28+`(
-        subtype: NetworkType,
-        mobileType: MobileType,
-        forge: Forge
-    ) {
-        // GIVEN
-        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
-
-        val carrierName = forge.anAlphabeticalString()
-        val carrierId = forge.aPositiveInt(strict = true)
-        stubNetworkInfo(mobileType.id, subtype.id)
-        stubTelephonyManager(carrierName, carrierId)
-        testedProvider.onReceive(mockContext, mockIntent)
-
-        // WHEN
-        val networkInfo = testedProvider.getLatestNetworkInfo()
-
-        // THEN
         assertThat(networkInfo)
             .hasConnectivity(NetworkInfo.Connectivity.NETWORK_5G)
             .hasCarrierName(carrierName)
@@ -405,40 +291,16 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
 
     @ParameterizedTest
     @MethodSource("getKnownMobileTypes")
-    fun `connected to mobile unknown`(mobileType: MobileType, forge: Forge) {
+    fun `connected to mobile unknown subtype`(mobileType: MobileType, forge: Forge) {
         val subtype = forge.anInt(min = 32)
         val carrierName = forge.anAlphabeticalString()
-        val carrierId = forge.aPositiveInt(strict = true)
+        val carrierId = forge.anInt(min = 10_000, max = 999_999).toString()
         stubNetworkInfo(mobileType.id, subtype)
         stubTelephonyManager(carrierName, carrierId)
         testedProvider.onReceive(mockContext, mockIntent)
 
         val networkInfo = testedProvider.getLatestNetworkInfo()
 
-        assertThat(networkInfo)
-            .hasConnectivity(NetworkInfo.Connectivity.NETWORK_MOBILE_OTHER)
-            .hasCarrierName(null)
-            .hasCarrierId(null)
-            .hasCellularTechnology(null)
-    }
-
-    @ParameterizedTest
-    @MethodSource("getKnownMobileTypes")
-    fun `connected to mobile unknown API 28+`(mobileType: MobileType, forge: Forge) {
-        // GIVEN
-        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
-
-        val subtype = forge.anInt(min = 32)
-        val carrierName = forge.anAlphabeticalString()
-        val carrierId = forge.aPositiveInt(strict = true)
-        stubNetworkInfo(mobileType.id, subtype)
-        stubTelephonyManager(carrierName, carrierId)
-        testedProvider.onReceive(mockContext, mockIntent)
-
-        // WHEN
-        val networkInfo = testedProvider.getLatestNetworkInfo()
-
-        // THEN
         assertThat(networkInfo)
             .hasConnectivity(NetworkInfo.Connectivity.NETWORK_MOBILE_OTHER)
             .hasCarrierName(carrierName)
@@ -448,25 +310,41 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
 
     @ParameterizedTest
     @MethodSource("getKnownMobileTypes")
-    fun `connected to mobile unknown carrier`(mobileType: MobileType) {
-        // GIVEN
-        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
+    fun `M leave carrier null W TelephonyManager returns empty operator`(mobileType: MobileType) {
+        // Given
+        stubNetworkInfo(mobileType.id, TelephonyManager.NETWORK_TYPE_UNKNOWN)
+        stubTelephonyManager(operatorName = "", operatorCode = "")
 
-        stubNetworkInfo(
-            mobileType.id,
-            TelephonyManager.NETWORK_TYPE_UNKNOWN
-        )
-        stubTelephonyManager(null, 0)
+        // When
         testedProvider.onReceive(mockContext, mockIntent)
-
-        // WHEN
         val networkInfo = testedProvider.getLatestNetworkInfo()
 
-        // THEN
+        // Then
         assertThat(networkInfo)
             .hasConnectivity(NetworkInfo.Connectivity.NETWORK_MOBILE_OTHER)
-            .hasCarrierName("Unknown Carrier Name")
-            .hasCarrierId(0)
+            .hasCarrierName(null)
+            .hasCarrierId(null)
+            .hasCellularTechnology(null)
+    }
+
+    @ParameterizedTest
+    @MethodSource("getKnownMobileTypes")
+    fun `M leave carrierId null W networkOperator is not numeric`(mobileType: MobileType, forge: Forge) {
+        // Given
+        val carrierName = forge.anAlphabeticalString()
+        val nonNumericOperator = forge.anAlphabeticalString()
+        stubNetworkInfo(mobileType.id, TelephonyManager.NETWORK_TYPE_UNKNOWN)
+        stubTelephonyManager(operatorName = carrierName, operatorCode = nonNumericOperator)
+
+        // When
+        testedProvider.onReceive(mockContext, mockIntent)
+        val networkInfo = testedProvider.getLatestNetworkInfo()
+
+        // Then
+        assertThat(networkInfo)
+            .hasConnectivity(NetworkInfo.Connectivity.NETWORK_MOBILE_OTHER)
+            .hasCarrierName(carrierName)
+            .hasCarrierId(null)
             .hasCellularTechnology(null)
     }
 
@@ -495,9 +373,9 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
 
     // region Internal
 
-    private fun stubTelephonyManager(carrierName: String?, carrierId: Int) {
-        whenever(mockTelephonyManager.simCarrierIdName) doReturn carrierName
-        whenever(mockTelephonyManager.simCarrierId) doReturn carrierId
+    private fun stubTelephonyManager(operatorName: String?, operatorCode: String?) {
+        whenever(mockTelephonyManager.networkOperatorName) doReturn operatorName
+        whenever(mockTelephonyManager.networkOperator) doReturn operatorCode
     }
 
     private fun stubNetworkInfo(networkType: Int, networkSubtype: Int) {
@@ -586,46 +464,38 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
             known5GSubtypes.map { NetworkType(mobileSubtypeNames[it], it) }
 
         @JvmStatic
-        fun `2gSubtypeToMobileTypes`(): Stream<Arguments> {
-            return allCombinations(known2GSubtypesWithNames, knownMobileTypesWithNames)
+        fun `2gSubtypeToMobileTypes`(): Stream<Arguments> =
+            allCombinations(known2GSubtypesWithNames, knownMobileTypesWithNames)
                 .map { Arguments.of(it.first, it.second) }
                 .stream()
-        }
 
         @JvmStatic
-        fun `3gSubtypeToMobileTypes`(): Stream<Arguments> {
-            return allCombinations(known3GSubtypesWithNames, knownMobileTypesWithNames)
+        fun `3gSubtypeToMobileTypes`(): Stream<Arguments> =
+            allCombinations(known3GSubtypesWithNames, knownMobileTypesWithNames)
                 .map { Arguments.of(it.first, it.second) }
                 .stream()
-        }
 
         @JvmStatic
-        fun `4gSubtypeToMobileTypes`(): Stream<Arguments> {
-            return allCombinations(known4GSubtypesWithNames, knownMobileTypesWithNames)
+        fun `4gSubtypeToMobileTypes`(): Stream<Arguments> =
+            allCombinations(known4GSubtypesWithNames, knownMobileTypesWithNames)
                 .map { Arguments.of(it.first, it.second) }
                 .stream()
-        }
 
         @JvmStatic
-        fun `5gSubtypeToMobileTypes`(): Stream<Arguments> {
-            return allCombinations(known5GSubtypesWithNames, knownMobileTypesWithNames)
+        fun `5gSubtypeToMobileTypes`(): Stream<Arguments> =
+            allCombinations(known5GSubtypesWithNames, knownMobileTypesWithNames)
                 .map { Arguments.of(it.first, it.second) }
                 .stream()
-        }
 
         @JvmStatic
-        fun getKnownMobileTypes(): List<MobileType> {
-            return knownMobileTypesWithNames
-        }
+        fun getKnownMobileTypes(): List<MobileType> = knownMobileTypesWithNames
 
         private fun allCombinations(
             networkTypes: Iterable<NetworkType>,
             mobileTypes: Iterable<MobileType>
-        ): Iterable<Pair<NetworkType, MobileType>> {
-            return networkTypes
-                .flatMap { item ->
-                    mobileTypes.map { item to it }
-                }
-        }
+        ): Iterable<Pair<NetworkType, MobileType>> = networkTypes
+            .flatMap { item ->
+                mobileTypes.map { item to it }
+            }
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProviderTest.kt
@@ -10,12 +10,14 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
+import android.telephony.TelephonyManager
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.utils.assertj.NetworkInfoAssert.Companion.assertThat
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
+import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -111,10 +113,7 @@ internal class CallbackNetworkInfoProviderTest {
     }
 
     @Test
-    fun `connected to wifi (no strength)`(
-        @IntForgery(min = 1) upSpeed: Int,
-        @IntForgery(min = 1) downSpeed: Int
-    ) {
+    fun `connected to wifi (no strength)`(@IntForgery(min = 1) upSpeed: Int, @IntForgery(min = 1) downSpeed: Int) {
         // GIVEN
         whenever(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) doReturn true
         whenever(mockCapabilities.linkUpstreamBandwidthKbps) doReturn upSpeed
@@ -227,10 +226,7 @@ internal class CallbackNetworkInfoProviderTest {
     }
 
     @Test
-    fun `connected to cellular`(
-        @IntForgery(min = 1) upSpeed: Int,
-        @IntForgery(min = 1) downSpeed: Int
-    ) {
+    fun `connected to cellular`(@IntForgery(min = 1) upSpeed: Int, @IntForgery(min = 1) downSpeed: Int) {
         whenever(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR))
             .doReturn(true)
         whenever(mockCapabilities.linkUpstreamBandwidthKbps) doReturn upSpeed
@@ -248,10 +244,7 @@ internal class CallbackNetworkInfoProviderTest {
     }
 
     @Test
-    fun `connected to ethernet`(
-        @IntForgery(min = 1) upSpeed: Int,
-        @IntForgery(min = 1) downSpeed: Int
-    ) {
+    fun `connected to ethernet`(@IntForgery(min = 1) upSpeed: Int, @IntForgery(min = 1) downSpeed: Int) {
         whenever(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET))
             .doReturn(true)
         whenever(mockCapabilities.linkUpstreamBandwidthKbps) doReturn upSpeed
@@ -269,10 +262,7 @@ internal class CallbackNetworkInfoProviderTest {
     }
 
     @Test
-    fun `connected to VPN`(
-        @IntForgery(min = 1) upSpeed: Int,
-        @IntForgery(min = 1) downSpeed: Int
-    ) {
+    fun `connected to VPN`(@IntForgery(min = 1) upSpeed: Int, @IntForgery(min = 1) downSpeed: Int) {
         whenever(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) doReturn true
         whenever(mockCapabilities.linkUpstreamBandwidthKbps) doReturn upSpeed
         whenever(mockCapabilities.linkDownstreamBandwidthKbps) doReturn downSpeed
@@ -290,10 +280,7 @@ internal class CallbackNetworkInfoProviderTest {
     }
 
     @Test
-    fun `connected to LoWPAN`(
-        @IntForgery(min = 1) upSpeed: Int,
-        @IntForgery(min = 1) downSpeed: Int
-    ) {
+    fun `connected to LoWPAN`(@IntForgery(min = 1) upSpeed: Int, @IntForgery(min = 1) downSpeed: Int) {
         whenever(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_LOWPAN))
             .doReturn(true)
         whenever(mockCapabilities.linkUpstreamBandwidthKbps) doReturn upSpeed
@@ -312,10 +299,7 @@ internal class CallbackNetworkInfoProviderTest {
     }
 
     @Test
-    fun `network lost`(
-        @IntForgery(min = 1) upSpeed: Int,
-        @IntForgery(min = 1) downSpeed: Int
-    ) {
+    fun `network lost`(@IntForgery(min = 1) upSpeed: Int, @IntForgery(min = 1) downSpeed: Int) {
         whenever(mockCapabilities.hasTransport(any())) doReturn true
         whenever(mockCapabilities.linkUpstreamBandwidthKbps) doReturn upSpeed
         whenever(mockCapabilities.linkDownstreamBandwidthKbps) doReturn downSpeed
@@ -372,9 +356,7 @@ internal class CallbackNetworkInfoProviderTest {
     }
 
     @Test
-    fun `M register callback safely W register() with SecurityException`(
-        @StringForgery message: String
-    ) {
+    fun `M register callback safely W register() with SecurityException`(@StringForgery message: String) {
         // RUMM-852 in some cases the device throws a SecurityException on register
         val context = mock<Context>()
         val manager = mock<ConnectivityManager>()
@@ -402,9 +384,7 @@ internal class CallbackNetworkInfoProviderTest {
     }
 
     @Test
-    fun `M warn developers W register() with SecurityException`(
-        @StringForgery message: String
-    ) {
+    fun `M warn developers W register() with SecurityException`(@StringForgery message: String) {
         // RUMM-852 in some cases the device throws a SecurityException on register
         val context = mock<Context>()
         val manager = mock<ConnectivityManager>()
@@ -423,9 +403,7 @@ internal class CallbackNetworkInfoProviderTest {
     }
 
     @Test
-    fun `M warn developers W register() with RuntimeException`(
-        @StringForgery message: String
-    ) {
+    fun `M warn developers W register() with RuntimeException`(@StringForgery message: String) {
         // RUMM-918 in some cases the device throws a IllegalArgumentException on register
         // "Too many NetworkRequests filed" This happens when registerDefaultNetworkCallback is
         // called too many times without matching unregisterNetworkCallback
@@ -505,9 +483,7 @@ internal class CallbackNetworkInfoProviderTest {
     }
 
     @Test
-    fun `M unregister callback safely W unregister() with SecurityException`(
-        @StringForgery message: String
-    ) {
+    fun `M unregister callback safely W unregister() with SecurityException`(@StringForgery message: String) {
         // RUMM-852 in some cases the device throws a SecurityException on register
         // Since we can't reproduce, let's assume it could happen on unregister too
         val context = mock<Context>()
@@ -522,9 +498,7 @@ internal class CallbackNetworkInfoProviderTest {
     }
 
     @Test
-    fun `M warn developers W unregister() with SecurityException`(
-        @StringForgery message: String
-    ) {
+    fun `M warn developers W unregister() with SecurityException`(@StringForgery message: String) {
         // RUMM-852 in some cases the device throws a SecurityException on register
         val context = mock<Context>()
         val manager = mock<ConnectivityManager>()
@@ -557,9 +531,7 @@ internal class CallbackNetworkInfoProviderTest {
     }
 
     @Test
-    fun `M warn developers W unregister() with RuntimeException`(
-        @StringForgery message: String
-    ) {
+    fun `M warn developers W unregister() with RuntimeException`(@StringForgery message: String) {
         // RUMM-918 in some cases the device throws a IllegalArgumentException on unregister
         // e.g. when the callback was not registered
         val context = mock<Context>()
@@ -576,5 +548,227 @@ internal class CallbackNetworkInfoProviderTest {
             CallbackNetworkInfoProvider.ERROR_UNREGISTER,
             exception
         )
+    }
+
+    // region carrier on cellular
+
+    @Test
+    fun `M report carrier from simCarrierIdName W onCapabilitiesChanged on cellular API 28+`(
+        @StringForgery carrierName: String,
+        @IntForgery(min = 1) carrierId: Int
+    ) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
+        val telephonyManager = mock<TelephonyManager> {
+            on { simCarrierIdName } doReturn carrierName
+            on { this.simCarrierId } doReturn carrierId
+        }
+        registerWithTelephony(telephonyManager)
+        whenever(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR))
+            .doReturn(true)
+
+        // When
+        testedProvider.onCapabilitiesChanged(mockNetwork, mockCapabilities)
+        val networkInfo = testedProvider.getLatestNetworkInfo()
+
+        // Then
+        assertThat(networkInfo)
+            .hasConnectivity(NetworkInfo.Connectivity.NETWORK_CELLULAR)
+            .hasCarrierName(carrierName)
+            .hasCarrierId(carrierId.toLong())
+    }
+
+    @Test
+    fun `M report carrier from networkOperator W onCapabilitiesChanged on cellular API 24-27`(
+        @StringForgery operatorName: String,
+        forge: Forge
+    ) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn false
+        val operatorCode = forge.anInt(min = 10_000, max = 999_999).toString()
+        val telephonyManager = mock<TelephonyManager> {
+            on { networkOperatorName } doReturn operatorName
+            on { networkOperator } doReturn operatorCode
+        }
+        registerWithTelephony(telephonyManager)
+        whenever(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR))
+            .doReturn(true)
+
+        // When
+        testedProvider.onCapabilitiesChanged(mockNetwork, mockCapabilities)
+        val networkInfo = testedProvider.getLatestNetworkInfo()
+
+        // Then
+        assertThat(networkInfo)
+            .hasConnectivity(NetworkInfo.Connectivity.NETWORK_CELLULAR)
+            .hasCarrierName(operatorName)
+            .hasCarrierId(operatorCode.toLong())
+    }
+
+    @Test
+    fun `M leave carrierId null W networkOperator is non-numeric on cellular API 24-27`(
+        @StringForgery operatorName: String,
+        @StringForgery(regex = "[A-Za-z]+") operatorCode: String
+    ) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn false
+        val telephonyManager = mock<TelephonyManager> {
+            on { networkOperatorName } doReturn operatorName
+            on { networkOperator } doReturn operatorCode
+        }
+        registerWithTelephony(telephonyManager)
+        whenever(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR))
+            .doReturn(true)
+
+        // When
+        testedProvider.onCapabilitiesChanged(mockNetwork, mockCapabilities)
+        val networkInfo = testedProvider.getLatestNetworkInfo()
+
+        // Then
+        assertThat(networkInfo)
+            .hasConnectivity(NetworkInfo.Connectivity.NETWORK_CELLULAR)
+            .hasCarrierName(operatorName)
+            .hasCarrierId(null)
+    }
+
+    @Test
+    fun `M leave carrier null W networkOperatorName and networkOperator are empty on cellular`() {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn false
+        val telephonyManager = mock<TelephonyManager> {
+            on { networkOperatorName } doReturn ""
+            on { networkOperator } doReturn ""
+        }
+        registerWithTelephony(telephonyManager)
+        whenever(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR))
+            .doReturn(true)
+
+        // When
+        testedProvider.onCapabilitiesChanged(mockNetwork, mockCapabilities)
+        val networkInfo = testedProvider.getLatestNetworkInfo()
+
+        // Then
+        assertThat(networkInfo)
+            .hasConnectivity(NetworkInfo.Connectivity.NETWORK_CELLULAR)
+            .hasCarrierName(null)
+            .hasCarrierId(null)
+    }
+
+    @Test
+    fun `M leave carrier null W onCapabilitiesChanged on wifi even when telephony available`(
+        @StringForgery carrierName: String,
+        @IntForgery(min = 1) carrierId: Int
+    ) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
+        val telephonyManager = mock<TelephonyManager> {
+            on { simCarrierIdName } doReturn carrierName
+            on { this.simCarrierId } doReturn carrierId
+        }
+        registerWithTelephony(telephonyManager)
+        whenever(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) doReturn true
+
+        // When
+        testedProvider.onCapabilitiesChanged(mockNetwork, mockCapabilities)
+        val networkInfo = testedProvider.getLatestNetworkInfo()
+
+        // Then
+        assertThat(networkInfo)
+            .hasConnectivity(NetworkInfo.Connectivity.NETWORK_WIFI)
+            .hasCarrierName(null)
+            .hasCarrierId(null)
+    }
+
+    @Test
+    fun `M leave carrier null W onCapabilitiesChanged on cellular but TelephonyManager unavailable`() {
+        // Given - no register() call → telephonyManager is null
+        whenever(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR))
+            .doReturn(true)
+
+        // When
+        testedProvider.onCapabilitiesChanged(mockNetwork, mockCapabilities)
+        val networkInfo = testedProvider.getLatestNetworkInfo()
+
+        // Then
+        assertThat(networkInfo)
+            .hasConnectivity(NetworkInfo.Connectivity.NETWORK_CELLULAR)
+            .hasCarrierName(null)
+            .hasCarrierId(null)
+    }
+
+    @Test
+    fun `M log error and leave carrierName null W simCarrierIdName throws on cellular API 28+`(
+        @StringForgery message: String,
+        @IntForgery(min = 1) carrierId: Int
+    ) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
+        val exception = SecurityException(message)
+        val telephonyManager = mock<TelephonyManager> {
+            on { simCarrierIdName } doThrow exception
+            on { this.simCarrierId } doReturn carrierId
+        }
+        registerWithTelephony(telephonyManager)
+        whenever(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR))
+            .doReturn(true)
+
+        // When
+        testedProvider.onCapabilitiesChanged(mockNetwork, mockCapabilities)
+        val networkInfo = testedProvider.getLatestNetworkInfo()
+
+        // Then
+        assertThat(networkInfo)
+            .hasConnectivity(NetworkInfo.Connectivity.NETWORK_CELLULAR)
+            .hasCarrierName(null)
+            .hasCarrierId(carrierId.toLong())
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            message = CarrierInfoResolver.ERROR_CARRIER_NAME,
+            throwable = exception
+        )
+    }
+
+    @Test
+    fun `M log error and leave carrierId null W simCarrierId throws on cellular API 28+`(
+        @StringForgery message: String,
+        @StringForgery carrierName: String
+    ) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
+        val exception = SecurityException(message)
+        val telephonyManager = mock<TelephonyManager> {
+            on { simCarrierIdName } doReturn carrierName
+            on { this.simCarrierId } doThrow exception
+        }
+        registerWithTelephony(telephonyManager)
+        whenever(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR))
+            .doReturn(true)
+
+        // When
+        testedProvider.onCapabilitiesChanged(mockNetwork, mockCapabilities)
+        val networkInfo = testedProvider.getLatestNetworkInfo()
+
+        // Then
+        assertThat(networkInfo)
+            .hasConnectivity(NetworkInfo.Connectivity.NETWORK_CELLULAR)
+            .hasCarrierName(carrierName)
+            .hasCarrierId(null)
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            message = CarrierInfoResolver.ERROR_CARRIER_ID,
+            throwable = exception
+        )
+    }
+
+    // endregion
+
+    private fun registerWithTelephony(telephonyManager: TelephonyManager) {
+        val context = mock<Context>()
+        val manager = mock<ConnectivityManager>()
+        whenever(context.getSystemService(Context.CONNECTIVITY_SERVICE)) doReturn manager
+        whenever(context.getSystemService(Context.TELEPHONY_SERVICE)) doReturn telephonyManager
+        testedProvider.register(context)
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/info/CarrierInfoResolverTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/info/CarrierInfoResolverTest.kt
@@ -1,0 +1,286 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.net.info
+
+import android.telephony.TelephonyManager
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.internal.system.BuildSdkVersionProvider
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.verifyLog
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class CarrierInfoResolverTest {
+
+    lateinit var testedResolver: CarrierInfoResolver
+
+    @Mock
+    lateinit var mockTelephonyManager: TelephonyManager
+
+    @Mock
+    lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @BeforeEach
+    fun `set up`() {
+        testedResolver = CarrierInfoResolver(
+            mockTelephonyManager,
+            mockInternalLogger,
+            mockBuildSdkVersionProvider
+        )
+    }
+
+    @Test
+    fun `M return simCarrierIdName W carrierName {API 28+}`(@StringForgery simCarrierIdName: String) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
+        whenever(mockTelephonyManager.simCarrierIdName) doReturn simCarrierIdName
+
+        // When / Then
+        assertThat(testedResolver.carrierName).isEqualTo(simCarrierIdName)
+    }
+
+    @Test
+    fun `M return null W carrierName {API 28+, simCarrierIdName is null}`() {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
+        whenever(mockTelephonyManager.simCarrierIdName) doReturn null
+
+        // When / Then
+        assertThat(testedResolver.carrierName).isNull()
+    }
+
+    @Test
+    fun `M log error and return null W carrierName {API 28+, simCarrierIdName throws}`(@StringForgery message: String) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
+        val exception = SecurityException(message)
+        whenever(mockTelephonyManager.simCarrierIdName) doThrow exception
+
+        // When
+        val result = testedResolver.carrierName
+
+        // Then
+        assertThat(result).isNull()
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            CarrierInfoResolver.ERROR_CARRIER_NAME,
+            exception
+        )
+    }
+
+    @Test
+    fun `M return networkOperatorName W carrierName {API 24-27}`(@StringForgery operatorName: String) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn false
+        whenever(mockTelephonyManager.networkOperatorName) doReturn operatorName
+
+        // When / Then
+        assertThat(testedResolver.carrierName).isEqualTo(operatorName)
+    }
+
+    @Test
+    fun `M return null W carrierName {API 24-27, networkOperatorName is empty}`() {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn false
+        whenever(mockTelephonyManager.networkOperatorName) doReturn ""
+
+        // When / Then
+        assertThat(testedResolver.carrierName).isNull()
+    }
+
+    @Test
+    fun `M return null W carrierName {API 24-27, networkOperatorName is null}`() {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn false
+        whenever(mockTelephonyManager.networkOperatorName) doReturn null
+
+        // When / Then
+        assertThat(testedResolver.carrierName).isNull()
+    }
+
+    @Test
+    fun `M log error and return null W carrierName {API 24-27, networkOperatorName throws}`(
+        @StringForgery message: String
+    ) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn false
+        val exception = SecurityException(message)
+        whenever(mockTelephonyManager.networkOperatorName) doThrow exception
+
+        // When
+        val result = testedResolver.carrierName
+
+        // Then
+        assertThat(result).isNull()
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            CarrierInfoResolver.ERROR_CARRIER_NAME,
+            exception
+        )
+    }
+
+    @Test
+    fun `M return simCarrierId as Long W carrierId {API 28+}`(@IntForgery(min = 1) simCarrierId: Int) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
+        whenever(mockTelephonyManager.simCarrierId) doReturn simCarrierId
+
+        // When / Then
+        assertThat(testedResolver.carrierId).isEqualTo(simCarrierId.toLong())
+    }
+
+    @Test
+    fun `M return null W carrierId {API 28+, simCarrierId is UNKNOWN_CARRIER_ID}`() {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
+        whenever(mockTelephonyManager.simCarrierId) doReturn TelephonyManager.UNKNOWN_CARRIER_ID
+
+        // When / Then
+        assertThat(testedResolver.carrierId).isNull()
+    }
+
+    @Test
+    fun `M log error and return null W carrierId {API 28+, simCarrierId throws}`(@StringForgery message: String) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
+        val exception = SecurityException(message)
+        whenever(mockTelephonyManager.simCarrierId) doThrow exception
+
+        // When
+        val result = testedResolver.carrierId
+
+        // Then
+        assertThat(result).isNull()
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            CarrierInfoResolver.ERROR_CARRIER_ID,
+            exception
+        )
+    }
+
+    @Test
+    fun `M return networkOperator as Long W carrierId {API 24-27, numeric MCC+MNC}`(forge: Forge) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn false
+        val operatorCode = forge.anInt(min = 10_000, max = 999_999).toString()
+        whenever(mockTelephonyManager.networkOperator) doReturn operatorCode
+
+        // When / Then
+        assertThat(testedResolver.carrierId).isEqualTo(operatorCode.toLong())
+    }
+
+    @Test
+    fun `M return null W carrierId {API 24-27, networkOperator is non-numeric}`(
+        @StringForgery(regex = "[A-Za-z]+") operatorCode: String
+    ) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn false
+        whenever(mockTelephonyManager.networkOperator) doReturn operatorCode
+
+        // When / Then
+        assertThat(testedResolver.carrierId).isNull()
+    }
+
+    @Test
+    fun `M return null W carrierId {API 24-27, networkOperator is empty}`() {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn false
+        whenever(mockTelephonyManager.networkOperator) doReturn ""
+
+        // When / Then
+        assertThat(testedResolver.carrierId).isNull()
+    }
+
+    @Test
+    fun `M return null W carrierId {API 24-27, networkOperator is null}`() {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn false
+        whenever(mockTelephonyManager.networkOperator) doReturn null
+
+        // When / Then
+        assertThat(testedResolver.carrierId).isNull()
+    }
+
+    @Test
+    fun `M log error and return null W carrierId {API 24-27, networkOperator throws}`(@StringForgery message: String) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn false
+        val exception = SecurityException(message)
+        whenever(mockTelephonyManager.networkOperator) doThrow exception
+
+        // When
+        val result = testedResolver.carrierId
+
+        // Then
+        assertThat(result).isNull()
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            CarrierInfoResolver.ERROR_CARRIER_ID,
+            exception
+        )
+    }
+
+    @Test
+    fun `M resolve carrierId W carrierName fails on cellular API 28+`(
+        @StringForgery message: String,
+        @IntForgery(min = 1) simCarrierId: Int
+    ) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
+        val exception = SecurityException(message)
+        whenever(mockTelephonyManager.simCarrierIdName) doThrow exception
+        whenever(mockTelephonyManager.simCarrierId) doReturn simCarrierId
+
+        // When / Then
+        assertThat(testedResolver.carrierName).isNull()
+        assertThat(testedResolver.carrierId).isEqualTo(simCarrierId.toLong())
+    }
+
+    @Test
+    fun `M resolve carrierName W carrierId fails on cellular API 28+`(
+        @StringForgery message: String,
+        @StringForgery carrierName: String
+    ) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
+        val exception = SecurityException(message)
+        whenever(mockTelephonyManager.simCarrierIdName) doReturn carrierName
+        whenever(mockTelephonyManager.simCarrierId) doThrow exception
+
+        // When / Then
+        assertThat(testedResolver.carrierName).isEqualTo(carrierName)
+        assertThat(testedResolver.carrierId).isNull()
+    }
+}

--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -1150,6 +1150,7 @@ datadog:
       - "kotlin.Int.coerceAtLeast(kotlin.Int)"
       - "kotlin.Int.coerceAtMost(kotlin.Int)"
       - "kotlin.Int.inv()"
+      - "kotlin.Int.takeIf(kotlin.Function1)"
       - "kotlin.Int.toChar()"
       - "kotlin.Int.toDouble()"
       - "kotlin.Int.toFloat()"

--- a/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/InternalSdkCoreTest.kt
+++ b/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/InternalSdkCoreTest.kt
@@ -18,6 +18,7 @@ import com.datadog.android.Datadog
 import com.datadog.android.DatadogSite
 import com.datadog.android._InternalProxy
 import com.datadog.android.api.context.DeviceType
+import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.stub.StubStorageBackedFeature
 import com.datadog.android.core.InternalSdkCore
@@ -150,7 +151,11 @@ class InternalSdkCoreTest : MockServerTest() {
         assertThat(context.source).isEqualTo(ANDROID_SOURCE)
         assertThat(context.processInfo.isMainProcess).isTrue()
         assertThat(context.networkInfo.connectivity).isNotNull()
-        assertThat(context.networkInfo.carrierName).isNull()
+        if (context.networkInfo.connectivity in cellularConnectivities) {
+            assertThat(context.networkInfo.carrierName).isNotNull()
+        } else {
+            assertThat(context.networkInfo.carrierName).isNull()
+        }
         assertThat(context.deviceInfo.deviceName).isNotEmpty()
         assertThat(context.deviceInfo.deviceBrand).isNotEmpty()
         assertThat(context.deviceInfo.deviceType).isEqualTo(DeviceType.MOBILE)
@@ -617,5 +622,14 @@ class InternalSdkCoreTest : MockServerTest() {
         private const val BUILD_ID = "core_it_build_id"
         private const val PACKAGE_NAME = "com.datadog.android.core.integration"
         internal const val DATADOG_STORAGE_DIR_NAME_FORMAT = "datadog-(.*)"
+
+        private val cellularConnectivities = setOf(
+            NetworkInfo.Connectivity.NETWORK_2G,
+            NetworkInfo.Connectivity.NETWORK_3G,
+            NetworkInfo.Connectivity.NETWORK_4G,
+            NetworkInfo.Connectivity.NETWORK_5G,
+            NetworkInfo.Connectivity.NETWORK_MOBILE_OTHER,
+            NetworkInfo.Connectivity.NETWORK_CELLULAR
+        )
     }
 }

--- a/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/InternalSdkCoreTest.kt
+++ b/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/InternalSdkCoreTest.kt
@@ -581,13 +581,11 @@ class InternalSdkCoreTest : MockServerTest() {
 
     // region internal
 
-    private fun getAppVersion(): String? {
-        return getPackageInfo(ApplicationProvider.getApplicationContext())?.let {
-            // we need to use the deprecated method because getLongVersionCode method is only
-            // available from API 28 and above
-            @Suppress("DEPRECATION")
-            it.versionName ?: it.versionCode.toString()
-        }
+    private fun getAppVersion(): String? = getPackageInfo(ApplicationProvider.getApplicationContext())?.let {
+        // we need to use the deprecated method because getLongVersionCode method is only
+        // available from API 28 and above
+        @Suppress("DEPRECATION")
+        it.versionName ?: it.versionCode.toString()
     }
 
     private fun getVersionCode(): Int? {
@@ -595,23 +593,20 @@ class InternalSdkCoreTest : MockServerTest() {
         return getPackageInfo(ApplicationProvider.getApplicationContext())?.versionCode
     }
 
-    private fun getPackageInfo(appContext: Context): PackageInfo? {
-        return try {
-            with(appContext.packageManager) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    getPackageInfo(appContext.packageName, PackageManager.PackageInfoFlags.of(0))
-                } else {
-                    getPackageInfo(appContext.packageName, 0)
-                }
+    private fun getPackageInfo(appContext: Context): PackageInfo? = try {
+        with(appContext.packageManager) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                getPackageInfo(appContext.packageName, PackageManager.PackageInfoFlags.of(0))
+            } else {
+                getPackageInfo(appContext.packageName, 0)
             }
-        } catch (e: PackageManager.NameNotFoundException) {
-            null
         }
+    } catch (e: PackageManager.NameNotFoundException) {
+        null
     }
 
-    private fun isAppDebuggable(context: Context): Boolean {
-        return (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
-    }
+    private fun isAppDebuggable(context: Context): Boolean =
+        (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
 
     // endregion
 


### PR DESCRIPTION
### What does this PR do?

Restores `carrier_name` and `carrier_id` reporting on Android API 24+.
A new `CarrierInfoResolver` helper wraps `TelephonyManager` and picks
the right API per SDK level:

- API 28+: `simCarrierIdName` / `simCarrierId` (Google-canonical, no permission).
- API 24-27: `networkOperatorName` / `networkOperator` (MCC+MNC parsed as Long).


### Additional Notes

- No new permissions required - `simCarrierIdName`, `simCarrierId`,
  `networkOperatorName`, `networkOperator` are all accessible without
  `READ_PHONE_STATE`.
- carrier fields are populated only when the active transport is
  cellular; Wi-Fi/Ethernet events keep them null.
- Public `NetworkInfo` data class is unchanged; all edits are in
  `internal` classes.
- Added `CarrierInfoResolverTest` (20 tests) and extended
  `CallbackNetworkInfoProviderTest` and `BroadcastReceiverNetworkInfoProviderTest`
  with carrier coverage for both SDK branches.
- Second commit (`82e3ffb36`) is a no-behaviour ktlint/detekt style
  cleanup of the same files (expression-body functions, collapsed
  parameter lists, removed stray blank lines).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)