### PR TITLE
RUM-15344 Pt.3 Send Profiling ANR event to RUM

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -170,11 +170,11 @@ sealed class com.datadog.android.internal.profiling.ProfilerEvent
   data class RumLongTaskEvent : ProfilerEvent
     constructor(String, Long, Long, ProfilingRumContext)
 data class com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
-  constructor(Long, List<StackTraceElement>, List<ProfilingThreadDump>)
+  constructor(Long, List<StackTraceElement>, String, Thread.State, List<ProfilingThreadDump>)
 data class com.datadog.android.internal.profiling.ProfilingRumContext
   constructor(String, String, String?, String?)
 data class com.datadog.android.internal.profiling.ProfilingThreadDump
-  constructor(String, String, String, Boolean)
+  constructor(String, Thread.State, String)
 data class com.datadog.android.internal.rum.RumSessionRenewedEvent
   constructor(String, Float)
 object com.datadog.android.internal.sampling.DeterministicSampling

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -335,15 +335,19 @@ public final class com/datadog/android/internal/profiling/ProfilerEvent$TTIDNotT
 }
 
 public final class com/datadog/android/internal/profiling/ProfilingAnrDetectedEvent {
-	public fun <init> (JLjava/util/List;Ljava/util/List;)V
+	public fun <init> (JLjava/util/List;Ljava/lang/String;Ljava/lang/Thread$State;Ljava/util/List;)V
 	public final fun component1 ()J
 	public final fun component2 ()Ljava/util/List;
-	public final fun component3 ()Ljava/util/List;
-	public final fun copy (JLjava/util/List;Ljava/util/List;)Lcom/datadog/android/internal/profiling/ProfilingAnrDetectedEvent;
-	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/ProfilingAnrDetectedEvent;JLjava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/datadog/android/internal/profiling/ProfilingAnrDetectedEvent;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Thread$State;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (JLjava/util/List;Ljava/lang/String;Ljava/lang/Thread$State;Ljava/util/List;)Lcom/datadog/android/internal/profiling/ProfilingAnrDetectedEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/ProfilingAnrDetectedEvent;JLjava/util/List;Ljava/lang/String;Ljava/lang/Thread$State;Ljava/util/List;ILjava/lang/Object;)Lcom/datadog/android/internal/profiling/ProfilingAnrDetectedEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllThreads ()Ljava/util/List;
+	public final fun getAnrThreadName ()Ljava/lang/String;
 	public final fun getAnrThreadStack ()Ljava/util/List;
+	public final fun getAnrThreadState ()Ljava/lang/Thread$State;
 	public final fun getDetectedAtMs ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -367,18 +371,16 @@ public final class com/datadog/android/internal/profiling/ProfilingRumContext {
 }
 
 public final class com/datadog/android/internal/profiling/ProfilingThreadDump {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Thread$State;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Thread$State;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Z
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Lcom/datadog/android/internal/profiling/ProfilingThreadDump;
-	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/ProfilingThreadDump;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lcom/datadog/android/internal/profiling/ProfilingThreadDump;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Thread$State;Ljava/lang/String;)Lcom/datadog/android/internal/profiling/ProfilingThreadDump;
+	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/ProfilingThreadDump;Ljava/lang/String;Ljava/lang/Thread$State;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/internal/profiling/ProfilingThreadDump;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCrashed ()Z
 	public final fun getName ()Ljava/lang/String;
 	public final fun getStack ()Ljava/lang/String;
-	public final fun getState ()Ljava/lang/String;
+	public final fun getState ()Ljava/lang/Thread$State;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilingAnrDetectedEvent.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilingAnrDetectedEvent.kt
@@ -15,10 +15,14 @@ package com.datadog.android.internal.profiling
  * @param anrThreadStack Stack trace of the thread that triggered the ANR
  *   (in practice the main looper thread) at capture time. Used as the
  *   synthesized `ANRException` stack trace on the RUM side.
+ * @param anrThreadName Name of the thread that triggered the ANR.
+ * @param anrThreadState JVM thread state of the ANR thread at capture time.
  * @param allThreads Per-thread dump for every other live thread (ANR thread excluded).
  */
 data class ProfilingAnrDetectedEvent(
     val detectedAtMs: Long,
     val anrThreadStack: List<StackTraceElement>,
+    val anrThreadName: String,
+    val anrThreadState: Thread.State,
     val allThreads: List<ProfilingThreadDump>
 )

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilingThreadDump.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilingThreadDump.kt
@@ -13,13 +13,11 @@ package com.datadog.android.internal.profiling
  * in this module without creating a circular dependency on `dd-sdk-android-core`.
  *
  * @param name Thread name.
