### PR TITLE
RUM-16661: Add dogfooding branch infrastructure

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
@@ -19,7 +19,7 @@ object AndroidConfig {
     const val MIN_SDK_FOR_AUTO = 29
     const val BUILD_TOOLS_VERSION = "36.0.0"
 
-    val VERSION = Version(3, 11, 0, Version.Type.Snapshot)
+    val VERSION = Version(3, 11, 0, Version.Type.Snapshot())
 }
 
 // TODO RUM-628 Switch to Java 17 bytecode

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/utils/Version.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/utils/Version.kt
@@ -39,8 +39,9 @@ data class Version(
             override val suffix: String = "-dev"
         }
 
-        object Snapshot : Type() {
-            override val suffix: String = "-SNAPSHOT"
+        data class Snapshot(val label: String? = null) : Type() {
+            override val suffix: String =
+                if (label.isNullOrEmpty()) "-SNAPSHOT" else "-$label-SNAPSHOT"
         }
     }
 

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/utils/VersionTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/utils/VersionTest.kt
@@ -117,10 +117,28 @@ class VersionTest {
     @Test
     fun addSuffixForSnapshot() {
         // When
-        val name = Version(4, 11, 5, Version.Type.Snapshot).name
+        val name = Version(4, 11, 5, Version.Type.Snapshot()).name
 
         // Then
         val expected = "4.11.5-SNAPSHOT"
         assertThat(name).isEqualTo(expected)
+    }
+
+    @Test
+    fun `M return labeled snapshot suffix W Snapshot with label`() {
+        // When
+        val name = Version(1, 2, 3, Version.Type.Snapshot("dogfooding")).name
+
+        // Then
+        assertThat(name).isEqualTo("1.2.3-dogfooding-SNAPSHOT")
+    }
+
+    @Test
+    fun `M return plain snapshot suffix W Snapshot with empty label`() {
+        // When
+        val name = Version(1, 2, 3, Version.Type.Snapshot("")).name
+
+        // Then
+        assertThat(name).isEqualTo("1.2.3-SNAPSHOT")
     }
 }

--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -92,12 +92,17 @@ stages:
       - cache/notifications/
     policy: pull
 
+# Skip all standard jobs on the dogfooding branch — only the manual publish runs there.
+.except-dogfooding-branch:
+  except:
+    - dogfooding
+
 # CI IMAGE
 
 ci-image:
   stage: ci-image
   when: manual
-  except: [ tags, schedules ]
+  except: [ tags, schedules, dogfooding ]
   tags: [ "arch:amd64" ]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:24.0.4-jammy
   script:
@@ -106,6 +111,8 @@ ci-image:
 # SECURITY
 
 create_key:
+  extends:
+    - .except-dogfooding-branch
   stage: security
   when: manual
   tags: [ "arch:amd64" ]
@@ -124,6 +131,8 @@ create_key:
 # STATIC ANALYSIS
 
 static-analysis:
+  extends:
+    - .except-dogfooding-branch
   stage: analysis
   variables:
     DETEKT_PUBLIC_API: "true"
@@ -137,6 +146,7 @@ static-analysis:
 analysis:detekt-custom:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags:
     - "arch:amd64"
   image: $CI_IMAGE_DOCKER
@@ -157,6 +167,7 @@ analysis:detekt-custom:
 test:debug:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: test
@@ -178,6 +189,7 @@ test:debug:
 test:tools:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: test
@@ -188,6 +200,8 @@ test:tools:
     - GRADLE_OPTS="-Xmx3072m" ./gradlew :unitTestTools --stacktrace --no-daemon --build-cache --gradle-user-home cache/
 
 test:kover:
+  extends:
+    - .except-dogfooding-branch
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: test
@@ -224,6 +238,7 @@ test:kover:
 test-pyramid:core-it-min-api:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "macos:sonoma", "specific:true" ]
   stage: test-pyramid
   timeout: 1h
