### PR TITLE
[Benchmark] Fix app crash when running baseline for SR scenario

### DIFF
--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/di/app/DatadogModule.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/di/app/DatadogModule.kt
@@ -41,7 +41,11 @@ internal interface DatadogModule {
             context: Context,
             config: BenchmarkConfig
         ): SdkCore {
-            if (config.run == SyntheticsRun.Baseline) {
+            // Session Replay (Compose) Baseline needs RUM
+            if (config.run == SyntheticsRun.Baseline &&
+                config.scenario != SyntheticsScenario.SessionReplay &&
+                config.scenario != SyntheticsScenario.SessionReplayCompose
+            ) {
                 return Datadog.getInstance() // returns NoOpInternalSdkCore under the hood
             }
 


### PR DESCRIPTION
### What does this PR do?

The previous [PR](https://github.com/DataDog/dd-sdk-android/pull/3467) caused the crash on synthetics when running with Session Replay (Compose) scenario and baseline run:
```
 AndroidRuntime: java.lang.RuntimeException: Unable to start activity ComponentInfo{com.datadog.sample.benchmark/com.datadog.benchmark.sample.activities.LaunchActivity}: 
bk.q: lateinit property appContext has not been initialized
```

This is because Session Replay (Compose) scenario has RUM enabled in baseline, but the SDK was not initialized.



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

