### PR TITLE
Update wrong API doc for the text and input privacy configuration in Session Replay

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
@@ -182,7 +182,7 @@ data class SessionReplayConfiguration internal constructor(
 
         /**
          * Sets the text and input recording level for the Session Replay feature.
-         * If not specified then sensitive text will be masked by default.
+         * If not specified then all text will be masked by default.
          * @see TextAndInputPrivacy.MASK_SENSITIVE_INPUTS
          * @see TextAndInputPrivacy.MASK_ALL_INPUTS
          * @see TextAndInputPrivacy.MASK_ALL


### PR DESCRIPTION
### What does this PR do?

Existing doc is wrong because default value is `MASK_ALL`.

https://github.com/DataDog/dd-sdk-android/blob/0b3c64ab5af89177b9e6d91b16e7b53c420af919/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt#L74

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

