### PR TITLE
Optimize `isMainProcess` detection

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.core.internal
 
 import android.app.ActivityManager
+import android.app.Application
 import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
@@ -69,7 +70,6 @@ import com.datadog.android.core.internal.user.DatadogUserInfoProvider
 import com.datadog.android.core.internal.user.MutableUserInfoProvider
 import com.datadog.android.core.internal.user.NoOpMutableUserInfoProvider
 import com.datadog.android.core.internal.utils.executeSafe
-import com.datadog.android.core.internal.utils.unboundInternalLogger
 import com.datadog.android.core.persistence.PersistenceStrategy
 import com.datadog.android.core.thread.FlushableExecutorService
 import com.datadog.android.internal.system.BuildSdkVersionProvider
@@ -95,7 +95,6 @@ import okhttp3.Request
 import okhttp3.TlsVersion
 import java.io.File
 import java.io.FileNotFoundException
-import java.lang.ref.WeakReference
 import java.util.Locale
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.ScheduledExecutorService
@@ -149,7 +148,7 @@ internal class CoreFeature(
     }
 
     internal val initialized = AtomicBoolean(false)
-    internal var contextRef: WeakReference<Context?> = WeakReference(null)
+    internal var appContext: Context? = null
 
     internal var firstPartyHostHeaderTypeResolver =
         DefaultFirstPartyHostHeaderTypeResolver(emptyMap())
