### PR TITLE
RUM-16501: Make file write atomic

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriter.kt
@@ -12,9 +12,9 @@ import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.internal.persistence.file.lengthSafe
 import com.datadog.android.core.internal.utils.use
 import java.io.File
-import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStream
+import java.io.RandomAccessFile
 import java.nio.ByteBuffer
 import java.util.Locale
 import kotlin.math.max
@@ -90,16 +90,23 @@ internal class PlainBatchFileReaderWriter(
     // region Internal
 
     @Throws(IOException::class)
-    @Suppress("UnsafeThirdPartyFunctionCall") // Called within a try/catch block
+    @Suppress("UnsafeThirdPartyFunctionCall", "NestedBlockDepth") // Called within a try/catch block
     private fun lockFileAndWriteData(
         file: File,
         append: Boolean,
         data: RawBatchEvent
     ) {
-        FileOutputStream(file, append).use { outputStream ->
-            outputStream.channel.lock().use {
-                val meta = data.metadata
+        RandomAccessFile(file, "rw").use { raf ->
+            val channel = raf.channel
+            channel.lock().use {
+                // Snapshot the pre-write length so a failed write can be rolled back
+                // to the last good record boundary (TLV records would otherwise become
+                // misaligned and corrupt every subsequent append).
+                val rollbackLength = if (append) channel.size() else 0L
+                channel.truncate(rollbackLength)
+                channel.position(rollbackLength)
 
+                val meta = data.metadata
                 val metaBlockSize = TYPE_SIZE_BYTES + LENGTH_SIZE_BYTES + meta.size
                 val dataBlockSize = TYPE_SIZE_BYTES + LENGTH_SIZE_BYTES + data.data.size
 
@@ -109,8 +116,28 @@ internal class PlainBatchFileReaderWriter(
                     .allocate(metaBlockSize + dataBlockSize)
                     .putAsTlv(BlockType.META, meta)
                     .putAsTlv(BlockType.EVENT, data.data)
+                buffer.flip()
 
-                outputStream.write(buffer.array())
+                try {
+                    while (buffer.hasRemaining()) {
+                        channel.write(buffer)
+                    }
+                } catch (e: IOException) {
+                    // Truncating to a smaller size frees blocks rather than allocating,
+                    // so it succeeds even when the failure was ENOSPC.
+                    try {
+                        channel.truncate(rollbackLength)
+                    } catch (fallbackException: IOException) {
+                        internalLogger.log(
+                            level = InternalLogger.Level.ERROR,
+                            target = InternalLogger.Target.USER,
+                            messageBuilder = { ERROR_WRITE_FALLBACK.format(Locale.US, file.path) },
+                            throwable = fallbackException
+                        )
+                    }
+                    @Suppress("ThrowingInternalException") // we are just propagating existing one
+                    throw e
+                }
             }
         }
     }
@@ -265,6 +292,7 @@ internal class PlainBatchFileReaderWriter(
         internal const val HEADER_SIZE_BYTES: Int = TYPE_SIZE_BYTES + LENGTH_SIZE_BYTES
 
         internal const val ERROR_WRITE = "Unable to write data to file: %s"
+        internal const val ERROR_WRITE_FALLBACK = "Unable to restore file after failed write: %s"
         internal const val ERROR_READ = "Unable to read data from file: %s"
 
         internal const val WARNING_NOT_ALL_DATA_READ =

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriterTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -24,12 +25,24 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.junit.jupiter.api.io.TempDir
 import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.io.File
 import java.io.FileNotFoundException
+import java.io.IOException
+import java.io.RandomAccessFile
 import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.channels.FileLock
 import java.util.Locale
 
 @Extensions(
@@ -208,6 +221,46 @@ internal class PlainBatchFileReaderWriterTest {
             PlainBatchFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path),
             FileNotFoundException::class.java
         )
+    }
+
+    @Test
+    fun `M roll back partial write W writeData() {channel write throws IOException}`(
+        @StringForgery fileName: String,
+        @Forgery event: RawBatchEvent,
+        @BoolForgery append: Boolean,
+        @LongForgery(min = 0L, max = 1024L) fakeFileLength: Long,
+        @StringForgery errorMessage: String
+    ) {
+        // Given
+        val file = File(fakeRootDirectory, fileName)
+        val expectedRollbackLength = if (append) fakeFileLength else 0L
+        val mockChannel = mock<FileChannel>()
+        val mockLock = mock<FileLock>()
+        whenever(mockChannel.size()) doReturn fakeFileLength
+        whenever(mockChannel.lock()) doReturn mockLock
+        whenever(mockChannel.write(any<ByteBuffer>())) doThrow IOException(errorMessage)
+
+        Mockito.mockConstruction(RandomAccessFile::class.java) { mock, _ ->
+            whenever(mock.channel) doReturn mockChannel
+        }.use {
+            // When
+            val result = testedReaderWriter.writeData(
+                file,
+                event,
+                append = append
+            )
+
+            // Then
+            assertThat(result).isFalse()
+            // initial alignment truncate + rollback truncate after IOException
+            verify(mockChannel, times(2)).truncate(expectedRollbackLength)
+            mockInternalLogger.verifyLog(
+                InternalLogger.Level.ERROR,
+                listOf(InternalLogger.Target.MAINTAINER),
+                PlainBatchFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path),
+                IOException::class.java
+            )
+        }
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

We may have a write failure, leading to the corrupted TLV block. This makes further read fail.

This PR makes file write atomic: we will try to rollback to the previous state if write failed.

The approach used is basically to record the original file size and truncate to that mark if write fails. It should work fine even if there is not enough space on the disk.

This change doesn't cover the situation when there is a process death, such case is harder to deal with. Maybe this change will be enough to get rid of majority read errors.

#### Performance impact

```
  ┌──────────────────────────┬────────────────────────┬───────────────────────────────────────────────────────────────────────────────────────────┬──────────────────────────────────────────────┐
  │        Operation         │         Before         │                                           After                                           │                      Δ                       │
  ├──────────────────────────┼────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────┤
  │ open()                   │ FileOutputStream       │ RandomAccessFile("rw")                                                                    │ same — both single syscalls, comparable cost │
  ├──────────────────────────┼────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────┤
  │ flock                    │ yes                    │ yes                                                                                       │ unchanged                                    │
  ├──────────────────────────┼────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────┤
  │ fstat for channel.size() │ —                      │ +1 syscall                                                                                │ ~1 µs                                        │
  ├──────────────────────────┼────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────┤
  │ ftruncate                │ —                      │ append=true: no-op (JDK short-circuits when new size ≥ current); append=false: +1 syscall │ 0 to ~2 µs                                   │
  ├──────────────────────────┼────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────┤
  │ lseek/position update    │ —                      │ in-memory field update, no syscall on Linux JDK                                           │ ~0                                           │
  ├──────────────────────────┼────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────┤
  │ write()                  │ one big buffered write │ same write() call, just looped for short-write safety                                     │ ~same                                        │
  ├──────────────────────────┼────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────┤
  │ buffer.flip()            │ —                      │ field update                                                                              │ ~0                                           │
  ├──────────────────────────┼────────────────────────┼───────────────────────────────────────────────────────────────────────────────────────────┼──────────────────────────────────────────────┤
  │ close()                  │ yes                    │ yes                                                                                       │ unchanged                                    │
  └──────────────────────────┴────────────────────────┴───────────────────────────────────────────────────────────────────────────────────────────┴──────────────────────────────────────────────┘
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