- * @param state Thread state string (e.g. `Thread.State.name.lowercase()`).
+ * @param state JVM thread state captured at dump time.
  * @param stack Serialized stack trace (lines joined with newline).
- * @param crashed Whether this thread was the one that triggered the ANR.
  */
 data class ProfilingThreadDump(
     val name: String,
-    val state: String,
-    val stack: String,
-    val crashed: Boolean
+    val state: Thread.State,
+    val stack: String
 )

--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilingAnrDetectedEventForgeryFactory.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilingAnrDetectedEventForgeryFactory.kt
@@ -23,6 +23,8 @@ class ProfilingAnrDetectedEventForgeryFactory : ForgeryFactory<ProfilingAnrDetec
                     forge.anInt(min = -2)
                 )
             },
+            anrThreadName = forge.anAlphabeticalString(),
+            anrThreadState = forge.aValueFrom(Thread.State::class.java),
             allThreads = forge.aList { getForgery<ProfilingThreadDump>() }
         )
     }

--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilingThreadDumpForgeryFactory.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilingThreadDumpForgeryFactory.kt
@@ -14,8 +14,7 @@ class ProfilingThreadDumpForgeryFactory : ForgeryFactory<ProfilingThreadDump> {
     override fun getForgery(forge: Forge): ProfilingThreadDump {
         return ProfilingThreadDump(
             name = forge.anAlphaNumericalString(),
-            state = forge.aValueFrom(Thread.State::class.java).name.lowercase(),
-            crashed = forge.aBool(),
+            state = forge.aValueFrom(Thread.State::class.java),
             stack = forge.aList {
                 StackTraceElement(
                     forge.anAlphabeticalString(),

--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -1073,6 +1073,7 @@ datadog:
       - "kotlin.collections.listOf(android.view.Window)"
       - "kotlin.collections.listOf(android.os.ProfilingTrigger)"
       - "kotlin.collections.listOf(com.datadog.android.api.InternalLogger.Target)"
+      - "kotlin.collections.listOf(com.datadog.android.core.feature.event.ThreadDump)"
       - "kotlin.collections.listOf(com.datadog.android.rum.internal.vitals.FPSVitalListener)"
       - "kotlin.collections.listOf(com.datadog.android.flags.model.BatchedFlagEvaluations.FlagEvaluation)"
       - "kotlin.collections.listOf(com.datadog.android.rum.model.ActionEvent.Interface)"

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilerCallback.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilerCallback.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.profiling.internal
 
-import com.datadog.android.internal.profiling.ProfilingThreadDump
+import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 
 internal interface ProfilerCallback {
@@ -14,9 +14,5 @@ internal interface ProfilerCallback {
 
     fun onFailure(tag: String)
 
-    fun onAnrDetected(
-        detectedAtMs: Long,
-        anrThreadStack: List<StackTraceElement>,
-        allThreads: List<ProfilingThreadDump>
-    )
+    fun onAnrDetected(event: ProfilingAnrDetectedEvent)
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -21,7 +21,6 @@ import com.datadog.android.internal.FeatureContextKeys
 import com.datadog.android.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.internal.profiling.ProfilerEvent
 import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
-import com.datadog.android.internal.profiling.ProfilingThreadDump
 import com.datadog.android.internal.rum.RumSessionRenewedEvent
 import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.profiling.ExperimentalProfilingApi
@@ -175,18 +174,9 @@ internal class ProfilingFeature(
         }
     }
 
-    override fun onAnrDetected(
-        detectedAtMs: Long,
-        anrThreadStack: List<StackTraceElement>,
-        allThreads: List<ProfilingThreadDump>
-    ) {
+    override fun onAnrDetected(event: ProfilingAnrDetectedEvent) {
         // The ANR event should be forwarded to RUM only when profiling is actually running.
         if (isLaunchProfilingActive || continuousProfilingScheduler?.isActive == true) {
-            val event = ProfilingAnrDetectedEvent(
-                detectedAtMs = detectedAtMs,
-                anrThreadStack = anrThreadStack,
-                allThreads = allThreads
-            )
             sdkCore.getFeature(Feature.RUM_FEATURE_NAME)?.sendEvent(event)
         }
     }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -20,6 +20,7 @@ import com.datadog.android.api.storage.FeatureStorageConfiguration
 import com.datadog.android.internal.FeatureContextKeys
 import com.datadog.android.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.internal.profiling.ProfilerEvent
+import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 import com.datadog.android.internal.profiling.ProfilingThreadDump
 import com.datadog.android.internal.rum.RumSessionRenewedEvent
 import com.datadog.android.internal.time.DefaultTimeProvider
@@ -179,7 +180,15 @@ internal class ProfilingFeature(
         anrThreadStack: List<StackTraceElement>,
         allThreads: List<ProfilingThreadDump>
     ) {
-        // TODO RUM-15498: forward ProfilingAnrDetectedEvent to RUM via sdkCore.
+        // The ANR event should be forwarded to RUM only when profiling is actually running.
+        if (isLaunchProfilingActive || continuousProfilingScheduler?.isActive == true) {
+            val event = ProfilingAnrDetectedEvent(
+                detectedAtMs = detectedAtMs,
+                anrThreadStack = anrThreadStack,
+                allThreads = allThreads
+            )
+            sdkCore.getFeature(Feature.RUM_FEATURE_NAME)?.sendEvent(event)
+        }
     }
 
     private fun onTtidEvent(event: ProfilerEvent) {

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/anr/AnrListener.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/anr/AnrListener.kt
@@ -6,12 +6,8 @@
 
 package com.datadog.android.profiling.internal.anr
 
-import com.datadog.android.internal.profiling.ProfilingThreadDump
+import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 
 internal fun interface AnrListener {
-    fun onAnrDetected(
-        detectedAtMs: Long,
-        anrThreadStack: List<StackTraceElement>,
-        allThreads: List<ProfilingThreadDump>
-    )
+    fun onAnrDetected(event: ProfilingAnrDetectedEvent)
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/anr/AnrProfilingTriggerRegistrar.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/anr/AnrProfilingTriggerRegistrar.kt
@@ -122,12 +122,7 @@ internal class AnrProfilingTriggerRegistrar(
                         additionalProperties = mapOf(LOG_KEY_DELAY_MS to delayMs)
                     )
                 } else {
-                    val dump = threadDumper.dump()
-                    currentListener.onAnrDetected(
-                        detectedAtMs,
-                        dump.anrThreadStack,
-                        dump.allThreads
-                    )
+                    currentListener.onAnrDetected(threadDumper.dump(detectedAtMs))
                 }
             }
             // We currently don't use the result profile, just delete it.

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
@@ -86,9 +86,9 @@ internal class PerfettoProfiler(
             }
         }
 
-    internal val anrListener = AnrListener { detectedAtMs, anrThreadStack, allThreads ->
+    internal val anrListener = AnrListener { event ->
         callbackMap.values.forEach { callback ->
-            callback.onAnrDetected(detectedAtMs, anrThreadStack, allThreads)
+            callback.onAnrDetected(event)
         }
     }
 

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/utils/ThreadDumper.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/utils/ThreadDumper.kt
@@ -8,8 +8,8 @@ package com.datadog.android.profiling.internal.utils
 
 import android.os.Looper
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 import com.datadog.android.internal.profiling.ProfilingThreadDump
-import com.datadog.android.internal.utils.asString
 import com.datadog.android.internal.utils.loggableStackTrace
 
 internal class ThreadDumper(
@@ -24,22 +24,26 @@ internal class ThreadDumper(
     @Volatile
     internal var internalLogger: InternalLogger? = null
 
-    fun dump(): Snapshot {
+    fun dump(detectedAtMs: Long): ProfilingAnrDetectedEvent {
         val mainThread = mainThreadProvider()
         val anrThreadStack = mainThread.stackTrace.toList()
-        // TODO RUM-16390: Replace Thread.getAllStackTraces() with per-thread iteration in ThreadDumper
         val allThreads = safeGetAllStackTraces()
             .filterKeys { it != mainThread }
             .filterValues { it.isNotEmpty() }
             .map { (thread, stack) ->
                 ProfilingThreadDump(
                     name = thread.name,
-                    state = thread.state.asString(),
-                    stack = stack.loggableStackTrace(),
-                    crashed = false
+                    state = thread.state,
+                    stack = stack.loggableStackTrace()
                 )
             }
-        return Snapshot(anrThreadStack = anrThreadStack, allThreads = allThreads)
+        return ProfilingAnrDetectedEvent(
+            detectedAtMs = detectedAtMs,
+            anrThreadStack = anrThreadStack,
+            anrThreadName = mainThread.name,
+            anrThreadState = mainThread.state,
+            allThreads = allThreads
+        )
     }
 
     private fun safeGetAllStackTraces(): Map<Thread, Array<StackTraceElement>> {
@@ -55,11 +59,6 @@ internal class ThreadDumper(
             emptyMap()
         }
     }
-
-    data class Snapshot(
-        val anrThreadStack: List<StackTraceElement>,
-        val allThreads: List<ProfilingThreadDump>
-    )
 
     private companion object {
         const val LOG_STACKS_FAILED = "Failed to capture all stack traces for thread dump."

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -898,11 +898,7 @@ internal class ProfilingFeatureTest {
         testedFeature.onInitialize(mockContext)
 
         // When
-        testedFeature.onAnrDetected(
-            fakeEvent.detectedAtMs,
-            fakeEvent.anrThreadStack,
-            fakeEvent.allThreads
-        )
+        testedFeature.onAnrDetected(fakeEvent)
 
         // Then
         verify(mockRumFeatureScope).sendEvent(fakeEvent)
@@ -918,11 +914,7 @@ internal class ProfilingFeatureTest {
         testedFeature.onInitialize(mockContext)
 
         // When
-        testedFeature.onAnrDetected(
-            fakeEvent.detectedAtMs,
-            fakeEvent.anrThreadStack,
-            fakeEvent.allThreads
-        )
+        testedFeature.onAnrDetected(fakeEvent)
 
         // Then
         verify(mockRumFeatureScope, never()).sendEvent(any())

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -16,6 +16,7 @@ import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.sampling.DeterministicSampler
 import com.datadog.android.internal.data.SharedPreferencesStorage
 import com.datadog.android.internal.profiling.ProfilerEvent
+import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 import com.datadog.android.internal.rum.RumSessionRenewedEvent
 import com.datadog.android.internal.sampling.SessionSamplingIdProvider
 import com.datadog.android.profiling.forge.Configurator
@@ -97,6 +98,9 @@ internal class ProfilingFeatureTest {
     private lateinit var mockProfilingFeatureScope: FeatureScope
 
     @Mock
+    private lateinit var mockRumFeatureScope: FeatureScope
+
+    @Mock
     private lateinit var mockDataWriter: ProfilingWriter
 
     @Mock
@@ -146,6 +150,7 @@ internal class ProfilingFeatureTest {
         whenever(mockEditor.putString(any(), any())) doReturn mockEditor
         whenever(mockEditor.putStringSet(any(), any())) doReturn mockEditor
         whenever(mockEditor.putFloat(any(), any())) doReturn mockEditor
+        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
         testedFeature = ProfilingFeature(mockSdkCore, fakeConfiguration, mockProfiler)
         ProfilingStorage.sharedPreferencesStorage = mockSharedPreferencesStorage
     }
@@ -881,6 +886,46 @@ internal class ProfilingFeatureTest {
         // Then
         assertThat(testedFeature.pendingRumEvents.pendingLongTasks).isEmpty()
         assertThat(testedFeature.pendingRumEvents.pendingAnrEvents).isEmpty()
+    }
+
+    @Test
+    fun `M forward ProfilingAnrDetectedEvent to RUM W onAnrDetected() {launch profiling active}`(
+        @Forgery fakeEvent: ProfilingAnrDetectedEvent
+    ) {
+        // Given
+        testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
+        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        testedFeature.onInitialize(mockContext)
+
+        // When
+        testedFeature.onAnrDetected(
+            fakeEvent.detectedAtMs,
+            fakeEvent.anrThreadStack,
+            fakeEvent.allThreads
+        )
+
+        // Then
+        verify(mockRumFeatureScope).sendEvent(fakeEvent)
+    }
+
+    @Test
+    fun `M drop ProfilingAnrDetectedEvent W onAnrDetected() {profiling inactive}`(
+        @Forgery fakeEvent: ProfilingAnrDetectedEvent
+    ) {
+        // Given
+        testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
+        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn false
+        testedFeature.onInitialize(mockContext)
+
+        // When
+        testedFeature.onAnrDetected(
+            fakeEvent.detectedAtMs,
+            fakeEvent.anrThreadStack,
+            fakeEvent.allThreads
+        )
+
+        // Then
+        verify(mockRumFeatureScope, never()).sendEvent(any())
     }
 
     @Test

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -13,7 +13,7 @@ import android.os.ProfilingManager
 import android.os.ProfilingResult
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.metrics.MethodCallSamplingRate
-import com.datadog.android.internal.profiling.ProfilingThreadDump
+import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.profiling.forge.Configurator
@@ -23,6 +23,7 @@ import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler.Companio
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler.Companion.PROFILING_SAMPLING_RATE
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -1095,19 +1096,14 @@ class PerfettoProfilerTest {
 
     @Test
     fun `M fan out to all callbacks W AnrListener fires`(
-        @LongForgery(min = 1L) fakeNow: Long,
-        forge: Forge
+        @Forgery fakeEvent: ProfilingAnrDetectedEvent
     ) {
-        // Given
-        val anrStack = forge.aList { getForgery<StackTraceElement>() }
-        val allThreads = forge.aList { getForgery<ProfilingThreadDump>() }
-
         // When
-        testedProfiler.anrListener.onAnrDetected(fakeNow, anrStack, allThreads)
+        testedProfiler.anrListener.onAnrDetected(fakeEvent)
 
         // Then
-        verify(mockProfilerCallback).onAnrDetected(fakeNow, anrStack, allThreads)
-        verify(mockOtherProfilerCallback).onAnrDetected(fakeNow, anrStack, allThreads)
+        verify(mockProfilerCallback).onAnrDetected(fakeEvent)
+        verify(mockOtherProfilerCallback).onAnrDetected(fakeEvent)
     }
 
     @Test

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ThreadDumperTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ThreadDumperTest.kt
@@ -10,6 +10,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.profiling.forge.Configurator
 import com.datadog.android.profiling.internal.utils.ThreadDumper
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -36,7 +37,10 @@ internal class ThreadDumperTest {
     private lateinit var mockInternalLogger: InternalLogger
 
     @Test
-    fun `M return ANR thread stack and other threads W dump()`(forge: Forge) {
+    fun `M return ANR thread stack and other threads W dump()`(
+        forge: Forge,
+        @LongForgery fakeDetectedAtMs: Long
+    ) {
         // Given
         val anrThread = Thread.currentThread()
         val otherThread = Thread("worker")
@@ -53,16 +57,21 @@ internal class ThreadDumperTest {
         ).apply { internalLogger = mockInternalLogger }
 
         // When
-        val dump = testedDumper.dump()
+        val dump = testedDumper.dump(fakeDetectedAtMs)
 
         // Then
+        assertThat(dump.detectedAtMs).isEqualTo(fakeDetectedAtMs)
         assertThat(dump.anrThreadStack).isNotEmpty()
+        assertThat(dump.anrThreadName).isEqualTo(anrThread.name)
+        assertThat(dump.anrThreadState).isEqualTo(anrThread.state)
         assertThat(dump.allThreads).hasSize(1)
         assertThat(dump.allThreads.first().name).isEqualTo("worker")
     }
 
     @Test
-    fun `M skip threads with empty stack W dump()`() {
+    fun `M skip threads with empty stack W dump()`(
+        @LongForgery fakeDetectedAtMs: Long
+    ) {
         // Given
         val mainThread = Thread.currentThread()
         val idleThread = Thread("idle")
@@ -77,14 +86,19 @@ internal class ThreadDumperTest {
         ).apply { internalLogger = mockInternalLogger }
 
         // When
-        val dump = testedDumper.dump()
+        val dump = testedDumper.dump(fakeDetectedAtMs)
 
         // Then
+        assertThat(dump.detectedAtMs).isEqualTo(fakeDetectedAtMs)
+        assertThat(dump.anrThreadName).isEqualTo(mainThread.name)
+        assertThat(dump.anrThreadState).isEqualTo(mainThread.state)
         assertThat(dump.allThreads).isEmpty()
     }
 
     @Test
-    fun `M return empty allThreads and log W getAllStackTraces throws`() {
+    fun `M return empty allThreads and log W getAllStackTraces throws`(
+        @LongForgery fakeDetectedAtMs: Long
+    ) {
         // Given
         val fakeBoom = RuntimeException("boom")
         val testedDumper = ThreadDumper(
@@ -93,7 +107,7 @@ internal class ThreadDumperTest {
         ).apply { internalLogger = mockInternalLogger }
 
         // When
-        val dump = testedDumper.dump()
+        val dump = testedDumper.dump(fakeDetectedAtMs)
 
         // Then
         assertThat(dump.allThreads).isEmpty()

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/anr/AnrProfilingTriggerRegistrarTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/anr/AnrProfilingTriggerRegistrarTest.kt
@@ -11,7 +11,7 @@ import android.os.ProfilingManager
 import android.os.ProfilingResult
 import android.os.ProfilingTrigger
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.internal.profiling.ProfilingThreadDump
+import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.profiling.internal.utils.ThreadDumper
 import fr.xgouchet.elmyr.annotation.LongForgery
@@ -135,7 +135,7 @@ internal class AnrProfilingTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(nonAnrResult)
 
         // Then
-        verify(mockAnrListener, never()).onAnrDetected(any(), any(), any())
+        verify(mockAnrListener, never()).onAnrDetected(any())
     }
 
     @Test
@@ -165,9 +165,9 @@ internal class AnrProfilingTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(anrResult)
 
         // Then
-        val captor = argumentCaptor<List<ProfilingThreadDump>>()
-        verify(mockAnrListener).onAnrDetected(any(), any(), captor.capture())
-        assertThat(captor.firstValue).isEmpty()
+        val captor = argumentCaptor<ProfilingAnrDetectedEvent>()
+        verify(mockAnrListener).onAnrDetected(captor.capture())
+        assertThat(captor.firstValue.allThreads).isEmpty()
     }
 
     @Test
@@ -292,7 +292,7 @@ internal class AnrProfilingTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(anrResult)
 
         // Then
-        verify(mockAnrListener, never()).onAnrDetected(any(), any(), any())
+        verify(mockAnrListener, never()).onAnrDetected(any())
         verify(mockInternalLogger).log(
             eq(InternalLogger.Level.WARN),
             eq(InternalLogger.Target.MAINTAINER),
@@ -340,7 +340,9 @@ internal class AnrProfilingTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(anrResult)
 
         // Then
-        verify(mockAnrListener).onAnrDetected(eq(fakeNow), any(), any())
+        val captor = argumentCaptor<ProfilingAnrDetectedEvent>()
+        verify(mockAnrListener).onAnrDetected(captor.capture())
+        assertThat(captor.firstValue.detectedAtMs).isEqualTo(fakeNow)
     }
 
     @Test
@@ -368,7 +370,7 @@ internal class AnrProfilingTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(anrResult)
 
         // Then
-        verify(mockAnrListener, never()).onAnrDetected(any(), any(), any())
+        verify(mockAnrListener, never()).onAnrDetected(any())
         val propsCaptor = argumentCaptor<Map<String, Any?>>()
         verify(mockInternalLogger).log(
             eq(InternalLogger.Level.WARN),

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -40,7 +40,9 @@ import com.datadog.android.internal.profiling.ProfilingThreadDump
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.thread.isMainThread
+import com.datadog.android.internal.utils.asString
 import com.datadog.android.internal.utils.getSystemServiceAs
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
@@ -448,17 +450,26 @@ internal class RumFeature(
 
     private fun handleProfilingAnrDetectedEvent(event: ProfilingAnrDetectedEvent) {
         val anrException = ANRException(event.anrThreadStack.toTypedArray())
-        val allThreads: List<ThreadDump> = event.allThreads.map { it.toThreadDump() }
+        val mainThreadDump = ThreadDump(
+            name = event.anrThreadName,
+            state = event.anrThreadState.asString(),
+            stack = anrException.loggableStackTrace(),
+            crashed = false
+        )
+        val allThreads = listOf(mainThreadDump) + event.allThreads.map { it.toThreadDump() }
         GlobalRumMonitor.get(sdkCore).addError(
             ANRDetectorRunnable.ANR_MESSAGE,
             RumErrorSource.SOURCE,
             anrException,
-            mapOf(RumAttributes.INTERNAL_ALL_THREADS to allThreads)
+            mapOf(
+                RumAttributes.INTERNAL_TIMESTAMP to event.detectedAtMs,
+                RumAttributes.INTERNAL_ALL_THREADS to allThreads
+            )
         )
     }
 
     private fun ProfilingThreadDump.toThreadDump(): ThreadDump =
-        ThreadDump(name = name, state = state, stack = stack, crashed = crashed)
+        ThreadDump(name = name, state = state.asString(), stack = stack, crashed = false)
 
     private fun handleMapLikeEvent(event: Map<*, *>) {
         when (event["type"]) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -28,23 +28,28 @@ import com.datadog.android.api.storage.FeatureStorageConfiguration
 import com.datadog.android.api.storage.NoOpDataWriter
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.feature.event.JvmCrash
+import com.datadog.android.core.feature.event.ThreadDump
 import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.core.internal.utils.scheduleSafe
 import com.datadog.android.event.EventMapper
 import com.datadog.android.event.MapperSerializer
 import com.datadog.android.event.NoOpEventMapper
 import com.datadog.android.internal.flags.RumFlagEvaluationMessage
+import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
+import com.datadog.android.internal.profiling.ProfilingThreadDump
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.thread.isMainThread
 import com.datadog.android.internal.utils.getSystemServiceAs
 import com.datadog.android.rum.GlobalRumMonitor
+import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.configuration.SlowFramesConfiguration
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
 import com.datadog.android.rum.internal.anr.ANRDetectorRunnable
+import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.debug.UiRumDebugListener
 import com.datadog.android.rum.internal.domain.InfoProvider
 import com.datadog.android.rum.internal.domain.RumDataWriter
@@ -420,6 +425,7 @@ internal class RumFeature(
             is JvmCrash.Rum -> addJvmCrash(event)
             is InternalTelemetryEvent -> handleTelemetryEvent(event)
             is RumFlagEvaluationMessage -> handleFlagEvaluationEvent(event)
+            is ProfilingAnrDetectedEvent -> handleProfilingAnrDetectedEvent(event)
             else -> {
                 sdkCore.internalLogger.log(
                     InternalLogger.Level.WARN,
@@ -439,6 +445,20 @@ internal class RumFeature(
             value = event.value
         )
     }
+
+    private fun handleProfilingAnrDetectedEvent(event: ProfilingAnrDetectedEvent) {
+        val anrException = ANRException(event.anrThreadStack.toTypedArray())
+        val allThreads: List<ThreadDump> = event.allThreads.map { it.toThreadDump() }
+        GlobalRumMonitor.get(sdkCore).addError(
+            ANRDetectorRunnable.ANR_MESSAGE,
+            RumErrorSource.SOURCE,
+            anrException,
+            mapOf(RumAttributes.INTERNAL_ALL_THREADS to allThreads)
+        )
+    }
+
+    private fun ProfilingThreadDump.toThreadDump(): ThreadDump =
+        ThreadDump(name = name, state = state, stack = stack, crashed = crashed)
 
     private fun handleMapLikeEvent(event: Map<*, *>) {
         when (event["type"]) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/anr/ANRException.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/anr/ANRException.kt
@@ -6,9 +6,13 @@
 
 package com.datadog.android.rum.internal.anr
 
-internal class ANRException(thread: Thread) : Exception() {
+internal class ANRException : Exception {
 
-    init {
+    constructor(thread: Thread) : super() {
         stackTrace = thread.stackTrace
+    }
+
+    constructor(stack: Array<StackTraceElement>) : super() {
+        stackTrace = stack
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -26,6 +26,8 @@ import com.datadog.android.internal.flags.RumFlagEvaluationMessage
 import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
+import com.datadog.android.internal.utils.asString
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
@@ -1116,15 +1118,57 @@ internal class RumFeatureTest {
         assertThat(throwable).isInstanceOf(ANRException::class.java)
         assertThat(throwable.stackTrace.toList()).isEqualTo(fakeEvent.anrThreadStack)
 
+        assertThat(attributesCaptor.firstValue[RumAttributes.INTERNAL_TIMESTAMP])
+            .isEqualTo(fakeEvent.detectedAtMs)
+
         @Suppress("UNCHECKED_CAST")
         val attached = attributesCaptor.firstValue[RumAttributes.INTERNAL_ALL_THREADS] as List<ThreadDump>
-        assertThat(attached).hasSize(fakeEvent.allThreads.size)
-        attached.zip(fakeEvent.allThreads).forEach { (mapped, original) ->
+        assertThat(attached).hasSize(fakeEvent.allThreads.size + 1)
+        val mainDump = attached.first()
+        assertThat(mainDump.name).isEqualTo(fakeEvent.anrThreadName)
+        assertThat(mainDump.state).isEqualTo(fakeEvent.anrThreadState.asString())
+        assertThat(mainDump.stack).isEqualTo(throwable.loggableStackTrace())
+        assertThat(mainDump.crashed).isFalse
+        attached.drop(1).zip(fakeEvent.allThreads).forEach { (mapped, original) ->
             assertThat(mapped.name).isEqualTo(original.name)
-            assertThat(mapped.state).isEqualTo(original.state)
+            assertThat(mapped.state).isEqualTo(original.state.asString())
             assertThat(mapped.stack).isEqualTo(original.stack)
-            assertThat(mapped.crashed).isEqualTo(original.crashed)
+            assertThat(mapped.crashed).isFalse
         }
+    }
+
+    @Test
+    fun `M include only main thread in _dd_error_threads W onReceive(ProfilingAnrDetectedEvent) {empty allThreads}`(
+        @Forgery fakeEvent: ProfilingAnrDetectedEvent
+    ) {
+        // Given
+        val eventWithNoOtherThreads = fakeEvent.copy(allThreads = emptyList())
+
+        // When
+        testedFeature.onReceive(eventWithNoOtherThreads)
+
+        // Then
+        val throwableCaptor = argumentCaptor<Throwable>()
+        val attributesCaptor = argumentCaptor<Map<String, Any?>>()
+        verify(mockRumMonitor).addError(
+            eq(ANRDetectorRunnable.ANR_MESSAGE),
+            eq(RumErrorSource.SOURCE),
+            throwableCaptor.capture(),
+            attributesCaptor.capture()
+        )
+        val throwable = throwableCaptor.firstValue
+
+        assertThat(attributesCaptor.firstValue[RumAttributes.INTERNAL_TIMESTAMP])
+            .isEqualTo(eventWithNoOtherThreads.detectedAtMs)
+
+        @Suppress("UNCHECKED_CAST")
+        val attached = attributesCaptor.firstValue[RumAttributes.INTERNAL_ALL_THREADS] as List<ThreadDump>
+        assertThat(attached).hasSize(1)
+        val mainDump = attached.first()
+        assertThat(mainDump.name).isEqualTo(eventWithNoOtherThreads.anrThreadName)
+        assertThat(mainDump.state).isEqualTo(eventWithNoOtherThreads.anrThreadState.asString())
+        assertThat(mainDump.stack).isEqualTo(throwable.loggableStackTrace())
+        assertThat(mainDump.crashed).isFalse
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -23,14 +23,18 @@ import com.datadog.android.core.feature.event.ThreadDump
 import com.datadog.android.event.EventMapper
 import com.datadog.android.event.MapperSerializer
 import com.datadog.android.internal.flags.RumFlagEvaluationMessage
+import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.rum.GlobalRumMonitor
+import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.assertj.RumFeatureAssert
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
 import com.datadog.android.rum.internal.RumFeature.Companion.SLOW_FRAMES_MONITORING_DISABLED_MESSAGE
 import com.datadog.android.rum.internal.RumFeature.Companion.SLOW_FRAMES_MONITORING_ENABLED_MESSAGE
+import com.datadog.android.rum.internal.anr.ANRDetectorRunnable
+import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.domain.InfoProvider
 import com.datadog.android.rum.internal.domain.RumDataWriter
 import com.datadog.android.rum.internal.domain.accessibility.DefaultAccessibilityReader
@@ -1090,6 +1094,37 @@ internal class RumFeatureTest {
         )
 
         verifyNoInteractions(mockRumMonitor)
+    }
+
+    @Test
+    fun `M call addError with ANRException using supplied stack W onReceive(ProfilingAnrDetectedEvent)`(
+        @Forgery fakeEvent: ProfilingAnrDetectedEvent
+    ) {
+        // When
+        testedFeature.onReceive(fakeEvent)
+
+        // Then
+        val throwableCaptor = argumentCaptor<Throwable>()
+        val attributesCaptor = argumentCaptor<Map<String, Any?>>()
+        verify(mockRumMonitor).addError(
+            eq(ANRDetectorRunnable.ANR_MESSAGE),
+            eq(RumErrorSource.SOURCE),
+            throwableCaptor.capture(),
+            attributesCaptor.capture()
+        )
+        val throwable = throwableCaptor.firstValue
+        assertThat(throwable).isInstanceOf(ANRException::class.java)
+        assertThat(throwable.stackTrace.toList()).isEqualTo(fakeEvent.anrThreadStack)
+
+        @Suppress("UNCHECKED_CAST")
+        val attached = attributesCaptor.firstValue[RumAttributes.INTERNAL_ALL_THREADS] as List<ThreadDump>
+        assertThat(attached).hasSize(fakeEvent.allThreads.size)
+        attached.zip(fakeEvent.allThreads).forEach { (mapped, original) ->
+            assertThat(mapped.name).isEqualTo(original.name)
+            assertThat(mapped.state).isEqualTo(original.state)
+            assertThat(mapped.stack).isEqualTo(original.stack)
+            assertThat(mapped.crashed).isEqualTo(original.crashed)
+        }
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
@@ -12,6 +12,8 @@ import com.datadog.android.internal.tests.elmyr.InternalTelemetryDebugLogForgery
 import com.datadog.android.internal.tests.elmyr.InternalTelemetryErrorLogForgeryFactory
 import com.datadog.android.internal.tests.elmyr.InternalTelemetryEventForgeryFactory
 import com.datadog.android.internal.tests.elmyr.InternalTelemetryMetricForgeryFactory
+import com.datadog.android.internal.tests.elmyr.ProfilingAnrDetectedEventForgeryFactory
+import com.datadog.android.internal.tests.elmyr.ProfilingThreadDumpForgeryFactory
 import com.datadog.android.internal.tests.elmyr.TracingHeaderTypesSetForgeryFactory
 import com.datadog.android.rum.tests.elmyr.BatteryInfoForgeryFactory
 import com.datadog.android.rum.tests.elmyr.DisplayInfoForgeryFactory
@@ -69,6 +71,8 @@ internal class Configurator : BaseConfigurator() {
         forge.addFactory(InternalTelemetryConfigurationForgeryFactory())
         forge.addFactory(InternalTelemetryApiUsageForgeryFactory())
         forge.addFactory(TracingHeaderTypesSetForgeryFactory())
+        forge.addFactory(ProfilingThreadDumpForgeryFactory())
+        forge.addFactory(ProfilingAnrDetectedEventForgeryFactory())
 
         // RumRawEvent
         forge.addFactory(ActionSentForgeryFactory())


### PR DESCRIPTION
### What does this PR do?

This PR sends Profiling ANR event to RUM when profiler is active for app launch or continuous profiling, then RUM adds an ANR error then send it back to Profiling Feature to attach with profile.

### Motivation
RUM-15344

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

