### PR TITLE
RUM-16187: Fix tap target mis-attribution for views clipped by scrolling ancestors

### DIFF
--- a/detekt_custom_unsafe_calls.yml
+++ b/detekt_custom_unsafe_calls.yml
@@ -42,7 +42,6 @@ datadog:
       - "android.view.Choreographer.postFrameCallback():java.lang.IllegalArgumentException"
       - "android.view.MotionEvent.obtain(android.view.MotionEvent):java.lang.IllegalArgumentException"
       - "android.view.View.getGlobalVisibleRect(android.graphics.Rect?):java.lang.NullPointerException"
-      - "android.view.View.getLocationInWindow(kotlin.IntArray):java.lang.IllegalArgumentException"
       - "android.view.ViewPropertyAnimator.setDuration(kotlin.Long):java.lang.IllegalArgumentException"
       - "android.view.ViewTreeObserver.removeOnDrawListener(android.view.ViewTreeObserver.OnDrawListener?):java.lang.IllegalStateException"
       - "android.view.ViewTreeObserver.addOnDrawListener(android.view.ViewTreeObserver.OnDrawListener?):java.lang.IllegalStateException"

--- a/detekt_custom_unsafe_calls.yml
+++ b/detekt_custom_unsafe_calls.yml
@@ -41,6 +41,7 @@ datadog:
       - "android.view.Choreographer.getInstance():java.lang.IllegalStateException"
       - "android.view.Choreographer.postFrameCallback():java.lang.IllegalArgumentException"
       - "android.view.MotionEvent.obtain(android.view.MotionEvent):java.lang.IllegalArgumentException"
+      - "android.view.View.getGlobalVisibleRect(android.graphics.Rect?):java.lang.NullPointerException"
       - "android.view.View.getLocationInWindow(kotlin.IntArray):java.lang.IllegalArgumentException"
       - "android.view.ViewPropertyAnimator.setDuration(kotlin.Long):java.lang.IllegalArgumentException"
       - "android.view.ViewTreeObserver.removeOnDrawListener(android.view.ViewTreeObserver.OnDrawListener?):java.lang.IllegalStateException"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AndroidActionTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AndroidActionTrackingStrategy.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.content.Context
+import android.graphics.Rect
 import android.view.View
 import android.widget.AbsListView
 import android.widget.ScrollView
