### PR TITLE
Bump version to 3.12.0-SNAPSHOT

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
@@ -19,7 +19,7 @@ object AndroidConfig {
     const val MIN_SDK_FOR_AUTO = 29
     const val BUILD_TOOLS_VERSION = "36.0.0"
 
-    val VERSION = Version(3, 11, 0, Version.Type.Snapshot)
+    val VERSION = Version(3, 12, 0, Version.Type.Snapshot)
 }
 
 // TODO RUM-628 Switch to Java 17 bytecode


### PR DESCRIPTION
## What does this PR do?

Bumps `AndroidConfig.VERSION` on `develop` to the next development version `3.12.0-SNAPSHOT`, following the `3.11.0` release.

## Review checklist

- [ ] Version bumped to `3.12.0` with `Snapshot` type

Made with [Cursor](https://cursor.com)