@@ -239,6 +254,7 @@ test-pyramid:core-it-min-api:
 test-pyramid:core-it-latest-api:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "macos:sonoma", "specific:true" ]
   stage: test-pyramid
   timeout: 1h
@@ -254,6 +270,7 @@ test-pyramid:core-it-latest-api:
 test-pyramid:core-it-median-api:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "macos:sonoma", "specific:true" ]
   stage: test-pyramid
   timeout: 1h
@@ -269,6 +286,7 @@ test-pyramid:core-it-median-api:
 test-pyramid:single-fit-logs:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: test-pyramid
@@ -286,6 +304,7 @@ test-pyramid:single-fit-logs:
 test-pyramid:single-fit-rum:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: test-pyramid
@@ -303,6 +322,7 @@ test-pyramid:single-fit-rum:
 test-pyramid:single-fit-trace:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: test-pyramid
@@ -320,6 +340,7 @@ test-pyramid:single-fit-trace:
 test-pyramid:single-fit-okhttp:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: test-pyramid
@@ -339,6 +360,7 @@ test-pyramid:single-fit-okhttp:
 test-pyramid:legacy-integration-instrumented-min-api:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "macos:sonoma", "specific:true" ]
   stage: test-pyramid
   timeout: 1h
@@ -354,6 +376,7 @@ test-pyramid:legacy-integration-instrumented-min-api:
 test-pyramid:legacy-integration-instrumented-latest-api:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "macos:sonoma", "specific:true" ]
   stage: test-pyramid
   timeout: 1h
@@ -369,6 +392,7 @@ test-pyramid:legacy-integration-instrumented-latest-api:
 test-pyramid:legacy-integration-instrumented-median-api:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "macos:sonoma", "specific:true" ]
   stage: test-pyramid
   timeout: 1h
@@ -384,6 +408,7 @@ test-pyramid:legacy-integration-instrumented-median-api:
 test-pyramid:ndk-instrumented-latest-api:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "macos:sonoma", "specific:true" ]
   stage: test-pyramid
   timeout: 1h
@@ -399,6 +424,7 @@ test-pyramid:ndk-instrumented-latest-api:
 test-pyramid:detekt-api-coverage:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: test-pyramid
@@ -419,6 +445,7 @@ test-pyramid:detekt-api-coverage:
 test-pyramid:publish-e2e-synthetics:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: test-pyramid
@@ -449,6 +476,7 @@ test-pyramid:publish-e2e-synthetics:
 test-pyramid:publish-webview-synthetics:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: test-pyramid
@@ -479,6 +507,7 @@ test-pyramid:publish-webview-synthetics:
 test-pyramid:publish-staging-synthetics:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: test-pyramid
@@ -509,6 +538,7 @@ test-pyramid:publish-staging-synthetics:
 test-pyramid:publish-benchmark-synthetics:
   extends:
     - .base-cache-pull-job
+    - .except-dogfooding-branch
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: test-pyramid
@@ -539,6 +569,8 @@ test-pyramid:publish-benchmark-synthetics:
 # PUBLISH ARTIFACTS ON MAVEN
 
 publish:release-all:
+  extends:
+    - .except-dogfooding-branch
   tags: [ "arch:amd64" ]
   only:
     - tags
@@ -555,11 +587,26 @@ publish:release-all:
     paths:
       - "**/verification-metadata.xml"
 
+publish:snapshot-dogfooding:
+  tags: [ "arch:amd64" ]
+  only:
+    - dogfooding
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  when: manual
+  script:
+    - !reference [.snippets, set-publishing-credentials]
+    # SNAPSHOT versions are published directly to the Sonatype SNAPSHOT repository
+    # and do not require staging/closing — only release artifacts need that step.
+    - ./gradlew publishToSonatype --stacktrace --no-daemon
 
 # SLACK NOTIFICATIONS
 
 notify:publish-develop-success:
-  extends: .slack-notifier-base
+  extends:
+    - .slack-notifier-base
+    - .except-dogfooding-branch
   stage: notify
   when: on_success
   only:
