### PR TITLE
RUM-15138: Preserve custom DeterministicTraceSampler subclasses from rebasing

### DIFF
--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/ApmNetworkInstrumentationConfiguration.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/ApmNetworkInstrumentationConfiguration.kt
@@ -136,8 +136,10 @@ class ApmNetworkInstrumentationConfiguration internal constructor(
      * sampling decision will be used instead.
      *
      * Note: custom samplers passed here do not participate in cross-product rebasing with the RUM session
-     * sample rate (even when `headerPropagationOnly` is enabled). Use [setTraceSampleRate] if you need
-     * correlated sampling between RUM sessions and APM traces.
+     * sample rate (even when `headerPropagationOnly` is enabled). Subclasses of [DeterministicTraceSampler]
+     * are also treated as custom samplers and bypass rebasing — only an exact [DeterministicTraceSampler]
+     * instance (equivalent to calling [setTraceSampleRate]) participates in rebasing. Use [setTraceSampleRate]
+     * if you need correlated sampling between RUM sessions and APM traces.
      *
      * @param traceSampler the trace sampler controlling the sampling of APM traces.
      * By default it is a sampler accepting 100% of the traces.
@@ -258,8 +260,12 @@ class ApmNetworkInstrumentationConfiguration internal constructor(
             val tracerProvider = TracerProvider(localTracerFactory, globalTracerProvider)
 
             val currentTraceSampler = traceSampler
-            val effectiveSampler = if (headerPropagationOnly && currentTraceSampler is DeterministicTraceSampler) {
-                SessionRebasedSampler(currentTraceSampler)
+            // Use exact-class match so subclasses of DeterministicTraceSampler are treated as
+            // custom samplers and bypass rebasing, matching the setTraceSampler contract.
+            val effectiveSampler = if (headerPropagationOnly &&
+                currentTraceSampler::class == DeterministicTraceSampler::class
+            ) {
+                SessionRebasedSampler(currentTraceSampler as DeterministicTraceSampler)
             } else {
                 currentTraceSampler
             }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmInstrumentationConfigurationTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmInstrumentationConfigurationTest.kt
@@ -269,4 +269,21 @@ internal class ApmInstrumentationConfigurationTest {
         assertThat(result.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
         assertThat(result.traceSampler.getSampleRate()).isEqualTo(fakeSampleRate)
     }
+
+    @Test
+    fun `M not wrap sampler W createInstrumentation() { headerPropagationOnly + DeterministicTraceSampler subclass }`(
+        @FloatForgery(min = 0f, max = 100f) fakeSampleRate: Float
+    ) {
+        // Given
+        val customSampler = object : DeterministicTraceSampler(fakeSampleRate) {}
+
+        // When
+        val result = testedBuilder
+            .setTraceSampler(customSampler)
+            .setHeaderPropagationOnly()
+            .createInstrumentation(fakeNetworkLibraryName)
+
+        // Then
+        assertThat(result.traceSampler).isSameAs(customSampler)
+    }
 }

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -397,8 +397,10 @@ open class DatadogInterceptor internal constructor(
          */
         override fun build(): DatadogInterceptor {
             val currentTraceSampler = traceSampler
-            val effectiveTraceSampler = if (currentTraceSampler is DeterministicTraceSampler) {
-                SessionRebasedSampler(currentTraceSampler)
+            // Use exact-class match so subclasses of DeterministicTraceSampler are treated as
+            // custom samplers and bypass rebasing, matching the setTraceSampler contract.
+            val effectiveTraceSampler = if (currentTraceSampler::class == DeterministicTraceSampler::class) {
+                SessionRebasedSampler(currentTraceSampler as DeterministicTraceSampler)
             } else {
                 currentTraceSampler
             }

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -823,7 +823,10 @@ internal constructor(
          * sampling decision will be used instead.
          *
          * Note: custom samplers passed here do not participate in cross-product rebasing with the RUM session
-         * sample rate. Use [setTraceSampleRate] if you need correlated sampling between RUM sessions and APM traces.
+         * sample rate. Subclasses of [DeterministicTraceSampler] are also treated as custom samplers and bypass
+         * rebasing — only an exact [DeterministicTraceSampler] instance (equivalent to calling
+         * [setTraceSampleRate]) participates in rebasing. Use [setTraceSampleRate] if you need correlated
+         * sampling between RUM sessions and APM traces.
          *
          * @param traceSampler the trace sampler controlling the sampling of APM traces.
          * By default it is a sampler accepting 100% of the traces.

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorBuilderTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorBuilderTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.okhttp.trace.TracedRequestListener
 import com.datadog.android.rum.NoOpRumResourceAttributesProvider
 import com.datadog.android.rum.RumResourceAttributesProvider
 import com.datadog.android.rum.resource.ResourceHeadersExtractor
+import com.datadog.android.trace.DeterministicTraceSampler
 import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.api.span.DatadogSpan
@@ -242,6 +243,22 @@ internal class DatadogInterceptorBuilderTest {
         assertThat(interceptor.traceSampler).isSameAs(mockSampler)
         assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
         assertThat(interceptor.localTracerFactory).isNotNull()
+    }
+
+    @Test
+    fun `M not wrap traceSampler W build { setTraceSampler with DeterministicTraceSampler subclass }`(
+        @FloatForgery(min = 0f, max = 100f) fakeSampleRate: Float
+    ) {
+        // Given
+        val customSampler = object : DeterministicTraceSampler(fakeSampleRate) {}
+
+        // When
+        val interceptor = DatadogInterceptor.Builder(fakeTracedHostsWithHeaderType)
+            .setTraceSampler(customSampler)
+            .build()
+
+        // Then
+        assertThat(interceptor.traceSampler).isSameAs(customSampler)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

Replaces the `is DeterministicTraceSampler` type check at two call sites (`DatadogInterceptor.Builder.build()` and `ApmNetworkInstrumentationConfiguration.createInstrumentation`) with an exact-class match, so subclasses of `DeterministicTraceSampler` passed via `setTraceSampler()` are preserved as custom samplers and bypass cross-product rebasing. KDoc on `setTraceSampler` in `TracingInterceptor` and `ApmNetworkInstrumentationConfiguration` updated to clarify this behavior.

### Motivation

Codex flagged a P2 in [PR #3454](https://github.com/DataDog/dd-sdk-android/pull/3454#discussion_r3260526696): when a customer passes a `DeterministicTraceSampler` subclass via `setTraceSampler()`, the previous `is DeterministicTraceSampler` check still wrapped it in `SessionRebasedSampler`. Inside `SessionRebasedSampler.sample()`, when the combined rate differs from the raw rate, a fresh `DeterministicTraceSampler(effectiveRate)` is constructed and used — silently bypassing the customer's subclass logic. This contradicts the documented `setTraceSampler` contract that custom samplers do not participate in cross-product rebasing.

With the exact-class match, only an exact `DeterministicTraceSampler` instance (which is what `setTraceSampleRate` produces internally) is wrapped. Subclasses and any other custom `Sampler<DatadogSpan>` are preserved as-is.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)