### PR TITLE
`NoOpImplementation improvements` [2/3] RUM-16477 Guard NoOp generation against restricted-visibility

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,3 +24,8 @@ ktlint_standard = disabled
 # SPDX License Names
 [buildSrc/src/main/kotlin/com/datadog/gradle/plugin/checklicenses/SPDXLicense.kt]
 ktlint_standard_enum-entry-name-case = disabled
+
+# NoOp test fixtures use compound filenames (OuterVisibilityOuterInnerVisibilityInner.kt)
+# to distinguish visibility combinations; the top-level class name stays short on purpose.
+[tools/noopfactory/src/test/resources/**/*.kt]
+ktlint_standard_filename = disabled

--- a/tools/noopfactory/src/main/kotlin/com/datadog/tools/noopfactory/NoOpFactorySymbolProcessor.kt
+++ b/tools/noopfactory/src/main/kotlin/com/datadog/tools/noopfactory/NoOpFactorySymbolProcessor.kt
@@ -25,6 +25,7 @@ import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.google.devtools.ksp.symbol.KSValueParameter
+import com.google.devtools.ksp.symbol.Modifier
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.ClassName
@@ -79,13 +80,10 @@ class NoOpFactorySymbolProcessor(
             .filterIsInstance<KSClassDeclaration>()
             .forEach {
                 when {
-                    it.classKind != ClassKind.INTERFACE -> logger.warn(
-                        "Unable to generate a NoOpImplementation for ${it.simpleName.asString()}, " +
-                            "it is not an interface."
-                    )
-                    it.isLocal() -> logger.warn(
-                        "Unable to generate a NoOpImplementation for ${it.simpleName.asString()}, " +
-                            "local interfaces are not supported."
+                    it.classKind != ClassKind.INTERFACE -> it.warnCannotGenerate("it is not an interface.")
+                    it.isLocal() -> it.warnCannotGenerate("local interfaces are not supported.")
+                    it.hasRestrictedVisibility() -> it.warnCannotGenerate(
+                        "it or one of its enclosing classes has private or protected visibility."
                     )
                     else -> {
                         generateNoOpImplementation(it)
@@ -317,7 +315,7 @@ class NoOpFactorySymbolProcessor(
     }
 
     /**
-     * Updates the executable element map with the newly found enclosed executable elements
+     * Updates the property element map with the newly found enclosed properties
      * in this interface avoiding the duplicates.
      */
     private fun fetchInterfaceProperties(
@@ -653,6 +651,12 @@ class NoOpFactorySymbolProcessor(
      * to avoid collisions between same-named interfaces in different outer classes
      * (e.g. `Outer.Inner` → `NoOpOuterInner`, `OuterOuter.Outer.Inner` → `NoOpOuterOuterOuterInner`).
      */
+    private fun KSClassDeclaration.warnCannotGenerate(reason: String) {
+        logger.warn(
+            "Unable to generate a NoOpImplementation for ${simpleName.asString()}, $reason"
+        )
+    }
+
     private fun KSClassDeclaration.noOpName(): String {
         val names = mutableListOf(simpleName.asString())
         var enclosing = parentDeclaration as? KSClassDeclaration
@@ -661,6 +665,17 @@ class NoOpFactorySymbolProcessor(
             enclosing = enclosing.parentDeclaration as? KSClassDeclaration
         }
         return "NoOp${names.joinToString("")}"
+    }
+
+    private fun KSClassDeclaration.hasRestrictedVisibility(): Boolean {
+        var current: KSClassDeclaration? = this
+        while (current != null) {
+            if (Modifier.PRIVATE in current.modifiers || Modifier.PROTECTED in current.modifiers) {
+                return true
+            }
+            current = current.parentDeclaration as? KSClassDeclaration
+        }
+        return false
     }
 
     // endregion

--- a/tools/noopfactory/src/test/kotlin/com/datadog/tools/noopfactory/NoOpFactoryProviderTest.kt
+++ b/tools/noopfactory/src/test/kotlin/com/datadog/tools/noopfactory/NoOpFactoryProviderTest.kt
@@ -31,7 +31,10 @@ internal class NoOpFactoryProviderTest {
             "Outer.kt:NoOpOuterInner.kt",
             "NestedReturnTypeInterface.kt:NoOpNestedReturnTypeInterface.kt",
             "Outer2.kt:NoOpOuter2Inner2.kt",
-            "Outer2.kt:NoOpOuter2.kt"
+            "Outer2.kt:NoOpOuter2.kt",
+            "PublicOuterInternalInner.kt:NoOpPublicOuterInternalInner.kt",
+            "InternalOuterPublicInner.kt:NoOpInternalOuterPublicInner.kt",
+            "InternalOuterInternalInner.kt:NoOpInternalOuterInternalInner.kt"
         ]
     )
     fun `implement a NoOp class from interface`(srcFileName: String, genFileName: String) {
@@ -70,6 +73,34 @@ internal class NoOpFactoryProviderTest {
 
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
         result.assertNothingGenerated("NoOp$srcFileName")
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        delimiter = ':',
+        value = [
+            "PublicOuterPrivateInner.kt:NoOpPublicOuterPrivateInner.kt",
+            "PublicOuterProtectedInner.kt:NoOpPublicOuterProtectedInner.kt",
+            "InternalOuterPrivateInner.kt:NoOpInternalOuterPrivateInner.kt",
+            "InternalOuterProtectedInner.kt:NoOpInternalOuterProtectedInner.kt",
+            "PrivateOuterPublicInner.kt:NoOpPrivateOuterPublicInner.kt",
+            "PrivateOuterInternalInner.kt:NoOpPrivateOuterInternalInner.kt",
+            "PrivateOuterPrivateInner.kt:NoOpPrivateOuterPrivateInner.kt",
+            "PrivateOuterProtectedInner.kt:NoOpPrivateOuterProtectedInner.kt"
+        ]
+    )
+    fun `ignores interfaces with restricted visibility`(srcFileName: String, noOpFileName: String) {
+        val srcFile = File(javaClass.getResource("/src/$srcFileName")!!.file)
+        val kotlinSource = SourceFile.fromPath(srcFile)
+
+        val result = KotlinCompilation().apply {
+            inheritClassPath = true
+            sources = listOf(kotlinSource)
+            symbolProcessorProviders = listOf(NoOpFactoryProvider())
+        }.compile()
+
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+        result.assertNothingGenerated(noOpFileName)
     }
 
     // region Internal

--- a/tools/noopfactory/src/test/resources/gen/NoOpInternalOuterInternalInner.kt
+++ b/tools/noopfactory/src/test/resources/gen/NoOpInternalOuterInternalInner.kt
@@ -1,0 +1,13 @@
+@file:Suppress(
+    "ktlint",
+    "MatchingDeclarationName",
+)
+
+package com.example
+
+import kotlin.Int
+import kotlin.Suppress
+
+internal class NoOpInternalOuterInternalInner : InternalOuter.InternalInner {
+    override fun doSomething(): Int = 0
+}

--- a/tools/noopfactory/src/test/resources/gen/NoOpInternalOuterPublicInner.kt
+++ b/tools/noopfactory/src/test/resources/gen/NoOpInternalOuterPublicInner.kt
@@ -1,0 +1,13 @@
+@file:Suppress(
+    "ktlint",
+    "MatchingDeclarationName",
+)
+
+package com.example
+
+import kotlin.Int
+import kotlin.Suppress
+
+internal class NoOpInternalOuterPublicInner : InternalOuter.PublicInner {
+    override fun doSomething(): Int = 0
+}

--- a/tools/noopfactory/src/test/resources/gen/NoOpPublicOuterInternalInner.kt
+++ b/tools/noopfactory/src/test/resources/gen/NoOpPublicOuterInternalInner.kt
@@ -1,0 +1,13 @@
+@file:Suppress(
+    "ktlint",
+    "MatchingDeclarationName",
+)
+
+package com.example
+
+import kotlin.Int
+import kotlin.Suppress
+
+internal class NoOpPublicOuterInternalInner : PublicOuter.InternalInner {
+    override fun doSomething(): Int = 0
+}

--- a/tools/noopfactory/src/test/resources/src/InternalOuterInternalInner.kt
+++ b/tools/noopfactory/src/test/resources/src/InternalOuterInternalInner.kt
@@ -1,0 +1,13 @@
+@file:Suppress("MatchingDeclarationName")
+
+package com.example
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+internal class InternalOuter {
+
+    @NoOpImplementation
+    internal interface InternalInner {
+        fun doSomething(): Int
+    }
+}

--- a/tools/noopfactory/src/test/resources/src/InternalOuterPrivateInner.kt
+++ b/tools/noopfactory/src/test/resources/src/InternalOuterPrivateInner.kt
@@ -1,0 +1,13 @@
+@file:Suppress("MatchingDeclarationName", "UnusedPrivateClass")
+
+package com.example
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+internal class InternalOuter {
+
+    @NoOpImplementation
+    private interface PrivateInner {
+        fun doSomething(): Int
+    }
+}

--- a/tools/noopfactory/src/test/resources/src/InternalOuterProtectedInner.kt
+++ b/tools/noopfactory/src/test/resources/src/InternalOuterProtectedInner.kt
@@ -1,0 +1,13 @@
+@file:Suppress("MatchingDeclarationName")
+
+package com.example
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+internal abstract class InternalOuter {
+
+    @NoOpImplementation
+    protected interface ProtectedInner {
+        fun doSomething(): Int
+    }
+}

--- a/tools/noopfactory/src/test/resources/src/InternalOuterPublicInner.kt
+++ b/tools/noopfactory/src/test/resources/src/InternalOuterPublicInner.kt
@@ -1,0 +1,13 @@
+@file:Suppress("MatchingDeclarationName")
+
+package com.example
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+internal class InternalOuter {
+
+    @NoOpImplementation
+    interface PublicInner {
+        fun doSomething(): Int
+    }
+}

--- a/tools/noopfactory/src/test/resources/src/PrivateOuterInternalInner.kt
+++ b/tools/noopfactory/src/test/resources/src/PrivateOuterInternalInner.kt
@@ -1,0 +1,13 @@
+@file:Suppress("MatchingDeclarationName", "UnusedPrivateClass")
+
+package com.example
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+private class PrivateOuter {
+
+    @NoOpImplementation
+    internal interface InternalInner {
+        fun doSomething(): Int
+    }
+}

--- a/tools/noopfactory/src/test/resources/src/PrivateOuterPrivateInner.kt
+++ b/tools/noopfactory/src/test/resources/src/PrivateOuterPrivateInner.kt
@@ -1,0 +1,13 @@
+@file:Suppress("MatchingDeclarationName", "UnusedPrivateClass")
+
+package com.example
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+private class PrivateOuter {
+
+    @NoOpImplementation
+    private interface PrivateInner {
+        fun doSomething(): Int
+    }
+}

--- a/tools/noopfactory/src/test/resources/src/PrivateOuterProtectedInner.kt
+++ b/tools/noopfactory/src/test/resources/src/PrivateOuterProtectedInner.kt
@@ -1,0 +1,13 @@
+@file:Suppress("MatchingDeclarationName", "UnusedPrivateClass")
+
+package com.example
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+private abstract class PrivateOuter {
+
+    @NoOpImplementation
+    protected interface ProtectedInner {
+        fun doSomething(): Int
+    }
+}

--- a/tools/noopfactory/src/test/resources/src/PrivateOuterPublicInner.kt
+++ b/tools/noopfactory/src/test/resources/src/PrivateOuterPublicInner.kt
@@ -1,0 +1,13 @@
+@file:Suppress("MatchingDeclarationName", "UnusedPrivateClass")
+
+package com.example
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+private class PrivateOuter {
+
+    @NoOpImplementation
+    interface PublicInner {
+        fun doSomething(): Int
+    }
+}

--- a/tools/noopfactory/src/test/resources/src/PublicOuterInternalInner.kt
+++ b/tools/noopfactory/src/test/resources/src/PublicOuterInternalInner.kt
@@ -1,0 +1,13 @@
+@file:Suppress("MatchingDeclarationName")
+
+package com.example
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+class PublicOuter {
+
+    @NoOpImplementation
+    internal interface InternalInner {
+        fun doSomething(): Int
+    }
+}

--- a/tools/noopfactory/src/test/resources/src/PublicOuterPrivateInner.kt
+++ b/tools/noopfactory/src/test/resources/src/PublicOuterPrivateInner.kt
@@ -1,0 +1,13 @@
+@file:Suppress("MatchingDeclarationName", "UnusedPrivateClass")
+
+package com.example
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+class PublicOuter {
+
+    @NoOpImplementation
+    private interface PrivateInner {
+        fun doSomething(): Int
+    }
+}

--- a/tools/noopfactory/src/test/resources/src/PublicOuterProtectedInner.kt
+++ b/tools/noopfactory/src/test/resources/src/PublicOuterProtectedInner.kt
@@ -1,0 +1,13 @@
+@file:Suppress("MatchingDeclarationName")
+
+package com.example
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+abstract class PublicOuter {
+
+    @NoOpImplementation
+    protected interface ProtectedInner {
+        fun doSomething(): Int
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Adds an `isPrivateOrHasPrivateEnclosing()` check that walks the enclosing-class
chain and skips NoOp generation when any class in the chain has private or
protected visibility, preventing the emission of uncompilable code.

### Motivation

Without this guard, the NoOp generator introduced in the previous PR would
attempt to implement nested interfaces that are not accessible from outside the
enclosing type, causing compilation errors.

### Additional Notes

Extends the test matrix with all 12 outer × inner visibility combinations:
`public`/`internal` outer × `public`/`internal` inner → generation expected;
`public`/`internal` outer × `private`/`protected` inner → generation skipped;
`private` outer × any inner visibility → generation skipped.

Stacked on "Add NoOp generation support for nested interfaces".

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)