### PR TITLE
RUM-16087: Catch `Throwable.loggableStackTrace()` throws

### DIFF
--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/utils/ThrowableExt.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/utils/ThrowableExt.kt
@@ -14,7 +14,15 @@ import java.io.StringWriter
  */
 fun Throwable.loggableStackTrace(): String {
     val stringWriter = StringWriter()
-    @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
-    printStackTrace(PrintWriter(stringWriter))
-    return stringWriter.toString()
+    return try {
+        @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
+        printStackTrace(PrintWriter(stringWriter))
+        stringWriter.toString()
+    } catch (@Suppress("TooGenericExceptionCaught") _: Throwable) {
+        // printStackTrace may throw when formatting cause/suppressed exceptions (e.g. a
+        // kotlinx.coroutines bug where toString() on the coroutine context throws).
+        // Return whatever was written before the throw (likely the full main frames),
+        // or fall back to the raw stack array if nothing was written yet.
+        stringWriter.toString().ifBlank { stackTrace.loggableStackTrace() }
+    }
 }

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/utils/ThrowableExtTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/utils/ThrowableExtTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.junit.jupiter.MockitoExtension
+import java.io.PrintWriter
 import java.lang.RuntimeException
 
 @Extensions(
@@ -82,5 +83,42 @@ internal class ThrowableExtTest {
                     .contains(frame.methodName)
             }
         }
+    }
+
+    @Test
+    fun `M return raw stack frames W loggableStackTrace() {printStackTrace throws before writing}`(
+        @StringForgery message: String
+    ) {
+        // Given
+        val throwable = object : Throwable("boom") {
+            override fun printStackTrace(s: PrintWriter) {
+                error(message)
+            }
+        }
+
+        // When
+        val result = throwable.loggableStackTrace()
+
+        // Then
+        assertThat(result).isEqualTo(throwable.stackTrace.loggableStackTrace())
+    }
+
+    @Test
+    fun `M return partial output W loggableStackTrace() {printStackTrace throws after writing}`(
+        @StringForgery fakePartial: String
+    ) {
+        // Given
+        val throwable = object : Throwable("boom") {
+            override fun printStackTrace(s: PrintWriter) {
+                s.print(fakePartial)
+                error("forced failure")
+            }
+        }
+
+        // When
+        val result = throwable.loggableStackTrace()
+
+        // Then
+        assertThat(result).isEqualTo(fakePartial)
     }
 }


### PR DESCRIPTION
### What does this PR do?

- Wrap `Throwable.loggableStackTrace()` in a `try - catch` block.

### Motivation
 
`Throwable.printStackTrace()` can throw, as seen [here](https://dd-rum-telemetry.datadoghq.com/error-tracking/issue/c46380d2-3c5a-11f1-a294-da7ad0900002?refresh_mode=sliding&from_ts=1778081079786&to_ts=1779290679786&live=true), which would silently drop the entire crash report. According to my quick investigation, it might be due to older versions of `kotlinx.coroutines` that had an internal bug in how they handle state.

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