@@ -569,7 +616,9 @@ notify:publish-develop-success:
     - postmessage "#mobile-sdk-ops" "$MESSAGE_TEXT"
 
 notify:publish-develop-failure:
-  extends: .slack-notifier-base
+  extends:
+    - .slack-notifier-base
+    - .except-dogfooding-branch
   stage: notify
   when: on_failure
   only:
@@ -580,7 +629,9 @@ notify:publish-develop-failure:
     - postmessage "#mobile-sdk-ops" "$MESSAGE_TEXT"
 
 notify:publish-release-success:
-  extends: .slack-notifier-base
+  extends:
+    - .slack-notifier-base
+    - .except-dogfooding-branch
   stage: notify
   when: on_success
   only:
@@ -591,7 +642,9 @@ notify:publish-release-success:
     - postmessage "#mobile-sdk-ops" "$MESSAGE_TEXT"
 
 notify:publish-release-failure:
-  extends: .slack-notifier-base
+  extends:
+    - .slack-notifier-base
+    - .except-dogfooding-branch
   stage: notify
   when: on_failure
   only:
@@ -602,6 +655,8 @@ notify:publish-release-failure:
     - postmessage "#mobile-sdk-ops" "$MESSAGE_TEXT"
 
 notify:dogfood-app:
+  extends:
+    - .except-dogfooding-branch
   tags: [ "arch:amd64" ]
   only:
     - tags
@@ -617,6 +672,8 @@ notify:dogfood-app:
     - python3 ./ci/scripts/dogfood.py -v $CI_COMMIT_TAG -t app
 
 notify:dogfood-demo:
+  extends:
+    - .except-dogfooding-branch
   tags: [ "arch:amd64" ]
   only:
     - tags
@@ -632,6 +689,8 @@ notify:dogfood-demo:
     - python3 ./ci/scripts/dogfood.py -v $CI_COMMIT_TAG -t demo
 
 notify:dogfood-gradle-plugin:
+  extends:
+    - .except-dogfooding-branch
   tags: [ "arch:amd64" ]
   only:
     - tags
@@ -647,6 +706,8 @@ notify:dogfood-gradle-plugin:
     - python3 ./ci/scripts/dogfood.py -v $CI_COMMIT_TAG -t gradle-plugin
 
 notify:merge-verification-metadata:
+  extends:
+    - .except-dogfooding-branch
   tags: [ "arch:amd64" ]
   only:
     - tags

--- a/ci/scripts/reset-dogfooding.sh
+++ b/ci/scripts/reset-dogfooding.sh
@@ -9,7 +9,8 @@
 # Resets the `dogfooding` branch to the current HEAD of `develop`,
 # applies the dogfooding version label, commits, and force-pushes.
 #
-# Usage: ./ci/scripts/reset-dogfooding.sh
+# Usage: ./ci/scripts/reset-dogfooding.sh [--force]
+#   --force  Skip the in-flight features confirmation (use in CI/non-interactive environments).
 # Run from the repo root on any branch.
 # NOTE: After this script completes your active branch will be `dogfooding`.
 
@@ -19,9 +20,30 @@ trap 'rm -f "${ANDROID_CONFIG}.tmp"' EXIT
 
 DOGFOODING_BRANCH="dogfooding"
 ANDROID_CONFIG="buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt"
+FORCE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --force) FORCE=true ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
 
 echo "Fetching latest from origin..."
 git fetch origin
+
+# Check for in-flight features that will be discarded
+AHEAD=$(git log origin/develop..origin/"$DOGFOODING_BRANCH" --oneline 2>/dev/null || true)
+if [ -n "$AHEAD" ] && [ "$FORCE" = false ]; then
+  echo "⚠️  The following commits on $DOGFOODING_BRANCH will be discarded:"
+  echo "$AHEAD"
+  echo ""
+  read -p "Are you sure you want to reset? [y/N] " confirm
+  if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+    echo "Aborted."
+    exit 0
+  fi
+fi
 
 echo "Resetting $DOGFOODING_BRANCH to origin/develop..."
 git checkout "$DOGFOODING_BRANCH" 2>/dev/null || git checkout -b "$DOGFOODING_BRANCH" "origin/develop"

