### PR TITLE
RUM-15702 Add trace sampling decision to DatadogEventBridge

### DIFF
--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/WebViewTracking.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/WebViewTracking.kt
@@ -95,7 +95,7 @@ object WebViewTracking {
             System.identityHashCode(webView).toString()
         )
         webView.addJavascriptInterface(
-            DatadogEventBridge(webViewEventConsumer, allowedHosts, privacyLevel),
+            DatadogEventBridge(webViewEventConsumer, allowedHosts, privacyLevel, featureSdkCore),
             DATADOG_EVENT_BRIDGE_NAME
         )
         featureSdkCore.internalLogger.logApiUsage {

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/WebViewTracking.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/WebViewTracking.kt
@@ -94,8 +94,11 @@ object WebViewTracking {
             logsSampleRate,
             System.identityHashCode(webView).toString()
         )
+        val webViewRumFeature = featureSdkCore
+            .getFeature(WebViewRumFeature.WEB_RUM_FEATURE_NAME)
+            ?.unwrap<StorageBackedFeature>() as? WebViewRumFeature
         webView.addJavascriptInterface(
-            DatadogEventBridge(webViewEventConsumer, allowedHosts, privacyLevel, featureSdkCore),
+            DatadogEventBridge(webViewEventConsumer, allowedHosts, privacyLevel, webViewRumFeature),
             DATADOG_EVENT_BRIDGE_NAME
         )
         featureSdkCore.internalLogger.logApiUsage {

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/DatadogEventBridge.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/DatadogEventBridge.kt
@@ -88,16 +88,12 @@ internal class DatadogEventBridge(
         val rumContext = sdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME, useContextThread = false)
         val tracingContext = sdkCore.getFeatureContext(Feature.TRACING_FEATURE_NAME, useContextThread = false)
 
-        val sessionId = rumContext[SESSION_ID_KEY] as? String
-        val sessionState = rumContext[SESSION_STATE_KEY] as? String
+        val sessionId = (rumContext[SESSION_ID_KEY] as? String)
+            ?.takeIf { rumContext[SESSION_STATE_KEY] == TRACKED_STATE }
         val sessionSampleRate = (rumContext[SESSION_SAMPLE_RATE_KEY] as? Number)?.toFloat()
         val traceSampleRate = (tracingContext[TRACE_SAMPLE_RATE_KEY] as? Number)?.toFloat()
 
-        if (sessionId == null ||
-            sessionState != TRACKED_STATE ||
-            sessionSampleRate == null ||
-            traceSampleRate == null
-        ) {
+        if (sessionId == null || sessionSampleRate == null || traceSampleRate == null) {
             return NULL_STRING
         }
 

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/DatadogEventBridge.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/DatadogEventBridge.kt
@@ -86,16 +86,20 @@ internal class DatadogEventBridge(
     @JavascriptInterface
     fun getIsTraceSampled(): String {
         val rumContext = sdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME, useContextThread = false)
-        val sessionId = rumContext[SESSION_ID_KEY] as? String ?: return NULL_STRING
-        val sessionState = rumContext[SESSION_STATE_KEY] as? String
-        if (sessionState != TRACKED_STATE) return NULL_STRING
-
-        val sessionSampleRate = (rumContext[SESSION_SAMPLE_RATE_KEY] as? Number)?.toFloat()
-            ?: return NULL_STRING
-
         val tracingContext = sdkCore.getFeatureContext(Feature.TRACING_FEATURE_NAME, useContextThread = false)
+
+        val sessionId = rumContext[SESSION_ID_KEY] as? String
+        val sessionState = rumContext[SESSION_STATE_KEY] as? String
+        val sessionSampleRate = (rumContext[SESSION_SAMPLE_RATE_KEY] as? Number)?.toFloat()
         val traceSampleRate = (tracingContext[TRACE_SAMPLE_RATE_KEY] as? Number)?.toFloat()
-            ?: return NULL_STRING
+
+        if (sessionId == null ||
+            sessionState != TRACKED_STATE ||
+            sessionSampleRate == null ||
+            traceSampleRate == null
+        ) {
+            return NULL_STRING
+        }
 
         val combinedRate = DeterministicSampling.combinedSampleRate(sessionSampleRate, traceSampleRate)
         val sampler = DeterministicSampler<String>(

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/DatadogEventBridge.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/DatadogEventBridge.kt
@@ -7,7 +7,12 @@
 package com.datadog.android.webview.internal
 
 import android.webkit.JavascriptInterface
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.configuration.HostsSanitizer
+import com.datadog.android.core.sampling.DeterministicSampler
+import com.datadog.android.internal.sampling.DeterministicSampling
+import com.datadog.android.internal.sampling.SessionSamplingIdProvider
 import com.google.gson.JsonArray
 
 /**
@@ -20,7 +25,8 @@ import com.google.gson.JsonArray
 internal class DatadogEventBridge(
     internal val webViewEventConsumer: WebViewEventConsumer<String>,
     private val allowedHosts: List<String>,
-    private val privacyLevel: String
+    private val privacyLevel: String,
+    private val sdkCore: FeatureSdkCore
 ) {
 
     // region Bridge
@@ -70,10 +76,50 @@ internal class DatadogEventBridge(
         return capabilities.toString()
     }
 
+    /**
+     * Called from the browser-sdk to get the trace sampling decision from the native SDK.
+     * Returns 'true', 'false', or 'null' as a string:
+     * - 'true' if traces should be sampled
+     * - 'false' if traces should not be sampled
+     * - 'null' if no decision can be made (no active session, or no tracing configured)
+     */
+    @JavascriptInterface
+    fun getIsTraceSampled(): String {
+        val rumContext = sdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME, useContextThread = false)
+        val sessionId = rumContext[SESSION_ID_KEY] as? String ?: return NULL_STRING
+        val sessionState = rumContext[SESSION_STATE_KEY] as? String
+        if (sessionState != TRACKED_STATE) return NULL_STRING
+
+        val sessionSampleRate = (rumContext[SESSION_SAMPLE_RATE_KEY] as? Number)?.toFloat()
+            ?: return NULL_STRING
+
+        val tracingContext = sdkCore.getFeatureContext(Feature.TRACING_FEATURE_NAME, useContextThread = false)
+        val traceSampleRate = (tracingContext[TRACE_SAMPLE_RATE_KEY] as? Number)?.toFloat()
+            ?: return NULL_STRING
+
+        val combinedRate = DeterministicSampling.combinedSampleRate(sessionSampleRate, traceSampleRate)
+        val sampler = DeterministicSampler<String>(
+            SessionSamplingIdProvider::provideId,
+            combinedRate
+        )
+
+        return if (sampler.sample(sessionId)) TRUE_STRING else FALSE_STRING
+    }
+
     // endregion
 
     companion object {
         internal const val WEB_VIEW_TRACKING_FEATURE_NAME = "WebView"
+
+        private const val SESSION_ID_KEY = "session_id"
+        private const val SESSION_STATE_KEY = "session_state"
+        private const val SESSION_SAMPLE_RATE_KEY = "session_sample_rate"
+        private const val TRACKED_STATE = "TRACKED"
+        private const val TRACE_SAMPLE_RATE_KEY = "okhttp_interceptor_sample_rate"
+
+        private const val TRUE_STRING = "true"
+        private const val FALSE_STRING = "false"
+        private const val NULL_STRING = "null"
 
         internal val capabilities = JsonArray().apply {
             add("records")

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/DatadogEventBridge.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/DatadogEventBridge.kt
@@ -7,12 +7,11 @@
 package com.datadog.android.webview.internal
 
 import android.webkit.JavascriptInterface
-import com.datadog.android.api.feature.Feature
-import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.configuration.HostsSanitizer
 import com.datadog.android.core.sampling.DeterministicSampler
 import com.datadog.android.internal.sampling.DeterministicSampling
 import com.datadog.android.internal.sampling.SessionSamplingIdProvider
+import com.datadog.android.webview.internal.rum.WebViewRumFeature
 import com.google.gson.JsonArray
 
 /**
@@ -26,7 +25,7 @@ internal class DatadogEventBridge(
     internal val webViewEventConsumer: WebViewEventConsumer<String>,
     private val allowedHosts: List<String>,
     private val privacyLevel: String,
-    private val sdkCore: FeatureSdkCore
+    private val webViewRumFeature: WebViewRumFeature?
 ) {
 
     // region Bridge
@@ -85,8 +84,8 @@ internal class DatadogEventBridge(
      */
     @JavascriptInterface
     fun getIsTraceSampled(): String {
-        val rumContext = sdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME, useContextThread = false)
-        val tracingContext = sdkCore.getFeatureContext(Feature.TRACING_FEATURE_NAME, useContextThread = false)
+        val rumContext = webViewRumFeature?.cachedRumContext.orEmpty()
+        val tracingContext = webViewRumFeature?.cachedTracingContext.orEmpty()
 
         val sessionId = (rumContext[SESSION_ID_KEY] as? String)
             ?.takeIf { rumContext[SESSION_STATE_KEY] == TRACKED_STATE }

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
@@ -65,12 +65,15 @@ internal class WebViewRumEventConsumer(
         try {
             val timeOffset = event.get(VIEW_KEY_NAME)?.asJsonObject?.get(VIEW_ID_KEY_NAME)
                 ?.asString?.let { offsetProvider.getOffset(it, datadogContext) } ?: 0L
+            val traceSampleRate = datadogContext.featuresContext[Feature.TRACING_FEATURE_NAME]
+                ?.get(TRACE_SAMPLE_RATE_KEY) as? Float
             return webViewRumEventMapper.mapEvent(
                 event,
                 rumContext,
                 timeOffset,
                 sessionReplayEnabled,
-                datadogContext.userInfo.anonymousId
+                datadogContext.userInfo.anonymousId,
+                traceSampleRate
             )
         } catch (e: ClassCastException) {
             sdkCore.internalLogger.log(
@@ -113,6 +116,7 @@ internal class WebViewRumEventConsumer(
         const val RUM_EVENT_TYPE = "rum"
         const val VIEW_KEY_NAME = "view"
         const val VIEW_ID_KEY_NAME = "id"
+        const val TRACE_SAMPLE_RATE_KEY = "okhttp_interceptor_sample_rate"
         const val JSON_PARSING_ERROR_MESSAGE = "The bundled web RUM event could not be deserialized"
         val RUM_EVENT_TYPES = setOf(
             VIEW_EVENT_TYPE,

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
@@ -38,7 +38,11 @@ internal class WebViewRumEventConsumer(
         )
         sdkCore.getFeature(WebViewRumFeature.WEB_RUM_FEATURE_NAME)
             ?.withWriteContext(
-                withFeatureContexts = setOf(Feature.RUM_FEATURE_NAME, Feature.SESSION_REPLAY_FEATURE_NAME)
+                withFeatureContexts = setOf(
+                    Feature.RUM_FEATURE_NAME,
+                    Feature.SESSION_REPLAY_FEATURE_NAME,
+                    Feature.TRACING_FEATURE_NAME
+                )
             ) { datadogContext, writeScope ->
                 val rumContext = contextProvider.getRumContext(datadogContext)
                 if (rumContext != null && rumContext.sessionState == "TRACKED") {

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
@@ -65,8 +65,8 @@ internal class WebViewRumEventConsumer(
         try {
             val timeOffset = event.get(VIEW_KEY_NAME)?.asJsonObject?.get(VIEW_ID_KEY_NAME)
                 ?.asString?.let { offsetProvider.getOffset(it, datadogContext) } ?: 0L
-            val traceSampleRate = datadogContext.featuresContext[Feature.TRACING_FEATURE_NAME]
-                ?.get(TRACE_SAMPLE_RATE_KEY) as? Float
+            val traceSampleRate = (datadogContext.featuresContext[Feature.TRACING_FEATURE_NAME]
+                ?.get(TRACE_SAMPLE_RATE_KEY) as? Number)?.toFloat()
             return webViewRumEventMapper.mapEvent(
                 event,
                 rumContext,

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
@@ -65,8 +65,10 @@ internal class WebViewRumEventConsumer(
         try {
             val timeOffset = event.get(VIEW_KEY_NAME)?.asJsonObject?.get(VIEW_ID_KEY_NAME)
                 ?.asString?.let { offsetProvider.getOffset(it, datadogContext) } ?: 0L
-            val traceSampleRate = (datadogContext.featuresContext[Feature.TRACING_FEATURE_NAME]
-                ?.get(TRACE_SAMPLE_RATE_KEY) as? Number)?.toFloat()
+            val traceSampleRate = (
+                datadogContext.featuresContext[Feature.TRACING_FEATURE_NAME]
+                    ?.get(TRACE_SAMPLE_RATE_KEY) as? Number
+                )?.toFloat()
             return webViewRumEventMapper.mapEvent(
                 event,
                 rumContext,

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventMapper.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventMapper.kt
@@ -24,7 +24,8 @@ internal class WebViewRumEventMapper(
         rumContext: RumContext?,
         timeOffset: Long,
         sessionReplayEnabled: Boolean,
-        anonymousId: String?
+        anonymousId: String?,
+        traceSampleRate: Float? = null
     ): JsonObject {
         val containerObject = JsonObject().apply {
             addProperty(SOURCE_KEY_NAME, SOURCE_VALUE)
@@ -48,6 +49,9 @@ internal class WebViewRumEventMapper(
             if (!sessionReplayEnabled) {
                 // RUM-4084 disable webview SR if host app doesn't have SR
                 dd.remove(DD_REPLAY_STATS)
+            }
+            if (traceSampleRate != null && dd.has(RULE_PSR_KEY_NAME)) {
+                dd.addProperty(RULE_PSR_KEY_NAME, traceSampleRate / SAMPLE_ALL_RATE)
             }
         }
 
@@ -90,7 +94,9 @@ internal class WebViewRumEventMapper(
         internal const val CONTAINER_KEY_NAME = "container"
         internal const val SOURCE_KEY_NAME = "source"
         internal const val SOURCE_VALUE = "android"
+        internal const val RULE_PSR_KEY_NAME = "rule_psr"
         internal const val USR_KEY_NAME = "usr"
         internal const val ANONYMOUS_ID_KEY_NAME = "anonymous_id"
+        private const val SAMPLE_ALL_RATE = 100f
     }
 }

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeature.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeature.kt
@@ -33,6 +33,12 @@ internal class WebViewRumFeature(
 
     internal val initialized = AtomicBoolean(false)
 
+    @Volatile
+    internal var cachedRumContext: Map<String, Any?> = emptyMap()
+
+    @Volatile
+    internal var cachedTracingContext: Map<String, Any?> = emptyMap()
+
     // region Feature
 
     override val name: String = WEB_RUM_FEATURE_NAME
@@ -44,8 +50,12 @@ internal class WebViewRumFeature(
     }
 
     override fun onContextUpdate(featureName: String, context: Map<String, Any?>) {
-        if (featureName == Feature.RUM_FEATURE_NAME) {
-            nativeRumViewsCache.addToCache(context)
+        when (featureName) {
+            Feature.RUM_FEATURE_NAME -> {
+                nativeRumViewsCache.addToCache(context)
+                cachedRumContext = context
+            }
+            Feature.TRACING_FEATURE_NAME -> cachedTracingContext = context
         }
     }
 
@@ -56,6 +66,8 @@ internal class WebViewRumFeature(
         sdkCore.removeContextUpdateReceiver(this)
         dataWriter = NoOpDataWriter()
         initialized.set(false)
+        cachedRumContext = emptyMap()
+        cachedTracingContext = emptyMap()
     }
 
     // endregion

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/WebViewTrackingTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/WebViewTrackingTest.kt
@@ -673,7 +673,13 @@ internal class WebViewTrackingTest {
         proxy.consumeWebviewEvent(fakeWebEvent.toString())
         argumentCaptor<(DatadogContext, EventWriteScope) -> Unit> {
             verify(mockWebViewRumFeature).withWriteContext(
-                eq(setOf(Feature.RUM_FEATURE_NAME, Feature.SESSION_REPLAY_FEATURE_NAME)),
+                eq(
+                    setOf(
+                        Feature.RUM_FEATURE_NAME,
+                        Feature.SESSION_REPLAY_FEATURE_NAME,
+                        Feature.TRACING_FEATURE_NAME
+                    )
+                ),
                 capture()
             )
             firstValue(mockDatadogContext, mockEventWriteScope)

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/DatadogEventBridgeTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/DatadogEventBridgeTest.kt
@@ -6,9 +6,8 @@
 
 package com.datadog.android.webview.internal
 
-import com.datadog.android.api.feature.Feature
-import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.webview.internal.rum.WebViewRumFeature
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -20,7 +19,6 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -44,7 +42,7 @@ internal class DatadogEventBridgeTest {
     lateinit var fakePrivacyLevel: String
 
     @Mock
-    lateinit var mockSdkCore: FeatureSdkCore
+    lateinit var mockWebViewRumFeature: WebViewRumFeature
 
     @BeforeEach
     fun `set up`() {
@@ -52,7 +50,7 @@ internal class DatadogEventBridgeTest {
             mockWebViewEventConsumer,
             emptyList(),
             fakePrivacyLevel,
-            mockSdkCore
+            mockWebViewRumFeature
         )
     }
 
@@ -74,7 +72,7 @@ internal class DatadogEventBridgeTest {
     ) {
         // Given
         val expectedHosts = hosts.joinToString(",", prefix = "[", postfix = "]") { "\"$it\"" }
-        testedDatadogEventBridge = DatadogEventBridge(mock(), hosts, fakePrivacyLevel, mockSdkCore)
+        testedDatadogEventBridge = DatadogEventBridge(mock(), hosts, fakePrivacyLevel, mockWebViewRumFeature)
 
         // When
         val allowedWebViewHosts = testedDatadogEventBridge.getAllowedWebViewHosts()
@@ -96,7 +94,7 @@ internal class DatadogEventBridgeTest {
             mockWebViewEventConsumer,
             hosts,
             fakePrivacyLevel,
-            mockSdkCore
+            mockWebViewRumFeature
         )
 
         // When
@@ -119,7 +117,7 @@ internal class DatadogEventBridgeTest {
             mockWebViewEventConsumer,
             hosts,
             fakePrivacyLevel,
-            mockSdkCore
+            mockWebViewRumFeature
         )
 
         // When
@@ -154,15 +152,14 @@ internal class DatadogEventBridgeTest {
     fun `M return true W getIsTraceSampled() { tracked session, sampled }`() {
         // Given
         val sessionId = "c5b3c4ab-fa4a-4de9-8199-a522131ec48a"
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
-            .thenReturn(
-                mapOf(
-                    "session_id" to sessionId,
-                    "session_state" to "TRACKED",
-                    "session_sample_rate" to 100f
-                )
+        whenever(mockWebViewRumFeature.cachedRumContext).thenReturn(
+            mapOf(
+                "session_id" to sessionId,
+                "session_state" to "TRACKED",
+                "session_sample_rate" to 100f
             )
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.TRACING_FEATURE_NAME), eq(false)))
+        )
+        whenever(mockWebViewRumFeature.cachedTracingContext)
             .thenReturn(mapOf("okhttp_interceptor_sample_rate" to 100f))
 
         // When
@@ -177,15 +174,14 @@ internal class DatadogEventBridgeTest {
         // Given
         // This UUID hashes to ~50.68%, so at combined rate 40% (100% session * 40% trace) it's not sampled
         val sessionId = "c5b3c4ab-fa4a-4de9-8199-a522131ec48a"
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
-            .thenReturn(
-                mapOf(
-                    "session_id" to sessionId,
-                    "session_state" to "TRACKED",
-                    "session_sample_rate" to 100f
-                )
+        whenever(mockWebViewRumFeature.cachedRumContext).thenReturn(
+            mapOf(
+                "session_id" to sessionId,
+                "session_state" to "TRACKED",
+                "session_sample_rate" to 100f
             )
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.TRACING_FEATURE_NAME), eq(false)))
+        )
+        whenever(mockWebViewRumFeature.cachedTracingContext)
             .thenReturn(mapOf("okhttp_interceptor_sample_rate" to 40f))
 
         // When
@@ -196,10 +192,26 @@ internal class DatadogEventBridgeTest {
     }
 
     @Test
+    fun `M return null W getIsTraceSampled() { no rum feature }`() {
+        // Given
+        testedDatadogEventBridge = DatadogEventBridge(
+            mockWebViewEventConsumer,
+            emptyList(),
+            fakePrivacyLevel,
+            null
+        )
+
+        // When
+        val result = testedDatadogEventBridge.getIsTraceSampled()
+
+        // Then
+        assertThat(result).isEqualTo("null")
+    }
+
+    @Test
     fun `M return null W getIsTraceSampled() { no session id }`() {
         // Given
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
-            .thenReturn(emptyMap())
+        whenever(mockWebViewRumFeature.cachedRumContext).thenReturn(emptyMap())
 
         // When
         val result = testedDatadogEventBridge.getIsTraceSampled()
@@ -211,13 +223,12 @@ internal class DatadogEventBridgeTest {
     @Test
     fun `M return null W getIsTraceSampled() { session not tracked }`() {
         // Given
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
-            .thenReturn(
-                mapOf(
-                    "session_id" to "some-session-id",
-                    "session_state" to "NOT_TRACKED"
-                )
+        whenever(mockWebViewRumFeature.cachedRumContext).thenReturn(
+            mapOf(
+                "session_id" to "some-session-id",
+                "session_state" to "NOT_TRACKED"
             )
+        )
 
         // When
         val result = testedDatadogEventBridge.getIsTraceSampled()
@@ -229,16 +240,14 @@ internal class DatadogEventBridgeTest {
     @Test
     fun `M return null W getIsTraceSampled() { no trace sample rate configured }`() {
         // Given
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
-            .thenReturn(
-                mapOf(
-                    "session_id" to "some-session-id",
-                    "session_state" to "TRACKED",
-                    "session_sample_rate" to 100f
-                )
+        whenever(mockWebViewRumFeature.cachedRumContext).thenReturn(
+            mapOf(
+                "session_id" to "some-session-id",
+                "session_state" to "TRACKED",
+                "session_sample_rate" to 100f
             )
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.TRACING_FEATURE_NAME), eq(false)))
-            .thenReturn(emptyMap())
+        )
+        whenever(mockWebViewRumFeature.cachedTracingContext).thenReturn(emptyMap())
 
         // When
         val result = testedDatadogEventBridge.getIsTraceSampled()
@@ -250,13 +259,12 @@ internal class DatadogEventBridgeTest {
     @Test
     fun `M return null W getIsTraceSampled() { no session sample rate }`() {
         // Given
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
-            .thenReturn(
-                mapOf(
-                    "session_id" to "some-session-id",
-                    "session_state" to "TRACKED"
-                )
+        whenever(mockWebViewRumFeature.cachedRumContext).thenReturn(
+            mapOf(
+                "session_id" to "some-session-id",
+                "session_state" to "TRACKED"
             )
+        )
 
         // When
         val result = testedDatadogEventBridge.getIsTraceSampled()
@@ -268,34 +276,20 @@ internal class DatadogEventBridgeTest {
     @Test
     fun `M update decision W getIsTraceSampled() { session rolls over to a different decision }`() {
         // Given
-        // First session: UUID hashes to ~50.68%, sampled at combined rate 60% (100% * 60%)
-        val sessionId1 = "c5b3c4ab-fa4a-4de9-8199-a522131ec48a"
-        // Second session: same UUID but with trace rate lowered to 40% — no longer sampled
-        val sessionId2 = sessionId1
-
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.TRACING_FEATURE_NAME), eq(false)))
+        // UUID hashes to ~50.68%: sampled at combined 60% (100% * 60%), not sampled at combined 30% (50% * 60%)
+        val sessionId = "c5b3c4ab-fa4a-4de9-8199-a522131ec48a"
+        whenever(mockWebViewRumFeature.cachedTracingContext)
             .thenReturn(mapOf("okhttp_interceptor_sample_rate" to 60f))
-
-        // First call: sampled at combined rate 60%
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
+        whenever(mockWebViewRumFeature.cachedRumContext)
             .thenReturn(
-                mapOf(
-                    "session_id" to sessionId1,
-                    "session_state" to "TRACKED",
-                    "session_sample_rate" to 100f
-                )
+                mapOf("session_id" to sessionId, "session_state" to "TRACKED", "session_sample_rate" to 100f)
             )
+            .thenReturn(
+                mapOf("session_id" to sessionId, "session_state" to "TRACKED", "session_sample_rate" to 50f)
+            )
+
+        // When
         val result1 = testedDatadogEventBridge.getIsTraceSampled()
-
-        // When: new session with lower session sample rate, combined rate = 50% * 60% = 30%
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
-            .thenReturn(
-                mapOf(
-                    "session_id" to sessionId2,
-                    "session_state" to "TRACKED",
-                    "session_sample_rate" to 50f
-                )
-            )
         val result2 = testedDatadogEventBridge.getIsTraceSampled()
 
         // Then: first sampled (combined 60%), second not sampled (combined 30%, UUID hashes at ~50.68%)
@@ -307,28 +301,18 @@ internal class DatadogEventBridgeTest {
     fun `M return null W getIsTraceSampled() { session stops after being tracked }`() {
         // Given: active tracked session
         val sessionId = "c5b3c4ab-fa4a-4de9-8199-a522131ec48a"
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.TRACING_FEATURE_NAME), eq(false)))
+        whenever(mockWebViewRumFeature.cachedTracingContext)
             .thenReturn(mapOf("okhttp_interceptor_sample_rate" to 100f))
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
+        whenever(mockWebViewRumFeature.cachedRumContext)
             .thenReturn(
-                mapOf(
-                    "session_id" to sessionId,
-                    "session_state" to "TRACKED",
-                    "session_sample_rate" to 100f
-                )
+                mapOf("session_id" to sessionId, "session_state" to "TRACKED", "session_sample_rate" to 100f)
+            )
+            .thenReturn(
+                mapOf("session_id" to sessionId, "session_state" to "NOT_TRACKED")
             )
 
+        // When
         val resultBeforeStop = testedDatadogEventBridge.getIsTraceSampled()
-
-        // When: session stops
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
-            .thenReturn(
-                mapOf(
-                    "session_id" to sessionId,
-                    "session_state" to "NOT_TRACKED"
-                )
-            )
-
         val resultAfterStop = testedDatadogEventBridge.getIsTraceSampled()
 
         // Then
@@ -338,21 +322,13 @@ internal class DatadogEventBridgeTest {
 
     @Test
     fun `M return null then decision W getIsTraceSampled() { new session starts after stop }`() {
-        // Given: no active session
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
-            .thenReturn(
-                mapOf(
-                    "session_id" to "old-session-id",
-                    "session_state" to "NOT_TRACKED"
-                )
-            )
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.TRACING_FEATURE_NAME), eq(false)))
+        // Given: no active session initially
+        whenever(mockWebViewRumFeature.cachedTracingContext)
             .thenReturn(mapOf("okhttp_interceptor_sample_rate" to 100f))
-
-        val resultNoSession = testedDatadogEventBridge.getIsTraceSampled()
-
-        // When: new session starts
-        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
+        whenever(mockWebViewRumFeature.cachedRumContext)
+            .thenReturn(
+                mapOf("session_id" to "old-session-id", "session_state" to "NOT_TRACKED")
+            )
             .thenReturn(
                 mapOf(
                     "session_id" to "c5b3c4ab-fa4a-4de9-8199-a522131ec48a",
@@ -361,6 +337,8 @@ internal class DatadogEventBridgeTest {
                 )
             )
 
+        // When
+        val resultNoSession = testedDatadogEventBridge.getIsTraceSampled()
         val resultNewSession = testedDatadogEventBridge.getIsTraceSampled()
 
         // Then

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/DatadogEventBridgeTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/DatadogEventBridgeTest.kt
@@ -264,4 +264,107 @@ internal class DatadogEventBridgeTest {
         // Then
         assertThat(result).isEqualTo("null")
     }
+
+    @Test
+    fun `M update decision W getIsTraceSampled() { session rolls over to a different decision }`() {
+        // Given
+        // First session: UUID hashes to ~50.68%, sampled at combined rate 60% (100% * 60%)
+        val sessionId1 = "c5b3c4ab-fa4a-4de9-8199-a522131ec48a"
+        // Second session: same UUID but with trace rate lowered to 40% — no longer sampled
+        val sessionId2 = sessionId1
+
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.TRACING_FEATURE_NAME), eq(false)))
+            .thenReturn(mapOf("okhttp_interceptor_sample_rate" to 60f))
+
+        // First call: sampled at combined rate 60%
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
+            .thenReturn(
+                mapOf(
+                    "session_id" to sessionId1,
+                    "session_state" to "TRACKED",
+                    "session_sample_rate" to 100f
+                )
+            )
+        val result1 = testedDatadogEventBridge.getIsTraceSampled()
+
+        // When: new session with lower session sample rate, combined rate = 50% * 60% = 30%
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
+            .thenReturn(
+                mapOf(
+                    "session_id" to sessionId2,
+                    "session_state" to "TRACKED",
+                    "session_sample_rate" to 50f
+                )
+            )
+        val result2 = testedDatadogEventBridge.getIsTraceSampled()
+
+        // Then: first sampled (combined 60%), second not sampled (combined 30%, UUID hashes at ~50.68%)
+        assertThat(result1).isEqualTo("true")
+        assertThat(result2).isEqualTo("false")
+    }
+
+    @Test
+    fun `M return null W getIsTraceSampled() { session stops after being tracked }`() {
+        // Given: active tracked session
+        val sessionId = "c5b3c4ab-fa4a-4de9-8199-a522131ec48a"
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.TRACING_FEATURE_NAME), eq(false)))
+            .thenReturn(mapOf("okhttp_interceptor_sample_rate" to 100f))
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
+            .thenReturn(
+                mapOf(
+                    "session_id" to sessionId,
+                    "session_state" to "TRACKED",
+                    "session_sample_rate" to 100f
+                )
+            )
+
+        val resultBeforeStop = testedDatadogEventBridge.getIsTraceSampled()
+
+        // When: session stops
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
+            .thenReturn(
+                mapOf(
+                    "session_id" to sessionId,
+                    "session_state" to "NOT_TRACKED"
+                )
+            )
+
+        val resultAfterStop = testedDatadogEventBridge.getIsTraceSampled()
+
+        // Then
+        assertThat(resultBeforeStop).isEqualTo("true")
+        assertThat(resultAfterStop).isEqualTo("null")
+    }
+
+    @Test
+    fun `M return null then decision W getIsTraceSampled() { new session starts after stop }`() {
+        // Given: no active session
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
+            .thenReturn(
+                mapOf(
+                    "session_id" to "old-session-id",
+                    "session_state" to "NOT_TRACKED"
+                )
+            )
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.TRACING_FEATURE_NAME), eq(false)))
+            .thenReturn(mapOf("okhttp_interceptor_sample_rate" to 100f))
+
+        val resultNoSession = testedDatadogEventBridge.getIsTraceSampled()
+
+        // When: new session starts
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
+            .thenReturn(
+                mapOf(
+                    "session_id" to "c5b3c4ab-fa4a-4de9-8199-a522131ec48a",
+                    "session_state" to "TRACKED",
+                    "session_sample_rate" to 100f
+                )
+            )
+
+        val resultNewSession = testedDatadogEventBridge.getIsTraceSampled()
+
+        // Then
+        assertThat(resultNoSession).isEqualTo("null")
+        assertThat(resultNewSession).isEqualTo("true")
+    }
 }

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/DatadogEventBridgeTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/DatadogEventBridgeTest.kt
@@ -6,6 +6,8 @@
 
 package com.datadog.android.webview.internal
 
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -18,8 +20,10 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.net.URL
 
@@ -39,12 +43,16 @@ internal class DatadogEventBridgeTest {
     @StringForgery
     lateinit var fakePrivacyLevel: String
 
+    @Mock
+    lateinit var mockSdkCore: FeatureSdkCore
+
     @BeforeEach
     fun `set up`() {
         testedDatadogEventBridge = DatadogEventBridge(
             mockWebViewEventConsumer,
             emptyList(),
-            fakePrivacyLevel
+            fakePrivacyLevel,
+            mockSdkCore
         )
     }
 
@@ -66,7 +74,7 @@ internal class DatadogEventBridgeTest {
     ) {
         // Given
         val expectedHosts = hosts.joinToString(",", prefix = "[", postfix = "]") { "\"$it\"" }
-        testedDatadogEventBridge = DatadogEventBridge(mock(), hosts, fakePrivacyLevel)
+        testedDatadogEventBridge = DatadogEventBridge(mock(), hosts, fakePrivacyLevel, mockSdkCore)
 
         // When
         val allowedWebViewHosts = testedDatadogEventBridge.getAllowedWebViewHosts()
@@ -87,7 +95,8 @@ internal class DatadogEventBridgeTest {
         testedDatadogEventBridge = DatadogEventBridge(
             mockWebViewEventConsumer,
             hosts,
-            fakePrivacyLevel
+            fakePrivacyLevel,
+            mockSdkCore
         )
 
         // When
@@ -109,7 +118,8 @@ internal class DatadogEventBridgeTest {
         testedDatadogEventBridge = DatadogEventBridge(
             mockWebViewEventConsumer,
             hosts,
-            fakePrivacyLevel
+            fakePrivacyLevel,
+            mockSdkCore
         )
 
         // When
@@ -138,5 +148,120 @@ internal class DatadogEventBridgeTest {
 
         // Then
         assertThat(capabilities).isEqualTo(expectedCapabilities)
+    }
+
+    @Test
+    fun `M return true W getIsTraceSampled() { tracked session, sampled }`() {
+        // Given
+        val sessionId = "c5b3c4ab-fa4a-4de9-8199-a522131ec48a"
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
+            .thenReturn(
+                mapOf(
+                    "session_id" to sessionId,
+                    "session_state" to "TRACKED",
+                    "session_sample_rate" to 100f
+                )
+            )
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.TRACING_FEATURE_NAME), eq(false)))
+            .thenReturn(mapOf("okhttp_interceptor_sample_rate" to 100f))
+
+        // When
+        val result = testedDatadogEventBridge.getIsTraceSampled()
+
+        // Then
+        assertThat(result).isEqualTo("true")
+    }
+
+    @Test
+    fun `M return false W getIsTraceSampled() { tracked session, not sampled }`() {
+        // Given
+        // This UUID hashes to ~50.68%, so at combined rate 40% (100% session * 40% trace) it's not sampled
+        val sessionId = "c5b3c4ab-fa4a-4de9-8199-a522131ec48a"
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
+            .thenReturn(
+                mapOf(
+                    "session_id" to sessionId,
+                    "session_state" to "TRACKED",
+                    "session_sample_rate" to 100f
+                )
+            )
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.TRACING_FEATURE_NAME), eq(false)))
+            .thenReturn(mapOf("okhttp_interceptor_sample_rate" to 40f))
+
+        // When
+        val result = testedDatadogEventBridge.getIsTraceSampled()
+
+        // Then
+        assertThat(result).isEqualTo("false")
+    }
+
+    @Test
+    fun `M return null W getIsTraceSampled() { no session id }`() {
+        // Given
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
+            .thenReturn(emptyMap())
+
+        // When
+        val result = testedDatadogEventBridge.getIsTraceSampled()
+
+        // Then
+        assertThat(result).isEqualTo("null")
+    }
+
+    @Test
+    fun `M return null W getIsTraceSampled() { session not tracked }`() {
+        // Given
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
+            .thenReturn(
+                mapOf(
+                    "session_id" to "some-session-id",
+                    "session_state" to "NOT_TRACKED"
+                )
+            )
+
+        // When
+        val result = testedDatadogEventBridge.getIsTraceSampled()
+
+        // Then
+        assertThat(result).isEqualTo("null")
+    }
+
+    @Test
+    fun `M return null W getIsTraceSampled() { no trace sample rate configured }`() {
+        // Given
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
+            .thenReturn(
+                mapOf(
+                    "session_id" to "some-session-id",
+                    "session_state" to "TRACKED",
+                    "session_sample_rate" to 100f
+                )
+            )
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.TRACING_FEATURE_NAME), eq(false)))
+            .thenReturn(emptyMap())
+
+        // When
+        val result = testedDatadogEventBridge.getIsTraceSampled()
+
+        // Then
+        assertThat(result).isEqualTo("null")
+    }
+
+    @Test
+    fun `M return null W getIsTraceSampled() { no session sample rate }`() {
+        // Given
+        whenever(mockSdkCore.getFeatureContext(eq(Feature.RUM_FEATURE_NAME), eq(false)))
+            .thenReturn(
+                mapOf(
+                    "session_id" to "some-session-id",
+                    "session_state" to "TRACKED"
+                )
+            )
+
+        // When
+        val result = testedDatadogEventBridge.getIsTraceSampled()
+
+        // Then
+        assertThat(result).isEqualTo("null")
     }
 }

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumerTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumerTest.kt
@@ -153,7 +153,13 @@ internal class WebViewRumEventConsumerTest {
         }
         whenever(
             mockWebViewRumFeatureScope.withWriteContext(
-                eq(setOf(Feature.RUM_FEATURE_NAME, Feature.SESSION_REPLAY_FEATURE_NAME)),
+                eq(
+                    setOf(
+                        Feature.RUM_FEATURE_NAME,
+                        Feature.SESSION_REPLAY_FEATURE_NAME,
+                        Feature.TRACING_FEATURE_NAME
+                    )
+                ),
                 any()
             )
         ) doAnswer {
@@ -574,6 +580,68 @@ internal class WebViewRumEventConsumerTest {
 
         // Then
         verify(mockDataWriter, never()).write(any(), any(), any())
+    }
+
+    // endregion
+
+    // region Trace Sampling
+
+    @Test
+    fun `M pass trace sample rate to mapper W consume() { tracing context present }`(forge: Forge) {
+        // Given
+        val fakeTraceSampleRate = forge.aFloat(min = 0f, max = 100f)
+        val tracingDatadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext + (
+                Feature.TRACING_FEATURE_NAME to mapOf(
+                    WebViewRumEventConsumer.TRACE_SAMPLE_RATE_KEY to fakeTraceSampleRate
+                )
+                )
+        )
+        whenever(
+            mockWebViewRumFeatureScope.withWriteContext(
+                eq(
+                    setOf(
+                        Feature.RUM_FEATURE_NAME,
+                        Feature.SESSION_REPLAY_FEATURE_NAME,
+                        Feature.TRACING_FEATURE_NAME
+                    )
+                ),
+                any()
+            )
+        ) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(it.arguments.lastIndex)
+            callback.invoke(tracingDatadogContext, mockEventWriteScope)
+        }
+        whenever(
+            mockOffsetProvider.getOffset(any(), eq(tracingDatadogContext))
+        ) doReturn fakeServerTimeOffsetInMillis
+
+        val fakeResourceEvent: ResourceEvent = forge.getForgery()
+        val fakeResourceEventAsJson = fakeResourceEvent.toJson().asJsonObject
+        whenever(
+            mockWebViewRumEventMapper.mapEvent(
+                fakeResourceEventAsJson,
+                fakeRumContext,
+                fakeServerTimeOffsetInMillis,
+                fakeSessionReplayEnabled,
+                tracingDatadogContext.userInfo.anonymousId,
+                fakeTraceSampleRate
+            )
+        ).thenReturn(fakeMappedResourceEvent)
+
+        // When
+        testedConsumer.consume(fakeResourceEventAsJson)
+
+        // Then
+        verify(mockWebViewRumEventMapper).mapEvent(
+            fakeResourceEventAsJson,
+            fakeRumContext,
+            fakeServerTimeOffsetInMillis,
+            fakeSessionReplayEnabled,
+            tracingDatadogContext.userInfo.anonymousId,
+            fakeTraceSampleRate
+        )
+        verify(mockDataWriter).write(mockEventBatchWriter, fakeMappedResourceEvent, EventType.DEFAULT)
     }
 
     // endregion

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventMapperTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventMapperTest.kt
@@ -417,6 +417,91 @@ internal class WebViewRumEventMapperTest {
         assertThat(usr).usingRecursiveComparison().isEqualTo(expectedUsr)
     }
 
+    @Test
+    fun `M overwrite rule_psr W mapEvent() { trace sample rate configured, event has rule_psr }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeResourceEvent = forge.getForgery<ResourceEvent>()
+        val fakeRumJsonObject = fakeResourceEvent.toJson().asJsonObject
+        val fakeBrowserRulePsr = forge.aFloat(min = 0f, max = 1f)
+        val fakeSampleRate = forge.aFloat(min = 0f, max = 100f)
+        fakeRumJsonObject.getAsJsonObject(WebViewRumEventMapper.DD_KEY_NAME)
+            .addProperty(WebViewRumEventMapper.RULE_PSR_KEY_NAME, fakeBrowserRulePsr)
+        whenever(mockNativeRumViewsCache.resolveLastParentIdForBrowserEvent(fakeResourceEvent.date))
+            .thenReturn(fakeResolvedNativeViewId)
+
+        // When
+        val mappedEvent = testedWebViewRumEventMapper.mapEvent(
+            fakeRumJsonObject,
+            fakeRumContext,
+            fakeServerTimeOffset,
+            true,
+            fakeAnonymousId,
+            fakeSampleRate
+        )
+
+        // Then
+        val dd = mappedEvent.getAsJsonObject(WebViewRumEventMapper.DD_KEY_NAME)
+        assertThat(dd).hasField(WebViewRumEventMapper.RULE_PSR_KEY_NAME, fakeSampleRate / 100f)
+    }
+
+    @Test
+    fun `M not add rule_psr W mapEvent() { trace sample rate configured, event has no rule_psr }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeResourceEvent = forge.getForgery<ResourceEvent>()
+        val fakeRumJsonObject = fakeResourceEvent.toJson().asJsonObject
+        val fakeSampleRate = forge.aFloat(min = 0f, max = 100f)
+        fakeRumJsonObject.getAsJsonObject(WebViewRumEventMapper.DD_KEY_NAME)
+            .remove(WebViewRumEventMapper.RULE_PSR_KEY_NAME)
+        whenever(mockNativeRumViewsCache.resolveLastParentIdForBrowserEvent(fakeResourceEvent.date))
+            .thenReturn(fakeResolvedNativeViewId)
+
+        // When
+        val mappedEvent = testedWebViewRumEventMapper.mapEvent(
+            fakeRumJsonObject,
+            fakeRumContext,
+            fakeServerTimeOffset,
+            true,
+            fakeAnonymousId,
+            fakeSampleRate
+        )
+
+        // Then
+        val dd = mappedEvent.getAsJsonObject(WebViewRumEventMapper.DD_KEY_NAME)
+        assertThat(dd).doesNotHaveField(WebViewRumEventMapper.RULE_PSR_KEY_NAME)
+    }
+
+    @Test
+    fun `M not modify rule_psr W mapEvent() { no trace sample rate configured }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeResourceEvent = forge.getForgery<ResourceEvent>()
+        val fakeRumJsonObject = fakeResourceEvent.toJson().asJsonObject
+        val originalRulePsr = forge.aFloat(min = 0f, max = 1f)
+        fakeRumJsonObject.getAsJsonObject(WebViewRumEventMapper.DD_KEY_NAME)
+            .addProperty(WebViewRumEventMapper.RULE_PSR_KEY_NAME, originalRulePsr)
+        whenever(mockNativeRumViewsCache.resolveLastParentIdForBrowserEvent(fakeResourceEvent.date))
+            .thenReturn(fakeResolvedNativeViewId)
+
+        // When
+        val mappedEvent = testedWebViewRumEventMapper.mapEvent(
+            fakeRumJsonObject,
+            fakeRumContext,
+            fakeServerTimeOffset,
+            true,
+            fakeAnonymousId,
+            traceSampleRate = null
+        )
+
+        // Then
+        val dd = mappedEvent.getAsJsonObject(WebViewRumEventMapper.DD_KEY_NAME)
+        assertThat(dd).hasField(WebViewRumEventMapper.RULE_PSR_KEY_NAME, originalRulePsr)
+    }
+
     private fun assertMappedEvent(
         expectedEvent: JsonObject,
         expectedDate: Long,

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeatureTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeatureTest.kt
@@ -113,7 +113,32 @@ internal class WebViewRumFeatureTest {
     }
 
     @Test
-    fun `M do nothing W onContextUpdate { no RUM feature }`(@StringForgery fakeFeatureName: String) {
+    fun `M cache rum context W onContextUpdate { RUM }`() {
+        // Given
+        val fakeContext = mapOf<String, Any?>("session_id" to "fake-id")
+
+        // When
+        testedFeature.onContextUpdate(Feature.RUM_FEATURE_NAME, fakeContext)
+
+        // Then
+        assertThat(testedFeature.cachedRumContext).isSameAs(fakeContext)
+    }
+
+    @Test
+    fun `M cache tracing context W onContextUpdate { TRACING }`() {
+        // Given
+        val fakeContext = mapOf<String, Any?>("okhttp_interceptor_sample_rate" to 50f)
+
+        // When
+        testedFeature.onContextUpdate(Feature.TRACING_FEATURE_NAME, fakeContext)
+
+        // Then
+        assertThat(testedFeature.cachedTracingContext).isSameAs(fakeContext)
+        verifyNoInteractions(mockNativeRumViewsCache)
+    }
+
+    @Test
+    fun `M do nothing W onContextUpdate { unknown feature }`(@StringForgery fakeFeatureName: String) {
         // Given
         val fakeContext = mock<Map<String, Any?>>()
 
@@ -122,5 +147,21 @@ internal class WebViewRumFeatureTest {
 
         // Then
         verifyNoInteractions(mockNativeRumViewsCache)
+        assertThat(testedFeature.cachedRumContext).isEmpty()
+        assertThat(testedFeature.cachedTracingContext).isEmpty()
+    }
+
+    @Test
+    fun `M clear cached contexts W onStop()`() {
+        // Given
+        testedFeature.onContextUpdate(Feature.RUM_FEATURE_NAME, mapOf("session_id" to "fake-id"))
+        testedFeature.onContextUpdate(Feature.TRACING_FEATURE_NAME, mapOf("okhttp_interceptor_sample_rate" to 50f))
+
+        // When
+        testedFeature.onStop()
+
+        // Then
+        assertThat(testedFeature.cachedRumContext).isEmpty()
+        assertThat(testedFeature.cachedTracingContext).isEmpty()
     }
 }

--- a/instrumented/integration/build.gradle.kts
+++ b/instrumented/integration/build.gradle.kts
@@ -91,6 +91,7 @@ dependencies {
     if (project.hasProperty(com.datadog.gradle.Properties.USE_DESUGARING)) {
         coreLibraryDesugaring(libs.androidDesugaringSdk)
     }
+    implementation(project(":features:dd-sdk-android-webview"))
     implementation(project(":features:dd-sdk-android-session-replay"))
     implementation(project(":features:dd-sdk-android-logs"))
     implementation(project(":features:dd-sdk-android-trace"))
@@ -98,6 +99,7 @@ dependencies {
     implementation(project(":dd-sdk-android-internal"))
     implementation(project(":integrations:dd-sdk-android-okhttp"))
     implementation(project(":integrations:dd-sdk-android-cronet"))
+    implementation(libs.okHttp)
     implementation(libs.cronetPlayServices)
 
     implementation(libs.gson)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/webview/WebViewBridgeTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/webview/WebViewBridgeTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sdk.integration.webview
+
+import android.webkit.WebView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.datadog.android.rum.GlobalRumMonitor
+import com.datadog.android.sdk.rules.MockServerActivityTestRule
+import org.assertj.core.api.Assertions.fail
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+internal class WebViewBridgeTest {
+
+    @get:Rule
+    val mockServerRule = MockServerActivityTestRule(WebViewBridgePlaygroundActivity::class.java)
+
+    @Test
+    fun testGetIsTraceSampledReturnsNullAfterSessionStop() {
+        val webView = mockServerRule.activity.webView
+
+        GlobalRumMonitor.get().startView("view-1", "TestView")
+        assertBridgeEventually(webView, "true")
+
+        GlobalRumMonitor.get().stopSession()
+        assertBridgeEventually(webView, "null")
+    }
+
+    @Test
+    fun testGetIsTraceSampledUpdatesDecisionOnSessionRollover() {
+        val webView = mockServerRule.activity.webView
+
+        GlobalRumMonitor.get().startView("view-1", "TestView")
+        assertBridgeEventually(webView, "true")
+
+        GlobalRumMonitor.get().stopSession()
+        assertBridgeEventually(webView, "null")
+
+        GlobalRumMonitor.get().startView("view-2", "TestView2")
+        assertBridgeEventually(webView, "true")
+    }
+
+    // Polls getIsTraceSampled() until it matches the expected value. Retrying is necessary
+    // because RUM events are processed on a background thread, so state changes from
+    // startView()/stopSession() aren't immediately visible to the bridge.
+    private fun assertBridgeEventually(
+        webView: WebView,
+        expectedResult: String,
+        timeoutMs: Long = 1_000
+    ) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        var lastActual: String? = null
+
+        while (System.currentTimeMillis() < deadline) {
+            val latch = CountDownLatch(1)
+            var actual: String? = null
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                webView.evaluateJavascript(GET_IS_TRACE_SAMPLED) { value ->
+                    // evaluateJavascript returns JSON-encoded results — strip surrounding quotes
+                    // for string values so "\"true\"" becomes "true".
+                    actual = value?.removeSurrounding("\"")
+                    latch.countDown()
+                }
+            }
+            latch.await(5, TimeUnit.SECONDS)
+            lastActual = actual
+            if (actual == expectedResult) return
+            Thread.sleep(100)
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        fail<Unit>("Expected getIsTraceSampled() to return '$expectedResult' but got '$lastActual' after ${timeoutMs}ms")
+    }
+
+    companion object {
+        private const val GET_IS_TRACE_SAMPLED = "DatadogEventBridge.getIsTraceSampled()"
+    }
+}

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/webview/WebViewBridgeTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/webview/WebViewBridgeTest.kt
@@ -78,7 +78,10 @@ internal class WebViewBridgeTest {
         }
 
         @Suppress("UNCHECKED_CAST")
-        fail<Unit>("Expected getIsTraceSampled() to return '$expectedResult' but got '$lastActual' after ${timeoutMs}ms")
+        fail<Unit>(
+            "Expected getIsTraceSampled() to return '$expectedResult' " +
+                "but got '$lastActual' after ${timeoutMs}ms"
+        )
     }
 
     companion object {

--- a/instrumented/integration/src/main/AndroidManifest.xml
+++ b/instrumented/integration/src/main/AndroidManifest.xml
@@ -96,6 +96,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".webview.WebViewBridgePlaygroundActivity"
+            android:label="WebView Bridge Test"
+            android:windowSoftInputMode="adjustResize"/>
         <activity android:name=".rum.AppLaunchPlaygroundActivity"
             android:label="@string/activity_app_launch"
             android:windowSoftInputMode="adjustResize"/>

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/webview/WebViewBridgePlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/webview/WebViewBridgePlaygroundActivity.kt
@@ -12,6 +12,7 @@ import android.util.Log
 import android.webkit.WebView
 import androidx.appcompat.app.AppCompatActivity
 import com.datadog.android.Datadog
+import com.datadog.android.core.sampling.DeterministicSampler
 import com.datadog.android.okhttp.DatadogInterceptor
 import com.datadog.android.rum.Rum
 import com.datadog.android.sdk.integration.RuntimeConfig
@@ -43,7 +44,7 @@ internal class WebViewBridgePlaygroundActivity : AppCompatActivity() {
         // okhttp_interceptor_sample_rate, which getIsTraceSampled() reads.
         Trace.enable(RuntimeConfig.tracesConfigBuilder().build(), sdkCore)
         DatadogInterceptor.Builder(listOf("localhost"))
-            .setTraceSampleRate(100f)
+            .setTraceSampleRate(DeterministicSampler.SAMPLE_ALL_RATE)
             .build()
 
         webView = WebView(this).also { wv ->

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/webview/WebViewBridgePlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/webview/WebViewBridgePlaygroundActivity.kt
@@ -1,0 +1,56 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sdk.integration.webview
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.util.Log
+import android.webkit.WebView
+import androidx.appcompat.app.AppCompatActivity
+import com.datadog.android.Datadog
+import com.datadog.android.okhttp.DatadogInterceptor
+import com.datadog.android.rum.Rum
+import com.datadog.android.sdk.integration.RuntimeConfig
+import com.datadog.android.sdk.utils.getTrackingConsent
+import com.datadog.android.trace.Trace
+import com.datadog.android.webview.WebViewTracking
+
+internal class WebViewBridgePlaygroundActivity : AppCompatActivity() {
+
+    lateinit var webView: WebView
+
+    @SuppressLint("SetJavaScriptEnabled")
+    @Suppress("CheckInternal")
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val config = RuntimeConfig.configBuilder().build()
+        val trackingConsent = intent.getTrackingConsent()
+
+        Datadog.setVerbosity(Log.VERBOSE)
+        val sdkCore = checkNotNull(
+            Datadog.initialize(this, config, trackingConsent)
+        )
+
+        Rum.enable(RuntimeConfig.rumConfigBuilder().build(), sdkCore)
+
+        // Trace.enable registers the "tracing" feature scope, which is required for
+        // updateFeatureContext to work. The interceptor then populates
+        // okhttp_interceptor_sample_rate, which getIsTraceSampled() reads.
+        Trace.enable(RuntimeConfig.tracesConfigBuilder().build(), sdkCore)
+        DatadogInterceptor.Builder(listOf("localhost"))
+            .setTraceSampleRate(100f)
+            .build()
+
+        webView = WebView(this).also { wv ->
+            wv.settings.javaScriptEnabled = true
+            WebViewTracking.enable(wv, listOf("localhost"), sdkCore = sdkCore)
+            setContentView(wv)
+            wv.loadData("<html><body></body></html>", "text/html", "UTF-8")
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR do?

With deterministic sampling, the decision of sampling requests on native clients became consistent, based on the sampling rate and session ID. However, when a native client loads an instrumented web site on a WebView, there is a disconnect between the sampling decision used by the browser SDK of the page being viewed in the WebView, and the native client's decision. This cannot be fixed by post-processing on the native client when the data is funneled through it, since the browser SDK needs to know if headers should be injected on requests, or not. More details [here](https://datadoghq.atlassian.net/browse/RUM-15702) (internal).

This is the Android counterpart of https://github.com/DataDog/browser-sdk/pull/4516 and https://github.com/DataDog/dd-sdk-ios/pull/2859.

### How?

To fix this problem, this patch introduces a way for Android to obtain the sampling decision from the Browser SDK running on the WebView through the JS bridge. Unlike iOS, this is a simple sync call that obtains the decision from the bridge.

On the JS side, depending on the decision being injected, tracing sample rate will be set to 100 (when the decision is true) or 0 (when it's false). Because of that, the Android SDK re-writes the _dd.rule_psr value with the actual sampling rate configured in the iOS SDK.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