@@ -255,11 +254,12 @@ internal class CoreFeature(
         if (initialized.get()) {
             return
         }
+        this.appContext = appContext
         readConfigurationSettings(configuration.coreConfig)
         readApplicationInformation(appContext, configuration)
         resolveProcessInfo(appContext)
         setupExecutors()
-        persistenceExecutorService.executeSafe("NTP Sync initialization", unboundInternalLogger) {
+        persistenceExecutorService.executeSafe("NTP Sync initialization", internalLogger) {
             // Kronos performs I/O operation on startup, it needs to run in background
             initializeClockSync(appContext)
         }
@@ -290,11 +290,10 @@ internal class CoreFeature(
 
     fun stop() {
         if (initialized.get()) {
-            contextRef.get()?.let {
+            appContext?.let {
                 networkInfoProvider.unregister(it)
                 systemInfoProvider.unregister(it)
             }
-            contextRef.clear()
 
             trackingConsentProvider.unregisterAllCallbacks()
 
@@ -318,6 +317,7 @@ internal class CoreFeature(
             initialized.set(false)
             ndkCrashHandler = NoOpNdkCrashHandler()
             trackingConsentProvider = NoOpConsentProvider()
+            appContext = null
         }
     }
 
@@ -524,8 +524,6 @@ internal class CoreFeature(
         envName = configuration.env
         variant = configuration.variant
         appBuildId = readBuildId(appContext)
-
-        contextRef = WeakReference(appContext)
     }
 
     private fun getPackageInfo(appContext: Context): PackageInfo? {
@@ -693,15 +691,19 @@ internal class CoreFeature(
     }
 
     private fun resolveProcessInfo(appContext: Context) {
-        val currentProcessId = Process.myPid()
-        val manager = appContext.getSystemServiceAs<ActivityManager>(Context.ACTIVITY_SERVICE)
-        val currentProcess = manager?.runningAppProcesses?.firstOrNull {
-            it.pid == currentProcessId
+        val processName = if (buildSdkVersionProvider.isAtLeastP) {
+            Application.getProcessName()
+        } else {
+            val currentProcessId = Process.myPid()
+            appContext.getSystemServiceAs<ActivityManager>(Context.ACTIVITY_SERVICE)
+                ?.runningAppProcesses
+                ?.firstOrNull { it.pid == currentProcessId }
+                ?.processName
         }
-        isMainProcess = if (currentProcess == null) {
+        isMainProcess = if (processName == null) {
             true
         } else {
-            appContext.packageName == currentProcess.processName
+            appContext.packageName == processName
         }
         if (!isMainProcess) {
             internalLogger.log(

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -160,7 +160,7 @@ internal class SdkFeature(
             uploader = NoOpDataUploader()
             fileOrchestrator = NoOpFileOrchestrator()
             metricsDispatcher = NoOpMetricsDispatcher()
-            (coreFeature.contextRef.get() as? Application)
+            (coreFeature.appContext as? Application)
                 ?.unregisterActivityLifecycleCallbacks(processLifecycleMonitor)
             processLifecycleMonitor = null
             featureContext.clear()

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -71,6 +71,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.junit.jupiter.api.io.TempDir
 import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
@@ -161,6 +162,7 @@ internal class CoreFeatureTest {
         whenever(mockPersistenceExecutorService.execute(any())) doAnswer {
             it.getArgument<Runnable>(0).run()
         }
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
         fakeConfig = fakeConfig.copy(version = fakeVersion)
     }
 
@@ -334,7 +336,7 @@ internal class CoreFeatureTest {
         assertThat(testedFeature.serviceName).isEqualTo(fakeConfig.service)
         assertThat(testedFeature.envName).isEqualTo(fakeConfig.env)
         assertThat(testedFeature.variant).isEqualTo(fakeConfig.variant)
-        assertThat(testedFeature.contextRef.get()).isEqualTo(appContext.mockInstance)
+        assertThat(testedFeature.appContext).isEqualTo(appContext.mockInstance)
         assertThat(testedFeature.batchSize).isEqualTo(fakeConfig.coreConfig.batchSize)
         assertThat(testedFeature.uploadFrequency).isEqualTo(fakeConfig.coreConfig.uploadFrequency)
     }
@@ -359,7 +361,7 @@ internal class CoreFeatureTest {
         assertThat(testedFeature.serviceName).isEqualTo(fakeConfig.service)
         assertThat(testedFeature.envName).isEqualTo(fakeConfig.env)
         assertThat(testedFeature.variant).isEqualTo(fakeConfig.variant)
-        assertThat(testedFeature.contextRef.get()).isEqualTo(appContext.mockInstance)
+        assertThat(testedFeature.appContext).isEqualTo(appContext.mockInstance)
         assertThat(testedFeature.batchSize).isEqualTo(fakeConfig.coreConfig.batchSize)
         assertThat(testedFeature.uploadFrequency).isEqualTo(fakeConfig.coreConfig.uploadFrequency)
     }
@@ -381,7 +383,7 @@ internal class CoreFeatureTest {
         assertThat(testedFeature.serviceName).isEqualTo(appContext.fakePackageName)
         assertThat(testedFeature.envName).isEqualTo(fakeConfig.env)
         assertThat(testedFeature.variant).isEqualTo(fakeConfig.variant)
-        assertThat(testedFeature.contextRef.get()).isEqualTo(appContext.mockInstance)
+        assertThat(testedFeature.appContext).isEqualTo(appContext.mockInstance)
         assertThat(testedFeature.batchSize).isEqualTo(fakeConfig.coreConfig.batchSize)
         assertThat(testedFeature.uploadFrequency).isEqualTo(fakeConfig.coreConfig.uploadFrequency)
     }
@@ -403,7 +405,7 @@ internal class CoreFeatureTest {
         assertThat(testedFeature.serviceName).isEqualTo(fakeConfig.service)
         assertThat(testedFeature.envName).isEqualTo(fakeConfig.env)
         assertThat(testedFeature.variant).isEqualTo(fakeConfig.variant)
-        assertThat(testedFeature.contextRef.get()).isEqualTo(appContext.mockInstance)
+        assertThat(testedFeature.appContext).isEqualTo(appContext.mockInstance)
         assertThat(testedFeature.batchSize).isEqualTo(fakeConfig.coreConfig.batchSize)
         assertThat(testedFeature.uploadFrequency).isEqualTo(fakeConfig.coreConfig.uploadFrequency)
     }
@@ -430,7 +432,7 @@ internal class CoreFeatureTest {
         assertThat(testedFeature.serviceName).isEqualTo(fakeConfig.service)
         assertThat(testedFeature.envName).isEqualTo(fakeConfig.env)
         assertThat(testedFeature.variant).isEqualTo(fakeConfig.variant)
-        assertThat(testedFeature.contextRef.get()).isEqualTo(appContext.mockInstance)
+        assertThat(testedFeature.appContext).isEqualTo(appContext.mockInstance)
         assertThat(testedFeature.batchSize).isEqualTo(fakeConfig.coreConfig.batchSize)
         assertThat(testedFeature.uploadFrequency).isEqualTo(fakeConfig.coreConfig.uploadFrequency)
     }
@@ -459,7 +461,7 @@ internal class CoreFeatureTest {
         assertThat(testedFeature.serviceName).isEqualTo(fakeConfig.service)
         assertThat(testedFeature.envName).isEqualTo(fakeConfig.env)
         assertThat(testedFeature.variant).isEqualTo(fakeConfig.variant)
-        assertThat(testedFeature.contextRef.get()).isEqualTo(appContext.mockInstance)
+        assertThat(testedFeature.appContext).isEqualTo(appContext.mockInstance)
         assertThat(testedFeature.batchSize).isEqualTo(fakeConfig.coreConfig.batchSize)
         assertThat(testedFeature.uploadFrequency).isEqualTo(fakeConfig.coreConfig.uploadFrequency)
     }
@@ -494,7 +496,7 @@ internal class CoreFeatureTest {
         assertThat(testedFeature.serviceName).isEqualTo(fakeConfig.service)
         assertThat(testedFeature.envName).isEqualTo(fakeConfig.env)
         assertThat(testedFeature.variant).isEqualTo(fakeConfig.variant)
-        assertThat(testedFeature.contextRef.get()).isEqualTo(appContext.mockInstance)
+        assertThat(testedFeature.appContext).isEqualTo(appContext.mockInstance)
         assertThat(testedFeature.batchSize).isEqualTo(fakeConfig.coreConfig.batchSize)
         assertThat(testedFeature.uploadFrequency).isEqualTo(fakeConfig.coreConfig.uploadFrequency)
     }
@@ -760,16 +762,68 @@ internal class CoreFeatureTest {
         assertThat(testedFeature.serviceName).isEqualTo(fakeConfig.service)
         assertThat(testedFeature.envName).isEqualTo(fakeConfig.env)
         assertThat(testedFeature.variant).isEqualTo(fakeConfig.variant)
-        assertThat(testedFeature.contextRef.get()).isEqualTo(appContext.mockInstance)
+        assertThat(testedFeature.appContext).isEqualTo(appContext.mockInstance)
         assertThat(testedFeature.batchSize).isEqualTo(fakeConfig.coreConfig.batchSize)
         assertThat(testedFeature.uploadFrequency).isEqualTo(fakeConfig.coreConfig.uploadFrequency)
     }
 
     @Test
-    fun `M detect current process W initialize() {main process}`(
+    fun `M detect current process W initialize() {main process}`() {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
+        Mockito.mockStatic(Application::class.java).use { mockedApplication ->
+            mockedApplication.`when`<String> {
+                Application.getProcessName()
+            } doReturn (appContext.fakePackageName)
+
+            // When
+            testedFeature.initialize(
+                appContext.mockInstance,
+                fakeSdkInstanceId,
+                fakeConfig,
+                fakeConsent
+            )
+
+            // Then
+            assertThat(testedFeature.isMainProcess).isTrue()
+        }
+    }
+
+    @Test
+    fun `M detect current process W initialize() {secondary process}`(
+        @StringForgery fakeOtherProcessName: String
+    ) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn true
+        Mockito.mockStatic(Application::class.java).use { mockedApplication ->
+            mockedApplication.`when`<String> {
+                Application.getProcessName()
+            } doReturn (fakeOtherProcessName)
+
+            // When
+            testedFeature.initialize(
+                appContext.mockInstance,
+                fakeSdkInstanceId,
+                fakeConfig,
+                fakeConsent
+            )
+
+            // Then
+            assertThat(testedFeature.isMainProcess).isFalse()
+            mockInternalLogger.verifyLog(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.USER,
+                CoreFeature.SDK_INITIALIZED_IN_SECONDARY_PROCESS_WARNING_MESSAGE
+            )
+        }
+    }
+
+    @Test
+    fun `M detect current process W initialize() {pre API 28, main process}`(
         @StringForgery otherProcessName: String
     ) {
         // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn false
         val mockActivityManager = mock<ActivityManager>()
         whenever(appContext.mockInstance.getSystemService(Context.ACTIVITY_SERVICE)).thenReturn(
             mockActivityManager
@@ -798,10 +852,11 @@ internal class CoreFeatureTest {
     }
 
     @Test
-    fun `M detect current process W initialize() {secondary process}`(
+    fun `M detect current process W initialize() {pre API 28, secondary process}`(
         @StringForgery otherProcessName: String
     ) {
         // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn false
         val mockActivityManager = mock<ActivityManager>()
         whenever(appContext.mockInstance.getSystemService(Context.ACTIVITY_SERVICE)).thenReturn(
             mockActivityManager
@@ -832,10 +887,11 @@ internal class CoreFeatureTest {
     }
 
     @Test
-    fun `M detect current process W initialize() {unknown process}`(
+    fun `M detect current process W initialize() {pre API 28, unknown process}`(
         @StringForgery otherProcessName: String
     ) {
         // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastP) doReturn false
         val mockActivityManager = mock<ActivityManager>()
         whenever(appContext.mockInstance.getSystemService(Context.ACTIVITY_SERVICE)).thenReturn(
             mockActivityManager
@@ -887,50 +943,39 @@ internal class CoreFeatureTest {
 
     @Test
     fun `M initialize the NdkCrashHandler data W initialize() {main process}`(
-        @TempDir tempDir: File,
-        @StringForgery otherProcessName: String
+        @TempDir tempDir: File
     ) {
         // Given
-        val mockActivityManager = mock<ActivityManager>()
-        whenever(appContext.mockInstance.getSystemService(Context.ACTIVITY_SERVICE)).thenReturn(
-            mockActivityManager
-        )
-        val myProcess = forgeAppProcessInfo(
-            Process.myPid(),
-            appContext.fakePackageName
-        )
-        val otherProcess = forgeAppProcessInfo(
-            Process.myPid() + 1,
-            otherProcessName
-        )
-        whenever(mockActivityManager.runningAppProcesses)
-            .thenReturn(listOf(myProcess, otherProcess))
+        whenever(mockBuildSdkVersionProvider.isAtLeastP).thenReturn(true)
         whenever(appContext.mockInstance.cacheDir) doReturn tempDir
+        Mockito.mockStatic(Application::class.java).use { mockedApplication ->
+            mockedApplication.`when`<String> {
+                Application.getProcessName()
+            } doReturn appContext.fakePackageName
 
-        // When
-        testedFeature.initialize(
-            appContext.mockInstance,
-            fakeSdkInstanceId,
-            fakeConfig,
-            fakeConsent
-        )
+            // When
+            testedFeature.initialize(
+                appContext.mockInstance,
+                fakeSdkInstanceId,
+                fakeConfig,
+                fakeConsent
+            )
 
-        // Then
-        assertThat(testedFeature.ndkCrashHandler)
-            .isInstanceOfSatisfying(DatadogNdkCrashHandler::class.java) {
-                assertThat(it.ndkCrashDataDirectory.parentFile).isEqualTo(
-                    File(
-                        tempDir,
-                        CoreFeature.DATADOG_STORAGE_DIR_NAME.format(Locale.US, fakeSdkInstanceId)
-                    )
+            // Then
+            val ndkCrashHandler = testedFeature.ndkCrashHandler
+            check(ndkCrashHandler is DatadogNdkCrashHandler)
+            assertThat(ndkCrashHandler.ndkCrashDataDirectory.parentFile).isEqualTo(
+                File(
+                    tempDir,
+                    CoreFeature.DATADOG_STORAGE_DIR_NAME.format(Locale.US, fakeSdkInstanceId)
                 )
-            }
+            )
+        }
     }
 
     @Test
     fun `M initialize the NdkCrashHandler data W initialize() {source type override}`(
-        @TempDir tempDir: File,
-        @StringForgery otherProcessName: String
+        @TempDir tempDir: File
     ) {
         // Given
         fakeConfig = fakeConfig.copy(
@@ -938,60 +983,50 @@ internal class CoreFeatureTest {
                 put(Datadog.DD_NATIVE_SOURCE_TYPE, "ndk+il2cpp")
             }
         )
-        val mockActivityManager = mock<ActivityManager>()
-        whenever(appContext.mockInstance.getSystemService(Context.ACTIVITY_SERVICE)).thenReturn(
-            mockActivityManager
-        )
-        val myProcess = forgeAppProcessInfo(
-            Process.myPid(),
-            appContext.fakePackageName
-        )
-        val otherProcess = forgeAppProcessInfo(
-            Process.myPid() + 1,
-            otherProcessName
-        )
-        whenever(mockActivityManager.runningAppProcesses)
-            .thenReturn(listOf(myProcess, otherProcess))
+        whenever(mockBuildSdkVersionProvider.isAtLeastP).thenReturn(true)
         whenever(appContext.mockInstance.cacheDir) doReturn tempDir
+        Mockito.mockStatic(Application::class.java).use { mockedApplication ->
+            mockedApplication.`when`<String> {
+                Application.getProcessName()
+            } doReturn appContext.fakePackageName
 
-        // When
-        testedFeature.initialize(
-            appContext.mockInstance,
-            fakeSdkInstanceId,
-            fakeConfig,
-            fakeConsent
-        )
+            // When
+            testedFeature.initialize(
+                appContext.mockInstance,
+                fakeSdkInstanceId,
+                fakeConfig,
+                fakeConsent
+            )
 
-        // Then
-        assertThat(testedFeature.ndkCrashHandler)
-            .isInstanceOfSatisfying(DatadogNdkCrashHandler::class.java) {
-                assertThat(it.nativeCrashSourceType).isEqualTo("ndk+il2cpp")
-            }
+            // Then
+            val ndkCrashHandler = testedFeature.ndkCrashHandler
+            check(ndkCrashHandler is DatadogNdkCrashHandler)
+            assertThat(ndkCrashHandler.nativeCrashSourceType).isEqualTo("ndk+il2cpp")
+        }
     }
 
     @Test
     fun `M not initialize the NdkCrashHandler data W initialize() {not main process}`(
-        @StringForgery otherProcessName: String
+        @StringForgery fakeOtherProcessName: String
     ) {
         // Given
-        val mockActivityManager = mock<ActivityManager>()
-        whenever(appContext.mockInstance.getSystemService(Context.ACTIVITY_SERVICE)).thenReturn(
-            mockActivityManager
-        )
-        val myProcess = forgeAppProcessInfo(Process.myPid(), otherProcessName)
-        whenever(mockActivityManager.runningAppProcesses)
-            .thenReturn(listOf(myProcess))
+        whenever(mockBuildSdkVersionProvider.isAtLeastP).thenReturn(true)
+        Mockito.mockStatic(Application::class.java).use { mockedApplication ->
+            mockedApplication.`when`<String> {
+                Application.getProcessName()
+            } doReturn fakeOtherProcessName
 
-        // When
-        testedFeature.initialize(
-            appContext.mockInstance,
-            fakeSdkInstanceId,
-            fakeConfig,
-            fakeConsent
-        )
+            // When
+            testedFeature.initialize(
+                appContext.mockInstance,
+                fakeSdkInstanceId,
+                fakeConfig,
+                fakeConsent
+            )
 
-        // Then
-        assertThat(testedFeature.ndkCrashHandler).isInstanceOf(NoOpNdkCrashHandler::class.java)
+            // Then
+            assertThat(testedFeature.ndkCrashHandler).isInstanceOf(NoOpNdkCrashHandler::class.java)
+        }
     }
 
     @Test
@@ -1314,7 +1349,7 @@ internal class CoreFeatureTest {
         assertThat(testedFeature.serviceName).isEqualTo("")
         assertThat(testedFeature.envName).isEqualTo("")
         assertThat(testedFeature.variant).isEqualTo("")
-        assertThat(testedFeature.contextRef.get()).isNull()
+        assertThat(testedFeature.appContext).isNull()
     }
 
     @Test

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/config/CoreFeatureTestConfiguration.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/config/CoreFeatureTestConfiguration.kt
@@ -30,7 +30,6 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.io.File
-import java.lang.ref.WeakReference
 import java.nio.file.Files
 import java.util.Locale
 import java.util.UUID
@@ -59,7 +58,6 @@ internal class CoreFeatureTestConfiguration<T : Context>(
     lateinit var mockPersistenceExecutor: FlushableExecutorService
     lateinit var mockContextExecutorService: ThreadPoolExecutor
     lateinit var mockKronosClock: KronosClock
-    lateinit var mockContextRef: WeakReference<Context?>
     lateinit var mockFirstPartyHostHeaderTypeResolver: DefaultFirstPartyHostHeaderTypeResolver
 
     lateinit var mockTimeProvider: TimeProvider
@@ -111,8 +109,6 @@ internal class CoreFeatureTestConfiguration<T : Context>(
         }
 
         mockKronosClock = mock()
-        // Mockito cannot mock WeakReference by some reason
-        mockContextRef = WeakReference(appContext.mockInstance)
         mockFirstPartyHostHeaderTypeResolver = mock()
 
         mockTimeProvider = mock()
@@ -147,7 +143,7 @@ internal class CoreFeatureTestConfiguration<T : Context>(
         whenever(mockInstance.uploadExecutorService) doReturn mockUploadExecutor
         whenever(mockInstance.callFactory) doReturn callFactory
         whenever(mockInstance.kronosClock) doReturn mockKronosClock
-        whenever(mockInstance.contextRef) doReturn mockContextRef
+        whenever(mockInstance.appContext) doReturn appContext.mockInstance
         whenever(mockInstance.firstPartyHostHeaderTypeResolver) doReturn mockFirstPartyHostHeaderTypeResolver
 
         whenever(mockInstance.timeProvider) doReturn mockTimeProvider

--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -6,6 +6,7 @@ datadog:
       - "android.app.Activity.getSystemService(kotlin.String)"
       - "android.app.Activity.hashCode()"
       - "android.app.ActivityManager.getHistoricalProcessStartReasons(kotlin.Int)"
+      - "android.app.Application.getProcessName()"
       - "android.app.Application.registerActivityLifecycleCallbacks(android.app.Application.ActivityLifecycleCallbacks?)"
       - "android.app.Application.unregisterActivityLifecycleCallbacks(android.app.Application.ActivityLifecycleCallbacks?)"
       - "android.app.FragmentManager.FragmentLifecycleCallbacks.onFragmentActivityCreated(android.app.FragmentManager?, android.app.Fragment?, android.os.Bundle?)"


### PR DESCRIPTION
### What does this PR do?

A bit of startup optimization which can shave of a few milliseconds: querying for all packages/processes on the device may be expensive, so we just can rely on the fact that the main process has the same name as package name.

See https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/app/Application.java;l=339-345?q=Application.java

```
    /**
     * Returns the name of the current process. A package's default process name
     * is the same as its package name. Non-default processes will look like
     * "$PACKAGE_NAME:$NAME", where $NAME corresponds to an android:process
     * attribute within AndroidManifest.xml.
     */
```

On the versions below Android P we can use the old approach.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

