### PR TITLE
RUM-16502: Dedup fatal ANR reported by Profiling pipeline

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/InternalSdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/InternalSdkCore.kt
@@ -104,7 +104,11 @@ interface InternalSdkCore : FeatureSdkCore {
     fun deleteLastViewEvent()
 
     /**
-     * Writes timestamp of the last fatal ANR sent.
+     * Writes the timestamp of the last ANR RUM reported. Despite the "fatal" in the name,
+     * this same timestamp is also written for non-fatal ANRs (see
+     * `RumViewScope.persistLastNonFatalAnrSent`) so that the fatal-ANR pipeline, which
+     * replays historical `ApplicationExitInfo` ANRs on the next launch, can dedupe
+     * against an ANR the watchdog/profiling-trigger path already reported in-process.
      */
     @InternalApi
     @WorkerThread

--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -1211,6 +1211,7 @@ datadog:
       - "kotlin.ULong.toDouble()"
       - "kotlin.UShort.toShort()"
       - "kotlin.math.abs(kotlin.Float)"
+      - "kotlin.math.abs(kotlin.Long)"
       - "kotlin.math.max(kotlin.Double, kotlin.Double)"
       - "kotlin.math.max(kotlin.Float, kotlin.Float)"
       - "kotlin.math.max(kotlin.Int, kotlin.Int)"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
@@ -32,6 +32,7 @@ import com.google.gson.JsonObject
 import java.io.IOException
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+import kotlin.math.abs
 
 internal class DatadogLateCrashReporter(
     private val sdkCore: InternalSdkCore,
@@ -133,7 +134,11 @@ internal class DatadogLateCrashReporter(
                 if (lastViewEvent.session.id == datadogContext.rumSessionId) return@withWriteContext
 
                 val lastFatalAnrSent = sdkCore.lastFatalAnrSent
-                if (anrExitInfo.timestamp == lastFatalAnrSent) return@withWriteContext
+                if (lastFatalAnrSent != null &&
+                    abs(anrExitInfo.timestamp - lastFatalAnrSent) <= FATAL_ANR_DEDUP_TOLERANCE_MS
+                ) {
+                    return@withWriteContext
+                }
 
                 val threadDumps = readThreadsDump(anrExitInfo)
                 if (threadDumps.isEmpty()) return@withWriteContext
@@ -380,5 +385,12 @@ internal class DatadogLateCrashReporter(
         internal const val OPEN_ANR_TRACE_ERROR = "Cannot open trace for the last known exit reason."
 
         internal val VIEW_EVENT_AVAILABILITY_TIME_THRESHOLD = TimeUnit.HOURS.toMillis(4)
+
+        // Profiling reports an ANR via in-session addError using `detectedAtMs` (in-process
+        // detection time), while the next-launch path reads `ApplicationExitInfo.timestamp`
+        // (process death time). These come from different moments and won't match exactly,
+        // so dedup is done with a tolerance window: any marker within this window of the
+        // exit-info timestamp is treated as the same ANR.
+        internal const val FATAL_ANR_DEDUP_TOLERANCE_MS = 10_000L
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -853,7 +853,17 @@ internal open class RumViewScope(
                 if (!isFatal) {
                     // if fatal, then we don't have time for the notification, app is crashing
                     onError { it.eventDropped(rumContext.viewId.orEmpty(), StorageEvent.Error()) }
-                    onSuccess { it.eventSent(rumContext.viewId.orEmpty(), StorageEvent.Error()) }
+                    onSuccess {
+                        it.eventSent(rumContext.viewId.orEmpty(), StorageEvent.Error())
+                        if (event.throwable is ANRException) {
+                            // Intentionally writing through `writeLastFatalAnrSent` even though this is a
+                            // non-fatal ANR: both pipelines share the same persisted timestamp so that the
+                            // fatal-ANR replay path (DatadogLateCrashReporter, via ApplicationExitInfo on
+                            // the next launch) can dedupe against an ANR the in-process watchdog/profiling
+                            // trigger already reported. The storage key keeps the legacy "fatal" name.
+                            sdkCore.writeLastFatalAnrSent(event.eventTime.timestamp)
+                        }
+                    }
                 }
             }
             .submit()

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
@@ -1241,7 +1241,7 @@ internal class DatadogLateCrashReporterTest {
     }
 
     @Test
-    fun `M not send anything W handleAnrCrash() { ANR was already sent }`(
+    fun `M not send anything W handleAnrCrash() { ANR was already sent, exact match }`(
         @Forgery viewEvent: ViewEvent,
         forge: Forge
     ) {
@@ -1276,6 +1276,143 @@ internal class DatadogLateCrashReporterTest {
 
         // Then
         verifyNoInteractions(mockRumWriter)
+    }
+
+    @Test
+    fun `M not send anything W handleAnrCrash() { marker within dedup tolerance }`(
+        @Forgery viewEvent: ViewEvent,
+        forge: Forge
+    ) {
+        // Given
+        val fakeViewEvent = viewEvent.copy(
+            date = fakeCurrentTimeMs - forge.aLong(
+                min = 0L,
+                max = DatadogLateCrashReporter.VIEW_EVENT_AVAILABILITY_TIME_THRESHOLD - 1000
+            )
+        )
+        val fakeTimestamp = fakeViewEvent.date + forge.aLong(min = 1L, max = 1000000L)
+        val fakeServerOffset =
+            forge.aLong(min = -fakeTimestamp, max = Long.MAX_VALUE - fakeTimestamp)
+        fakeDatadogContext = fakeDatadogContext.copy(
+            time = fakeDatadogContext.time.copy(
+                serverTimeOffsetMs = fakeServerOffset
+            )
+        )
+
+        val fakeViewEventJson = fakeViewEvent.toJson().asJsonObject
+
+        whenever(mockRumEventDeserializer.deserialize(fakeViewEventJson)) doReturn fakeViewEvent
+
+        // stub a non-empty threads dump so that dedup is the only thing that can suppress the write
+        val fakeThreadsDump = forge.anrCrashThreadDump()
+        whenever(mockAndroidTraceParser.parse(any())) doReturn fakeThreadsDump
+        val mockAnrExitInfo = mock<ApplicationExitInfo>().apply {
+            whenever(traceInputStream) doReturn mock()
+            whenever(timestamp) doReturn fakeTimestamp
+        }
+        // marker is offset by a positive or negative delta within (and including) the tolerance
+        val fakeDelta = forge.aLong(
+            min = -DatadogLateCrashReporter.FATAL_ANR_DEDUP_TOLERANCE_MS,
+            max = DatadogLateCrashReporter.FATAL_ANR_DEDUP_TOLERANCE_MS
+        )
+        whenever(mockSdkCore.lastFatalAnrSent) doReturn (fakeTimestamp + fakeDelta)
+
+        // When
+        testedHandler.handleAnrCrash(mockAnrExitInfo, fakeViewEventJson, mockRumWriter)
+
+        // Then
+        verifyNoInteractions(mockRumWriter)
+    }
+
+    @Test
+    fun `M send RUM view+error W handleAnrCrash() { marker outside dedup tolerance }`(
+        @Forgery viewEvent: ViewEvent,
+        forge: Forge
+    ) {
+        // Given
+        val fakeViewEvent = viewEvent.copy(
+            date = fakeCurrentTimeMs - forge.aLong(
+                min = 0L,
+                max = DatadogLateCrashReporter.VIEW_EVENT_AVAILABILITY_TIME_THRESHOLD - 1000
+            )
+        )
+        val fakeTimestamp = fakeViewEvent.date + forge.aLong(
+            min = DatadogLateCrashReporter.FATAL_ANR_DEDUP_TOLERANCE_MS + 1L,
+            max = 1000000L
+        )
+        val fakeServerOffset =
+            forge.aLong(min = -fakeTimestamp, max = Long.MAX_VALUE - fakeTimestamp)
+        fakeDatadogContext = fakeDatadogContext.copy(
+            time = fakeDatadogContext.time.copy(
+                serverTimeOffsetMs = fakeServerOffset
+            )
+        )
+
+        val fakeViewEventJson = fakeViewEvent.toJson().asJsonObject
+
+        whenever(mockRumEventDeserializer.deserialize(fakeViewEventJson)) doReturn fakeViewEvent
+
+        val fakeThreadsDump = forge.anrCrashThreadDump()
+        whenever(mockAndroidTraceParser.parse(any())) doReturn fakeThreadsDump
+        val mockAnrExitInfo = mock<ApplicationExitInfo>().apply {
+            whenever(traceInputStream) doReturn mock()
+            whenever(timestamp) doReturn fakeTimestamp
+        }
+        // marker is strictly outside the tolerance window
+        val fakeOutsideMarker = fakeTimestamp -
+            forge.aLong(
+                min = DatadogLateCrashReporter.FATAL_ANR_DEDUP_TOLERANCE_MS + 1L,
+                max = DatadogLateCrashReporter.FATAL_ANR_DEDUP_TOLERANCE_MS + 1000L
+            )
+        whenever(mockSdkCore.lastFatalAnrSent) doReturn fakeOutsideMarker
+
+        // When
+        testedHandler.handleAnrCrash(mockAnrExitInfo, fakeViewEventJson, mockRumWriter)
+
+        // Then
+        verify(mockSdkCore).writeLastFatalAnrSent(fakeTimestamp)
+        verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), any(), eq(EventType.CRASH))
+    }
+
+    @Test
+    fun `M send RUM view+error W handleAnrCrash() { lastFatalAnrSent is null }`(
+        @Forgery viewEvent: ViewEvent,
+        forge: Forge
+    ) {
+        // Given
+        val fakeViewEvent = viewEvent.copy(
+            date = fakeCurrentTimeMs - forge.aLong(
+                min = 0L,
+                max = DatadogLateCrashReporter.VIEW_EVENT_AVAILABILITY_TIME_THRESHOLD - 1000
+            )
+        )
+        val fakeTimestamp = fakeViewEvent.date + forge.aLong(min = 1L, max = 1000000L)
+        val fakeServerOffset =
+            forge.aLong(min = -fakeTimestamp, max = Long.MAX_VALUE - fakeTimestamp)
+        fakeDatadogContext = fakeDatadogContext.copy(
+            time = fakeDatadogContext.time.copy(
+                serverTimeOffsetMs = fakeServerOffset
+            )
+        )
+
+        val fakeViewEventJson = fakeViewEvent.toJson().asJsonObject
+
+        whenever(mockRumEventDeserializer.deserialize(fakeViewEventJson)) doReturn fakeViewEvent
+
+        val fakeThreadsDump = forge.anrCrashThreadDump()
+        whenever(mockAndroidTraceParser.parse(any())) doReturn fakeThreadsDump
+        val mockAnrExitInfo = mock<ApplicationExitInfo>().apply {
+            whenever(traceInputStream) doReturn mock()
+            whenever(timestamp) doReturn fakeTimestamp
+        }
+        whenever(mockSdkCore.lastFatalAnrSent) doReturn null
+
+        // When
+        testedHandler.handleAnrCrash(mockAnrExitInfo, fakeViewEventJson, mockRumWriter)
+
+        // Then
+        verify(mockSdkCore).writeLastFatalAnrSent(fakeTimestamp)
+        verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), any(), eq(EventType.CRASH))
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -132,6 +132,7 @@ import org.mockito.quality.Strictness
 import java.util.Arrays
 import java.util.Locale
 import java.util.UUID
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
@@ -3896,6 +3897,100 @@ internal class RumViewScopeTest {
         }
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
+    }
+
+    @Test
+    fun `M persist lastFatalAnrSent W handleEvent(AddError) {throwable is ANRException, write succeeds}`(
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @StringForgery stacktrace: String,
+        forge: Forge
+    ) {
+        // Given
+        val throwable = ANRException(Thread.currentThread())
+        testedScope.activeActionScope = mockActionScope
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        fakeEvent = RumRawEvent.AddError(
+            message,
+            source,
+            throwable,
+            stacktrace,
+            isFatal = false,
+            threads = emptyList(),
+            attributes = attributes
+        )
+        val persistenceExecutor = sameThreadExecutorService()
+        whenever(rumMonitorConfiguration.mockSdkCore.getPersistenceExecutorService())
+            .doReturn(persistenceExecutor)
+
+        // When
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        verify(rumMonitorConfiguration.mockSdkCore).writeLastFatalAnrSent(fakeEvent.eventTime.timestamp)
+    }
+
+    @Test
+    fun `M not persist lastFatalAnrSent W handleEvent(AddError) {throwable is not ANRException}`(
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @StringForgery stacktrace: String,
+        @Forgery throwable: Throwable,
+        forge: Forge
+    ) {
+        // Given
+        testedScope.activeActionScope = mockActionScope
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        fakeEvent = RumRawEvent.AddError(
+            message,
+            source,
+            throwable,
+            stacktrace,
+            isFatal = false,
+            threads = emptyList(),
+            attributes = attributes
+        )
+        val persistenceExecutor = sameThreadExecutorService()
+        whenever(rumMonitorConfiguration.mockSdkCore.getPersistenceExecutorService())
+            .doReturn(persistenceExecutor)
+
+        // When
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        verify(rumMonitorConfiguration.mockSdkCore, never()).writeLastFatalAnrSent(any())
+    }
+
+    @Test
+    fun `M not persist lastFatalAnrSent W handleEvent(AddError) {throwable is ANRException, write fails}`(
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @StringForgery stacktrace: String,
+        forge: Forge
+    ) {
+        // Given
+        val throwable = ANRException(Thread.currentThread())
+        testedScope.activeActionScope = mockActionScope
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        fakeEvent = RumRawEvent.AddError(
+            message,
+            source,
+            throwable,
+            stacktrace,
+            isFatal = false,
+            threads = emptyList(),
+            attributes = attributes
+        )
+        whenever(mockWriter.write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))) doReturn false
+        val persistenceExecutor = sameThreadExecutorService()
+        whenever(rumMonitorConfiguration.mockSdkCore.getPersistenceExecutorService())
+            .doReturn(persistenceExecutor)
+
+        // When
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        verify(rumMonitorConfiguration.mockSdkCore, never()).writeLastFatalAnrSent(any())
     }
 
     @Test
