### PR TITLE
[PANA-5681] Preparation for Heatmaps cross-platform integration

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -3,7 +3,6 @@ data class com.datadog.android.heatmaps.CrossPlatformHeatmapActionData
 interface com.datadog.android.heatmaps.HeatmapIdentifierRegistryProvider
   val heatmapIdentifierRegistry: com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
 fun heatmapViewKey(android.view.View): Long
-fun android.view.View.isValidTapTarget(): Boolean
 interface com.datadog.android.internal.attributes.LocalAttribute
   enum Key
     constructor(String)
@@ -285,6 +284,7 @@ fun StringBuilder.appendIfNotEmpty(String)
 fun StringBuilder.appendIfNotEmpty(Char)
 fun String.toBase64(): String
 fun String.fromBase64(): String?
+fun android.view.View.isValidTapTarget(): Boolean
 fun Thread.safeGetThreadId(): Long
 fun Thread.State.asString(): String
 fun Array<StackTraceElement>.loggableStackTrace(): String

--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -1,3 +1,9 @@
+data class com.datadog.android.heatmaps.CrossPlatformHeatmapActionData
+  constructor(List<String>, String, Long, Long, Long?, Long?)
+interface com.datadog.android.heatmaps.HeatmapIdentifierRegistryProvider
+  val heatmapIdentifierRegistry: com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
+fun heatmapViewKey(android.view.View): Long
+fun android.view.View.isValidTapTarget(): Boolean
 interface com.datadog.android.internal.attributes.LocalAttribute
   enum Key
     constructor(String)
@@ -69,10 +75,6 @@ interface com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
   fun getHeatmapIdentifier(Long, String): HeatmapIdentifier?
   companion object 
     fun create(): HeatmapIdentifierRegistry
-interface com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistryProvider
-  val heatmapIdentifierRegistry: HeatmapIdentifierRegistry
-fun heatmapViewKey(android.view.View): Long
-fun android.view.View.isValidTapTarget(): Boolean
 class com.datadog.android.internal.lifecycle.ProcessLifecycleMonitor : android.app.Application.ActivityLifecycleCallbacks
   constructor(Callback)
   val activitiesResumedCounter: java.util.concurrent.atomic.AtomicInteger

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -1,3 +1,36 @@
+public final class com/datadog/android/heatmaps/CrossPlatformHeatmapActionData {
+	public fun <init> (Ljava/util/List;Ljava/lang/String;JJLjava/lang/Long;Ljava/lang/Long;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6 ()Ljava/lang/Long;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;JJLjava/lang/Long;Ljava/lang/Long;)Lcom/datadog/android/heatmaps/CrossPlatformHeatmapActionData;
+	public static synthetic fun copy$default (Lcom/datadog/android/heatmaps/CrossPlatformHeatmapActionData;Ljava/util/List;Ljava/lang/String;JJLjava/lang/Long;Ljava/lang/Long;ILjava/lang/Object;)Lcom/datadog/android/heatmaps/CrossPlatformHeatmapActionData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getElementPath ()Ljava/util/List;
+	public final fun getPositionX ()J
+	public final fun getPositionY ()J
+	public final fun getTargetHeight ()Ljava/lang/Long;
+	public final fun getTargetWidth ()Ljava/lang/Long;
+	public final fun getViewUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/datadog/android/heatmaps/HeatmapIdentifierRegistryProvider {
+	public abstract fun getHeatmapIdentifierRegistry ()Lcom/datadog/android/internal/heatmaps/HeatmapIdentifierRegistry;
+}
+
+public final class com/datadog/android/heatmaps/HeatmapViewKeyKt {
+	public static final fun heatmapViewKey (Landroid/view/View;)J
+}
+
+public final class com/datadog/android/heatmaps/TapTargetUtilsKt {
+	public static final fun isValidTapTarget (Landroid/view/View;)Z
+}
+
 public abstract interface class com/datadog/android/internal/attributes/LocalAttribute {
 }
 
@@ -150,22 +183,10 @@ public final class com/datadog/android/internal/heatmaps/HeatmapIdentifierRegist
 	public final fun create ()Lcom/datadog/android/internal/heatmaps/HeatmapIdentifierRegistry;
 }
 
