### PR TITLE
RUM-16604: Read process importance early

### DIFF
--- a/dd-sdk-android-internal/src/main/AndroidManifest.xml
+++ b/dd-sdk-android-internal/src/main/AndroidManifest.xml
@@ -8,9 +8,11 @@
 
     <application>
 
+        <!-- initOrder 1000 is for DdProfilingContentProvider, it can go before -->
         <provider
             android:name="com.datadog.android.rum.DdRumContentProvider"
             android:authorities="${applicationId}.provider.datadog.rum"
+            android:initOrder="999"
             android:exported="false" />
 
     </application>

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/rum/DdRumContentProvider.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/rum/DdRumContentProvider.kt
@@ -9,12 +9,10 @@ package com.datadog.android.rum
 import android.app.ActivityManager
 import android.content.ContentProvider
 import android.content.ContentValues
-import android.content.Context
 import android.database.Cursor
 import android.net.Uri
-import android.os.Process
 import android.util.Log
-import com.datadog.android.internal.utils.getSystemServiceAs
+import androidx.annotation.VisibleForTesting
 
 /**
  * A Content provider used to monitor the Application startup time efficiently.
@@ -22,14 +20,9 @@ import com.datadog.android.internal.utils.getSystemServiceAs
 class DdRumContentProvider : ContentProvider() {
 
     override fun onCreate(): Boolean {
-        if (processImportance == 0) {
-            val manager = context?.getSystemServiceAs<ActivityManager>(Context.ACTIVITY_SERVICE)
-            val currentProcessId = Process.myPid()
-            val currentProcess = manager?.runningAppProcesses?.firstOrNull {
-                it.pid == currentProcessId
-            }
-            processImportance = currentProcess?.importance ?: DEFAULT_IMPORTANCE
-            Log.w("DdRumContentProvider", "processImportance:$processImportance")
+        if (_processImportance == null) {
+            _processImportance = readProcessImportance()
+            Log.w("DdRumContentProvider", "processImportance:$_processImportance")
         }
         return true
     }
@@ -66,14 +59,43 @@ class DdRumContentProvider : ContentProvider() {
     }
 
     companion object {
-        internal const val DEFAULT_IMPORTANCE: Int =
-            ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+        @Volatile
+        private var _processImportance: Int? = null
 
         /**
-         * Process importance at the moment of creating [DdRumContentProvider]
-         * Should be set from the outside only in tests.
+         * Process importance at the moment of creating [DdRumContentProvider].
+         * If accessed before [DdRumContentProvider.onCreate] is called (e.g. by another
+         * ContentProvider initialised first), it is computed on demand so the value is
+         * never stale. Should be set from the outside only in tests.
          */
