### PR TITLE
RUM-16882: Fix the cronet sample crashing when loading 404.png

### DIFF
--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/cronet/CronetImageFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/cronet/CronetImageFragment.kt
@@ -22,9 +22,6 @@ import com.datadog.android.sample.SampleApplication
 import com.datadog.android.trace.ApmNetworkInstrumentationConfiguration
 import com.datadog.android.trace.ExperimentalTraceApi
 import org.chromium.net.CronetEngine
-import org.chromium.net.CronetException
-import org.chromium.net.UrlRequest
-import org.chromium.net.UrlResponseInfo
 import java.util.concurrent.Executors
 
 internal class CronetImageFragment : Fragment() {
@@ -91,11 +88,7 @@ internal class CronetImageFragment : Fragment() {
                     }
                 }
 
-                override fun onFailed(
-                    request: UrlRequest,
-                    info: UrlResponseInfo?,
-                    error: CronetException
-                ) {
+                override fun onBitmapFailed(error: Exception) {
                     activity?.runOnUiThread {
                         Toast.makeText(
                             requireContext(),

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/cronet/CronetImageLoaderRequestCallback.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/cronet/CronetImageLoaderRequestCallback.kt
@@ -7,6 +7,7 @@ package com.datadog.android.sample.cronet
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import org.chromium.net.CronetException
 import org.chromium.net.UrlRequest
 import org.chromium.net.UrlResponseInfo
 import timber.log.Timber
@@ -46,13 +47,32 @@ internal abstract class CronetImageLoaderRequestCallback : UrlRequest.Callback()
     }
 
     override fun onSucceeded(request: UrlRequest, info: UrlResponseInfo) {
-        val imageData = receivedData.toByteArray()
-        onBitmapLoaded(BitmapFactory.decodeByteArray(imageData, 0, imageData.size))
+        if (info.httpStatusCode != HTTP_OK) {
+            onBitmapFailed(IllegalStateException("Non-200 response received: ${info.httpStatusCode}"))
+            return
+        }
+        try {
+            val imageData = receivedData.toByteArray()
+            onBitmapLoaded(BitmapFactory.decodeByteArray(imageData, 0, imageData.size))
+        } catch (@Suppress("TooGenericExceptionCaught") e: RuntimeException) {
+            onBitmapFailed(e)
+        }
     }
 
-    abstract fun onBitmapLoaded(bitmap: Bitmap)
+    override fun onFailed(
+        request: UrlRequest?,
+        info: UrlResponseInfo?,
+        error: CronetException
+    ) {
+        onBitmapFailed(error)
+    }
 
-    companion object {
+    protected abstract fun onBitmapLoaded(bitmap: Bitmap)
+
+    protected abstract fun onBitmapFailed(error: Exception)
+
+    private companion object {
         private const val BUFFER_SIZE_100_KB = 102400
+        private const val HTTP_OK = 200
     }
 }


### PR DESCRIPTION
### What does this PR do?
Cronet considers any successful HTTP call to be a success, regardless of status code. We should only be decoding the bitmap if it was a HTTP 200.

On the 404, the body contains an XML status page saying resource not found, leading to this exception:
```
Exception in onSucceeded method
java.lang.NullPointerException: decodeByteArray(imageData, 0, imageData.size) must not be null
	at com.datadog.android.sample.cronet.CronetImageLoaderRequestCallback.onSucceeded(CronetImageLoaderRequestCallback.kt:55)
	at com.datadog.android.cronet.internal.CronetRequestCallback.onSucceeded(CronetRequestCallback.kt:76)
	at m1.nt.onSucceeded(:com.google.android.gms.dynamite_cronetdynamite@261833035@26.18.33 (260400-0):3)
	at m1.mm.run(:com.google.android.gms.dynamite_cronetdynamite@261833035@26.18.33 (260400-0):21)
	at m1.mg.run(:com.google.android.gms.dynamite_cronetdynamite@261833035@26.18.33 (260400-0):31)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1154)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:652)
	at java.lang.Thread.run(Thread.java:1563)
```

### Motivation
I was using cronet integration to test client side stats
