### PR TITLE
RUM-15510: Resolve dependencies through Magic Mirror Depot in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,15 @@ variables:
 
   CACHE_FALLBACK_KEY: "develop"
 
+  # Magic Mirror Depot proxy URLs. The depot proxies both Maven Central and the Gradle
+  # Plugin Portal for the Java ecosystem from the same endpoint. Setting these routes
+  # dependency/plugin resolution through Datadog's internal mirror to avoid HTTP 429
+  # rate-limits from upstream registries.
+  # Declared as ORG_GRADLE_PROJECT_* so Gradle reads them as
+  # `providers.gradleProperty("<name>")` and they propagate to triggered child pipelines.
+  ORG_GRADLE_PROJECT_mavenRepositoryProxy: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"
+  ORG_GRADLE_PROJECT_gradlePluginProxy: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"
+
 include:
   - local: 'ci/pipelines/default-pipeline.yml'
     rules:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@
 
 import com.android.build.gradle.LibraryExtension
 import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.depotProxied
 import com.datadog.gradle.config.registerSubModuleAggregationTask
 import org.gradle.api.internal.file.UnionFileTree
 import org.gradle.api.internal.tasks.DefaultTaskDependencyFactory
@@ -37,6 +38,11 @@ version = AndroidConfig.VERSION.name
 
 buildscript {
     repositories {
+        // Magic Mirror Depot proxy (only set in CI via `.gitlab-ci.yml`).
+        // Inlined here because `buildscript {}` runs before buildSrc classes are on the classpath.
+        listOf("gradlePluginProxy", "mavenRepositoryProxy")
+            .mapNotNull { providers.gradleProperty(it).orNull?.takeIf { url -> url.isNotBlank() } }
+            .forEach { url -> maven { setUrl(url) } }
         google()
         mavenCentral()
         maven { setUrl(com.datadog.gradle.Dependencies.Repositories.Gradle) }
@@ -48,7 +54,7 @@ buildscript {
 }
 
 allprojects {
-    repositories {
+    repositories.depotProxied(providers) {
         google()
         mavenCentral()
         maven { setUrl(com.datadog.gradle.Dependencies.Repositories.Jitpack) }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,11 +14,19 @@ plugins {
 
 buildscript {
     repositories {
+        // Magic Mirror Depot proxy (only set in CI via `.gitlab-ci.yml`).
+        listOf("gradlePluginProxy", "mavenRepositoryProxy")
+            .mapNotNull { providers.gradleProperty(it).orNull?.takeIf { url -> url.isNotBlank() } }
+            .forEach { url -> maven { setUrl(url) } }
         mavenCentral()
     }
 }
 
 repositories {
+    // Magic Mirror Depot proxy (only set in CI via `.gitlab-ci.yml`).
+    listOf("gradlePluginProxy", "mavenRepositoryProxy")
+        .mapNotNull { providers.gradleProperty(it).orNull?.takeIf { url -> url.isNotBlank() } }
+        .forEach { url -> maven { setUrl(url) } }
     mavenCentral()
     google()
     maven { setUrl("https://plugins.gradle.org/m2/") }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -4,6 +4,18 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
+pluginManagement {
+    repositories {
+        // Magic Mirror Depot proxy (only set in CI via `.gitlab-ci.yml`).
+        listOf("gradlePluginProxy", "mavenRepositoryProxy")
+            .mapNotNull { providers.gradleProperty(it).orNull?.takeIf { url -> url.isNotBlank() } }
+            .forEach { url -> maven(url) }
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/DepotRepositories.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/DepotRepositories.kt
@@ -1,0 +1,44 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.config
+
+import org.gradle.api.Action
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.provider.ProviderFactory
+
+/**
+ * Prepends the Magic Mirror Depot proxy repositories (when the `gradlePluginProxy` and
+ * `mavenRepositoryProxy` Gradle properties are set) before invoking [configure] to
+ * declare the regular fallback repositories.
+ *
+ * The proxy properties are only set in CI (via `.gitlab-ci.yml`), so local builds keep
+ * resolving from public registries unchanged.
+ *
+ * Usage:
+ * ```
+ * allprojects {
+ *     repositories.depotProxied(providers) {
+ *         google()
+ *         mavenCentral()
+ *     }
+ * }
+ * ```
+ */
+fun RepositoryHandler.depotProxied(
+    providers: ProviderFactory,
+    configure: RepositoryHandler.() -> Unit
+) {
+    val pluginProxy = providers.gradleProperty(GradlePropertiesKeys.GRADLE_PLUGIN_PROXY).orNull
+    if (!pluginProxy.isNullOrBlank()) {
+        maven(Action { setUrl(pluginProxy) })
+    }
+    val mavenProxy = providers.gradleProperty(GradlePropertiesKeys.MAVEN_REPOSITORY_PROXY).orNull
+    if (!mavenProxy.isNullOrBlank()) {
+        maven(Action { setUrl(mavenProxy) })
+    }
+    configure()
+}

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/GradlePropertiesKeys.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/GradlePropertiesKeys.kt
@@ -9,4 +9,20 @@ object GradlePropertiesKeys {
 
     // you can set this property from your gradle.properties as: forceEnableLogcat = true | false
     const val FORCE_ENABLE_LOGCAT = "forceEnableLogcat"
+
+    /**
+     * Maven repository proxy URL (Magic Mirror Depot). When set, prepended to dependency
+     * repositories so artifact resolution goes through Datadog's internal mirror instead of
+     * hitting public registries (e.g. Maven Central) directly. Used in CI to avoid 429s.
+     * Set via -PmavenRepositoryProxy=... or in gradle.properties.
+     */
+    const val MAVEN_REPOSITORY_PROXY = "mavenRepositoryProxy"
+
+    /**
+     * Gradle plugin portal proxy URL (Magic Mirror Depot). When set, prepended to plugin
+     * resolution repositories so plugin resolution goes through Datadog's internal mirror
+     * instead of hitting plugins.gradle.org directly. Used in CI to avoid 429s.
+     * Set via -PgradlePluginProxy=... or in gradle.properties.
+     */
+    const val GRADLE_PLUGIN_PROXY = "gradlePluginProxy"
 }

--- a/instrumented/integration/build.gradle.kts
+++ b/instrumented/integration/build.gradle.kts
@@ -5,6 +5,7 @@
  */
 
 import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.depotProxied
 import com.datadog.gradle.config.java17
 import com.datadog.gradle.config.kotlinConfig
 
@@ -80,7 +81,7 @@ android {
     }
 }
 
-repositories {
+repositories.depotProxied(providers) {
     google()
     mavenLocal()
     mavenCentral()

--- a/sample/tv/build.gradle.kts
+++ b/sample/tv/build.gradle.kts
@@ -7,6 +7,7 @@
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.configureFlavorForTvApp
 import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.depotProxied
 import com.datadog.gradle.config.java17
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -62,7 +63,7 @@ android {
     }
 }
 
-repositories {
+repositories.depotProxied(providers) {
     maven { setUrl("https://jitpack.io") }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,10 @@
 
 pluginManagement {
     repositories {
+        // Magic Mirror Depot proxy (only set in CI via `.gitlab-ci.yml`).
+        listOf("gradlePluginProxy", "mavenRepositoryProxy")
+            .mapNotNull { providers.gradleProperty(it).orNull?.takeIf { url -> url.isNotBlank() } }
+            .forEach { url -> maven(url) }
         gradlePluginPortal()
         google()
         mavenCentral()


### PR DESCRIPTION
## What and why

Routes Gradle dependency and plugin resolution through Datadog's internal Magic Mirror Depot (`depot-read-api-java`) when running in GitLab CI, to eliminate HTTP 429 rate-limits from public registries (Maven Central, Gradle Plugin Portal).

The change is gated behind two Gradle properties (`mavenRepositoryProxy`, `gradlePluginProxy`) that are only set in CI via `.gitlab-ci.yml`. Local builds with no properties set are a strict no-op; the existing public registries (`mavenCentral`, `gradlePluginPortal`, `google`, `jitpack`) remain as fallbacks in every `repositories { }` block.

Follows the same approach as [DataDog/dd-trace-java#9351](https://github.com/DataDog/dd-trace-java/pull/9351) and [DataDog/dd-trace-java#9802](https://github.com/DataDog/dd-trace-java/pull/9802) (which switched property injection from `gradle.properties` file writes to `ORG_GRADLE_PROJECT_*` environment variables).

## What changes

### CI configuration
- `.gitlab-ci.yml`: declare `MAVEN_REPOSITORY_PROXY` and `GRADLE_PLUGIN_PROXY` env vars pointing at the depot URL.
- `ci/pipelines/default-pipeline.yml`: add a `default.before_script` that exports `ORG_GRADLE_PROJECT_mavenRepositoryProxy` and `ORG_GRADLE_PROJECT_gradlePluginProxy`. Gradle reads any `ORG_GRADLE_PROJECT_<name>` env var as `providers.gradleProperty("<name>")`, and the env vars naturally inherit to child Gradle processes via the shell environment.

## How to verify

1. **No-op locally**: build without the proxy properties (the normal developer flow) — no behavior change. Confirmed via `./gradlew :features:dd-sdk-android-session-replay-compose:assembleRelease` with cold cache; resolves entirely from public registries.
2. **Depot routing in CI**: on the CI runner the proxy properties are set; every Gradle process reads them via `providers.gradleProperty(...)`. Verified via a temporary `--info` diagnostic on the `test:tools` job that logged all repository URL hits ([logs here](https://gitlab.ddbuild.io/DataDog/dd-sdk-android/-/jobs/1682845818/viewer)) — depot served Maven Central artifacts, Google and Jitpack served their canonical content, no direct `repo1.maven.org` or `repo.maven.apache.org` traffic.
3. **Existing test suites pass**: full CI pipeline green on `hector.morilloprieto/RUM-15510-v2`.