### PR TITLE
Regression: slow map copies in DatadogCore.updateFeatureContext

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -63,7 +63,7 @@ import java.util.concurrent.locks.Lock
  * benchmark validation. Must be `false` in production.
  */
 @Suppress("TopLevelPropertyNaming")
-internal var useSlowMapCopy = false
+internal var useSlowMapCopy = true
 
 /**
  * Internal implementation of the [SdkCore] interface.


### PR DESCRIPTION
## Summary

Enables the `useSlowMapCopy` toggle in `DatadogCore.kt`, replacing optimized map construction with slow defensive HashMap copies using intermediate collections.

This reproduces the regression that was fixed in [PR #2489]. The benchmark pipeline should detect this via the `UpdateFeatureContextBenchmark` microbenchmark.

## Purpose

Demo PR to validate the benchmark CI pipeline detects microbenchmark-level regressions in core SDK code.