@@ -23,7 +24,7 @@ import java.lang.ref.WeakReference
  */
 internal class AndroidActionTrackingStrategy : ActionTrackingStrategy {
 
-    private val coordinatesContainer = IntArray(2)
+    private val visibleRect = Rect()
 
     override fun register(sdkCore: SdkCore, context: Context) {
         // sdkCore & context are not needed in this strategy, no-op
@@ -34,7 +35,7 @@ internal class AndroidActionTrackingStrategy : ActionTrackingStrategy {
     }
 
     override fun findTargetForTap(view: View, x: Float, y: Float): ViewTarget? {
-        return if (hitTest(view, x, y, coordinatesContainer) && isValidTapTarget(view)) {
+        return if (hitTest(view, x, y, visibleRect) && isValidTapTarget(view)) {
             ViewTarget(viewRef = WeakReference(view))
         } else {
             null
@@ -42,7 +43,7 @@ internal class AndroidActionTrackingStrategy : ActionTrackingStrategy {
     }
 
     override fun findTargetForScroll(view: View, x: Float, y: Float): ViewTarget? {
-        return if (hitTest(view, x, y, coordinatesContainer) && isValidScrollableTarget(view)) {
+        return if (hitTest(view, x, y, visibleRect) && isValidScrollableTarget(view)) {
             ViewTarget(viewRef = WeakReference(view))
         } else {
             null
@@ -60,16 +61,19 @@ internal class AndroidActionTrackingStrategy : ActionTrackingStrategy {
         view: View,
         x: Float,
         y: Float,
-        container: IntArray
+        outRect: Rect
     ): Boolean {
-        @Suppress("UnsafeThirdPartyFunctionCall") // container always have the correct size
-        view.getLocationInWindow(container)
-        val vx = container[0]
-        val vy = container[1]
-        val w = view.width
-        val h = view.height
-
-        return !(x < vx || x > vx + w || y < vy || y > vy + h)
+        // Use getGlobalVisibleRect to get the view's bounds intersected with all ancestor
+        // clip rects. This ensures views that are scrolled out of their parent's visible
+        // area (e.g. a child inside a NestedScrollView/RecyclerView that extends behind a
+        // BottomNavigationView) are NOT considered as hit targets in the clipped region.
+        @Suppress("UnsafeThirdPartyFunctionCall") // outRect is never null
+        val isVisible = view.getGlobalVisibleRect(outRect)
+        if (!isVisible) return false
+        val ix = x.toInt()
+        val iy = y.toInt()
+        return ix >= outRect.left && ix <= outRect.right &&
+            iy >= outRect.top && iy <= outRect.bottom
     }
 
     private fun isValidScrollableTarget(view: View): Boolean {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AndroidActionTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AndroidActionTrackingStrategy.kt
@@ -70,10 +70,8 @@ internal class AndroidActionTrackingStrategy : ActionTrackingStrategy {
         @Suppress("UnsafeThirdPartyFunctionCall") // outRect is never null
         val isVisible = view.getGlobalVisibleRect(outRect)
         if (!isVisible) return false
-        val ix = x.toInt()
-        val iy = y.toInt()
-        return ix >= outRect.left && ix <= outRect.right &&
-            iy >= outRect.top && iy <= outRect.bottom
+        return x >= outRect.left && x <= outRect.right &&
+            y >= outRect.top && y <= outRect.bottom
     }
 
     private fun isValidScrollableTarget(view: View): Boolean {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AbstractGesturesListenerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AbstractGesturesListenerTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.app.Application
 import android.content.res.Resources
+import android.graphics.Rect
 import android.util.Log
 import android.view.MotionEvent
 import android.view.View
@@ -112,6 +113,23 @@ internal abstract class AbstractGesturesListenerTest {
             locationOnScreenArray[0] = (forEvent.x).toInt() - forge.anInt(min = 1, max = 10)
             locationOnScreenArray[1] = (forEvent.y).toInt() - forge.anInt(min = 1, max = 10)
         }
+
+        val viewLeft = locationOnScreenArray[0]
+        val viewTop = locationOnScreenArray[1]
+
+        val diffPosX = abs(forEvent.x - viewLeft).toInt()
+        val diffPosY = abs(forEvent.y - viewTop).toInt()
+
+        val viewWidth: Int
+        val viewHeight: Int
+        if (!hitTest && failHitTestBecauseOfWidthHeight) {
+            viewWidth = diffPosX - forge.anInt(min = 1, max = 10)
+            viewHeight = diffPosY - forge.anInt(min = 1, max = 10)
+        } else {
+            viewWidth = diffPosX + forge.anInt(min = 1, max = 10)
+            viewHeight = diffPosY + forge.anInt(min = 1, max = 10)
+        }
+
         val mockView: T = mock {
             whenever(it.id).thenReturn(id)
             whenever(it.isClickable).thenReturn(clickable)
@@ -124,14 +142,24 @@ internal abstract class AbstractGesturesListenerTest {
                 null
             }
 
-            val diffPosX = abs(forEvent.x - locationOnScreenArray[0]).toInt()
-            val diffPosY = abs(forEvent.y - locationOnScreenArray[1]).toInt()
-            if (!hitTest && failHitTestBecauseOfWidthHeight) {
-                whenever(it.width).thenReturn(diffPosX - forge.anInt(min = 1, max = 10))
-                whenever(it.height).thenReturn(diffPosY - forge.anInt(min = 1, max = 10))
-            } else {
-                whenever(it.width).thenReturn(diffPosX + forge.anInt(min = 1, max = 10))
-                whenever(it.height).thenReturn(diffPosY + forge.anInt(min = 1, max = 10))
+            whenever(it.width).thenReturn(viewWidth)
+            whenever(it.height).thenReturn(viewHeight)
+
+            // Mock getGlobalVisibleRect to match the hitTest/visible outcome.
+            // When visible=false, getGlobalVisibleRect returns false (view not shown).
+            // Otherwise the Rect fields are assigned directly (Rect.set() is a no-op
+            // in Android unit test stubs with returnDefaultValues=true).
+            whenever(it.getGlobalVisibleRect(any())).doAnswer { invocation ->
+                if (!visible) {
+                    false
+                } else {
+                    val rect = invocation.arguments[0] as Rect
+                    rect.left = viewLeft
+                    rect.top = viewTop
+                    rect.right = viewLeft + viewWidth
+                    rect.bottom = viewTop + viewHeight
+                    true
+                }
             }
 
             applyOthers(this.mock)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AbstractGesturesListenerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AbstractGesturesListenerTest.kt
@@ -105,17 +105,15 @@ internal abstract class AbstractGesturesListenerTest {
     ): T {
         val failHitTestBecauseOfXY = forge.aBool()
         val failHitTestBecauseOfWidthHeight = !failHitTestBecauseOfXY
-        val locationOnScreenArray = IntArray(2)
+        val viewLeft: Int
+        val viewTop: Int
         if (!hitTest && failHitTestBecauseOfXY) {
-            locationOnScreenArray[0] = (forEvent.x).toInt() + forge.anInt(min = 1, max = 10)
-            locationOnScreenArray[1] = (forEvent.y).toInt() + forge.anInt(min = 1, max = 10)
+            viewLeft = (forEvent.x).toInt() + forge.anInt(min = 1, max = 10)
+            viewTop = (forEvent.y).toInt() + forge.anInt(min = 1, max = 10)
         } else {
-            locationOnScreenArray[0] = (forEvent.x).toInt() - forge.anInt(min = 1, max = 10)
-            locationOnScreenArray[1] = (forEvent.y).toInt() - forge.anInt(min = 1, max = 10)
+            viewLeft = (forEvent.x).toInt() - forge.anInt(min = 1, max = 10)
+            viewTop = (forEvent.y).toInt() - forge.anInt(min = 1, max = 10)
         }
-
-        val viewLeft = locationOnScreenArray[0]
-        val viewTop = locationOnScreenArray[1]
 
         val diffPosX = abs(forEvent.x - viewLeft).toInt()
         val diffPosY = abs(forEvent.y - viewTop).toInt()
@@ -135,20 +133,9 @@ internal abstract class AbstractGesturesListenerTest {
             whenever(it.isClickable).thenReturn(clickable)
             whenever(it.visibility).thenReturn(if (visible) View.VISIBLE else View.GONE)
 
-            whenever(it.getLocationInWindow(any())).doAnswer {
-                val array = it.arguments[0] as IntArray
-                array[0] = locationOnScreenArray[0]
-                array[1] = locationOnScreenArray[1]
-                null
-            }
-
             whenever(it.width).thenReturn(viewWidth)
             whenever(it.height).thenReturn(viewHeight)
 
-            // Mock getGlobalVisibleRect to match the hitTest/visible outcome.
-            // When visible=false, getGlobalVisibleRect returns false (view not shown).
-            // Otherwise the Rect fields are assigned directly (Rect.set() is a no-op
-            // in Android unit test stubs with returnDefaultValues=true).
             whenever(it.getGlobalVisibleRect(any())).doAnswer { invocation ->
                 if (!visible) {
                     false

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerScrollSwipeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerScrollSwipeTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.instrumentation.gestures
 
+import android.graphics.Rect
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
@@ -471,6 +472,61 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             },
             mode = times(intermediaryEvents.size + 2)
         )
+        verifyNoInteractions(rumMonitor.mockInstance)
+    }
+
+    @Test
+    fun `M ignore clipped scrollable W onScroll {visible rect does not contain scroll coordinate}`(
+        forge: Forge
+    ) {
+        // Given — a scrollable target whose getGlobalVisibleRect is clipped so the scroll
+        // coordinate falls outside the visible portion.
+        val startDownEvent: MotionEvent = forge.getForgery()
+        val listSize = forge.anInt(1, 20)
+        val intermediaryEvents =
+            forge.aList(size = listSize) { forge.getForgery(MotionEvent::class.java) }
+        val distancesX = forge.aList(listSize) { forge.aFloat() }
+        val distancesY = forge.aList(listSize) { forge.aFloat() }
+        val targetId = forge.anInt()
+        val endUpEvent = intermediaryEvents[intermediaryEvents.size - 1]
+        val clippedScrollable: ScrollableListView = mockView(
+            id = targetId,
+            forEvent = startDownEvent,
+            hitTest = true,
+            forge = forge
+        )
+        whenever(clippedScrollable.getGlobalVisibleRect(any())).thenAnswer { invocation ->
+            val rect = invocation.arguments[0] as Rect
+            rect.left = 0
+            rect.top = 0
+            rect.right = 10
+            rect.bottom = 10
+            true
+        }
+        mockDecorView = mockDecorView<ViewGroup>(
+            id = forge.anInt(),
+            forEvent = startDownEvent,
+            hitTest = true,
+            forge = forge
+        ) {
+            whenever(it.childCount).thenReturn(1)
+            whenever(it.getChildAt(0)).thenReturn(clippedScrollable)
+        }
+        testedListener = GesturesListener(
+            rumMonitor.mockSdkCore,
+            WeakReference(mockWindow),
+            contextRef = WeakReference(mockAppContext),
+            internalLogger = mockInternalLogger
+        )
+
+        // When
+        testedListener.onDown(startDownEvent)
+        intermediaryEvents.forEachIndexed { index, event ->
+            testedListener.onScroll(startDownEvent, event, distancesX[index], distancesY[index])
+        }
+        testedListener.onUp(endUpEvent)
+
+        // Then — the clipped scrollable should NOT be selected as scroll target
         verifyNoInteractions(rumMonitor.mockInstance)
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.content.Context
 import android.content.res.Resources
+import android.graphics.Rect
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
@@ -866,6 +867,83 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
             fakeAttributes
         )
     }
+
+    // region — clipping
+
+    @Test
+    fun `M ignore clipped child W onTap {child visible rect does not contain tap coordinate}`(
+        forge: Forge
+    ) {
+        // Given — a clickable child whose getGlobalVisibleRect is clipped so the tap
+        // coordinate falls outside the visible portion (simulates NestedScrollView clipping
+        // a child behind a BottomNavigationView). Another sibling IS visible at the tap.
+        val mockEvent: MotionEvent = forge.getForgery()
+
+        // This child is clickable but its visible rect is clipped to NOT contain the tap
+        val clippedChild: View = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true, // layout rect would pass the old hitTest
+            clickable = true,
+            forge = forge
+        )
+        // Override getGlobalVisibleRect to return a rect that does NOT contain the event
+        whenever(clippedChild.getGlobalVisibleRect(any())).thenAnswer { invocation ->
+            val rect = invocation.arguments[0] as Rect
+            // Set the visible rect well above the event coordinate (direct field assignment
+            // because Rect.set() is a no-op in Android unit test stubs)
+            rect.left = 0
+            rect.top = 0
+            rect.right = 10
+            rect.bottom = 10
+            true
+        }
+
+        // This sibling IS visible at the tap coordinate
+        val visibleTarget: View = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            clickable = true,
+            forge = forge
+        )
+
+        val container: ViewGroup = mockView<ViewGroup>(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            forge = forge
+        ) {
+            whenever(it.childCount).thenReturn(2)
+            whenever(it.getChildAt(0)).thenReturn(clippedChild)
+            whenever(it.getChildAt(1)).thenReturn(visibleTarget)
+        }
+        mockDecorView = mockDecorView<ViewGroup>(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            forge = forge
+        ) {
+            whenever(it.childCount).thenReturn(1)
+            whenever(it.getChildAt(0)).thenReturn(container)
+        }
+        val expectedResourceName = forge.anAlphabeticalString()
+        mockResourcesForTarget(visibleTarget, expectedResourceName)
+        testedListener = GesturesListener(
+            rumMonitor.mockSdkCore,
+            WeakReference(mockWindow),
+            contextRef = WeakReference(mockAppContext),
+            internalLogger = mockInternalLogger
+        )
+
+        // When
+        testedListener.onSingleTapUp(mockEvent)
+
+        // Then — the clipped child should NOT be chosen; the visible sibling should win
+        verifyMonitorCalledWithUserAction(visibleTarget, "", expectedResourceName)
+    }
+
+    // endregion
 
     // region Internal
 


### PR DESCRIPTION
### What does this PR do?

Replaces `View.getLocationInWindow + width × height` with `View.getGlobalVisibleRect` in `AndroidActionTrackingStrategy.hitTest` so the gesture target resolver respects ancestor clipping.

Before this change, a clickable view scrolled past its parent's visible region (for example, a `Button` inside a `NestedScrollView` whose layout position falls behind a sibling `BottomNavigationView`) was still considered a valid tap target. Because `findTarget` performs a BFS that overwrites `target` on every later match, the visually hidden button was visited after the legitimate `BottomNavigationItemView` and won the resolution, causing taps on the `BottomNavigationView` to be attributed to the hidden underlying button.

`getGlobalVisibleRect` returns the view's bounds intersected with all ancestor clip rectangles, so views that are scrolled out of their parent's visible area no longer satisfy the hit-test. Both APIs return coordinates in the window coordinate space, so the comparison against `MotionEvent` coordinates is unchanged.

### Motivation

RUM-16187 (escalated from RUMS-5868).

Customers report that taps on `BottomNavigationView` items get mis-attributed to underlying `Button` views inside the `ViewPager2` page when those buttons sit at scroll positions that place their raw layout rect behind the nav bar. The behaviour was reproduced on stock SDK 3.9.1 and 3.10.0 in a controlled repro app mirroring the customer's layout (`ConstraintLayout` with `ViewPager2.bottom_toTopOf="@id/separator"`, `separator.bottom_toTopOf="@id/bottom_nav"`, `BottomNavigationView.bottom_toBottomOf="parent"`). At the initial scroll position of the `NestedScrollView`, the last-but-one and last items have layout positions that fall in the window-coord range occupied by the nav bar (item_11 at `y ∈ [2132, 2321]` for a tap at `y = 2232`). The stock SDK's raw-bounds hit-test reported these as valid targets.

### Additional Notes

- **Coordinate space** is unchanged. Both `getLocationInWindow` and `getGlobalVisibleRect` return window-space coordinates (top-left of the decorView is origin) per the AOSP Javadocs. The `MotionEvent` coordinates received via `Window.Callback.dispatchTouchEvent` are in the same space, so no conversion is needed.
- **A reproducer project** is attached to RUM-16187 in Jira for local verification.

The fix was verified end-to-end with `dd-sdk-android` published to Maven local against a repro app that mirrors the customer-reported layout. With SDK 3.10.0, three of three overlap-state Messages-tab taps were attributed to `MaterialButton(item_11)`. With this patch applied, all three were correctly attributed to `BottomNavigationItemView(nav_messages)`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)