@@ -9681,6 +9776,11 @@ internal class RumViewScopeTest {
     private fun resolveExpectedTimestamp(timestamp: Long): Long {
         return timestamp + fakeTimeInfoAtScopeStart.serverTimeOffsetMs
     }
+
+    private fun sameThreadExecutorService(): ExecutorService =
+        mock<ExecutorService>().apply {
+            whenever(execute(any())) doAnswer { it.getArgument<Runnable>(0).run() }
+        }
 
     private fun mockSessionReplayContext(testedScope: RumViewScope) {
         whenever(


### PR DESCRIPTION
### What does this PR do?

Dedups fatal ANRs so the late-crash reporter does not re-emit an ANR that was already reported in-session — covering both the new Profiling pipeline path and the existing `ANRDetectorRunnable` path.

The marker write now lives in `RumViewScope.onAddError`: when an `AddError` event with an `ANRException` throwable is successfully written, `lastFatalAnrSent` is persisted (using `event.eventTime.timestamp`, which is device time and matches `ApplicationExitInfo.timestamp`). On the next launch, `DatadogLateCrashReporter.handleAnrCrash` skips re-emitting when the marker is within a 10s tolerance of `ApplicationExitInfo.timestamp` (the two come from different moments — in-process detection vs. process death — so exact equality won't hold).

Hooking at the write path (rather than at each call site) means:
- Background ANRs that are silently dropped by `RumViewManagerScope.handleBackgroundEvent` no longer write the marker → no false-negative on background-fatal cases.
- Both the Profiling path and the legacy `ANRDetectorRunnable` path are covered by the same hook → the pre-existing duplicate where an in-session foreground ANR turned fatal is also fixed.

### Motivation

RUM-16502 — without this, an ANR detected and uploaded by the profiling pipeline is duplicated as a fatal ANR error in RUM on the next launch. The same gap also existed in the legacy path (foreground ANR reported in-session, user closes the ANR dialog, fatal ANR re-reported next launch) and is closed by the same fix.

### Additional Notes

**Possible regression to the existing late-crash dedup:** the previous check compared `ApplicationExitInfo.timestamp` to itself (marker written by `handleAnrCrash`, read on next launch — exact equality always held). With the 10s tolerance, two **distinct** fatal ANRs whose `ApplicationExitInfo.timestamp` values fall within 10s of each other would now be treated as duplicates.

In practice this requires: ANR → process death → user relaunches the app → second ANR → process death, all within 10s of the first death. The relaunch alone almost always takes longer than 10s, so this collision is only realistic in a tight crash loop, where collapsing the two reports is arguably acceptable. The same-source case (one exit-info entry re-read across multiple launches) still dedups identically since \`|0| <= 10_000\`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)