### PR TITLE
RUM-16634: Add wildcard host pattern matching to `WebViewTracking`

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -284,6 +284,8 @@ data class com.datadog.android.core.configuration.Configuration
     fun setUploadSchedulerStrategy(UploadSchedulerStrategy?): Builder
     fun setVersion(String): Builder
   companion object 
+class com.datadog.android.core.configuration.HostPatternValidator
+  fun validate(List<String>, String): List<String>
 class com.datadog.android.core.configuration.HostsSanitizer
   fun sanitizeHosts(List<String>, String): List<String>
 enum com.datadog.android.core.configuration.UploadFrequency

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -773,6 +773,11 @@ public final class com/datadog/android/core/configuration/Configuration$Builder 
 public final class com/datadog/android/core/configuration/Configuration$Companion {
 }
 
+public final class com/datadog/android/core/configuration/HostPatternValidator {
+	public fun <init> ()V
+	public final fun validate (Ljava/util/List;Ljava/lang/String;)Ljava/util/List;
+}
+
 public final class com/datadog/android/core/configuration/HostsSanitizer {
 	public fun <init> ()V
 	public final fun sanitizeHosts (Ljava/util/List;Ljava/lang/String;)Ljava/util/List;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/HostPatternValidator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/HostPatternValidator.kt
@@ -1,0 +1,75 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.configuration
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.internal.utils.unboundInternalLogger
+import com.datadog.android.lint.InternalApi
+import java.util.Locale
+
+/**
+ * Utility class to validate wildcard host patterns.
+ *
+ * A host pattern may contain at most one `*` wildcard and may only use the characters `a-z`, `0-9`,
+ * `.`, `-` and `*`. Plain host names (without a wildcard) are valid patterns too. This is the
+ * counterpart of [HostsSanitizer] for entries that are allowed to carry a wildcard.
+ */
+class HostPatternValidator {
+
+    /**
+     * Validates the given host patterns, returning the valid ones lowercased and in their original
+     * order. Entries containing characters outside `[a-z0-9.*-]` or more than one `*` wildcard are
+     * dropped and a warning is logged.
+     *
+     * @param patterns Host patterns to validate.
+     * @param feature SDK feature requesting the validation.
+     */
+    @InternalApi
+    fun validate(
+        patterns: List<String>,
+        feature: String
+    ): List<String> {
+        return patterns.mapNotNull { validatePattern(it, feature) }
+    }
+
+    private fun validatePattern(pattern: String, feature: String): String? {
+        val lowercased = pattern.lowercase(Locale.US)
+        return when {
+            lowercased.any { it !in ALLOWED_CHARACTERS } -> {
+                unboundInternalLogger.log(
+                    InternalLogger.Level.WARN,
+                    InternalLogger.Target.USER,
+                    { ERROR_INVALID_CHARACTERS.format(Locale.US, pattern, feature) }
+                )
+                null
+            }
+            lowercased.count { it == WILDCARD } > 1 -> {
+                unboundInternalLogger.log(
+                    InternalLogger.Level.WARN,
+                    InternalLogger.Target.USER,
+                    { ERROR_MULTIPLE_WILDCARDS.format(Locale.US, pattern, feature) }
+                )
+                null
+            }
+            else -> lowercased
+        }
+    }
+
+    internal companion object {
+        private const val WILDCARD = '*'
+
+        private const val ALLOWED_CHARACTERS = "abcdefghijklmnopqrstuvwxyz0123456789.-*"
+
+        internal const val ERROR_INVALID_CHARACTERS: String =
+            "You are using a malformed host pattern \"%s\" to setup %s tracking. It will be dropped. " +
+                "A host pattern may only contain lowercase letters, digits, '.', '-' and a single '*' wildcard."
+
+        internal const val ERROR_MULTIPLE_WILDCARDS: String =
+            "You are using a host pattern \"%s\" with more than one wildcard to setup %s tracking. " +
+                "It will be dropped. A host pattern may contain at most one '*' wildcard."
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/HostPatternValidatorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/HostPatternValidatorTest.kt
@@ -1,0 +1,209 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.configuration
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.utils.config.InternalLoggerTestConfiguration
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import java.util.Locale
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+internal class HostPatternValidatorTest {
+
+    lateinit var testedValidator: HostPatternValidator
+
+    @StringForgery(type = StringForgeryType.ALPHABETICAL)
+    lateinit var fakeFeature: String
+
+    @BeforeEach
+    fun `set up`() {
+        testedValidator = HostPatternValidator()
+    }
+
+    @Test
+    fun `M keep valid wildcard patterns W validate()`() {
+        // Given
+        val patterns = listOf("*.example.com", "preview-*.shopist.io", "example.net")
+
+        // When
+        val result = testedValidator.validate(patterns, fakeFeature)
+
+        // Then
+        assertThat(result).isEqualTo(patterns)
+    }
+
+    @Test
+    fun `M keep plain hosts W validate { no wildcard }`(
+        @StringForgery(
+            regex = "(([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])\\.)+([a-z]|[a-z][a-z0-9-]*[a-z0-9])"
+        ) hosts: List<String>
+    ) {
+        // When
+        val result = testedValidator.validate(hosts, fakeFeature)
+
+        // Then
+        assertThat(result).isEqualTo(hosts)
+    }
+
+    @Test
+    fun `M keep single wildcard W validate { star }`() {
+        // When
+        val result = testedValidator.validate(listOf("*"), fakeFeature)
+
+        // Then
+        assertThat(result).containsExactly("*")
+    }
+
+    @Test
+    fun `M keep empty string W validate { blank }`() {
+        // When
+        val result = testedValidator.validate(listOf(""), fakeFeature)
+
+        // Then
+        assertThat(result).containsExactly("")
+    }
+
+    @Test
+    fun `M lowercase patterns W validate { uppercase }`() {
+        // When
+        val result = testedValidator.validate(
+            listOf("*.SHOPIST.IO", "Preview-*.Example.COM"),
+            fakeFeature
+        )
+
+        // Then
+        assertThat(result).containsExactly("*.shopist.io", "preview-*.example.com")
+    }
+
+    @Test
+    fun `M drop and warn W validate { more than one wildcard }`() {
+        // Given
+        val pattern = "*.foo.*.bar"
+
+        // When
+        val result = testedValidator.validate(listOf(pattern), fakeFeature)
+
+        // Then
+        assertThat(result).isEmpty()
+        val expectedMessage = HostPatternValidator.ERROR_MULTIPLE_WILDCARDS.format(
+            Locale.US,
+            pattern,
+            fakeFeature
+        )
+        argumentCaptor<() -> String> {
+            verify(logger.mockInternalLogger).log(
+                eq(InternalLogger.Level.WARN),
+                eq(InternalLogger.Target.USER),
+                capture(),
+                isNull(),
+                eq(false),
+                eq(null)
+            )
+            assertThat(firstValue()).isEqualTo(expectedMessage)
+        }
+    }
+
+    @Test
+    fun `M drop and warn W validate { invalid characters }`() {
+        // Given
+        val patterns = listOf("foo'bar.com", "back\\slash.com", "https://foo.com")
+
+        // When
+        val result = testedValidator.validate(patterns, fakeFeature)
+
+        // Then
+        assertThat(result).isEmpty()
+        val expectedMessages = patterns.map {
+            HostPatternValidator.ERROR_INVALID_CHARACTERS.format(Locale.US, it, fakeFeature)
+        }
+        argumentCaptor<() -> String> {
+            verify(logger.mockInternalLogger, times(patterns.size)).log(
+                eq(InternalLogger.Level.WARN),
+                eq(InternalLogger.Target.USER),
+                capture(),
+                isNull(),
+                eq(false),
+                eq(null)
+            )
+            assertThat(allValues.map { it() })
+                .containsExactlyInAnyOrderElementsOf(expectedMessages)
+        }
+    }
+
+    @Test
+    fun `M warn with original pattern W validate { uppercase invalid characters }`() {
+        // Given
+        val pattern = "FOO'BAR.com"
+
+        // When
+        testedValidator.validate(listOf(pattern), fakeFeature)
+
+        // Then
+        val expectedMessage = HostPatternValidator.ERROR_INVALID_CHARACTERS.format(
+            Locale.US,
+            pattern,
+            fakeFeature
+        )
+        argumentCaptor<() -> String> {
+            verify(logger.mockInternalLogger).log(
+                eq(InternalLogger.Level.WARN),
+                eq(InternalLogger.Target.USER),
+                capture(),
+                isNull(),
+                eq(false),
+                eq(null)
+            )
+            assertThat(firstValue()).isEqualTo(expectedMessage)
+        }
+    }
+
+    @Test
+    fun `M keep valid and drop invalid W validate { mixed }`() {
+        // Given
+        val validWildcard = "*.shopist.io"
+        val plainHost = "example.com"
+        val multiWildcard = "*.foo.*.bar"
+        val invalidChars = "foo'bar.com"
+        val patterns = listOf(validWildcard, multiWildcard, plainHost, invalidChars)
+
+        // When
+        val result = testedValidator.validate(patterns, fakeFeature)
+
+        // Then
+        assertThat(result).containsExactly(validWildcard, plainHost)
+    }
+
+    companion object {
+        val logger = InternalLoggerTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(logger)
+        }
+    }
+}

--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -1215,6 +1215,7 @@ datadog:
       - "kotlin.Any?.hashCode()"
       - "kotlin.CharSequence.isNullOrEmpty()"
       - "kotlin.String.all(kotlin.Function1)"
+      - "kotlin.String.any(kotlin.Function1)"
       - "kotlin.String.codePoints()"
       - "kotlin.String.constructor()"
       - "kotlin.String.contains(kotlin.Char, kotlin.Boolean)"

--- a/features/dd-sdk-android-webview/api/apiSurface
+++ b/features/dd-sdk-android-webview/api/apiSurface
@@ -1,5 +1,6 @@
 object com.datadog.android.webview.WebViewTracking
   fun enable(android.webkit.WebView, List<String>, Float = 100f, com.datadog.android.api.SdkCore = Datadog.getInstance())
+  fun enableWithPatterns(android.webkit.WebView, List<String>, Float = 100f, com.datadog.android.api.SdkCore = Datadog.getInstance())
   class _InternalWebViewProxy
     constructor(com.datadog.android.api.SdkCore, String? = null)
     fun consumeWebviewEvent(String)

--- a/features/dd-sdk-android-webview/api/dd-sdk-android-webview.api
+++ b/features/dd-sdk-android-webview/api/dd-sdk-android-webview.api
@@ -4,6 +4,10 @@ public final class com/datadog/android/webview/WebViewTracking {
 	public static final fun enable (Landroid/webkit/WebView;Ljava/util/List;F)V
 	public static final fun enable (Landroid/webkit/WebView;Ljava/util/List;FLcom/datadog/android/api/SdkCore;)V
 	public static synthetic fun enable$default (Landroid/webkit/WebView;Ljava/util/List;FLcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
+	public static final fun enableWithPatterns (Landroid/webkit/WebView;Ljava/util/List;)V
+	public static final fun enableWithPatterns (Landroid/webkit/WebView;Ljava/util/List;F)V
+	public static final fun enableWithPatterns (Landroid/webkit/WebView;Ljava/util/List;FLcom/datadog/android/api/SdkCore;)V
+	public static synthetic fun enableWithPatterns$default (Landroid/webkit/WebView;Ljava/util/List;FLcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
 }
 
 public final class com/datadog/android/webview/WebViewTracking$_InternalWebViewProxy {

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/WebViewTracking.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/WebViewTracking.kt
@@ -75,6 +75,78 @@ object WebViewTracking {
         @FloatRange(from = 0.0, to = 100.0) logsSampleRate: Float = 100f,
         sdkCore: SdkCore = Datadog.getInstance()
     ) {
+        enableInternal(
+            webView = webView,
+            allowedHosts = allowedHosts,
+            allowedHostPatterns = emptyList(),
+            logsSampleRate = logsSampleRate,
+            sdkCore = sdkCore
+        )
+    }
+
+    /**
+     * Attach the bridge to track events from the WebView as part of the same session, matching the
+     * web page's URL host against a list of wildcard host patterns.
+     *
+     * This is the pattern-matching counterpart of [enable]. Use it when the hosts you want to track
+     * cannot be enumerated up front (e.g. ephemeral preview URLs or multi-tenant subdomains).
+     *
+     * This method must be called from the Main Thread.
+     * Please note that:
+     * - you need to enable the JavaScript support in the WebView settings for this feature
+     * to be functional:
+     * ```
+     * webView.settings.javaScriptEnabled = true
+     * ```
+     * - by default, navigation will happen outside of your application (in a browser or a different app). To prevent
+     * that and ensure Datadog can track the full WebView user journey, attach a [android.webkit.WebViewClient] to your
+     * WebView, as following:
+     * ```
+     * webView.webViewClient = WebViewClient()
+     * ```
+     * The WebView events will not be tracked unless the web page's URL Host matches one of the
+     * provided patterns.
+     *
+     * Each pattern may contain at most a single `*` wildcard (matching any sequence of characters)
+     * and may only use the characters `a-z`, `0-9`, `.`, `-` and `*`. Patterns are lowercased before
+     * matching. Plain host names (without a wildcard) are accepted too and match exactly or as a
+     * subdomain suffix, exactly like [enable]. Entries containing other characters, or more than one
+     * wildcard, are dropped with a warning.
+     *
+     * @param webView the webView on which to attach the bridge.
+     * @param hostPatterns a list of wildcard host patterns that you want to track when loaded in the
+     * WebView (e.g.: `listOf("*.example.com", "preview-*.shopist.io", "example.net")`).
+     * @param logsSampleRate the sample rate for logs coming from the WebView, in percent. A value of `30` means we'll
+     * send 30% of the logs. If value is `0`, no logs will be sent to Datadog. Default is 100.0 (ie: all logs are sent).
+     * @param sdkCore SDK instance on which to attach the bridge.
+     * [More here](https://developer.android.com/guide/webapps/webview#HandlingNavigation).
+     */
+    @MainThread
+    @JvmOverloads
+    @JvmStatic
+    fun enableWithPatterns(
+        webView: WebView,
+        hostPatterns: List<String>,
+        @FloatRange(from = 0.0, to = 100.0) logsSampleRate: Float = 100f,
+        sdkCore: SdkCore = Datadog.getInstance()
+    ) {
+        enableInternal(
+            webView = webView,
+            allowedHosts = emptyList(),
+            allowedHostPatterns = hostPatterns,
+            logsSampleRate = logsSampleRate,
+            sdkCore = sdkCore
+        )
+    }
+
+    @MainThread
+    private fun enableInternal(
+        webView: WebView,
+        allowedHosts: List<String>,
+        allowedHostPatterns: List<String>,
+        logsSampleRate: Float,
+        sdkCore: SdkCore
+    ) {
         val featureSdkCore = sdkCore as FeatureSdkCore
         if (!webView.settings.javaScriptEnabled) {
             featureSdkCore.internalLogger.log(
@@ -98,7 +170,13 @@ object WebViewTracking {
             .getFeature(WebViewRumFeature.WEB_RUM_FEATURE_NAME)
             ?.unwrap<StorageBackedFeature>() as? WebViewRumFeature
         webView.addJavascriptInterface(
-            DatadogEventBridge(webViewEventConsumer, allowedHosts, privacyLevel, webViewRumFeature),
+            DatadogEventBridge(
+                webViewEventConsumer,
+                allowedHosts,
+                allowedHostPatterns,
+                privacyLevel,
+                webViewRumFeature
+            ),
             DATADOG_EVENT_BRIDGE_NAME
         )
         featureSdkCore.internalLogger.logApiUsage {

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/DatadogEventBridge.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/DatadogEventBridge.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.webview.internal
 
 import android.webkit.JavascriptInterface
+import com.datadog.android.core.configuration.HostPatternValidator
 import com.datadog.android.core.configuration.HostsSanitizer
 import com.datadog.android.core.sampling.DeterministicSampler
 import com.datadog.android.internal.sampling.DeterministicSampling
@@ -24,6 +25,7 @@ import com.google.gson.JsonArray
 internal class DatadogEventBridge(
     internal val webViewEventConsumer: WebViewEventConsumer<String>,
     private val allowedHosts: List<String>,
+    private val allowedHostPatterns: List<String>,
     private val privacyLevel: String,
     private val webViewRumFeature: WebViewRumFeature?
 ) {
@@ -51,6 +53,11 @@ internal class DatadogEventBridge(
         val origins = JsonArray()
         HostsSanitizer()
             .sanitizeHosts(allowedHosts, WEB_VIEW_TRACKING_FEATURE_NAME)
+            .forEach {
+                origins.add(it)
+            }
+        HostPatternValidator()
+            .validate(allowedHostPatterns, WEB_VIEW_TRACKING_FEATURE_NAME)
             .forEach {
                 origins.add(it)
             }

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/WebViewTrackingTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/WebViewTrackingTest.kt
@@ -352,6 +352,99 @@ internal class WebViewTrackingTest {
     }
 
     @Test
+    fun `M attach the bridge W enableWithPatterns`(@Forgery fakeUrls: List<URL>) {
+        // Given
+        val fakeHostPatterns = fakeUrls.map { it.host }
+        val mockSettings: WebSettings = mock {
+            whenever(it.javaScriptEnabled).thenReturn(true)
+        }
+        val mockWebView: WebView = mock {
+            whenever(it.settings).thenReturn(mockSettings)
+        }
+
+        // When
+        WebViewTracking.enableWithPatterns(mockWebView, fakeHostPatterns, sdkCore = mockCore)
+
+        // Then
+        verify(mockWebView).addJavascriptInterface(
+            argThat { this is DatadogEventBridge },
+            eq(WebViewTracking.DATADOG_EVENT_BRIDGE_NAME)
+        )
+    }
+
+    @Test
+    fun `M pass valid patterns to the bridge W enableWithPatterns`() {
+        // Given
+        val fakeHostPatterns = listOf("*.example.com", "preview-*.shopist.io", "example.net")
+        val mockSettings: WebSettings = mock {
+            whenever(it.javaScriptEnabled).thenReturn(true)
+        }
+        val mockWebView: WebView = mock {
+            whenever(it.settings).thenReturn(mockSettings)
+        }
+
+        // When
+        WebViewTracking.enableWithPatterns(mockWebView, fakeHostPatterns, sdkCore = mockCore)
+
+        // Then
+        argumentCaptor<DatadogEventBridge> {
+            verify(mockWebView).addJavascriptInterface(
+                capture(),
+                eq(WebViewTracking.DATADOG_EVENT_BRIDGE_NAME)
+            )
+            assertThat(firstValue.getAllowedWebViewHosts())
+                .isEqualTo("[\"*.example.com\",\"preview-*.shopist.io\",\"example.net\"]")
+        }
+    }
+
+    @Test
+    fun `M attach the bridge and send a warn log W enableWithPatterns { javascript not enabled }`() {
+        // Given
+        val fakeHostPatterns = listOf("*.example.com")
+        val mockSettings: WebSettings = mock {
+            whenever(it.javaScriptEnabled).thenReturn(false)
+        }
+        val mockWebView: WebView = mock {
+            whenever(it.settings).thenReturn(mockSettings)
+        }
+
+        // When
+        WebViewTracking.enableWithPatterns(mockWebView, fakeHostPatterns, sdkCore = mockCore)
+
+        // Then
+        verify(mockWebView).addJavascriptInterface(
+            argThat { this is DatadogEventBridge },
+            eq(WebViewTracking.DATADOG_EVENT_BRIDGE_NAME)
+        )
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            WebViewTracking.JAVA_SCRIPT_NOT_ENABLED_WARNING_MESSAGE
+        )
+    }
+
+    @Test
+    fun `M send telemetry W enableWithPatterns`() {
+        // Given
+        val fakeHostPatterns = listOf("*.example.com")
+        val mockSettings: WebSettings = mock {
+            whenever(it.javaScriptEnabled).thenReturn(true)
+        }
+        val mockWebView: WebView = mock {
+            whenever(it.settings).thenReturn(mockSettings)
+        }
+
+        // When
+        WebViewTracking.enableWithPatterns(mockWebView, fakeHostPatterns, sdkCore = mockCore)
+
+        // Then
+        verify(mockInternalLogger).logApiUsage(
+            any(),
+            argThat { this() is InternalTelemetryEvent.ApiUsage.TrackWebView }
+        )
+    }
+
+    @Test
     fun `M create a default WebEventConsumer W enable()`(
         @Forgery fakeUrls: List<URL>
     ) {

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/DatadogEventBridgeTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/DatadogEventBridgeTest.kt
@@ -49,6 +49,7 @@ internal class DatadogEventBridgeTest {
         testedDatadogEventBridge = DatadogEventBridge(
             mockWebViewEventConsumer,
             emptyList(),
+            emptyList(),
             fakePrivacyLevel,
             mockWebViewRumFeature
         )
@@ -72,7 +73,13 @@ internal class DatadogEventBridgeTest {
     ) {
         // Given
         val expectedHosts = hosts.joinToString(",", prefix = "[", postfix = "]") { "\"$it\"" }
-        testedDatadogEventBridge = DatadogEventBridge(mock(), hosts, fakePrivacyLevel, mockWebViewRumFeature)
+        testedDatadogEventBridge = DatadogEventBridge(
+            mock(),
+            hosts,
+            emptyList(),
+            fakePrivacyLevel,
+            mockWebViewRumFeature
+        )
 
         // When
         val allowedWebViewHosts = testedDatadogEventBridge.getAllowedWebViewHosts()
@@ -93,6 +100,7 @@ internal class DatadogEventBridgeTest {
         testedDatadogEventBridge = DatadogEventBridge(
             mockWebViewEventConsumer,
             hosts,
+            emptyList(),
             fakePrivacyLevel,
             mockWebViewRumFeature
         )
@@ -116,6 +124,7 @@ internal class DatadogEventBridgeTest {
         testedDatadogEventBridge = DatadogEventBridge(
             mockWebViewEventConsumer,
             hosts,
+            emptyList(),
             fakePrivacyLevel,
             mockWebViewRumFeature
         )
@@ -125,6 +134,65 @@ internal class DatadogEventBridgeTest {
 
         // Then
         assertThat(allowedWebViewHosts).isEqualTo(expectedHosts)
+    }
+
+    @Test
+    fun `M return host patterns as-is W getAllowedWebViewHosts() { wildcard patterns }`() {
+        // Given
+        val patterns = listOf("*.example.com", "preview-*.shopist.io", "example.net")
+        val expectedHosts = patterns.joinToString(",", prefix = "[", postfix = "]") { "\"$it\"" }
+        testedDatadogEventBridge = DatadogEventBridge(
+            mockWebViewEventConsumer,
+            emptyList(),
+            patterns,
+            fakePrivacyLevel,
+            mockWebViewRumFeature
+        )
+
+        // When
+        val allowedWebViewHosts = testedDatadogEventBridge.getAllowedWebViewHosts()
+
+        // Then
+        assertThat(allowedWebViewHosts).isEqualTo(expectedHosts)
+    }
+
+    @Test
+    fun `M drop invalid patterns W getAllowedWebViewHosts() { invalid patterns }`() {
+        // Given
+        val patterns = listOf("*.example.com", "*.foo.*.bar", "in valid", "EXAMPLE.NET")
+        testedDatadogEventBridge = DatadogEventBridge(
+            mockWebViewEventConsumer,
+            emptyList(),
+            patterns,
+            fakePrivacyLevel,
+            mockWebViewRumFeature
+        )
+
+        // When
+        val allowedWebViewHosts = testedDatadogEventBridge.getAllowedWebViewHosts()
+
+        // Then
+        assertThat(allowedWebViewHosts).isEqualTo("[\"*.example.com\",\"example.net\"]")
+    }
+
+    @Test
+    fun `M merge sanitized hosts and patterns W getAllowedWebViewHosts() { mixed }`() {
+        // Given
+        val hosts = listOf("example.com")
+        val patterns = listOf("*.shopist.io")
+        testedDatadogEventBridge = DatadogEventBridge(
+            mockWebViewEventConsumer,
+            hosts,
+            patterns,
+            fakePrivacyLevel,
+            mockWebViewRumFeature
+        )
+
+        // When
+        val allowedWebViewHosts = testedDatadogEventBridge.getAllowedWebViewHosts()
+
+        // Then
+        assertThat(allowedWebViewHosts).isEqualTo("[\"example.com\",\"*.shopist.io\"]")
     }
 
     @Test
@@ -196,6 +264,7 @@ internal class DatadogEventBridgeTest {
         // Given
         testedDatadogEventBridge = DatadogEventBridge(
             mockWebViewEventConsumer,
+            emptyList(),
             emptyList(),
             fakePrivacyLevel,
             null


### PR DESCRIPTION
### What does this PR do?

- Adds a new `WebViewTracking.enableWithPatterns` API that accepts wildcard host patterns (e.g., `"*.example.com`, `"preview-*.shopist.io"`) in addition to plain hosts. Patterns are validated on our side and then transmitted to the Browser SDK through the existing `getAllowedWebViewHosts()` bridge.
- Adds a `HostPatternValidator` to `dd-sdk-android-core` which handles validating and normalizing wildcard patterns. It lives in the `core` so the incoming first-party-hosts widlcard matching work can reuse it.

### Motivation

Customers weren't able to easily enumerate hostnames loaded in a WebView such as ephemeral preview URLs, multi-tenant subdomains.

### Additional Notes

iOS PR: https://github.com/DataDog/dd-sdk-ios/pull/2963
Broswer PR: https://github.com/DataDog/browser-sdk/pull/4703

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

