### PR TITLE
RUM-16086: Catch errors in convertToRumViewAttributes

### DIFF
--- a/detekt_custom_unsafe_calls.yml
+++ b/detekt_custom_unsafe_calls.yml
@@ -33,6 +33,8 @@ datadog:
       - "android.graphics.Paint.measureText(kotlin.String?):java.lang.IllegalArgumentException,java.lang.IndexOutOfBoundsException"
       - "android.net.ConnectivityManager.registerDefaultNetworkCallback(android.net.ConnectivityManager.NetworkCallback):java.lang.IllegalArgumentException,java.lang.SecurityException"
       - "android.net.ConnectivityManager.unregisterNetworkCallback(android.net.ConnectivityManager.NetworkCallback):java.lang.SecurityException"
+      - "android.os.BaseBundle.get(kotlin.String?):android.os.BadParcelableException,java.lang.LinkageError"
+      - "android.os.BaseBundle.keySet():android.os.BadParcelableException,java.lang.LinkageError"
       - "android.os.BatteryManager.getIntProperty(kotlin.Int):java.lang.RuntimeException"
       - "android.provider.Settings.System.getInt(android.content.ContentResolver?, kotlin.String?):android.provider.Settings.SettingNotFoundException"
       - "android.text.SpannableStringBuilder.setSpan(kotlin.Any?, kotlin.Int, kotlin.Int, kotlin.Int):java.lang.RuntimeException"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/BundleExt.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/BundleExt.kt
