### PR TITLE
Regression: forEach allocation in FrameStatesAggregator.onFrame

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/FrameStatesAggregator.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/FrameStatesAggregator.kt
@@ -35,7 +35,7 @@ import java.util.WeakHashMap
  * RUM-8785 regression for benchmark validation. Must be `false` in production.
  */
 @Suppress("TopLevelPropertyNaming")
-internal var useForEachIteration = false
+internal var useForEachIteration = true
 
 /**
  * Utility class listening to frame rate information.


### PR DESCRIPTION
## Summary

Enables the `useForEachIteration` toggle in `FrameStatesAggregator.kt`, switching from an allocation-free indexed loop to `forEach` with lambda allocation on the hot path (called every frame for RUM vitals).

This reproduces the **RUM-8785** regression (~3x slower, +1 allocation per call). The benchmark pipeline should detect this via the `FrameStatesAggregatorBenchmark` microbenchmark.

## Purpose

Demo PR to validate the benchmark CI pipeline detects microbenchmark-level regressions in RUM vitals code.

Made with [Cursor](https://cursor.com)