### PR TITLE
Regression: slow reflection in Session Replay compose traversal

### DIFF
--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeUtils.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeUtils.kt
@@ -31,7 +31,7 @@ import java.lang.reflect.Method
  * benchmark validation. Must be `false` in production.
  */
 @Suppress("TopLevelPropertyNaming")
-internal var useSlowReflection = false
+internal var useSlowReflection = true
 
 internal class LayoutNodeUtils {
 


### PR DESCRIPTION
## Summary

Enables the `useSlowReflection` toggle in `LayoutNodeUtils.kt`, switching from cached `Class.getMethod()` to `Class.getMethods()` scan on every layout node per frame during Session Replay compose traversal.

This reproduces the **RUM-15813** regression that shipped to production. The benchmark pipeline should detect ~10ms/frame increase in `frameDurationCpuMs`.

## Purpose

Demo PR to validate the benchmark CI pipeline detects macrobenchmark-level regressions.

Made with [Cursor](https://cursor.com)