--- a/ci/scripts/reset-dogfooding.sh
+++ b/ci/scripts/reset-dogfooding.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2016-Present Datadog, Inc.
+#
+# reset-dogfooding.sh
+#
+# Resets the `dogfooding` branch to the current HEAD of `develop`,
+# applies the dogfooding version label, commits, and force-pushes.
+#
+# Usage: ./ci/scripts/reset-dogfooding.sh
+# Run from the repo root on any branch.
+# NOTE: After this script completes your active branch will be `dogfooding`.
+
+set -euo pipefail
+
+trap 'rm -f "${ANDROID_CONFIG}.tmp"' EXIT
+
+DOGFOODING_BRANCH="dogfooding"
+ANDROID_CONFIG="buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt"
+
+echo "Fetching latest from origin..."
+git fetch origin
+
+echo "Resetting $DOGFOODING_BRANCH to origin/develop..."
+git checkout "$DOGFOODING_BRANCH" 2>/dev/null || git checkout -b "$DOGFOODING_BRANCH" "origin/develop"
+git reset --hard "origin/develop"
+
+echo "Patching version in $ANDROID_CONFIG..."
+# Replace: Version.Type.Snapshot() (no label, as develop uses)
+# With:    Version.Type.Snapshot("dogfooding")
+# GNU sed (Linux/CI) uses -i without argument; BSD sed (macOS) requires -i ''
+# Use a temp-file approach that works on both:
+sed 's/Version\.Type\.Snapshot()/Version.Type.Snapshot("dogfooding")/g' \
+    "$ANDROID_CONFIG" > "${ANDROID_CONFIG}.tmp" \
+    && mv "${ANDROID_CONFIG}.tmp" "$ANDROID_CONFIG"
+
+# Verify the patch was applied
+if ! grep -q 'Version\.Type\.Snapshot("dogfooding")' "$ANDROID_CONFIG"; then
+  echo "ERROR: failed to patch $ANDROID_CONFIG — expected pattern not found." >&2
+  exit 1
+fi
+
+echo "Committing version patch..."
+git add "$ANDROID_CONFIG"
+git commit -m "Reset dogfooding branch to develop"
+
+echo "Force-pushing to origin/$DOGFOODING_BRANCH..."
+git push --force-with-lease origin "$DOGFOODING_BRANCH"
+
+echo ""
+echo "Done. dogfooding branch is now at:"
+git log --oneline -1


### PR DESCRIPTION
### What does this PR do?
Adds the infrastructure needed to support a long-lived `dogfooding` branch that publishes `x.y.z-dogfooding-SNAPSHOT` Maven artifacts for internal dogfooding of in-flight features before they land on `develop`.

### Motivation
The team needs a structured way to dogfood in-flight SDK features in the Datadog Android app and Shopist Android, mirroring what the iOS SDK already does with its `dogfooding` branch. Previous ad-hoc approaches (e.g. `bplasovska/feature/timeseries-dogfooding`) were undiscoverable, one-off, and required consumers to update their version string for every feature.

### Additional Notes
- `Version.Type.Snapshot` is extended from a singleton `object` to a `data class` with an optional label — `Snapshot("dogfooding")` → `x.y.z-dogfooding-SNAPSHOT`, `Snapshot()` → `x.y.z-SNAPSHOT` (develop behaviour unchanged).
- All standard CI jobs skip on the `dogfooding` branch via `.except-dogfooding-branch`; only the new manual `publish:snapshot-dogfooding` job runs there.
- `ci/scripts/reset-dogfooding.sh` automates resetting the `dogfooding` branch to `develop` HEAD and re-applying the version label — run after a feature graduates to `develop`.
- No public API surface changes.

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)