### PR TITLE
RUM-16728: Report TTFD to profiling

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -174,6 +174,7 @@ sealed class com.datadog.android.internal.profiling.ProfilerEvent
     constructor(String, String?, Type, Long, Long, ProfilingRumContext)
     enum Type
       - TTID
+      - TTFD
       - OPERATION
 data class com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
   constructor(Long, List<StackTraceElement>, String, Thread.State, List<ProfilingThreadDump>)

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -341,6 +341,7 @@ public final class com/datadog/android/internal/profiling/ProfilerEvent$RumVital
 
 public final class com/datadog/android/internal/profiling/ProfilerEvent$RumVitalEvent$Type : java/lang/Enum {
 	public static final field OPERATION Lcom/datadog/android/internal/profiling/ProfilerEvent$RumVitalEvent$Type;
+	public static final field TTFD Lcom/datadog/android/internal/profiling/ProfilerEvent$RumVitalEvent$Type;
 	public static final field TTID Lcom/datadog/android/internal/profiling/ProfilerEvent$RumVitalEvent$Type;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/internal/profiling/ProfilerEvent$RumVitalEvent$Type;
 	public static fun values ()[Lcom/datadog/android/internal/profiling/ProfilerEvent$RumVitalEvent$Type;

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilerEvent.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilerEvent.kt
@@ -48,7 +48,6 @@ sealed class ProfilerEvent {
 
     /**
      * Sent by the RUM feature to the profiling feature whenever a vital is recorded.
-     * Currently, is sent only for TTID events.
      *
      * @param id The ID of the corresponding RUM vital event.
      * @param name The name of the corresponding vital event.
@@ -73,6 +72,11 @@ sealed class ProfilerEvent {
              * TTID (Time to initial display) type.
              */
             TTID,
+
+            /**
+             * TTFD (Time to full display) type.
+             */
+            TTFD,
 
             /**
              * Operation API type.

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -880,6 +880,32 @@ internal class ProfilingFeatureTest {
     }
 
     @Test
+    fun `M not stop Profiling W receive TTFD vital event {continuous disabled}`(
+        @Forgery fakeTtfdVital: ProfilerEvent.RumVitalEvent
+    ) {
+        // Given
+        testedFeature = ProfilingFeature(
+            mockSdkCore,
+            ProfilingConfiguration(
+                customEndpointUrl = null,
+                applicationLaunchSampleRate = 100f,
+                continuousSampleRate = 0f
+            ),
+            mockProfiler
+        )
+        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        testedFeature.onInitialize(mockContext)
+
+        // When
+        testedFeature.onReceive(
+            fakeTtfdVital.copy(type = ProfilerEvent.RumVitalEvent.Type.TTFD)
+        )
+
+        // Then
+        verify(mockProfiler, never()).stop(fakeInstanceName)
+    }
+
+    @Test
     fun `M not write launch event W app-launch profiling result received {only OPERATION vital, no TTID}`(
         @Forgery fakePerfettoResult: PerfettoResult,
         @Forgery fakeOperationVital: ProfilerEvent.RumVitalEvent

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManager.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManager.kt
@@ -250,19 +250,37 @@ internal class RumSessionScopeStartupManagerImpl(
             return
         }
 
-        sdkCore.newRumEventWriteOperation(datadogContext, writeScope, writer) {
-            rumVitalAppLaunchEventHelper.newVitalAppLaunchEvent(
-                timestampMs = scenario.initialTime.timestamp + sdkCore.time.serverTimeOffsetMs,
-                datadogContext = datadogContext,
-                eventAttributes = emptyMap(),
-                customAttributes = customAttributes,
-                hasReplay = null,
-                rumContext = rumContext,
-                durationNs = durationNs,
-                appLaunchMetric = VitalAppLaunchEvent.AppLaunchMetric.TTFD,
-                scenario = scenario,
-                profilingStatus = null
+        val ttfdEvent = rumVitalAppLaunchEventHelper.newVitalAppLaunchEvent(
+            timestampMs = scenario.initialTime.timestamp + sdkCore.time.serverTimeOffsetMs,
+            datadogContext = datadogContext,
+            eventAttributes = emptyMap(),
+            customAttributes = customAttributes,
+            hasReplay = null,
+            rumContext = rumContext,
+            durationNs = durationNs,
+            appLaunchMetric = VitalAppLaunchEvent.AppLaunchMetric.TTFD,
+            scenario = scenario,
+            profilingStatus = datadogContext.getProfilingStatus()
+        )
+
+        sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.sendEvent(
+            ProfilerEvent.RumVitalEvent(
+                rumContext = ProfilingRumContext(
+                    applicationId = rumContext.applicationId,
+                    sessionId = rumContext.sessionId,
+                    viewId = rumContext.viewId,
+                    viewName = rumContext.viewName
+                ),
+                id = ttfdEvent.vital.id,
+                name = ttfdEvent.vital.name,
+                type = ProfilerEvent.RumVitalEvent.Type.TTFD,
+                startMs = ttfdEvent.date,
+                durationNs = durationNs
             )
+        )
+
+        sdkCore.newRumEventWriteOperation(datadogContext, writeScope, writer) {
+            ttfdEvent
         }.submit()
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManagerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManagerTest.kt
@@ -307,6 +307,71 @@ internal class RumSessionScopeStartupManagerTest {
     }
 
     @ParameterizedTest
+    @MethodSource("testScenarios")
+    fun `M notify profiling W onTTFDEvent`(
+        scenario: RumStartupScenario,
+        forge: Forge
+    ) {
+        // Given
+        val info = RumTTIDInfo(
+            scenario = scenario,
+            durationNs = forge.aLong(min = 0, max = 10000)
+        )
+
+        val ttidEvent = RumRawEvent.AppStartTTIDEvent(info = info)
+        val ttfdEvent = forge.createTTFDEvent(scenario.initialTime)
+
+        val mockProfilingFeatureScope = mock<FeatureScope>()
+        whenever(
+            mockSdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)
+        ) doReturn mockProfilingFeatureScope
+
+        // When
+        manager.onAppStartEvent(RumRawEvent.AppStartEvent(scenario = scenario))
+
+        manager.onTTIDEvent(
+            event = ttidEvent,
+            isSessionTracked = true,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter,
+            rumContext = rumContext,
+            customAttributes = fakeParentAttributes
+        )
+
+        manager.onTTFDEvent(
+            event = ttfdEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter,
+            rumContext = rumContext,
+            customAttributes = fakeParentAttributes
+        )
+
+        // Then
+        argumentCaptor<VitalAppLaunchEvent> {
+            verify(mockWriter, times(2))
+                .write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+
+            verify(mockProfilingFeatureScope).sendEvent(
+                ProfilerEvent.RumVitalEvent(
+                    rumContext = ProfilingRumContext(
+                        applicationId = rumContext.applicationId,
+                        sessionId = rumContext.sessionId,
+                        viewId = rumContext.viewId,
+                        viewName = rumContext.viewName
+                    ),
+                    id = lastValue.vital.id,
+                    name = lastValue.vital.name,
+                    type = ProfilerEvent.RumVitalEvent.Type.TTFD,
+                    startMs = lastValue.date,
+                    durationNs = ttfdEvent.eventTime.nanoTime - scenario.initialTime.nanoTime
+                )
+            )
+        }
+    }
+
+    @ParameterizedTest
     @MethodSource("testScenariosPairs")
     fun `M write telemetry twice and TTID Vital event once W onTTIDEvent { called 2 times per session }`(
         scenario1: RumStartupScenario,
@@ -837,7 +902,13 @@ internal class RumSessionScopeStartupManagerTest {
             hasVersion(fakeDatadogContext.version)
             hasServiceName(fakeDatadogContext.service)
             hasDDTags(buildDDTagsString(fakeDatadogContext))
-            hasNoProfilingStatus()
+                .apply {
+                    if (fakeDatadogContext.featuresContext.containsKey(Feature.PROFILING_FEATURE_NAME)) {
+                        hasProfilingStatus(VitalAppLaunchEvent.ProfilingStatus.RUNNING)
+                    } else {
+                        hasNoProfilingStatus()
+                    }
+                }
             hasNoProfilingErrorReason()
         }
 


### PR DESCRIPTION
### What does this PR do?

Similar to the TTID reporting for profiling, we can report TTFD as well.

The difference is that TTFD is optional, user needs to call RUM API explicitly.

That means that TTFD won't stop any profiling session and is recorded only if there is continuous profiling running (in this case application launch profiling session is extended).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

