### PR TITLE
Fix ProfilingFeature shutdown and Continuous Profiling timestamp bug

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
@@ -225,7 +225,6 @@ internal class ContinuousProfilingScheduler(
         if (currentSessionSampled) {
             onActiveWindowStarted()
             isActive = true
-            activeWindowEndMs = timeProvider.getDeviceTimestampMillis() + activeMs
             state = State.ACTIVE
             logToUser { LOG_ACTIVE_WINDOW_STARTED.format(Locale.US, activeMs) }
             profiler.start(
@@ -242,13 +241,14 @@ internal class ContinuousProfilingScheduler(
             logToUser { LOG_ACTIVE_WINDOW_SKIPPED }
             // Skipped windows behave like cooldown for lifecycle purposes.
             state = State.COOLDOWN
+            cooldownWindowEndMs = timeProvider.getDeviceTimestampMillis() + activeMs
         }
 
         scheduleActiveWindowEnd(activeMs)
     }
 
     private fun scheduleActiveWindowEnd(delayMs: Long) {
-        cooldownWindowEndMs = timeProvider.getDeviceTimestampMillis() + delayMs
+        activeWindowEndMs = timeProvider.getDeviceTimestampMillis() + delayMs
         pendingFuture = schedulerExecutor.scheduleSafe(
             operationName = OPERATION_ACTIVE_WINDOW_END,
             delay = delayMs,

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -115,7 +115,6 @@ internal class ProfilingFeature(
         profiler.apply {
             stop(sdkCore.name)
             unregisterProfilingCallback(sdkCore.name)
-            scheduledExecutorService.shutdown()
         }
         sdkCore.removeEventReceiver(name)
         pendingRumEvents.clear()


### PR DESCRIPTION
### What does this PR do?

This PR fixes two existing bug:
* If Multiple SDK instances enable Profiling Feature, when one of them stops the Profiling Feature, it shutdown the `scheduledExecutorService` which is shared for all the instances.
* In `ContinuousProfilingScheduler`, wrong field is assigned when calling `scheduleActiveWindowEnd`


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

