### PR TITLE
RUM-16727: Integrate the client side stat systems into ClientStatsFeature

### DIFF
--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -590,6 +590,7 @@ datadog:
       - "java.util.concurrent.atomic.AtomicLong.compareAndSet(kotlin.Long, kotlin.Long)"
       - "java.util.concurrent.atomic.AtomicLong.constructor(kotlin.Long)"
       - "java.util.concurrent.atomic.AtomicLong.get()"
+      - "java.util.concurrent.atomic.AtomicLong.getAndIncrement()"
       - "java.util.concurrent.atomic.AtomicLong.set(kotlin.Long)"
       - "java.util.concurrent.atomic.AtomicReference.compareAndSet(com.datadog.trace.core.CoreTracer?, com.datadog.trace.core.CoreTracer?)"
       - "java.util.concurrent.atomic.AtomicReference.compareAndSet(com.datadog.android.api.SdkCore?, com.datadog.android.api.SdkCore?)"

--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -556,6 +556,7 @@ datadog:
       - "java.util.concurrent.LinkedBlockingQueue.constructor()"
       - "java.util.concurrent.LinkedBlockingQueue.toArray()"
       - "java.util.concurrent.RejectedExecutionHandler(kotlin.Function2)"
+      - "java.util.concurrent.ScheduledExecutorService.shutdown()"
       - "java.util.concurrent.ScheduledExecutorService.shutdownNow()"
       - "java.util.concurrent.ScheduledFuture.cancel(kotlin.Boolean)"
       - "java.util.concurrent.ScheduledThreadPoolExecutor.afterExecute(java.lang.Runnable?, kotlin.Throwable?)"

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/Trace.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/Trace.kt
@@ -38,7 +38,10 @@ object Trace {
 
         if (traceConfiguration.statsComputationEnabled) {
             val stats = ClientStatsFeature(
-                customEndpointUrl = traceConfiguration.customStatsEndpointUrl
+                sdkCore = sdkCore,
+                customEndpointUrl = traceConfiguration.customStatsEndpointUrl,
+                spanEventMapper = traceConfiguration.eventMapper,
+                networkInfoEnabled = traceConfiguration.networkInfoEnabled
             )
 
             sdkCore.registerFeature(stats)

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ClientStatsFeature.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ClientStatsFeature.kt
@@ -7,33 +7,119 @@
 package com.datadog.android.trace.internal
 
 import android.content.Context
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.feature.StorageBackedFeature
 import com.datadog.android.api.storage.FeatureStorageConfiguration
+import com.datadog.android.trace.event.SpanEventMapper
+import com.datadog.android.trace.internal.domain.event.CoreTracerSpanToSpanEventMapper
+import com.datadog.android.trace.internal.domain.event.SpanEventMapperWrapper
+import com.datadog.android.trace.internal.domain.metrics.BatchStatsWriter
+import com.datadog.android.trace.internal.domain.metrics.ClientStatsAdapter
+import com.datadog.android.trace.internal.domain.metrics.StatsConcentrator
 import com.datadog.android.trace.internal.net.ClientStatsRequestFactory
-import com.datadog.trace.common.metrics.NoOpMetricsAggregator
+import com.datadog.trace.api.Config
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
 
 internal class ClientStatsFeature(
-    customEndpointUrl: String?
+    private val sdkCore: FeatureSdkCore,
+    customEndpointUrl: String?,
+    spanEventMapper: SpanEventMapper,
+    networkInfoEnabled: Boolean
 ) : StorageBackedFeature {
     override val name = Feature.TRACING_CLIENT_STATS_FEATURE_NAME
 
     override val storageConfiguration = FeatureStorageConfiguration(
-        // 512 KB
-        maxItemSize = 512L * 1024,
-        maxItemsPerBatch = 4000,
+        // 15 MB
+        maxItemSize = 15L * 1024 * 1024,
+        // Batching is handled by the flush/aggregation mechanism, only one ClientStatsPayload per upload
+        maxItemsPerBatch = 1,
         // 15 MB
         maxBatchSize = 15L * 1024 * 1024,
         // 18 hours
         oldBatchThreshold = 18L * 60L * 60L * 1000L
     )
 
-    // TODO RUM-16565 Implement stats aggregator
-    internal val aggregator = NoOpMetricsAggregator()
+    private val timeProvider = sdkCore.timeProvider
+    private val statAggregator: ExecutorService by lazy {
+        sdkCore.createSingleThreadExecutorService("client-side-stats-aggregator")
+    }
+    private val flushScheduler: ScheduledExecutorService by lazy {
+        sdkCore.createScheduledExecutorService("client-side-flush-scheduler")
+    }
+    private val statsConcentrator by lazy {
+        // runtimeId is static and encapsulated in Tracer core's Config. There is no way to get it except via the root
+        // span's tags or this Config object
+        val runtimeID = Config.get().runtimeId
+
+        StatsConcentrator(
+            sdkCore,
+            ddSpanToSpanEventMapper = CoreTracerSpanToSpanEventMapper(networkInfoEnabled),
+            eventMapper = SpanEventMapperWrapper(spanEventMapper, sdkCore.internalLogger),
+            statAggregator,
+            BatchStatsWriter(sdkCore, runtimeID),
+            timeProvider
+        )
+    }
+
+    internal val aggregator by lazy {
+        ClientStatsAdapter(statsConcentrator)
+    }
 
     override val requestFactory = ClientStatsRequestFactory(customEndpointUrl)
 
-    override fun onInitialize(appContext: Context) {}
+    override fun onInitialize(appContext: Context) {
+        startPeriodicFlush()
+    }
 
-    override fun onStop() {}
+    private fun startPeriodicFlush() {
+        try {
+            @Suppress("UnsafeThirdPartyFunctionCall") // exception caught below
+            flushScheduler.scheduleWithFixedDelay(
+                { triggerFlush(flushAll = false) },
+                FLUSH_INTERVAL.inWholeMilliseconds,
+                FLUSH_INTERVAL.inWholeMilliseconds,
+                TimeUnit.MILLISECONDS
+            )
+        } catch (e: RejectedExecutionException) {
+            sdkCore.internalLogger.log(
+                InternalLogger.Level.WARN,
+                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                { "Failed to schedule stats flush" },
+                e
+            )
+        }
+    }
+
+    override fun onStop() {
+        flushScheduler.shutdownNow()
+
+        triggerFlush(flushAll = true)
+
+        statAggregator.shutdown()
+        try {
+            @Suppress("UnsafeThirdPartyFunctionCall") // InterruptedException is caught and handled
+            if (!statAggregator.awaitTermination(DRAIN_WAIT_SECONDS, TimeUnit.SECONDS)) {
+                statAggregator.shutdownNow()
+            }
+        } catch (_: InterruptedException) {
+            statAggregator.shutdownNow()
+            @Suppress("UnsafeThirdPartyFunctionCall") // safe - SecurityException not thrown in Android
+            Thread.currentThread().interrupt()
+        }
+    }
+
+    private fun triggerFlush(flushAll: Boolean) {
+        statsConcentrator.scheduleFlush(flushAll)
+    }
+
+    private companion object {
+        private const val DRAIN_WAIT_SECONDS = 10L
+        private val FLUSH_INTERVAL = 10.seconds
+    }
 }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ClientStatsFeature.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ClientStatsFeature.kt
@@ -35,10 +35,9 @@ internal class ClientStatsFeature(
     override val name = Feature.TRACING_CLIENT_STATS_FEATURE_NAME
 
     override val storageConfiguration = FeatureStorageConfiguration(
-        // 15 MB
-        maxItemSize = 15L * 1024 * 1024,
-        // Batching is handled by the flush/aggregation mechanism, only one ClientStatsPayload per upload
-        maxItemsPerBatch = 1,
+        // 512 KB
+        maxItemSize = 512L * 1024,
+        maxItemsPerBatch = 4000,
         // 15 MB
         maxBatchSize = 15L * 1024 * 1024,
         // 18 hours

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ClientStatsFeature.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ClientStatsFeature.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.trace.internal
 
 import android.content.Context
-import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.feature.StorageBackedFeature
@@ -20,11 +19,7 @@ import com.datadog.android.trace.internal.domain.metrics.ClientStatsAdapter
 import com.datadog.android.trace.internal.domain.metrics.StatsConcentrator
 import com.datadog.android.trace.internal.net.ClientStatsRequestFactory
 import com.datadog.trace.api.Config
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.TimeUnit
-import kotlin.time.Duration.Companion.seconds
 
 internal class ClientStatsFeature(
     private val sdkCore: FeatureSdkCore,
@@ -44,12 +39,8 @@ internal class ClientStatsFeature(
         oldBatchThreshold = 18L * 60L * 60L * 1000L
     )
 
-    private val timeProvider = sdkCore.timeProvider
-    private val statAggregator: ExecutorService by lazy {
-        sdkCore.createSingleThreadExecutorService("client-side-stats-aggregator")
-    }
-    private val flushScheduler: ScheduledExecutorService by lazy {
-        sdkCore.createScheduledExecutorService("client-side-flush-scheduler")
+    private val statsExecutor: ScheduledExecutorService by lazy {
+        sdkCore.createScheduledExecutorService("client-side-stats-aggregator")
     }
     private val statsConcentrator by lazy {
         // runtimeId is static and encapsulated in Tracer core's Config. There is no way to get it except via the root
@@ -60,9 +51,9 @@ internal class ClientStatsFeature(
             sdkCore,
             ddSpanToSpanEventMapper = CoreTracerSpanToSpanEventMapper(networkInfoEnabled),
             eventMapper = SpanEventMapperWrapper(spanEventMapper, sdkCore.internalLogger),
-            statAggregator,
+            statsExecutor,
             BatchStatsWriter(sdkCore, runtimeID),
-            timeProvider
+            sdkCore.timeProvider
         )
     }
 
@@ -72,53 +63,11 @@ internal class ClientStatsFeature(
 
     override val requestFactory = ClientStatsRequestFactory(customEndpointUrl)
 
-    override fun onInitialize(appContext: Context) {
-        startPeriodicFlush()
-    }
-
-    private fun startPeriodicFlush() {
-        try {
-            @Suppress("UnsafeThirdPartyFunctionCall") // exception caught below
-            flushScheduler.scheduleWithFixedDelay(
-                { triggerFlush(flushAll = false) },
-                FLUSH_INTERVAL.inWholeMilliseconds,
-                FLUSH_INTERVAL.inWholeMilliseconds,
-                TimeUnit.MILLISECONDS
-            )
-        } catch (e: RejectedExecutionException) {
-            sdkCore.internalLogger.log(
-                InternalLogger.Level.WARN,
-                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                { "Failed to schedule stats flush" },
-                e
-            )
-        }
-    }
+    override fun onInitialize(appContext: Context) {}
 
     override fun onStop() {
-        flushScheduler.shutdownNow()
+        statsConcentrator.stop()
 
-        triggerFlush(flushAll = true)
-
-        statAggregator.shutdown()
-        try {
-            @Suppress("UnsafeThirdPartyFunctionCall") // InterruptedException is caught and handled
-            if (!statAggregator.awaitTermination(DRAIN_WAIT_SECONDS, TimeUnit.SECONDS)) {
-                statAggregator.shutdownNow()
-            }
-        } catch (_: InterruptedException) {
-            statAggregator.shutdownNow()
-            @Suppress("UnsafeThirdPartyFunctionCall") // safe - SecurityException not thrown in Android
-            Thread.currentThread().interrupt()
-        }
-    }
-
-    private fun triggerFlush(flushAll: Boolean) {
-        statsConcentrator.scheduleFlush(flushAll)
-    }
-
-    private companion object {
-        private const val DRAIN_WAIT_SECONDS = 10L
-        private val FLUSH_INTERVAL = 10.seconds
+        statsExecutor.shutdown()
     }
 }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/BatchStatsWriter.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/BatchStatsWriter.kt
@@ -1,0 +1,45 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.internal.domain.metrics
+
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.api.storage.EventType
+import com.datadog.android.api.storage.RawBatchEvent
+import java.util.concurrent.atomic.AtomicLong
+
+internal class BatchStatsWriter(
+    private val sdkCore: FeatureSdkCore,
+    private val runtimeID: String
+) : StatsWriter {
+    private val sequenceNumber = AtomicLong(0)
+
+    override fun write(statBuckets: List<ClientStatsBucket>) {
+        sdkCore.getFeature(Feature.TRACING_CLIENT_STATS_FEATURE_NAME)
+            ?.withWriteContext { datadogContext, writeScope ->
+                val payload = ClientStatsPayload(
+                    hostname = "", // left blank intentionally
+                    env = datadogContext.env,
+                    version = datadogContext.version,
+                    service = datadogContext.service,
+                    tracerVersion = datadogContext.sdkVersion,
+                    runtimeID = runtimeID,
+                    sequenceNumber = sequenceNumber.getAndIncrement(),
+                    stats = statBuckets
+                )
+
+                writeScope { batchWriter ->
+                    val rawBatchEvent = RawBatchEvent(data = payload.toMsgPackPayload())
+                    batchWriter.write(
+                        event = rawBatchEvent,
+                        batchMetadata = null,
+                        eventType = EventType.DEFAULT
+                    )
+                }
+            }
+    }
+}

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/ClientStatsAdapter.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/ClientStatsAdapter.kt
@@ -1,0 +1,42 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.internal.domain.metrics
+
+import com.datadog.trace.common.metrics.MetricsAggregator
+import com.datadog.trace.core.CoreSpan
+import com.datadog.trace.core.DDSpan
+import java.util.concurrent.Future
+
+internal class ClientStatsAdapter(
+    private val statsConcentrator: StatsConcentrator
+) : MetricsAggregator {
+    override fun start() {
+        // NO - OP
+    }
+
+    override fun report(): Boolean {
+        // NO - OP
+        return false
+    }
+
+    override fun forceReport(): Future<Boolean?>? {
+        // NO - OP
+        return null
+    }
+
+    override fun publish(trace: List<CoreSpan<*>>?): Boolean {
+        if (trace == null) return false
+
+        statsConcentrator.record(trace.filterIsInstance<DDSpan>())
+
+        return false
+    }
+
+    override fun close() {
+        // NO - OP
+    }
+}

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
@@ -11,6 +11,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.event.EventMapper
+import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.trace.api.DatadogTracingConstants
 import com.datadog.android.trace.internal.ddsketch.DDSketch
 import com.datadog.android.trace.internal.domain.event.ContextAwareMapper
@@ -19,6 +20,7 @@ import com.datadog.trace.bootstrap.instrumentation.api.Tags
 import com.datadog.trace.core.DDSpan
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 internal class StatsConcentrator(
@@ -26,18 +28,19 @@ internal class StatsConcentrator(
     private val ddSpanToSpanEventMapper: ContextAwareMapper<DDSpan, SpanEvent>,
     private val eventMapper: EventMapper<SpanEvent>,
     /**
+     * Executor that owns stat calculations. It must be a single-thread executor to enforce threading contracts.
+     */
+    private val executorService: ExecutorService,
+    private val statsWriter: StatsWriter,
+    private val timeProvider: TimeProvider,
+    /**
      * The number of stats buckets we keep in memory before flushing them.
      * It means that we can compute stats only for the last `bufferLen * bucketSizeNs` and that we
      * wait such time before flushing the stats.
      * This only applies to past buckets. Stats buckets in the future are allowed with no restriction.
      */
-    private val bufferLen: Int,
-    private val bucketSizeNs: Long = 10.seconds.inWholeNanoseconds,
-    /**
-     * Executor that owns stat calculations. It must be a single-thread executor to enforce threading contracts.
-     */
-    private val executorService: ExecutorService,
-    private val statsWriter: StatsWriter
+    private val bufferLen: Int = DEFAULT_BUFFER_SIZE,
+    private val bucketSizeNs: Long = DEFAULT_BUCKET_LENGTH.inWholeNanoseconds
 ) {
     // These fields below are confined to executorService; never access them from another thread.
     private var oldestTs: Long = 0L
@@ -87,10 +90,10 @@ internal class StatsConcentrator(
      * [forcePending] is set before the coalescing check so the already-queued task picks it up.
      * Flushed buckets are written to [statsWriter].
      *
-     * @param now Current device-local time in nanoseconds
      * @param flushAll When `true`, drains all buckets regardless of age. Used during SDK teardown.
      */
-    fun scheduleFlush(now: Long, flushAll: Boolean) {
+    fun scheduleFlush(flushAll: Boolean) {
+        val now = timeProvider.getDeviceTimestampMillis().milliseconds.inWholeNanoseconds
         if (flushAll) {
             forcePending.set(true)
         }
@@ -126,7 +129,7 @@ internal class StatsConcentrator(
 
         return closedBuckets.map { (bucketStart, groups) ->
             ClientStatsBucket(
-                start = bucketStart,
+                start = bucketStart + timeProvider.getServerOffsetNanos(),
                 duration = bucketSizeNs,
                 stats = groups.map { (key, stats) ->
                     ClientGroupedStats(
@@ -248,6 +251,8 @@ internal class StatsConcentrator(
         private const val RELATIVE_ACCURACY = 0.01
         private const val MAX_NUM_BINS = 2048
         private const val KEY_SVC_SRC = "_dd.svc_src"
+        private const val DEFAULT_BUFFER_SIZE = 2
+        private val DEFAULT_BUCKET_LENGTH = 10.seconds
 
         private val ELIGIBLE_SPAN_KINDS = setOf(
             Tags.SPAN_KIND_SERVER,

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
@@ -10,6 +10,7 @@ import androidx.annotation.VisibleForTesting
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.internal.utils.executeSafe
+import com.datadog.android.core.internal.utils.scheduleSafe
 import com.datadog.android.event.EventMapper
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.trace.api.DatadogTracingConstants
@@ -18,7 +19,8 @@ import com.datadog.android.trace.internal.domain.event.ContextAwareMapper
 import com.datadog.android.trace.model.SpanEvent
 import com.datadog.trace.bootstrap.instrumentation.api.Tags
 import com.datadog.trace.core.DDSpan
-import java.util.concurrent.ExecutorService
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -29,7 +31,7 @@ internal class StatsConcentrator(
     /**
      * Executor that owns stat calculations. It must be a single-thread executor to enforce threading contracts.
      */
-    private val executorService: ExecutorService,
+    private val executorService: ScheduledExecutorService,
     private val statsWriter: StatsWriter,
     private val timeProvider: TimeProvider,
     /**
@@ -39,11 +41,21 @@ internal class StatsConcentrator(
      * This only applies to past buckets. Stats buckets in the future are allowed with no restriction.
      */
     private val bufferLen: Int = DEFAULT_BUFFER_SIZE,
-    private val bucketSizeNs: Long = DEFAULT_BUCKET_LENGTH.inWholeNanoseconds
+    private val bucketSizeNs: Long = DEFAULT_BUCKET_LENGTH.inWholeNanoseconds,
+    startPeriodicFlush: Boolean = true
 ) {
     // These fields below are confined to executorService; never access them from another thread.
     private var oldestTs: Long = 0L
     private val buckets = mutableMapOf<Long, MutableMap<AggregationKey, GroupedStats>>()
+
+    @Volatile
+    private var isStopped = false
+
+    init {
+        if (startPeriodicFlush) {
+            schedulePeriodicFlush()
+        }
+    }
 
     fun record(trace: List<DDSpan>) {
         val metricsFeature = sdkCore.getFeature(Feature.TRACING_CLIENT_STATS_FEATURE_NAME) ?: return
@@ -77,18 +89,46 @@ internal class StatsConcentrator(
         }
     }
 
+    fun stop() {
+        isStopped = true
+        scheduleFlush(flushAll = true)
+    }
+
+    private fun schedulePeriodicFlush() {
+        if (isStopped) {
+            return
+        }
+
+        executorService.scheduleSafe(
+            "stats-flush-periodic",
+            FLUSH_INTERVAL_SECS,
+            TimeUnit.SECONDS,
+            sdkCore.internalLogger
+        ) {
+            flushBuckets(flushAll = false)
+
+            // Schedule next refresh
+            schedulePeriodicFlush()
+        }
+    }
+
     /**
      * Schedules a drain of ready buckets and returns immediately.
      * Flushed buckets are written to [statsWriter].
      *
      * @param flushAll When `true`, drains all buckets regardless of age. Used during SDK teardown.
      */
+    @VisibleForTesting
     fun scheduleFlush(flushAll: Boolean) {
-        executorService.executeSafe("stats-flush", sdkCore.internalLogger) {
-            val buckets = drainBuckets(flushAll)
-            if (buckets.isNotEmpty()) {
-                statsWriter.write(buckets)
-            }
+        executorService.executeSafe("stats-flush-all=$flushAll", sdkCore.internalLogger) {
+            flushBuckets(flushAll)
+        }
+    }
+
+    private fun flushBuckets(flushAll: Boolean) {
+        val buckets = drainBuckets(flushAll)
+        if (buckets.isNotEmpty()) {
+            statsWriter.write(buckets)
         }
     }
 
@@ -236,6 +276,7 @@ internal class StatsConcentrator(
         private const val KEY_SVC_SRC = "_dd.svc_src"
         private const val DEFAULT_BUFFER_SIZE = 2
         private val DEFAULT_BUCKET_LENGTH = 10.seconds
+        private const val FLUSH_INTERVAL_SECS = 10L
 
         private val ELIGIBLE_SPAN_KINDS = setOf(
             Tags.SPAN_KIND_SERVER,

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
@@ -19,7 +19,6 @@ import com.datadog.android.trace.model.SpanEvent
 import com.datadog.trace.bootstrap.instrumentation.api.Tags
 import com.datadog.trace.core.DDSpan
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -45,12 +44,6 @@ internal class StatsConcentrator(
     // These fields below are confined to executorService; never access them from another thread.
     private var oldestTs: Long = 0L
     private val buckets = mutableMapOf<Long, MutableMap<AggregationKey, GroupedStats>>()
-
-    // Coalescing flags: at most one flush task lives in the executor queue at any time.
-    // forcePending is set unconditionally so a force flush is never lost even if a scheduled
-    // flush is already queued and will pick it up.
-    private val flushPending = AtomicBoolean(false)
-    private val forcePending = AtomicBoolean(false)
 
     fun record(trace: List<DDSpan>) {
         val metricsFeature = sdkCore.getFeature(Feature.TRACING_CLIENT_STATS_FEATURE_NAME) ?: return
@@ -85,26 +78,14 @@ internal class StatsConcentrator(
     }
 
     /**
-     * Schedules a drain of ready buckets and returns immediately. If a flush is already queued,
-     * this call is a no-op — the queued task will cover the window. A [flushAll] flush is never dropped:
-     * [forcePending] is set before the coalescing check so the already-queued task picks it up.
+     * Schedules a drain of ready buckets and returns immediately.
      * Flushed buckets are written to [statsWriter].
      *
      * @param flushAll When `true`, drains all buckets regardless of age. Used during SDK teardown.
      */
     fun scheduleFlush(flushAll: Boolean) {
-        val now = timeProvider.getDeviceTimestampMillis().milliseconds.inWholeNanoseconds
-        if (flushAll) {
-            forcePending.set(true)
-        }
-
-        if (!flushPending.compareAndSet(false, true)) {
-            return
-        }
-
         executorService.executeSafe("stats-flush", sdkCore.internalLogger) {
-            flushPending.set(false)
-            val buckets = drainBuckets(now, forcePending.getAndSet(false))
+            val buckets = drainBuckets(flushAll)
             if (buckets.isNotEmpty()) {
                 statsWriter.write(buckets)
             }
@@ -117,7 +98,9 @@ internal class StatsConcentrator(
         buckets.getOrPut(bucketKey) { mutableMapOf() }.getOrPut(key) { GroupedStats() }.add(s)
     }
 
-    private fun drainBuckets(now: Long, flushAll: Boolean): List<ClientStatsBucket> {
+    private fun drainBuckets(flushAll: Boolean): List<ClientStatsBucket> {
+        val now = timeProvider.getDeviceTimestampMillis().milliseconds.inWholeNanoseconds
+
         // Determine the current cuff off for which buckets to leave as still in progress
         val cutoff = now - (bufferLen * bucketSizeNs)
 

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsWriter.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsWriter.kt
@@ -7,5 +7,5 @@
 package com.datadog.android.trace.internal.domain.metrics
 
 internal fun interface StatsWriter {
-    fun write(buckets: List<ClientStatsBucket>)
+    fun write(statBuckets: List<ClientStatsBucket>)
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/ClientStatsFeatureTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/ClientStatsFeatureTest.kt
@@ -13,7 +13,6 @@ import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.trace.event.SpanEventMapper
 import com.datadog.android.trace.internal.domain.metrics.ClientStatsAdapter
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -29,17 +28,11 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.doThrow
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.TimeUnit
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -61,10 +54,7 @@ internal class ClientStatsFeatureTest {
     lateinit var mockSpanEventMapper: SpanEventMapper
 
     @Mock
-    lateinit var mockStatAggregatorExecutor: ExecutorService
-
-    @Mock
-    lateinit var mockFlushSchedulerExecutor: ScheduledExecutorService
+    lateinit var mockStatsExecutor: ScheduledExecutorService
 
     @Mock
     lateinit var mockTimeProvider: TimeProvider
@@ -83,8 +73,7 @@ internal class ClientStatsFeatureTest {
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockSdkCore.timeProvider) doReturn mockTimeProvider
         whenever(mockTimeProvider.getDeviceTimestampMillis()) doReturn fakeTimestampMillis
-        whenever(mockSdkCore.createSingleThreadExecutorService(any())) doReturn mockStatAggregatorExecutor
-        whenever(mockSdkCore.createScheduledExecutorService(any())) doReturn mockFlushSchedulerExecutor
+        whenever(mockSdkCore.createScheduledExecutorService(any())) doReturn mockStatsExecutor
 
         testedFeature = ClientStatsFeature(
             sdkCore = mockSdkCore,
@@ -157,92 +146,35 @@ internal class ClientStatsFeatureTest {
 
     // endregion
 
-    // region onInitialize
-
-    @Test
-    fun `M schedule periodic flush with 10 second interval W onInitialize()`() {
-        // When
-        testedFeature.onInitialize(mock())
-
-        // Then
-        verify(mockFlushSchedulerExecutor).scheduleWithFixedDelay(
-            any(),
-            eq(10_000L),
-            eq(10_000L),
-            eq(TimeUnit.MILLISECONDS)
-        )
-    }
-
-    @Test
-    fun `M log warning W onInitialize() { flush scheduling rejected }`() {
-        // Given
-        whenever(mockFlushSchedulerExecutor.scheduleWithFixedDelay(any(), any(), any(), any()))
-            .doThrow(RejectedExecutionException("Rejected"))
-
-        // When
-        testedFeature.onInitialize(mock())
-
-        // Then
-        mockInternalLogger.verifyLog(
-            level = InternalLogger.Level.WARN,
-            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            message = "Failed to schedule stats flush",
-            throwableClass = RejectedExecutionException::class.java
-        )
-    }
-
-    // endregion
-
     // region onStop
 
     @Test
-    fun `M shutdown flush scheduler W onStop()`() {
-        // Given
-        testedFeature.onInitialize(mock())
-
+    fun `M submit flush all task W onStop()`() {
         // When
         testedFeature.onStop()
 
         // Then
-        verify(mockFlushSchedulerExecutor).shutdownNow()
+        verify(mockStatsExecutor).execute(any())
     }
 
     @Test
-    fun `M submit flush all task to stat aggregator W onStop()`() {
-        // Given
-        testedFeature.onInitialize(mock())
-
+    fun `M shutdown stats executor W onStop()`() {
         // When
         testedFeature.onStop()
 
         // Then
-        verify(mockStatAggregatorExecutor).execute(any())
+        verify(mockStatsExecutor).shutdown()
     }
 
     @Test
-    fun `M shutdown stat aggregator W onStop()`() {
-        // Given
-        testedFeature.onInitialize(mock())
-
+    fun `M submit flush all task before shutting down stats executor W onStop()`() {
         // When
         testedFeature.onStop()
 
         // Then
-        verify(mockStatAggregatorExecutor).shutdown()
-    }
-
-    @Test
-    fun `M shutdown flush scheduler before shutting down stat aggregator W onStop()`() {
-        // Given
-        testedFeature.onInitialize(mock())
-
-        // When
-        testedFeature.onStop()
-
-        // Then
-        inOrder(mockFlushSchedulerExecutor, mockStatAggregatorExecutor) {
-            verify(mockFlushSchedulerExecutor).shutdownNow()
-            verify(mockStatAggregatorExecutor).shutdown()
+        inOrder(mockStatsExecutor) {
+            verify(mockStatsExecutor).execute(any())
+            verify(mockStatsExecutor).shutdown()
         }
     }
 

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/ClientStatsFeatureTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/ClientStatsFeatureTest.kt
@@ -107,15 +107,15 @@ internal class ClientStatsFeatureTest {
     // region storageConfiguration
 
     @Test
-    fun `M return 15 MB max item size W storageConfiguration()`() {
+    fun `M return 512 KB max item size W storageConfiguration()`() {
         // When + Then
-        assertThat(testedFeature.storageConfiguration.maxItemSize).isEqualTo(15L * 1024 * 1024)
+        assertThat(testedFeature.storageConfiguration.maxItemSize).isEqualTo(512L * 1024)
     }
 
     @Test
-    fun `M return 1 max items per batch W storageConfiguration()`() {
+    fun `M return 4000 max items per batch W storageConfiguration()`() {
         // When + Then
-        assertThat(testedFeature.storageConfiguration.maxItemsPerBatch).isEqualTo(1)
+        assertThat(testedFeature.storageConfiguration.maxItemsPerBatch).isEqualTo(4000)
     }
 
     @Test

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/ClientStatsFeatureTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/ClientStatsFeatureTest.kt
@@ -1,0 +1,260 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.internal
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.trace.event.SpanEventMapper
+import com.datadog.android.trace.internal.domain.metrics.ClientStatsAdapter
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.verifyLog
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class ClientStatsFeatureTest {
+
+    private lateinit var testedFeature: ClientStatsFeature
+
+    @Mock
+    lateinit var mockSdkCore: FeatureSdkCore
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @Mock
+    lateinit var mockSpanEventMapper: SpanEventMapper
+
+    @Mock
+    lateinit var mockStatAggregatorExecutor: ExecutorService
+
+    @Mock
+    lateinit var mockFlushSchedulerExecutor: ScheduledExecutorService
+
+    @Mock
+    lateinit var mockTimeProvider: TimeProvider
+
+    @StringForgery(regex = "https://[a-z]+\\.com")
+    lateinit var fakeEndpointUrl: String
+
+    @BoolForgery
+    var fakeNetworkInfoEnabled: Boolean = false
+
+    @LongForgery(min = 1L)
+    var fakeTimestampMillis: Long = 0L
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
+        whenever(mockSdkCore.timeProvider) doReturn mockTimeProvider
+        whenever(mockTimeProvider.getDeviceTimestampMillis()) doReturn fakeTimestampMillis
+        whenever(mockSdkCore.createSingleThreadExecutorService(any())) doReturn mockStatAggregatorExecutor
+        whenever(mockSdkCore.createScheduledExecutorService(any())) doReturn mockFlushSchedulerExecutor
+
+        testedFeature = ClientStatsFeature(
+            sdkCore = mockSdkCore,
+            customEndpointUrl = fakeEndpointUrl,
+            spanEventMapper = mockSpanEventMapper,
+            networkInfoEnabled = fakeNetworkInfoEnabled
+        )
+    }
+
+    // region name
+
+    @Test
+    fun `M return client stats feature name W name()`() {
+        // When + Then
+        assertThat(testedFeature.name).isEqualTo(Feature.TRACING_CLIENT_STATS_FEATURE_NAME)
+    }
+
+    // endregion
+
+    // region storageConfiguration
+
+    @Test
+    fun `M return 15 MB max item size W storageConfiguration()`() {
+        // When + Then
+        assertThat(testedFeature.storageConfiguration.maxItemSize).isEqualTo(15L * 1024 * 1024)
+    }
+
+    @Test
+    fun `M return 1 max items per batch W storageConfiguration()`() {
+        // When + Then
+        assertThat(testedFeature.storageConfiguration.maxItemsPerBatch).isEqualTo(1)
+    }
+
+    @Test
+    fun `M return 15 MB max batch size W storageConfiguration()`() {
+        // When + Then
+        assertThat(testedFeature.storageConfiguration.maxBatchSize).isEqualTo(15L * 1024 * 1024)
+    }
+
+    @Test
+    fun `M return 18 hour old batch threshold W storageConfiguration()`() {
+        // When + Then
+        assertThat(testedFeature.storageConfiguration.oldBatchThreshold)
+            .isEqualTo(18L * 60L * 60L * 1000L)
+    }
+
+    // endregion
+
+    // region requestFactory
+
+    @Test
+    fun `M return ClientStatsRequestFactory with custom endpoint W requestFactory()`() {
+        // When + Then
+        assertThat(testedFeature.requestFactory.customStatsEndpointUrl).isEqualTo(fakeEndpointUrl)
+    }
+
+    @Test
+    fun `M return ClientStatsRequestFactory with null endpoint W requestFactory() { no custom url }`() {
+        // Given
+        val feature = ClientStatsFeature(
+            sdkCore = mockSdkCore,
+            customEndpointUrl = null,
+            spanEventMapper = mockSpanEventMapper,
+            networkInfoEnabled = fakeNetworkInfoEnabled
+        )
+
+        // When + Then
+        assertThat(feature.requestFactory.customStatsEndpointUrl).isNull()
+    }
+
+    // endregion
+
+    // region onInitialize
+
+    @Test
+    fun `M schedule periodic flush with 10 second interval W onInitialize()`() {
+        // When
+        testedFeature.onInitialize(mock())
+
+        // Then
+        verify(mockFlushSchedulerExecutor).scheduleWithFixedDelay(
+            any(),
+            eq(10_000L),
+            eq(10_000L),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @Test
+    fun `M log warning W onInitialize() { flush scheduling rejected }`() {
+        // Given
+        whenever(mockFlushSchedulerExecutor.scheduleWithFixedDelay(any(), any(), any(), any()))
+            .doThrow(RejectedExecutionException("Rejected"))
+
+        // When
+        testedFeature.onInitialize(mock())
+
+        // Then
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.WARN,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            message = "Failed to schedule stats flush",
+            throwableClass = RejectedExecutionException::class.java
+        )
+    }
+
+    // endregion
+
+    // region onStop
+
+    @Test
+    fun `M shutdown flush scheduler W onStop()`() {
+        // Given
+        testedFeature.onInitialize(mock())
+
+        // When
+        testedFeature.onStop()
+
+        // Then
+        verify(mockFlushSchedulerExecutor).shutdownNow()
+    }
+
+    @Test
+    fun `M submit flush all task to stat aggregator W onStop()`() {
+        // Given
+        testedFeature.onInitialize(mock())
+
+        // When
+        testedFeature.onStop()
+
+        // Then
+        verify(mockStatAggregatorExecutor).execute(any())
+    }
+
+    @Test
+    fun `M shutdown stat aggregator W onStop()`() {
+        // Given
+        testedFeature.onInitialize(mock())
+
+        // When
+        testedFeature.onStop()
+
+        // Then
+        verify(mockStatAggregatorExecutor).shutdown()
+    }
+
+    @Test
+    fun `M shutdown flush scheduler before shutting down stat aggregator W onStop()`() {
+        // Given
+        testedFeature.onInitialize(mock())
+
+        // When
+        testedFeature.onStop()
+
+        // Then
+        inOrder(mockFlushSchedulerExecutor, mockStatAggregatorExecutor) {
+            verify(mockFlushSchedulerExecutor).shutdownNow()
+            verify(mockStatAggregatorExecutor).shutdown()
+        }
+    }
+
+    // endregion
+
+    // region aggregator
+
+    @Test
+    fun `M expose ClientStatsAdapter W aggregator`() {
+        // When + Then
+        assertThat(testedFeature.aggregator).isInstanceOf(ClientStatsAdapter::class.java)
+    }
+
+    // endregion
+}

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/BatchStatsWriterTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/BatchStatsWriterTest.kt
@@ -1,0 +1,223 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.internal.domain.metrics
+
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.EventWriteScope
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureScope
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
+import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.trace.assertj.MsgPackAssert
+import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class BatchStatsWriterTest {
+
+    private lateinit var testedWriter: BatchStatsWriter
+
+    @Mock
+    lateinit var mockSdkCore: FeatureSdkCore
+
+    @Mock
+    lateinit var mockFeatureScope: FeatureScope
+
+    @Mock
+    lateinit var mockEventWriteScope: EventWriteScope
+
+    @Mock
+    lateinit var mockEventBatchWriter: EventBatchWriter
+
+    @Forgery
+    lateinit var fakeDatadogContext: DatadogContext
+
+    @LongForgery(min = 0L)
+    var fakeBucketStart: Long = 0L
+
+    @LongForgery(min = 1L)
+    var fakeBucketDuration: Long = 0L
+
+    @StringForgery
+    lateinit var fakeRuntimeID: String
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(mockSdkCore.getFeature(Feature.TRACING_CLIENT_STATS_FEATURE_NAME)) doReturn mockFeatureScope
+        whenever(mockFeatureScope.withWriteContext(eq(emptySet()), any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(1)
+            callback.invoke(fakeDatadogContext, mockEventWriteScope)
+        }
+        whenever(mockEventWriteScope.invoke(any())) doAnswer {
+            val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
+            callback.invoke(mockEventBatchWriter)
+        }
+
+        testedWriter = BatchStatsWriter(mockSdkCore, fakeRuntimeID)
+    }
+
+    // region write
+
+    @Test
+    fun `M write payload to batch writer W write()`() {
+        // Given
+        val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
+
+        // When
+        testedWriter.write(fakeBuckets)
+
+        // Then
+        verify(mockEventBatchWriter).write(any(), eq(null), eq(EventType.DEFAULT))
+    }
+
+    @Test
+    fun `M encode context env in payload W write()`() {
+        // Given
+        val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
+
+        // When
+        testedWriter.write(fakeBuckets)
+
+        // Then
+        val captor = argumentCaptor<RawBatchEvent>()
+        verify(mockEventBatchWriter).write(captor.capture(), eq(null), eq(EventType.DEFAULT))
+        MsgPackAssert.assertThat(captor.firstValue.data).hasField("Env", fakeDatadogContext.env)
+    }
+
+    @Test
+    fun `M encode context version in payload W write()`() {
+        // Given
+        val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
+
+        // When
+        testedWriter.write(fakeBuckets)
+
+        // Then
+        val captor = argumentCaptor<RawBatchEvent>()
+        verify(mockEventBatchWriter).write(captor.capture(), eq(null), eq(EventType.DEFAULT))
+        MsgPackAssert.assertThat(captor.firstValue.data).hasField("Version", fakeDatadogContext.version)
+    }
+
+    @Test
+    fun `M encode context service in payload W write()`() {
+        // Given
+        val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
+
+        // When
+        testedWriter.write(fakeBuckets)
+
+        // Then
+        val captor = argumentCaptor<RawBatchEvent>()
+        verify(mockEventBatchWriter).write(captor.capture(), eq(null), eq(EventType.DEFAULT))
+        MsgPackAssert.assertThat(captor.firstValue.data).hasField("Service", fakeDatadogContext.service)
+    }
+
+    @Test
+    fun `M encode context sdkVersion as tracer version in payload W write()`() {
+        // Given
+        val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
+
+        // When
+        testedWriter.write(fakeBuckets)
+
+        // Then
+        val captor = argumentCaptor<RawBatchEvent>()
+        verify(mockEventBatchWriter).write(captor.capture(), eq(null), eq(EventType.DEFAULT))
+        MsgPackAssert.assertThat(captor.firstValue.data).hasField("TracerVersion", fakeDatadogContext.sdkVersion)
+    }
+
+    @Test
+    fun `M use sequence number 0 on first call W write()`() {
+        // Given
+        val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
+
+        // When
+        testedWriter.write(fakeBuckets)
+
+        // Then
+        val captor = argumentCaptor<RawBatchEvent>()
+        verify(mockEventBatchWriter).write(captor.capture(), eq(null), eq(EventType.DEFAULT))
+        MsgPackAssert.assertThat(captor.firstValue.data).hasField("Sequence", 0L)
+    }
+
+    @Test
+    fun `M increment sequence number on each call W write() { multiple calls }`(
+        @IntForgery(min = 2, max = 10) callCount: Int
+    ) {
+        // Given
+        val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
+
+        // When
+        repeat(callCount) { testedWriter.write(fakeBuckets) }
+
+        // Then
+        val captor = argumentCaptor<RawBatchEvent>()
+        verify(mockEventBatchWriter, times(callCount)).write(captor.capture(), eq(null), eq(EventType.DEFAULT))
+        captor.allValues.forEachIndexed { index, event ->
+            MsgPackAssert.assertThat(event.data).hasField("Sequence", index.toLong())
+        }
+    }
+
+    @Test
+    fun `M encode runtimeID in payload W write()`() {
+        // Given
+        val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
+
+        // When
+        testedWriter.write(fakeBuckets)
+
+        // Then
+        val captor = argumentCaptor<RawBatchEvent>()
+        verify(mockEventBatchWriter).write(captor.capture(), eq(null), eq(EventType.DEFAULT))
+        MsgPackAssert.assertThat(captor.firstValue.data).hasField("RuntimeID", fakeRuntimeID)
+    }
+
+    @Test
+    fun `M do nothing W write() { feature not registered }`() {
+        // Given
+        whenever(mockSdkCore.getFeature(Feature.TRACING_CLIENT_STATS_FEATURE_NAME)) doReturn null
+        val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
+
+        // When
+        testedWriter.write(fakeBuckets)
+
+        // Then
+        verify(mockEventBatchWriter, never()).write(any(), any(), any())
+    }
+
+    // endregion
+}

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentratorTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentratorTest.kt
@@ -46,10 +46,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
-import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -635,79 +632,6 @@ internal class StatsConcentratorTest {
 
     // endregion
 
-    // region Flush conflation
-
-    @Test
-    fun `M submit only one flush task W scheduleFlush() { called twice while flush pending }`(forge: Forge) {
-        // Uses a real single-thread executor so tasks actually queue so we can test conflation
-        val realExecutor = Executors.newSingleThreadExecutor()
-        val concentrator = makeConcentrator(realExecutor)
-        try {
-            // Given
-            val (span) = forge.makeEligibleSpan()
-            concentrator.record(listOf(span))
-
-            // When: block the executor, then call scheduleFlush twice
-            val blocker = CountDownLatch(1)
-            realExecutor.submit { blocker.await() }
-            stubNow(farFuture())
-            // First call: CAS false→true succeeds, queues flush task (blocked behind latch).
-            concentrator.scheduleFlush(flushAll = false)
-            // Second call: CAS fails (flushPending already true) → coalesced, no second task queued.
-            concentrator.scheduleFlush(flushAll = false)
-
-            // Unblock the queue and drain all requests
-            blocker.countDown()
-            realExecutor.submit {}.get(FLUSH_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-        } finally {
-            realExecutor.shutdown()
-        }
-
-        // Then: only one flush task ran → write called exactly once with the span's bucket
-        val buckets = captureBuckets()
-        assertThat(buckets).hasSize(1)
-        assertThat(buckets[0].start).isEqualTo(6 * fakeBucketSizeNs)
-        assertThat(buckets[0].stats[0].hits).isEqualTo(1L)
-    }
-
-    @Test
-    fun `M preserve flushAll when coalesced W scheduleFlush() { flushAll=true merged into pending flush }`(
-        forge: Forge
-    ) {
-        // Uses a real single-thread executor so tasks actually queue; same reasoning as above.
-        val realExecutor = Executors.newSingleThreadExecutor()
-        val concentrator = makeConcentrator(realExecutor)
-        try {
-            // Given: span in a very recent bucket that a non-force flush won't drain
-            val recentBucketStart = 50 * fakeBucketSizeNs
-            val (span) = forge.makeEligibleSpan(startTime = recentBucketStart)
-            concentrator.record(listOf(span))
-
-            // When: block the executor, queue a normal flush then a force flush
-            val blocker = CountDownLatch(1)
-            realExecutor.submit { blocker.await() }
-            stubNow(recentBucketStart)
-            // First call: queues flush task that would NOT drain the recent bucket on its own.
-            concentrator.scheduleFlush(flushAll = false)
-            // Second call: coalesced (CAS fails), but sets forcePending=true so the queued task picks it up.
-            concentrator.scheduleFlush(flushAll = true)
-
-            // Unblock the queue and drain all requests
-            blocker.countDown()
-            realExecutor.submit {}.get(FLUSH_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-        } finally {
-            realExecutor.shutdown()
-        }
-
-        // Then: the queued task picked up forcePending=true and flushed the recent bucket anyway
-        val buckets = captureBuckets()
-        assertThat(buckets).hasSize(1)
-        assertThat(buckets[0].start).isEqualTo(51 * fakeBucketSizeNs)
-        assertThat(buckets[0].stats[0].hits).isEqualTo(1L)
-    }
-
-    // endregion
-
     // region alignTimestamp
 
     @Test
@@ -827,17 +751,6 @@ internal class StatsConcentratorTest {
         whenever(mockTimeProvider.getDeviceTimestampMillis()) doReturn nowNs / 1_000_000
     }
 
-    private fun makeConcentrator(executor: ExecutorService) = StatsConcentrator(
-        sdkCore = mockSdkCore,
-        ddSpanToSpanEventMapper = mockSpanEventMapper,
-        eventMapper = mockEventMapper,
-        bufferLen = fakeBufferLen,
-        bucketSizeNs = fakeBucketSizeNs,
-        executorService = executor,
-        statsWriter = mockStatsWriter,
-        timeProvider = mockTimeProvider
-    )
-
     private fun captureBuckets(): List<ClientStatsBucket> {
         val captor = argumentCaptor<List<ClientStatsBucket>>()
         verify(mockStatsWriter).write(captor.capture())
@@ -847,8 +760,4 @@ internal class StatsConcentratorTest {
     private fun firstGroup(): ClientGroupedStats = captureBuckets()[0].stats[0]
 
     // endregion
-
-    private companion object {
-        private const val FLUSH_TIMEOUT_MS = 5_000L
-    }
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentratorTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentratorTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.threads.FakeSameThreadExecutorService
 import com.datadog.android.event.EventMapper
+import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.trace.api.DatadogTracingConstants
 import com.datadog.android.trace.internal.domain.event.ContextAwareMapper
 import com.datadog.android.trace.internal.domain.metrics.StatsConcentrator.Companion.alignTimestamp
@@ -74,6 +75,9 @@ internal class StatsConcentratorTest {
     lateinit var mockStatsWriter: StatsWriter
 
     @Mock
+    lateinit var mockTimeProvider: TimeProvider
+
+    @Mock
     lateinit var mockInternalLogger: InternalLogger
 
     @Forgery
@@ -102,7 +106,8 @@ internal class StatsConcentratorTest {
             bufferLen = fakeBufferLen,
             bucketSizeNs = fakeBucketSizeNs,
             executorService = executorService,
-            statsWriter = mockStatsWriter
+            statsWriter = mockStatsWriter,
+            timeProvider = mockTimeProvider
         )
     }
 
@@ -120,7 +125,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         assertThat(firstGroup().hits).isEqualTo(1L)
@@ -133,7 +139,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         assertThat(firstGroup().hits).isEqualTo(1L)
@@ -146,7 +153,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         assertThat(firstGroup().hits).isEqualTo(1L)
@@ -159,7 +167,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         assertThat(firstGroup().hits).isEqualTo(1L)
@@ -172,7 +181,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         assertThat(firstGroup().hits).isEqualTo(1L)
@@ -185,7 +195,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         assertThat(firstGroup().hits).isEqualTo(1L)
@@ -201,7 +212,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         verifyNoInteractions(mockStatsWriter)
@@ -214,7 +226,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         verifyNoInteractions(mockStatsWriter)
@@ -228,7 +241,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         verifyNoInteractions(mockStatsWriter)
@@ -242,7 +256,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         verifyNoInteractions(mockStatsWriter)
@@ -263,10 +278,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(
-            now = expectedBucketStart + fakeBufferLen.toLong() * fakeBucketSizeNs,
-            flushAll = false
-        )
+        stubNow(expectedBucketStart + fakeBufferLen.toLong() * fakeBucketSizeNs)
+        testedConcentrator.scheduleFlush(flushAll = false)
 
         // Then
         val buckets = captureBuckets()
@@ -284,10 +297,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(
-            now = 7 * fakeBucketSizeNs + fakeBucketSizeNs / 2,
-            flushAll = false
-        )
+        stubNow(7 * fakeBucketSizeNs + fakeBucketSizeNs / 2)
+        testedConcentrator.scheduleFlush(flushAll = false)
 
         // Then
         verifyNoInteractions(mockStatsWriter)
@@ -302,10 +313,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(
-            now = (fakeBufferLen + 6).toLong() * fakeBucketSizeNs,
-            flushAll = false
-        )
+        stubNow((fakeBufferLen + 6).toLong() * fakeBucketSizeNs)
+        testedConcentrator.scheduleFlush(flushAll = false)
 
         // Then
         val buckets = captureBuckets()
@@ -321,7 +330,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(now = fakeStartTime, flushAll = true)
+        stubNow(fakeStartTime)
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         assertThat(captureBuckets()).hasSize(1)
@@ -333,8 +343,10 @@ internal class StatsConcentratorTest {
         // After now = 30*B flush: oldestTs = (30 - 1) * B = 29 * B
         val nBuckets = 30L
         val expectedOldestTs = (nBuckets - (fakeBufferLen - 1)) * fakeBucketSizeNs // 29 * B
-        testedConcentrator.scheduleFlush(now = 10 * fakeBucketSizeNs, flushAll = false)
-        testedConcentrator.scheduleFlush(now = nBuckets * fakeBucketSizeNs, flushAll = false)
+        stubNow(10 * fakeBucketSizeNs)
+        testedConcentrator.scheduleFlush(flushAll = false)
+        stubNow(nBuckets * fakeBucketSizeNs)
+        testedConcentrator.scheduleFlush(flushAll = false)
 
         // Late span: startTime=1s, duration=1s → deviceEnd=2s → align(2s,10s)=0 < oldestTs → clamps to 29*B
         // subBucketNs = B/10 = 1s; non-zero so the span is not filtered out by the duration check
@@ -343,12 +355,35 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(lateSpan))
-        testedConcentrator.scheduleFlush(now = 50 * fakeBucketSizeNs, flushAll = true)
+        stubNow(50 * fakeBucketSizeNs)
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         val buckets = captureBuckets()
         assertThat(buckets).isNotEmpty()
         assertThat(buckets[0].start).isEqualTo(expectedOldestTs)
+    }
+
+    @Test
+    fun `M apply server time offset to bucket start W scheduleFlush()`(
+        @LongForgery fakeServerOffsetNanos: Long,
+        forge: Forge
+    ) {
+        // Given
+        val fakeStartTime = 5 * fakeBucketSizeNs
+        val (span) = forge.makeEligibleSpan(startTime = fakeStartTime)
+        val expectedBucketStart = alignTimestamp(fakeBucketSizeNs, fakeStartTime + fakeBucketSizeNs)
+        whenever(mockTimeProvider.getServerOffsetNanos()) doReturn fakeServerOffsetNanos
+
+        // When
+        testedConcentrator.record(listOf(span))
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
+
+        // Then
+        val buckets = captureBuckets()
+        assertThat(buckets).hasSize(1)
+        assertThat(buckets[0].start).isEqualTo(expectedBucketStart + fakeServerOffsetNanos)
     }
 
     // endregion
@@ -370,7 +405,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(spans)
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         val group = firstGroup()
@@ -401,7 +437,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(topLevelSpan, nonTopLevelSpan))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         val group = firstGroup()
@@ -431,7 +468,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(okSpan, errorSpan))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         val group = firstGroup()
@@ -454,7 +492,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span1, span2))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         val groups = captureBuckets()[0].stats
@@ -475,7 +514,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span1, span2))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         val groups = captureBuckets()[0].stats
@@ -497,7 +537,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         assertThat(firstGroup().peerTags).isEqualTo(listOf("${Tags.PEER_SERVICE}:$fakePeerService"))
@@ -510,7 +551,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         assertThat(firstGroup().isTraceRoot).isEqualTo(Trilean.TRUE)
@@ -528,7 +570,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         assertThat(firstGroup().resource).isEqualTo(fakeRewrittenResource)
@@ -545,7 +588,8 @@ internal class StatsConcentratorTest {
 
         // When
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(now = farFuture(), flushAll = true)
+        stubNow(farFuture())
+        testedConcentrator.scheduleFlush(flushAll = true)
 
         // Then
         assertThat(firstGroup().duration).isEqualTo(fakeDuration)
@@ -563,10 +607,8 @@ internal class StatsConcentratorTest {
 
         // When: flush with now before the bucket cutoff — bucket is too recent
         testedConcentrator.record(listOf(span))
-        testedConcentrator.scheduleFlush(
-            now = bucketStart + (fakeBufferLen - 1).toLong() * fakeBucketSizeNs,
-            flushAll = false
-        )
+        stubNow(bucketStart + (fakeBufferLen - 1).toLong() * fakeBucketSizeNs)
+        testedConcentrator.scheduleFlush(flushAll = false)
 
         // Then
         verifyNoInteractions(mockStatsWriter)
@@ -578,11 +620,11 @@ internal class StatsConcentratorTest {
         val (span) = forge.makeEligibleSpan(startTime = 5 * fakeBucketSizeNs)
         testedConcentrator.record(listOf(span))
 
-        val flushNow = (fakeBufferLen + 6).toLong() * fakeBucketSizeNs
-        testedConcentrator.scheduleFlush(now = flushNow, flushAll = false)
+        stubNow((fakeBufferLen + 6).toLong() * fakeBucketSizeNs)
+        testedConcentrator.scheduleFlush(flushAll = false)
 
         // When: second flush after the first has already drained the bucket
-        testedConcentrator.scheduleFlush(now = flushNow, flushAll = false)
+        testedConcentrator.scheduleFlush(flushAll = false)
 
         // Then: write called exactly once with the span's bucket — second flush found empty buckets
         val buckets = captureBuckets()
@@ -608,10 +650,11 @@ internal class StatsConcentratorTest {
             // When: block the executor, then call scheduleFlush twice
             val blocker = CountDownLatch(1)
             realExecutor.submit { blocker.await() }
+            stubNow(farFuture())
             // First call: CAS false→true succeeds, queues flush task (blocked behind latch).
-            concentrator.scheduleFlush(now = farFuture(), flushAll = false)
+            concentrator.scheduleFlush(flushAll = false)
             // Second call: CAS fails (flushPending already true) → coalesced, no second task queued.
-            concentrator.scheduleFlush(now = farFuture(), flushAll = false)
+            concentrator.scheduleFlush(flushAll = false)
 
             // Unblock the queue and drain all requests
             blocker.countDown()
@@ -643,10 +686,11 @@ internal class StatsConcentratorTest {
             // When: block the executor, queue a normal flush then a force flush
             val blocker = CountDownLatch(1)
             realExecutor.submit { blocker.await() }
+            stubNow(recentBucketStart)
             // First call: queues flush task that would NOT drain the recent bucket on its own.
-            concentrator.scheduleFlush(now = recentBucketStart, flushAll = false)
+            concentrator.scheduleFlush(flushAll = false)
             // Second call: coalesced (CAS fails), but sets forcePending=true so the queued task picks it up.
-            concentrator.scheduleFlush(now = recentBucketStart, flushAll = true)
+            concentrator.scheduleFlush(flushAll = true)
 
             // Unblock the queue and drain all requests
             blocker.countDown()
@@ -776,8 +820,12 @@ internal class StatsConcentratorTest {
         )
     }
 
-    /** `now` value that puts any reasonable span bucket well past the flush cutoff. */
+    /** `now` in nanoseconds that puts any reasonable span bucket well past the flush cutoff. */
     private fun farFuture(): Long = 100 * fakeBucketSizeNs
+
+    private fun stubNow(nowNs: Long) {
+        whenever(mockTimeProvider.getDeviceTimestampMillis()) doReturn nowNs / 1_000_000
+    }
 
     private fun makeConcentrator(executor: ExecutorService) = StatsConcentrator(
         sdkCore = mockSdkCore,
@@ -786,7 +834,8 @@ internal class StatsConcentratorTest {
         bufferLen = fakeBufferLen,
         bucketSizeNs = fakeBucketSizeNs,
         executorService = executor,
-        statsWriter = mockStatsWriter
+        statsWriter = mockStatsWriter,
+        timeProvider = mockTimeProvider
     )
 
     private fun captureBuckets(): List<ClientStatsBucket> {

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentratorTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentratorTest.kt
@@ -11,7 +11,6 @@ import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
-import com.datadog.android.api.threads.FakeSameThreadExecutorService
 import com.datadog.android.event.EventMapper
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.trace.api.DatadogTracingConstants
@@ -29,7 +28,6 @@ import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -41,12 +39,15 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
-import java.util.concurrent.ExecutorService
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -77,10 +78,12 @@ internal class StatsConcentratorTest {
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
+    @Mock
+    lateinit var mockExecutorService: ScheduledExecutorService
+
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
-    private val executorService: ExecutorService = FakeSameThreadExecutorService()
     private lateinit var testedConcentrator: StatsConcentrator
 
     // Fixed parameters for deterministic timestamp math
@@ -95,6 +98,7 @@ internal class StatsConcentratorTest {
             it.getArgument<(DatadogContext) -> Unit>(1).invoke(fakeDatadogContext)
         }
         whenever(mockEventMapper.map(any())) doAnswer { it.getArgument(0) }
+        whenever(mockExecutorService.execute(any())) doAnswer { it.getArgument<Runnable>(0).run() }
 
         testedConcentrator = StatsConcentrator(
             sdkCore = mockSdkCore,
@@ -102,16 +106,35 @@ internal class StatsConcentratorTest {
             eventMapper = mockEventMapper,
             bufferLen = fakeBufferLen,
             bucketSizeNs = fakeBucketSizeNs,
-            executorService = executorService,
+            executorService = mockExecutorService,
             statsWriter = mockStatsWriter,
-            timeProvider = mockTimeProvider
+            timeProvider = mockTimeProvider,
+            startPeriodicFlush = false
         )
     }
 
-    @AfterEach
-    fun tearDown() {
-        executorService.shutdown()
+    // region Periodic flush scheduling
+
+    @Test
+    fun `M schedule periodic flush on executor W init() { startPeriodicFlush = true }`() {
+        // When
+        StatsConcentrator(
+            sdkCore = mockSdkCore,
+            ddSpanToSpanEventMapper = mockSpanEventMapper,
+            eventMapper = mockEventMapper,
+            bufferLen = fakeBufferLen,
+            bucketSizeNs = fakeBucketSizeNs,
+            executorService = mockExecutorService,
+            statsWriter = mockStatsWriter,
+            timeProvider = mockTimeProvider,
+            startPeriodicFlush = true
+        )
+
+        // Then
+        verify(mockExecutorService).schedule(any<Runnable>(), eq(10L), eq(TimeUnit.SECONDS))
     }
+
+    // endregion
 
     // region Span eligibility
 
@@ -628,6 +651,49 @@ internal class StatsConcentratorTest {
         assertThat(buckets).hasSize(1)
         assertThat(buckets[0].start).isEqualTo(6 * fakeBucketSizeNs)
         assertThat(buckets[0].stats[0].hits).isEqualTo(1L)
+    }
+
+    // endregion
+
+    // region stop
+
+    @Test
+    fun `M submit flush all task W stop()`(forge: Forge) {
+        // Given
+        val (span) = forge.makeEligibleSpan()
+        testedConcentrator.record(listOf(span))
+        stubNow(farFuture())
+
+        // When
+        testedConcentrator.stop()
+
+        // Then
+        verify(mockStatsWriter).write(any())
+    }
+
+    @Test
+    fun `M not reschedule periodic flush W stop() { periodic flush fires after stop }`() {
+        // Given: create concentrator with live scheduling and capture the first scheduled runnable
+        val runnableCaptor = argumentCaptor<Runnable>()
+        val concentrator = StatsConcentrator(
+            sdkCore = mockSdkCore,
+            ddSpanToSpanEventMapper = mockSpanEventMapper,
+            eventMapper = mockEventMapper,
+            bufferLen = fakeBufferLen,
+            bucketSizeNs = fakeBucketSizeNs,
+            executorService = mockExecutorService,
+            statsWriter = mockStatsWriter,
+            timeProvider = mockTimeProvider,
+            startPeriodicFlush = true
+        )
+        verify(mockExecutorService).schedule(runnableCaptor.capture(), any(), any())
+
+        // When: stop then fire the already-scheduled periodic flush callback
+        concentrator.stop()
+        runnableCaptor.firstValue.run()
+
+        // Then: schedule was called exactly once (initial), never re-scheduled after stop
+        verify(mockExecutorService, times(1)).schedule(any<Runnable>(), any(), any())
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?
Combines the StatsCombinatator, flush scheduling, and upload process together inside of  ClientStatsFeature.

StatsCombinator also includes changes for how it manages to get time to encapsulate the `now` logic and also to offset the generated stat bucket by the server time offset

### Motivation
This combines the current individual parts into a single system allowing client side stats to work end to end

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

