### PR TITLE
RUM-16089: Catch exception on the battery level query

### DIFF
--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -56,7 +56,6 @@ datadog:
       - "android.net.ConnectivityManager.NetworkCallback.onLost(android.net.Network)"
       - "android.net.ConnectivityManager.getNetworkCapabilities(android.net.Network?)"
       - "android.net.NetworkCapabilities.hasTransport(kotlin.Int)"
-      - "android.os.BatteryManager.getIntProperty(kotlin.Int)"
       - "android.os.Bundle.get(kotlin.String?)"
       - "android.os.Bundle.getString(kotlin.String?)"
       - "android.os.Bundle.keySet()"

--- a/detekt_custom_unsafe_calls.yml
+++ b/detekt_custom_unsafe_calls.yml
@@ -33,6 +33,7 @@ datadog:
       - "android.graphics.Paint.measureText(kotlin.String?):java.lang.IllegalArgumentException,java.lang.IndexOutOfBoundsException"
       - "android.net.ConnectivityManager.registerDefaultNetworkCallback(android.net.ConnectivityManager.NetworkCallback):java.lang.IllegalArgumentException,java.lang.SecurityException"
       - "android.net.ConnectivityManager.unregisterNetworkCallback(android.net.ConnectivityManager.NetworkCallback):java.lang.SecurityException"
+      - "android.os.BatteryManager.getIntProperty(kotlin.Int):java.lang.RuntimeException"
       - "android.provider.Settings.System.getInt(android.content.ContentResolver?, kotlin.String?):android.provider.Settings.SettingNotFoundException"
       - "android.text.SpannableStringBuilder.setSpan(kotlin.Any?, kotlin.Int, kotlin.Int, kotlin.Int):java.lang.RuntimeException"
       - "android.util.Base64.decode(kotlin.String?, kotlin.Int):java.lang.IllegalArgumentException"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -224,7 +224,8 @@ internal class RumFeature(
         trackFrustrations = configuration.trackFrustrations
         batteryInfoProvider = DefaultBatteryInfoProvider(
             applicationContext = appContext,
-            timeProvider = sdkCore.timeProvider
+            timeProvider = sdkCore.timeProvider,
+            internalLogger = sdkCore.internalLogger
         )
         displayInfoProvider = DefaultDisplayInfoProvider(
             applicationContext = appContext,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/battery/DefaultBatteryInfoProvider.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/battery/DefaultBatteryInfoProvider.kt
@@ -18,6 +18,7 @@ import android.os.Build
 import android.os.PowerManager
 import android.os.PowerManager.ACTION_POWER_SAVE_MODE_CHANGED
 import androidx.annotation.FloatRange
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.rum.internal.domain.InfoProvider
 import java.util.concurrent.atomic.AtomicLong
@@ -30,7 +31,8 @@ internal class DefaultBatteryInfoProvider(
     private val batteryManager: BatteryManager? = applicationContext.getSystemService(
         BATTERY_SERVICE
     ) as? BatteryManager,
-    private val batteryLevelPollInterval: Int = BATTERY_POLL_INTERVAL_MS
+    private val batteryLevelPollInterval: Int = BATTERY_POLL_INTERVAL_MS,
+    private val internalLogger: InternalLogger
 ) : InfoProvider<BatteryInfo> {
 
     @Volatile
@@ -101,7 +103,17 @@ internal class DefaultBatteryInfoProvider(
     }
 
     private fun resolveBatteryLevel(): Float? {
-        val batteryLevel = batteryManager?.getIntProperty(BATTERY_PROPERTY_CAPACITY)
+        val batteryLevel = try {
+            batteryManager?.getIntProperty(BATTERY_PROPERTY_CAPACITY)
+        } catch (@Suppress("TooGenericExceptionCaught") re: RuntimeException) {
+            internalLogger.log(
+                target = InternalLogger.Target.MAINTAINER,
+                level = InternalLogger.Level.ERROR,
+                messageBuilder = { "Problem retrieving battery level value" },
+                throwable = re
+            )
+            null
+        }
 
         return batteryLevel?.let {
             // if there was a problem retrieving the capacity

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/battery/DefaultBatteryInfoProviderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/battery/DefaultBatteryInfoProviderTest.kt
@@ -16,8 +16,10 @@ import android.os.BatteryManager
 import android.os.BatteryManager.BATTERY_PROPERTY_CAPACITY
 import android.os.Build
 import android.os.PowerManager
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.rum.utils.forge.Configurator
+import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
@@ -34,6 +36,7 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -61,6 +64,9 @@ internal class DefaultBatteryInfoProviderTest {
 
     @Mock
     lateinit var mockBatteryManager: BatteryManager
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
 
     @LongForgery(min = 0L)
     private var fakeStartTimeMs: Long = 0L
@@ -221,6 +227,28 @@ internal class DefaultBatteryInfoProviderTest {
         assertThat(batteryInfo.lowPowerMode).isEqualTo(false)
     }
 
+    @Test
+    fun `M return null battery level W getBatteryLevel() { system throws on query }`() {
+        // Given
+        whenever(mockPowerManager.isPowerSaveMode) doReturn false
+        val fakeException = RuntimeException()
+        whenever(mockBatteryManager.getIntProperty(BATTERY_PROPERTY_CAPACITY)) doThrow fakeException
+        initializeBatteryManager()
+
+        // When
+        val batteryInfo = testedProvider.getState()
+
+        // Then
+        assertThat(batteryInfo.batteryLevel).isNull()
+        assertThat(batteryInfo.lowPowerMode).isEqualTo(false)
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            target = InternalLogger.Target.MAINTAINER,
+            message = "Problem retrieving battery level value",
+            throwableClass = RuntimeException::class.java
+        )
+    }
+
     // endregion
 
     private fun initializeBatteryManager(
@@ -230,6 +258,7 @@ internal class DefaultBatteryInfoProviderTest {
         testedProvider = DefaultBatteryInfoProvider(
             applicationContext = mockApplicationContext,
             timeProvider = mockTimeProvider,
+            internalLogger = mockInternalLogger,
             batteryLevelPollInterval = shortPollingInterval,
             powerManager = powerManager,
             batteryManager = batteryManager


### PR DESCRIPTION
### What does this PR do?

Calling a query on the battery level value may throw `RuntimeException`, so adding a `catch` block.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

