### PR TITLE
RUM-15945: Sign automatically created commits

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  CURRENT_CI_IMAGE: "24"
+  CURRENT_CI_IMAGE: "25"
   CI_IMAGE_DOCKER: registry.ddbuild.io/ci/dd-sdk-android:$CURRENT_CI_IMAGE
   GIT_DEPTH: 5
 

--- a/ci/Dockerfile.gitlab
+++ b/ci/Dockerfile.gitlab
@@ -109,3 +109,4 @@ RUN mkdir -p $DD_TRACER_FOLDER
 RUN wget -O $DD_TRACER_FOLDER/dd-java-agent.jar https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/$DD_TRACER_VERSION/dd-java-agent-$DD_TRACER_VERSION.jar
 
 COPY --from=registry.ddbuild.io/dd-octo-sts:v1.8.2 /usr/local/bin/dd-octo-sts /usr/local/bin/dd-octo-sts
+COPY --from=registry.ddbuild.io/commit-headless:v2.0.1 /commit-headless /usr/local/bin/commit-headless

--- a/ci/scripts/dogfood.py
+++ b/ci/scripts/dogfood.py
@@ -106,14 +106,32 @@ def git_clone_repository(repo_name: str, gh_token: str, temp_dir_path: str) -> T
     return repo, base_name
 
 
-def git_push_changes(repo: Repo, version: str):
+def git_push_changes(repo: Repo, version: str, repo_name: str, branch_name: str, base_sha: str, gh_token: str):
     print("Committing changes")
     repo.git.add(update=True)
     repo.index.commit("Update Datadog SDK to " + version)
 
-    print("Pushing branch")
-    origin = repo.remote(name="origin")
-    repo.git.push("--set-upstream", "--force", origin, repo.head.ref)
+    print("Pushing branch with commit-headless (signed)")
+    target = "DataDog/" + repo_name
+    head_sha = repo.head.commit.hexsha
+    result = subprocess.run(
+        [
+            "commit-headless", "push",
+            "-T", target,
+            "--branch", branch_name,
+            "--head-sha", base_sha,
+            "--create-branch",
+            head_sha,
+        ],
+        cwd=repo.working_dir,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "HEADLESS_TOKEN": gh_token},
+    )
+    if result.returncode != 0:
+        print("commit-headless push failed: " + result.stderr)
+        sys.exit(1)
+    print("Signed commit pushed: " + result.stdout.strip())
 
 
 def update_dependant(version: str, target: str, gh_token: str, dry_run: bool) -> int:
@@ -123,6 +141,7 @@ def update_dependant(version: str, target: str, gh_token: str, dry_run: bool) ->
     repo_name = REPOSITORIES[target]
 
     repo, base_name = git_clone_repository(repo_name, gh_token, temp_dir_path)
+    base_sha = repo.head.commit.hexsha
 
     print("Creating branch " + branch_name)
     repo.git.checkout('HEAD', b=branch_name)
@@ -134,7 +153,7 @@ def update_dependant(version: str, target: str, gh_token: str, dry_run: bool) ->
         return 0
 
     if not dry_run:
-        git_push_changes(repo, version)
+        git_push_changes(repo, version, repo_name, branch_name, base_sha, gh_token)
 
         return github_create_pr(repo_name, branch_name, base_name, version, previous_version, gh_token)
     


### PR DESCRIPTION
### What does this PR do?

Using [commit-headless](https://github.com/datadog/commit-headless) tool to sign commits that our CI creates automatically.

The result looks like this https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/560

**How this works**
1. Our CI obtains the GitHub token using `dd-octo-sts`.
2. It uses this token to call the `commit-headless` tool.
3. The tool uses some GitHub API to produce signed commits. GitHub signs the commit using its own key (see [docs](https://github.blog/changelog/2021-09-13-a-simpler-api-for-authoring-commits/#:~:text=Commits%20authored%20using%20the%20new%20API%20are%20automatically%20GPG%20signed%20and%20are%20marked%20as%20verified%20in%20the%20GitHub%20UI.%20GitHub%20Apps%20can%20use%20the%20mutation%20to%20author%20commits%20directly%20or%20on%20behalf%20of%20users.)). 
4. The author of the commit is `dd-octo-sts[bot]`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

