### PR TITLE
RUM-16653: Route androidNetworkInstrumentation through InternalLogger#logApiUsage

### DIFF
--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/utils/InternalLoggerUtils.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/utils/InternalLoggerUtils.kt
@@ -171,10 +171,11 @@ fun InternalLogger.verifyLog(
 
 fun InternalLogger.verifyApiUsage(
     apiUsage: InternalTelemetryEvent.ApiUsage,
-    samplingRate: Float
+    samplingRate: Float,
+    verificationMode: VerificationMode = times(1)
 ) {
     argumentCaptor<() -> InternalTelemetryEvent.ApiUsage> {
-        verify(this@verifyApiUsage).logApiUsage(eq(samplingRate), capture())
+        verify(this@verifyApiUsage, verificationMode).logApiUsage(eq(samplingRate), capture())
         InternalApiUsageEventAssert.assertThat(firstValue()).isEqualTo(apiUsage)
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -636,9 +636,7 @@ internal class DatadogRumMonitor(
     }
 
     override fun reportNetworkingLibraryType(type: InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType) {
-        handleEvent(
-            RumRawEvent.TelemetryEventWrapper(InternalTelemetryEvent.ApiUsage.NetworkInstrumentation(type))
-        )
+        sdkCore.internalLogger.logApiUsage { InternalTelemetryEvent.ApiUsage.NetworkInstrumentation(type) }
     }
 
     override fun notifyResourceHeadersTrackingConfigured(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -2245,16 +2245,10 @@ internal class DatadogRumMonitorTest {
         testedMonitor.reportNetworkingLibraryType(fakeLibraryType)
 
         // Then
-        argumentCaptor<RumRawEvent.TelemetryEventWrapper> {
-            verify(mockTelemetryEventHandler).handleEvent(
-                capture(),
-                eq(mockWriter)
-            )
-            val event = lastValue.event
-            assertThat(event).isInstanceOf(InternalTelemetryEvent.ApiUsage.NetworkInstrumentation::class.java)
-            assertThat((event as InternalTelemetryEvent.ApiUsage.NetworkInstrumentation).type)
-                .isEqualTo(fakeLibraryType)
-        }
+        mockSdkCore.internalLogger.verifyApiUsage(
+            apiUsage = InternalTelemetryEvent.ApiUsage.NetworkInstrumentation(fakeLibraryType),
+            samplingRate = 15f
+        )
     }
 
     @Test
@@ -2266,18 +2260,11 @@ internal class DatadogRumMonitorTest {
         testedMonitor.reportNetworkingLibraryType(fakeLibraryType)
 
         // Then
-        argumentCaptor<RumRawEvent.TelemetryEventWrapper> {
-            verify(mockTelemetryEventHandler, times(2)).handleEvent(
-                capture(),
-                eq(mockWriter)
-            )
-            allValues.forEach { wrapper ->
-                val event = wrapper.event
-                assertThat(event).isInstanceOf(InternalTelemetryEvent.ApiUsage.NetworkInstrumentation::class.java)
-                assertThat((event as InternalTelemetryEvent.ApiUsage.NetworkInstrumentation).type)
-                    .isEqualTo(fakeLibraryType)
-            }
-        }
+        mockSdkCore.internalLogger.verifyApiUsage(
+            apiUsage = InternalTelemetryEvent.ApiUsage.NetworkInstrumentation(fakeLibraryType),
+            samplingRate = 15f,
+            verificationMode = times(2)
+        )
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
The androidNetworkInstrumentation reporting was bypassing the logApiUsage API so it was being reporting at 100% event-level sampling. By moving it to go through the standard API, we will apply the standard 15% event sampling to decrease the number of events generated (decreasing effective_sampling_rate from 20% to 3%)

### Motivation
Cost savings, see attached ticket for details

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

