### PR TITLE
RUM-15577: Write CUSTOM RUM actions immediately

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -597,8 +597,11 @@ internal open class RumViewScope(
         if (stopped) return
 
         if (event.type == RumActionType.CUSTOM && !event.waitForStop) {
-            // Custom actions are discrete events and must be written immediately, without waiting
-            // for an inactivity timeout. This also holds when another action is ongoing.
+            // Discrete custom actions (added via addAction(), i.e. waitForStop == false) are
+            // self-contained events: they must be written immediately, without waiting for an
+            // inactivity timeout or a subsequent event. This also holds when another action is
+            // ongoing. Continuous custom actions (startAction(), waitForStop == true) are not
+            // handled here: they stay open until stopAction() is called.
             val customActionScope = RumActionScope.fromEvent(
                 parentScope = this,
                 sdkCore = sdkCore,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -596,31 +596,32 @@ internal open class RumViewScope(
 
         if (stopped) return
 
+        if (event.type == RumActionType.CUSTOM && !event.waitForStop) {
+            // Custom actions are discrete events and must be written immediately, without waiting
+            // for an inactivity timeout. This also holds when another action is ongoing.
+            val customActionScope = RumActionScope.fromEvent(
+                parentScope = this,
+                sdkCore = sdkCore,
+                event = event,
+                timestampOffset = serverTimeOffsetInMs,
+                featuresContextResolver = featuresContextResolver,
+                trackFrustrations = trackFrustrations,
+                sampleRate = sampleRate,
+                rumSessionTypeOverride = rumSessionTypeOverride,
+                insightsCollector = insightsCollector
+            )
+            pendingActionCount++
+            customActionScope.handleEvent(RumRawEvent.SendCustomActionNow(), datadogContext, writeScope, writer)
+            return
+        }
+
         if (activeActionScope != null) {
-            if (event.type == RumActionType.CUSTOM && !event.waitForStop) {
-                // deliver it anyway, even if there is active action ongoing
-                val customActionScope = RumActionScope.fromEvent(
-                    parentScope = this,
-                    sdkCore = sdkCore,
-                    event = event,
-                    timestampOffset = serverTimeOffsetInMs,
-                    featuresContextResolver = featuresContextResolver,
-                    trackFrustrations = trackFrustrations,
-                    sampleRate = sampleRate,
-                    rumSessionTypeOverride = rumSessionTypeOverride,
-                    insightsCollector = insightsCollector
-                )
-                pendingActionCount++
-                customActionScope.handleEvent(RumRawEvent.SendCustomActionNow(), datadogContext, writeScope, writer)
-                return
-            } else {
-                sdkCore.internalLogger.log(
-                    InternalLogger.Level.WARN,
-                    InternalLogger.Target.USER,
-                    { ACTION_DROPPED_WARNING.format(Locale.US, event.type, event.name) }
-                )
-                return
-            }
+            sdkCore.internalLogger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.USER,
+                { ACTION_DROPPED_WARNING.format(Locale.US, event.type, event.name) }
+            )
+            return
         }
 
         activeActionScope = RumActionScope.fromEvent(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -2853,9 +2853,10 @@ internal class RumViewScopeTest {
 
     // region Action
 
-    @Test
-    fun `M create ActionScope W handleEvent(StartAction)`(
-        @Forgery type: RumActionType,
+    @ParameterizedTest
+    @EnumSource(RumActionType::class, names = ["CUSTOM"], mode = EnumSource.Mode.EXCLUDE)
+    fun `M create ActionScope W handleEvent(StartAction+!CUSTOM)`(
+        type: RumActionType,
         @StringForgery name: String,
         @BoolForgery waitForStop: Boolean,
         forge: Forge
@@ -2884,6 +2885,75 @@ internal class RumViewScopeTest {
         assertThat(actionScope.actionAttributes).containsAllEntriesOf(attributes)
         assertThat(actionScope.parentScope).isSameAs(testedScope)
         assertThat(actionScope.sampleRate).isCloseTo(fakeSampleRate, Assertions.offset(0.001f))
+    }
+
+    @Test
+    fun `M create ActionScope W handleEvent(StartAction+CUSTOM+cont)`(
+        @StringForgery name: String,
+        forge: Forge
+    ) {
+        // Given
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+
+        // When
+        val fakeStartActionEvent =
+            RumRawEvent.StartAction(RumActionType.CUSTOM, name, waitForStop = true, attributes)
+        val result = testedScope.handleEvent(
+            fakeStartActionEvent,
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then
+        verifyNoInteractions(mockWriter)
+        assertThat(result).isSameAs(testedScope)
+        assertThat(testedScope.activeActionScope).isInstanceOf(RumActionScope::class.java)
+        val actionScope = testedScope.activeActionScope as RumActionScope
+        assertThat(actionScope.name).isEqualTo(name)
+        assertThat(actionScope.eventTimestamp)
+            .isEqualTo(resolveExpectedTimestamp(fakeStartActionEvent.eventTime.timestamp))
+        assertThat(actionScope.waitForStop).isTrue()
+        assertThat(actionScope.actionAttributes).containsAllEntriesOf(attributes)
+        assertThat(actionScope.parentScope).isSameAs(testedScope)
+        assertThat(actionScope.sampleRate).isCloseTo(fakeSampleRate, Assertions.offset(0.001f))
+    }
+
+    @Test
+    fun `M send action immediately W handleEvent(StartAction+CUSTOM+instant) + no active ActionScope`(
+        @StringForgery name: String,
+        forge: Forge
+    ) {
+        // Given
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        fakeEvent = RumRawEvent.StartAction(RumActionType.CUSTOM, name, false, attributes)
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        argumentCaptor<ActionEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(firstValue)
+                .apply {
+                    hasNonNullId()
+                    hasType(RumActionType.CUSTOM)
+                    hasTargetName(name)
+                    hasResourceCount(0)
+                    hasErrorCount(0)
+                    hasCrashCount(0)
+                    hasLongTaskCount(0)
+                    hasView(testedScope.getRumContext())
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                    hasSampleRate(fakeSampleRate)
+                }
+        }
+        verifyNoMoreInteractions(mockWriter)
+
+        assertThat(result).isSameAs(testedScope)
+        assertThat(testedScope.activeActionScope).isNull()
+        assertThat(testedScope.pendingActionCount).isEqualTo(1)
     }
 
     @ParameterizedTest

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingRumTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingRumTest.kt
@@ -209,8 +209,6 @@ class ManualTrackingRumTest {
         // When
         rumMonitor.startView(viewKey, viewName)
         rumMonitor.addAction(RumActionType.CUSTOM, actionName)
-        stubSdkCore.advanceTimeBy(100)
-        // Used to trigger the action event
         rumMonitor.stopView(viewKey)
 
         // Then
@@ -254,7 +252,7 @@ class ManualTrackingRumTest {
                 hasDocumentVersion(2)
             }
             .hasRumEvent(index = 3) {
-                // View updated with FF
+                // View updated on stopView
                 hasService(stubSdkCore.getDatadogContext().service)
                 hasApplicationId(fakeApplicationId)
                 hasSessionType("user")
@@ -263,6 +261,89 @@ class ManualTrackingRumTest {
                 hasViewUrl(viewKey)
                 hasActionCount(1)
                 hasViewName(viewName)
+                hasDocumentVersion(3)
+            }
+    }
+
+    @Test
+    fun `M send view events with actions W startView() + multiple addAction()`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String,
+        @StringForgery actionName1: String,
+        @StringForgery actionName2: String
+    ) {
+        // Given
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        rumMonitor.startView(viewKey, viewName)
+        // Each CUSTOM action must be written immediately. In particular the last action
+        // must not be lost just because no further event triggers an inactivity timeout.
+        rumMonitor.addAction(RumActionType.CUSTOM, actionName1)
+        stubSdkCore.advanceTimeBy(1000)
+        rumMonitor.addAction(RumActionType.CUSTOM, actionName2)
+        stubSdkCore.advanceTimeBy(1000)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(5)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionCount(0)
+                hasDocumentVersion(1)
+            }
+            .hasRumEvent(index = 1) {
+                // First custom action
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("action")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionName(actionName1)
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with first action
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionCount(1)
+                hasDocumentVersion(2)
+            }
+            .hasRumEvent(index = 3) {
+                // Second custom action
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("action")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionName(actionName2)
+            }
+            .hasRumEvent(index = 4) {
+                // View updated with second action
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionCount(2)
                 hasDocumentVersion(3)
             }
     }

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingRumTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingRumTest.kt
@@ -280,9 +280,7 @@ class ManualTrackingRumTest {
         // Each CUSTOM action must be written immediately. In particular the last action
         // must not be lost just because no further event triggers an inactivity timeout.
         rumMonitor.addAction(RumActionType.CUSTOM, actionName1)
-        stubSdkCore.advanceTimeBy(1000)
         rumMonitor.addAction(RumActionType.CUSTOM, actionName2)
-        stubSdkCore.advanceTimeBy(1000)
 
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)


### PR DESCRIPTION
### What does this PR do?

Custom RUM actions (`addAction(CUSTOM, ...)`) are now written immediately instead of waiting on an inactivity timeout. Previously, a custom action with no subsequent event was never flushed and got lost.

### Motivation

Fixes RUM-15577. This also aligns Android with iOS, where discrete custom actions are sent instantly (regardless of whether another action is ongoing):

- [`RUMViewScope` routes `.custom` actions to an instant send](https://github.com/DataDog/dd-sdk-ios/blob/417c69393637ab9d6fc51fa350bcdfdfca4280af/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift#L301-L313)
- [`sendDiscreteCustomUserAction` flushes it immediately](https://github.com/DataDog/dd-sdk-ios/blob/417c69393637ab9d6fc51fa350bcdfdfca4280af/DatadogRUM/Sources/RUMMonitor/Scopes/RUMViewScope.swift#L460-L473)

### Additional Notes

Behavior change: a standalone custom action no longer aggregates resources/errors over the 100ms window; it becomes a discrete immediate event (matching iOS). Non-custom discrete actions (tap/scroll) are unchanged.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)
