### PR TITLE
RUM-16564: Create and register stub for client stats feature if enabled

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -117,6 +117,7 @@ interface com.datadog.android.api.feature.Feature
     const val FLAGS_FEATURE_NAME: String
     const val FLAGS_EVALUATIONS_FEATURE_NAME: String
     const val TRACING_FEATURE_NAME: String
+    const val TRACING_CLIENT_STATS_FEATURE_NAME: String
     const val SESSION_REPLAY_FEATURE_NAME: String
     const val SESSION_REPLAY_RESOURCES_FEATURE_NAME: String
     const val NDK_CRASH_REPORTS_FEATURE_NAME: String

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -385,6 +385,7 @@ public abstract interface class com/datadog/android/api/feature/Feature {
 	public static final field RUM_FEATURE_NAME Ljava/lang/String;
 	public static final field SESSION_REPLAY_FEATURE_NAME Ljava/lang/String;
 	public static final field SESSION_REPLAY_RESOURCES_FEATURE_NAME Ljava/lang/String;
+	public static final field TRACING_CLIENT_STATS_FEATURE_NAME Ljava/lang/String;
 	public static final field TRACING_FEATURE_NAME Ljava/lang/String;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun onInitialize (Landroid/content/Context;)V
@@ -400,6 +401,7 @@ public final class com/datadog/android/api/feature/Feature$Companion {
 	public static final field RUM_FEATURE_NAME Ljava/lang/String;
 	public static final field SESSION_REPLAY_FEATURE_NAME Ljava/lang/String;
 	public static final field SESSION_REPLAY_RESOURCES_FEATURE_NAME Ljava/lang/String;
+	public static final field TRACING_CLIENT_STATS_FEATURE_NAME Ljava/lang/String;
 	public static final field TRACING_FEATURE_NAME Ljava/lang/String;
 }
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/Feature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/Feature.kt
@@ -60,6 +60,11 @@ interface Feature {
         const val TRACING_FEATURE_NAME: String = "tracing"
 
         /**
+         * Tracing Client Stats feature name.
+         */
+        const val TRACING_CLIENT_STATS_FEATURE_NAME: String = "tracing-client-stats"
+
+        /**
          * Session Replay feature name.
          */
         const val SESSION_REPLAY_FEATURE_NAME: String = "session-replay"

--- a/features/dd-sdk-android-trace-internal/api/dd-sdk-android-trace-internal.api
+++ b/features/dd-sdk-android-trace-internal/api/dd-sdk-android-trace-internal.api
@@ -2686,6 +2686,7 @@ public class com/datadog/trace/core/CoreTracer$CoreTracerBuilder {
 	public fun injectBaggageAsTags (Z)Lcom/datadog/trace/core/CoreTracer$CoreTracerBuilder;
 	public fun injector (Lcom/datadog/trace/core/propagation/HttpCodec$Injector;)Lcom/datadog/trace/core/CoreTracer$CoreTracerBuilder;
 	public fun localRootSpanTags (Ljava/util/Map;)Lcom/datadog/trace/core/CoreTracer$CoreTracerBuilder;
+	public fun metricsAggregator (Lcom/datadog/trace/common/metrics/MetricsAggregator;)Lcom/datadog/trace/core/CoreTracer$CoreTracerBuilder;
 	public fun partialFlushMinSpans (I)Lcom/datadog/trace/core/CoreTracer$CoreTracerBuilder;
 	public fun sampler (Lcom/datadog/trace/common/sampling/Sampler;)Lcom/datadog/trace/core/CoreTracer$CoreTracerBuilder;
 	public fun scopeManager (Lcom/datadog/trace/bootstrap/instrumentation/api/AgentScopeManager;)Lcom/datadog/trace/core/CoreTracer$CoreTracerBuilder;

--- a/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/core/CoreTracer.java
+++ b/features/dd-sdk-android-trace-internal/src/main/java/com/datadog/trace/core/CoreTracer.java
@@ -209,6 +209,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         private Config config;
         private String serviceName;
         private Writer writer = new NoOpWriter();
+        private MetricsAggregator metricsAggregator = NoOpMetricsAggregator.INSTANCE;
         private IdGenerationStrategy idGenerationStrategy;
         private Sampler sampler;
         private HttpCodec.Extractor extractor;
@@ -235,6 +236,11 @@ public class CoreTracer implements AgentTracer.TracerAPI {
 
         public CoreTracerBuilder writer(Writer writer) {
             this.writer = writer;
+            return this;
+        }
+
+        public CoreTracerBuilder metricsAggregator(MetricsAggregator metricsAggregator) {
+            this.metricsAggregator = metricsAggregator;
             return this;
         }
 
@@ -350,6 +356,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
                     config,
                     serviceName,
                     writer,
+                    metricsAggregator,
                     idGenerationStrategy,
                     sampler,
                     injector,
@@ -375,6 +382,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
             final Config config,
             final String serviceName,
             final Writer writer,
+            final MetricsAggregator metricsAggregator,
             final IdGenerationStrategy idGenerationStrategy,
             final Sampler sampler,
             final HttpCodec.Injector injector,
@@ -479,7 +487,7 @@ public class CoreTracer implements AgentTracer.TracerAPI {
         pendingTraceBuffer.start();
 
         this.writer.start();
-        metricsAggregator = NoOpMetricsAggregator.INSTANCE;
+        this.metricsAggregator = metricsAggregator;
         // Schedule the metrics aggregator to begin reporting after a random delay of 1 to 10 seconds
         // (using milliseconds granularity.) This avoids a fleet of traced applications starting at the
         // same time from sending metrics in sync.

--- a/features/dd-sdk-android-trace/api/apiSurface
+++ b/features/dd-sdk-android-trace/api/apiSurface
@@ -41,6 +41,7 @@ data class com.datadog.android.trace.TraceConfiguration
     fun setEventMapper(com.datadog.android.trace.event.SpanEventMapper): Builder
     fun setNetworkInfoEnabled(Boolean): Builder
     fun setStatsComputationEnabled(Boolean): Builder
+    fun useCustomStatsEndpoint(String): Builder
     fun build(): TraceConfiguration
 enum com.datadog.android.trace.TraceContextInjection
   - ALL

--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -68,8 +68,8 @@ public final class com/datadog/android/trace/Trace {
 }
 
 public final class com/datadog/android/trace/TraceConfiguration {
-	public final fun copy (Ljava/lang/String;Lcom/datadog/android/trace/event/SpanEventMapper;ZZ)Lcom/datadog/android/trace/TraceConfiguration;
-	public static synthetic fun copy$default (Lcom/datadog/android/trace/TraceConfiguration;Ljava/lang/String;Lcom/datadog/android/trace/event/SpanEventMapper;ZZILjava/lang/Object;)Lcom/datadog/android/trace/TraceConfiguration;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/trace/event/SpanEventMapper;ZZLjava/lang/String;)Lcom/datadog/android/trace/TraceConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/trace/TraceConfiguration;Ljava/lang/String;Lcom/datadog/android/trace/event/SpanEventMapper;ZZLjava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/trace/TraceConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -82,6 +82,7 @@ public final class com/datadog/android/trace/TraceConfiguration$Builder {
 	public final fun setNetworkInfoEnabled (Z)Lcom/datadog/android/trace/TraceConfiguration$Builder;
 	public final fun setStatsComputationEnabled (Z)Lcom/datadog/android/trace/TraceConfiguration$Builder;
 	public final fun useCustomEndpoint (Ljava/lang/String;)Lcom/datadog/android/trace/TraceConfiguration$Builder;
+	public final fun useCustomStatsEndpoint (Ljava/lang/String;)Lcom/datadog/android/trace/TraceConfiguration$Builder;
 }
 
 public final class com/datadog/android/trace/TraceContextInjection : java/lang/Enum {

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/DatadogTracing.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/DatadogTracing.kt
@@ -12,9 +12,11 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.trace.api.tracer.DatadogTracerBuilder
 import com.datadog.android.trace.api.tracer.NoOpDatadogTracerBuilder
+import com.datadog.android.trace.internal.ClientStatsFeature
 import com.datadog.android.trace.internal.DatadogSpanWriterWrapper
 import com.datadog.android.trace.internal.DatadogTracerBuilderAdapter
 import com.datadog.android.trace.internal._TraceInternalProxy
+import com.datadog.trace.common.metrics.NoOpMetricsAggregator
 import com.datadog.trace.common.writer.NoOpWriter
 import com.datadog.trace.core.CoreTracer
 
@@ -46,6 +48,13 @@ object DatadogTracing {
             val tracingFeature = sdkCore.getFeature(Feature.TRACING_FEATURE_NAME)?.unwrap<Feature>()
             val internalCoreWriterProvider = tracingFeature as? InternalCoreWriterProvider
             val writer = (internalCoreWriterProvider?.getCoreTracerWriter() as? DatadogSpanWriterWrapper)?.delegate
+
+            val metricsFeature = if (tracingFeature != null) {
+                sdkCore.getFeature(Feature.TRACING_CLIENT_STATS_FEATURE_NAME)?.unwrap<ClientStatsFeature>()
+            } else {
+                null
+            }
+            val internalMetricsAggregator = metricsFeature?.aggregator
 
             when {
                 null == tracingFeature -> internalLogger.log(
@@ -80,7 +89,9 @@ object DatadogTracing {
             DatadogTracerBuilderAdapter(
                 sdkCore = sdkCore,
                 serviceName = sdkCore.service,
-                delegate = CoreTracer.CoreTracerBuilder(sdkCore.internalLogger).writer(writer ?: NoOpWriter())
+                delegate = CoreTracer.CoreTracerBuilder(sdkCore.internalLogger)
+                    .writer(writer ?: NoOpWriter())
+                    .metricsAggregator(internalMetricsAggregator ?: NoOpMetricsAggregator.INSTANCE)
             )
         }
     }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/Trace.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/Trace.kt
@@ -9,6 +9,7 @@ package com.datadog.android.trace
 import com.datadog.android.Datadog
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.trace.internal.ClientStatsFeature
 import com.datadog.android.trace.internal.TracingFeature
 
 /**
@@ -34,5 +35,13 @@ object Trace {
         )
 
         sdkCore.registerFeature(tracingFeature)
+
+        if (traceConfiguration.statsComputationEnabled) {
+            val stats = ClientStatsFeature(
+                customEndpointUrl = traceConfiguration.customStatsEndpointUrl
+            )
+
+            sdkCore.registerFeature(stats)
+        }
     }
 }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/TraceConfiguration.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/TraceConfiguration.kt
@@ -16,7 +16,8 @@ data class TraceConfiguration internal constructor(
     internal val customEndpointUrl: String?,
     internal val eventMapper: SpanEventMapper,
     internal val networkInfoEnabled: Boolean,
-    internal val statsComputationEnabled: Boolean
+    internal val statsComputationEnabled: Boolean,
+    internal val customStatsEndpointUrl: String?
 ) {
 
     /**
@@ -27,6 +28,7 @@ data class TraceConfiguration internal constructor(
         private var spanEventMapper: SpanEventMapper = NoOpSpanEventMapper()
         private var networkInfoEnabled: Boolean = true
         private var statsComputationEnabled: Boolean = false
+        private var customStatsEndpointUrl: String? = null
 
         /**
          * Let the Tracing feature target a custom server.
@@ -72,6 +74,15 @@ data class TraceConfiguration internal constructor(
         }
 
         /**
+         * Let the Tracing client-side stats feature target a custom server.
+         * The provided url should be the full endpoint url, e.g.: https://example.com/stats/upload
+         */
+        fun useCustomStatsEndpoint(endpoint: String): Builder {
+            customStatsEndpointUrl = endpoint
+            return this
+        }
+
+        /**
          * Builds a [TraceConfiguration] based on the current state of this Builder.
          */
         fun build(): TraceConfiguration {
@@ -79,7 +90,8 @@ data class TraceConfiguration internal constructor(
                 customEndpointUrl = customEndpointUrl,
                 eventMapper = spanEventMapper,
                 networkInfoEnabled = networkInfoEnabled,
-                statsComputationEnabled = statsComputationEnabled
+                statsComputationEnabled = statsComputationEnabled,
+                customStatsEndpointUrl = customStatsEndpointUrl
             )
         }
     }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ClientStatsFeature.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ClientStatsFeature.kt
@@ -1,0 +1,39 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.internal
+
+import android.content.Context
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.StorageBackedFeature
+import com.datadog.android.api.storage.FeatureStorageConfiguration
+import com.datadog.android.trace.internal.net.ClientStatsRequestFactory
+import com.datadog.trace.common.metrics.NoOpMetricsAggregator
+
+internal class ClientStatsFeature(
+    customEndpointUrl: String?
+) : StorageBackedFeature {
+    override val name = Feature.TRACING_CLIENT_STATS_FEATURE_NAME
+
+    override val storageConfiguration = FeatureStorageConfiguration(
+        // 512 KB
+        maxItemSize = 512L * 1024,
+        maxItemsPerBatch = 4000,
+        // 15 MB
+        maxBatchSize = 15L * 1024 * 1024,
+        // 18 hours
+        oldBatchThreshold = 18L * 60L * 60L * 1000L
+    )
+
+    // TODO RUM-16565 Implement stats aggregator
+    internal val aggregator = NoOpMetricsAggregator()
+
+    override val requestFactory = ClientStatsRequestFactory(customEndpointUrl)
+
+    override fun onInitialize(appContext: Context) {}
+
+    override fun onStop() {}
+}

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ClientStatsRequestFactory.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ClientStatsRequestFactory.kt
@@ -1,0 +1,63 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.internal.net
+
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.net.Request
+import com.datadog.android.api.net.RequestExecutionContext
+import com.datadog.android.api.net.RequestFactory
+import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.trace.internal.domain.metrics.StatsPayload
+import java.util.UUID
+
+internal class ClientStatsRequestFactory(
+    internal val customStatsEndpointUrl: String?
+) : RequestFactory {
+
+    override fun create(
+        context: DatadogContext,
+        executionContext: RequestExecutionContext,
+        batchData: List<RawBatchEvent>,
+        batchMetadata: ByteArray?
+    ): Request {
+        val requestId = UUID.randomUUID().toString()
+
+        val baseUrl = customStatsEndpointUrl ?: (context.site.intakeEndpoint + "/api/v0.2/stats")
+        // Batches can't be split currently due to we can't create more than 1 Request in this class,
+        // nor can the batch building system report back when a batch will be filled before writing it,
+        // so we cant set a splitPayload flag in the batch's metadata.
+        val payload = StatsPayload(batchData.map { it.data }, splitPayload = false)
+
+        return Request(
+            id = requestId,
+            description = "Client Stats Request",
+            url = baseUrl,
+            headers = buildHeaders(
+                requestId,
+                context.clientToken,
+                context.source,
+                context.sdkVersion
+            ),
+            body = payload.toMsgPackPayload(),
+            contentType = "application/msgpack"
+        )
+    }
+
+    private fun buildHeaders(
+        requestId: String,
+        clientToken: String,
+        source: String,
+        sdkVersion: String
+    ): Map<String, String> {
+        return mapOf(
+            RequestFactory.HEADER_API_KEY to clientToken,
+            RequestFactory.HEADER_EVP_ORIGIN to source,
+            RequestFactory.HEADER_EVP_ORIGIN_VERSION to sdkVersion,
+            RequestFactory.HEADER_REQUEST_ID to requestId
+        )
+    }
+}

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/DatadogTracingTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/DatadogTracingTest.kt
@@ -14,11 +14,14 @@ import com.datadog.android.trace.DatadogTracing.ErrorMessages.TRACING_NOT_ENABLE
 import com.datadog.android.trace.DatadogTracing.ErrorMessages.WRITER_PROVIDER_INTERFACE_NOT_IMPLEMENTED_ERROR_MESSAGE
 import com.datadog.android.trace.DatadogTracing.ErrorMessages.buildWrongWrapperMessage
 import com.datadog.android.trace.api.span.DatadogSpanWriter
+import com.datadog.android.trace.internal.ClientStatsFeature
 import com.datadog.android.trace.internal.DatadogSpanWriterWrapper
 import com.datadog.android.trace.internal.DatadogTracerAdapter
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import com.datadog.tools.unit.getFieldValue
+import com.datadog.trace.common.metrics.MetricsAggregator
+import com.datadog.trace.common.metrics.NoOpMetricsAggregator
 import com.datadog.trace.common.writer.NoOpWriter
 import com.datadog.trace.common.writer.Writer
 import com.datadog.trace.core.CoreTracer
@@ -44,7 +47,7 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-class DatadogTracingTest {
+internal class DatadogTracingTest {
 
     @Mock
     lateinit var mockSdkCore: FeatureSdkCore
@@ -58,7 +61,13 @@ class DatadogTracingTest {
     lateinit var mockTracingFeature: FeatureScope
 
     @Mock
+    lateinit var mockStatsFeature: FeatureScope
+
+    @Mock
     lateinit var mockTracingFeatureScope: StubTracingFeature
+
+    @Mock
+    lateinit var mockStatsFeatureScope: ClientStatsFeature
 
     lateinit var fakeServiceName: String
 
@@ -73,6 +82,9 @@ class DatadogTracingTest {
         whenever(mockTracingFeature.unwrap<Feature>()) doReturn mockTracingFeatureScope
         whenever(mockSdkCore.getFeature(Feature.TRACING_FEATURE_NAME)) doReturn mockTracingFeature
         whenever(mockTracingFeatureScope.getCoreTracerWriter()) doReturn writerWrapperMock
+        whenever(mockSdkCore.getFeature(Feature.TRACING_CLIENT_STATS_FEATURE_NAME)) doReturn mockStatsFeature
+        whenever(mockStatsFeature.unwrap<Feature>()) doReturn mockStatsFeatureScope
+        whenever(mockStatsFeatureScope.aggregator) doReturn mock()
     }
 
     @Test
@@ -156,5 +168,44 @@ class DatadogTracingTest {
             InternalLogger.Target.USER,
             TRACING_NOT_ENABLED_ERROR_MESSAGE
         )
+    }
+
+    @Test
+    fun `M use a NoOpMetricsAggregator W build { TracingFeature not enabled }`() {
+        // Given
+        whenever(mockSdkCore.getFeature(Feature.TRACING_FEATURE_NAME)) doReturn null
+
+        // When
+        val tracer = DatadogTracing.newTracerBuilder(mockSdkCore).build() as DatadogTracerAdapter
+
+        // Then
+        val coreTracer = tracer.delegate as CoreTracer
+        val aggregator: MetricsAggregator = coreTracer.getFieldValue("metricsAggregator")
+        assertThat(aggregator).isInstanceOf(NoOpMetricsAggregator::class.java)
+    }
+
+    @Test
+    fun `M use a NoOpMetricsAggregator W build { ClientStatsFeature not enabled }`() {
+        // Given
+        whenever(mockSdkCore.getFeature(Feature.TRACING_CLIENT_STATS_FEATURE_NAME)) doReturn null
+
+        // When
+        val tracer = DatadogTracing.newTracerBuilder(mockSdkCore).build() as DatadogTracerAdapter
+
+        // Then
+        val coreTracer = tracer.delegate as CoreTracer
+        val aggregator: MetricsAggregator = coreTracer.getFieldValue("metricsAggregator")
+        assertThat(aggregator).isInstanceOf(NoOpMetricsAggregator::class.java)
+    }
+
+    @Test
+    fun `M use stats feature's MetricAggregator W build `() {
+        // When
+        val tracer = DatadogTracing.newTracerBuilder(mockSdkCore).build() as DatadogTracerAdapter
+
+        // Then
+        val coreTracer = tracer.delegate as CoreTracer
+        val aggregator: MetricsAggregator = coreTracer.getFieldValue("metricsAggregator")
+        assertThat(aggregator).isSameAs(mockStatsFeatureScope.aggregator)
     }
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TraceConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TraceConfigurationBuilderTest.kt
@@ -60,6 +60,7 @@ internal class TraceConfigurationBuilderTest {
             .isInstanceOf(NoOpSpanEventMapper::class.java)
         assertThat(traceConfiguration.networkInfoEnabled).isTrue()
         assertThat(traceConfiguration.statsComputationEnabled).isFalse()
+        assertThat(traceConfiguration.customStatsEndpointUrl).isNull()
     }
 
     @Test
@@ -114,5 +115,18 @@ internal class TraceConfigurationBuilderTest {
 
         // Then
         assertThat(config.statsComputationEnabled).isEqualTo(clientStats)
+    }
+
+    @Test
+    fun `M build configuration with custom stats site W useCustomStatsEndpoint() and build()`(
+        @StringForgery(regex = "https://[a-z]+\\.com(/[a-z]+)+") statsEndpointUrl: String
+    ) {
+        // When
+        val config = testedBuilder
+            .useCustomStatsEndpoint(statsEndpointUrl)
+            .build()
+
+        // Then
+        assertThat(config.customStatsEndpointUrl).isEqualTo(statsEndpointUrl)
     }
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TraceTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TraceTest.kt
@@ -6,7 +6,9 @@
 
 package com.datadog.android.trace
 
+import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.trace.internal.ClientStatsFeature
 import com.datadog.android.trace.internal.TracingFeature
 import com.datadog.android.trace.internal.net.TracesRequestFactory
 import com.datadog.android.utils.forge.Configurator
@@ -25,6 +27,7 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -46,12 +49,15 @@ internal class TraceTest {
     }
 
     @Test
-    fun `M register traces feature W enable()`(
+    fun `M register traces features W enable() { statsComputationEnabled = false }`(
         @StringForgery fakePackageName: String,
         @Forgery fakeTraceConfiguration: TraceConfiguration
     ) {
+        // Given
+        val config = fakeTraceConfiguration.copy(statsComputationEnabled = false)
+
         // When
-        Trace.enable(fakeTraceConfiguration, mockSdkCore)
+        Trace.enable(config, mockSdkCore)
 
         // Then
         argumentCaptor<TracingFeature> {
@@ -60,9 +66,38 @@ internal class TraceTest {
             lastValue.onInitialize(
                 appContext = mock { whenever(it.packageName) doReturn fakePackageName }
             )
-            assertThat(lastValue.spanEventMapper).isEqualTo(fakeTraceConfiguration.eventMapper)
+            assertThat(lastValue.spanEventMapper).isEqualTo(config.eventMapper)
             assertThat((lastValue.requestFactory as TracesRequestFactory).customEndpointUrl)
-                .isEqualTo(fakeTraceConfiguration.customEndpointUrl)
+                .isEqualTo(config.customEndpointUrl)
+        }
+    }
+
+    @Test
+    fun `M register traces features W enable() { statsComputationEnabled = true }`(
+        @StringForgery fakePackageName: String,
+        @Forgery fakeTraceConfiguration: TraceConfiguration
+    ) {
+        // Given
+        val config = fakeTraceConfiguration.copy(statsComputationEnabled = true)
+
+        // When
+        Trace.enable(config, mockSdkCore)
+
+        // Then
+        argumentCaptor<Feature> {
+            verify(mockSdkCore, times(2)).registerFeature(capture())
+
+            val tracingFeature = allValues.filterIsInstance<TracingFeature>().first()
+            tracingFeature.onInitialize(
+                appContext = mock { whenever(it.packageName) doReturn fakePackageName }
+            )
+            assertThat(tracingFeature.spanEventMapper).isEqualTo(config.eventMapper)
+            assertThat((tracingFeature.requestFactory as TracesRequestFactory).customEndpointUrl)
+                .isEqualTo(config.customEndpointUrl)
+
+            val statsFeature = allValues.filterIsInstance<ClientStatsFeature>().first()
+            assertThat(statsFeature.requestFactory.customStatsEndpointUrl)
+                .isEqualTo(config.customStatsEndpointUrl)
         }
     }
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ClientStatsRequestFactoryTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ClientStatsRequestFactoryTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.internal.net
+
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.net.RequestExecutionContext
+import com.datadog.android.api.net.RequestFactory
+import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.trace.internal.domain.metrics.StatsPayload
+import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class ClientStatsRequestFactoryTest {
+
+    private lateinit var testedFactory: ClientStatsRequestFactory
+
+    @Forgery
+    lateinit var fakeDatadogContext: DatadogContext
+
+    @BeforeEach
+    fun `set up`() {
+        testedFactory = ClientStatsRequestFactory(customStatsEndpointUrl = null)
+    }
+
+    @Test
+    fun `M create a proper request W create()`(
+        @Forgery batchData: List<RawBatchEvent>,
+        @StringForgery fakeMetadata: String,
+        @Forgery executionContext: RequestExecutionContext,
+        forge: Forge
+    ) {
+        // Given
+        val fakeBatchMetadata = forge.aNullable { fakeMetadata.toByteArray() }
+
+        // When
+        val request = testedFactory.create(fakeDatadogContext, executionContext, batchData, fakeBatchMetadata)
+
+        // Then
+        assertThat(request.url).isEqualTo("${fakeDatadogContext.site.intakeEndpoint}/api/v0.2/stats")
+        assertThat(request.contentType).isEqualTo("application/msgpack")
+        assertThat(request.headers.minus(RequestFactory.HEADER_REQUEST_ID)).isEqualTo(
+            mapOf(
+                RequestFactory.HEADER_API_KEY to fakeDatadogContext.clientToken,
+                RequestFactory.HEADER_EVP_ORIGIN to fakeDatadogContext.source,
+                RequestFactory.HEADER_EVP_ORIGIN_VERSION to fakeDatadogContext.sdkVersion
+            )
+        )
+        assertThat(request.headers[RequestFactory.HEADER_REQUEST_ID]).isNotEmpty()
+        assertThat(request.id).isEqualTo(request.headers[RequestFactory.HEADER_REQUEST_ID])
+        assertThat(request.description).isEqualTo("Client Stats Request")
+        assertThat(request.body).isEqualTo(
+            StatsPayload(batchData.map { it.data }, splitPayload = false).toMsgPackPayload()
+        )
+    }
+
+    @Test
+    fun `M create a proper request W create() { custom endpoint }`(
+        @StringForgery(regex = "https://[a-z]+\\.com(/[a-z]+)+") fakeEndpoint: String,
+        @Forgery batchData: List<RawBatchEvent>,
+        @StringForgery fakeMetadata: String,
+        @Forgery executionContext: RequestExecutionContext,
+        forge: Forge
+    ) {
+        // Given
+        testedFactory = ClientStatsRequestFactory(customStatsEndpointUrl = fakeEndpoint)
+        val fakeBatchMetadata = forge.aNullable { fakeMetadata.toByteArray() }
+
+        // When
+        val request = testedFactory.create(fakeDatadogContext, executionContext, batchData, fakeBatchMetadata)
+
+        // Then
+        assertThat(request.url).isEqualTo(fakeEndpoint)
+    }
+}

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/TraceConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/TraceConfigurationForgeryFactory.kt
@@ -17,7 +17,8 @@ class TraceConfigurationForgeryFactory : ForgeryFactory<TraceConfiguration> {
             customEndpointUrl = forge.aNullable { aStringMatching("https://[a-z]+\\.com") },
             eventMapper = mock(),
             networkInfoEnabled = forge.aBool(),
-            statsComputationEnabled = forge.aBool()
+            statsComputationEnabled = forge.aBool(),
+            customStatsEndpointUrl = forge.aNullable { aStringMatching("https://[a-z]+\\.com") }
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?
The client stats feature is wired into the CoreTracer via the MetricsAggregator interface defined in the internal tracer module. This is the same interface that dd-trace-java uses to implement the aggregation of client stats before submitting them to the agent, so it is already wired into the correct spot in CoreTracer (before span sampling occurs).

A new config value was also added so we can override the intake location for the stats intake, since it needs to be different than the /spans endpoint that the TraceConfiguration already configures.

### Motivation
Sets up the SDK feature for receiving the spans for client stats aggregation from CoreTracer

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

