### PR TITLE
Add Context.getSystemServiceAs extension

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -76,6 +76,7 @@ import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.internal.utils.allowThreadDiskReads
+import com.datadog.android.internal.utils.getSystemServiceAs
 import com.datadog.android.ndk.internal.DatadogNdkCrashHandler
 import com.datadog.android.ndk.internal.NdkCrashHandler
 import com.datadog.android.ndk.internal.NdkCrashLogDeserializer
@@ -693,7 +694,7 @@ internal class CoreFeature(
 
     private fun resolveProcessInfo(appContext: Context) {
         val currentProcessId = Process.myPid()
-        val manager = appContext.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+        val manager = appContext.getSystemServiceAs<ActivityManager>(Context.ACTIVITY_SERVICE)
         val currentProcess = manager?.runningAppProcesses?.firstOrNull {
             it.pid == currentProcessId
         }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
@@ -19,6 +19,7 @@ import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.core.internal.receiver.ThreadSafeReceiver
 import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.internal.system.BuildSdkVersionProvider
+import com.datadog.android.internal.utils.getSystemServiceAs
 import java.util.concurrent.ExecutorService
 import android.net.NetworkInfo as AndroidNetworkInfo
 
@@ -43,8 +44,7 @@ internal class BroadcastReceiverNetworkInfoProvider(
     }
 
     private fun handleIntent(context: Context) {
-        val connectivityMgr =
-            context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+        val connectivityMgr = context.getSystemServiceAs<ConnectivityManager>(Context.CONNECTIVITY_SERVICE)
         val activeNetworkInfo = connectivityMgr?.activeNetworkInfo
 
         networkInfo = buildNetworkInfo(context, activeNetworkInfo)
@@ -89,7 +89,7 @@ internal class BroadcastReceiverNetworkInfoProvider(
                 NetworkInfo.Connectivity.NETWORK_ETHERNET
             )
         } else if (activeNetworkInfo.type in knownMobileTypes) {
-            val telephonyManager = context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
+            val telephonyManager = context.getSystemServiceAs<TelephonyManager>(Context.TELEPHONY_SERVICE)
             val carrierInfoResolver = telephonyManager?.let {
                 CarrierInfoResolver(it, internalLogger, buildSdkVersionProvider)
             }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProvider.kt
@@ -16,6 +16,7 @@ import androidx.annotation.RequiresApi
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.internal.system.BuildSdkVersionProvider
+import com.datadog.android.internal.utils.getSystemServiceAs
 
 @RequiresApi(Build.VERSION_CODES.N)
 internal class CallbackNetworkInfoProvider(
@@ -56,10 +57,9 @@ internal class CallbackNetworkInfoProvider(
 
     @Suppress("TooGenericExceptionCaught")
     override fun register(context: Context) {
-        carrierInfoResolver = (context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager)
+        carrierInfoResolver = context.getSystemServiceAs<TelephonyManager>(Context.TELEPHONY_SERVICE)
             ?.let { CarrierInfoResolver(it, internalLogger, buildSdkVersionProvider) }
-        val systemService = context.getSystemService(Context.CONNECTIVITY_SERVICE)
-        val connMgr = systemService as? ConnectivityManager
+        val connMgr = context.getSystemServiceAs<ConnectivityManager>(Context.CONNECTIVITY_SERVICE)
 
         if (connMgr == null) {
             internalLogger.log(
@@ -104,8 +104,7 @@ internal class CallbackNetworkInfoProvider(
     @Suppress("TooGenericExceptionCaught")
     override fun unregister(context: Context) {
         carrierInfoResolver = null
-        val systemService = context.getSystemService(Context.CONNECTIVITY_SERVICE)
-        val connMgr = systemService as? ConnectivityManager
+        val connMgr = context.getSystemServiceAs<ConnectivityManager>(Context.CONNECTIVITY_SERVICE)
 
         if (connMgr == null) {
             internalLogger.log(

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/CarrierInfoResolver.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/CarrierInfoResolver.kt
@@ -56,7 +56,7 @@ internal class CarrierInfoResolver(
     }
 
     internal companion object {
-        internal const val ERROR_CARRIER_ID = "Failed to resolve carrier id information from TelephonyManager."
+        internal const val ERROR_CARRIER_ID = "Failed to resolve carrier ID information from TelephonyManager."
         internal const val ERROR_CARRIER_NAME = "Failed to resolve carrier name information from TelephonyManager."
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
@@ -15,14 +15,14 @@ import android.os.PowerManager
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.receiver.ThreadSafeReceiver
 import com.datadog.android.core.internal.utils.executeSafe
+import com.datadog.android.internal.utils.getSystemServiceAs
 import java.util.concurrent.ExecutorService
 import kotlin.math.roundToInt
 
 internal class BroadcastReceiverSystemInfoProvider(
     private val internalLogger: InternalLogger,
     private val executorService: ExecutorService
-) :
-    ThreadSafeReceiver(), SystemInfoProvider {
+) : ThreadSafeReceiver(), SystemInfoProvider {
 
     @Volatile
     private var systemInfo: SystemInfo = SystemInfo()
@@ -118,7 +118,7 @@ internal class BroadcastReceiverSystemInfoProvider(
     }
 
     private fun handlePowerSaveIntent(context: Context) {
-        val powerManager = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
+        val powerManager = context.getSystemServiceAs<PowerManager>(Context.POWER_SERVICE)
         val powerSaveMode = powerManager?.isPowerSaveMode ?: false
         systemInfo = systemInfo.copy(
             powerSaveMode = powerSaveMode

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/system/DefaultAndroidInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/system/DefaultAndroidInfoProvider.kt
@@ -17,6 +17,7 @@ import android.telephony.TelephonyManager
 import android.view.Display
 import com.datadog.android.api.context.DeviceType
 import com.datadog.android.internal.system.BuildSdkVersionProvider
+import com.datadog.android.internal.utils.getSystemServiceAs
 import java.util.Locale
 import java.util.TimeZone
 
@@ -119,8 +120,8 @@ internal class DefaultAndroidInfoProvider(
     }
 
     override val numberOfDisplays: Int? by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        val displayManager = appContext.getSystemService(Context.DISPLAY_SERVICE)
-            as? DisplayManager ?: return@lazy null
+        val displayManager = appContext.getSystemServiceAs<DisplayManager>(Context.DISPLAY_SERVICE)
+            ?: return@lazy null
 
         displayManager.displays.count {
             it.state !in setOf(
@@ -173,8 +174,7 @@ internal class DefaultAndroidInfoProvider(
         }
 
         private fun isTv(appContext: Context): Boolean {
-            val uiModeManager =
-                appContext.getSystemService(Context.UI_MODE_SERVICE) as? UiModeManager
+            val uiModeManager = appContext.getSystemServiceAs<UiModeManager>(Context.UI_MODE_SERVICE)
             if (uiModeManager?.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION) {
                 return true
             }
@@ -209,7 +209,7 @@ internal class DefaultAndroidInfoProvider(
             if (model.lowercase(Locale.US).contains("phone")) return true
 
             val telephonyManager =
-                appContext.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
+                appContext.getSystemServiceAs<TelephonyManager>(Context.TELEPHONY_SERVICE)
             return telephonyManager?.phoneType != TelephonyManager.PHONE_TYPE_NONE
         }
     }

--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -247,6 +247,7 @@ abstract class com.datadog.android.internal.time.BaseTimeProvider : TimeProvider
   override fun getDeviceElapsedTimeNanos(): Long
   override fun getDeviceElapsedRealtimeMillis(): Long
 fun ByteArray.toHexString(): String
+fun <T> android.content.Context.getSystemServiceAs(String): T?
 interface com.datadog.android.internal.utils.DDCoreSubscription<T: Any>
   fun addListener(T)
   fun removeListener(T)

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/utils/ContextExt.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/utils/ContextExt.kt
@@ -1,0 +1,16 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.android.internal.utils
+
+import android.content.Context
+
+/**
+ * Returns the system service associated with [name], cast to the reified type [T], or `null` if
+ * the service is unavailable or not assignable to [T].
+ * @param T the expected type of the system service.
+ * @param name the name of the system service, e.g. [Context.ACTIVITY_SERVICE].
+ */
+inline fun <reified T> Context.getSystemServiceAs(name: String): T? = getSystemService(name) as? T

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/rum/DdRumContentProvider.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/rum/DdRumContentProvider.kt
@@ -14,6 +14,7 @@ import android.database.Cursor
 import android.net.Uri
 import android.os.Process
 import android.util.Log
+import com.datadog.android.internal.utils.getSystemServiceAs
 
 /**
  * A Content provider used to monitor the Application startup time efficiently.
@@ -22,7 +23,7 @@ class DdRumContentProvider : ContentProvider() {
 
     override fun onCreate(): Boolean {
         if (processImportance == 0) {
-            val manager = context?.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+            val manager = context?.getSystemServiceAs<ActivityManager>(Context.ACTIVITY_SERVICE)
             val currentProcessId = Process.myPid()
             val currentProcess = manager?.runningAppProcesses?.firstOrNull {
                 it.pid == currentProcessId

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/DdProfilingContentProvider.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/DdProfilingContentProvider.kt
@@ -18,6 +18,7 @@ import androidx.annotation.RequiresApi
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.system.BuildSdkVersionProvider.Companion.DEFAULT
+import com.datadog.android.internal.utils.getSystemServiceAs
 import com.datadog.android.profiling.internal.ProfilingStartReason
 import com.datadog.android.profiling.internal.ProfilingStorage
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
@@ -66,7 +67,7 @@ class DdProfilingContentProvider(
      */
     @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
     private fun getAppStartInfo(context: Context): String? {
-        val manager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+        val manager = context.getSystemServiceAs<ActivityManager>(Context.ACTIVITY_SERVICE)
         val startReason = manager?.getHistoricalProcessStartReasons(1)
             ?.firstOrNull()?.reason
         return when (startReason) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -37,6 +37,7 @@ import com.datadog.android.internal.flags.RumFlagEvaluationMessage
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.thread.isMainThread
+import com.datadog.android.internal.utils.getSystemServiceAs
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumSessionListener
@@ -278,17 +279,12 @@ internal class RumFeature(
         initialized.set(true)
     }
 
-    private fun initializeFrameStatesAggregator(
-        application: Application?,
-        listeners: List<FrameStateListener>
-    ) {
+    private fun initializeFrameStatesAggregator(application: Application?, listeners: List<FrameStateListener>) {
         frameStatesAggregator = FrameStatesAggregator(listeners, sdkCore.internalLogger)
         application?.registerActivityLifecycleCallbacks(frameStatesAggregator)
     }
 
-    private fun initializeSlowFrameListener(
-        slowFramesConfiguration: SlowFramesConfiguration?
-    ): FrameStateListener? {
+    private fun initializeSlowFrameListener(slowFramesConfiguration: SlowFramesConfiguration?): FrameStateListener? {
         slowFramesListener = if (slowFramesConfiguration != null) {
             sdkCore.internalLogger.log(
                 InternalLogger.Level.INFO,
@@ -507,13 +503,12 @@ internal class RumFeature(
 
     @RequiresApi(Build.VERSION_CODES.R)
     internal fun consumeLastFatalAnr(rumEventsExecutorService: ExecutorService) {
-        val activityManager =
-            appContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val activityManager = appContext.getSystemServiceAs<ActivityManager>(Context.ACTIVITY_SERVICE)
         val lastKnownAnr = try {
-            activityManager.getHistoricalProcessExitReasons(null, 0, 0)
+            activityManager?.getHistoricalProcessExitReasons(null, 0, 0)
                 // from docs: Returns: a list of ApplicationExitInfo records matching the criteria,
                 // sorted in the order from most recent to least recent.
-                .firstOrNull { it.reason == ApplicationExitInfo.REASON_ANR }
+                ?.firstOrNull { it.reason == ApplicationExitInfo.REASON_ANR }
         } catch (@Suppress("TooGenericExceptionCaught") e: RuntimeException) {
             sdkCore.internalLogger.log(
                 InternalLogger.Level.ERROR,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/accessibility/DefaultAccessibilityReader.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/accessibility/DefaultAccessibilityReader.kt
@@ -22,6 +22,7 @@ import android.view.accessibility.AccessibilityManager
 import android.view.accessibility.AccessibilityManager.TouchExplorationStateChangeListener
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.internal.utils.getSystemServiceAs
 import com.datadog.android.rum.internal.domain.InfoProvider
 import java.util.concurrent.atomic.AtomicLong
 
@@ -32,9 +33,9 @@ internal class DefaultAccessibilityReader(
     private val timeProvider: TimeProvider,
     private val resources: Resources = applicationContext.resources,
     private val activityManager: ActivityManager? =
-        applicationContext.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager,
+        applicationContext.getSystemServiceAs<ActivityManager>(Context.ACTIVITY_SERVICE),
     private val accessibilityManager: AccessibilityManager? =
-        applicationContext.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager,
+        applicationContext.getSystemServiceAs<AccessibilityManager>(Context.ACCESSIBILITY_SERVICE),
     private val secureWrapper: SecureWrapper = SecureWrapper(),
     private val globalWrapper: GlobalWrapper = GlobalWrapper(),
     private val handler: Handler = Handler(Looper.getMainLooper())

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/battery/DefaultBatteryInfoProvider.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/battery/DefaultBatteryInfoProvider.kt
@@ -20,17 +20,17 @@ import android.os.PowerManager.ACTION_POWER_SAVE_MODE_CHANGED
 import androidx.annotation.FloatRange
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.internal.utils.getSystemServiceAs
 import com.datadog.android.rum.internal.domain.InfoProvider
 import java.util.concurrent.atomic.AtomicLong
 
 internal class DefaultBatteryInfoProvider(
     private val applicationContext: Context,
     private val timeProvider: TimeProvider,
-    private val powerManager: PowerManager? =
-        applicationContext.getSystemService(POWER_SERVICE) as? PowerManager,
-    private val batteryManager: BatteryManager? = applicationContext.getSystemService(
+    private val powerManager: PowerManager? = applicationContext.getSystemServiceAs<PowerManager>(POWER_SERVICE),
+    private val batteryManager: BatteryManager? = applicationContext.getSystemServiceAs<BatteryManager>(
         BATTERY_SERVICE
-    ) as? BatteryManager,
+    ),
     private val batteryLevelPollInterval: Int = BATTERY_POLL_INTERVAL_MS,
     private val internalLogger: InternalLogger
 ) : InfoProvider<BatteryInfo> {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/FrameStatesAggregator.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/FrameStatesAggregator.kt
@@ -24,6 +24,7 @@ import androidx.metrics.performance.FrameData
 import androidx.metrics.performance.JankStats
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.system.BuildSdkVersionProvider
+import com.datadog.android.internal.utils.getSystemServiceAs
 import com.datadog.android.rum.internal.domain.FrameMetricsData
 import java.lang.ref.WeakReference
 import java.util.WeakHashMap
@@ -36,7 +37,8 @@ internal class FrameStatesAggregator(
     private val internalLogger: InternalLogger,
     private val jankStatsProvider: JankStatsProvider = JankStatsProvider.DEFAULT,
     private val buildSdkVersionProvider: BuildSdkVersionProvider = BuildSdkVersionProvider.DEFAULT
-) : ActivityLifecycleCallbacks, JankStats.OnFrameListener {
+) : ActivityLifecycleCallbacks,
+    JankStats.OnFrameListener {
 
     internal val activeWindowsListener = WeakHashMap<Window, JankStats>()
 
@@ -208,8 +210,8 @@ internal class FrameStatesAggregator(
         } else if (display == null && buildSdkVersionProvider.version == Build.VERSION_CODES.R) {
             // Fallback - Android 30 allows apps to not run at a fixed 60hz, but didn't yet have
             // Frame Metrics callbacks available
-            val displayManager = activity.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
-            display = displayManager.getDisplay(Display.DEFAULT_DISPLAY)
+            val displayManager = activity.getSystemServiceAs<DisplayManager>(Context.DISPLAY_SERVICE)
+            display = displayManager?.getDisplay(Display.DEFAULT_DISPLAY)
         }
     }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/MiscUtils.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/MiscUtils.kt
@@ -14,6 +14,7 @@ import android.view.WindowManager
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.utils.densityNormalized
+import com.datadog.android.internal.utils.getSystemServiceAs
 import com.datadog.android.sessionreplay.recorder.SystemInformation
 import com.datadog.android.sessionreplay.utils.DefaultColorStringFormatter
 import com.datadog.android.sessionreplay.utils.GlobalBounds
@@ -103,7 +104,7 @@ internal object MiscUtils {
         screenDensity: Float,
         buildSdkVersionProvider: BuildSdkVersionProvider
     ): GlobalBounds {
-        val windowManager = (context.getSystemService(Context.WINDOW_SERVICE) as? WindowManager)
+        val windowManager = context.getSystemServiceAs<WindowManager>(Context.WINDOW_SERVICE)
             ?: return GlobalBounds(0, 0, 0, 0)
         val screenHeight: Long
         val screenWidth: Long


### PR DESCRIPTION
### What does this PR do?

`Context.getSystemServiceAs<T>(name)` in `dd-sdk-android-internal`
   and migrates 13 call sites in core, internal, profiling, RUM, and
   session-replay to use it.