-        var processImportance: Int = 0
+        var processImportance: Int
+            get() {
+                val stored = _processImportance
+                if (stored != null) return stored
+                val currentProcessImportance = readProcessImportance()
+                _processImportance = currentProcessImportance
+                return currentProcessImportance
+            }
+
+            /**
+             * Do not call this from production code.
+             */
+            @VisibleForTesting
+            set(value) {
+                _processImportance = if (value == 0) null else value
+            }
+
+        private fun readProcessImportance(): Int {
+            val processInfo = ActivityManager.RunningAppProcessInfo()
+            try {
+                ActivityManager.getMyMemoryState(processInfo)
+            } catch (@Suppress("TooGenericExceptionCaught") e: RuntimeException) {
+                // in this case default value of RunningAppProcessInfo.importance will be returned,
+                // which is IMPORTANCE_FOREGROUND
+                Log.e("DdRumContentProvider", "Cannot read process importance from ActivityManager", e)
+            }
+            return processInfo.importance
+        }
 
         /**
          * fallback for APIs below Android N, see [DefaultAppStartTimeProvider].

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/rum/DdRumContentProviderTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/rum/DdRumContentProviderTest.kt
@@ -9,13 +9,8 @@ package com.datadog.android.rum
 import android.app.ActivityManager
 import android.content.ContentProvider
 import android.content.ContentValues
-import android.content.Context
 import android.net.Uri
-import android.os.Process
 import com.datadog.android.internal.forge.Configurator
-import com.datadog.tools.unit.extensions.TestConfigurationExtension
-import com.datadog.tools.unit.setFieldValue
-import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -23,23 +18,20 @@ import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
-import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.whenever
+import org.mockito.kotlin.any
 import org.mockito.quality.Strictness
 import java.net.URI
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
-    ExtendWith(ForgeExtension::class),
-    ExtendWith(TestConfigurationExtension::class)
+    ExtendWith(ForgeExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
@@ -47,37 +39,9 @@ class DdRumContentProviderTest {
 
     lateinit var testedProvider: ContentProvider
 
-    @Mock
-    lateinit var mockContext: Context
-
-    @Mock
-    lateinit var mockActivityManager: ActivityManager
-
-    lateinit var fakeCurrentProcessInfo: ActivityManager.RunningAppProcessInfo
-    lateinit var fakeOtherProcessInfo: ActivityManager.RunningAppProcessInfo
-
     @BeforeEach
-    fun `set up`(forge: Forge) {
-        fakeCurrentProcessInfo = ActivityManager.RunningAppProcessInfo().apply {
-            this.processName = forge.anAlphabeticalString()
-            this.pid = Process.myPid()
-            this.importance = forge.anInt()
-        }
-        fakeOtherProcessInfo = ActivityManager.RunningAppProcessInfo().apply {
-            this.processName = forge.anAlphabeticalString()
-            this.pid = Process.myPid() + forge.aSmallInt()
-            this.importance = forge.anInt()
-        }
-
-        whenever(mockContext.getSystemService(Context.ACTIVITY_SERVICE)).thenReturn(
-            mockActivityManager
-        )
-        whenever(mockActivityManager.runningAppProcesses).thenReturn(
-            listOf(fakeCurrentProcessInfo, fakeOtherProcessInfo)
-        )
-
+    fun `set up`() {
         testedProvider = DdRumContentProvider()
-        testedProvider.setFieldValue("mContext", mockContext)
     }
 
     @AfterEach
@@ -89,60 +53,121 @@ class DdRumContentProviderTest {
 
     @Test
     fun `M detect process importance W onCreate()`(
-        @IntForgery processImportance: Int
+        @IntForgery fakeImportance: Int
     ) {
         // Given
-        fakeCurrentProcessInfo.importance = processImportance
+        Mockito.mockStatic(ActivityManager::class.java).use { mock ->
+            mock.`when`<Unit> { ActivityManager.getMyMemoryState(any()) }
+                .thenAnswer { invocation ->
+                    invocation
+                        .getArgument<ActivityManager.RunningAppProcessInfo>(0)
+                        .importance = fakeImportance
+                    Unit
+                }
 
-        // When
-        testedProvider.onCreate()
+            // When
+            val response = testedProvider.onCreate()
 
-        // Then
-        assertThat(DdRumContentProvider.processImportance).isEqualTo(processImportance)
+            // Then
+            assertThat(DdRumContentProvider.processImportance).isEqualTo(fakeImportance)
+            assertThat(response).isTrue
+        }
+    }
+
+    @Test
+    fun `M detect process importance W onCreate() { exception is thrown }`() {
+        // Given
+        Mockito.mockStatic(ActivityManager::class.java).use { mock ->
+            mock.`when`<Unit> { ActivityManager.getMyMemoryState(any()) }
+                .thenThrow(RuntimeException())
+
+            // When
+            val response = testedProvider.onCreate()
+
+            // Then
+            assertThat(DdRumContentProvider.processImportance)
+                // normally it is IMPORTANCE_FOREGROUND, but on JVM the real constructor is not called, so it will be 0
+                .isEqualTo(0)
+            assertThat(response).isTrue
+        }
     }
 
     @Test
     fun `M detect process importance once W onCreate() twice`(
-        @IntForgery processImportance1: Int,
-        @IntForgery processImportance2: Int
+        @IntForgery(min = 0, max = 10) fakeImportance1: Int,
+        @IntForgery(min = 10, max = 100) fakeImportance2: Int
     ) {
         // Given
-        assumeTrue(processImportance1 != processImportance2)
+        Mockito.mockStatic(ActivityManager::class.java).use { mock ->
+            var callCount = 0
+            mock.`when`<Unit> { ActivityManager.getMyMemoryState(any()) }
+                .thenAnswer { invocation ->
+                    callCount++
+                    invocation.getArgument<ActivityManager.RunningAppProcessInfo>(0)
+                        .importance = if (callCount == 1) fakeImportance1 else fakeImportance2
+                    Unit
+                }
 
-        // When
-        fakeCurrentProcessInfo.importance = processImportance1
-        testedProvider.onCreate()
-        fakeCurrentProcessInfo.importance = processImportance2
-        testedProvider.onCreate()
+            // When
+            val response1 = testedProvider.onCreate()
+            val response2 = testedProvider.onCreate()
 
-        // Then
-        assertThat(DdRumContentProvider.processImportance).isEqualTo(processImportance1)
+            // Then
+            assertThat(DdRumContentProvider.processImportance).isEqualTo(fakeImportance1)
+            assertThat(response1).isTrue
+            assertThat(response2).isTrue
+        }
+    }
+
+    // endregion
+
+    // region processImportance lazy fallback
+
+    @Test
+    fun `M read process importance from ActivityManager W processImportance {onCreate not yet called}`(
+        @IntForgery fakeImportance: Int
+    ) {
+        // Given
+        Mockito.mockStatic(ActivityManager::class.java).use { mock ->
+            mock.`when`<Unit> { ActivityManager.getMyMemoryState(any()) }
+                .thenAnswer { invocation ->
+                    invocation.getArgument<ActivityManager.RunningAppProcessInfo>(0)
+                        .importance = fakeImportance
+                    Unit
+                }
+
+            // When
+            val result = DdRumContentProvider.processImportance
+
+            // Then
+            assertThat(result).isEqualTo(fakeImportance)
+        }
     }
 
     @Test
-    fun `M detect default process importance W onCreate() {no context}`() {
+    fun `M cache process importance W processImportance {accessed twice before onCreate}`(
+        @IntForgery(min = 0, max = 10) fakeImportance1: Int,
+        @IntForgery(min = 10, max = 100) fakeImportance2: Int
+    ) {
         // Given
-        testedProvider.setFieldValue("mContext", null as Context?)
+        Mockito.mockStatic(ActivityManager::class.java).use { mock ->
+            var callCount = 0
+            mock.`when`<Unit> { ActivityManager.getMyMemoryState(any()) }
+                .thenAnswer { invocation ->
+                    callCount++
+                    invocation.getArgument<ActivityManager.RunningAppProcessInfo>(0)
+                        .importance = if (callCount == 1) fakeImportance1 else fakeImportance2
+                    Unit
+                }
 
-        // When
-        testedProvider.onCreate()
+            // When
+            val first = DdRumContentProvider.processImportance
+            val second = DdRumContentProvider.processImportance
 
-        // Then
-        assertThat(DdRumContentProvider.processImportance)
-            .isEqualTo(DdRumContentProvider.DEFAULT_IMPORTANCE)
-    }
-
-    @Test
-    fun `M detect default process importance W onCreate() {no activity mgr}`() {
-        // Given
-        whenever(mockContext.getSystemService(Context.ACTIVITY_SERVICE)) doReturn null
-
-        // When
-        testedProvider.onCreate()
-
-        // Then
-        assertThat(DdRumContentProvider.processImportance)
-            .isEqualTo(DdRumContentProvider.DEFAULT_IMPORTANCE)
+            // Then
+            assertThat(first).isEqualTo(fakeImportance1)
+            assertThat(second).isEqualTo(fakeImportance1)
+        }
     }
 
     // endregion

--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -5,6 +5,7 @@ datadog:
       - "android.app.Activity.findViewById(kotlin.Int)"
       - "android.app.Activity.getSystemService(kotlin.String)"
       - "android.app.Activity.hashCode()"
+      - "android.app.ActivityManager.RunningAppProcessInfo.constructor()"
       - "android.app.ActivityManager.getHistoricalProcessStartReasons(kotlin.Int)"
       - "android.app.Application.getProcessName()"
       - "android.app.Application.registerActivityLifecycleCallbacks(android.app.Application.ActivityLifecycleCallbacks?)"

--- a/detekt_custom_unsafe_calls.yml
+++ b/detekt_custom_unsafe_calls.yml
@@ -5,6 +5,7 @@ datadog:
       - "android.app.ActivityManager.getHistoricalProcessExitReasons(kotlin.String?, kotlin.Int, kotlin.Int):java.lang.RuntimeException"
       - "android.app.ActivityManager.MemoryInfo.constructor():java.lang.RuntimeException"
       - "android.app.ActivityManager.getMemoryInfo(android.app.ActivityManager.MemoryInfo?):java.lang.RuntimeException"
+      - "android.app.ActivityManager.getMyMemoryState(android.app.ActivityManager.RunningAppProcessInfo?):java.lang.RuntimeException"
       - "android.app.ApplicationExitInfo.getTraceInputStream():java.io.IOException"
       - "android.content.pm.PackageManager.getPackageInfo(kotlin.String, android.content.pm.PackageManager.PackageInfoFlags):android.content.pm.PackageManager.NameNotFoundException"
       - "android.content.pm.PackageManager.getPackageInfo(kotlin.String, kotlin.Int):android.content.pm.PackageManager.NameNotFoundException"


### PR DESCRIPTION
### What does this PR do?

In case of https://developer.android.com/topic/libraries/app-startup usage Datadog SDK may be started from the Content Provider.

And since we use process importance to start RUM pipeline https://github.com/DataDog/dd-sdk-android/blob/e9efd7c8c8cd57f356cd7ba7c65a92df05a4e7ad/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt#L499-L506

and process importance is read in another Content Provider https://github.com/DataDog/dd-sdk-android/blob/e9efd7c8c8cd57f356cd7ba7c65a92df05a4e7ad/dd-sdk-android-internal/src/main/java/com/datadog/android/rum/DdRumContentProvider.kt#L24-L35

we may have it not yet available by the time SDK starts, because it all depends on the initialization order.

This PR does the following:

* assigns `initOrder` to the `DdRumContentProvider`, so it has a priority in the startup list
* switches to [getMyMemoryState](https://developer.android.com/reference/android/app/ActivityManager#getMyMemoryState(android.app.ActivityManager.RunningAppProcessInfo)) API. It is available since API 16, so it is safe to use
* to support rare cases when process importance is requested before `DdRumContentProvider` is initialized, we try to read it in the getter as well.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

