### PR TITLE
Add empty reliability:single-fit:profiling integration test module

### DIFF
--- a/reliability/single-fit/profiling/build.gradle.kts
+++ b/reliability/single-fit/profiling/build.gradle.kts
@@ -1,0 +1,58 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+import com.datadog.gradle.config.androidLibraryConfig
+import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.junitConfig
+import com.datadog.gradle.config.kotlinConfig
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    // Build
+    id("com.android.library")
+    kotlin("android")
+    id("com.google.devtools.ksp")
+
+    // Analysis tools
+    id("com.github.ben-manes.versions")
+
+    // Tests
+    id("de.mobilej.unmock")
+}
+
+android {
+    namespace = "com.datadog.android.profiling.integration"
+}
+
+dependencies {
+    implementation(project(":dd-sdk-android-core"))
+    implementation(project(":features:dd-sdk-android-profiling"))
+    implementation(libs.kotlin)
+
+    testImplementation(project(":tools:unit")) {
+        attributes {
+            attribute(
+                com.android.build.api.attributes.ProductFlavorAttr.of("platform"),
+                objects.named("jvm")
+            )
+        }
+    }
+    testImplementation(testFixtures(project(":dd-sdk-android-core")))
+    testImplementation(project(":reliability:stub-core"))
+    testImplementation(libs.bundles.jUnit5)
+    testImplementation(libs.bundles.testTools)
+    unmock(libs.robolectric)
+}
+
+unMock {
+    keepStartingWith("android.os")
+    keepStartingWith("org.json")
+}
+
+androidLibraryConfig()
+kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+junitConfig()
+dependencyUpdateConfig()

--- a/reliability/single-fit/profiling/src/main/AndroidManifest.xml
+++ b/reliability/single-fit/profiling/src/main/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+  ~ This product includes software developed at Datadog (https://www.datadoghq.com/).
+  ~ Copyright 2016-Present Datadog, Inc.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+    </application>
+
+</manifest>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -63,6 +63,7 @@ include(":reliability:single-fit:logs")
 include(":reliability:single-fit:rum")
 include(":reliability:single-fit:trace")
 include(":reliability:single-fit:okhttp")
+include(":reliability:single-fit:profiling")
 
 // CORE INTEGRATION TESTS
 include(":reliability:core-it")


### PR DESCRIPTION
Scaffolds a new Gradle module under reliability/single-fit/profiling/ that mirrors the existing single-fit/{logs,rum,trace,okhttp} layout. Includes only the build.gradle.kts skeleton (Android library plugin, minimal core/profiling dependencies, stub-core for tests) and an empty AndroidManifest.xml, plus the settings.gradle.kts registration entry. No test sources yet — those land in a follow-up commit alongside the testFixtures and stub-core changes they depend on.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

