### PR TITLE
RUM-16637: Report Profiling system package version and client clock drift

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/AndroidManifest.xml
+++ b/features/dd-sdk-android-profiling/src/main/AndroidManifest.xml
@@ -6,6 +6,10 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <queries>
+        <package android:name="com.google.android.profiling" />
+    </queries>
+
     <application>
 
         <provider

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/Profiling.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/Profiling.kt
@@ -19,6 +19,7 @@ import com.datadog.android.profiling.internal.ProfilingFeature
 import com.datadog.android.profiling.internal.ProfilingStartReason
 import com.datadog.android.profiling.internal.ProfilingStorage
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
+import com.datadog.android.profiling.internal.time.MutableTimeProvider
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -107,7 +108,7 @@ object Profiling {
     private fun initializeProfiler() {
         if (!isProfilerInitialized.getAndSet(true)) {
             profiler = PerfettoProfiler(
-                timeProvider = DefaultTimeProvider(),
+                timeProvider = MutableTimeProvider.create(DefaultTimeProvider()),
                 scheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
             )
         }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/NoOpProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/NoOpProfiler.kt
@@ -8,6 +8,8 @@ package com.datadog.android.profiling.internal
 
 import android.content.Context
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.internal.time.DefaultTimeProvider
+import com.datadog.android.profiling.internal.time.MutableTimeProvider
 import java.util.concurrent.Callable
 import java.util.concurrent.Future
 import java.util.concurrent.ScheduledExecutorService
@@ -15,6 +17,7 @@ import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
 internal class NoOpProfiler : Profiler {
+    override val timeProvider: MutableTimeProvider = MutableTimeProvider.create(DefaultTimeProvider())
     override var internalLogger: InternalLogger? = null
     override val scheduledExecutorService: ScheduledExecutorService = NoOpScheduledExecutorService()
 
@@ -24,11 +27,9 @@ internal class NoOpProfiler : Profiler {
         additionalAttributes: Map<String, String>,
         sdkInstanceNames: Set<String>,
         durationMs: Int
-    ) {
-    }
+    ) = Unit
 
-    override fun stop(sdkInstanceName: String) {
-    }
+    override fun stop(sdkInstanceName: String) = Unit
 
     override fun isRunning(sdkInstanceName: String): Boolean = false
 
@@ -36,14 +37,13 @@ internal class NoOpProfiler : Profiler {
         appContext: Context,
         sdkInstanceName: String,
         callback: ProfilerCallback
-    ) {
-    }
+    ) = Unit
 
-    override fun unregisterProfilingCallback(appContext: Context, sdkInstanceName: String) {
-    }
+    override fun unregisterProfilingCallback(appContext: Context, sdkInstanceName: String) = Unit
 
-    override fun setExtendLaunchSession(extend: Boolean) {
-    }
+    override fun setExtendLaunchSession(extend: Boolean) = Unit
+
+    override fun setProfilingPackageVersionCode(versionCode: Long) = Unit
 
     class NoOpScheduledExecutorService : ScheduledExecutorService {
         override fun schedule(

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/Profiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/Profiler.kt
@@ -8,9 +8,12 @@ package com.datadog.android.profiling.internal
 
 import android.content.Context
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.profiling.internal.time.MutableTimeProvider
 import java.util.concurrent.ScheduledExecutorService
 
 internal interface Profiler {
+
+    val timeProvider: MutableTimeProvider
 
     var internalLogger: InternalLogger?
 
@@ -38,4 +41,6 @@ internal interface Profiler {
      * so the launch window merges into the first continuous cycle.
      */
     fun setExtendLaunchSession(extend: Boolean)
+
+    fun setProfilingPackageVersionCode(versionCode: Long)
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -27,6 +27,7 @@ import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.profiling.ExperimentalProfilingApi
 import com.datadog.android.profiling.ProfilingConfiguration
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
+import com.datadog.android.profiling.internal.utils.getProfilingModuleLongVersionCode
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -78,6 +79,10 @@ internal class ProfilingFeature(
         this.appContext = appContext
         profiler.apply {
             this.internalLogger = sdkCore.internalLogger
+            this.timeProvider.delegate = sdkCore.timeProvider
+            setProfilingPackageVersionCode(
+                appContext.packageManager.getProfilingModuleLongVersionCode(sdkCore.internalLogger)
+            )
             registerProfilingCallback(appContext, sdkCore.name, this@ProfilingFeature)
         }
         setMinimumSampleRate(appContext, configuration.applicationLaunchSampleRate)

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/anr/AnrProfilingTriggerRegistrar.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/anr/AnrProfilingTriggerRegistrar.kt
@@ -138,6 +138,7 @@ internal class AnrProfilingTriggerRegistrar(
                 errorMessage = result.errorMessage,
                 fileSize = fileSize,
                 callbackDelayMs = callbackDelayMs,
+                clientClockDriftMs = timeProvider.getServerOffsetMillis(),
                 droppedAsStale = droppedAsStale
             )
         )

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
@@ -17,7 +17,6 @@ import androidx.core.os.requestProfiling
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.utils.scheduleSafe
 import com.datadog.android.internal.system.BuildSdkVersionProvider
-import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.profiling.internal.Profiler
 import com.datadog.android.profiling.internal.ProfilerCallback
 import com.datadog.android.profiling.internal.ProfilingStartReason
@@ -26,9 +25,9 @@ import com.datadog.android.profiling.internal.anr.AnrProfilingTriggerRegistrar
 import com.datadog.android.profiling.internal.anr.AnrTriggerRegistrar
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetry
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetryEvent
+import com.datadog.android.profiling.internal.time.MutableTimeProvider
 import com.datadog.android.profiling.internal.utils.fileSizeSafe
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
@@ -51,8 +50,8 @@ import kotlin.random.Random
  */
 @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
 internal class PerfettoProfiler(
-    private val timeProvider: TimeProvider,
-    override val scheduledExecutorService: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor(),
+    override val timeProvider: MutableTimeProvider,
+    override val scheduledExecutorService: ScheduledExecutorService,
     internal val profilingTelemetry: ProfilingTelemetry = ProfilingTelemetry(),
     internal val anrTriggerRegistrar: AnrTriggerRegistrar =
         AnrProfilingTriggerRegistrar(timeProvider, scheduledExecutorService, profilingTelemetry),
@@ -139,6 +138,7 @@ internal class PerfettoProfiler(
                     fileSize = fileSizeSafe(result.resultFilePath, internalLogger),
                     durationMs = duration,
                     resultCallbackDelayMs = resultCallbackDelayMs,
+                    clientClockDriftMs = timeProvider.getServerOffsetMillis(),
                     stopReason = resolveStopReason(result.errorCode),
                     bufferSizeKb = BUFFER_SIZE_KB,
                     samplingFrequencyHz = profilingSamplingRateHz
@@ -260,6 +260,10 @@ internal class PerfettoProfiler(
 
     override fun setExtendLaunchSession(extend: Boolean) {
         this.extendLaunchSession = extend
+    }
+
+    override fun setProfilingPackageVersionCode(versionCode: Long) {
+        profilingTelemetry.profilingPackageVersionCode = versionCode
     }
 
     private fun resolveStopReason(errorCode: Int): String {

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/telemetry/ProfilingTelemetry.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/telemetry/ProfilingTelemetry.kt
@@ -14,6 +14,7 @@ internal class ProfilingTelemetry {
     private val lock = Any()
     private val pendingEvents: MutableList<ProfilingTelemetryEvent> = mutableListOf()
 
+    @Volatile
     var internalLogger: InternalLogger? = null
         set(value) {
             val toFlush: List<ProfilingTelemetryEvent>
@@ -29,6 +30,9 @@ internal class ProfilingTelemetry {
             }
             value?.let { logger -> toFlush.forEach { dispatch(logger, it) } }
         }
+
+    @Volatile
+    var profilingPackageVersionCode: Long = 0L
 
     fun report(event: ProfilingTelemetryEvent) {
         val logger = synchronized(lock) {
@@ -63,6 +67,7 @@ internal class ProfilingTelemetry {
                     KEY_START_REASON to event.startReason,
                     KEY_DURATION to event.durationMs,
                     KEY_CALLBACK_DELAY to event.resultCallbackDelayMs,
+                    KEY_CLIENT_CLOCK_DRIFT to event.clientClockDriftMs,
                     KEY_ERROR_MESSAGE to event.errorMessage,
                     KEY_FILE_SIZE to event.fileSize,
                     KEY_STOPPED_REASON to event.stopReason,
@@ -70,7 +75,8 @@ internal class ProfilingTelemetry {
                 ),
                 KEY_PROFILING_CONFIG to mapOf(
                     KEY_BUFFER_SIZE to event.bufferSizeKb,
-                    KEY_SAMPLING_FREQUENCY to event.samplingFrequencyHz
+                    KEY_SAMPLING_FREQUENCY to event.samplingFrequencyHz,
+                    KEY_PROFILING_PACKAGE_VERSION_CODE to profilingPackageVersionCode
                 )
             ),
             samplingRate = MethodCallSamplingRate.ALL.rate
@@ -91,7 +97,11 @@ internal class ProfilingTelemetry {
                     KEY_ERROR_MESSAGE to event.errorMessage,
                     KEY_FILE_SIZE to event.fileSize,
                     KEY_CALLBACK_DELAY to event.callbackDelayMs,
+                    KEY_CLIENT_CLOCK_DRIFT to event.clientClockDriftMs,
                     KEY_DROPPED_AS_STALE to event.droppedAsStale
+                ),
+                KEY_PROFILING_CONFIG to mapOf(
+                    KEY_PROFILING_PACKAGE_VERSION_CODE to profilingPackageVersionCode
                 )
             ),
             samplingRate = MethodCallSamplingRate.ALL.rate
@@ -111,6 +121,8 @@ internal class ProfilingTelemetry {
         internal const val KEY_START_REASON = "start_reason"
         internal const val KEY_DURATION = "duration"
         internal const val KEY_CALLBACK_DELAY = "callback_delay_ms"
+        internal const val KEY_CLIENT_CLOCK_DRIFT = "client_clock_drift_ms"
+        internal const val KEY_PROFILING_PACKAGE_VERSION_CODE = "profiling_package_version_code"
         internal const val KEY_STOPPED_REASON = "stopped_reason"
         internal const val KEY_APP_START_INFO = "app_start_info"
         internal const val KEY_BUFFER_SIZE = "buffer_size"

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/telemetry/ProfilingTelemetryEvent.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/telemetry/ProfilingTelemetryEvent.kt
@@ -16,6 +16,7 @@ internal sealed class ProfilingTelemetryEvent {
         val fileSize: Long,
         val durationMs: Long,
         val resultCallbackDelayMs: Long,
+        val clientClockDriftMs: Long,
         val stopReason: String,
         val bufferSizeKb: Int,
         val samplingFrequencyHz: Int
@@ -26,6 +27,7 @@ internal sealed class ProfilingTelemetryEvent {
         val errorMessage: String?,
         val fileSize: Long,
         val callbackDelayMs: Long?,
+        val clientClockDriftMs: Long,
         val droppedAsStale: Boolean
     ) : ProfilingTelemetryEvent()
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/time/MutableTimeProvider.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/time/MutableTimeProvider.kt
@@ -1,0 +1,35 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling.internal.time
+
+import com.datadog.android.internal.time.TimeProvider
+
+/**
+ * This is a terrible hack just to handle the fact that [com.datadog.android.profiling.internal.perfetto
+ * .PerfettoProfiler] can be created when Datadog SDK is not yet initialized.
+ */
+internal interface MutableTimeProvider : TimeProvider {
+    var delegate: TimeProvider
+
+    private class MutableTimeProviderImpl(@Volatile override var delegate: TimeProvider) : MutableTimeProvider {
+        override fun getDeviceTimestampMillis(): Long = delegate.getDeviceTimestampMillis()
+
+        override fun getServerTimestampMillis(): Long = delegate.getServerTimestampMillis()
+
+        override fun getDeviceElapsedTimeNanos(): Long = delegate.getDeviceElapsedTimeNanos()
+
+        override fun getServerOffsetNanos(): Long = delegate.getServerOffsetNanos()
+
+        override fun getServerOffsetMillis(): Long = delegate.getServerOffsetMillis()
+
+        override fun getDeviceElapsedRealtimeMillis(): Long = delegate.getDeviceElapsedRealtimeMillis()
+    }
+
+    companion object {
+        fun create(delegate: TimeProvider): MutableTimeProvider = MutableTimeProviderImpl(delegate)
+    }
+}

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/utils/PackageManagerExt.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/utils/PackageManagerExt.kt
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling.internal.utils
+
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.datadog.android.api.InternalLogger
+
+@RequiresApi(Build.VERSION_CODES.Q)
+internal fun PackageManager.getProfilingModuleLongVersionCode(internalLogger: InternalLogger): Long {
+    val packageInfo = try {
+        getPackageInfo("com.google.android.profiling", PackageManager.MATCH_APEX)
+    } catch (e: PackageManager.NameNotFoundException) {
+        internalLogger.log(
+            level = InternalLogger.Level.ERROR,
+            target = InternalLogger.Target.MAINTAINER,
+            messageBuilder = { "System package com.google.android.profiling is not found" },
+            throwable = e
+        )
+        null
+    }
+    return packageInfo?.longVersionCode ?: 0L
+}

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -8,6 +8,8 @@ package com.datadog.android.profiling
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import android.os.ProfilingManager
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
@@ -20,6 +22,7 @@ import com.datadog.android.internal.profiling.ProfilerEvent
 import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 import com.datadog.android.internal.rum.RumSessionConstants
 import com.datadog.android.internal.sampling.SessionSamplingIdProvider
+import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.profiling.forge.Configurator
 import com.datadog.android.profiling.internal.Profiler
 import com.datadog.android.profiling.internal.ProfilerCallback
@@ -29,6 +32,7 @@ import com.datadog.android.profiling.internal.ProfilingStartReason
 import com.datadog.android.profiling.internal.ProfilingStorage
 import com.datadog.android.profiling.internal.ProfilingWriter
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
+import com.datadog.android.profiling.internal.time.MutableTimeProvider
 import com.datadog.android.profiling.utils.config.MainLooperTestConfiguration
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -36,6 +40,7 @@ import com.datadog.tools.unit.extensions.config.TestConfiguration
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.FloatForgery
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -46,6 +51,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
+import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
@@ -54,6 +60,7 @@ import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -111,6 +118,15 @@ internal class ProfilingFeatureTest {
     @Mock
     private lateinit var mockEditor: SharedPreferences.Editor
 
+    @Mock
+    private lateinit var mockMutableTimeProvider: MutableTimeProvider
+
+    @Mock
+    private lateinit var mockTimeProvider: TimeProvider
+
+    @Mock
+    private lateinit var mockPackageManager: PackageManager
+
     @Forgery
     private lateinit var fakeConfiguration: ProfilingConfiguration
 
@@ -129,6 +145,9 @@ internal class ProfilingFeatureTest {
     @StringForgery
     private lateinit var fakeInstanceName: String
 
+    @LongForgery(min = 1L)
+    private var fakeProfilingPackageVersionCode: Long = 0L
+
     private val fakeAllSampledConfiguration = ProfilingConfiguration(
         customEndpointUrl = null,
         applicationLaunchSampleRate = 100f,
@@ -138,8 +157,20 @@ internal class ProfilingFeatureTest {
     @BeforeEach
     fun `set up`() {
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
+        whenever(mockSdkCore.timeProvider) doReturn mockTimeProvider
+        whenever(mockContext.packageManager) doReturn mockPackageManager
+        val mockPackageInfo = mock<PackageInfo> {
+            on { longVersionCode } doReturn fakeProfilingPackageVersionCode
+        }
+        whenever(
+            mockPackageManager.getPackageInfo(
+                "com.google.android.profiling",
+                PackageManager.MATCH_APEX
+            )
+        ) doReturn mockPackageInfo
         whenever(mockSdkCore.name) doReturn fakeInstanceName
         whenever(mockSdkCore.createSingleThreadExecutorService(any())) doReturn mockProfilingExecutor
+        whenever(mockProfiler.timeProvider) doReturn mockMutableTimeProvider
         whenever(mockProfiler.scheduledExecutorService) doReturn mockSchedulerExecutor
         whenever(mockContext.getSystemService(ProfilingManager::class.java)) doReturn (mockService)
         whenever(mockContext.getSharedPreferences(any(), any())) doReturn mockSharedPreferences
@@ -185,6 +216,16 @@ internal class ProfilingFeatureTest {
 
         // Then
         assertThat(testedFeature.requestFactory).isInstanceOf(ProfilingRequestFactory::class.java)
+    }
+
+    @Test
+    fun `M bind profiler to the SDK core W initialize()`() {
+        // When
+        testedFeature.onInitialize(mockContext)
+
+        // Then
+        verify(mockProfiler).internalLogger = mockInternalLogger
+        verify(mockProfiler.timeProvider).delegate = mockTimeProvider
     }
 
     @Test

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
@@ -33,11 +33,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
-import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 import com.datadog.android.internal.system.BuildSdkVersionProvider
+import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.profiling.forge.Configurator
 import com.datadog.android.profiling.internal.anr.AnrTriggerRegistrar
@@ -23,6 +24,8 @@ import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler.Companio
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler.Companion.PROFILING_SAMPLING_RATE_APP_LAUNCH
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler.Companion.PROFILING_SAMPLING_RATE_CONTINUOUS
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
+import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetry
+import com.datadog.android.profiling.internal.time.MutableTimeProvider
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
@@ -99,6 +102,9 @@ class PerfettoProfilerTest {
 
     private val callbackCaptor = argumentCaptor<Consumer<ProfilingResult>>()
 
+    @LongForgery(min = 1L)
+    private var fakeProfilingPackageLongVersionCode: Long = 0L
+
     @StringForgery
     private lateinit var fakePath: String
 
@@ -118,7 +124,10 @@ class PerfettoProfilerTest {
             timeProvider = stubTimeProvider,
             scheduledExecutorService = mockExecutorService,
             anrTriggerRegistrar = mockAnrRegistrar,
-            buildSdkVersionProvider = mockBuildSdkVersionProvider
+            buildSdkVersionProvider = mockBuildSdkVersionProvider,
+            profilingTelemetry = ProfilingTelemetry().apply {
+                profilingPackageVersionCode = fakeProfilingPackageLongVersionCode
+            }
         )
         testedProfiler.internalLogger = mockInternalLogger
         testedProfiler.registerProfilingCallback(mockContext, fakeInstanceName, mockProfilerCallback)
@@ -232,13 +241,15 @@ class PerfettoProfilerTest {
                 "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
                 "duration" to fakeDuration,
                 "callback_delay_ms" to 0L,
+                "client_clock_drift_ms" to 0L,
                 "file_size" to 0L,
                 "stopped_reason" to "timeout",
                 "app_start_info" to null
             ),
             "profiling_config" to mapOf(
                 "buffer_size" to 5120,
-                "sampling_frequency" to PROFILING_SAMPLING_RATE_APP_LAUNCH
+                "sampling_frequency" to PROFILING_SAMPLING_RATE_APP_LAUNCH,
+                "profiling_package_version_code" to fakeProfilingPackageLongVersionCode
             )
         )
         verify(mockInternalLogger)
@@ -293,6 +304,7 @@ class PerfettoProfilerTest {
                 "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
                 "duration" to fakeDuration,
                 "callback_delay_ms" to 0L,
+                "client_clock_drift_ms" to 0L,
                 "error_message" to fakeErrorMessage,
                 "file_size" to 0L,
                 "stopped_reason" to "error",
@@ -300,7 +312,8 @@ class PerfettoProfilerTest {
             ),
             "profiling_config" to mapOf(
                 "buffer_size" to 5120,
-                "sampling_frequency" to PROFILING_SAMPLING_RATE_APP_LAUNCH
+                "sampling_frequency" to PROFILING_SAMPLING_RATE_APP_LAUNCH,
+                "profiling_package_version_code" to fakeProfilingPackageLongVersionCode
             )
         )
         verify(mockInternalLogger)
@@ -356,6 +369,7 @@ class PerfettoProfilerTest {
                 "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
                 "duration" to fakeDuration,
                 "callback_delay_ms" to 0L,
+                "client_clock_drift_ms" to 0L,
                 "error_message" to fakeErrorMessage,
                 "file_size" to 0L,
                 "stopped_reason" to "error",
@@ -363,7 +377,8 @@ class PerfettoProfilerTest {
             ),
             "profiling_config" to mapOf(
                 "buffer_size" to 5120,
-                "sampling_frequency" to PROFILING_SAMPLING_RATE_APP_LAUNCH
+                "sampling_frequency" to PROFILING_SAMPLING_RATE_APP_LAUNCH,
+                "profiling_package_version_code" to fakeProfilingPackageLongVersionCode
             )
         )
         verify(mockInternalLogger)
@@ -760,6 +775,7 @@ class PerfettoProfilerTest {
                 "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
                 "duration" to fakeDuration,
                 "callback_delay_ms" to 0L,
+                "client_clock_drift_ms" to 0L,
                 "error_message" to null,
                 "file_size" to 0L,
                 "stopped_reason" to "timeout",
@@ -767,7 +783,8 @@ class PerfettoProfilerTest {
             ),
             "profiling_config" to mapOf(
                 "buffer_size" to 5120,
-                "sampling_frequency" to PROFILING_SAMPLING_RATE_APP_LAUNCH
+                "sampling_frequency" to PROFILING_SAMPLING_RATE_APP_LAUNCH,
+                "profiling_package_version_code" to fakeProfilingPackageLongVersionCode
             )
         )
         verify(mockInternalLogger)
@@ -824,6 +841,7 @@ class PerfettoProfilerTest {
                 "start_reason" to startReason.value,
                 "duration" to fakeDuration,
                 "callback_delay_ms" to 0L,
+                "client_clock_drift_ms" to 0L,
                 "error_message" to null,
                 "file_size" to 0L,
                 "stopped_reason" to "timeout",
@@ -831,7 +849,8 @@ class PerfettoProfilerTest {
             ),
             "profiling_config" to mapOf(
                 "buffer_size" to 5120,
-                "sampling_frequency" to expectedSamplingRate
+                "sampling_frequency" to expectedSamplingRate,
+                "profiling_package_version_code" to fakeProfilingPackageLongVersionCode
             )
         )
         verify(mockInternalLogger)
@@ -892,13 +911,15 @@ class PerfettoProfilerTest {
                 "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value,
                 "duration" to fakeStopDelta,
                 "callback_delay_ms" to fakeCallbackDelta,
+                "client_clock_drift_ms" to 0L,
                 "file_size" to 0L,
                 "stopped_reason" to "manual",
                 "app_start_info" to null
             ),
             "profiling_config" to mapOf(
                 "buffer_size" to 5120,
-                "sampling_frequency" to PROFILING_SAMPLING_RATE_APP_LAUNCH
+                "sampling_frequency" to PROFILING_SAMPLING_RATE_APP_LAUNCH,
+                "profiling_package_version_code" to fakeProfilingPackageLongVersionCode
             )
         )
         verify(mockInternalLogger)
@@ -985,13 +1006,15 @@ class PerfettoProfilerTest {
                 "start_reason" to ProfilingStartReason.CONTINUOUS.value,
                 "duration" to fakeDuration2,
                 "callback_delay_ms" to 0L,
+                "client_clock_drift_ms" to 0L,
                 "file_size" to 0L,
                 "stopped_reason" to "timeout",
                 "app_start_info" to null
             ),
             "profiling_config" to mapOf(
                 "buffer_size" to 5120,
-                "sampling_frequency" to PROFILING_SAMPLING_RATE_CONTINUOUS
+                "sampling_frequency" to PROFILING_SAMPLING_RATE_CONTINUOUS,
+                "profiling_package_version_code" to fakeProfilingPackageLongVersionCode
             )
         )
         verify(mockInternalLogger).logMetric(
@@ -1178,7 +1201,10 @@ class PerfettoProfilerTest {
 
     // endregion
 
-    private class StubTimeProvider : TimeProvider {
+    private class StubTimeProvider : MutableTimeProvider {
+        // not really used
+        override var delegate: TimeProvider = DefaultTimeProvider()
+
         var startTime: Long = 0L
 
         var stopTime: Long = 0L

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/anr/AnrProfilingTriggerRegistrarTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/anr/AnrProfilingTriggerRegistrarTest.kt
@@ -172,6 +172,7 @@ internal class AnrProfilingTriggerRegistrarTest {
                 errorMessage = null,
                 fileSize = 0L,
                 callbackDelayMs = null,
+                clientClockDriftMs = 0L,
                 droppedAsStale = false
             )
         )
@@ -204,6 +205,7 @@ internal class AnrProfilingTriggerRegistrarTest {
                 errorMessage = fakeErrorMessage,
                 fileSize = 0L,
                 callbackDelayMs = null,
+                clientClockDriftMs = 0L,
                 droppedAsStale = false
             )
         )
@@ -421,6 +423,7 @@ internal class AnrProfilingTriggerRegistrarTest {
                 errorMessage = null,
                 fileSize = expectedFileSize,
                 callbackDelayMs = fakeDelayMs,
+                clientClockDriftMs = 0L,
                 droppedAsStale = false
             )
         )
@@ -461,6 +464,7 @@ internal class AnrProfilingTriggerRegistrarTest {
                 errorMessage = null,
                 fileSize = expectedFileSize,
                 callbackDelayMs = fakeDelayMs,
+                clientClockDriftMs = 0L,
                 droppedAsStale = true
             )
         )

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/telemetry/ProfilingTelemetryTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/telemetry/ProfilingTelemetryTest.kt
@@ -41,17 +41,23 @@ internal class ProfilingTelemetryTest {
     @Mock
     private lateinit var mockLogger: InternalLogger
 
+    @LongForgery(min = 1L)
+    private var fakeProfilingPackageVersionCode: Long = 0L
+
     private lateinit var testedTelemetry: ProfilingTelemetry
 
     @BeforeEach
     fun `set up`() {
-        testedTelemetry = ProfilingTelemetry()
+        testedTelemetry = ProfilingTelemetry().apply {
+            profilingPackageVersionCode = fakeProfilingPackageVersionCode
+        }
     }
 
     @Test
     fun `M dispatch SessionEnd through logMetric W report() {logger set}`(
         @StringForgery fakeErrorMessage: String,
         @LongForgery(min = 0L) fakeDuration: Long,
+        @LongForgery fakeClientClockDriftMs: Long,
         @IntForgery(min = 1, max = 8) fakeErrorCode: Int
     ) {
         // Given
@@ -64,6 +70,7 @@ internal class ProfilingTelemetryTest {
             fileSize = 0L,
             durationMs = fakeDuration,
             resultCallbackDelayMs = 0L,
+            clientClockDriftMs = fakeClientClockDriftMs,
             stopReason = ProfilingTelemetry.STOPPED_REASON_ERROR,
             bufferSizeKb = 5120,
             samplingFrequencyHz = 201
@@ -81,14 +88,18 @@ internal class ProfilingTelemetryTest {
                 ProfilingTelemetry.KEY_START_REASON to ProfilingStartReason.APPLICATION_LAUNCH.value,
                 ProfilingTelemetry.KEY_DURATION to fakeDuration,
                 ProfilingTelemetry.KEY_CALLBACK_DELAY to 0L,
+                ProfilingTelemetry.KEY_CLIENT_CLOCK_DRIFT to fakeClientClockDriftMs,
                 ProfilingTelemetry.KEY_ERROR_MESSAGE to fakeErrorMessage,
                 ProfilingTelemetry.KEY_FILE_SIZE to 0L,
                 ProfilingTelemetry.KEY_STOPPED_REASON to ProfilingTelemetry.STOPPED_REASON_ERROR,
                 ProfilingTelemetry.KEY_APP_START_INFO to null
             ),
             ProfilingTelemetry.KEY_PROFILING_CONFIG to mapOf(
-                ProfilingTelemetry.KEY_BUFFER_SIZE to 5120,
-                ProfilingTelemetry.KEY_SAMPLING_FREQUENCY to 201
+                // toInt here is needed because otherwise compiler may treat them as Long, in this case verify -> eq
+                // below may fail since 5120 != 5120L
+                ProfilingTelemetry.KEY_BUFFER_SIZE to 5120.toInt(),
+                ProfilingTelemetry.KEY_SAMPLING_FREQUENCY to 201.toInt(),
+                ProfilingTelemetry.KEY_PROFILING_PACKAGE_VERSION_CODE to fakeProfilingPackageVersionCode
             )
         )
         verify(mockLogger).logMetric(
@@ -104,6 +115,7 @@ internal class ProfilingTelemetryTest {
     @Test
     fun `M dispatch AnrTriggerResult through logMetric W report() {logger set}`(
         @StringForgery fakeErrorMessage: String,
+        @LongForgery fakeClientClockDriftMs: Long,
         @IntForgery(min = 0, max = 8) fakeErrorCode: Int
     ) {
         // Given
@@ -113,6 +125,7 @@ internal class ProfilingTelemetryTest {
             errorMessage = fakeErrorMessage,
             fileSize = 0L,
             callbackDelayMs = null,
+            clientClockDriftMs = fakeClientClockDriftMs,
             droppedAsStale = false
         )
 
@@ -129,7 +142,11 @@ internal class ProfilingTelemetryTest {
                 ProfilingTelemetry.KEY_ERROR_MESSAGE to fakeErrorMessage,
                 ProfilingTelemetry.KEY_FILE_SIZE to 0L,
                 ProfilingTelemetry.KEY_CALLBACK_DELAY to null,
+                ProfilingTelemetry.KEY_CLIENT_CLOCK_DRIFT to fakeClientClockDriftMs,
                 ProfilingTelemetry.KEY_DROPPED_AS_STALE to false
+            ),
+            ProfilingTelemetry.KEY_PROFILING_CONFIG to mapOf(
+                ProfilingTelemetry.KEY_PROFILING_PACKAGE_VERSION_CODE to fakeProfilingPackageVersionCode
             )
         )
         verify(mockLogger).logMetric(
@@ -150,6 +167,7 @@ internal class ProfilingTelemetryTest {
             errorMessage = null,
             fileSize = 0L,
             callbackDelayMs = null,
+            clientClockDriftMs = 0L,
             droppedAsStale = false
         )
 
@@ -168,6 +186,7 @@ internal class ProfilingTelemetryTest {
             errorMessage = null,
             fileSize = 0L,
             callbackDelayMs = null,
+            clientClockDriftMs = 0L,
             droppedAsStale = false
         )
         val secondEvent = ProfilingTelemetryEvent.AnrTriggerResult(
@@ -175,6 +194,7 @@ internal class ProfilingTelemetryTest {
             errorMessage = "in_progress",
             fileSize = 0L,
             callbackDelayMs = null,
+            clientClockDriftMs = 0L,
             droppedAsStale = false
         )
         testedTelemetry.report(firstEvent)
@@ -200,6 +220,7 @@ internal class ProfilingTelemetryTest {
             errorMessage = null,
             fileSize = 0L,
             callbackDelayMs = null,
+            clientClockDriftMs = 0L,
             droppedAsStale = false
         )
         testedTelemetry.report(event)
@@ -227,6 +248,7 @@ internal class ProfilingTelemetryTest {
             errorMessage = null,
             fileSize = 0L,
             callbackDelayMs = null,
+            clientClockDriftMs = 0L,
             droppedAsStale = false
         )
 


### PR DESCRIPTION
### What does this PR do?

Add additional profiling telemetry fields:

* Version of the system profiling package. It may be update as a part of mainline updates and not tied to the OS version. This comes in the `profiling_config` section, it doesn't depend on the profiling session run.
* Client clock drift: Perfetto is using system clock, but in RUM we use NTP-corrected clock. This can create misalignment between the two time-wise.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

