### PR TITLE
RUM-16696: Attach profiling context to the View events

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -1394,7 +1394,8 @@ internal open class RumViewScope(
                         sessionSampleRate = sampleRate,
                         sessionReplaySampleRate = resolveSessionReplaySampleRate(datadogContext),
                         traceSampleRate = resolveTraceSampleRate(datadogContext)
-                    )
+                    ),
+                    profiling = resolveViewProfilingStatus(datadogContext)
                 ),
                 connectivity = datadogContext.networkInfo.toViewConnectivity(),
                 service = datadogContext.service,
@@ -1710,6 +1711,19 @@ internal open class RumViewScope(
                 quotaReason = quotaReason
             )
 
+            else -> null
+        }
+    }
+
+    private fun resolveViewProfilingStatus(datadogContext: DatadogContext): ViewEvent.Profiling? {
+        val isRunning = datadogContext.isProfilerRunning()
+        val quotaReason = datadogContext.resolveProfilingQuotaReason(sessionId)
+        return when {
+            isRunning -> ViewEvent.Profiling(status = ViewEvent.ProfilingStatus.RUNNING)
+            quotaReason != null -> ViewEvent.Profiling(
+                status = ViewEvent.ProfilingStatus.STOPPED,
+                quotaReason = quotaReason
+            )
             else -> null
         }
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
@@ -845,6 +845,26 @@ internal class ViewEventAssert(actual: ViewEvent) :
         return this
     }
 
+    fun hasProfilingStatus(profilingStatus: ViewEvent.ProfilingStatus?): ViewEventAssert {
+        assertThat(actual.dd.profiling?.status)
+            .overridingErrorMessage(
+                "Expected RUM event to have profiling status: $profilingStatus" +
+                    " but instead was: ${actual.dd.profiling?.status}"
+            )
+            .isEqualTo(profilingStatus)
+        return this
+    }
+
+    fun hasNoProfiling(): ViewEventAssert {
+        assertThat(actual.dd.profiling)
+            .overridingErrorMessage(
+                "Expected RUM event to have no profiling" +
+                    " but instead was: ${actual.dd.profiling}"
+            )
+            .isNull()
+        return this
+    }
+
     companion object {
 
         internal val ONE_SECOND_NS = TimeUnit.SECONDS.toNanos(1)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -6083,6 +6083,109 @@ internal class RumViewScopeTest {
     }
 
     @Test
+    fun `M set profiling status RUNNING in ViewEvent W handleEvent(StartView) {profiler running}`(
+        @Forgery key: RumScopeKey
+    ) {
+        // Given
+        val datadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(Feature.PROFILING_FEATURE_NAME, mapOf(FeatureContextKeys.PROFILER_IS_RUNNING to true))
+            }
+        )
+
+        // When
+        testedScope.handleEvent(RumRawEvent.StartView(key, emptyMap()), datadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue).hasProfilingStatus(ViewEvent.ProfilingStatus.RUNNING)
+        }
+    }
+
+    @Test
+    fun `M not set profiling in ViewEvent W handleEvent(StartView) {profiler not running}`(
+        @Forgery key: RumScopeKey
+    ) {
+        // Given
+        val datadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(Feature.PROFILING_FEATURE_NAME, mapOf(PROFILER_IS_RUNNING to false))
+            }
+        )
+
+        // When
+        testedScope.handleEvent(RumRawEvent.StartView(key, emptyMap()), datadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue).hasNoProfiling()
+        }
+    }
+
+    @Test
+    fun `M include quotaReason in ViewEvent W handleEvent(StartView) {profiler not running and quota denied}`(
+        @Forgery key: RumScopeKey,
+        @StringForgery fakeQuotaReason: String
+    ) {
+        // Given
+        val datadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(
+                    Feature.PROFILING_FEATURE_NAME,
+                    mapOf(
+                        PROFILER_IS_RUNNING to false,
+                        FeatureContextKeys.PROFILING_QUOTA_REASON to fakeQuotaReason,
+                        FeatureContextKeys.PROFILING_QUOTA_SESSION_ID to fakeParentContext.sessionId
+                    )
+                )
+            }
+        )
+
+        // When
+        testedScope.handleEvent(RumRawEvent.StartView(key, emptyMap()), datadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue.dd.profiling?.quotaReason).isEqualTo(fakeQuotaReason)
+            assertThat(lastValue.dd.profiling?.status).isEqualTo(ViewEvent.ProfilingStatus.STOPPED)
+        }
+    }
+
+    @Test
+    fun `M ignore stale quotaReason in ViewEvent W handleEvent(StartView) {quota reason for other session}`(
+        @Forgery key: RumScopeKey,
+        @StringForgery fakeQuotaReason: String,
+        @StringForgery fakeOtherSessionId: String
+    ) {
+        // Given — the quota reason is stamped with a different session than the current one
+        val datadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(
+                    Feature.PROFILING_FEATURE_NAME,
+                    mapOf(
+                        PROFILER_IS_RUNNING to false,
+                        FeatureContextKeys.PROFILING_QUOTA_REASON to fakeQuotaReason,
+                        FeatureContextKeys.PROFILING_QUOTA_SESSION_ID to fakeOtherSessionId
+                    )
+                )
+            }
+        )
+
+        // When
+        testedScope.handleEvent(RumRawEvent.StartView(key, emptyMap()), datadogContext, mockEventWriteScope, mockWriter)
+
+        // Then — the stale reason is ignored and no profiling status is attached
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue.dd.profiling?.quotaReason).isNull()
+            assertThat(lastValue.dd.profiling?.status).isNull()
+        }
+    }
+
+    @Test
     fun `M decrease pending Long Task W handleEvent(LongTaskDropped) on active view {not frozen}`(
         @LongForgery(1) pendingLongTask: Long,
         @LongForgery(1) pendingFrozenFrame: Long


### PR DESCRIPTION
### What does this PR do?

Attach profiling context to the View events as we did for RUM Errors and Vitals

### Motivation

RUM-16696

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

