### PR TITLE
Fix flaky `InternalApiUsageDetectorTest` due to Kotlin reserved keywords in package regex

### DIFF
--- a/tools/lint/src/test/kotlin/com/datadog/android/lint/InternalApiUsageDetectorTest.kt
+++ b/tools/lint/src/test/kotlin/com/datadog/android/lint/InternalApiUsageDetectorTest.kt
@@ -22,10 +22,10 @@ import org.junit.jupiter.api.extension.Extensions
 )
 internal class InternalApiUsageDetectorTest {
 
-    @StringForgery(regex = "(com|org|fr)\\.[a-z]{1,10}")
+    @StringForgery(regex = "(com|org|fr)\\.[a-z]{1,7}pkg")
     lateinit var nonDatadogPackage: String
 
-    @StringForgery(regex = "com\\.datadog(|\\.[a-z]{1,13})")
+    @StringForgery(regex = "com\\.datadog(|\\.[a-z]{1,10}pkg)")
     lateinit var datadogPackage: String
 
     @Test


### PR DESCRIPTION
### What does this PR do?

Fixes a flaky test in `InternalApiUsageDetectorTest` where Forge-generated package names could contain Kotlin reserved keywords (e.g. `org.do`, `com.datadog.for`), causing the lint test runner to fail when parsing the generated Kotlin stubs.

### Motivation

The `@StringForgery` regex patterns `(com|org|fr)\\.[a-z]{1,10}` and `com\\.datadog(|\\.[a-z]{1,13})` could generate segments like `do`, `for`, `fun`, `val`, etc. — all reserved Kotlin keywords — as package name components. When embedded in `package` declarations inside lint test stubs, these caused an `IllegalStateException` in the lint test runner.

Fix: append `pkg` to each variable-length segment, making it impossible for the generated value to be a reserved word.

### Additional Notes

No behaviour change — the tests only care whether the package starts with `com.datadog` or not; the exact suffix is irrelevant to the detector logic.