### PR TITLE
Catch `IllegalArgumentException` when reading trace input stream for last fatal ANR

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
@@ -302,6 +302,14 @@ internal class DatadogLateCrashReporter(
                 ioe
             )
             return emptyList()
+        } catch (iae: IllegalArgumentException) {
+            sdkCore.internalLogger.log(
+                InternalLogger.Level.ERROR,
+                InternalLogger.Target.USER,
+                { OPEN_ANR_TRACE_ERROR },
+                iae
+            )
+            return emptyList()
         }
         if (traceInputStream == null) {
             sdkCore.internalLogger.log(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
@@ -1317,7 +1317,7 @@ internal class DatadogLateCrashReporterTest {
     }
 
     @Test
-    fun `M not send anything W handleAnrCrash() { cannot open trace information, IOException }`(
+    fun `M not send anything W handleAnrCrash() {cannot open trace information, IOException,IllegalArgumentException }`(
         @LongForgery(min = 1) fakeTimestamp: Long,
         @Forgery viewEvent: ViewEvent,
         forge: Forge
@@ -1341,7 +1341,7 @@ internal class DatadogLateCrashReporterTest {
 
         whenever(mockRumEventDeserializer.deserialize(fakeViewEventJson)) doReturn fakeViewEvent
 
-        val fakeException = IOException()
+        val fakeException = forge.anElementFrom(IOException(), IllegalArgumentException())
         val mockAnrExitInfo = mock<ApplicationExitInfo>().apply {
             whenever(traceInputStream) doThrow fakeException
             whenever(timestamp) doReturn fakeTimestamp


### PR DESCRIPTION
### What does this PR do?

Apparently it can be like this:

```
java.lang.IllegalArgumentException: java.lang.IllegalArgumentException: Invalid package name
at android.os.Parcel.createExceptionOrNull Parcel.java:3083
at android.os.Parcel.createException Parcel.java:3063
at android.os.Parcel.readException Parcel.java:3046
at android.os.Parcel.readException Parcel.java:2988
at android.app.IAppTraceRetriever$Stub$Proxy.getTraceFileDescriptor IAppTraceRetriever.java:151
at android.app.ApplicationExitInfo.getTraceInputStream ApplicationExitInfo.java:813
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

