### PR TITLE
RUM-16592: Remove regex usage in the `MemoryVitalReader`

### DIFF
--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -1178,6 +1178,8 @@ datadog:
       - "kotlin.Short.toUShort()"
       - "kotlin.ULong.toLong()"
       - "kotlin.String.lowercase()"
+      - "kotlin.String.removePrefix(kotlin.CharSequence)"
+      - "kotlin.String.removeSuffix(kotlin.CharSequence)"
       - "kotlin.String.takeIf(kotlin.Function1)"
       - "kotlin.String.toBigIntegerOrNull()"
       - "kotlin.String.toBoolean()"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/MemoryVitalReader.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/MemoryVitalReader.kt
@@ -27,10 +27,11 @@ internal class MemoryVitalReader(
         }
 
         val memorySizeKb = statusFile.readLinesSafe(internalLogger = internalLogger)
-            ?.mapNotNull { line ->
-                VM_RSS_REGEX.matchEntire(line)?.groupValues?.getOrNull(1)
-            }
-            ?.firstOrNull()
+            ?.firstOrNull { it.startsWith("VmRSS:") }
+            ?.removePrefix("VmRSS:")
+            ?.trim()
+            ?.removeSuffix("kB")
+            ?.trim()
             ?.toDoubleOrNull()
 
         return if (memorySizeKb == null) {
@@ -46,7 +47,5 @@ internal class MemoryVitalReader(
 
         private const val STATUS_PATH = "/proc/self/status"
         internal val STATUS_FILE = File(STATUS_PATH)
-        private const val VM_RSS_PATTERN = "VmRSS:\\s+(\\d+) kB"
-        private val VM_RSS_REGEX = Regex(VM_RSS_PATTERN)
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR removes regex usage in the `MemoryVitalReader`, see #3498 for the original suggestion.

The performance gain is ~4x (3364 ns/op before vs 814 ns/op after).

Note: it seems that Linux kernel always uses `kB` as a unit in the `/proc/[pid]/status` file.

https://github.com/torvalds/linux/blob/ba3e43a9e601636f5edb54e259a74f96ca3b8fd8/fs/proc/task_mmu.c#L65-L85

See also https://docs.kernel.org/filesystems/proc.html for the `proc` FS description.

Fixes #3498.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

