### PR TITLE
RUM-16551: Fix hidden API reflection noise in Session Replay drawable mappers

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapper.kt
@@ -21,6 +21,7 @@ import android.graphics.drawable.RippleDrawable
 import android.graphics.drawable.ShapeDrawable
 import android.graphics.drawable.StateListDrawable
 import android.graphics.drawable.VectorDrawable
+import android.os.Build
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.utils.ALPHA_SHIFT_ANDROID
 import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
@@ -98,7 +99,7 @@ internal open class AndroidMDrawableToColorMapper(
      * Resolves the color from a [LayerDrawable].
      * @param drawable the color drawable
      * @param internalLogger the internalLogger to report warnings
-     * @param predicate a predicate to filter which ayers should be taken into account (default: accept all layers)
+     * @param predicate a predicate to filter which layers should be taken into account (default: accept all layers)
      * @return the color to map to or null if not applicable
      */
     protected open fun resolveLayerDrawable(
@@ -228,16 +229,22 @@ internal open class AndroidMDrawableToColorMapper(
             null
         }
 
+        // PorterDuffColorFilter.mColor is blocked (max-target-o) on API 28+ and unused on API 29+
+        // (AndroidQDrawableToColorMapper overrides resolveGradientDrawable). Skip reflection on P+.
         @Suppress("PrivateAPI", "SwallowedException", "TooGenericExceptionCaught")
-        internal val mColorField = try {
-            PorterDuffColorFilter::class.java.getDeclaredField("mColor").apply {
-                this.isAccessible = true
+        internal val mColorField = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            try {
+                PorterDuffColorFilter::class.java.getDeclaredField("mColor").apply {
+                    this.isAccessible = true
+                }
+            } catch (_: NoSuchFieldException) {
+                null
+            } catch (_: SecurityException) {
+                null
+            } catch (_: NullPointerException) {
+                null
             }
-        } catch (e: NoSuchFieldException) {
-            null
-        } catch (e: SecurityException) {
-            null
-        } catch (e: NullPointerException) {
+        } else {
             null
         }
     }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapper.kt
@@ -22,6 +22,7 @@ import android.graphics.drawable.ShapeDrawable
 import android.graphics.drawable.StateListDrawable
 import android.graphics.drawable.VectorDrawable
 import android.os.Build
+import androidx.annotation.RequiresApi
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.utils.ALPHA_SHIFT_ANDROID
 import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
@@ -32,6 +33,7 @@ import com.datadog.android.sessionreplay.utils.MAX_ALPHA_VALUE
  * Drawable utility object needed in the Session Replay Wireframe Mappers.
  * This class is meant for internal usage so please use it carefully as it might change in time.
  */
+@Suppress("TooManyFunctions")
 internal open class AndroidMDrawableToColorMapper(
     private val extensionMappers: List<DrawableToColorMapper> = emptyList()
 ) : DrawableToColorMapper {
@@ -125,15 +127,32 @@ internal open class AndroidMDrawableToColorMapper(
      * @return the color to map to or null if not applicable
      */
     protected open fun resolveGradientDrawable(drawable: GradientDrawable, internalLogger: InternalLogger): Int? {
-        @Suppress("SwallowedException")
+        return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            resolveGradientDrawableReflection(drawable, internalLogger)
+        } else {
+            resolveGradientDrawableNPlus(drawable)
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    internal fun resolveGradientDrawableNPlus(drawable: GradientDrawable): Int? {
+        return resolveGradientFillColor(drawable)?.let { resolvedColor ->
+            val colorAlpha = (resolvedColor ushr ALPHA_SHIFT_ANDROID) and MAX_ALPHA_VALUE
+            val fillAlpha = (colorAlpha * drawable.alpha) / MAX_ALPHA_VALUE
+            if (fillAlpha == 0) null else mergeColorAndAlpha(resolvedColor, fillAlpha)
+        }
+    }
+
+    @Suppress("SwallowedException")
+    private fun resolveGradientDrawableReflection(drawable: GradientDrawable, internalLogger: InternalLogger): Int? {
         val fillPaint = try {
             @Suppress("UnsafeThirdPartyFunctionCall") // Can't throw NPE here
             fillPaintField?.get(drawable) as? Paint
-        } catch (e: IllegalArgumentException) {
+        } catch (_: IllegalArgumentException) {
             null
-        } catch (e: IllegalAccessException) {
+        } catch (_: IllegalAccessException) {
             null
-        } catch (e: ExceptionInInitializerError) {
+        } catch (_: ExceptionInInitializerError) {
             null
         }
 
@@ -161,12 +180,13 @@ internal open class AndroidMDrawableToColorMapper(
             fillPaint.color
         }
         val fillAlpha = (fillPaint.alpha * drawable.alpha) / MAX_ALPHA_VALUE
+        return if (fillAlpha == 0) null else mergeColorAndAlpha(filterColor, fillAlpha)
+    }
 
-        return if (fillAlpha == 0) {
-            null
-        } else {
-            mergeColorAndAlpha(filterColor, fillAlpha)
-        }
+    @RequiresApi(Build.VERSION_CODES.N)
+    protected open fun resolveGradientFillColor(drawable: GradientDrawable): Int? {
+        val colorStateList = drawable.color ?: return null
+        return colorStateList.getColorForState(drawable.state, colorStateList.defaultColor)
     }
 
     /**
@@ -215,17 +235,22 @@ internal open class AndroidMDrawableToColorMapper(
     }
 
     companion object {
+        // mFillPaint is @UnsupportedAppUsage — skip reflection on API 24+ where getColor() is public.
         @SuppressLint("DiscouragedPrivateApi")
         @Suppress("PrivateAPI", "SwallowedException", "TooGenericExceptionCaught")
-        internal val fillPaintField = try {
-            GradientDrawable::class.java.getDeclaredField("mFillPaint").apply {
-                this.isAccessible = true
+        internal val fillPaintField = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            try {
+                GradientDrawable::class.java.getDeclaredField("mFillPaint").apply {
+                    this.isAccessible = true
+                }
+            } catch (_: NoSuchFieldException) {
+                null
+            } catch (_: SecurityException) {
+                null
+            } catch (_: NullPointerException) {
+                null
             }
-        } catch (e: NoSuchFieldException) {
-            null
-        } catch (e: SecurityException) {
-            null
-        } catch (e: NullPointerException) {
+        } else {
             null
         }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidQDrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidQDrawableToColorMapper.kt
@@ -10,11 +10,11 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 import android.graphics.BlendMode
 import android.graphics.BlendModeColorFilter
 import android.graphics.ColorFilter
-import android.graphics.Paint
 import android.graphics.drawable.GradientDrawable
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.utils.ALPHA_SHIFT_ANDROID
 import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
 import com.datadog.android.sessionreplay.utils.MAX_ALPHA_VALUE
 
@@ -28,33 +28,19 @@ internal open class AndroidQDrawableToColorMapper(
 ) : AndroidMDrawableToColorMapper(extensionMappers) {
 
     override fun resolveGradientDrawable(drawable: GradientDrawable, internalLogger: InternalLogger): Int? {
-        @Suppress("SwallowedException")
-        val fillPaint = try {
-            @Suppress("UnsafeThirdPartyFunctionCall")
-            fillPaintField?.get(drawable) as? Paint
-        } catch (e: IllegalArgumentException) {
-            null
-        } catch (e: IllegalAccessException) {
-            null
-        } catch (e: ExceptionInInitializerError) {
-            null
-        }
-
-        if (fillPaint == null) return null
-
-        val colorFilter = fillPaint.colorFilter
-        var fillColor: Int = fillPaint.color
-        val fillAlpha = (fillPaint.alpha * drawable.alpha) / MAX_ALPHA_VALUE
-
-        return if (fillAlpha == 0) {
-            null
+        val resolvedColor = resolveGradientFillColor(drawable) ?: return null
+        val colorAlpha = (resolvedColor ushr ALPHA_SHIFT_ANDROID) and MAX_ALPHA_VALUE
+        val fillAlpha = (colorAlpha * drawable.alpha) / MAX_ALPHA_VALUE
+        val colorFilter = resolveGradientColorFilter(drawable)
+        val fillColor = if (colorFilter != null) {
+            resolveBlendModeColorFilter(resolvedColor, colorFilter, internalLogger)
         } else {
-            if (colorFilter != null) {
-                fillColor = resolveBlendModeColorFilter(fillColor, colorFilter, internalLogger)
-            }
-            mergeColorAndAlpha(fillColor, fillAlpha)
+            resolvedColor
         }
+        return if (fillAlpha == 0) null else mergeColorAndAlpha(fillColor, fillAlpha)
     }
+
+    protected open fun resolveGradientColorFilter(drawable: GradientDrawable): ColorFilter? = drawable.colorFilter
 
     /**
      * This is an oversimplification as the result image would only have some

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableCompoundButtonMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableCompoundButtonMapper.kt
@@ -96,8 +96,6 @@ internal abstract class CheckableCompoundButtonMapper<T : CompoundButton>(
 
     companion object {
         internal const val DEFAULT_CHECKABLE_HEIGHT_IN_DP = 32L
-        internal const val GET_DRAWABLE_FAIL_MESSAGE =
-            "Failed to get buttonDrawable from the checkable compound button."
         internal const val NULL_BUTTON_DRAWABLE_MSG =
             "ButtonDrawable of the compound button is null"
     }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableCompoundButtonMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableCompoundButtonMapper.kt
@@ -100,19 +100,5 @@ internal abstract class CheckableCompoundButtonMapper<T : CompoundButton>(
             "Failed to get buttonDrawable from the checkable compound button."
         internal const val NULL_BUTTON_DRAWABLE_MSG =
             "ButtonDrawable of the compound button is null"
-
-        // Reflects the field at the initialization of the class instead of reflecting it for every wireframe generation
-        @Suppress("PrivateApi", "SwallowedException", "TooGenericExceptionCaught")
-        internal val mButtonDrawableField = try {
-            CompoundButton::class.java.getDeclaredField("mButtonDrawable").apply {
-                isAccessible = true
-            }
-        } catch (e: NoSuchFieldException) {
-            null
-        } catch (e: SecurityException) {
-            null
-        } catch (e: NullPointerException) {
-            null
-        }
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapperTest.kt
@@ -281,4 +281,57 @@ open class AndroidMDrawableToColorMapperTest {
         // Then
         assertThat(result).isEqualTo(drawableColor)
     }
+
+    @Test
+    fun `M map GradientDrawable to fill color W resolveGradientDrawableNPlus() {public API path}`(
+        @IntForgery fillColor: Int
+    ) {
+        // Given
+        val baseAlpha = (fillColor.toLong() and 0xFF000000) shr 24
+        assumeTrue(baseAlpha != 0L)
+        val testableMMapper = TestableMMapper().apply { fakeResolvedColor = fillColor }
+        val gradientDrawable = GradientDrawable()
+
+        // When
+        val result = testableMMapper.resolveGradientDrawableNPlus(gradientDrawable)
+
+        // Then
+        assertThat(result).isEqualTo(fillColor)
+    }
+
+    @Test
+    fun `M return null W resolveGradientDrawableNPlus() {public API path, fully transparent}`(
+        @IntForgery fillColor: Int
+    ) {
+        // Given
+        val testableMMapper = TestableMMapper().apply { fakeResolvedColor = fillColor and 0x00FFFFFF }
+        val gradientDrawable = GradientDrawable()
+
+        // When
+        val result = testableMMapper.resolveGradientDrawableNPlus(gradientDrawable)
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M return null W resolveGradientDrawableNPlus() {public API path, no fill color}`() {
+        // Given
+        val testableMMapper = TestableMMapper().apply { fakeResolvedColor = null }
+        val gradientDrawable = GradientDrawable()
+
+        // When
+        val result = testableMMapper.resolveGradientDrawableNPlus(gradientDrawable)
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    // Seam to test the N+ public API branch: only overrides resolveGradientFillColor so that
+    // resolveGradientDrawableNPlus is the real production code under test.
+    private class TestableMMapper : AndroidMDrawableToColorMapper() {
+        var fakeResolvedColor: Int? = null
+
+        override fun resolveGradientFillColor(drawable: GradientDrawable): Int? = fakeResolvedColor
+    }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidQDrawableToColorMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidQDrawableToColorMapperTest.kt
@@ -8,10 +8,10 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 //noinspection SuspiciousImport
 import android.graphics.BlendModeColorFilter
+import android.graphics.ColorFilter
 import android.graphics.Paint
 import android.graphics.drawable.GradientDrawable
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
-import com.datadog.android.sessionreplay.internal.recorder.mapper.AndroidMDrawableToColorMapper.Companion.fillPaintField
 import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.IntForgery
@@ -38,8 +38,10 @@ import org.mockito.quality.Strictness
 class AndroidQDrawableToColorMapperTest : AndroidMDrawableToColorMapperTest() {
 
     override fun createTestedMapper(): DrawableToColorMapper {
-        return AndroidQDrawableToColorMapper()
+        return TestableQMapper()
     }
+
+    private val testableMapper get() = testedMapper as TestableQMapper
 
     @Test
     fun `M map GradientDrawable to fill paint's color blend color W mapDrawableToColor()`(
@@ -55,17 +57,11 @@ class AndroidQDrawableToColorMapperTest : AndroidMDrawableToColorMapperTest() {
             whenever(this.color) doReturn blendColor
             whenever(this.mode) doReturn blendMode
         }
-        val baseColor = fillPaintColor and 0xFFFFFF
         val baseAlpha = (fillPaintColor.toLong() and 0xFF000000) shr 24
         assumeTrue(baseAlpha != 0L)
-        val mockFillPaint = mock<Paint>().apply {
-            whenever(this.color) doReturn baseColor
-            whenever(this.alpha) doReturn baseAlpha.toInt()
-            whenever(this.colorFilter) doReturn mockColorFilter
-        }
-        val gradientDrawable = GradientDrawable().apply {
-            fillPaintField?.set(this, mockFillPaint)
-        }
+        testableMapper.fakeResolvedColor = fillPaintColor
+        testableMapper.fakeColorFilter = mockColorFilter
+        val gradientDrawable = GradientDrawable()
 
         // When
         val result = testedMapper.mapDrawableToColor(gradientDrawable, mockInternalLogger)
@@ -87,16 +83,9 @@ class AndroidQDrawableToColorMapperTest : AndroidMDrawableToColorMapperTest() {
             whenever(this.color) doReturn blendColor
             whenever(this.mode) doReturn blendMode
         }
-        val baseColor = fillPaintColor and 0xFFFFFF
-        val baseAlpha = 0L
-        val mockFillPaint = mock<Paint>().apply {
-            whenever(this.color) doReturn baseColor
-            whenever(this.alpha) doReturn baseAlpha.toInt()
-            whenever(this.colorFilter) doReturn mockColorFilter
-        }
-        val gradientDrawable = GradientDrawable().apply {
-            fillPaintField?.set(this, mockFillPaint)
-        }
+        testableMapper.fakeResolvedColor = fillPaintColor and 0x00FFFFFF // alpha = 0
+        testableMapper.fakeColorFilter = mockColorFilter
+        val gradientDrawable = GradientDrawable()
 
         // When
         val result = testedMapper.mapDrawableToColor(gradientDrawable, mockInternalLogger)
@@ -118,17 +107,11 @@ class AndroidQDrawableToColorMapperTest : AndroidMDrawableToColorMapperTest() {
             whenever(this.color) doReturn blendColor
             whenever(this.mode) doReturn blendMode
         }
-        val baseColor = fillPaintColor and 0xFFFFFF
         val baseAlpha = (fillPaintColor.toLong() and 0xFF000000) shr 24
         assumeTrue(baseAlpha != 0L)
-        val mockFillPaint = mock<Paint>().apply {
-            whenever(this.color) doReturn baseColor
-            whenever(this.alpha) doReturn baseAlpha.toInt()
-            whenever(this.colorFilter) doReturn mockColorFilter
-        }
-        val gradientDrawable = GradientDrawable().apply {
-            fillPaintField?.set(this, mockFillPaint)
-        }
+        testableMapper.fakeResolvedColor = fillPaintColor
+        testableMapper.fakeColorFilter = mockColorFilter
+        val gradientDrawable = GradientDrawable()
 
         // When
         val result = testedMapper.mapDrawableToColor(gradientDrawable, mockInternalLogger)
@@ -150,21 +133,27 @@ class AndroidQDrawableToColorMapperTest : AndroidMDrawableToColorMapperTest() {
             whenever(this.color) doReturn blendColor
             whenever(this.mode) doReturn blendMode
         }
-        val baseColor = fillPaintColor and 0xFFFFFF
-        val baseAlpha = 0L
-        val mockFillPaint = mock<Paint>().apply {
-            whenever(this.color) doReturn baseColor
-            whenever(this.alpha) doReturn baseAlpha.toInt()
-            whenever(this.colorFilter) doReturn mockColorFilter
-        }
-        val gradientDrawable = GradientDrawable().apply {
-            fillPaintField?.set(this, mockFillPaint)
-        }
+        testableMapper.fakeResolvedColor = fillPaintColor and 0x00FFFFFF // alpha = 0
+        testableMapper.fakeColorFilter = mockColorFilter
+        val gradientDrawable = GradientDrawable()
 
         // When
         val result = testedMapper.mapDrawableToColor(gradientDrawable, mockInternalLogger)
 
         // Then
         assertThat(result).isNull()
+    }
+
+    // Seam to avoid calling API 24+ methods on the test JVM; falls back to parent-injected fillPaintField when fakeResolvedColor is null.
+    private class TestableQMapper : AndroidQDrawableToColorMapper() {
+        var fakeResolvedColor: Int? = null
+        var fakeColorFilter: ColorFilter? = null
+
+        override fun resolveGradientFillColor(drawable: GradientDrawable): Int? {
+            val fillPaint = fillPaintField?.get(drawable) as? Paint
+            return fakeResolvedColor ?: fillPaint?.let { (it.alpha shl 24) or (it.color and 0xFFFFFF) }
+        }
+
+        override fun resolveGradientColorFilter(drawable: GradientDrawable): ColorFilter? = fakeColorFilter
     }
 }


### PR DESCRIPTION
### What does this PR do?

- Gates `PorterDuffColorFilter.mColor` reflection to `API < 28`, where the field is actually accessible. ON API 28+ the field is classified as `max-target-o`, meaning it's blocked and was causing some noise in the logcat.
- Removes unused `mButtonDrawableField` in `CheckableCompoundButtonMapper` that was also causing noise.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