@@ -20,7 +20,7 @@ fun Bundle?.convertToRumViewAttributes(): Map<String, Any?> {
     return try {
         val attributes = mutableMapOf<String, Any?>()
 
-        // Either keySet() and get(), depending on API version, can throw:
+        // Either keySet() or get(), depending on API version, can throw:
         //   BadParcelableException — IOException/ClassNotFoundException wrapped by Parcel
         //   LinkageError (e.g. NoClassDefFoundError) — not caught and wrapped
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/BundleExt.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/BundleExt.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.tracking
 
+import android.os.BadParcelableException
 import android.os.Bundle
 
 internal const val ARGUMENT_TAG = "view.arguments"
@@ -16,14 +17,24 @@ internal const val ARGUMENT_TAG = "view.arguments"
 fun Bundle?.convertToRumViewAttributes(): Map<String, Any?> {
     if (this == null) return emptyMap()
 
-    val attributes = mutableMapOf<String, Any?>()
+    return try {
+        val attributes = mutableMapOf<String, Any?>()
 
-    keySet().forEach {
-        // TODO RUM-503 Bundle#get is deprecated, but there is no replacement for it.
-        // Issue is opened in the Google Issue Tracker.
-        @Suppress("DEPRECATION")
-        attributes["$ARGUMENT_TAG.$it"] = get(it)
+        // Either keySet() and get(), depending on API version, can throw:
+        //   BadParcelableException — IOException/ClassNotFoundException wrapped by Parcel
+        //   LinkageError (e.g. NoClassDefFoundError) — not caught and wrapped
+
+        keySet().forEach {
+            // TODO RUM-503 Bundle#get is deprecated, but there is no replacement for it.
+            // Issue is opened in the Google Issue Tracker.
+            @Suppress("DEPRECATION")
+            attributes["$ARGUMENT_TAG.$it"] = get(it)
+        }
+
+        attributes
+    } catch (_: BadParcelableException) {
+        emptyMap()
+    } catch (_: LinkageError) {
+        emptyMap()
     }
-
-    return attributes
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/BundleExtTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/BundleExtTest.kt
@@ -6,17 +6,21 @@
 
 package com.datadog.android.rum.tracking
 
+import android.os.BadParcelableException
 import android.os.Bundle
 import com.datadog.android.rum.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 
 @Extensions(
@@ -49,6 +53,68 @@ class BundleExtTest {
 
         // Then
 
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `M return empty map W convertToRumViewAttributes() {parcelize error on keySet}`(
+        @Mock mockBundle: Bundle
+    ) {
+        // Given
+        whenever(mockBundle.keySet()).thenThrow(BadParcelableException("simulated"))
+
+        // When
+        val result = mockBundle.convertToRumViewAttributes()
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `M return empty map W convertToRumViewAttributes() {NoClassDefFoundError on keySet}`(
+        @Mock mockBundle: Bundle
+    ) {
+        // Given
+        whenever(mockBundle.keySet()).thenThrow(NoClassDefFoundError("Invalid descriptor: ."))
+
+        // When
+        val result = mockBundle.convertToRumViewAttributes()
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `M return empty map W convertToRumViewAttributes() {parcelize error on get}`(
+        @Mock mockBundle: Bundle,
+        @StringForgery fakeKey: String
+    ) {
+        // Given
+        whenever(mockBundle.keySet()).thenReturn(setOf(fakeKey))
+        @Suppress("DEPRECATION")
+        whenever(mockBundle.get(fakeKey)).thenThrow(BadParcelableException("simulated"))
+
+        // When
+        val result = mockBundle.convertToRumViewAttributes()
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `M return empty map W convertToRumViewAttributes() {NoClassDefFoundError on get}`(
+        @Mock mockBundle: Bundle,
+        @StringForgery fakeKey: String
+    ) {
+        // Given
+        whenever(mockBundle.keySet()).thenReturn(setOf(fakeKey))
+        @Suppress("DEPRECATION")
+        whenever(mockBundle.get(fakeKey)).thenThrow(NoClassDefFoundError("Invalid descriptor: ."))
+
+        // When
+        val result = mockBundle.convertToRumViewAttributes()
+
+        // Then
         assertThat(result).isEmpty()
     }
 


### PR DESCRIPTION
### What does this PR do?
When [deserializing](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/os/Parcel.java#5365) the Parcel inside the Bundle, the methods get/keySet may throw LinkageErrors from Class.forName or BadParcelableException when other errors happen. In those situations, return an empty map for the view attributes.

API versions before 33 threw from `keySet()` due to the eager deserialization, but after that version, `get` throws due to switching to lazy deserialization so we must wrap both method calls.

### Motivation

Code can throw if the Parcel data is invalid:
```
java.lang.NoClassDefFoundError: Invalid descriptor: .
	at java.lang.Class.classForName(Native Method:0)
	at java.lang.Class.forName(Class.java:453)
	at android.os.Parcel$2.resolveClass(Parcel.java:2920)
	at java.io.ObjectInputStream.readNonProxyDesc(ObjectInputStream.java:1615)
	at java.io.ObjectInputStream.readClassDesc(ObjectInputStream.java:1520)
	at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:1776)
	at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1353)
	at java.io.ObjectInputStream.readObject(ObjectInputStream.java:373)
	at android.os.Parcel.readSerializable(Parcel.java:2928)
	at android.os.Parcel.readValue(Parcel.java:2720)
	at android.os.Parcel.readArrayMapInternal(Parcel.java:3038)
	at android.os.BaseBundle.initializeFromParcelLocked(BaseBundle.java:288)
	at android.os.BaseBundle.unparcel(BaseBundle.java:232)
	at android.os.BaseBundle.keySet(BaseBundle.java:557)
	at com.datadog.android.rum.tracking.BundleExtKt.convertToRumViewAttributes(BundleExt.kt:21)
```

### Additional Notes

For testing, I am using Mockito to inject the behavior due to in our version of roboeletric, the Parcel serialization/deserialization uses an Android specific `java.util.Array.checkOffsetAndCount(int, int, int)` leading to NoSuchMethodErrors

I attempted to upgrade it to API version 35 (36 requires JDK 21, and we still run 17 in CI), but that change got too big for this PR so I stopped. LMK if there is any interest in that and I can take another look into finishing the upgrade as another set of PRs

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

