### PR TITLE
Move FakeSameThreadExecutorService into core textFixtures

### DIFF
--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AbstractStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AbstractStorageTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.FeatureStorageConfiguration
 import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.api.threads.FakeSameThreadExecutorService
 import com.datadog.android.core.internal.metrics.RemovalReason
 import com.datadog.android.core.internal.privacy.ConsentProvider
 import com.datadog.android.core.persistence.PersistenceStrategy

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
@@ -10,6 +10,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.api.threads.FakeSameThreadExecutorService
 import com.datadog.android.core.internal.data.upload.DataOkHttpUploader.Companion.HTTP_ACCEPTED
 import com.datadog.android.core.internal.metrics.BenchmarkUploads
 import com.datadog.android.core.internal.metrics.MetricsDispatcher

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/api/threads/FakeSameThreadExecutorService.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/api/threads/FakeSameThreadExecutorService.kt
@@ -4,13 +4,13 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.core.internal.persistence
+package com.datadog.android.api.threads
 
 import java.util.concurrent.AbstractExecutorService
 import java.util.concurrent.FutureTask
 import java.util.concurrent.TimeUnit
 
-internal class FakeSameThreadExecutorService : AbstractExecutorService() {
+class FakeSameThreadExecutorService : AbstractExecutorService() {
 
     private var isShutdown = false
 


### PR DESCRIPTION
### What does this PR do?

`FakeSameThreadExecutorService` can be reused across all the module to fake an `ExecutorService` to run the task on the same thread, this PRs move the class to core/textFixtures for the purpose.



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

