### PR TITLE
[Benchmarking] Enable RUM for Session Relay baseline run

### DIFF
--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/DatadogFeaturesInitializer.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/DatadogFeaturesInitializer.kt
@@ -48,10 +48,6 @@ internal class DatadogFeaturesInitializer @Inject constructor(
     private var isInitialized = false
 
     fun initialize(config: BenchmarkConfig, intent: Intent) {
-        if (config.run == SyntheticsRun.Baseline) {
-            return
-        }
-
         if (isInitialized) {
             return
         }
@@ -100,11 +96,9 @@ internal class DatadogFeaturesInitializer @Inject constructor(
     }
 
     private fun needToEnableRum(config: BenchmarkConfig): Boolean {
-        return if (isInstrumentedRun(config)) {
-            isSessionReplayScenario(config) || isRumScenario(config)
-        } else {
-            false
-        }
+        // Session Replay requires RUM, so RUM is enabled in both baseline and instrumented for SR
+        // scenarios — this way the diff isolates Session Replay overhead.
+        return isSessionReplayScenario(config) || (isInstrumentedRun(config) && isRumScenario(config))
     }
 
     @OptIn(ExperimentalRumApi::class)

--- a/sample/benchmark/src/test/java/com/datadog/benchmark/sample/config/DatadogFeaturesInitializerTest.kt
+++ b/sample/benchmark/src/test/java/com/datadog/benchmark/sample/config/DatadogFeaturesInitializerTest.kt
@@ -51,7 +51,23 @@ class DatadogFeaturesInitializerTest {
     }
 
     @Test
-    fun `M enable nothing W run is baseline and scenario is sr`() {
+    fun `M enable session replay and rum W run is instrumented and scenario is srCompose`() {
+        // Given
+        val config = BenchmarkConfig(
+            run = SyntheticsRun.Instrumented,
+            scenario = SyntheticsScenario.SessionReplayCompose
+        )
+
+        mockAllAndCheck(config) {
+            // Then
+            sessionReplay.verifySessionReplayEnabled()
+            rum.verifyRumEnabled()
+            logs.verifyNoInteractions()
+        }
+    }
+
+    @Test
+    fun `M enable rum only W run is baseline and scenario is sr`() {
         // Given
         val config = BenchmarkConfig(
             run = SyntheticsRun.Baseline,
@@ -61,7 +77,39 @@ class DatadogFeaturesInitializerTest {
         mockAllAndCheck(config) {
             // Then
             sessionReplay.verifyNoInteractions()
-            rum.verifyNoInteractions()
+            rum.verifyRumEnabled()
+            logs.verifyNoInteractions()
+        }
+    }
+
+    @Test
+    fun `M enable rum only W run is baseline and scenario is srCompose`() {
+        // Given
+        val config = BenchmarkConfig(
+            run = SyntheticsRun.Baseline,
+            scenario = SyntheticsScenario.SessionReplayCompose
+        )
+
+        mockAllAndCheck(config) {
+            // Then
+            sessionReplay.verifyNoInteractions()
+            rum.verifyRumEnabled()
+            logs.verifyNoInteractions()
+        }
+    }
+
+    @Test
+    fun `M enable rum only W run is baseline and scenario is upload`() {
+        // Given
+        val config = BenchmarkConfig(
+            run = SyntheticsRun.Baseline,
+            scenario = SyntheticsScenario.Upload
+        )
+
+        mockAllAndCheck(config) {
+            // Then
+            sessionReplay.verifyNoInteractions()
+            rum.verifyRumEnabled()
             logs.verifyNoInteractions()
         }
     }


### PR DESCRIPTION
### What does this PR do?

 In the benchmark app, SessionReplay and SessionReplayCompose scenarios now enable RUM in both baseline and instrumented runs (instead of only in instrumented), since Session Replay depends on RUM. This way the baseline-vs-instrumented delta isolates Session Replay's own overhead rather than conflating it with the cost of bringing up RUM.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

