### PR TITLE
Add end-to-end coverage for the Profiling-RUM session bootstrap

### DIFF
--- a/features/dd-sdk-android-profiling/build.gradle.kts
+++ b/features/dd-sdk-android-profiling/build.gradle.kts
@@ -3,6 +3,7 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2016-Present Datadog, Inc.
  */
+@file:Suppress("StringLiteralDuplication")
 
 import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
@@ -40,6 +41,10 @@ plugins {
 
 android {
     namespace = "com.datadog.android.profiling"
+
+    testFixtures {
+        enable = true
+    }
 }
 
 dependencies {
@@ -68,6 +73,11 @@ dependencies {
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     unmock(libs.robolectric)
+
+    // Test Fixtures
+    testFixturesImplementation(libs.kotlin)
+    testFixturesImplementation(project(":dd-sdk-android-internal"))
+    testFixturesImplementation(libs.androidXAnnotation)
 }
 
 unMock {

--- a/features/dd-sdk-android-profiling/src/testFixtures/kotlin/com/datadog/android/profiling/fixtures/ProfilingFeatureTestHandle.kt
+++ b/features/dd-sdk-android-profiling/src/testFixtures/kotlin/com/datadog/android/profiling/fixtures/ProfilingFeatureTestHandle.kt
@@ -1,0 +1,59 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling.fixtures
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.profiling.ExperimentalProfilingApi
+import com.datadog.android.profiling.ProfilingConfiguration
+import com.datadog.android.profiling.internal.NoOpProfiler
+import com.datadog.android.profiling.internal.ProfilingFeature
+
+/**
+ * Test handle around an internal [ProfilingFeature] for use from integration tests in
+ * other modules. Holds a [NoOpProfiler] so no real Perfetto profiling is started, while
+ * the surrounding cross-feature wiring (event receiver, context-update receiver,
+ * scheduler bootstrap) runs exactly as in production.
+ */
+@OptIn(ExperimentalProfilingApi::class)
+@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+class ProfilingFeatureTestHandle internal constructor(
+    private val feature: ProfilingFeature
+) {
+
+    val asFeature: Feature get() = feature
+
+    val lastSeenRumSessionId: String? get() = feature.lastSeenRumSessionId
+
+    val schedulerSessionId: String? get() = feature.continuousProfilingScheduler?.currentSessionId
+
+    val isSchedulerSessionSampled: Boolean
+        get() = feature.continuousProfilingScheduler?.currentSessionSampled ?: false
+
+    companion object {
+
+        /**
+         * Build a [ProfilingFeatureTestHandle] backed by a [NoOpProfiler] and register the
+         * feature with [sdkCore], mirroring the production `Profiling.enable` entry point.
+         */
+        @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+        fun create(
+            sdkCore: FeatureSdkCore,
+            configuration: ProfilingConfiguration = ProfilingConfiguration.DEFAULT
+        ): ProfilingFeatureTestHandle {
+            val feature = ProfilingFeature(
+                sdkCore = sdkCore,
+                configuration = configuration,
+                profiler = NoOpProfiler()
+            )
+            sdkCore.registerFeature(feature)
+            return ProfilingFeatureTestHandle(feature)
+        }
+    }
+}

--- a/features/dd-sdk-android-profiling/src/testFixtures/kotlin/com/datadog/android/profiling/fixtures/ProfilingStorageFixture.kt
+++ b/features/dd-sdk-android-profiling/src/testFixtures/kotlin/com/datadog/android/profiling/fixtures/ProfilingStorageFixture.kt
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling.fixtures
+
+import com.datadog.android.internal.data.SharedPreferencesStorage
+import com.datadog.android.profiling.internal.ProfilingStorage
+
+/**
+ * Test-only access to the [SharedPreferencesStorage] used by [ProfilingStorage].
+ *
+ * Integration tests that drive [ProfilingFeatureTestHandle] without a real Android
+ * [android.content.Context] must inject a Mockito mock here in `@BeforeEach` and call
+ * [reset] in `@AfterEach`.
+ */
+object ProfilingStorageFixture {
+
+    /** Replace the storage instance used by [ProfilingStorage] (typically a Mockito mock). */
+    fun stubWith(storage: SharedPreferencesStorage?) {
+        ProfilingStorage.sharedPreferencesStorage = storage
+    }
+
+    /** Clear the stubbed storage instance. */
+    fun reset() {
+        ProfilingStorage.sharedPreferencesStorage = null
+    }
+}

--- a/reliability/single-fit/profiling/build.gradle.kts
+++ b/reliability/single-fit/profiling/build.gradle.kts
@@ -29,9 +29,12 @@ android {
 
 dependencies {
     implementation(project(":dd-sdk-android-core"))
+    implementation(project(":dd-sdk-android-internal"))
+    implementation(project(":features:dd-sdk-android-rum"))
     implementation(project(":features:dd-sdk-android-profiling"))
     implementation(libs.kotlin)
 
+    // Testing
     testImplementation(project(":tools:unit")) {
         attributes {
             attribute(
@@ -41,6 +44,8 @@ dependencies {
         }
     }
     testImplementation(testFixtures(project(":dd-sdk-android-core")))
+    testImplementation(testFixtures(project(":dd-sdk-android-internal")))
+    testImplementation(testFixtures(project(":features:dd-sdk-android-profiling")))
     testImplementation(project(":reliability:stub-core"))
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)

--- a/reliability/single-fit/profiling/src/test/kotlin/com/datadog/android/profiling/integration/ProfilingRumSessionBootstrapTest.kt
+++ b/reliability/single-fit/profiling/src/test/kotlin/com/datadog/android/profiling/integration/ProfilingRumSessionBootstrapTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling.integration
+
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.core.stub.StubSDKCore
+import com.datadog.android.internal.FeatureContextKeys
+import com.datadog.android.internal.data.SharedPreferencesStorage
+import com.datadog.android.internal.rum.RumSessionConstants
+import com.datadog.android.profiling.ExperimentalProfilingApi
+import com.datadog.android.profiling.ProfilingConfiguration
+import com.datadog.android.profiling.fixtures.ProfilingFeatureTestHandle
+import com.datadog.android.profiling.fixtures.ProfilingStorageFixture
+import com.datadog.android.profiling.integration.tests.elmyr.ProfilingIntegrationForgeConfigurator
+import com.datadog.android.profiling.integration.tests.utils.MainLooperTestConfiguration
+import com.datadog.android.rum.GlobalRumMonitor
+import com.datadog.android.rum.Rum
+import com.datadog.android.rum.RumConfiguration
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.mock
+import org.mockito.quality.Strictness
+
+@OptIn(ExperimentalProfilingApi::class)
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@ForgeConfiguration(ProfilingIntegrationForgeConfigurator::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProfilingRumSessionBootstrapTest {
+
+    private lateinit var stubSdkCore: StubSDKCore
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        stubSdkCore = StubSDKCore(forge)
+        // The stub Application has no real SharedPreferences; inject a Mockito mock so
+        // ProfilingFeature.onInitialize() can persist its launch flag.
+        ProfilingStorageFixture.stubWith(mock<SharedPreferencesStorage>())
+    }
+
+    @AfterEach
+    fun `tear down`() {
+        ProfilingStorageFixture.reset()
+    }
+
+    @Test
+    fun `M bootstrap profiling with existing session W Rum#enable before Profiling#enable`(
+        @StringForgery applicationId: String,
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String
+    ) {
+        // Given
+        Rum.enable(
+            RumConfiguration.Builder(applicationId)
+                .trackNonFatalAnrs(false)
+                .setSessionSampleRate(100f)
+                .build(),
+            stubSdkCore
+        )
+        GlobalRumMonitor.get(stubSdkCore).startView(viewKey, viewName)
+        val rumSessionId = stubSdkCore
+            .getFeatureContext(Feature.RUM_FEATURE_NAME)[FeatureContextKeys.RUM_SESSION_ID] as? String
+        check(!rumSessionId.isNullOrEmpty() && rumSessionId != RumSessionConstants.EMPTY_RUM_SESSION_ID) {
+            "Precondition: RUM feature context must hold a real session id before Profiling registers"
+        }
+
+        // When
+        val handle = ProfilingFeatureTestHandle.create(
+            sdkCore = stubSdkCore,
+            configuration = ProfilingConfiguration.Builder()
+                .setApplicationLaunchSampleRate(100f)
+                .setContinuousSampleRate(100f)
+                .build()
+        )
+
+        // Then — Profiling and its scheduler picked up the existing RUM session.
+        assertThat(handle.lastSeenRumSessionId).isEqualTo(rumSessionId)
+        assertThat(handle.schedulerSessionId).isEqualTo(rumSessionId)
+        assertThat(handle.isSchedulerSessionSampled).isTrue()
+    }
+
+    @Test
+    fun `M observe session renewal W Rum renews session after Profiling already enabled`(
+        @StringForgery applicationId: String,
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String
+    ) {
+        // Given
+        val handle = ProfilingFeatureTestHandle.create(
+            sdkCore = stubSdkCore,
+            configuration = ProfilingConfiguration.Builder()
+                .setApplicationLaunchSampleRate(100f)
+                .setContinuousSampleRate(100f)
+                .build()
+        )
+        check(handle.lastSeenRumSessionId == null) {
+            "Precondition: no RUM session should have been observed before RUM is enabled"
+        }
+
+        // When
+        Rum.enable(
+            RumConfiguration.Builder(applicationId)
+                .trackNonFatalAnrs(false)
+                .setSessionSampleRate(100f)
+                .build(),
+            stubSdkCore
+        )
+        GlobalRumMonitor.get(stubSdkCore).startView(viewKey, viewName)
+
+        // Then
+        val rumSessionId = stubSdkCore
+            .getFeatureContext(Feature.RUM_FEATURE_NAME)[FeatureContextKeys.RUM_SESSION_ID] as? String
+        assertThat(rumSessionId).isNotNull()
+        assertThat(handle.lastSeenRumSessionId).isEqualTo(rumSessionId)
+        assertThat(handle.schedulerSessionId).isEqualTo(rumSessionId)
+    }
+
+    companion object {
+        private val mainLooper = MainLooperTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(mainLooper)
+        }
+    }
+}

--- a/reliability/single-fit/profiling/src/test/kotlin/com/datadog/android/profiling/integration/tests/elmyr/ProfilingIntegrationForgeConfigurator.kt
+++ b/reliability/single-fit/profiling/src/test/kotlin/com/datadog/android/profiling/integration/tests/elmyr/ProfilingIntegrationForgeConfigurator.kt
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling.integration.tests.elmyr
+
+import com.datadog.android.tests.elmyr.useCoreFactories
+import com.datadog.tools.unit.forge.BaseConfigurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.jvm.useJvmFactories
+
+class ProfilingIntegrationForgeConfigurator : BaseConfigurator() {
+    override fun configure(forge: Forge) {
+        super.configure(forge)
+        forge.useJvmFactories()
+        forge.useCoreFactories()
+    }
+}

--- a/reliability/single-fit/profiling/src/test/kotlin/com/datadog/android/profiling/integration/tests/utils/MainLooperTestConfiguration.kt
+++ b/reliability/single-fit/profiling/src/test/kotlin/com/datadog/android/profiling/integration/tests/utils/MainLooperTestConfiguration.kt
@@ -1,0 +1,36 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling.integration.tests.utils
+
+import android.os.Looper
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import com.datadog.tools.unit.getStaticValue
+import com.datadog.tools.unit.setStaticValue
+import fr.xgouchet.elmyr.Forge
+
+class MainLooperTestConfiguration : TestConfiguration {
+
+    override fun setUp(forge: Forge) {
+        val mainLooper = Looper.getMainLooper()
+        if (mainLooper == null) {
+            try {
+                @Suppress("DEPRECATION")
+                Looper.prepareMainLooper()
+            } catch (e: IllegalStateException) {
+                // main looper already prepared
+            }
+        }
+        checkNotNull(Looper.getMainLooper())
+    }
+
+    override fun tearDown(forge: Forge) {
+        Looper::class.java.setStaticValue("sMainLooper", null)
+        Looper::class.java.getStaticValue<Looper, ThreadLocal<Looper>>("sThreadLocal").set(null)
+
+        check(Looper.getMainLooper() == null)
+    }
+}

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
@@ -18,6 +18,7 @@ import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.api.context.TimeInfo
 import com.datadog.android.api.context.UserInfo
 import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureContextUpdateReceiver
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
@@ -46,6 +47,8 @@ class StubSDKCore(
 ) : InternalSdkCore by mockSdkCore {
 
     private val featureScopes = mutableMapOf<String, FeatureScope>()
+
+    private val contextUpdateReceivers = mutableSetOf<FeatureContextUpdateReceiver>()
 
     private var currentTimestampMillis: Long = 0L
     private var currentNanoTime: Long = 0L
@@ -204,10 +207,29 @@ class StubSDKCore(
                 put(featureName, featureContext)
             }
         )
+        contextUpdateReceivers.forEach { it.onContextUpdate(featureName, featureContext) }
     }
 
     override fun getFeatureContext(featureName: String, useContextThread: Boolean): Map<String, Any?> {
         return datadogContext.featuresContext[featureName].orEmpty()
+    }
+
+    override fun setContextUpdateReceiver(listener: FeatureContextUpdateReceiver) {
+        // Mirror DatadogCore: replay the current context for every registered feature so
+        // listeners that subscribe after some feature has already populated its context
+        // still receive a bootstrap update. Forged entries for non-registered features are
+        // ignored to keep the stub faithful to production behavior.
+        featureScopes.keys.forEach { featureName ->
+            val context = datadogContext.featuresContext[featureName].orEmpty()
+            if (context.isNotEmpty()) {
+                listener.onContextUpdate(featureName, context)
+            }
+        }
+        contextUpdateReceivers.add(listener)
+    }
+
+    override fun removeContextUpdateReceiver(listener: FeatureContextUpdateReceiver) {
+        contextUpdateReceivers.remove(listener)
     }
 
     override fun createScheduledExecutorService(executorContext: String): ScheduledExecutorService {


### PR DESCRIPTION
### What does this PR do?

Adds end-to-end coverage for the Profiling↔RUM session bootstrap. Exposes `ProfilingFeatureTestHandle` and `ProfilingStorageFixture` as test fixtures of `dd-sdk-android-profiling`, then drives the real `ProfilingFeature` against a `StubSDKCore` + real `RumFeature` in `reliability/single-fit/profiling` to assert that the scheduler picks up the first RUM session id (and skips the empty sentinel) emitted via the features context.

### Motivation

Until now, the Profiling↔RUM context-update wiring was only covered by unit tests with mocked SDK core. This adds a single-fit reliability test that exercises the full event/context path with the production RUM feature in place.

### Additional Notes

- No production behavior change; only test fixtures, gradle wiring, and a new reliability test module entry.
- `StubSDKCore` gains a small helper needed by the new test.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)