### PR TITLE
RUM-16563: Add statsComputationEnabled to TraceConfiguration

### DIFF
--- a/features/dd-sdk-android-trace/api/apiSurface
+++ b/features/dd-sdk-android-trace/api/apiSurface
@@ -40,6 +40,7 @@ data class com.datadog.android.trace.TraceConfiguration
     fun useCustomEndpoint(String): Builder
     fun setEventMapper(com.datadog.android.trace.event.SpanEventMapper): Builder
     fun setNetworkInfoEnabled(Boolean): Builder
+    fun setStatsComputationEnabled(Boolean): Builder
     fun build(): TraceConfiguration
 enum com.datadog.android.trace.TraceContextInjection
   - ALL

--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -68,8 +68,8 @@ public final class com/datadog/android/trace/Trace {
 }
 
 public final class com/datadog/android/trace/TraceConfiguration {
-	public final fun copy (Ljava/lang/String;Lcom/datadog/android/trace/event/SpanEventMapper;Z)Lcom/datadog/android/trace/TraceConfiguration;
-	public static synthetic fun copy$default (Lcom/datadog/android/trace/TraceConfiguration;Ljava/lang/String;Lcom/datadog/android/trace/event/SpanEventMapper;ZILjava/lang/Object;)Lcom/datadog/android/trace/TraceConfiguration;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/trace/event/SpanEventMapper;ZZ)Lcom/datadog/android/trace/TraceConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/trace/TraceConfiguration;Ljava/lang/String;Lcom/datadog/android/trace/event/SpanEventMapper;ZZILjava/lang/Object;)Lcom/datadog/android/trace/TraceConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -80,6 +80,7 @@ public final class com/datadog/android/trace/TraceConfiguration$Builder {
 	public final fun build ()Lcom/datadog/android/trace/TraceConfiguration;
 	public final fun setEventMapper (Lcom/datadog/android/trace/event/SpanEventMapper;)Lcom/datadog/android/trace/TraceConfiguration$Builder;
 	public final fun setNetworkInfoEnabled (Z)Lcom/datadog/android/trace/TraceConfiguration$Builder;
+	public final fun setStatsComputationEnabled (Z)Lcom/datadog/android/trace/TraceConfiguration$Builder;
 	public final fun useCustomEndpoint (Ljava/lang/String;)Lcom/datadog/android/trace/TraceConfiguration$Builder;
 }
 

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/TraceConfiguration.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/TraceConfiguration.kt
@@ -15,7 +15,8 @@ import com.datadog.android.trace.event.SpanEventMapper
 data class TraceConfiguration internal constructor(
     internal val customEndpointUrl: String?,
     internal val eventMapper: SpanEventMapper,
-    internal val networkInfoEnabled: Boolean
+    internal val networkInfoEnabled: Boolean,
+    internal val statsComputationEnabled: Boolean
 ) {
 
     /**
@@ -25,6 +26,7 @@ data class TraceConfiguration internal constructor(
         private var customEndpointUrl: String? = null
         private var spanEventMapper: SpanEventMapper = NoOpSpanEventMapper()
         private var networkInfoEnabled: Boolean = true
+        private var statsComputationEnabled: Boolean = false
 
         /**
          * Let the Tracing feature target a custom server.
@@ -57,13 +59,27 @@ data class TraceConfiguration internal constructor(
         }
 
         /**
+         * Enables client-side stats computation for APM.
+         *
+         * When enabled, the SDK computes trace statistics (hit counts, error rates, latency distributions)
+         * locally on all finished spans — including sampled-out ones.
+         *
+         * @param enabled false by default
+         */
+        fun setStatsComputationEnabled(enabled: Boolean): Builder {
+            statsComputationEnabled = enabled
+            return this
+        }
+
+        /**
          * Builds a [TraceConfiguration] based on the current state of this Builder.
          */
         fun build(): TraceConfiguration {
             return TraceConfiguration(
                 customEndpointUrl = customEndpointUrl,
                 eventMapper = spanEventMapper,
-                networkInfoEnabled = networkInfoEnabled
+                networkInfoEnabled = networkInfoEnabled,
+                statsComputationEnabled = statsComputationEnabled
             )
         }
     }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TraceConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TraceConfigurationBuilderTest.kt
@@ -58,6 +58,8 @@ internal class TraceConfigurationBuilderTest {
         assertThat(traceConfiguration.customEndpointUrl).isNull()
         assertThat(traceConfiguration.eventMapper)
             .isInstanceOf(NoOpSpanEventMapper::class.java)
+        assertThat(traceConfiguration.networkInfoEnabled).isTrue()
+        assertThat(traceConfiguration.statsComputationEnabled).isFalse()
     }
 
     @Test
@@ -99,5 +101,18 @@ internal class TraceConfigurationBuilderTest {
         // Then
         assertThat(traceConfiguration.customEndpointUrl).isNull()
         assertThat(traceConfiguration.eventMapper).isEqualTo(mockEventMapper)
+    }
+
+    @Test
+    fun `M build configuration with client stats W setStatsComputationEnabled() and build()`(
+        @BoolForgery clientStats: Boolean
+    ) {
+        // When
+        val config = testedBuilder
+            .setStatsComputationEnabled(clientStats)
+            .build()
+
+        // Then
+        assertThat(config.statsComputationEnabled).isEqualTo(clientStats)
     }
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/TraceConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/TraceConfigurationForgeryFactory.kt
@@ -16,7 +16,8 @@ class TraceConfigurationForgeryFactory : ForgeryFactory<TraceConfiguration> {
         return TraceConfiguration(
             customEndpointUrl = forge.aNullable { aStringMatching("https://[a-z]+\\.com") },
             eventMapper = mock(),
-            networkInfoEnabled = forge.aBool()
+            networkInfoEnabled = forge.aBool(),
+            statsComputationEnabled = forge.aBool()
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?
Adds in the configuration value to enable/disable the client side stats calculation in the TraceConfiguration. The default value will be false. It may be changed to true in the future but for now we are going with false.

### Motivation
Will allow the users to enable and disable the feature once it launches.

### Additional Notes
Corresponding iOS change: https://github.com/DataDog/dd-sdk-ios/pull/2838

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

