### PR TITLE
Fix Detekt stackoverflow on wildcard projections

### DIFF
--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/ext/KotlinTypeExt.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/ext/KotlinTypeExt.kt
@@ -31,7 +31,7 @@ internal fun KotlinType.fqTypeName(
     val arguments = if (getArguments().isNotEmpty()) {
         if (includeTypeArguments) {
             arguments.joinToString(", ", prefix = "<", postfix = ">") {
-                it.type.fqTypeName(treatGenericAsSuper)
+                if (it.isStarProjection) "*" else it.type.fqTypeName(treatGenericAsSuper)
             }
         } else {
             ""


### PR DESCRIPTION
### What does this PR do?
Fix detekt failing with a stack overflow on methods such as `fun publish(trace: List<CoreSpan<*>>?): Boolean`

### Motivation
Fixes
```
datadog/android/trace/internal/domain/metrics/ClientStatsAdapter.kt led to an exception.
Location: java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315)
The original exception message was: java.lang.StackOverflowError
Running detekt '1.23.8' on Java '17.0.19+10-LTS' on OS 'Mac OS X'
If the exception message does not help, please feel free to create an issue on our GitHub page.
        at io.gitlab.arturbosch.detekt.core.AnalyzerKt.throwIllegalStateException(Analyzer.kt:185)
        at io.gitlab.arturbosch.detekt.core.AnalyzerKt.access$throwIllegalStateException(Analyzer.kt:1)
        at io.gitlab.arturbosch.detekt.core.Analyzer.runAsync$lambda$9$lambda$8(Analyzer.kt:93)
        at io.gitlab.arturbosch.detekt.core.TaskPoolKt.recover$lambda$1(TaskPool.kt:14)
        at java.base/java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:990)
        ... 6 more
Caused by: java.util.concurrent.CompletionException: java.lang.StackOverflowError
        at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315)
        at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1770)
        ... 3 more
Caused by: java.lang.StackOverflowError
        at org.jetbrains.kotlin.types.ClassifierBasedTypeConstructor.equals(ClassifierBasedTypeConstructor.kt:40)
        at java.base/java.util.ArrayList.indexOfRange(ArrayList.java:299)
        at java.base/java.util.ArrayList.indexOf(ArrayList.java:286)
        at java.base/java.util.ArrayList.contains(ArrayList.java:275)
        at org.jetbrains.kotlin.types.StarProjectionImplKt$buildStarProjectionTypeByTypeParameters$1.get(StarProjectionImpl.kt:55)
        at org.jetbrains.kotlin.types.TypeConstructorSubstitution.get(TypeSubstitution.kt:64)
        at org.jetbrains.kotlin.types.TypeSubstitutor.unsafeSubstitute(TypeSubstitutor.java:206)
        at org.jetbrains.kotlin.types.TypeSubstitutor.unsafeSubstitute(TypeSubstitutor.java:216)
        at org.jetbrains.kotlin.types.TypeSubstitutor.substituteWithoutApproximation(TypeSubstitutor.java:164)
        at org.jetbrains.kotlin.types.TypeSubstitutor.substitute(TypeSubstitutor.java:149)
        at org.jetbrains.kotlin.types.TypeSubstitutor.substitute(TypeSubstitutor.java:143)
        at org.jetbrains.kotlin.types.StarProjectionImplKt.buildStarProjectionTypeByTypeParameters(StarProjectionImpl.kt:60)
        at org.jetbrains.kotlin.types.StarProjectionImplKt.starProjectionType(StarProjectionImpl.kt:65)
        at org.jetbrains.kotlin.types.StarProjectionImpl._type_delegate$lambda$0(StarProjectionImpl.kt:35)
        at kotlin.SafePublicationLazyImpl.getValue(LazyJVM.kt:107)
        at org.jetbrains.kotlin.types.StarProjectionImpl.get_type(StarProjectionImpl.kt:34)
        at org.jetbrains.kotlin.types.StarProjectionImpl.getType(StarProjectionImpl.kt:38)
        at com.datadog.tools.detekt.ext.KotlinTypeExtKt$fqTypeName$arguments$1.invoke(KotlinTypeExt.kt:34)
        at com.datadog.tools.detekt.ext.KotlinTypeExtKt$fqTypeName$arguments$1.invoke(KotlinTypeExt.kt:33)
        at kotlin.text.StringsKt__AppendableKt.appendElement(Appendable.kt:84)
        at kotlin.collections.CollectionsKt___CollectionsKt.joinTo(_Collections.kt:3493)
        at kotlin.collections.CollectionsKt___CollectionsKt.joinToString(_Collections.kt:3510)
        at kotlin.collections.CollectionsKt___CollectionsKt.joinToString$default(_Collections.kt:3509)
        at com.datadog.tools.detekt.ext.KotlinTypeExtKt.fqTypeName(KotlinTypeExt.kt:33)
        at com.datadog.tools.detekt.ext.KotlinTypeExtKt.fqTypeName$default(KotlinTypeExt.kt:16)
        at com.datadog.tools.detekt.ext.KotlinTypeExtKt$fqTypeName$arguments$1.invoke(KotlinTypeExt.kt:34)
        at com.datadog.tools.detekt.ext.KotlinTypeExtKt$fqTypeName$arguments$1.invoke(KotlinTypeExt.kt:33)
        at kotlin.text.StringsKt__AppendableKt.appendElement(Appendable.kt:84)
        at kotlin.collections.CollectionsKt___CollectionsKt.joinTo(_Collections.kt:3493)
        at kotlin.collections.CollectionsKt___CollectionsKt.joinToString(_Collections.kt:3510)
        at kotlin.collections.CollectionsKt___CollectionsKt.joinToString$default(_Collections.kt:3509)
        at com.datadog.tools.detekt.ext.KotlinTypeExtKt.fqTypeName(KotlinTypeExt.kt:33)
        at com.datadog.tools.detekt.ext.KotlinTypeExtKt.fqTypeName$default(KotlinTypeExt.kt:16)
        at com.datadog.tools.detekt.ext.KotlinTypeExtKt$fqTypeName$arguments$1.invoke(KotlinTypeExt.kt:34)
        at com.datadog.tools.detekt.ext.KotlinTypeExtKt$fqTypeName$arguments$1.invoke(KotlinTypeExt.kt:33)
        at kotlin.text.StringsKt__AppendableKt.appendElement(Appendable.kt:84)
        at kotlin.collections.CollectionsKt___CollectionsKt.joinTo(_Collections.kt:3493)
        at kotlin.collections.CollectionsKt___CollectionsKt.joinToString(_Collections.kt:3510)
        at kotlin.collections.CollectionsKt___CollectionsKt.joinToString$default(_Collections.kt:3509)
        at com.datadog.tools.detekt.ext.KotlinTypeExtKt.fqTypeName(KotlinTypeExt.kt:33)
        at com.datadog.tools.detekt.ext.KotlinTypeExtKt.fqTypeName$default(KotlinTypeExt.kt:16)
        at com.datadog.tools.detekt.ext.KotlinTypeExtKt$fqTypeName$arguments$1.invoke(KotlinTypeExt.kt:34)
        at com.datadog.tools.detekt.ext.KotlinTypeExtKt$fqTypeName$arguments$1.invoke(KotlinTypeExt.kt:33)
        at kotlin.text.StringsKt__AppendableKt.appendElement(Appendable.kt:84)
```