### PR TITLE
RUM-16394 Pt.3: Wire Quota Checker with Profiling Feature

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -3,6 +3,7 @@ object com.datadog.android.internal.FeatureContextKeys
   const val RUM_SESSION_ID: String
   const val RUM_SESSION_SAMPLE_RATE: String
   const val PROFILING_QUOTA_REASON: String
+  const val PROFILING_QUOTA_SESSION_ID: String
 interface com.datadog.android.internal.attributes.LocalAttribute
   enum Key
     constructor(String)

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -2,6 +2,7 @@ public final class com/datadog/android/internal/FeatureContextKeys {
 	public static final field INSTANCE Lcom/datadog/android/internal/FeatureContextKeys;
 	public static final field PROFILER_IS_RUNNING Ljava/lang/String;
 	public static final field PROFILING_QUOTA_REASON Ljava/lang/String;
+	public static final field PROFILING_QUOTA_SESSION_ID Ljava/lang/String;
 	public static final field RUM_SESSION_ID Ljava/lang/String;
 	public static final field RUM_SESSION_SAMPLE_RATE Ljava/lang/String;
 }

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/FeatureContextKeys.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/FeatureContextKeys.kt
@@ -36,4 +36,12 @@ object FeatureContextKeys {
      * Absent when profiling is allowed or no quota check has been performed.
      */
     const val PROFILING_QUOTA_REASON: String = "profiling_quota_reason"
+
+    /**
+     * RUM session id the [PROFILING_QUOTA_REASON] decision was made for. Written alongside
+     * the reason by the profiling feature so consumers can detect (and ignore) a decision
+     * that belongs to a previous session — e.g. while the new session's quota check is still
+     * in flight.
+     */
+    const val PROFILING_QUOTA_SESSION_ID: String = "profiling_quota_session_id"
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
@@ -19,6 +19,7 @@ import com.datadog.android.internal.FeatureContextKeys
 import com.datadog.android.internal.sampling.DeterministicSampling
 import com.datadog.android.internal.sampling.SessionSamplingIdProvider
 import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.profiling.internal.quota.QuotaResult
 import java.util.Locale
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
@@ -66,6 +67,9 @@ internal class ContinuousProfilingScheduler(
 
     @Volatile
     private var remainingCooldownMs: Long = 0L
+
+    @Volatile
+    internal var lastQuotaResult: QuotaResult? = null
 
     private val schedulerExecutor: ScheduledExecutorService = profiler.scheduledExecutorService
 
@@ -230,6 +234,18 @@ internal class ContinuousProfilingScheduler(
     private fun scheduleNextCycle() {
         val activeMs = jitter(CONTINUOUS_WINDOW_DURATION_MS)
         if (currentSessionSampled) {
+            val quota = lastQuotaResult
+            if (quota == null || quota.decision == QuotaResult.Decision.DENIED) {
+                logToUser {
+                    if (quota == null) {
+                        LOG_QUOTA_PENDING
+                    } else {
+                        LOG_QUOTA_DENIED.format(Locale.US, quota.reason.rawValue)
+                    }
+                }
+                scheduleCooldown(activeMs)
+                return
+            }
             onActiveWindowStarted()
             isActive = true
             state = State.ACTIVE
@@ -386,5 +402,9 @@ internal class ContinuousProfilingScheduler(
             "Grace period expired; profiler stopped."
         internal const val LOG_RUM_SESSION_DECISION =
             "RUM session decision: rumSessionSampleRate=%s, currentSessionSampled=%s."
+        internal const val LOG_QUOTA_DENIED =
+            "Continuous profiling skipped: quota denied (reason=%s)."
+        internal const val LOG_QUOTA_PENDING =
+            "Continuous profiling skipped: awaiting quota decision."
     }
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -27,8 +27,14 @@ import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.profiling.ExperimentalProfilingApi
 import com.datadog.android.profiling.ProfilingConfiguration
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
+import com.datadog.android.profiling.internal.quota.NoOpQuotaChecker
+import com.datadog.android.profiling.internal.quota.ProfilingQuotaChecker
+import com.datadog.android.profiling.internal.quota.QuotaChecker
+import com.datadog.android.profiling.internal.quota.QuotaResult
 import com.datadog.android.profiling.internal.utils.getProfilingModuleLongVersionCode
 import java.util.Locale
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 @OptIn(ExperimentalProfilingApi::class)
@@ -55,12 +61,21 @@ internal class ProfilingFeature(
     private val isTtidVitalReceived: AtomicBoolean = AtomicBoolean(false)
     private val isTtidProfileSent: AtomicBoolean = AtomicBoolean(false)
 
+    @Volatile
+    internal var quotaChecker: QuotaChecker = NoOpQuotaChecker()
+
+    @Volatile
+    private var quotaExecutor: ExecutorService? = null
+
     private lateinit var appContext: Context
 
     @Volatile
     internal var continuousProfilingScheduler: ContinuousProfilingScheduler? = null
 
     private var processLifecycleMonitor: ProcessLifecycleMonitor? = null
+
+    @Volatile
+    private var lastQuotaResult: QuotaResult? = null
 
     override val requestFactory: RequestFactory = ProfilingRequestFactory(
         customEndpointUrl = configuration.customEndpointUrl,
@@ -95,6 +110,18 @@ internal class ProfilingFeature(
         }
         dataWriter = createDataWriter(sdkCore)
 
+        val quotaCallFactory = sdkCore.createOkHttpCallFactory {
+            callTimeout(QUOTA_CHECK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        }
+        val qExecutor = sdkCore.createSingleThreadExecutorService(QUOTA_EXECUTOR_CONTEXT)
+        quotaExecutor = qExecutor
+        quotaChecker = ProfilingQuotaChecker(
+            callFactory = quotaCallFactory,
+            executor = qExecutor,
+            internalLogger = sdkCore.internalLogger,
+            onResult = ::propagateQuotaResult
+        )
+
         val scheduler = ContinuousProfilingScheduler(
             appContext = appContext,
             profiler = profiler,
@@ -128,6 +155,11 @@ internal class ProfilingFeature(
         }
         sdkCore.removeEventReceiver(name)
         sdkCore.removeContextUpdateReceiver(this)
+        quotaChecker.reset()
+        quotaChecker = NoOpQuotaChecker()
+        quotaExecutor?.shutdownNow()
+        quotaExecutor = null
+        lastQuotaResult = null
         lastSeenRumSessionId = null
         pendingRumEvents.clear()
     }
@@ -224,9 +256,14 @@ internal class ProfilingFeature(
         ) {
             return
         }
+        this.lastQuotaResult = null
+        continuousProfilingScheduler?.lastQuotaResult = null
         val sampleRate = (context[FeatureContextKeys.RUM_SESSION_SAMPLE_RATE] as? Number)?.toFloat()
             ?: DEFAULT_RUM_SESSION_SAMPLE_RATE
         lastSeenRumSessionId = sessionId
+        sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.withContext { datadogContext ->
+            quotaChecker.checkAsync(sessionId, datadogContext)
+        }
         continuousProfilingScheduler?.onRumSessionRenewed(
             sessionId = sessionId,
             rumSessionSampleRate = sampleRate
@@ -242,21 +279,39 @@ internal class ProfilingFeature(
         }
     }
 
+    @Suppress("ReturnCount")
     private fun tryWriteProfilingEvent() {
         val result = perfettoResult ?: return
         when (result.startReason) {
             ProfilingStartReason.APPLICATION_LAUNCH -> {
-                // Wait until the TTID event has been received before proceeding — both the
-                // profiler result and the TTID event are needed.
+                // Wait until both the TTID event and the quota decision have been received before
+                // proceeding — the profiler result, the TTID event and the quota result are all
+                // required. If the quota decision has not arrived yet, hold the buffered result and
+                // return; the quota callback (or the timeout fallback) will re-trigger this write
+                // once it lands. Capture the result once to avoid a re-read race with a concurrent
+                // session renewal resetting it to null.
+                val quotaResult = this.lastQuotaResult ?: return
                 if (isTtidVitalReceived.get() && !isTtidProfileSent.getAndSet(true)) {
                     isLaunchProfilingActive = false
-                    val (longTasks, anrEvents, vitalEvents) = pendingRumEvents.drain()
-                    dataWriter.write(
-                        profilingResult = result,
-                        longTasks = longTasks,
-                        anrEvents = anrEvents,
-                        vitalEvents = vitalEvents
-                    )
+                    if (quotaResult.decision == QuotaResult.Decision.DENIED) {
+                        logToUser(
+                            LOG_LAUNCH_PROFILING_DROPPED_QUOTA_DENIED.format(
+                                Locale.US,
+                                quotaResult.reason.rawValue
+                            )
+                        )
+                        pendingRumEvents.clear()
+                    } else {
+                        val (longTasks, anrEvents, vitalEvents) = pendingRumEvents.drain()
+                        dataWriter.write(
+                            profilingResult = result,
+                            longTasks = longTasks,
+                            anrEvents = anrEvents,
+                            vitalEvents = vitalEvents
+                        )
+                    }
+                    // Clear the consumed result so a later quota callback can't re-trigger a write.
+                    perfettoResult = null
                     continuousProfilingScheduler?.onAppLaunchProfilingComplete()
                 }
             }
@@ -271,6 +326,7 @@ internal class ProfilingFeature(
                     anrEvents = anrEvents,
                     vitalEvents = vitalEvents
                 )
+                perfettoResult = null
                 if (longTasks.isEmpty() && anrEvents.isEmpty() && vitalEvents.isEmpty()) {
                     logToUser(LOG_CONTINUOUS_PROFILING_NOT_UPLOADED_NO_RUM_EVENTS)
                 } else {
@@ -304,6 +360,21 @@ internal class ProfilingFeature(
         return ProfilingDataWriter(sdkCore)
     }
 
+    internal fun propagateQuotaResult(result: QuotaResult) {
+        this.lastQuotaResult = result
+        continuousProfilingScheduler?.lastQuotaResult = result
+        sdkCore.updateFeatureContext(Feature.PROFILING_FEATURE_NAME) { context ->
+            if (result.decision == QuotaResult.Decision.DENIED) {
+                context[FeatureContextKeys.PROFILING_QUOTA_REASON] = result.reason.rawValue
+                context[FeatureContextKeys.PROFILING_QUOTA_SESSION_ID] = lastSeenRumSessionId
+            } else {
+                context.remove(FeatureContextKeys.PROFILING_QUOTA_REASON)
+                context.remove(FeatureContextKeys.PROFILING_QUOTA_SESSION_ID)
+            }
+        }
+        tryWriteProfilingEvent()
+    }
+
     private fun isRecordingProfile(): Boolean {
         return isLaunchProfilingActive || continuousProfilingScheduler?.isActive == true
     }
@@ -319,5 +390,9 @@ internal class ProfilingFeature(
             "Continuous profiling result not uploaded: no pending RUM events."
         private const val LOG_CONTINUOUS_PROFILING_WRITTEN =
             "Continuous profiling result written: %d long task(s), %d ANR event(s)."
+        internal const val QUOTA_CHECK_TIMEOUT_MS = 5_000L
+        private const val QUOTA_EXECUTOR_CONTEXT = "dd-profiling-quota"
+        internal const val LOG_LAUNCH_PROFILING_DROPPED_QUOTA_DENIED =
+            "Launch profiling dropped: quota denied (reason=%s)."
     }
 }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -12,6 +12,7 @@ import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.os.ProfilingManager
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.core.InternalSdkCore
@@ -32,6 +33,10 @@ import com.datadog.android.profiling.internal.ProfilingStartReason
 import com.datadog.android.profiling.internal.ProfilingStorage
 import com.datadog.android.profiling.internal.ProfilingWriter
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
+import com.datadog.android.profiling.internal.quota.NoOpQuotaChecker
+import com.datadog.android.profiling.internal.quota.QuotaChecker
+import com.datadog.android.profiling.internal.quota.QuotaReason
+import com.datadog.android.profiling.internal.quota.QuotaResult
 import com.datadog.android.profiling.internal.time.MutableTimeProvider
 import com.datadog.android.profiling.utils.config.MainLooperTestConfiguration
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
@@ -44,6 +49,7 @@ import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import okhttp3.Call
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -51,12 +57,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
-import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeastOnce
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
@@ -107,7 +113,16 @@ internal class ProfilingFeatureTest {
     private lateinit var mockRumFeatureScope: FeatureScope
 
     @Mock
+    private lateinit var mockProfilingFeatureScope: FeatureScope
+
+    @Mock
     private lateinit var mockDataWriter: ProfilingWriter
+
+    @Mock
+    private lateinit var mockQuotaChecker: QuotaChecker
+
+    @Mock
+    private lateinit var mockCallFactory: Call.Factory
 
     @Mock
     private lateinit var mockSharedPreferences: SharedPreferences
@@ -148,6 +163,9 @@ internal class ProfilingFeatureTest {
     @LongForgery(min = 1L)
     private var fakeProfilingPackageVersionCode: Long = 0L
 
+    @Forgery
+    private lateinit var fakeDatadogContext: DatadogContext
+
     private val fakeAllSampledConfiguration = ProfilingConfiguration(
         customEndpointUrl = null,
         applicationLaunchSampleRate = 100f,
@@ -171,6 +189,7 @@ internal class ProfilingFeatureTest {
         whenever(mockSdkCore.name) doReturn fakeInstanceName
         whenever(mockSdkCore.createSingleThreadExecutorService(any())) doReturn mockProfilingExecutor
         whenever(mockProfiler.timeProvider) doReturn mockMutableTimeProvider
+        whenever(mockSdkCore.createOkHttpCallFactory(any())) doReturn mockCallFactory
         whenever(mockProfiler.scheduledExecutorService) doReturn mockSchedulerExecutor
         whenever(mockContext.getSystemService(ProfilingManager::class.java)) doReturn (mockService)
         whenever(mockContext.getSharedPreferences(any(), any())) doReturn mockSharedPreferences
@@ -181,6 +200,10 @@ internal class ProfilingFeatureTest {
         whenever(mockEditor.putStringSet(any(), any())) doReturn mockEditor
         whenever(mockEditor.putFloat(any(), any())) doReturn mockEditor
         whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
+        whenever(mockSdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)) doReturn mockProfilingFeatureScope
+        whenever(mockProfilingFeatureScope.withContext(any(), any())) doAnswer {
+            it.getArgument<(DatadogContext) -> Unit>(1).invoke(fakeDatadogContext)
+        }
         testedFeature = ProfilingFeature(mockSdkCore, fakeConfiguration, mockProfiler)
         ProfilingStorage.sharedPreferencesStorage = mockSharedPreferencesStorage
         fakeTTID = fakeTTID.copy(type = ProfilerEvent.RumVitalEvent.Type.TTID)
@@ -249,10 +272,12 @@ internal class ProfilingFeatureTest {
     @Test
     fun `M not set Profiling sample rate W initialize() {smaller sample rate exists}`() {
         // Given
+        // A non-negative existing rate that is <= the configured rate (the configured rate is
+        // forged in 0f..100f, so subtracting would underflow below the "unset" sentinel).
         whenever(
             mockSharedPreferencesStorage
                 .getFloat("dd_profiling_sample_rate", -1f)
-        ) doReturn fakeConfiguration.applicationLaunchSampleRate - 1f
+        ) doReturn fakeConfiguration.applicationLaunchSampleRate / 2f
 
         // When
         testedFeature.onInitialize(mockContext)
@@ -496,6 +521,20 @@ internal class ProfilingFeatureTest {
     }
 
     @Test
+    fun `M reset quota checker W onStop()`() {
+        // Given
+        testedFeature.onInitialize(mockContext)
+        testedFeature.quotaChecker = mockQuotaChecker
+
+        // When
+        testedFeature.onStop()
+
+        // Then
+        verify(mockQuotaChecker).reset()
+        assertThat(testedFeature.quotaChecker).isInstanceOf(NoOpQuotaChecker::class.java)
+    }
+
+    @Test
     fun `M start continuous cycle W profiler result received {TTID session unsampled}`() {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
@@ -509,6 +548,7 @@ internal class ProfilingFeatureTest {
         )
 
         testedFeature.dispatchRumSession("session-id", 100f)
+        testedFeature.simulateQuotaAllowed()
 
         testedFeature.onReceive(ProfilerEvent.TTIDNotTracked)
 
@@ -550,6 +590,7 @@ internal class ProfilingFeatureTest {
             callbackCaptor.capture()
         )
         testedFeature.dispatchRumSession(fakeSessionId, 100f)
+        testedFeature.simulateQuotaAllowed()
         testedFeature.onReceive(ProfilerEvent.TTIDNotTracked)
 
         val runnableCaptor = argumentCaptor<Runnable>()
@@ -654,6 +695,7 @@ internal class ProfilingFeatureTest {
         )
         // Open the continuous accumulation window
         testedFeature.dispatchRumSession(fakeSessionId, 100f)
+        testedFeature.simulateQuotaAllowed()
         testedFeature.onReceive(fakeTTID)
         callbackCaptor.firstValue.onSuccess(
             fakePerfettoResult.copy(startReason = ProfilingStartReason.APPLICATION_LAUNCH)
@@ -695,6 +737,7 @@ internal class ProfilingFeatureTest {
         )
         // Open the continuous accumulation window
         testedFeature.dispatchRumSession(fakeSessionId, 100f)
+        testedFeature.simulateQuotaAllowed()
         testedFeature.onReceive(fakeTTID)
         callbackCaptor.firstValue.onSuccess(
             fakePerfettoResult.copy(startReason = ProfilingStartReason.APPLICATION_LAUNCH)
@@ -733,6 +776,7 @@ internal class ProfilingFeatureTest {
         )
         // Close launch window
         testedFeature.onReceive(fakeTTID)
+        testedFeature.simulateQuotaAllowed()
         callbackCaptor.firstValue.onSuccess(
             PerfettoResult(
                 start = 0L,
@@ -743,6 +787,7 @@ internal class ProfilingFeatureTest {
         )
         // Open continuous active window
         testedFeature.dispatchRumSession(fakeSessionId, 100f)
+        testedFeature.simulateQuotaAllowed()
         val runnableCaptor = argumentCaptor<Runnable>()
         verify(mockSchedulerExecutor).schedule(runnableCaptor.capture(), any(), any())
         runnableCaptor.firstValue.run()
@@ -810,6 +855,7 @@ internal class ProfilingFeatureTest {
         )
         // Close launch window
         testedFeature.onReceive(fakeTTID)
+        testedFeature.simulateQuotaAllowed()
         callbackCaptor.firstValue.onSuccess(
             PerfettoResult(
                 start = 0L,
@@ -820,6 +866,7 @@ internal class ProfilingFeatureTest {
         )
         // Open continuous active window
         testedFeature.dispatchRumSession(fakeSessionId, 100f)
+        testedFeature.simulateQuotaAllowed()
         val runnableCaptor = argumentCaptor<Runnable>()
         verify(mockSchedulerExecutor).schedule(runnableCaptor.capture(), any(), any())
         runnableCaptor.firstValue.run()
@@ -948,6 +995,7 @@ internal class ProfilingFeatureTest {
         )
         // Close launch window
         testedFeature.onReceive(fakeTTID)
+        testedFeature.simulateQuotaAllowed()
         callbackCaptor.firstValue.onSuccess(
             PerfettoResult(
                 start = 0L,
@@ -958,6 +1006,7 @@ internal class ProfilingFeatureTest {
         )
         // Open window 1
         testedFeature.dispatchRumSession(fakeSessionId, 100f)
+        testedFeature.simulateQuotaAllowed()
         val runnableCaptor = argumentCaptor<Runnable>()
         verify(mockSchedulerExecutor, atLeastOnce()).schedule(
             runnableCaptor.capture(),
@@ -1008,6 +1057,7 @@ internal class ProfilingFeatureTest {
             callbackCaptor.capture()
         )
         testedFeature.dispatchRumSession(fakeSessionId, 100f)
+        testedFeature.simulateQuotaAllowed()
         testedFeature.onReceive(fakeTTID)
         callbackCaptor.firstValue.onSuccess(
             fakePerfettoResult.copy(startReason = ProfilingStartReason.APPLICATION_LAUNCH)
@@ -1044,6 +1094,7 @@ internal class ProfilingFeatureTest {
         )
         testedFeature.onReceive(fakeRumLongTaskEvent)
         testedFeature.onReceive(fakeTTID)
+        testedFeature.simulateQuotaAllowed()
 
         // When
         callbackCaptor.firstValue.onSuccess(
@@ -1076,6 +1127,7 @@ internal class ProfilingFeatureTest {
         )
         testedFeature.onReceive(fakeRumAnrEvent)
         testedFeature.onReceive(fakeTTID)
+        testedFeature.simulateQuotaAllowed()
 
         // When
         callbackCaptor.firstValue.onSuccess(
@@ -1140,6 +1192,7 @@ internal class ProfilingFeatureTest {
             callbackCaptor.capture()
         )
         testedFeature.onReceive(fakeTTID)
+        testedFeature.simulateQuotaAllowed()
         callbackCaptor.firstValue.onSuccess(
             fakePerfettoResult.copy(startReason = ProfilingStartReason.APPLICATION_LAUNCH)
         )
@@ -1171,6 +1224,7 @@ internal class ProfilingFeatureTest {
         testedFeature.onReceive(fakeRumLongTaskEvent)
         testedFeature.onReceive(fakeRumAnrEvent)
         testedFeature.onReceive(fakeTTID)
+        testedFeature.simulateQuotaAllowed()
         callbackCaptor.firstValue.onSuccess(
             fakePerfettoResult.copy(startReason = ProfilingStartReason.APPLICATION_LAUNCH)
         )
@@ -1242,6 +1296,208 @@ internal class ProfilingFeatureTest {
 
         // Then
         verify(mockProfiler).unregisterProfilingCallback(mockContext, fakeInstanceName)
+    }
+
+    @Test
+    fun `M fire quota check W onContextUpdate { new session id }`(forge: Forge) {
+        // Given
+        val fakeNewSessionId = forge.aString()
+        testedFeature.quotaChecker = mockQuotaChecker
+
+        // When
+        testedFeature.onContextUpdate(
+            Feature.RUM_FEATURE_NAME,
+            mapOf(
+                FeatureContextKeys.RUM_SESSION_ID to fakeNewSessionId,
+                FeatureContextKeys.RUM_SESSION_SAMPLE_RATE to 100f
+            )
+        )
+
+        // Then
+        verify(mockQuotaChecker).checkAsync(eq(fakeNewSessionId), any())
+    }
+
+    @Test
+    fun `M stamp reason and session id W propagateQuotaResult {denied for current session}`(
+        @StringForgery fakeQuotaSessionId: String
+    ) {
+        // Given
+        val fakeProfilingContext = mutableMapOf<String, Any?>()
+        whenever(
+            mockSdkCore.updateFeatureContext(eq(Feature.PROFILING_FEATURE_NAME), any(), any())
+        ) doAnswer {
+            it.getArgument<(MutableMap<String, Any?>) -> Unit>(2).invoke(fakeProfilingContext)
+        }
+        testedFeature.onInitialize(mockContext)
+        testedFeature.dispatchRumSession(fakeQuotaSessionId, 100f)
+
+        // When
+        testedFeature.propagateQuotaResult(QuotaResult.QUOTA_EXCEEDED)
+
+        // Then — the decision is stamped with the current session in context and fed to the scheduler
+        assertThat(fakeProfilingContext[FeatureContextKeys.PROFILING_QUOTA_REASON])
+            .isEqualTo(QuotaResult.QUOTA_EXCEEDED.reason.rawValue)
+        assertThat(fakeProfilingContext[FeatureContextKeys.PROFILING_QUOTA_SESSION_ID])
+            .isEqualTo(fakeQuotaSessionId)
+        assertThat(testedFeature.continuousProfilingScheduler?.lastQuotaResult)
+            .isEqualTo(QuotaResult.QUOTA_EXCEEDED)
+    }
+
+    @Test
+    fun `M clear reason and session id W propagateQuotaResult {allowed for current session}`(
+        @StringForgery fakeQuotaSessionId: String
+    ) {
+        // Given — a stale denial stamp from a previous session is present
+        val fakeProfilingContext = mutableMapOf<String, Any?>(
+            FeatureContextKeys.PROFILING_QUOTA_REASON to "stale-reason",
+            FeatureContextKeys.PROFILING_QUOTA_SESSION_ID to "stale-session"
+        )
+        whenever(
+            mockSdkCore.updateFeatureContext(eq(Feature.PROFILING_FEATURE_NAME), any(), any())
+        ) doAnswer {
+            it.getArgument<(MutableMap<String, Any?>) -> Unit>(2).invoke(fakeProfilingContext)
+        }
+        testedFeature.onInitialize(mockContext)
+        testedFeature.dispatchRumSession(fakeQuotaSessionId, 100f)
+
+        // When
+        testedFeature.propagateQuotaResult(QuotaResult.FAIL_OPEN)
+
+        // Then — both the reason and its session stamp are removed
+        assertThat(fakeProfilingContext).doesNotContainKey(FeatureContextKeys.PROFILING_QUOTA_REASON)
+        assertThat(fakeProfilingContext).doesNotContainKey(FeatureContextKeys.PROFILING_QUOTA_SESSION_ID)
+    }
+
+    @Test
+    fun `M clear scheduler quota result W onContextUpdate {new session}`() {
+        // Given — the current session was denied
+        testedFeature.onInitialize(mockContext)
+        testedFeature.dispatchRumSession(fakeSessionId, 100f)
+        testedFeature.propagateQuotaResult(QuotaResult.QUOTA_EXCEEDED)
+        assertThat(testedFeature.continuousProfilingScheduler?.lastQuotaResult)
+            .isEqualTo(QuotaResult.QUOTA_EXCEEDED)
+
+        // When — a new session rolls over before its own quota check resolves
+        testedFeature.dispatchRumSession("new-$fakeSessionId", 100f)
+
+        // Then — the scheduler's decision is cleared until the new session's check resolves
+        assertThat(testedFeature.continuousProfilingScheduler?.lastQuotaResult).isNull()
+    }
+
+    @Test
+    fun `M not write launch event W app-launch profiling result received {quota denied}`(
+        @Forgery fakePerfettoResult: PerfettoResult
+    ) {
+        // Given
+        testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
+        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        val callbackCaptor = argumentCaptor<ProfilerCallback>()
+        testedFeature.onInitialize(mockContext)
+        testedFeature.dataWriter = mockDataWriter
+        verify(mockProfiler).registerProfilingCallback(
+            eq(mockContext),
+            eq(fakeInstanceName),
+            callbackCaptor.capture()
+        )
+        testedFeature.propagateQuotaResult(QuotaResult.QUOTA_EXCEEDED)
+        testedFeature.onReceive(fakeRumLongTaskEvent)
+        testedFeature.onReceive(fakeTTID)
+
+        // When
+        callbackCaptor.firstValue.onSuccess(
+            fakePerfettoResult.copy(startReason = ProfilingStartReason.APPLICATION_LAUNCH)
+        )
+
+        // Then
+        verify(mockDataWriter, never()).write(
+            profilingResult = any(),
+            longTasks = any(),
+            anrEvents = any(),
+            vitalEvents = any()
+        )
+    }
+
+    @Test
+    fun `M write launch event W app-launch profiling result received {quota allowed}`(
+        @Forgery fakePerfettoResult: PerfettoResult
+    ) {
+        // Given
+        testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
+        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        val callbackCaptor = argumentCaptor<ProfilerCallback>()
+        testedFeature.onInitialize(mockContext)
+        testedFeature.dataWriter = mockDataWriter
+        verify(mockProfiler).registerProfilingCallback(
+            eq(mockContext),
+            eq(fakeInstanceName),
+            callbackCaptor.capture()
+        )
+        testedFeature.propagateQuotaResult(QuotaResult(QuotaResult.Decision.ALLOWED, QuotaReason.QUOTA_OK))
+        testedFeature.onReceive(fakeRumLongTaskEvent)
+        testedFeature.onReceive(fakeTTID)
+
+        // When
+        callbackCaptor.firstValue.onSuccess(
+            fakePerfettoResult.copy(startReason = ProfilingStartReason.APPLICATION_LAUNCH)
+        )
+
+        // Then
+        verify(mockDataWriter).write(
+            profilingResult = fakePerfettoResult.copy(startReason = ProfilingStartReason.APPLICATION_LAUNCH),
+            longTasks = listOf(fakeRumLongTaskEvent),
+            anrEvents = emptyList(),
+            vitalEvents = listOf(fakeTTID)
+        )
+    }
+
+    @Test
+    fun `M buffer launch event then write W quota result arrives after app-launch result`(
+        @Forgery fakePerfettoResult: PerfettoResult
+    ) {
+        // Given — no quota decision is ever propagated (e.g. the quota check could not be
+        // scheduled). The launch event must still be written (fail open) rather than stalled.
+        testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
+        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        val callbackCaptor = argumentCaptor<ProfilerCallback>()
+        testedFeature.onInitialize(mockContext)
+        testedFeature.dataWriter = mockDataWriter
+        verify(mockProfiler).registerProfilingCallback(
+            eq(mockContext),
+            eq(fakeInstanceName),
+            callbackCaptor.capture()
+        )
+        testedFeature.onReceive(fakeRumLongTaskEvent)
+        testedFeature.onReceive(fakeTTID)
+        callbackCaptor.firstValue.onSuccess(
+            fakePerfettoResult.copy(startReason = ProfilingStartReason.APPLICATION_LAUNCH)
+        )
+
+        // Then — nothing is written while the quota decision is still pending
+        verify(mockDataWriter, never()).write(
+            profilingResult = any(),
+            longTasks = any(),
+            anrEvents = any(),
+            vitalEvents = any()
+        )
+
+        // When — the quota decision finally lands
+        testedFeature.simulateQuotaAllowed()
+
+        // Then — the buffered launch event is now written
+        verify(mockDataWriter).write(
+            profilingResult = fakePerfettoResult.copy(startReason = ProfilingStartReason.APPLICATION_LAUNCH),
+            longTasks = listOf(fakeRumLongTaskEvent),
+            anrEvents = emptyList(),
+            vitalEvents = listOf(fakeTTID)
+        )
+    }
+
+    // Simulates the asynchronous quota decision landing (in production this is driven by the quota
+    // checker's HTTP callback). Launch profiling is held until this arrives, so tests that expect a
+    // launch write or a launch->continuous transition must call this before the APPLICATION_LAUNCH
+    // result is delivered.
+    private fun ProfilingFeature.simulateQuotaAllowed() {
+        propagateQuotaResult(QuotaResult(QuotaResult.Decision.ALLOWED, QuotaReason.QUOTA_OK))
     }
 
     private fun ProfilingFeature.dispatchRumSession(sessionId: String, sampleRate: Float) {

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ContinuousProfilingSchedulerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ContinuousProfilingSchedulerTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.sampling.DeterministicSampler
 import com.datadog.android.internal.sampling.SessionSamplingIdProvider
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.profiling.forge.Configurator
+import com.datadog.android.profiling.internal.quota.QuotaResult
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -30,6 +31,7 @@ import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -115,6 +117,7 @@ internal class ContinuousProfilingSchedulerTest {
             sampleRate = 100f,
             onActiveWindowStarted = { activeWindowStartedCount++ }
         )
+        testedScheduler.lastQuotaResult = QuotaResult.FAIL_OPEN
     }
 
     // region start()
@@ -485,6 +488,95 @@ internal class ContinuousProfilingSchedulerTest {
 
         // Then
         verify(mockProfiler, times(1)).setExtendLaunchSession(true)
+    }
+
+    // endregion
+
+    // region quota gate
+
+    @Test
+    fun `M skip active window and stay in COOLDOWN W scheduleNextCycle {quota denied}`() {
+        // Given
+        testedScheduler.lastQuotaResult = QuotaResult.QUOTA_EXCEEDED
+        testedScheduler.onRumSessionRenewed(sessionId = fakeSessionId, rumSessionSampleRate = 100f)
+        testedScheduler.start(launchProfilingActive = true)
+        val runnableCaptor = argumentCaptor<Runnable>()
+        testedScheduler.onAppLaunchProfilingComplete()
+        verify(mockSchedulerExecutor, atLeastOnce()).schedule(runnableCaptor.capture(), any(), any())
+
+        // When
+        runnableCaptor.firstValue.run()
+
+        // Then
+        verify(mockProfiler, never()).start(any(), any(), any(), any(), any())
+        assertThat(testedScheduler.state).isEqualTo(ContinuousProfilingScheduler.State.COOLDOWN)
+        assertThat(testedScheduler.isActive).isFalse()
+        assertThat(activeWindowStartedCount).isEqualTo(0)
+        val logCaptor = argumentCaptor<() -> String>()
+        verify(mockInternalLogger, atLeastOnce()).log(
+            eq(InternalLogger.Level.DEBUG),
+            eq(InternalLogger.Target.USER),
+            logCaptor.capture(),
+            isNull(),
+            eq(false),
+            isNull()
+        )
+        assertThat(logCaptor.allValues.map { it.invoke() })
+            .anyMatch { it.contains("quota denied") }
+    }
+
+    @Test
+    fun `M skip active window and stay in COOLDOWN W scheduleNextCycle {quota decision not received}`() {
+        // Given — no quota decision has arrived yet for the session
+        testedScheduler.lastQuotaResult = null
+        testedScheduler.onRumSessionRenewed(sessionId = fakeSessionId, rumSessionSampleRate = 100f)
+        testedScheduler.start(launchProfilingActive = true)
+        val runnableCaptor = argumentCaptor<Runnable>()
+        testedScheduler.onAppLaunchProfilingComplete()
+        verify(mockSchedulerExecutor, atLeastOnce()).schedule(runnableCaptor.capture(), any(), any())
+
+        // When
+        runnableCaptor.firstValue.run()
+
+        // Then — the window is skipped until the decision lands
+        verify(mockProfiler, never()).start(any(), any(), any(), any(), any())
+        assertThat(testedScheduler.state).isEqualTo(ContinuousProfilingScheduler.State.COOLDOWN)
+        assertThat(testedScheduler.isActive).isFalse()
+        assertThat(activeWindowStartedCount).isEqualTo(0)
+        val logCaptor = argumentCaptor<() -> String>()
+        verify(mockInternalLogger, atLeastOnce()).log(
+            eq(InternalLogger.Level.DEBUG),
+            eq(InternalLogger.Target.USER),
+            logCaptor.capture(),
+            isNull(),
+            eq(false),
+            isNull()
+        )
+        assertThat(logCaptor.allValues.map { it.invoke() })
+            .anyMatch { it.contains("awaiting quota decision") }
+    }
+
+    @Test
+    fun `M start active window W scheduleNextCycle {quota allowed}`() {
+        // Given
+        testedScheduler.onRumSessionRenewed(sessionId = fakeSessionId, rumSessionSampleRate = 100f)
+        testedScheduler.start(launchProfilingActive = true)
+        val runnableCaptor = argumentCaptor<Runnable>()
+        testedScheduler.onAppLaunchProfilingComplete()
+        verify(mockSchedulerExecutor, atLeastOnce()).schedule(runnableCaptor.capture(), any(), any())
+
+        // When
+        runnableCaptor.firstValue.run()
+
+        // Then
+        verify(mockProfiler).start(
+            appContext = eq(mockApplication),
+            startReason = eq(ProfilingStartReason.CONTINUOUS),
+            additionalAttributes = eq(emptyMap()),
+            sdkInstanceNames = eq(setOf(fakeInstanceName)),
+            durationMs = any()
+        )
+        assertThat(testedScheduler.isActive).isTrue()
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -16,7 +16,6 @@ import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
-import com.datadog.android.internal.FeatureContextKeys
 import com.datadog.android.internal.attributes.LocalAttribute
 import com.datadog.android.internal.attributes.ViewScopeInstrumentationType
 import com.datadog.android.internal.profiling.ProfilerEvent
@@ -47,6 +46,8 @@ import com.datadog.android.rum.internal.metric.networksettled.InternalResourceCo
 import com.datadog.android.rum.internal.metric.networksettled.NetworkSettledMetricResolver
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
 import com.datadog.android.rum.internal.monitor.StorageEvent
+import com.datadog.android.rum.internal.profiling.isProfilerRunning
+import com.datadog.android.rum.internal.profiling.resolveProfilingQuotaReason
 import com.datadog.android.rum.internal.toError
 import com.datadog.android.rum.internal.toLongTask
 import com.datadog.android.rum.internal.toView
@@ -1687,28 +1688,30 @@ internal open class RumViewScope(
     }
 
     private fun resolveErrorProfilingStatus(datadogContext: DatadogContext): ErrorEvent.Profiling? {
-        return if (resolveProfilingRunning(datadogContext)) {
-            ErrorEvent.Profiling(status = ErrorEvent.ProfilingStatus.RUNNING)
-        } else {
-            null
+        val isRunning = datadogContext.isProfilerRunning()
+        val quotaReason = datadogContext.resolveProfilingQuotaReason(sessionId)
+        return when {
+            isRunning -> ErrorEvent.Profiling(status = ErrorEvent.ProfilingStatus.RUNNING)
+            quotaReason != null -> ErrorEvent.Profiling(
+                status = ErrorEvent.ProfilingStatus.STOPPED,
+                quotaReason = quotaReason
+            )
+            else -> null
         }
     }
 
     private fun resolveLongTaskProfilingStatus(datadogContext: DatadogContext): LongTaskEvent.Profiling? {
-        return if (resolveProfilingRunning(datadogContext)) {
-            LongTaskEvent.Profiling(status = LongTaskEvent.ProfilingStatus.RUNNING)
-        } else {
-            null
-        }
-    }
+        val isRunning = datadogContext.isProfilerRunning()
+        val quotaReason = datadogContext.resolveProfilingQuotaReason(sessionId)
+        return when {
+            isRunning -> LongTaskEvent.Profiling(status = LongTaskEvent.ProfilingStatus.RUNNING)
+            quotaReason != null -> LongTaskEvent.Profiling(
+                status = LongTaskEvent.ProfilingStatus.STOPPED,
+                quotaReason = quotaReason
+            )
 
-    private fun resolveProfilingRunning(datadogContext: DatadogContext): Boolean {
-        val profilingFeature = sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)
-        return profilingFeature?.let {
-            datadogContext.featuresContext[Feature.PROFILING_FEATURE_NAME]?.get(
-                FeatureContextKeys.PROFILER_IS_RUNNING
-            ) == true
-        } ?: false
+            else -> null
+        }
     }
 
     private fun logSynthetics(key: String, value: String) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumVitalAppLaunchEventHelper.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumVitalAppLaunchEventHelper.kt
@@ -38,7 +38,8 @@ internal class RumVitalAppLaunchEventHelper(
         durationNs: Long,
         scenario: RumStartupScenario,
         appLaunchMetric: VitalAppLaunchEvent.AppLaunchMetric,
-        profilingStatus: VitalAppLaunchEvent.ProfilingStatus?
+        profilingStatus: VitalAppLaunchEvent.ProfilingStatus?,
+        profilingQuotaReason: String? = null
     ): VitalAppLaunchEvent {
         val syntheticsAttribute = if (
             rumContext.syntheticsTestId.isNullOrBlank() ||
@@ -82,7 +83,8 @@ internal class RumVitalAppLaunchEventHelper(
                 ),
                 configuration = VitalAppLaunchEvent.Configuration(sessionSampleRate = sampleRate),
                 profiling = VitalAppLaunchEvent.Profiling(
-                    status = profilingStatus
+                    status = profilingStatus,
+                    quotaReason = profilingQuotaReason
                 )
             ),
             application = VitalAppLaunchEvent.Application(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/profiling/ProfilingFeatureContext.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/profiling/ProfilingFeatureContext.kt
@@ -1,0 +1,33 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.profiling
+
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.internal.FeatureContextKeys
+
+/**
+ * Whether the profiler is currently running, as published by the profiling feature.
+ */
+internal fun DatadogContext.isProfilerRunning(): Boolean =
+    featuresContext[Feature.PROFILING_FEATURE_NAME]
+        ?.get(FeatureContextKeys.PROFILER_IS_RUNNING) == true
+
+/**
+ * Returns the profiling quota-denied reason only when it applies to [currentSessionId].
+ *
+ * The profiling feature stamps each quota decision with the session id it was made for. A reason
+ * left over from a previous session — e.g. published before the current session's quota check has
+ * resolved — has a mismatching session id and is treated as absent.
+ */
+@Suppress("ReturnCount")
+internal fun DatadogContext.resolveProfilingQuotaReason(currentSessionId: String?): String? {
+    val profilingContext = featuresContext[Feature.PROFILING_FEATURE_NAME] ?: return null
+    val reason = profilingContext[FeatureContextKeys.PROFILING_QUOTA_REASON] as? String ?: return null
+    val quotaSessionId = profilingContext[FeatureContextKeys.PROFILING_QUOTA_SESSION_ID] as? String
+    return reason.takeIf { quotaSessionId != null && quotaSessionId == currentSessionId }
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManager.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManager.kt
@@ -12,12 +12,13 @@ import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.core.InternalSdkCore
-import com.datadog.android.internal.FeatureContextKeys
 import com.datadog.android.internal.profiling.ProfilerEvent
 import com.datadog.android.internal.profiling.ProfilingRumContext
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.scope.RumRawEvent
 import com.datadog.android.rum.internal.domain.scope.RumVitalAppLaunchEventHelper
+import com.datadog.android.rum.internal.profiling.isProfilerRunning
+import com.datadog.android.rum.internal.profiling.resolveProfilingQuotaReason
 import com.datadog.android.rum.internal.utils.newRumEventWriteOperation
 import com.datadog.android.rum.model.VitalAppLaunchEvent
 import kotlin.time.Duration.Companion.minutes
@@ -114,6 +115,7 @@ internal class RumSessionScopeStartupManagerImpl(
 
         ttidSentForSession = true
 
+        val profilingStatus = datadogContext.getProfilingStatus(rumContext.sessionId)
         val ttidEvent = rumVitalAppLaunchEventHelper.newVitalAppLaunchEvent(
             timestampMs = event.info.scenario.initialTime.timestamp + sdkCore.time.serverTimeOffsetMs,
             datadogContext = datadogContext,
@@ -124,7 +126,14 @@ internal class RumSessionScopeStartupManagerImpl(
             durationNs = event.info.durationNs,
             appLaunchMetric = VitalAppLaunchEvent.AppLaunchMetric.TTID,
             scenario = event.info.scenario,
-            profilingStatus = datadogContext.getProfilingStatus()
+            profilingStatus = profilingStatus,
+            // The quota reason is only meaningful when profiling is STOPPED; a running profiler
+            // must not carry a denial reason (mirrors the Error/LongTask path in RumViewScope).
+            profilingQuotaReason = if (profilingStatus == VitalAppLaunchEvent.ProfilingStatus.STOPPED) {
+                datadogContext.resolveProfilingQuotaReason(rumContext.sessionId)
+            } else {
+                null
+            }
         )
 
         sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.sendEvent(
@@ -250,6 +259,7 @@ internal class RumSessionScopeStartupManagerImpl(
             return
         }
 
+        val profilingStatus = datadogContext.getProfilingStatus(rumContext.sessionId)
         val ttfdEvent = rumVitalAppLaunchEventHelper.newVitalAppLaunchEvent(
             timestampMs = scenario.initialTime.timestamp + sdkCore.time.serverTimeOffsetMs,
             datadogContext = datadogContext,
@@ -260,7 +270,14 @@ internal class RumSessionScopeStartupManagerImpl(
             durationNs = durationNs,
             appLaunchMetric = VitalAppLaunchEvent.AppLaunchMetric.TTFD,
             scenario = scenario,
-            profilingStatus = datadogContext.getProfilingStatus()
+            profilingStatus = profilingStatus,
+            // The quota reason is only meaningful when profiling is STOPPED; a running profiler
+            // must not carry a denial reason (mirrors the TTID and Error/LongTask paths).
+            profilingQuotaReason = if (profilingStatus == VitalAppLaunchEvent.ProfilingStatus.STOPPED) {
+                datadogContext.resolveProfilingQuotaReason(rumContext.sessionId)
+            } else {
+                null
+            }
         )
 
         sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.sendEvent(
@@ -311,10 +328,12 @@ internal class RumSessionScopeStartupManagerImpl(
         }.submit()
     }
 
-    private fun DatadogContext.getProfilingStatus(): VitalAppLaunchEvent.ProfilingStatus? {
-        val isProfilerRunning = featuresContext[Feature.PROFILING_FEATURE_NAME]
-            ?.get(FeatureContextKeys.PROFILER_IS_RUNNING)
-        return if (isProfilerRunning == true) VitalAppLaunchEvent.ProfilingStatus.RUNNING else null
+    private fun DatadogContext.getProfilingStatus(
+        currentSessionId: String
+    ): VitalAppLaunchEvent.ProfilingStatus? = when {
+        isProfilerRunning() -> VitalAppLaunchEvent.ProfilingStatus.RUNNING
+        resolveProfilingQuotaReason(currentSessionId) != null -> VitalAppLaunchEvent.ProfilingStatus.STOPPED
+        else -> null
     }
 
     companion object {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/VitalAppLaunchEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/VitalAppLaunchEventAssert.kt
@@ -389,6 +389,24 @@ internal class VitalAppLaunchEventAssert(
             .isNull()
     }
 
+    fun hasProfilingQuotaReason(quotaReason: String?) = apply {
+        assertThat(actual.dd.profiling?.quotaReason)
+            .overridingErrorMessage(
+                "Expected RUM event to have profiling quota reason: $quotaReason" +
+                    " but instead was: ${actual.dd.profiling?.quotaReason}"
+            )
+            .isEqualTo(quotaReason)
+    }
+
+    fun hasNoProfilingQuotaReason() = apply {
+        assertThat(actual.dd.profiling?.quotaReason)
+            .overridingErrorMessage(
+                "Expected RUM event to have no profiling quota reason" +
+                    " but instead was: ${actual.dd.profiling?.quotaReason}"
+            )
+            .isNull()
+    }
+
     companion object {
         internal fun assertThat(
             actual: VitalAppLaunchEvent

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -5786,6 +5786,73 @@ internal class RumViewScopeTest {
     }
 
     @Test
+    fun `M include quotaReason in LongTaskEvent W handleEvent(AddLongTask) {profiler not running and quota denied}`(
+        @LongForgery(0L, 700_000_000L) durationNs: Long,
+        @StringForgery target: String,
+        @StringForgery fakeQuotaReason: String
+    ) {
+        // Given
+        testedScope.activeActionScope = null
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        val datadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(
+                    Feature.PROFILING_FEATURE_NAME,
+                    mapOf(
+                        PROFILER_IS_RUNNING to false,
+                        FeatureContextKeys.PROFILING_QUOTA_REASON to fakeQuotaReason,
+                        FeatureContextKeys.PROFILING_QUOTA_SESSION_ID to fakeParentContext.sessionId
+                    )
+                )
+            }
+        )
+
+        // When
+        testedScope.handleEvent(fakeEvent, datadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        argumentCaptor<LongTaskEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(firstValue.dd.profiling?.quotaReason).isEqualTo(fakeQuotaReason)
+            assertThat(firstValue.dd.profiling?.status).isEqualTo(LongTaskEvent.ProfilingStatus.STOPPED)
+        }
+    }
+
+    @Test
+    fun `M ignore stale quotaReason in LongTaskEvent W handleEvent(AddLongTask) {quota reason for other session}`(
+        @LongForgery(0L, 700_000_000L) durationNs: Long,
+        @StringForgery target: String,
+        @StringForgery fakeQuotaReason: String,
+        @StringForgery fakeOtherSessionId: String
+    ) {
+        // Given — the quota reason is stamped with a different session than the current one
+        testedScope.activeActionScope = null
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        val datadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(
+                    Feature.PROFILING_FEATURE_NAME,
+                    mapOf(
+                        PROFILER_IS_RUNNING to false,
+                        FeatureContextKeys.PROFILING_QUOTA_REASON to fakeQuotaReason,
+                        FeatureContextKeys.PROFILING_QUOTA_SESSION_ID to fakeOtherSessionId
+                    )
+                )
+            }
+        )
+
+        // When
+        testedScope.handleEvent(fakeEvent, datadogContext, mockEventWriteScope, mockWriter)
+
+        // Then — the stale reason is ignored and no profiling status is attached
+        argumentCaptor<LongTaskEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(firstValue.dd.profiling?.quotaReason).isNull()
+            assertThat(firstValue.dd.profiling?.status).isNull()
+        }
+    }
+
+    @Test
     fun `M send RumLongTaskEvent to profiling W handleEvent(AddLongTask) {profiling feature registered}`(
         @LongForgery(0L, 700_000_000L) durationNs: Long,
         @StringForgery target: String
@@ -5921,6 +5988,97 @@ internal class RumViewScopeTest {
         argumentCaptor<ErrorEvent> {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue).hasNoProfiling()
+        }
+    }
+
+    @Test
+    fun `M include quotaReason in ErrorEvent W handleEvent(AddError) {ANR, profiler not running and quota denied}`(
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @StringForgery stacktrace: String,
+        @StringForgery fakeQuotaReason: String,
+        forge: Forge
+    ) {
+        // Given
+        val throwable = ANRException(Thread.currentThread())
+        testedScope.activeActionScope = mockActionScope
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        fakeEvent = RumRawEvent.AddError(
+            message,
+            source,
+            throwable,
+            stacktrace,
+            isFatal = false,
+            threads = emptyList(),
+            attributes = attributes
+        )
+        val datadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(
+                    Feature.PROFILING_FEATURE_NAME,
+                    mapOf(
+                        PROFILER_IS_RUNNING to false,
+                        FeatureContextKeys.PROFILING_QUOTA_REASON to fakeQuotaReason,
+                        FeatureContextKeys.PROFILING_QUOTA_SESSION_ID to fakeParentContext.sessionId
+                    )
+                )
+            }
+        )
+
+        // When
+        testedScope.handleEvent(fakeEvent, datadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        argumentCaptor<ErrorEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(firstValue.dd.profiling?.quotaReason).isEqualTo(fakeQuotaReason)
+            assertThat(firstValue.dd.profiling?.status).isEqualTo(ErrorEvent.ProfilingStatus.STOPPED)
+        }
+    }
+
+    @Test
+    fun `M ignore stale quotaReason in ErrorEvent W handleEvent(AddError) {quota reason for other session}`(
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @StringForgery stacktrace: String,
+        @StringForgery fakeQuotaReason: String,
+        @StringForgery fakeOtherSessionId: String,
+        forge: Forge
+    ) {
+        // Given — the quota reason is stamped with a different session than the current one
+        val throwable = ANRException(Thread.currentThread())
+        testedScope.activeActionScope = mockActionScope
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        fakeEvent = RumRawEvent.AddError(
+            message,
+            source,
+            throwable,
+            stacktrace,
+            isFatal = false,
+            threads = emptyList(),
+            attributes = attributes
+        )
+        val datadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(
+                    Feature.PROFILING_FEATURE_NAME,
+                    mapOf(
+                        PROFILER_IS_RUNNING to false,
+                        FeatureContextKeys.PROFILING_QUOTA_REASON to fakeQuotaReason,
+                        FeatureContextKeys.PROFILING_QUOTA_SESSION_ID to fakeOtherSessionId
+                    )
+                )
+            }
+        )
+
+        // When
+        testedScope.handleEvent(fakeEvent, datadogContext, mockEventWriteScope, mockWriter)
+
+        // Then — the stale reason is ignored and no profiling status is attached
+        argumentCaptor<ErrorEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(firstValue.dd.profiling?.quotaReason).isNull()
+            assertThat(firstValue.dd.profiling?.status).isNull()
         }
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManagerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManagerTest.kt
@@ -254,6 +254,311 @@ internal class RumSessionScopeStartupManagerTest {
 
     @ParameterizedTest
     @MethodSource("testScenarios")
+    fun `M not attach quota reason W onTTIDEvent {profiler running and quota reason present}`(
+        scenario: RumStartupScenario,
+        forge: Forge
+    ) {
+        // Given
+        val fakeQuotaReason = forge.anAlphabeticalString()
+        fakeDatadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(
+                    Feature.PROFILING_FEATURE_NAME,
+                    mapOf(
+                        FeatureContextKeys.PROFILER_IS_RUNNING to true,
+                        FeatureContextKeys.PROFILING_QUOTA_REASON to fakeQuotaReason,
+                        FeatureContextKeys.PROFILING_QUOTA_SESSION_ID to rumContext.sessionId
+                    )
+                )
+            }
+        )
+        val info = RumTTIDInfo(
+            scenario = scenario,
+            durationNs = forge.aLong(min = 0, max = 10000)
+        )
+        val event = RumRawEvent.AppStartTTIDEvent(info = info)
+
+        // When
+        manager.onAppStartEvent(mock())
+        manager.onTTIDEvent(
+            event = event,
+            isSessionTracked = true,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter,
+            rumContext = rumContext,
+            customAttributes = fakeParentAttributes
+        )
+
+        // Then
+        argumentCaptor<VitalAppLaunchEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue)
+                .hasProfilingStatus(VitalAppLaunchEvent.ProfilingStatus.RUNNING)
+                .hasNoProfilingQuotaReason()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("testScenarios")
+    fun `M attach quota reason W onTTIDEvent {profiler stopped by quota}`(
+        scenario: RumStartupScenario,
+        forge: Forge
+    ) {
+        // Given — profiling is not running and the quota API denied the session
+        val fakeQuotaReason = forge.anAlphabeticalString()
+        fakeDatadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(
+                    Feature.PROFILING_FEATURE_NAME,
+                    mapOf(
+                        FeatureContextKeys.PROFILER_IS_RUNNING to false,
+                        FeatureContextKeys.PROFILING_QUOTA_REASON to fakeQuotaReason,
+                        FeatureContextKeys.PROFILING_QUOTA_SESSION_ID to rumContext.sessionId
+                    )
+                )
+            }
+        )
+        val info = RumTTIDInfo(
+            scenario = scenario,
+            durationNs = forge.aLong(min = 0, max = 10000)
+        )
+        val event = RumRawEvent.AppStartTTIDEvent(info = info)
+
+        // When
+        manager.onAppStartEvent(mock())
+        manager.onTTIDEvent(
+            event = event,
+            isSessionTracked = true,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter,
+            rumContext = rumContext,
+            customAttributes = fakeParentAttributes
+        )
+
+        // Then — status is STOPPED and the quota reason is attached
+        argumentCaptor<VitalAppLaunchEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue)
+                .hasProfilingStatus(VitalAppLaunchEvent.ProfilingStatus.STOPPED)
+                .hasProfilingQuotaReason(fakeQuotaReason)
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("testScenarios")
+    fun `M ignore stale quota reason W onTTIDEvent {quota reason for other session}`(
+        scenario: RumStartupScenario,
+        forge: Forge
+    ) {
+        // Given — a quota reason stamped with a session other than the current one
+        val fakeQuotaReason = forge.anAlphabeticalString()
+        val fakeOtherSessionId = forge.anHexadecimalString()
+        fakeDatadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(
+                    Feature.PROFILING_FEATURE_NAME,
+                    mapOf(
+                        FeatureContextKeys.PROFILER_IS_RUNNING to false,
+                        FeatureContextKeys.PROFILING_QUOTA_REASON to fakeQuotaReason,
+                        FeatureContextKeys.PROFILING_QUOTA_SESSION_ID to fakeOtherSessionId
+                    )
+                )
+            }
+        )
+        val info = RumTTIDInfo(
+            scenario = scenario,
+            durationNs = forge.aLong(min = 0, max = 10000)
+        )
+        val event = RumRawEvent.AppStartTTIDEvent(info = info)
+
+        // When
+        manager.onAppStartEvent(mock())
+        manager.onTTIDEvent(
+            event = event,
+            isSessionTracked = true,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter,
+            rumContext = rumContext,
+            customAttributes = fakeParentAttributes
+        )
+
+        // Then — the stale reason is ignored: no status and no quota reason
+        argumentCaptor<VitalAppLaunchEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue)
+                .hasNoProfilingStatus()
+                .hasNoProfilingQuotaReason()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("testScenarios")
+    fun `M attach quota reason W onTTFDEvent {profiler stopped by quota}`(
+        scenario: RumStartupScenario,
+        forge: Forge
+    ) {
+        // Given — profiling is not running and the quota API denied the session
+        val fakeQuotaReason = forge.anAlphabeticalString()
+        fakeDatadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(
+                    Feature.PROFILING_FEATURE_NAME,
+                    mapOf(
+                        FeatureContextKeys.PROFILER_IS_RUNNING to false,
+                        FeatureContextKeys.PROFILING_QUOTA_REASON to fakeQuotaReason,
+                        FeatureContextKeys.PROFILING_QUOTA_SESSION_ID to rumContext.sessionId
+                    )
+                )
+            }
+        )
+        val ttidEvent = RumRawEvent.AppStartTTIDEvent(
+            info = RumTTIDInfo(scenario = scenario, durationNs = forge.aLong(min = 0, max = 10000))
+        )
+        val ttfdEvent = forge.createTTFDEvent(scenario.initialTime)
+
+        // When
+        manager.onAppStartEvent(RumRawEvent.AppStartEvent(scenario = scenario))
+        manager.onTTIDEvent(
+            event = ttidEvent,
+            isSessionTracked = true,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter,
+            rumContext = rumContext,
+            customAttributes = fakeParentAttributes
+        )
+        manager.onTTFDEvent(
+            event = ttfdEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter,
+            rumContext = rumContext,
+            customAttributes = fakeParentAttributes
+        )
+
+        // Then — the TTFD vital carries STOPPED and the denial reason, like TTID
+        argumentCaptor<VitalAppLaunchEvent> {
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue)
+                .hasProfilingStatus(VitalAppLaunchEvent.ProfilingStatus.STOPPED)
+                .hasProfilingQuotaReason(fakeQuotaReason)
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("testScenarios")
+    fun `M not attach quota reason W onTTFDEvent {profiler running and quota reason present}`(
+        scenario: RumStartupScenario,
+        forge: Forge
+    ) {
+        // Given — the profiler is still running but a quota-denied reason is also present
+        val fakeQuotaReason = forge.anAlphabeticalString()
+        fakeDatadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(
+                    Feature.PROFILING_FEATURE_NAME,
+                    mapOf(
+                        FeatureContextKeys.PROFILER_IS_RUNNING to true,
+                        FeatureContextKeys.PROFILING_QUOTA_REASON to fakeQuotaReason,
+                        FeatureContextKeys.PROFILING_QUOTA_SESSION_ID to rumContext.sessionId
+                    )
+                )
+            }
+        )
+        val ttidEvent = RumRawEvent.AppStartTTIDEvent(
+            info = RumTTIDInfo(scenario = scenario, durationNs = forge.aLong(min = 0, max = 10000))
+        )
+        val ttfdEvent = forge.createTTFDEvent(scenario.initialTime)
+
+        // When
+        manager.onAppStartEvent(RumRawEvent.AppStartEvent(scenario = scenario))
+        manager.onTTIDEvent(
+            event = ttidEvent,
+            isSessionTracked = true,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter,
+            rumContext = rumContext,
+            customAttributes = fakeParentAttributes
+        )
+        manager.onTTFDEvent(
+            event = ttfdEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter,
+            rumContext = rumContext,
+            customAttributes = fakeParentAttributes
+        )
+
+        // Then — status is RUNNING and no quota reason leaks onto a running profiler
+        argumentCaptor<VitalAppLaunchEvent> {
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue)
+                .hasProfilingStatus(VitalAppLaunchEvent.ProfilingStatus.RUNNING)
+                .hasNoProfilingQuotaReason()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("testScenarios")
+    fun `M ignore stale quota reason W onTTFDEvent {quota reason for other session}`(
+        scenario: RumStartupScenario,
+        forge: Forge
+    ) {
+        // Given — a quota reason stamped with a session other than the current one
+        val fakeQuotaReason = forge.anAlphabeticalString()
+        val fakeOtherSessionId = forge.anHexadecimalString()
+        fakeDatadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(
+                    Feature.PROFILING_FEATURE_NAME,
+                    mapOf(
+                        FeatureContextKeys.PROFILER_IS_RUNNING to false,
+                        FeatureContextKeys.PROFILING_QUOTA_REASON to fakeQuotaReason,
+                        FeatureContextKeys.PROFILING_QUOTA_SESSION_ID to fakeOtherSessionId
+                    )
+                )
+            }
+        )
+        val ttidEvent = RumRawEvent.AppStartTTIDEvent(
+            info = RumTTIDInfo(scenario = scenario, durationNs = forge.aLong(min = 0, max = 10000))
+        )
+        val ttfdEvent = forge.createTTFDEvent(scenario.initialTime)
+
+        // When
+        manager.onAppStartEvent(RumRawEvent.AppStartEvent(scenario = scenario))
+        manager.onTTIDEvent(
+            event = ttidEvent,
+            isSessionTracked = true,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter,
+            rumContext = rumContext,
+            customAttributes = fakeParentAttributes
+        )
+        manager.onTTFDEvent(
+            event = ttfdEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter,
+            rumContext = rumContext,
+            customAttributes = fakeParentAttributes
+        )
+
+        // Then — the stale reason is ignored: no status and no quota reason on the TTFD vital
+        argumentCaptor<VitalAppLaunchEvent> {
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue)
+                .hasNoProfilingStatus()
+                .hasNoProfilingQuotaReason()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("testScenarios")
     fun `M stop profiler W onTTIDEvent`(
         scenario: RumStartupScenario,
         forge: Forge


### PR DESCRIPTION
### What does this PR do?

Connects the ProfilingQuotaChecker to the Profiling Feature so profiling is gated on the backend quota decision, and surfaces the quota outcome on RUM events.

### Motivation

- Profiling feature
  - On each new RUM session, `ProfilingFeature` fires an async quota check (createOkHttpCallFactory + dedicated single-thread executor, 5s call timeout).
  - Launch profiling holds its buffered result until the quota decision arrives (or the timeout fallback fails open); on DENIED the launch event is dropped, otherwise it's written. Continuous profiling skips its active window (stays in cooldown) when the decision is DENIED.
  - The denied reason is propagated into the profiling feature context (PROFILING_QUOTA_REASON) and cleared when allowed; onStop tears the checker/executor down cleanly.
- RUM
  - RumViewScope (Error / Long Task) and the app-launch vital now report profiling.status = STOPPED with quota_reason when profiling was denied by quota, and RUNNING otherwise. Reading profiling state was simplified to go straight through the feature context.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

