### PR TITLE
RUM-16593: Fix `WorkDatabase` initialization crash in R8 full mode

### DIFF
--- a/dd-sdk-android-core/build.gradle.kts
+++ b/dd-sdk-android-core/build.gradle.kts
@@ -52,6 +52,7 @@ fun isLogEnabledInRelease(): String {
 
 android {
     defaultConfig {
+        consumerProguardFiles("consumer-rules.pro")
         buildFeatures {
             buildConfig = true
         }

--- a/dd-sdk-android-core/consumer-rules.pro
+++ b/dd-sdk-android-core/consumer-rules.pro
@@ -1,0 +1,3 @@
+# see https://github.com/DataDog/dd-sdk-android/issues/3491 for motivation
+# we are using Work Manager version which is not compatible with R8 full mode
+-keep class androidx.work.impl.WorkDatabase_Impl { <init>(); }


### PR DESCRIPTION
### What does this PR do?

See #3491 for the motivation.

Fix R8 fullMode crash when using WorkManager 2.8.1

R8 fullMode (enabled by default in AGP 9.x) strips the no-arg constructor of `WorkDatabase_Impl` because it's only called via reflection. WorkManager's own bundled ProGuard rules don't protect it. This adds a consumer ProGuard rule to `dd-sdk-android-core` so the constructor is preserved in any app consuming the SDK. We cannot update WorkManager dependency, because it will bring coroutines and also may impose compile SDK restrictions.

Fixes #3491.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

