### PR TITLE
refactor(flags): rename flag names to flag keys

### DIFF
--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/DatadogFlagsClient.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/DatadogFlagsClient.kt
@@ -82,7 +82,7 @@ internal class DatadogFlagsClient(
      *
      * If the flag cannot be found, is not a boolean, or an error occurs, the default value is returned.
      *
-     * @param flagKey The name of the flag to query. Cannot be null.
+     * @param flagKey The key of the flag to query. Cannot be null.
      * @param defaultValue The value to return if the flag cannot be found or resolved for any reason. Cannot be null.
      * @return The boolean value of the flag, or the default value if the flag cannot be resolved for any reason.
      */
@@ -94,7 +94,7 @@ internal class DatadogFlagsClient(
      *
      * If the flag cannot be found, is not a string, or an error occurs, the default value is returned.
      *
-     * @param flagKey The name of the flag to query. Cannot be null.
+     * @param flagKey The key of the flag to query. Cannot be null.
      * @param defaultValue The value to return if the flag cannot be found or resolved for any reason. Cannot be null.
      * @return The string value of the flag, or the default value if the flag cannot be resolved for any reason.
      */
@@ -105,7 +105,7 @@ internal class DatadogFlagsClient(
      *
      * If the flag cannot be found, is not an integer, or an error occurs, the default value is returned.
      *
-     * @param flagKey The name of the flag to query. Cannot be null.
+     * @param flagKey The key of the flag to query. Cannot be null.
      * @param defaultValue The value to return if the flag cannot be found or resolved for any reason. Cannot be null.
      * @return The integer value of the flag, or the default value if the flag cannot be resolved for any reason.
      */
@@ -116,7 +116,7 @@ internal class DatadogFlagsClient(
      *
      * If the flag cannot be found, is not a double, or an error occurs, the default value is returned.
      *
-     * @param flagKey The name of the flag to query. Cannot be null.
+     * @param flagKey The key of the flag to query. Cannot be null.
      * @param defaultValue The value to return if the flag cannot be found or resolved for any reason. Cannot be null.
      * @return The double value of the flag, or the default value if the flag cannot be resolved for any reason.
      */
@@ -127,7 +127,7 @@ internal class DatadogFlagsClient(
      *
      * If the flag cannot be found or an error occurs, the default value is returned.
      *
-     * @param flagKey The name of the flag to query. Cannot be null.
+     * @param flagKey The key of the flag to query. Cannot be null.
      * @param defaultValue The value to return if the flag cannot be found or resolved for any reason. Cannot be null.
      * @return The JSON object value of the flag, or the default value if the flag cannot be resolved for any reason.
      */
@@ -142,7 +142,7 @@ internal class DatadogFlagsClient(
      *
      * If the flag cannot be found or an error occurs, the default value is returned.
      *
-     * @param flagKey The name of the flag to query. Cannot be null.
+     * @param flagKey The key of the flag to query. Cannot be null.
      * @param defaultValue The map to return if the flag cannot be found or resolved.
      * @return The map value of the flag, or the default value if unavailable.
      */
@@ -155,7 +155,7 @@ internal class DatadogFlagsClient(
      * Resolves a flag value with detailed resolution information.
      *
      * @param T The type of the flag value (Boolean, String, Int, Double, or JSONObject).
-     * @param flagKey The name of the flag to query.
+     * @param flagKey The key of the flag to query.
      * @param defaultValue The value to return if the flag cannot be retrieved or parsed.
      * @return [ResolutionDetails] with either the parsed value and metadata, or an error.
      */
@@ -190,7 +190,7 @@ internal class DatadogFlagsClient(
      * of resolving a flag internally and then processing it through the tracking layer.
      *
      * @param T The type of the flag value
-     * @param flagKey The name of the flag to query
+     * @param flagKey The key of the flag to query
      * @param defaultValue The default value to return if resolution fails
      * @return The resolved value or the default value
      */
@@ -199,7 +199,7 @@ internal class DatadogFlagsClient(
 
     private fun writeExposureEvent(name: String, data: UnparsedFlag, context: EvaluationContext) {
         exposureProcessor.processEvent(
-            flagName = name,
+            flagKey = name,
             context = context,
             data = data
         )

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EventsProcessor.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/EventsProcessor.kt
@@ -12,5 +12,5 @@ import com.datadog.tools.annotation.NoOpImplementation
 
 @NoOpImplementation
 internal interface EventsProcessor {
-    fun processEvent(flagName: String, context: EvaluationContext, data: UnparsedFlag)
+    fun processEvent(flagKey: String, context: EvaluationContext, data: UnparsedFlag)
 }

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/ExposureEventsProcessor.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/ExposureEventsProcessor.kt
@@ -18,7 +18,7 @@ internal class ExposureEventsProcessor(private val writer: RecordWriter, private
 
     private data class CacheKey(
         val targetingKey: String,
-        val flagName: String,
+        val flagKey: String,
         val allocationKey: String,
         val variationKey: String
     )
@@ -32,7 +32,7 @@ internal class ExposureEventsProcessor(private val writer: RecordWriter, private
             // Boolean: ~1 byte
             val keySize = OBJECT_OVERHEAD +
                 (STRING_OVERHEAD + key.targetingKey.length * CHAR_SIZE) +
-                (STRING_OVERHEAD + key.flagName.length * CHAR_SIZE) +
+                (STRING_OVERHEAD + key.flagKey.length * CHAR_SIZE) +
                 (STRING_OVERHEAD + key.allocationKey.length * CHAR_SIZE) +
                 (STRING_OVERHEAD + key.variationKey.length * CHAR_SIZE)
             val valueSize = BOOLEAN_SIZE
@@ -40,10 +40,10 @@ internal class ExposureEventsProcessor(private val writer: RecordWriter, private
         }
     }
 
-    override fun processEvent(flagName: String, context: EvaluationContext, data: UnparsedFlag) {
+    override fun processEvent(flagKey: String, context: EvaluationContext, data: UnparsedFlag) {
         val cacheKey = CacheKey(
             targetingKey = context.targetingKey,
-            flagName = flagName,
+            flagKey = flagKey,
             allocationKey = data.allocationKey,
             variationKey = data.variationKey
         )
@@ -61,17 +61,17 @@ internal class ExposureEventsProcessor(private val writer: RecordWriter, private
         }
 
         if (isFirstTime) {
-            val event = buildExposureEvent(flagName, context, data)
+            val event = buildExposureEvent(flagKey, context, data)
             writeExposureEvent(event)
         }
     }
 
-    private fun buildExposureEvent(flagName: String, context: EvaluationContext, data: UnparsedFlag): ExposureEvent {
+    private fun buildExposureEvent(flagKey: String, context: EvaluationContext, data: UnparsedFlag): ExposureEvent {
         val now = timeProvider.getDeviceTimestampMillis()
         return ExposureEvent(
             timestamp = now,
             allocation = ExposureEvent.Identifier(data.allocationKey),
-            flag = ExposureEvent.Identifier(flagName),
+            flag = ExposureEvent.Identifier(flagKey),
             variant = ExposureEvent.Identifier(data.variationKey),
             subject = ExposureEvent.Subject(
                 id = context.targetingKey,

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/repository/net/PrecomputeMapper.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/repository/net/PrecomputeMapper.kt
@@ -27,10 +27,10 @@ internal class PrecomputeMapper(private val internalLogger: InternalLogger) {
 
         val flagsMap = mutableMapOf<String, PrecomputedFlag>()
 
-        val flagNames = flags.keys()
-        while (flagNames.hasNext()) {
-            val flagName = flagNames.next()
-            val flagData = flags.getJSONObject(flagName)
+        val flagKeys = flags.keys()
+        while (flagKeys.hasNext()) {
+            val flagKey = flagKeys.next()
+            val flagData = flags.getJSONObject(flagKey)
 
             val precomputedFlag = PrecomputedFlag(
                 variationType = flagData.getString(JsonKeys.VARIATION_TYPE.value),
@@ -47,7 +47,7 @@ internal class PrecomputeMapper(private val internalLogger: InternalLogger) {
                 reason = flagData.getString(JsonKeys.REASON.value)
             )
 
-            flagsMap[flagName] = precomputedFlag
+            flagsMap[flagKey] = precomputedFlag
         }
 
         flagsMap

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/FlagsClientTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/FlagsClientTest.kt
@@ -123,12 +123,12 @@ internal class FlagsClientTest {
 
     @Test
     fun `M return no-op default W get() + resolveBooleanValue() {no client registered for SDK core}`(
-        @StringForgery fakeFlagName: String,
+        @StringForgery fakeFlagKey: String,
         @BoolForgery fakeFlagDefaultValue: Boolean
     ) {
         // When
         val client = FlagsClient.get(sdkCore = mockSdkCore)
-        val result = client.resolveBooleanValue(fakeFlagName, fakeFlagDefaultValue)
+        val result = client.resolveBooleanValue(fakeFlagKey, fakeFlagDefaultValue)
 
         // Then
         assertThat(client).isInstanceOf(NoOpFlagsClient::class.java)

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/DatadogFlagsClientTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/DatadogFlagsClientTest.kt
@@ -678,7 +678,7 @@ internal class DatadogFlagsClientTest {
 
         // Verify exposure tracked
         verify(mockProcessor).processEvent(
-            flagName = eq(fakeFlagKey),
+            flagKey = eq(fakeFlagKey),
             context = eq(fakeContext),
             data = eq(fakeFlag)
         )
@@ -1099,7 +1099,7 @@ internal class DatadogFlagsClientTest {
         assertThat(result.value).isEqualTo(fakeFlagValue)
         // Verify exposure tracked for successful resolution
         verify(mockProcessor).processEvent(
-            flagName = eq(fakeFlagKey),
+            flagKey = eq(fakeFlagKey),
             context = eq(fakeContext),
             data = eq(fakeFlag)
         )
@@ -1304,7 +1304,7 @@ internal class DatadogFlagsClientTest {
         assertThat(result).isEqualTo(fakeFlagValue)
         // Verify that processor was called to write exposure event to backend
         verify(mockProcessor).processEvent(
-            flagName = eq(fakeFlagKey),
+            flagKey = eq(fakeFlagKey),
             context = eq(fakeEvaluationContext),
             data = eq(fakeFlag)
         )
@@ -1697,7 +1697,7 @@ internal class DatadogFlagsClientTest {
 
         // Then
         verify(mockProcessor).processEvent(
-            flagName = fakeFlagKey,
+            flagKey = fakeFlagKey,
             context = fakeContext,
             data = fakeFlag
         )
@@ -1727,7 +1727,7 @@ internal class DatadogFlagsClientTest {
 
         // Then
         verify(mockProcessor).processEvent(
-            flagName = fakeFlagKey,
+            flagKey = fakeFlagKey,
             context = fakeContext,
             data = fakeFlag
         )
@@ -1757,7 +1757,7 @@ internal class DatadogFlagsClientTest {
 
         // Then
         verify(mockProcessor).processEvent(
-            flagName = fakeFlagKey,
+            flagKey = fakeFlagKey,
             context = fakeContext,
             data = fakeFlag
         )
@@ -1787,7 +1787,7 @@ internal class DatadogFlagsClientTest {
 
         // Then
         verify(mockProcessor).processEvent(
-            flagName = fakeFlagKey,
+            flagKey = fakeFlagKey,
             context = fakeContext,
             data = fakeFlag
         )
@@ -1819,7 +1819,7 @@ internal class DatadogFlagsClientTest {
 
         // Then
         verify(mockProcessor).processEvent(
-            flagName = fakeFlagKey,
+            flagKey = fakeFlagKey,
             context = fakeContext,
             data = fakeFlag
         )
@@ -1929,7 +1929,7 @@ internal class DatadogFlagsClientTest {
 
         // Then
         verify(mockProcessor).processEvent(
-            flagName = fakeFlagKey,
+            flagKey = fakeFlagKey,
             context = fakeContext,
             data = fakeFlag
         )

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/ExposureEventsProcessorTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/ExposureEventsProcessorTest.kt
@@ -47,7 +47,7 @@ internal class ExposureEventsProcessorTest {
     var fakeTimestamp = 0L
 
     @StringForgery
-    lateinit var fakeFlagName: String
+    lateinit var fakeFlagKey: String
 
     @StringForgery
     lateinit var fakeTargetingKey: String
@@ -86,14 +86,14 @@ internal class ExposureEventsProcessorTest {
 
         // When
         whenever(mockTimeProvider.getDeviceTimestampMillis()) doReturn fakeTimestamp
-        testedProcessor.processEvent(fakeFlagName, fakeContext, fakeFlag)
+        testedProcessor.processEvent(fakeFlagKey, fakeContext, fakeFlag)
 
         // Then
         val eventCaptor = argumentCaptor<ExposureEvent>()
         verify(mockRecordWriter).write(eventCaptor.capture())
 
         val capturedEvent = eventCaptor.firstValue
-        assertThat(capturedEvent.flag.key).isEqualTo(fakeFlagName)
+        assertThat(capturedEvent.flag.key).isEqualTo(fakeFlagKey)
         assertThat(capturedEvent.allocation.key).isEqualTo(fakeAllocationKey)
         assertThat(capturedEvent.variant.key).isEqualTo(fakeVariationKey)
         assertThat(capturedEvent.subject.id).isEqualTo(fakeTargetingKey)
@@ -111,25 +111,25 @@ internal class ExposureEventsProcessorTest {
         )
 
         // When
-        testedProcessor.processEvent(fakeFlagName, fakeContext, fakeFlag)
-        testedProcessor.processEvent(fakeFlagName, fakeContext, fakeFlag) // Duplicate
+        testedProcessor.processEvent(fakeFlagKey, fakeContext, fakeFlag)
+        testedProcessor.processEvent(fakeFlagKey, fakeContext, fakeFlag) // Duplicate
 
         // Then
         verify(mockRecordWriter).write(any())
     }
 
     @Test
-    fun `M process different exposures W processEvent() { different flag names }`(forge: Forge) {
+    fun `M process different exposures W processEvent() { different flag keys }`(forge: Forge) {
         // Given
         val fakeContext = EvaluationContext(
             targetingKey = fakeTargetingKey,
             attributes = mapOf("user_id" to forge.anAlphabeticalString())
         )
-        val anotherFlagName = forge.anAlphabeticalString()
+        val anotherFlagKey = forge.anAlphabeticalString()
 
         // When
-        testedProcessor.processEvent(fakeFlagName, fakeContext, fakeFlag)
-        testedProcessor.processEvent(anotherFlagName, fakeContext, fakeFlag)
+        testedProcessor.processEvent(fakeFlagKey, fakeContext, fakeFlag)
+        testedProcessor.processEvent(anotherFlagKey, fakeContext, fakeFlag)
 
         // Then
         verify(mockRecordWriter, times(2)).write(any())
@@ -141,7 +141,7 @@ internal class ExposureEventsProcessorTest {
         val fakeContext = EvaluationContext(targetingKey = fakeTargetingKey)
 
         // When
-        testedProcessor.processEvent(fakeFlagName, fakeContext, fakeFlag)
+        testedProcessor.processEvent(fakeFlagKey, fakeContext, fakeFlag)
 
         // Then
         val eventCaptor = argumentCaptor<ExposureEvent>()
@@ -166,7 +166,7 @@ internal class ExposureEventsProcessorTest {
         )
 
         // When
-        testedProcessor.processEvent(fakeFlagName, fakeContext, fakeFlag)
+        testedProcessor.processEvent(fakeFlagKey, fakeContext, fakeFlag)
 
         // Then
         val eventCaptor = argumentCaptor<ExposureEvent>()
@@ -180,9 +180,9 @@ internal class ExposureEventsProcessorTest {
     }
 
     @Test
-    fun `M handle empty strings in parameters W processEvent() { empty flag name and keys }`() {
+    fun `M handle empty strings in parameters W processEvent() { empty flag key and keys }`() {
         // Given
-        val emptyFlagName = ""
+        val emptyFlagKey = ""
         val contextWithEmptyTargeting = EvaluationContext(
             targetingKey = "",
             attributes = mapOf("attr" to "value")
@@ -193,7 +193,7 @@ internal class ExposureEventsProcessorTest {
         )
 
         // When
-        testedProcessor.processEvent(emptyFlagName, contextWithEmptyTargeting, flagWithEmptyKeys)
+        testedProcessor.processEvent(emptyFlagKey, contextWithEmptyTargeting, flagWithEmptyKeys)
 
         // Then
         val eventCaptor = argumentCaptor<ExposureEvent>()
@@ -219,8 +219,8 @@ internal class ExposureEventsProcessorTest {
         )
 
         // When
-        testedProcessor.processEvent(fakeFlagName, context1, fakeFlag)
-        testedProcessor.processEvent(fakeFlagName, context2, fakeFlag)
+        testedProcessor.processEvent(fakeFlagKey, context1, fakeFlag)
+        testedProcessor.processEvent(fakeFlagKey, context2, fakeFlag)
 
         // Then
         verify(mockRecordWriter).write(any())
@@ -245,8 +245,8 @@ internal class ExposureEventsProcessorTest {
             .thenReturn(fakeTimestamp2)
 
         // When
-        testedProcessor.processEvent(fakeFlagName, fakeContext1, fakeFlag)
-        testedProcessor.processEvent(fakeFlagName, fakeContext2, fakeFlag)
+        testedProcessor.processEvent(fakeFlagKey, fakeContext1, fakeFlag)
+        testedProcessor.processEvent(fakeFlagKey, fakeContext2, fakeFlag)
 
         // Then
         val eventCaptor = argumentCaptor<ExposureEvent>()
@@ -265,12 +265,12 @@ internal class ExposureEventsProcessorTest {
     fun `M prevent cache collision W processEvent() { components with separator characters }`(forge: Forge) {
         // Given
         val targetingKey1 = "user|123"
-        val flagName1 = "feature"
+        val flagKey1 = "feature"
         val allocationKey1 = "allocation"
         val variationKey1 = "variation"
 
         val targetingKey2 = "user"
-        val flagName2 = "123|feature"
+        val flagKey2 = "123|feature"
         val allocationKey2 = "allocation"
         val variationKey2 = "variation"
 
@@ -298,8 +298,8 @@ internal class ExposureEventsProcessorTest {
         )
 
         // When
-        testedProcessor.processEvent(flagName1, context1, flag1)
-        testedProcessor.processEvent(flagName2, context2, flag2)
+        testedProcessor.processEvent(flagKey1, context1, flag1)
+        testedProcessor.processEvent(flagKey2, context2, flag2)
 
         // Then
         verify(mockRecordWriter, times(2)).write(any())
@@ -395,7 +395,7 @@ internal class ExposureEventsProcessorTest {
         testedProcessor.processEvent("flag1", context1, flag1) // New
         testedProcessor.processEvent("flag1", context1, flag1) // Duplicate
         testedProcessor.processEvent("flag1", context2, flag1) // Different context
-        testedProcessor.processEvent("flag2", context1, flag1) // Different flag name
+        testedProcessor.processEvent("flag2", context1, flag1) // Different flag key
         testedProcessor.processEvent("flag1", context1, flag2) // Different flag data
         testedProcessor.processEvent("flag1", context1, flag1) // Duplicate again
 
@@ -422,7 +422,7 @@ internal class ExposureEventsProcessorTest {
         val threads = (1..threadCount).map {
             Thread {
                 repeat(executionsPerThread) {
-                    testedProcessor.processEvent(fakeFlagName, context, flag)
+                    testedProcessor.processEvent(fakeFlagKey, context, flag)
                 }
             }
         }
@@ -484,7 +484,7 @@ internal class ExposureEventsProcessorTest {
         val processingThreads = (1..processingThreadCount).map {
             Thread {
                 repeat(executionsPerThread) {
-                    testedProcessor.processEvent(fakeFlagName, context, flag)
+                    testedProcessor.processEvent(fakeFlagKey, context, flag)
                 }
             }
         }

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/aggregation/EvaluationAggregationStatsTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/aggregation/EvaluationAggregationStatsTest.kt
@@ -44,7 +44,7 @@ internal class EvaluationAggregationStatsTest {
     lateinit var fakeAllocationKey: String
 
     @StringForgery
-    lateinit var fakeFlagName: String
+    lateinit var fakeFlagKey: String
 
     @StringForgery
     lateinit var fakeApplicationId: String
@@ -62,7 +62,7 @@ internal class EvaluationAggregationStatsTest {
     fun `set up`() {
         fakeContext = EvaluationContext(targetingKey = fakeTargetingKey)
         fakeEvaluationAggregationKey = EvaluationAggregationKey(
-            flagKey = fakeFlagName,
+            flagKey = fakeFlagKey,
             variantKey = fakeVariantKey,
             allocationKey = fakeAllocationKey,
             targetingKey = fakeTargetingKey,
@@ -87,7 +87,7 @@ internal class EvaluationAggregationStatsTest {
 
         // Then
         assertThat(event.timestamp).isEqualTo(fakeFirstTimestamp)
-        assertThat(event.flag.key).isEqualTo(fakeFlagName)
+        assertThat(event.flag.key).isEqualTo(fakeFlagKey)
         assertThat(event.variant?.key).isEqualTo(fakeVariantKey)
         assertThat(event.allocation?.key).isEqualTo(fakeAllocationKey)
         assertThat(event.targetingKey).isEqualTo(fakeTargetingKey)

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/persistence/SerializedFlagsStateAssert.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/persistence/SerializedFlagsStateAssert.kt
@@ -27,11 +27,11 @@ internal class SerializedFlagsStateAssert(actual: JSONObject) :
         return this
     }
 
-    fun hasFlag(flagName: String): SerializedFlagsStateAssert {
+    fun hasFlag(flagKey: String): SerializedFlagsStateAssert {
         val flags = actual.getJSONObject("flags")
-        assertThat(flags.has(flagName))
+        assertThat(flags.has(flagKey))
             .overridingErrorMessage(
-                "Expected flags to contain flag named $flagName"
+                "Expected flags to contain flag key $flagKey"
             )
             .isTrue()
         return this

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/net/PrecomputeMapperTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/net/PrecomputeMapperTest.kt
@@ -37,7 +37,7 @@ internal class PrecomputeMapperTest {
     lateinit var mockInternalLogger: InternalLogger
 
     @StringForgery
-    lateinit var fakeFlagName: String
+    lateinit var fakeFlagKey: String
 
     @StringForgery
     lateinit var fakeAllocationKey: String
@@ -72,7 +72,7 @@ internal class PrecomputeMapperTest {
         val fakeStringValue = "test-value"
         val json = buildValidJson(
             mapOf(
-                fakeFlagName to buildFlagJson(
+                fakeFlagKey to buildFlagJson(
                     variationType = VariationType.STRING.value,
                     variationValue = fakeStringValue
                 )
@@ -84,7 +84,7 @@ internal class PrecomputeMapperTest {
 
         // Then
         assertThat(result).hasSize(1)
-        val flag = result[fakeFlagName]
+        val flag = result[fakeFlagKey]
         checkNotNull(flag)
         assertThat(flag.variationType).isEqualTo(VariationType.STRING.value)
         assertThat(flag.variationValue).isEqualTo(fakeStringValue)
@@ -101,7 +101,7 @@ internal class PrecomputeMapperTest {
         // Given
         val json = buildValidJson(
             mapOf(
-                fakeFlagName to buildFlagJson(
+                fakeFlagKey to buildFlagJson(
                     variationType = VariationType.BOOLEAN.value,
                     variationValue = true
                 )
@@ -113,7 +113,7 @@ internal class PrecomputeMapperTest {
 
         // Then
         assertThat(result).hasSize(1)
-        val flag = result[fakeFlagName]
+        val flag = result[fakeFlagKey]
         checkNotNull(flag)
         assertThat(flag.variationType).isEqualTo(VariationType.BOOLEAN.value)
         assertThat(flag.variationValue).isEqualTo("true")
@@ -125,7 +125,7 @@ internal class PrecomputeMapperTest {
         // Given
         val json = buildValidJson(
             mapOf(
-                fakeFlagName to buildFlagJson(
+                fakeFlagKey to buildFlagJson(
                     variationType = VariationType.BOOLEAN.value,
                     variationValue = false
                 )
@@ -137,7 +137,7 @@ internal class PrecomputeMapperTest {
 
         // Then
         assertThat(result).hasSize(1)
-        val flag = result[fakeFlagName]
+        val flag = result[fakeFlagKey]
         checkNotNull(flag)
         assertThat(flag.variationType).isEqualTo(VariationType.BOOLEAN.value)
         assertThat(flag.variationValue).isEqualTo("false")
@@ -149,7 +149,7 @@ internal class PrecomputeMapperTest {
         // Given
         val json = buildValidJson(
             mapOf(
-                fakeFlagName to buildFlagJson(
+                fakeFlagKey to buildFlagJson(
                     variationType = VariationType.INTEGER.value,
                     variationValue = fakeIntValue
                 )
@@ -161,7 +161,7 @@ internal class PrecomputeMapperTest {
 
         // Then
         assertThat(result).hasSize(1)
-        val flag = result[fakeFlagName]
+        val flag = result[fakeFlagKey]
         checkNotNull(flag)
         assertThat(flag.variationType).isEqualTo(VariationType.INTEGER.value)
         assertThat(flag.variationValue).isEqualTo(fakeIntValue.toString())
@@ -173,7 +173,7 @@ internal class PrecomputeMapperTest {
         // Given
         val json = buildValidJson(
             mapOf(
-                fakeFlagName to buildFlagJson(
+                fakeFlagKey to buildFlagJson(
                     variationType = VariationType.NUMBER.value,
                     variationValue = fakeDoubleValue
                 )
@@ -185,7 +185,7 @@ internal class PrecomputeMapperTest {
 
         // Then
         assertThat(result).hasSize(1)
-        val flag = result[fakeFlagName]
+        val flag = result[fakeFlagKey]
         checkNotNull(flag)
         assertThat(flag.variationType).isEqualTo(VariationType.NUMBER.value)
         assertThat(flag.variationValue).isEqualTo(fakeDoubleValue.toString())
@@ -201,7 +201,7 @@ internal class PrecomputeMapperTest {
         }
         val json = buildValidJson(
             mapOf(
-                fakeFlagName to buildFlagJson(
+                fakeFlagKey to buildFlagJson(
                     variationType = VariationType.OBJECT.value,
                     variationValue = jsonValue
                 )
@@ -213,7 +213,7 @@ internal class PrecomputeMapperTest {
 
         // Then
         assertThat(result).hasSize(1)
-        val flag = result[fakeFlagName]
+        val flag = result[fakeFlagKey]
         checkNotNull(flag)
         assertThat(flag.variationType).isEqualTo(VariationType.OBJECT.value)
         assertThat(flag.variationValue).isEqualTo(jsonValue.toString())
@@ -229,7 +229,7 @@ internal class PrecomputeMapperTest {
         }
         val json = buildValidJsonWithExtraLogging(
             mapOf(
-                fakeFlagName to buildFlagJsonWithExtraLogging(
+                fakeFlagKey to buildFlagJsonWithExtraLogging(
                     variationType = VariationType.STRING.value,
                     variationValue = "test-value",
                     extraLogging = extraLogging
@@ -242,7 +242,7 @@ internal class PrecomputeMapperTest {
 
         // Then
         assertThat(result).hasSize(1)
-        val flag = result[fakeFlagName]
+        val flag = result[fakeFlagKey]
         checkNotNull(flag)
         assertThat(flag.extraLogging.toString()).isEqualTo(extraLogging.toString())
         verifyNoInteractions(mockInternalLogger)
@@ -251,21 +251,21 @@ internal class PrecomputeMapperTest {
     @Test
     fun `M parse multiple flags W map() { valid JSON with multiple flags }`(forge: Forge) {
         // Given
-        val flagName1 = forge.anAlphabeticalString()
-        val flagName2 = forge.anAlphabeticalString()
-        val flagName3 = forge.anAlphabeticalString()
+        val flagKey1 = forge.anAlphabeticalString()
+        val flagKey2 = forge.anAlphabeticalString()
+        val flagKey3 = forge.anAlphabeticalString()
 
         val json = buildValidJson(
             mapOf(
-                flagName1 to buildFlagJson(
+                flagKey1 to buildFlagJson(
                     variationType = VariationType.STRING.value,
                     variationValue = "value1"
                 ),
-                flagName2 to buildFlagJson(
+                flagKey2 to buildFlagJson(
                     variationType = VariationType.BOOLEAN.value,
                     variationValue = true
                 ),
-                flagName3 to buildFlagJson(
+                flagKey3 to buildFlagJson(
                     variationType = VariationType.INTEGER.value,
                     variationValue = 42
                 )
@@ -277,16 +277,16 @@ internal class PrecomputeMapperTest {
 
         // Then
         assertThat(result).hasSize(3)
-        assertThat(result).containsKeys(flagName1, flagName2, flagName3)
+        assertThat(result).containsKeys(flagKey1, flagKey2, flagKey3)
 
-        assertThat(result[flagName1]!!.variationType).isEqualTo(VariationType.STRING.value)
-        assertThat(result[flagName1]!!.variationValue).isEqualTo("value1")
+        assertThat(result[flagKey1]!!.variationType).isEqualTo(VariationType.STRING.value)
+        assertThat(result[flagKey1]!!.variationValue).isEqualTo("value1")
 
-        assertThat(result[flagName2]!!.variationType).isEqualTo(VariationType.BOOLEAN.value)
-        assertThat(result[flagName2]!!.variationValue).isEqualTo("true")
+        assertThat(result[flagKey2]!!.variationType).isEqualTo(VariationType.BOOLEAN.value)
+        assertThat(result[flagKey2]!!.variationValue).isEqualTo("true")
 
-        assertThat(result[flagName3]!!.variationType).isEqualTo(VariationType.INTEGER.value)
-        assertThat(result[flagName3]!!.variationValue).isEqualTo("42")
+        assertThat(result[flagKey3]!!.variationType).isEqualTo(VariationType.INTEGER.value)
+        assertThat(result[flagKey3]!!.variationValue).isEqualTo("42")
 
         verifyNoInteractions(mockInternalLogger)
     }
@@ -414,7 +414,7 @@ internal class PrecomputeMapperTest {
         val jsonWithIncompleteFlag = JSONObject().data {
             attributes {
                 flags {
-                    flag(fakeFlagName) {
+                    flag(fakeFlagKey) {
                         put("variationType", VariationType.STRING)
                         // Missing other required fields
                     }
@@ -469,7 +469,7 @@ internal class PrecomputeMapperTest {
         val json = JSONObject().data {
             attributes {
                 flags {
-                    flag(fakeFlagName) {
+                    flag(fakeFlagKey) {
                         put("variationType", VariationType.STRING.value)
                         put("variationValue", JSONObject.NULL)
                         put("doLog", fakeDoLog)
@@ -487,7 +487,7 @@ internal class PrecomputeMapperTest {
 
         // Then
         assertThat(result).hasSize(1)
-        val flag = result[fakeFlagName]
+        val flag = result[fakeFlagKey]
         checkNotNull(flag)
         assertThat(flag.variationValue).isEqualTo("null")
         verifyNoInteractions(mockInternalLogger)


### PR DESCRIPTION
## Motivation

Feature flag identifiers are keys, not display names. The Android flags implementation already exposes `flagKey` in the public `FlagsClient` API, but some internal processor, mapper, and test code still used `flagName` terminology.

## Changes

- Rename remaining `flagName`/`flagNames` identifiers in `dd-sdk-android-flags` internals to `flagKey`/`flagKeys`.
- Update exposure processor cache-key field naming and precompute mapper locals.
- Update feature-flags tests, helpers, assertions, and KDoc to use flag key terminology.

## Decisions

- No behavior changes. This is a naming-only cleanup.
- No public API changes: the public flags API already uses `flagKey`.
- Scoped to `features/dd-sdk-android-flags`; RUM feature flag evaluation APIs and tests still use their existing `name`/`flagName` vocabulary and are left untouched in this PR.