-public abstract interface class com/datadog/android/internal/heatmaps/HeatmapIdentifierRegistryProvider {
-	public abstract fun getHeatmapIdentifierRegistry ()Lcom/datadog/android/internal/heatmaps/HeatmapIdentifierRegistry;
-}
-
-public final class com/datadog/android/internal/heatmaps/HeatmapViewKeyKt {
-	public static final fun heatmapViewKey (Landroid/view/View;)J
-}
-
 public final class com/datadog/android/internal/heatmaps/NoOpHeatmapIdentifierRegistry : com/datadog/android/internal/heatmaps/HeatmapIdentifierRegistry {
 	public fun <init> ()V
 	public fun getHeatmapIdentifier (JLjava/lang/String;)Lcom/datadog/android/internal/heatmaps/HeatmapIdentifier;
 	public fun setHeatmapIdentifiers (Ljava/util/Map;Ljava/lang/String;)V
-}
-
-public final class com/datadog/android/internal/heatmaps/TapTargetUtilsKt {
-	public static final fun isValidTapTarget (Landroid/view/View;)Z
 }
 
 public final class com/datadog/android/internal/lifecycle/ProcessLifecycleMonitor : android/app/Application$ActivityLifecycleCallbacks {

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -27,10 +27,6 @@ public final class com/datadog/android/heatmaps/HeatmapViewKeyKt {
 	public static final fun heatmapViewKey (Landroid/view/View;)J
 }
 
-public final class com/datadog/android/heatmaps/TapTargetUtilsKt {
-	public static final fun isValidTapTarget (Landroid/view/View;)Z
-}
-
 public abstract interface class com/datadog/android/internal/attributes/LocalAttribute {
 }
 
@@ -672,6 +668,10 @@ public final class com/datadog/android/internal/utils/StringBuilderExtKt {
 public final class com/datadog/android/internal/utils/StringExtKt {
 	public static final fun fromBase64 (Ljava/lang/String;)Ljava/lang/String;
 	public static final fun toBase64 (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class com/datadog/android/internal/utils/TapTargetUtilsKt {
+	public static final fun isValidTapTarget (Landroid/view/View;)Z
 }
 
 public final class com/datadog/android/internal/utils/ThreadExtKt {

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/heatmaps/CrossPlatformHeatmapActionData.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/heatmaps/CrossPlatformHeatmapActionData.kt
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.heatmaps
+
+/**
+ * Heatmap data for a RUM action, used by cross-platform SDKs to correlate a tap action with
+ * a specific UI element.
+ *
+ * @property elementPath the path segments from the root component down to the tapped element
+ *   (e.g. `["root", "container", "submitButton"]`), using the same naming convention as the
+ *   cross-platform Session Replay layer so that the resulting identifier matches the wireframe.
+ * @property viewUrl the RUM view URL returned by `_RumInternalProxy.getCurrentViewUrl()` at tap time.
+ * @property positionX the x-coordinate of the tap relative to the target element, in dp.
+ * @property positionY the y-coordinate of the tap relative to the target element, in dp.
+ * @property targetWidth the width of the tapped element, in dp, or null if unavailable.
+ * @property targetHeight the height of the tapped element, in dp, or null if unavailable.
+ */
+data class CrossPlatformHeatmapActionData(
+    val elementPath: List<String>,
+    val viewUrl: String,
+    val positionX: Long,
+    val positionY: Long,
+    val targetWidth: Long?,
+    val targetHeight: Long?
+)

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/heatmaps/HeatmapIdentifierRegistryProvider.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/heatmaps/HeatmapIdentifierRegistryProvider.kt
@@ -4,13 +4,14 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.internal.heatmaps
+package com.datadog.android.heatmaps
+
+import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
 
 /**
  * Implemented by SDK features that own a [HeatmapIdentifierRegistry], allowing peer features
  * to obtain a typed reference via [com.datadog.android.api.feature.FeatureScope.unwrap].
  */
 interface HeatmapIdentifierRegistryProvider {
-    /** The [HeatmapIdentifierRegistry] owned by this feature. */
     val heatmapIdentifierRegistry: HeatmapIdentifierRegistry
 }

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/heatmaps/HeatmapIdentifierRegistryProvider.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/heatmaps/HeatmapIdentifierRegistryProvider.kt
@@ -13,5 +13,10 @@ import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
  * to obtain a typed reference via [com.datadog.android.api.feature.FeatureScope.unwrap].
  */
 interface HeatmapIdentifierRegistryProvider {
+    /**
+     * The registry that maps view identity keys to their stable [HeatmapIdentifier]s for this
+     * feature's current screen. Session Replay writes identifiers into this registry during
+     * each traversal; the RUM layer reads from it when a tap action is sent.
+     */
     val heatmapIdentifierRegistry: HeatmapIdentifierRegistry
 }

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/heatmaps/HeatmapViewKey.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/heatmaps/HeatmapViewKey.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.internal.heatmaps
+package com.datadog.android.heatmaps
 
 import android.view.View
 

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/heatmaps/TapTargetUtils.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/heatmaps/TapTargetUtils.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.internal.heatmaps
+package com.datadog.android.heatmaps
 
 import android.view.View
 

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/heatmaps/HeatmapIdentifier.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/heatmaps/HeatmapIdentifier.kt
@@ -26,11 +26,6 @@ data class HeatmapIdentifier(val rawValue: String) {
 
         private const val SCREEN_NAMESPACE_VIEW_PREFIX = "view:"
 
-        private val sha256DigestPerThread = object : ThreadLocal<MessageDigest>() {
-            @Suppress("UnsafeThirdPartyFunctionCall") // SHA-256 is always available on Android
-            override fun initialValue(): MessageDigest = MessageDigest.getInstance("SHA-256")
-        }
-
         /**
          * Creates a [HeatmapIdentifier] for the given UI element by hashing its canonical path,
          * or null if hashing fails.
@@ -57,9 +52,9 @@ data class HeatmapIdentifier(val rawValue: String) {
         ): HeatmapIdentifier? {
             return try {
                 val path = canonicalPath(elementPath, screenName, appPackageName)
-                sha256Hex(path, onHashingFailure)?.let { HeatmapIdentifier(it) }
+                HeatmapIdentifier(sha256Hex(path))
             } catch (e: NoSuchAlgorithmException) {
-                // Thrown by the ThreadLocal initialiser if SHA-256 is unavailable.
+                // Unreachable on Android: SHA-256 is always available.
                 onHashingFailure(e)
                 null
             } catch (e: UnsupportedEncodingException) {
@@ -86,15 +81,10 @@ data class HeatmapIdentifier(val rawValue: String) {
         @Suppress("UnsafeThirdPartyFunctionCall") // UnsupportedEncodingException caught in create()
         private fun escape(input: String): String = URLEncoder.encode(input, "UTF-8")
 
-        private fun sha256Hex(input: String, onHashingFailure: (Throwable) -> Unit): String? {
-            // ThreadLocal.get() is typed as MessageDigest? (Kotlin platform type) — the ?: guard
-            // routes any unexpected null through onHashingFailure rather than throwing an NPE.
-            @Suppress("UnsafeThirdPartyFunctionCall")
-            val digest = sha256DigestPerThread.get() ?: run {
-                onHashingFailure(NoSuchAlgorithmException("SHA-256 MessageDigest unavailable"))
-                return null
-            }
-            // digest(ByteArray) auto-resets on completion, so no explicit reset is needed.
+        @Suppress("UnsafeThirdPartyFunctionCall") // SHA-256 is always available on Android
+        private fun sha256Hex(input: String): String {
+            val digest = MessageDigest.getInstance("SHA-256")
+            // digest(ByteArray): input is non-null, DigestException not thrown on this overload.
             @Suppress("UnsafeThirdPartyFunctionCall")
             return digest.digest(input.toByteArray(Charsets.UTF_8)).toHexString()
         }

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/heatmaps/HeatmapIdentifier.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/heatmaps/HeatmapIdentifier.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.internal.heatmaps
 
 import com.datadog.android.internal.utils.toHexString
+import java.io.UnsupportedEncodingException
 import java.net.URLEncoder
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
@@ -25,9 +26,19 @@ data class HeatmapIdentifier(val rawValue: String) {
 
         private const val SCREEN_NAMESPACE_VIEW_PREFIX = "view:"
 
+        private val sha256DigestPerThread = object : ThreadLocal<MessageDigest>() {
+            @Suppress("UnsafeThirdPartyFunctionCall") // SHA-256 is always available on Android
+            override fun initialValue(): MessageDigest = MessageDigest.getInstance("SHA-256")
+        }
+
         /**
          * Creates a [HeatmapIdentifier] for the given UI element by hashing its canonical path,
          * or null if hashing fails.
+         *
+         * All string parameters must be **raw, unencoded** values — this function applies
+         * percent-encoding internally. Cross-platform SDKs must pass raw strings (e.g. the
+         * literal screen name returned by `getCurrentViewUrl()`, not a pre-encoded version)
+         * so that the identifier is always produced by the same Android encoding logic.
          *
          * @param elementPath the path segments from the root view down to this element,
          *   where each segment identifies a view in the hierarchy (e.g. its resource entry name).
@@ -37,7 +48,6 @@ data class HeatmapIdentifier(val rawValue: String) {
          * @param appPackageName the application package name (e.g. `com.example.app`),
          *   used to globally namespace identifiers across apps.
          * @param onHashingFailure invoked with the caught exception if hashing fails.
-         *   Callers should forward this to telemetry.
          */
         fun create(
             elementPath: List<String>,
@@ -45,8 +55,18 @@ data class HeatmapIdentifier(val rawValue: String) {
             appPackageName: String,
             onHashingFailure: (Throwable) -> Unit = {}
         ): HeatmapIdentifier? {
-            val path = canonicalPath(elementPath, screenName, appPackageName)
-            return sha256Hex(path, onHashingFailure)?.let { HeatmapIdentifier(it) }
+            return try {
+                val path = canonicalPath(elementPath, screenName, appPackageName)
+                sha256Hex(path, onHashingFailure)?.let { HeatmapIdentifier(it) }
+            } catch (e: NoSuchAlgorithmException) {
+                // Thrown by the ThreadLocal initialiser if SHA-256 is unavailable.
+                onHashingFailure(e)
+                null
+            } catch (e: UnsupportedEncodingException) {
+                // Thrown by URLEncoder.encode if UTF-8 is unavailable (unreachable on Android).
+                onHashingFailure(e)
+                null
+            }
         }
 
         private fun canonicalPath(
@@ -63,21 +83,20 @@ data class HeatmapIdentifier(val rawValue: String) {
             }
         }
 
-        @Suppress("UnsafeThirdPartyFunctionCall") // UTF-8 is always available on Android; cannot throw
+        @Suppress("UnsafeThirdPartyFunctionCall") // UnsupportedEncodingException caught in create()
         private fun escape(input: String): String = URLEncoder.encode(input, "UTF-8")
 
         private fun sha256Hex(input: String, onHashingFailure: (Throwable) -> Unit): String? {
-            return try {
-                val digest = MessageDigest.getInstance("SHA-256")
-                // digest(ByteArray) does not throw: the input is non-null (toByteArray always
-                // returns a non-null array) and DigestException is only declared on the
-                // offset/length overload, not this one.
-                @Suppress("UnsafeThirdPartyFunctionCall")
-                digest.digest(input.toByteArray(Charsets.UTF_8)).toHexString()
-            } catch (e: NoSuchAlgorithmException) {
-                onHashingFailure(e)
-                null
+            // ThreadLocal.get() is typed as MessageDigest? (Kotlin platform type) — the ?: guard
+            // routes any unexpected null through onHashingFailure rather than throwing an NPE.
+            @Suppress("UnsafeThirdPartyFunctionCall")
+            val digest = sha256DigestPerThread.get() ?: run {
+                onHashingFailure(NoSuchAlgorithmException("SHA-256 MessageDigest unavailable"))
+                return null
             }
+            // digest(ByteArray) auto-resets on completion, so no explicit reset is needed.
+            @Suppress("UnsafeThirdPartyFunctionCall")
+            return digest.digest(input.toByteArray(Charsets.UTF_8)).toHexString()
         }
     }
 }

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/utils/TapTargetUtils.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/utils/TapTargetUtils.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.heatmaps
+package com.datadog.android.internal.utils
 
 import android.view.View
 

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/heatmaps/HeatmapViewKeyTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/heatmaps/HeatmapViewKeyTest.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.internal.heatmaps
+package com.datadog.android.heatmaps
 
 import android.view.View
 import android.view.ViewParent

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/heatmaps/TapTargetUtilsTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/heatmaps/TapTargetUtilsTest.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.internal.heatmaps
+package com.datadog.android.heatmaps
 
 import android.view.View
 import com.datadog.android.internal.forge.Configurator

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/utils/TapTargetUtilsTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/utils/TapTargetUtilsTest.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.heatmaps
+package com.datadog.android.internal.utils
 
 import android.view.View
 import com.datadog.android.internal.forge.Configurator

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -172,6 +172,8 @@ enum com.datadog.android.rum.RumSessionType
   - SYNTHETICS
   - USER
 class com.datadog.android.rum._RumInternalProxy
+  fun addActionWithHeatmap(RumActionType, String, com.datadog.android.heatmaps.CrossPlatformHeatmapActionData, Map<String, Any?>)
+  fun getCurrentViewUrl(): String?
   fun addLongTask(Long, String)
   fun updatePerformanceMetric(RumPerformanceMetric, Double)
   fun updateExternalRefreshRate(Double)

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -272,8 +272,10 @@ public final class com/datadog/android/rum/RumSessionType : java/lang/Enum {
 
 public final class com/datadog/android/rum/_RumInternalProxy {
 	public static final field Companion Lcom/datadog/android/rum/_RumInternalProxy$Companion;
+	public final fun addActionWithHeatmap (Lcom/datadog/android/rum/RumActionType;Ljava/lang/String;Lcom/datadog/android/heatmaps/CrossPlatformHeatmapActionData;Ljava/util/Map;)V
 	public final fun addLongTask (JLjava/lang/String;)V
 	public final fun enableJankStatsTracking (Landroid/app/Activity;)V
+	public final fun getCurrentViewUrl ()Ljava/lang/String;
 	public final fun setInternalViewAttribute (Ljava/lang/String;Ljava/lang/Object;)V
 	public final fun setSyntheticsAttribute (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun setSyntheticsAttributeFromIntent (Landroid/content/Intent;)V

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
@@ -137,6 +137,7 @@ object Rum {
         return DatadogRumMonitor(
             applicationId = rumFeature.applicationId,
             sdkCore = sdkCore,
+            appPackageName = rumFeature.appContext.packageName,
             sessionEndedMetricDispatcher = sessionEndedMetricDispatcher,
             sessionSampler = sessionSampler,
             writer = rumFeature.dataWriter,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
@@ -10,6 +10,7 @@ import android.app.Activity
 import android.content.Intent
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.event.EventMapper
+import com.datadog.android.heatmaps.CrossPlatformHeatmapActionData
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType
 import com.datadog.android.lint.InternalApi
 import com.datadog.android.rum.RumConfiguration.Builder
@@ -41,6 +42,17 @@ import com.datadog.android.telemetry.model.TelemetryConfigurationEvent
 )
 class _RumInternalProxy internal constructor(private val rumMonitor: AdvancedRumMonitor) {
     @Volatile private var handledSyntheticsAttribute = false
+
+    fun addActionWithHeatmap(
+        type: RumActionType,
+        name: String,
+        crossPlatformHeatmapActionData: CrossPlatformHeatmapActionData,
+        attributes: Map<String, Any?>
+    ) {
+        rumMonitor.addActionWithHeatmapAttributes(type, name, crossPlatformHeatmapActionData, attributes)
+    }
+
+    fun getCurrentViewUrl(): String? = rumMonitor.getCurrentViewUrl()
 
     fun addLongTask(durationNs: Long, target: String) {
         rumMonitor.addLongTask(durationNs, target)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -33,9 +33,9 @@ import com.datadog.android.core.internal.utils.scheduleSafe
 import com.datadog.android.event.EventMapper
 import com.datadog.android.event.MapperSerializer
 import com.datadog.android.event.NoOpEventMapper
+import com.datadog.android.heatmaps.HeatmapIdentifierRegistryProvider
 import com.datadog.android.internal.flags.RumFlagEvaluationMessage
 import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
-import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistryProvider
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.thread.isMainThread

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
@@ -17,6 +17,7 @@ import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.FeaturesContextResolver
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
+import com.datadog.android.rum.internal.heatmaps.HeatmapActionResolver
 import com.datadog.android.rum.internal.instrumentation.insights.InsightsCollector
 import com.datadog.android.rum.internal.monitor.StorageEvent
 import com.datadog.android.rum.internal.toAction
@@ -46,8 +47,7 @@ internal class RumActionScope(
     internal val sampleRate: Float,
     private val rumSessionTypeOverride: RumSessionType?,
     private val insightsCollector: InsightsCollector,
-    internal val heatmapData: HeatmapActionData? = null,
-    private val heatmapIdentifierRegistry: HeatmapIdentifierRegistry? = null
+    internal val heatmapResolver: HeatmapActionResolver? = null
 ) : RumScope {
 
     private val inactivityThresholdNs = TimeUnit.MILLISECONDS.toNanos(inactivityThresholdMs)
@@ -357,7 +357,7 @@ internal class RumActionScope(
                         sessionPrecondition = rumContext.sessionStartReason.toActionSessionPrecondition()
                     ),
                     configuration = ActionEvent.Configuration(sessionSampleRate = sampleRate),
-                    action = heatmapData?.let { resolveHeatmapAction(it, rumContext.viewUrl.orEmpty()) }
+                    action = heatmapResolver?.resolve(rumContext.viewUrl.orEmpty())
                 ),
                 connectivity = networkInfo.toActionConnectivity(),
                 service = datadogContext.service,
@@ -380,20 +380,6 @@ internal class RumActionScope(
             .submit()
 
         sent = true
-    }
-
-    private fun resolveHeatmapAction(data: HeatmapActionData, viewUrl: String): ActionEvent.DdAction? {
-        val permanentId = heatmapIdentifierRegistry
-            ?.getHeatmapIdentifier(data.viewKey, viewUrl)
-            ?.rawValue ?: return null
-        return ActionEvent.DdAction(
-            position = ActionEvent.Position(x = data.positionX, y = data.positionY),
-            target = ActionEvent.DdActionTarget(
-                permanentId = permanentId,
-                width = data.targetWidth,
-                height = data.targetHeight
-            )
-        )
     }
 
     // endregion
@@ -429,8 +415,19 @@ internal class RumActionScope(
                 sampleRate = sampleRate,
                 rumSessionTypeOverride = rumSessionTypeOverride,
                 insightsCollector = insightsCollector,
-                heatmapData = event.heatmapData,
-                heatmapIdentifierRegistry = heatmapIdentifierRegistry
+                heatmapResolver = when {
+                    event.crossPlatformHeatmapActionData != null && event.appPackageName != null ->
+                        HeatmapActionResolver.CrossPlatform(
+                            data = event.crossPlatformHeatmapActionData,
+                            appPackageName = event.appPackageName,
+                            logger = sdkCore.internalLogger
+                        )
+                    event.nativeHeatmapActionData != null -> HeatmapActionResolver.Native(
+                        data = event.nativeHeatmapActionData,
+                        registry = heatmapIdentifierRegistry
+                    )
+                    else -> null
+                }
             )
         }
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.rum.internal.domain.scope
 
 import com.datadog.android.core.feature.event.ThreadDump
+import com.datadog.android.heatmaps.CrossPlatformHeatmapActionData
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
@@ -16,6 +17,7 @@ import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
+import com.datadog.android.rum.internal.heatmaps.NativeHeatmapActionData
 import com.datadog.android.rum.internal.startup.RumStartupScenario
 import com.datadog.android.rum.internal.startup.RumTTIDInfo
 import com.datadog.android.rum.model.ActionEvent
@@ -41,7 +43,9 @@ internal sealed class RumRawEvent {
         val type: RumActionType,
         val name: String,
         val waitForStop: Boolean,
-        val heatmapData: HeatmapActionData? = null,
+        val nativeHeatmapActionData: NativeHeatmapActionData? = null,
+        val crossPlatformHeatmapActionData: CrossPlatformHeatmapActionData? = null,
+        val appPackageName: String? = null,
         override val eventTime: Time = Time(),
         val attributes: Map<String, Any?> = emptyMap()
     ) : RumRawEvent()

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/heatmaps/HeatmapActionResolver.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/heatmaps/HeatmapActionResolver.kt
@@ -1,0 +1,97 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.heatmaps
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.heatmaps.CrossPlatformHeatmapActionData
+import com.datadog.android.internal.heatmaps.HeatmapIdentifier
+import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
+import com.datadog.android.rum.model.ActionEvent
+import java.util.Locale
+
+internal sealed class HeatmapActionResolver {
+
+    abstract fun resolve(viewUrl: String): ActionEvent.DdAction?
+
+    internal class Native(
+        private val data: NativeHeatmapActionData,
+        private val registry: HeatmapIdentifierRegistry?
+    ) : HeatmapActionResolver() {
+        override fun resolve(viewUrl: String): ActionEvent.DdAction? {
+            val permanentId = registry
+                ?.getHeatmapIdentifier(data.viewKey, viewUrl)
+                ?.rawValue ?: return null
+            return buildDdAction(permanentId, data.positionX, data.positionY, data.targetWidth, data.targetHeight)
+        }
+    }
+
+    internal class CrossPlatform(
+        private val data: CrossPlatformHeatmapActionData,
+        private val appPackageName: String,
+        private val logger: InternalLogger
+    ) : HeatmapActionResolver() {
+        @Suppress("ReturnCount")
+        override fun resolve(viewUrl: String): ActionEvent.DdAction? {
+            if (data.viewUrl != viewUrl) {
+                logger.log(
+                    InternalLogger.Level.WARN,
+                    InternalLogger.Target.USER,
+                    { HEATMAP_VIEW_URL_MISMATCH.format(Locale.US, data.viewUrl, viewUrl) }
+                )
+                return null
+            }
+            if (data.elementPath.isEmpty()) {
+                logger.log(InternalLogger.Level.ERROR, InternalLogger.Target.USER, { HEATMAP_EMPTY_ELEMENT_PATH })
+                return null
+            }
+            val identifier = HeatmapIdentifier.create(
+                elementPath = data.elementPath,
+                screenName = viewUrl,
+                appPackageName = appPackageName,
+                onHashingFailure = { throwable ->
+                    logger.log(
+                        InternalLogger.Level.ERROR,
+                        InternalLogger.Target.USER,
+                        { HEATMAP_IDENTIFIER_HASH_FAILURE },
+                        throwable
+                    )
+                }
+            ) ?: return null
+            return buildDdAction(
+                identifier.rawValue,
+                data.positionX,
+                data.positionY,
+                data.targetWidth,
+                data.targetHeight
+            )
+        }
+    }
+
+    companion object {
+        internal const val HEATMAP_VIEW_URL_MISMATCH =
+            "Heatmap view URL mismatch (recorded \"%s\", current \"%s\") — heatmap data dropped."
+        internal const val HEATMAP_EMPTY_ELEMENT_PATH =
+            "CrossPlatformHeatmapActionData.elementPath is empty — heatmap data dropped."
+        internal const val HEATMAP_IDENTIFIER_HASH_FAILURE =
+            "Failed to compute heatmap identifier — heatmap data dropped."
+
+        internal fun buildDdAction(
+            permanentId: String,
+            positionX: Long,
+            positionY: Long,
+            targetWidth: Long?,
+            targetHeight: Long?
+        ): ActionEvent.DdAction = ActionEvent.DdAction(
+            position = ActionEvent.Position(x = positionX, y = positionY),
+            target = ActionEvent.DdActionTarget(
+                permanentId = permanentId,
+                width = targetWidth,
+                height = targetHeight
+            )
+        )
+    }
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/heatmaps/NativeHeatmapActionData.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/heatmaps/NativeHeatmapActionData.kt
@@ -4,9 +4,9 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.rum.internal.domain.scope
+package com.datadog.android.rum.internal.heatmaps
 
-internal data class HeatmapActionData(
+internal data class NativeHeatmapActionData(
     val viewKey: Long,
     val positionX: Long,
     val positionY: Long,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AndroidActionTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AndroidActionTrackingStrategy.kt
@@ -12,7 +12,7 @@ import android.widget.AbsListView
 import android.widget.ScrollView
 import androidx.core.view.ScrollingView
 import com.datadog.android.api.SdkCore
-import com.datadog.android.heatmaps.isValidTapTarget
+import com.datadog.android.internal.utils.isValidTapTarget
 import com.datadog.android.rum.tracking.ActionTrackingStrategy
 import com.datadog.android.rum.tracking.ViewTarget
 import java.lang.ref.WeakReference

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AndroidActionTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AndroidActionTrackingStrategy.kt
@@ -12,7 +12,7 @@ import android.widget.AbsListView
 import android.widget.ScrollView
 import androidx.core.view.ScrollingView
 import com.datadog.android.api.SdkCore
-import com.datadog.android.internal.heatmaps.isValidTapTarget
+import com.datadog.android.heatmaps.isValidTapTarget
 import com.datadog.android.rum.tracking.ActionTrackingStrategy
 import com.datadog.android.rum.tracking.ViewTarget
 import java.lang.ref.WeakReference

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
@@ -14,11 +14,11 @@ import android.view.Window
 import androidx.core.view.isVisible
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.FeatureSdkCore
-import com.datadog.android.internal.heatmaps.heatmapViewKey
+import com.datadog.android.heatmaps.heatmapViewKey
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
-import com.datadog.android.rum.internal.domain.scope.HeatmapActionData
+import com.datadog.android.rum.internal.heatmaps.NativeHeatmapActionData
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.internal.tracking.NoOpInteractionPredicate
 import com.datadog.android.rum.tracking.ActionTrackingStrategy
@@ -270,7 +270,7 @@ internal class GesturesListener(
 
     private fun sendTapEventWithTarget(target: ViewTarget, touchX: Float, touchY: Float) {
         val attributes = mutableMapOf<String, Any?>()
-        var heatmapData: HeatmapActionData? = null
+        var nativeHeatmapActionData: NativeHeatmapActionData? = null
         target.viewRef.get()?.let { view ->
             addViewAttributes(view, attributes)
 
@@ -281,7 +281,7 @@ internal class GesturesListener(
                 // the user adjusts display size, so caching it as a field would be incorrect.
                 val density = view.resources.displayMetrics.density
 
-                heatmapData = HeatmapActionData(
+                nativeHeatmapActionData = NativeHeatmapActionData(
                     viewKey = heatmapViewKey(view),
                     positionX = ((touchX - tapLocationBuffer[0]) / density).roundToLong(),
                     positionY = ((touchY - tapLocationBuffer[1]) / density).roundToLong(),
@@ -298,7 +298,7 @@ internal class GesturesListener(
         (rumMonitor as? AdvancedRumMonitor)?.addActionWithHeatmap(
             RumActionType.TAP,
             targetName,
-            heatmapData,
+            nativeHeatmapActionData,
             attributes
         ) ?: rumMonitor.addAction(RumActionType.TAP, targetName, attributes)
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -8,13 +8,14 @@ package com.datadog.android.rum.internal.monitor
 
 import android.app.Activity
 import com.datadog.android.core.feature.event.ThreadDump
+import com.datadog.android.heatmaps.CrossPlatformHeatmapActionData
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.internal.debug.RumDebugListener
-import com.datadog.android.rum.internal.domain.scope.HeatmapActionData
+import com.datadog.android.rum.internal.heatmaps.NativeHeatmapActionData
 import com.datadog.android.rum.internal.startup.RumStartupScenario
 import com.datadog.android.rum.internal.startup.RumTTIDInfo
 import com.datadog.tools.annotation.NoOpImplementation
@@ -33,9 +34,18 @@ internal interface AdvancedRumMonitor : RumMonitor, AdvancedNetworkRumMonitor {
     fun addActionWithHeatmap(
         type: RumActionType,
         name: String,
-        heatmapData: HeatmapActionData?,
+        nativeHeatmapActionData: NativeHeatmapActionData?,
         attributes: Map<String, Any?>
     )
+
+    fun addActionWithHeatmapAttributes(
+        type: RumActionType,
+        name: String,
+        crossPlatformHeatmapActionData: CrossPlatformHeatmapActionData,
+        attributes: Map<String, Any?>
+    )
+
+    fun getCurrentViewUrl(): String?
 
     fun sendWebViewEvent()
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -27,6 +27,7 @@ import com.datadog.android.core.internal.utils.getSafe
 import com.datadog.android.core.internal.utils.submitSafe
 import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.heatmaps.CrossPlatformHeatmapActionData
 import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent.ApiUsage.AddOperationStepVital.ActionType
@@ -55,11 +56,11 @@ import com.datadog.android.rum.internal.domain.asTime
 import com.datadog.android.rum.internal.domain.battery.BatteryInfo
 import com.datadog.android.rum.internal.domain.display.DisplayInfo
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
-import com.datadog.android.rum.internal.domain.scope.HeatmapActionData
 import com.datadog.android.rum.internal.domain.scope.RumApplicationScope
 import com.datadog.android.rum.internal.domain.scope.RumRawEvent
 import com.datadog.android.rum.internal.domain.scope.RumScopeKey
 import com.datadog.android.rum.internal.domain.scope.RumSessionScope
+import com.datadog.android.rum.internal.heatmaps.NativeHeatmapActionData
 import com.datadog.android.rum.internal.instrumentation.insights.InsightsCollector
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
@@ -86,6 +87,7 @@ import com.datadog.android.rum.featureoperations.FailureReason as DeprecatedFail
 internal class DatadogRumMonitor(
     applicationId: String,
     private val sdkCore: InternalSdkCore,
+    internal val appPackageName: String,
     internal val sessionSampler: Sampler<String>,
     internal val backgroundTrackingEnabled: Boolean,
     internal val trackFrustrations: Boolean,
@@ -110,6 +112,8 @@ internal class DatadogRumMonitor(
     insightsCollector: InsightsCollector,
     heatmapIdentifierRegistry: HeatmapIdentifierRegistry?
 ) : RumMonitor, AdvancedRumMonitor {
+
+    @Volatile private var cachedViewUrl: String? = null
 
     internal var rootScope = RumApplicationScope(
         applicationId = applicationId,
@@ -217,7 +221,7 @@ internal class DatadogRumMonitor(
     override fun addActionWithHeatmap(
         type: RumActionType,
         name: String,
-        heatmapData: HeatmapActionData?,
+        nativeHeatmapActionData: NativeHeatmapActionData?,
         attributes: Map<String, Any?>
     ) {
         val eventTime = getEventTime(attributes)
@@ -226,7 +230,27 @@ internal class DatadogRumMonitor(
                 type = type,
                 name = name,
                 waitForStop = false,
-                heatmapData = heatmapData,
+                nativeHeatmapActionData = nativeHeatmapActionData,
+                eventTime = eventTime,
+                attributes = attributes.toMap()
+            )
+        )
+    }
+
+    override fun addActionWithHeatmapAttributes(
+        type: RumActionType,
+        name: String,
+        crossPlatformHeatmapActionData: CrossPlatformHeatmapActionData,
+        attributes: Map<String, Any?>
+    ) {
+        val eventTime = getEventTime(attributes)
+        handleEvent(
+            RumRawEvent.StartAction(
+                type = type,
+                name = name,
+                waitForStop = false,
+                crossPlatformHeatmapActionData = crossPlatformHeatmapActionData,
+                appPackageName = appPackageName,
                 eventTime = eventTime,
                 attributes = attributes.toMap()
             )
@@ -922,7 +946,9 @@ internal class DatadogRumMonitor(
                                 synchronized(rootScope) {
                                     handleEventWithMethodCallPerf(event, datadogContext, writeScope)
                                     notifyDebugListenerWithState()
-                                    currentRumContext()
+                                    val context = currentRumContext()
+                                    updateCachedViewUrl(context)
+                                    context
                                 }
                             }
                         )
@@ -974,6 +1000,13 @@ internal class DatadogRumMonitor(
                 )
             }
         }
+    }
+
+    override fun getCurrentViewUrl(): String? = cachedViewUrl
+
+    private fun updateCachedViewUrl(context: RumContext?) {
+        val newUrl = context?.viewUrl
+        if (cachedViewUrl != newUrl) cachedViewUrl = newUrl
     }
 
     private fun currentRumContext(): RumContext? {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumInternalProxyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumInternalProxyTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.rum
 
 import android.app.Activity
+import com.datadog.android.heatmaps.CrossPlatformHeatmapActionData
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent.ApiUsage.NetworkInstrumentation.LibraryType
 import com.datadog.android.rum.configuration.RumNetworkInstrumentationConfiguration
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
@@ -25,7 +26,9 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 
 @Extensions(
@@ -35,6 +38,42 @@ import org.mockito.quality.Strictness
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
 internal class RumInternalProxyTest {
+
+    @Test
+    fun `M proxy getCurrentViewUrl to RumMonitor W getCurrentViewUrl()`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeViewUrl = forge.aNullable { anAlphabeticalString() }
+        val mockRumMonitor = mock(AdvancedRumMonitor::class.java)
+        whenever(mockRumMonitor.getCurrentViewUrl()) doReturn fakeViewUrl
+        val proxy = _RumInternalProxy(mockRumMonitor)
+
+        // When
+        val result = proxy.getCurrentViewUrl()
+
+        // Then
+        assertThat(result).isEqualTo(fakeViewUrl)
+    }
+
+    @Test
+    fun `M proxy addActionWithHeatmap to RumMonitor W addActionWithHeatmap()`(
+        forge: Forge,
+        @Forgery fakeHeatmapAttributes: CrossPlatformHeatmapActionData,
+        @StringForgery fakeName: String
+    ) {
+        // Given
+        val fakeType = forge.aValueFrom(RumActionType::class.java)
+        val fakeAttributes = forge.aMap { anAlphabeticalString() to anAlphabeticalString() }
+        val mockRumMonitor = mock(AdvancedRumMonitor::class.java)
+        val proxy = _RumInternalProxy(mockRumMonitor)
+
+        // When
+        proxy.addActionWithHeatmap(fakeType, fakeName, fakeHeatmapAttributes, fakeAttributes)
+
+        // Then
+        verify(mockRumMonitor).addActionWithHeatmapAttributes(fakeType, fakeName, fakeHeatmapAttributes, fakeAttributes)
+    }
 
     @Test
     fun `M proxy addLongTask to RumMonitor W addLongTask()`(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
@@ -74,25 +74,23 @@ internal class RumTest {
         @StringForgery fakePackageName: String,
         @Forgery fakeRumConfiguration: RumConfiguration
     ) {
+        val mockApplication = mock<Application> {
+            whenever(it.packageName) doReturn fakePackageName
+            whenever(it.resources) doReturn mock()
+            whenever(it.contentResolver) doReturn mock()
+            whenever(it.resources.configuration) doReturn mock()
+        }
+        whenever(mockApplication.applicationContext) doReturn mockApplication
+        whenever(mockSdkCore.registerFeature(any())) doAnswer {
+            it.getArgument<RumFeature>(0).onInitialize(appContext = mockApplication)
+        }
+
         // When
         Rum.enable(fakeRumConfiguration, mockSdkCore)
 
         // Then
         argumentCaptor<RumFeature> {
             verify(mockSdkCore).registerFeature(capture())
-
-            val mockApplication = mock<Application> {
-                whenever(it.packageName) doReturn fakePackageName
-                whenever(it.resources) doReturn mock()
-                whenever(it.contentResolver) doReturn mock()
-                whenever(it.resources.configuration) doReturn mock()
-            }
-
-            whenever(mockApplication.applicationContext) doReturn mockApplication
-
-            lastValue.onInitialize(
-                appContext = mockApplication
-            )
             assertThat(lastValue.sampleRate)
                 .isEqualTo(fakeRumConfiguration.featureConfiguration.sampleRate)
             assertThat(lastValue.telemetrySampleRate)
@@ -182,6 +180,7 @@ internal class RumTest {
             .isSameAs(fakeRumConfiguration.featureConfiguration.initialResourceIdentifier)
         assertThat(rumApplicationScope.lastInteractionIdentifier)
             .isSameAs(fakeRumConfiguration.featureConfiguration.lastInteractionIdentifier)
+        assertThat(monitor.appPackageName).isEqualTo(fakePackageName)
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
+import com.datadog.android.heatmaps.CrossPlatformHeatmapActionData
 import com.datadog.android.internal.heatmaps.HeatmapIdentifier
 import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
 import com.datadog.android.rum.RumActionType
@@ -24,6 +25,8 @@ import com.datadog.android.rum.assertj.ActionEventAssert.Companion.assertThat
 import com.datadog.android.rum.internal.FeaturesContextResolver
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
+import com.datadog.android.rum.internal.heatmaps.HeatmapActionResolver
+import com.datadog.android.rum.internal.heatmaps.NativeHeatmapActionData
 import com.datadog.android.rum.internal.instrumentation.insights.InsightsCollector
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.internal.monitor.StorageEvent
@@ -59,6 +62,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isA
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -3192,14 +3196,16 @@ internal class RumActionScopeTest {
             sampleRate = fakeSampleRate,
             rumSessionTypeOverride = fakeRumSessionType,
             insightsCollector = mockInsightsCollector,
-            heatmapData = HeatmapActionData(
-                viewKey = fakeViewKey,
-                positionX = fakePosX,
-                positionY = fakePosY,
-                targetWidth = fakeWidth,
-                targetHeight = fakeHeight
-            ),
-            heatmapIdentifierRegistry = mockHeatmapRegistry
+            heatmapResolver = HeatmapActionResolver.Native(
+                data = NativeHeatmapActionData(
+                    viewKey = fakeViewKey,
+                    positionX = fakePosX,
+                    positionY = fakePosY,
+                    targetWidth = fakeWidth,
+                    targetHeight = fakeHeight
+                ),
+                registry = mockHeatmapRegistry
+            )
         )
 
         // When
@@ -3250,14 +3256,16 @@ internal class RumActionScopeTest {
             sampleRate = fakeSampleRate,
             rumSessionTypeOverride = fakeRumSessionType,
             insightsCollector = mockInsightsCollector,
-            heatmapData = HeatmapActionData(
-                viewKey = fakeViewKey,
-                positionX = fakePosX,
-                positionY = fakePosY,
-                targetWidth = fakeWidth,
-                targetHeight = fakeHeight
-            ),
-            heatmapIdentifierRegistry = mockHeatmapRegistry
+            heatmapResolver = HeatmapActionResolver.Native(
+                data = NativeHeatmapActionData(
+                    viewKey = fakeViewKey,
+                    positionX = fakePosX,
+                    positionY = fakePosY,
+                    targetWidth = fakeWidth,
+                    targetHeight = fakeHeight
+                ),
+                registry = mockHeatmapRegistry
+            )
         )
 
         // When
@@ -3298,14 +3306,16 @@ internal class RumActionScopeTest {
             sampleRate = fakeSampleRate,
             rumSessionTypeOverride = fakeRumSessionType,
             insightsCollector = mockInsightsCollector,
-            heatmapData = HeatmapActionData(
-                viewKey = fakeViewKey,
-                positionX = fakePosX,
-                positionY = fakePosY,
-                targetWidth = null,
-                targetHeight = null
-            ),
-            heatmapIdentifierRegistry = null
+            heatmapResolver = HeatmapActionResolver.Native(
+                data = NativeHeatmapActionData(
+                    viewKey = fakeViewKey,
+                    positionX = fakePosX,
+                    positionY = fakePosY,
+                    targetWidth = null,
+                    targetHeight = null
+                ),
+                registry = null
+            )
         )
 
         // When
@@ -3357,6 +3367,236 @@ internal class RumActionScopeTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue.dd.action).isNull()
         }
+    }
+
+    @Test
+    fun `M populate heatmap fields W sendAction() {crossPlatformHeatmapActionData set}`(
+        @Forgery fakeHeatmapAttributes: CrossPlatformHeatmapActionData,
+        @StringForgery fakeAppPackageName: String
+    ) {
+        val matchingHeatmapAttributes = fakeHeatmapAttributes.copy(
+            viewUrl = fakeParentContext.viewUrl.orEmpty()
+        )
+        val expectedPermanentId = HeatmapIdentifier.create(
+            elementPath = matchingHeatmapAttributes.elementPath,
+            screenName = fakeParentContext.viewUrl.orEmpty(),
+            appPackageName = fakeAppPackageName
+        )?.rawValue
+        testedScope = RumActionScope(
+            parentScope = mockParentScope,
+            sdkCore = rumMonitor.mockSdkCore,
+            waitForStop = false,
+            eventTime = fakeEventTime,
+            initialType = fakeType,
+            initialName = fakeName,
+            initialAttributes = fakeAttributes,
+            serverTimeOffsetInMs = fakeServerOffset,
+            inactivityThresholdMs = TEST_INACTIVITY_MS,
+            maxDurationMs = TEST_MAX_DURATION_MS,
+            featuresContextResolver = mockFeaturesContextResolver,
+            trackFrustrations = true,
+            sampleRate = fakeSampleRate,
+            rumSessionTypeOverride = fakeRumSessionType,
+            insightsCollector = mockInsightsCollector,
+            heatmapResolver = HeatmapActionResolver.CrossPlatform(
+                data = matchingHeatmapAttributes,
+                appPackageName = fakeAppPackageName,
+                logger = rumMonitor.mockSdkCore.internalLogger
+            )
+        )
+
+        // When
+        testedScope.handleEvent(
+            mockEvent(TEST_INACTIVITY_MS + 1),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then
+        argumentCaptor<ActionEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue)
+                .hasPermanentId(checkNotNull(expectedPermanentId))
+                .hasPositionX(fakeHeatmapAttributes.positionX)
+                .hasPositionY(fakeHeatmapAttributes.positionY)
+                .hasTargetWidth(fakeHeatmapAttributes.targetWidth)
+                .hasTargetHeight(fakeHeatmapAttributes.targetHeight)
+        }
+    }
+
+    @Test
+    fun `M prefer crossPlatformHeatmapActionData over nativeHeatmapActionData W sendAction() {both set}`(
+        @Forgery fakeHeatmapAttributes: CrossPlatformHeatmapActionData,
+        @StringForgery fakeAppPackageName: String
+    ) {
+        // StartAction.init enforces mutual exclusivity, so RumActionScope is constructed directly here.
+        val mockHeatmapRegistry: HeatmapIdentifierRegistry = mock()
+        whenever(mockHeatmapRegistry.getHeatmapIdentifier(any(), any()))
+            .thenReturn(HeatmapIdentifier("native-id"))
+        val matchingHeatmapAttributes = fakeHeatmapAttributes.copy(
+            viewUrl = fakeParentContext.viewUrl.orEmpty()
+        )
+        val expectedPermanentId = HeatmapIdentifier.create(
+            elementPath = matchingHeatmapAttributes.elementPath,
+            screenName = fakeParentContext.viewUrl.orEmpty(),
+            appPackageName = fakeAppPackageName
+        )?.rawValue
+
+        testedScope = RumActionScope(
+            parentScope = mockParentScope,
+            sdkCore = rumMonitor.mockSdkCore,
+            waitForStop = false,
+            eventTime = fakeEventTime,
+            initialType = fakeType,
+            initialName = fakeName,
+            initialAttributes = fakeAttributes,
+            serverTimeOffsetInMs = fakeServerOffset,
+            inactivityThresholdMs = TEST_INACTIVITY_MS,
+            maxDurationMs = TEST_MAX_DURATION_MS,
+            featuresContextResolver = mockFeaturesContextResolver,
+            trackFrustrations = true,
+            sampleRate = fakeSampleRate,
+            rumSessionTypeOverride = fakeRumSessionType,
+            insightsCollector = mockInsightsCollector,
+            heatmapResolver = HeatmapActionResolver.CrossPlatform(
+                data = matchingHeatmapAttributes,
+                appPackageName = fakeAppPackageName,
+                logger = rumMonitor.mockSdkCore.internalLogger
+            )
+        )
+
+        // When
+        testedScope.handleEvent(
+            mockEvent(TEST_INACTIVITY_MS + 1),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        verifyNoInteractions(mockHeatmapRegistry)
+        argumentCaptor<ActionEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue).hasPermanentId(checkNotNull(expectedPermanentId))
+        }
+    }
+
+    @Test
+    fun `M drop heatmap data and warn W sendAction() {heatmapAttributes viewUrl mismatches current view}`(
+        @Forgery fakeHeatmapAttributes: CrossPlatformHeatmapActionData,
+        @StringForgery fakeAppPackageName: String,
+        @StringForgery fakeDifferentViewUrl: String
+    ) {
+        // Given — simulate a race: the action was recorded for a different view than the one
+        // that is active when sendAction() fires (e.g. navigation happened on the async hop
+        // between the cross-platform tap and Android's RUM event queue processing).
+        val staleViewUrl = if (fakeDifferentViewUrl != fakeParentContext.viewUrl.orEmpty()) {
+            fakeDifferentViewUrl
+        } else {
+            "$fakeDifferentViewUrl#other"
+        }
+        val staleHeatmapAttributes = fakeHeatmapAttributes.copy(viewUrl = staleViewUrl)
+
+        testedScope = RumActionScope(
+            parentScope = mockParentScope,
+            sdkCore = rumMonitor.mockSdkCore,
+            waitForStop = false,
+            eventTime = fakeEventTime,
+            initialType = fakeType,
+            initialName = fakeName,
+            initialAttributes = fakeAttributes,
+            serverTimeOffsetInMs = fakeServerOffset,
+            inactivityThresholdMs = TEST_INACTIVITY_MS,
+            maxDurationMs = TEST_MAX_DURATION_MS,
+            featuresContextResolver = mockFeaturesContextResolver,
+            trackFrustrations = true,
+            sampleRate = fakeSampleRate,
+            rumSessionTypeOverride = fakeRumSessionType,
+            insightsCollector = mockInsightsCollector,
+            heatmapResolver = HeatmapActionResolver.CrossPlatform(
+                data = staleHeatmapAttributes,
+                appPackageName = fakeAppPackageName,
+                logger = rumMonitor.mockSdkCore.internalLogger
+            )
+        )
+
+        // When
+        testedScope.handleEvent(
+            mockEvent(TEST_INACTIVITY_MS + 1),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then — heatmap fields are absent; a developer warning was logged
+        argumentCaptor<ActionEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue.dd.action).isNull()
+        }
+        verify(mockInternalLogger).log(
+            eq(InternalLogger.Level.WARN),
+            eq(InternalLogger.Target.USER),
+            any(),
+            isNull(),
+            eq(false),
+            isNull()
+        )
+    }
+
+    @Test
+    fun `M drop heatmap data and log user error W sendAction() {empty elementPath}`(
+        @Forgery fakeHeatmapAttributes: CrossPlatformHeatmapActionData,
+        @StringForgery fakeAppPackageName: String
+    ) {
+        // Given — elementPath is empty; every tap on the same screen would collide to the same hash
+        val emptyPathAttributes = fakeHeatmapAttributes.copy(
+            elementPath = emptyList(),
+            viewUrl = fakeParentContext.viewUrl.orEmpty()
+        )
+        testedScope = RumActionScope(
+            parentScope = mockParentScope,
+            sdkCore = rumMonitor.mockSdkCore,
+            waitForStop = false,
+            eventTime = fakeEventTime,
+            initialType = fakeType,
+            initialName = fakeName,
+            initialAttributes = fakeAttributes,
+            serverTimeOffsetInMs = fakeServerOffset,
+            inactivityThresholdMs = TEST_INACTIVITY_MS,
+            maxDurationMs = TEST_MAX_DURATION_MS,
+            featuresContextResolver = mockFeaturesContextResolver,
+            trackFrustrations = true,
+            sampleRate = fakeSampleRate,
+            rumSessionTypeOverride = fakeRumSessionType,
+            insightsCollector = mockInsightsCollector,
+            heatmapResolver = HeatmapActionResolver.CrossPlatform(
+                data = emptyPathAttributes,
+                appPackageName = fakeAppPackageName,
+                logger = rumMonitor.mockSdkCore.internalLogger
+            )
+        )
+
+        // When
+        testedScope.handleEvent(
+            mockEvent(TEST_INACTIVITY_MS + 1),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then
+        argumentCaptor<ActionEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue.dd.action).isNull()
+        }
+        verify(mockInternalLogger).log(
+            eq(InternalLogger.Level.ERROR),
+            eq(InternalLogger.Target.USER),
+            any(),
+            isNull(),
+            eq(false),
+            isNull()
+        )
     }
 
     // region Internal

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
@@ -11,6 +11,7 @@ import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.internal.domain.Time
+import com.datadog.android.rum.internal.heatmaps.NativeHeatmapActionData
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.operations.FailureReason
 import com.datadog.tools.unit.forge.aThrowable
@@ -45,13 +46,13 @@ internal fun Forge.stopViewEvent(): RumRawEvent.StopView {
 internal fun Forge.startActionEvent(
     continuous: Boolean? = null,
     eventTime: Time = Time(),
-    heatmapData: HeatmapActionData? = null
+    nativeHeatmapActionData: NativeHeatmapActionData? = null
 ): RumRawEvent.StartAction {
     return RumRawEvent.StartAction(
         type = aValueFrom(RumActionType::class.java),
         name = anAlphabeticalString(),
         waitForStop = continuous ?: aBool(),
-        heatmapData = heatmapData,
+        nativeHeatmapActionData = nativeHeatmapActionData,
         eventTime = eventTime,
         attributes = exhaustiveAttributes()
     )

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -44,6 +44,8 @@ import com.datadog.android.rum.internal.domain.battery.BatteryInfo
 import com.datadog.android.rum.internal.domain.display.DisplayInfo
 import com.datadog.android.rum.internal.domain.state.SlowFrameRecord
 import com.datadog.android.rum.internal.domain.state.ViewUIPerformanceReport
+import com.datadog.android.rum.internal.heatmaps.HeatmapActionResolver
+import com.datadog.android.rum.internal.heatmaps.NativeHeatmapActionData
 import com.datadog.android.rum.internal.instrumentation.insights.InsightsCollector
 import com.datadog.android.rum.internal.metric.NoValueReason
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
@@ -2897,7 +2899,7 @@ internal class RumViewScopeTest {
         @Forgery type: RumActionType,
         @StringForgery name: String,
         @BoolForgery waitForStop: Boolean,
-        @Forgery fakeHeatmapData: HeatmapActionData,
+        @Forgery fakeHeatmapData: NativeHeatmapActionData,
         forge: Forge
     ) {
         // Given
@@ -2907,7 +2909,7 @@ internal class RumViewScopeTest {
             type = type,
             name = name,
             waitForStop = waitForStop,
-            heatmapData = fakeHeatmapData,
+            nativeHeatmapActionData = fakeHeatmapData,
             attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         )
 
@@ -2916,7 +2918,7 @@ internal class RumViewScopeTest {
 
         // Then
         val actionScope = testedScope.activeActionScope as RumActionScope
-        assertThat(actionScope.heatmapData).isEqualTo(fakeHeatmapData)
+        assertThat(actionScope.heatmapResolver).isInstanceOf(HeatmapActionResolver.Native::class.java)
     }
 
     @ParameterizedTest

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
@@ -14,13 +14,13 @@ import android.view.ViewGroup
 import android.view.Window
 import androidx.compose.ui.platform.ComposeView
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.internal.heatmaps.heatmapViewKey
+import com.datadog.android.heatmaps.heatmapViewKey
 import com.datadog.android.internal.utils.toHexString
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumMonitor
-import com.datadog.android.rum.internal.domain.scope.HeatmapActionData
+import com.datadog.android.rum.internal.heatmaps.NativeHeatmapActionData
 import com.datadog.android.rum.internal.instrumentation.gestures.GesturesListenerScrollSwipeTest.ScrollableListView
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.tracking.ActionTrackingStrategy
@@ -840,7 +840,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         val expectedYInTarget = ((touchY - targetY) / fakeDensity).roundToLong()
         val expectedTargetWidth = (fakeTargetWidth / fakeDensity).roundToLong()
         val expectedTargetHeight = (fakeTargetHeight / fakeDensity).roundToLong()
-        val heatmapCaptor = argumentCaptor<HeatmapActionData>()
+        val heatmapCaptor = argumentCaptor<NativeHeatmapActionData>()
         verify(rumMonitor.mockInstance as AdvancedRumMonitor).addActionWithHeatmap(
             eq(RumActionType.TAP),
             eq(""),

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -21,6 +21,7 @@ import com.datadog.android.core.feature.event.ThreadDump
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.sampling.DeterministicSampler
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.heatmaps.CrossPlatformHeatmapActionData
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.rum.DdRumContentProvider
 import com.datadog.android.rum.ExperimentalRumApi
@@ -41,7 +42,6 @@ import com.datadog.android.rum.internal.domain.accessibility.AccessibilitySnapsh
 import com.datadog.android.rum.internal.domain.battery.BatteryInfo
 import com.datadog.android.rum.internal.domain.display.DisplayInfo
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
-import com.datadog.android.rum.internal.domain.scope.HeatmapActionData
 import com.datadog.android.rum.internal.domain.scope.RumApplicationScope
 import com.datadog.android.rum.internal.domain.scope.RumRawEvent
 import com.datadog.android.rum.internal.domain.scope.RumScopeKey
@@ -49,6 +49,7 @@ import com.datadog.android.rum.internal.domain.scope.RumSessionScope
 import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
 import com.datadog.android.rum.internal.domain.scope.RumViewScope
 import com.datadog.android.rum.internal.domain.state.ViewUIPerformanceReport
+import com.datadog.android.rum.internal.heatmaps.NativeHeatmapActionData
 import com.datadog.android.rum.internal.instrumentation.insights.InsightsCollector
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
@@ -201,6 +202,9 @@ internal class DatadogRumMonitorTest {
     @StringForgery(regex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
     lateinit var fakeApplicationId: String
 
+    @StringForgery
+    lateinit var fakeApplicationPackageName: String
+
     lateinit var fakeAttributes: Map<String, Any?>
 
     @FloatForgery(min = 0f, max = 100f)
@@ -302,6 +306,7 @@ internal class DatadogRumMonitorTest {
             displayInfoProvider = mockDisplayInfoProvider,
             rumSessionScopeStartupManagerFactory = mock(),
             insightsCollector = mockInsightsCollector,
+            appPackageName = fakeApplicationPackageName,
             heatmapIdentifierRegistry = null
         )
         testedMonitor.rootScope = mockApplicationScope
@@ -335,6 +340,7 @@ internal class DatadogRumMonitorTest {
             displayInfoProvider = mockDisplayInfoProvider,
             rumSessionScopeStartupManagerFactory = mock(),
             insightsCollector = mockInsightsCollector,
+            appPackageName = fakeApplicationPackageName,
             heatmapIdentifierRegistry = null
         )
 
@@ -411,6 +417,7 @@ internal class DatadogRumMonitorTest {
             displayInfoProvider = mockDisplayInfoProvider,
             rumSessionScopeStartupManagerFactory = mock(),
             insightsCollector = mockInsightsCollector,
+            appPackageName = fakeApplicationPackageName,
             heatmapIdentifierRegistry = null
         )
         testedMonitor.start()
@@ -455,6 +462,7 @@ internal class DatadogRumMonitorTest {
             displayInfoProvider = mockDisplayInfoProvider,
             rumSessionScopeStartupManagerFactory = mock(),
             insightsCollector = mockInsightsCollector,
+            appPackageName = fakeApplicationPackageName,
             heatmapIdentifierRegistry = null
         )
         testedMonitor.start()
@@ -514,7 +522,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.waitForStop).isFalse
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
             assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
-            assertThat(event.heatmapData).isNull()
+            assertThat(event.nativeHeatmapActionData).isNull()
         }
         verifyNoMoreInteractions(mockWriter)
     }
@@ -523,13 +531,13 @@ internal class DatadogRumMonitorTest {
     fun `M enqueue StartAction with heatmapData set W addActionWithHeatmap() {heatmapData non-null}`(
         @Forgery type: RumActionType,
         @StringForgery name: String,
-        @Forgery fakeHeatmapData: HeatmapActionData
+        @Forgery fakeHeatmapData: NativeHeatmapActionData
     ) {
         // When
         testedMonitor.addActionWithHeatmap(
             type = type,
             name = name,
-            heatmapData = fakeHeatmapData,
+            nativeHeatmapActionData = fakeHeatmapData,
             attributes = fakeAttributes
         )
 
@@ -548,9 +556,152 @@ internal class DatadogRumMonitorTest {
             assertThat(event.waitForStop).isFalse
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
             assertThat(event.eventTime.timestamp).isEqualTo(eventTimeMs)
-            assertThat(event.heatmapData).isEqualTo(fakeHeatmapData)
+            assertThat(event.nativeHeatmapActionData).isEqualTo(fakeHeatmapData)
         }
         verifyNoMoreInteractions(mockWriter)
+    }
+
+    @Test
+    fun `M enqueue StartAction with crossPlatformHeatmapActionData set W addActionWithHeatmapAttributes()`(
+        @Forgery type: RumActionType,
+        @StringForgery name: String,
+        @Forgery fakeHeatmapAttributes: CrossPlatformHeatmapActionData
+    ) {
+        // When
+        testedMonitor.addActionWithHeatmapAttributes(
+            type = type,
+            name = name,
+            crossPlatformHeatmapActionData = fakeHeatmapAttributes,
+            attributes = fakeAttributes
+        )
+
+        // Then
+        argumentCaptor<RumRawEvent> {
+            verify(mockApplicationScope).handleEvent(
+                capture(),
+                same(fakeDatadogContext),
+                same(mockEventWriteScope),
+                same(mockWriter)
+            )
+
+            val event = firstValue as RumRawEvent.StartAction
+            assertThat(event.type).isEqualTo(type)
+            assertThat(event.name).isEqualTo(name)
+            assertThat(event.waitForStop).isFalse
+            assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+            assertThat(event.nativeHeatmapActionData).isNull()
+            assertThat(event.crossPlatformHeatmapActionData).isEqualTo(fakeHeatmapAttributes)
+            assertThat(event.appPackageName).isEqualTo(fakeApplicationPackageName)
+        }
+        verifyNoMoreInteractions(mockWriter)
+    }
+
+    @Test
+    fun `M return current view URL W getCurrentViewUrl()`(
+        @Forgery fakeRumContext: RumContext,
+        @Forgery type: RumActionType,
+        @StringForgery name: String
+    ) {
+        // Given
+        val fakeContextWithSession = fakeRumContext.copy(
+            sessionId = java.util.UUID.randomUUID().toString(),
+            sessionState = RumSessionScope.State.TRACKED
+        )
+        val mockSessionScope = mock<RumSessionScope>()
+        val mockViewScope = mock<RumViewScope>()
+        whenever(mockApplicationScope.activeSession) doReturn mockSessionScope
+        whenever(mockSessionScope.activeView) doReturn mockViewScope
+        whenever(mockViewScope.getRumContext()) doReturn fakeContextWithSession
+        testedMonitor.startAction(type, name, fakeAttributes)
+
+        // When
+        val result = testedMonitor.getCurrentViewUrl()
+
+        // Then
+        assertThat(result).isEqualTo(fakeContextWithSession.viewUrl)
+    }
+
+    @Test
+    fun `M return null W getCurrentViewUrl() { no active session }`(
+        @Forgery fakeRumContext: RumContext,
+        @Forgery type: RumActionType,
+        @StringForgery name: String
+    ) {
+        // Given
+        val primeContext = fakeRumContext.copy(
+            sessionId = java.util.UUID.randomUUID().toString(),
+            sessionState = RumSessionScope.State.TRACKED
+        )
+        val mockSessionScope = mock<RumSessionScope>()
+        val mockViewScope = mock<RumViewScope>()
+        whenever(mockApplicationScope.activeSession) doReturn mockSessionScope
+        whenever(mockSessionScope.activeView) doReturn mockViewScope
+        whenever(mockViewScope.getRumContext()) doReturn primeContext
+        testedMonitor.startAction(type, name, fakeAttributes)
+        whenever(mockApplicationScope.activeSession) doReturn null
+        testedMonitor.startAction(type, name, fakeAttributes)
+
+        // When
+        val result = testedMonitor.getCurrentViewUrl()
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M return null W getCurrentViewUrl() { session exists but has NULL_UUID — not yet sampled in }`(
+        @Forgery fakeRumContext: RumContext,
+        @Forgery type: RumActionType,
+        @StringForgery name: String
+    ) {
+        // Given
+        val primeContext = fakeRumContext.copy(
+            sessionId = java.util.UUID.randomUUID().toString(),
+            sessionState = RumSessionScope.State.TRACKED
+        )
+        val mockSessionScope = mock<RumSessionScope>()
+        val mockViewScope = mock<RumViewScope>()
+        whenever(mockApplicationScope.activeSession) doReturn mockSessionScope
+        whenever(mockSessionScope.activeView) doReturn mockViewScope
+        whenever(mockViewScope.getRumContext()) doReturn primeContext
+        testedMonitor.startAction(type, name, fakeAttributes)
+        whenever(mockSessionScope.activeView) doReturn null
+        whenever(mockSessionScope.getRumContext()) doReturn RumContext(sessionId = RumContext.NULL_UUID)
+        testedMonitor.startAction(type, name, fakeAttributes)
+
+        // When
+        val result = testedMonitor.getCurrentViewUrl()
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M return null W getCurrentViewUrl() { view stopped with no new view started }`(
+        @Forgery fakeRumContext: RumContext,
+        @Forgery type: RumActionType,
+        @StringForgery name: String
+    ) {
+        // Given
+        val primeContext = fakeRumContext.copy(
+            sessionId = java.util.UUID.randomUUID().toString(),
+            sessionState = RumSessionScope.State.TRACKED
+        )
+        val mockSessionScope = mock<RumSessionScope>()
+        val mockViewScope = mock<RumViewScope>()
+        whenever(mockApplicationScope.activeSession) doReturn mockSessionScope
+        whenever(mockSessionScope.activeView) doReturn mockViewScope
+        whenever(mockViewScope.getRumContext()) doReturn primeContext
+        testedMonitor.startAction(type, name, fakeAttributes)
+        whenever(mockSessionScope.activeView) doReturn null
+        whenever(mockSessionScope.getRumContext()) doReturn primeContext.copy(viewUrl = null)
+        testedMonitor.startAction(type, name, fakeAttributes)
+
+        // When
+        val result = testedMonitor.getCurrentViewUrl()
+
+        // Then
+        assertThat(result).isNull()
     }
 
     @Test
@@ -2074,6 +2225,7 @@ internal class DatadogRumMonitorTest {
             displayInfoProvider = mockDisplayInfoProvider,
             rumSessionScopeStartupManagerFactory = mock(),
             insightsCollector = mockInsightsCollector,
+            appPackageName = fakeApplicationPackageName,
             heatmapIdentifierRegistry = null
         )
 
@@ -2115,6 +2267,7 @@ internal class DatadogRumMonitorTest {
             displayInfoProvider = mockDisplayInfoProvider,
             rumSessionScopeStartupManagerFactory = mock(),
             insightsCollector = mockInsightsCollector,
+            appPackageName = fakeApplicationPackageName,
             heatmapIdentifierRegistry = null
         )
 
@@ -2157,6 +2310,7 @@ internal class DatadogRumMonitorTest {
             rumSessionTypeOverride = null,
             rumSessionScopeStartupManagerFactory = mock(),
             insightsCollector = mockInsightsCollector,
+            appPackageName = fakeApplicationPackageName,
             heatmapIdentifierRegistry = null
         )
         whenever(mockExecutorService.isShutdown).thenReturn(true)
@@ -2394,6 +2548,7 @@ internal class DatadogRumMonitorTest {
             displayInfoProvider = mockDisplayInfoProvider,
             rumSessionScopeStartupManagerFactory = mock(),
             insightsCollector = mockInsightsCollector,
+            appPackageName = fakeApplicationPackageName,
             heatmapIdentifierRegistry = null
         )
         testedMonitor.startView(key, name, attributes)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/config/GlobalRumMonitorTestConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/config/GlobalRumMonitorTestConfiguration.kt
@@ -7,7 +7,9 @@
 package com.datadog.android.rum.utils.config
 
 import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.heatmaps.CrossPlatformHeatmapActionData
 import com.datadog.android.rum.GlobalRumMonitor
+import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum._RumInternalProxy
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
@@ -18,9 +20,14 @@ import org.mockito.kotlin.whenever
 
 @Suppress("TestFunctionName")
 internal abstract class InternalAdvancedRumMonitor : AdvancedRumMonitor {
-    override fun _getInternal(): _RumInternalProxy? {
-        return null
-    }
+    override fun _getInternal(): _RumInternalProxy? = null
+    override fun addActionWithHeatmapAttributes(
+        type: RumActionType,
+        name: String,
+        crossPlatformHeatmapActionData: CrossPlatformHeatmapActionData,
+        attributes: Map<String, Any?>
+    ) = Unit
+    override fun getCurrentViewUrl(): String? = null
 }
 
 internal class GlobalRumMonitorTestConfiguration :

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
@@ -54,7 +54,8 @@ internal class Configurator : BaseConfigurator() {
         forge.addFactory(SlowFramesConfigurationForgeryFactory())
         forge.addFactory(DisplayInfoForgeryFactory())
         forge.addFactory(BatteryInfoForgeryFactory())
-        forge.addFactory(HeatmapActionDataForgeryFactory())
+        forge.addFactory(NativeHeatmapActionDataForgeryFactory())
+        forge.addFactory(CrossPlatformHeatmapActionDataForgeryFactory())
 
         // Telemetry schema models
         forge.addFactory(TelemetryDebugEventForgeryFactory())

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/CrossPlatformHeatmapActionDataForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/CrossPlatformHeatmapActionDataForgeryFactory.kt
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.utils.forge
+
+import com.datadog.android.heatmaps.CrossPlatformHeatmapActionData
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class CrossPlatformHeatmapActionDataForgeryFactory : ForgeryFactory<CrossPlatformHeatmapActionData> {
+
+    override fun getForgery(forge: Forge): CrossPlatformHeatmapActionData {
+        return CrossPlatformHeatmapActionData(
+            elementPath = forge.aList(size = forge.anInt(min = 1, max = 7)) { anAlphabeticalString() },
+            viewUrl = forge.aString(),
+            positionX = forge.aPositiveLong(),
+            positionY = forge.aPositiveLong(),
+            targetWidth = forge.aNullable { aPositiveLong() },
+            targetHeight = forge.aNullable { aPositiveLong() }
+        )
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/NativeHeatmapActionDataForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/NativeHeatmapActionDataForgeryFactory.kt
@@ -6,14 +6,14 @@
 
 package com.datadog.android.rum.utils.forge
 
-import com.datadog.android.rum.internal.domain.scope.HeatmapActionData
+import com.datadog.android.rum.internal.heatmaps.NativeHeatmapActionData
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
-internal class HeatmapActionDataForgeryFactory : ForgeryFactory<HeatmapActionData> {
+internal class NativeHeatmapActionDataForgeryFactory : ForgeryFactory<NativeHeatmapActionData> {
 
-    override fun getForgery(forge: Forge): HeatmapActionData {
-        return HeatmapActionData(
+    override fun getForgery(forge: Forge): NativeHeatmapActionData {
+        return NativeHeatmapActionData(
             viewKey = forge.aLong(),
             positionX = forge.aLong(),
             positionY = forge.aLong(),

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/LazyHeatmapIdentifierRegistry.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/LazyHeatmapIdentifierRegistry.kt
@@ -10,9 +10,9 @@ import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.heatmaps.HeatmapIdentifierRegistryProvider
 import com.datadog.android.internal.heatmaps.HeatmapIdentifier
 import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
-import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistryProvider
 
 /**
  * Session Replay may be initialized before RUM — the SDK does not mandate a registration order.
@@ -27,9 +27,7 @@ internal class LazyHeatmapIdentifierRegistry(
     private val sdkCore: FeatureSdkCore
 ) : HeatmapIdentifierRegistry {
 
-    // null  → not yet resolved
-    // NoOpHeatmapIdentifierRegistry → RUM absent or not a provider (terminal, won't retry)
-    // anything else → the real registry
+    // null = not yet attempted; UNAVAILABLE = permanently failed; anything else = real registry
     private var resolved: HeatmapIdentifierRegistry? = null
 
     private fun delegate(): HeatmapIdentifierRegistry? {
@@ -62,8 +60,8 @@ internal class LazyHeatmapIdentifierRegistry(
     }
 
     companion object {
-        // Sentinel: RUM is registered but doesn't implement HeatmapIdentifierRegistryProvider.
-        // We stop retrying once we know this — it won't change without an SDK restart.
+        // Sentinel for a permanent failure (RUM registered but not a HeatmapIdentifierRegistryProvider).
+        // Won't change without an SDK restart, so we stop retrying once set.
         private val UNAVAILABLE: HeatmapIdentifierRegistry = NoOpHeatmapIdentifierRegistry()
 
         const val RUM_FEATURE_NOT_A_REGISTRY_PROVIDER =

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/HeatmapIdentifierResolver.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/HeatmapIdentifierResolver.kt
@@ -12,10 +12,10 @@ import android.view.ViewGroup
 import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.heatmaps.heatmapViewKey
+import com.datadog.android.heatmaps.isValidTapTarget
 import com.datadog.android.internal.heatmaps.HeatmapIdentifier
 import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
-import com.datadog.android.internal.heatmaps.heatmapViewKey
-import com.datadog.android.internal.heatmaps.isValidTapTarget
 
 internal class HeatmapIdentifierResolver(
     private val appPackageName: String,
@@ -134,7 +134,7 @@ internal class HeatmapIdentifierResolver(
     private fun logHashingFailure(error: Throwable) {
         internalLogger.log(
             InternalLogger.Level.WARN,
-            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            InternalLogger.Target.USER,
             { HASHING_FAILURE_MESSAGE },
             error
         )

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/HeatmapIdentifierResolver.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/HeatmapIdentifierResolver.kt
@@ -134,7 +134,7 @@ internal class HeatmapIdentifierResolver(
     private fun logHashingFailure(error: Throwable) {
         internalLogger.log(
             InternalLogger.Level.WARN,
-            InternalLogger.Target.USER,
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
             { HASHING_FAILURE_MESSAGE },
             error
         )

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/HeatmapIdentifierResolver.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/HeatmapIdentifierResolver.kt
@@ -13,9 +13,9 @@ import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.heatmaps.heatmapViewKey
-import com.datadog.android.heatmaps.isValidTapTarget
 import com.datadog.android.internal.heatmaps.HeatmapIdentifier
 import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
+import com.datadog.android.internal.utils.isValidTapTarget
 
 internal class HeatmapIdentifierResolver(
     private val appPackageName: String,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
@@ -10,7 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.internal.heatmaps.isValidTapTarget
+import com.datadog.android.heatmaps.isValidTapTarget
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.R
 import com.datadog.android.sessionreplay.TextAndInputPrivacy

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
@@ -10,7 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.heatmaps.isValidTapTarget
+import com.datadog.android.internal.utils.isValidTapTarget
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.R
 import com.datadog.android.sessionreplay.TextAndInputPrivacy

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/LazyHeatmapIdentifierRegistryTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/LazyHeatmapIdentifierRegistryTest.kt
@@ -10,9 +10,9 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.heatmaps.HeatmapIdentifierRegistryProvider
 import com.datadog.android.internal.heatmaps.HeatmapIdentifier
 import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
-import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistryProvider
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.LazyHeatmapIdentifierRegistry.Companion.RUM_FEATURE_NOT_A_REGISTRY_PROVIDER
 import com.datadog.android.utils.verifyLog

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/HeatmapIdentifierContractTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/HeatmapIdentifierContractTest.kt
@@ -13,9 +13,9 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.heatmaps.HeatmapIdentifierRegistryProvider
+import com.datadog.android.heatmaps.heatmapViewKey
 import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
-import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistryProvider
-import com.datadog.android.internal.heatmaps.heatmapViewKey
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducerHeatmapIdentifierTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducerHeatmapIdentifierTest.kt
@@ -10,9 +10,9 @@ import android.content.res.Resources
 import android.view.View
 import android.view.ViewGroup
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.heatmaps.heatmapViewKey
 import com.datadog.android.internal.heatmaps.HeatmapIdentifier
 import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
-import com.datadog.android.internal.heatmaps.heatmapViewKey
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator


### PR DESCRIPTION
### What does this PR do?
Reorganise heatmap types into correct packages

Public declarations (`CrossPlatformHeatmapActionData`, `HeatmapIdentifierRegistryProvider`, `heatmapViewKey`) are moved out of com.datadog.android.internal.heatmaps, since public types must not live in a package named internal. `isValidTapTarget` was moved out of heatmaps since it is a general util.

HeatmapActionData is split into two distinct types:

NativeHeatmapActionData — carries a viewKey (a composite identity hash of the tapped View and its parent), used to look up a pre-computed identifier from the HeatmapIdentifierRegistry that Session Replay populated during its last traversal.
CrossPlatformHeatmapActionData — carries an elementPath (a list of string path segments) and viewUrl, from which the identifier is computed on demand at action-send time via HeatmapIdentifier.create().
HeatmapActionResolver and NativeHeatmapActionData are also moved from rum.internal.domain.scope (where they are not scope concepts) to the dedicated rum.internal.heatmaps package.

Add cross-platform heatmap tap action support

Exposes two new methods on _RumInternalProxy for cross-platform SDKs (React Native, etc.):

getCurrentViewUrl() — returns the URL of the currently active RUM view. Cross-platform SDKs must call this at tap time and use the result as both the screen name for Session Replay wireframe identifier computation and the viewUrl field of CrossPlatformHeatmapActionData.
addActionWithHeatmap() — records a tap action with heatmap data attached. The Android SDK validates that the view URL captured at tap time still matches the active view at action-send time, dropping the heatmap data (with a developer-facing warning) if navigation has occurred in between.

### Motivation

Heatmaps on Android currently only work with native gesture tracking. This PR lays the foundation for cross-platform SDKs to emit heatmap-tagged tap actions, enabling heatmap features in React Native and future cross-platform targets.

### Additional Notes

getCurrentViewUrl() reads from a volatile cached field updated after each RUM event, making it safe to call from the UI thread without blocking on the RUM executor.
The view URL mismatch guard in HeatmapActionResolver.CrossPlatform handles the inherent race between a tap on screen A and a navigation to screen B: if the view has changed by the time the action is processed, the heatmap data is dropped rather than attributed to the wrong screen.
Identifier computation for cross-platform actions uses the same HeatmapIdentifier.create() path as Session Replay, ensuring the resulting permanentId matches the wireframe identifier SR computed for the same element.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

