### PR TITLE
Fix regression of missing tinted backgrounds

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapper.kt
@@ -136,11 +136,11 @@ internal open class AndroidMDrawableToColorMapper(
 
     @RequiresApi(Build.VERSION_CODES.N)
     internal fun resolveGradientDrawableNPlus(drawable: GradientDrawable): Int? {
-        return resolveGradientFillColor(drawable)?.let { resolvedColor ->
-            val colorAlpha = (resolvedColor ushr ALPHA_SHIFT_ANDROID) and MAX_ALPHA_VALUE
-            val fillAlpha = (colorAlpha * drawable.alpha) / MAX_ALPHA_VALUE
-            if (fillAlpha == 0) null else mergeColorAndAlpha(resolvedColor, fillAlpha)
-        }
+        val resolvedColor = resolveGradientFillColor(drawable)
+        if (resolvedColor == null || drawable.colorFilter == null) return null
+        val colorAlpha = (resolvedColor ushr ALPHA_SHIFT_ANDROID) and MAX_ALPHA_VALUE
+        val fillAlpha = (colorAlpha * drawable.alpha) / MAX_ALPHA_VALUE
+        return if (fillAlpha == 0) null else mergeColorAndAlpha(resolvedColor, fillAlpha)
     }
 
     @Suppress("SwallowedException")

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidQDrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidQDrawableToColorMapper.kt
@@ -28,19 +28,17 @@ internal open class AndroidQDrawableToColorMapper(
 ) : AndroidMDrawableToColorMapper(extensionMappers) {
 
     override fun resolveGradientDrawable(drawable: GradientDrawable, internalLogger: InternalLogger): Int? {
-        val resolvedColor = resolveGradientFillColor(drawable) ?: return null
+        val resolvedColor = resolveGradientFillColor(drawable)
+        val colorFilter = resolveGradientColorFilter(drawable)
+        if (resolvedColor == null || colorFilter == null) return null
         val colorAlpha = (resolvedColor ushr ALPHA_SHIFT_ANDROID) and MAX_ALPHA_VALUE
         val fillAlpha = (colorAlpha * drawable.alpha) / MAX_ALPHA_VALUE
-        val colorFilter = resolveGradientColorFilter(drawable)
-        val fillColor = if (colorFilter != null) {
-            resolveBlendModeColorFilter(resolvedColor, colorFilter, internalLogger)
-        } else {
-            resolvedColor
-        }
+        val fillColor = resolveBlendModeColorFilter(resolvedColor, colorFilter, internalLogger)
         return if (fillAlpha == 0) null else mergeColorAndAlpha(fillColor, fillAlpha)
     }
 
-    protected open fun resolveGradientColorFilter(drawable: GradientDrawable): ColorFilter? = drawable.colorFilter
+    protected open fun resolveGradientColorFilter(drawable: GradientDrawable): ColorFilter? =
+        drawable.colorFilter
 
     /**
      * This is an oversimplification as the result image would only have some

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapperTest.kt
@@ -153,7 +153,7 @@ open class AndroidMDrawableToColorMapperTest {
     }
 
     @Test
-    fun `M map GradientDrawable to fill paint's color W mapDrawableToColor()`(
+    open fun `M map GradientDrawable to fill paint's color W mapDrawableToColor()`(
         @IntForgery drawableColor: Int
     ) {
         // Given

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapperTest.kt
@@ -283,20 +283,20 @@ open class AndroidMDrawableToColorMapperTest {
     }
 
     @Test
-    fun `M map GradientDrawable to fill color W resolveGradientDrawableNPlus() {public API path}`(
+    fun `M return null W resolveGradientDrawableNPlus() {public API path, no color filter}`(
         @IntForgery fillColor: Int
     ) {
         // Given
         val baseAlpha = (fillColor.toLong() and 0xFF000000) shr 24
         assumeTrue(baseAlpha != 0L)
         val testableMMapper = TestableMMapper().apply { fakeResolvedColor = fillColor }
-        val gradientDrawable = GradientDrawable()
+        val gradientDrawable = GradientDrawable() // colorFilter is null by default
 
         // When
         val result = testableMMapper.resolveGradientDrawableNPlus(gradientDrawable)
 
         // Then
-        assertThat(result).isEqualTo(fillColor)
+        assertThat(result).isNull()
     }
 
     @Test

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidQDrawableToColorMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidQDrawableToColorMapperTest.kt
@@ -144,6 +144,45 @@ class AndroidQDrawableToColorMapperTest : AndroidMDrawableToColorMapperTest() {
         assertThat(result).isNull()
     }
 
+    @Test
+    fun `M return null W mapDrawableToColor {no accessible color filter}`(
+        @IntForgery fillColor: Int
+    ) {
+        // When drawable.colorFilter is null (e.g. tint applied via DrawableCompat.setTintList,
+        // which stores it in the blocked private Drawable.mTintFilter on API 28+), the mapper
+        // returns null so the image wireframe path captures the actual tinted appearance.
+        val baseAlpha = (fillColor.toLong() and 0xFF000000) shr 24
+        assumeTrue(baseAlpha != 0L)
+        testableMapper.fakeResolvedColor = fillColor
+        testableMapper.fakeColorFilter = null
+        val gradientDrawable = GradientDrawable()
+
+        val result = testedMapper.mapDrawableToColor(gradientDrawable, mockInternalLogger)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    override fun `M map GradientDrawable to fill paint's color W mapDrawableToColor()`(
+        @IntForgery drawableColor: Int
+    ) {
+        // On Q+, when no color filter is accessible (drawable.colorFilter is null), the mapper
+        // returns null regardless of the fill color so the image wireframe path is used instead.
+        val baseAlpha = (drawableColor.toLong() and 0xFF000000) shr 24
+        assumeTrue(baseAlpha != 0L)
+        val mockFillPaint = mock<Paint>().apply {
+            whenever(this.color) doReturn (drawableColor and 0xFFFFFF)
+            whenever(this.alpha) doReturn baseAlpha.toInt()
+        }
+        val gradientDrawable = GradientDrawable().apply {
+            AndroidMDrawableToColorMapper.fillPaintField?.set(this, mockFillPaint)
+        }
+
+        val result = testedMapper.mapDrawableToColor(gradientDrawable, mockInternalLogger)
+
+        assertThat(result).isNull()
+    }
+
     // Seam to avoid calling API 24+ methods on the test JVM; falls back to parent-injected fillPaintField when fakeResolvedColor is null.
     private class TestableQMapper : AndroidQDrawableToColorMapper() {
         var fakeResolvedColor: Int? = null


### PR DESCRIPTION
### What does this PR do?

RUM-16551 replaced GradientDrawable.mFillPaint reflection with the public getColor() API, which returns only the raw fill colour. AppCompat stores tints applied via DrawableCompat.setTintList() in the private Drawable.mTintFilter field, which is inaccessible on API 30+ (Android 11's catch-all hidden-API enforcement) and was also not read by the new code on API 24–28. This caused tinted button backgrounds to appear as invisible white ShapeWireframes instead of falling back to the image wireframe path.

Fix: return null from resolveGradientDrawable (Q mapper) and resolveGradientDrawableNPlus (M mapper) when drawable.colorFilter is null, restoring the image wireframe fallback which correctly renders the tinted appearance.

Expected:
<img width="490" height="702" alt="Screenshot 2026-06-21 at 11 24 53" src="https://github.com/user-attachments/assets/1624f35b-4743-4077-9ba4-0bd8b70536e8" />

Regression:
<img width="494" height="688" alt="Screenshot 2026-06-21 at 11 25 19" src="https://github.com/user-attachments/assets/9bb503c6-b69d-4c1b-b8b5-1cc78f1e9d38" />

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

