### PR TITLE
RUM-16713: Gate profiles with big system clock drift

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
@@ -22,7 +22,9 @@ import com.datadog.android.profiling.model.ProfileEvent
 import com.datadog.android.profiling.model.RumMetadataEvent
 import com.google.gson.JsonArray
 import java.io.File
+import java.util.Locale
 import java.util.concurrent.TimeUnit
+import kotlin.math.abs
 
 internal class ProfilingDataWriter(
     private val sdkCore: FeatureSdkCore
@@ -68,6 +70,23 @@ internal class ProfilingDataWriter(
         vitalEvents: List<ProfilerEvent.RumVitalEvent>
     ): RawBatchEvent? {
         if (longTaskEvents.isEmpty() && anrEvents.isEmpty() && vitalEvents.isEmpty()) return null
+
+        val driftMs = abs(context.time.serverTimeOffsetMs)
+        if (driftMs > MAX_CLOCK_DRIFT_MS) {
+            sdkCore.internalLogger.log(
+                InternalLogger.Level.INFO,
+                InternalLogger.Target.MAINTAINER,
+                {
+                    LOG_PROFILE_DROPPED_CLOCK_DRIFT.format(
+                        Locale.US,
+                        context.time.serverTimeOffsetMs
+                    )
+                }
+            )
+            // TODO RUM-16953: Uncomment the code below to prevent writing the event.
+            // return null
+        }
+
         val perfettoBytes = readProfilingData(profilingResult.resultFilePath)
         val firstRumContext =
             longTaskEvents.firstOrNull()?.rumContext
@@ -232,6 +251,9 @@ internal class ProfilingDataWriter(
     }
 
     companion object {
+        internal const val MAX_CLOCK_DRIFT_MS = 1000L
+        private const val LOG_PROFILE_DROPPED_CLOCK_DRIFT =
+            "Profile dropped during write: clock drift %d ms exceeds threshold"
         private const val LOG_FILE_DELETE_FAILED = "Failed to delete Perfetto trace file: %s"
         private const val TAG_KEY_SERVICE = "service"
         private const val TAG_KEY_VERSION = "version"

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingDataWriterTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingDataWriterTest.kt
@@ -86,6 +86,12 @@ internal class ProfilingDataWriterTest {
 
     @BeforeEach
     fun `set up`() {
+        // Clamp serverTimeOffsetMs within the accepted threshold so existing tests are not
+        // accidentally rejected by the clock-drift guard. Tests that exercise the reject path
+        // override this value explicitly.
+        fakeDatadogContext = fakeDatadogContext.copy(
+            time = fakeDatadogContext.time.copy(serverTimeOffsetMs = 0L)
+        )
         testedDataWriterTest = ProfilingDataWriter(mockSdkCore)
         whenever(mockEventWriteScope.invoke(any())) doAnswer {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
@@ -431,5 +437,73 @@ internal class ProfilingDataWriterTest {
         // Then
         assertThat(file.exists()).isFalse()
         verify(mockEventBatchWriter).write(any(), isNull(), eq(EventType.DEFAULT))
+    }
+
+    @Test
+    fun `M log drift and write W write {drift over threshold positive}`(
+        @Forgery fakeResult: PerfettoResult,
+        @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
+        forge: Forge
+    ) {
+        // Given
+        val fakeDriftMs = forge.aLong(min = ProfilingDataWriter.MAX_CLOCK_DRIFT_MS + 1, max = Long.MAX_VALUE / 2)
+        fakeDatadogContext = fakeDatadogContext.copy(
+            time = fakeDatadogContext.time.copy(serverTimeOffsetMs = fakeDriftMs)
+        )
+        val file = tmp.resolve(fakeResult.resultFilePath)
+        file.writeBytes(forge.aString().toByteArray())
+
+        // When
+        testedDataWriterTest.write(
+            profilingResult = fakeResult.copy(resultFilePath = file.absolutePath),
+            vitalEvents = fakeVitals,
+            anrEvents = emptyList(),
+            longTasks = emptyList()
+        )
+
+        // Then
+        verify(mockInternalLogger).log(
+            eq(InternalLogger.Level.INFO),
+            eq(InternalLogger.Target.MAINTAINER),
+            any<() -> String>(),
+            isNull(),
+            eq(false),
+            isNull()
+        )
+        assertThat(file.exists()).isFalse()
+    }
+
+    @Test
+    fun `M log drift and write W write {drift over threshold negative}`(
+        @Forgery fakeResult: PerfettoResult,
+        @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
+        forge: Forge
+    ) {
+        // Given — negative drift beyond -(MAX_CLOCK_DRIFT_MS)
+        val fakeDriftMs = forge.aLong(min = Long.MIN_VALUE / 2, max = -(ProfilingDataWriter.MAX_CLOCK_DRIFT_MS + 1))
+        fakeDatadogContext = fakeDatadogContext.copy(
+            time = fakeDatadogContext.time.copy(serverTimeOffsetMs = fakeDriftMs)
+        )
+        val file = tmp.resolve(fakeResult.resultFilePath)
+        file.writeBytes(forge.aString().toByteArray())
+
+        // When
+        testedDataWriterTest.write(
+            profilingResult = fakeResult.copy(resultFilePath = file.absolutePath),
+            vitalEvents = fakeVitals,
+            anrEvents = emptyList(),
+            longTasks = emptyList()
+        )
+
+        // Then
+        verify(mockInternalLogger).log(
+            eq(InternalLogger.Level.INFO),
+            eq(InternalLogger.Target.MAINTAINER),
+            any<() -> String>(),
+            isNull(),
+            eq(false),
+            isNull()
+        )
+        assertThat(file.exists()).isFalse()
     }
 }

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -824,7 +824,7 @@ data class com.datadog.android.rum.model.ErrorEvent
       fun fromJson(kotlin.String): Configuration
       fun fromJsonObject(com.google.gson.JsonObject): Configuration
   data class Profiling
-    constructor(ProfilingStatus? = null, ErrorReason? = null, kotlin.String? = null)
+    constructor(ProfilingStatus? = null, ErrorReason? = null, kotlin.String? = null, kotlin.Number? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Profiling
@@ -1199,7 +1199,7 @@ data class com.datadog.android.rum.model.LongTaskEvent
       fun fromJson(kotlin.String): Configuration
       fun fromJsonObject(com.google.gson.JsonObject): Configuration
   data class Profiling
-    constructor(ProfilingStatus? = null, ErrorReason? = null, kotlin.String? = null)
+    constructor(ProfilingStatus? = null, ErrorReason? = null, kotlin.String? = null, kotlin.Number? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Profiling
@@ -1956,7 +1956,7 @@ data class com.datadog.android.rum.model.ViewEvent
       fun fromJson(kotlin.String): DdCls
       fun fromJsonObject(com.google.gson.JsonObject): DdCls
   data class Profiling
-    constructor(ProfilingStatus? = null, ErrorReason? = null, kotlin.String? = null)
+    constructor(ProfilingStatus? = null, ErrorReason? = null, kotlin.String? = null, kotlin.Number? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Profiling
@@ -2280,7 +2280,7 @@ data class com.datadog.android.rum.model.VitalAppLaunchEvent
       fun fromJson(kotlin.String): Configuration
       fun fromJsonObject(com.google.gson.JsonObject): Configuration
   data class Profiling
-    constructor(ProfilingStatus? = null, ErrorReason? = null, kotlin.String? = null)
+    constructor(ProfilingStatus? = null, ErrorReason? = null, kotlin.String? = null, kotlin.Number? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Profiling
@@ -2533,7 +2533,7 @@ data class com.datadog.android.rum.model.VitalOperationStepEvent
       fun fromJson(kotlin.String): Configuration
       fun fromJsonObject(com.google.gson.JsonObject): Configuration
   data class Profiling
-    constructor(ProfilingStatus? = null, ErrorReason? = null, kotlin.String? = null)
+    constructor(ProfilingStatus? = null, ErrorReason? = null, kotlin.String? = null, kotlin.Number? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Profiling

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -2442,16 +2442,18 @@ public final class com/datadog/android/rum/model/ErrorEvent$Plan$Companion {
 public final class com/datadog/android/rum/model/ErrorEvent$Profiling {
 	public static final field Companion Lcom/datadog/android/rum/model/ErrorEvent$Profiling$Companion;
 	public fun <init> ()V
-	public fun <init> (Lcom/datadog/android/rum/model/ErrorEvent$ProfilingStatus;Lcom/datadog/android/rum/model/ErrorEvent$ErrorReason;Ljava/lang/String;)V
-	public synthetic fun <init> (Lcom/datadog/android/rum/model/ErrorEvent$ProfilingStatus;Lcom/datadog/android/rum/model/ErrorEvent$ErrorReason;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/datadog/android/rum/model/ErrorEvent$ProfilingStatus;Lcom/datadog/android/rum/model/ErrorEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/ErrorEvent$ProfilingStatus;Lcom/datadog/android/rum/model/ErrorEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/datadog/android/rum/model/ErrorEvent$ProfilingStatus;
 	public final fun component2 ()Lcom/datadog/android/rum/model/ErrorEvent$ErrorReason;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Lcom/datadog/android/rum/model/ErrorEvent$ProfilingStatus;Lcom/datadog/android/rum/model/ErrorEvent$ErrorReason;Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Profiling;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ErrorEvent$Profiling;Lcom/datadog/android/rum/model/ErrorEvent$ProfilingStatus;Lcom/datadog/android/rum/model/ErrorEvent$ErrorReason;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ErrorEvent$Profiling;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun copy (Lcom/datadog/android/rum/model/ErrorEvent$ProfilingStatus;Lcom/datadog/android/rum/model/ErrorEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;)Lcom/datadog/android/rum/model/ErrorEvent$Profiling;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ErrorEvent$Profiling;Lcom/datadog/android/rum/model/ErrorEvent$ProfilingStatus;Lcom/datadog/android/rum/model/ErrorEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ErrorEvent$Profiling;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Profiling;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ErrorEvent$Profiling;
+	public final fun getClockDrift ()Ljava/lang/Number;
 	public final fun getErrorReason ()Lcom/datadog/android/rum/model/ErrorEvent$ErrorReason;
 	public final fun getQuotaReason ()Ljava/lang/String;
 	public final fun getStatus ()Lcom/datadog/android/rum/model/ErrorEvent$ProfilingStatus;
@@ -3429,16 +3431,18 @@ public final class com/datadog/android/rum/model/LongTaskEvent$Plan$Companion {
 public final class com/datadog/android/rum/model/LongTaskEvent$Profiling {
 	public static final field Companion Lcom/datadog/android/rum/model/LongTaskEvent$Profiling$Companion;
 	public fun <init> ()V
-	public fun <init> (Lcom/datadog/android/rum/model/LongTaskEvent$ProfilingStatus;Lcom/datadog/android/rum/model/LongTaskEvent$ErrorReason;Ljava/lang/String;)V
-	public synthetic fun <init> (Lcom/datadog/android/rum/model/LongTaskEvent$ProfilingStatus;Lcom/datadog/android/rum/model/LongTaskEvent$ErrorReason;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/datadog/android/rum/model/LongTaskEvent$ProfilingStatus;Lcom/datadog/android/rum/model/LongTaskEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/LongTaskEvent$ProfilingStatus;Lcom/datadog/android/rum/model/LongTaskEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/datadog/android/rum/model/LongTaskEvent$ProfilingStatus;
 	public final fun component2 ()Lcom/datadog/android/rum/model/LongTaskEvent$ErrorReason;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Lcom/datadog/android/rum/model/LongTaskEvent$ProfilingStatus;Lcom/datadog/android/rum/model/LongTaskEvent$ErrorReason;Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$Profiling;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/LongTaskEvent$Profiling;Lcom/datadog/android/rum/model/LongTaskEvent$ProfilingStatus;Lcom/datadog/android/rum/model/LongTaskEvent$ErrorReason;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/LongTaskEvent$Profiling;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun copy (Lcom/datadog/android/rum/model/LongTaskEvent$ProfilingStatus;Lcom/datadog/android/rum/model/LongTaskEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;)Lcom/datadog/android/rum/model/LongTaskEvent$Profiling;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/LongTaskEvent$Profiling;Lcom/datadog/android/rum/model/LongTaskEvent$ProfilingStatus;Lcom/datadog/android/rum/model/LongTaskEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/LongTaskEvent$Profiling;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$Profiling;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/LongTaskEvent$Profiling;
+	public final fun getClockDrift ()Ljava/lang/Number;
 	public final fun getErrorReason ()Lcom/datadog/android/rum/model/LongTaskEvent$ErrorReason;
 	public final fun getQuotaReason ()Ljava/lang/String;
 	public final fun getStatus ()Lcom/datadog/android/rum/model/LongTaskEvent$ProfilingStatus;
@@ -6044,16 +6048,18 @@ public final class com/datadog/android/rum/model/ViewEvent$Privacy$Companion {
 public final class com/datadog/android/rum/model/ViewEvent$Profiling {
 	public static final field Companion Lcom/datadog/android/rum/model/ViewEvent$Profiling$Companion;
 	public fun <init> ()V
-	public fun <init> (Lcom/datadog/android/rum/model/ViewEvent$ProfilingStatus;Lcom/datadog/android/rum/model/ViewEvent$ErrorReason;Ljava/lang/String;)V
-	public synthetic fun <init> (Lcom/datadog/android/rum/model/ViewEvent$ProfilingStatus;Lcom/datadog/android/rum/model/ViewEvent$ErrorReason;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/datadog/android/rum/model/ViewEvent$ProfilingStatus;Lcom/datadog/android/rum/model/ViewEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/ViewEvent$ProfilingStatus;Lcom/datadog/android/rum/model/ViewEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/datadog/android/rum/model/ViewEvent$ProfilingStatus;
 	public final fun component2 ()Lcom/datadog/android/rum/model/ViewEvent$ErrorReason;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Lcom/datadog/android/rum/model/ViewEvent$ProfilingStatus;Lcom/datadog/android/rum/model/ViewEvent$ErrorReason;Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$Profiling;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewEvent$Profiling;Lcom/datadog/android/rum/model/ViewEvent$ProfilingStatus;Lcom/datadog/android/rum/model/ViewEvent$ErrorReason;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewEvent$Profiling;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun copy (Lcom/datadog/android/rum/model/ViewEvent$ProfilingStatus;Lcom/datadog/android/rum/model/ViewEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;)Lcom/datadog/android/rum/model/ViewEvent$Profiling;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewEvent$Profiling;Lcom/datadog/android/rum/model/ViewEvent$ProfilingStatus;Lcom/datadog/android/rum/model/ViewEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewEvent$Profiling;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$Profiling;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewEvent$Profiling;
+	public final fun getClockDrift ()Ljava/lang/Number;
 	public final fun getErrorReason ()Lcom/datadog/android/rum/model/ViewEvent$ErrorReason;
 	public final fun getQuotaReason ()Ljava/lang/String;
 	public final fun getStatus ()Lcom/datadog/android/rum/model/ViewEvent$ProfilingStatus;
@@ -7042,16 +7048,18 @@ public final class com/datadog/android/rum/model/VitalAppLaunchEvent$Plan$Compan
 public final class com/datadog/android/rum/model/VitalAppLaunchEvent$Profiling {
 	public static final field Companion Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Profiling$Companion;
 	public fun <init> ()V
-	public fun <init> (Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ErrorReason;Ljava/lang/String;)V
-	public synthetic fun <init> (Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ErrorReason;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ProfilingStatus;
 	public final fun component2 ()Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ErrorReason;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ErrorReason;Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Profiling;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Profiling;Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ErrorReason;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Profiling;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun copy (Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Profiling;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Profiling;Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Profiling;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Profiling;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Profiling;
+	public final fun getClockDrift ()Ljava/lang/Number;
 	public final fun getErrorReason ()Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ErrorReason;
 	public final fun getQuotaReason ()Ljava/lang/String;
 	public final fun getStatus ()Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ProfilingStatus;
@@ -7867,16 +7875,18 @@ public final class com/datadog/android/rum/model/VitalOperationStepEvent$Plan$Co
 public final class com/datadog/android/rum/model/VitalOperationStepEvent$Profiling {
 	public static final field Companion Lcom/datadog/android/rum/model/VitalOperationStepEvent$Profiling$Companion;
 	public fun <init> ()V
-	public fun <init> (Lcom/datadog/android/rum/model/VitalOperationStepEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalOperationStepEvent$ErrorReason;Ljava/lang/String;)V
-	public synthetic fun <init> (Lcom/datadog/android/rum/model/VitalOperationStepEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalOperationStepEvent$ErrorReason;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/datadog/android/rum/model/VitalOperationStepEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalOperationStepEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;)V
+	public synthetic fun <init> (Lcom/datadog/android/rum/model/VitalOperationStepEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalOperationStepEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/datadog/android/rum/model/VitalOperationStepEvent$ProfilingStatus;
 	public final fun component2 ()Lcom/datadog/android/rum/model/VitalOperationStepEvent$ErrorReason;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Lcom/datadog/android/rum/model/VitalOperationStepEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalOperationStepEvent$ErrorReason;Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$Profiling;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalOperationStepEvent$Profiling;Lcom/datadog/android/rum/model/VitalOperationStepEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalOperationStepEvent$ErrorReason;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$Profiling;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun copy (Lcom/datadog/android/rum/model/VitalOperationStepEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalOperationStepEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$Profiling;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/VitalOperationStepEvent$Profiling;Lcom/datadog/android/rum/model/VitalOperationStepEvent$ProfilingStatus;Lcom/datadog/android/rum/model/VitalOperationStepEvent$ErrorReason;Ljava/lang/String;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$Profiling;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$Profiling;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$Profiling;
+	public final fun getClockDrift ()Ljava/lang/Number;
 	public final fun getErrorReason ()Lcom/datadog/android/rum/model/VitalOperationStepEvent$ErrorReason;
 	public final fun getQuotaReason ()Ljava/lang/String;
 	public final fun getStatus ()Lcom/datadog/android/rum/model/VitalOperationStepEvent$ProfilingStatus;

--- a/features/dd-sdk-android-rum/src/main/json/rum/_profiling-internal-context-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/_profiling-internal-context-schema.json
@@ -26,6 +26,11 @@
       "type": "string",
       "description": "The reason profiling was denied by the quota API for this session. Present only when the quota API returned a denied decision.",
       "readOnly": true
+    },
+    "clock_drift": {
+      "type": "number",
+      "description": "The device clock offset relative to the NTP server time in milliseconds at the time the RUM event was recorded (serverTime - deviceTime). Present only when the profiler is active. Used by the backend to align Perfetto profile timestamps with RUM event timestamps.",
+      "readOnly": true
     }
   }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -1690,8 +1690,12 @@ internal open class RumViewScope(
     private fun resolveErrorProfilingStatus(datadogContext: DatadogContext): ErrorEvent.Profiling? {
         val isRunning = datadogContext.isProfilerRunning()
         val quotaReason = datadogContext.resolveProfilingQuotaReason(sessionId)
+        val clockDrift = datadogContext.time.serverTimeOffsetMs
         return when {
-            isRunning -> ErrorEvent.Profiling(status = ErrorEvent.ProfilingStatus.RUNNING)
+            isRunning -> ErrorEvent.Profiling(
+                status = ErrorEvent.ProfilingStatus.RUNNING,
+                clockDrift = clockDrift
+            )
             quotaReason != null -> ErrorEvent.Profiling(
                 status = ErrorEvent.ProfilingStatus.STOPPED,
                 quotaReason = quotaReason
@@ -1703,8 +1707,13 @@ internal open class RumViewScope(
     private fun resolveLongTaskProfilingStatus(datadogContext: DatadogContext): LongTaskEvent.Profiling? {
         val isRunning = datadogContext.isProfilerRunning()
         val quotaReason = datadogContext.resolveProfilingQuotaReason(sessionId)
+        val clockDrift = datadogContext.time.serverTimeOffsetMs
         return when {
-            isRunning -> LongTaskEvent.Profiling(status = LongTaskEvent.ProfilingStatus.RUNNING)
+            isRunning -> LongTaskEvent.Profiling(
+                status = LongTaskEvent.ProfilingStatus.RUNNING,
+                clockDrift = clockDrift
+            )
+
             quotaReason != null -> LongTaskEvent.Profiling(
                 status = LongTaskEvent.ProfilingStatus.STOPPED,
                 quotaReason = quotaReason

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumVitalAppLaunchEventHelper.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumVitalAppLaunchEventHelper.kt
@@ -84,7 +84,8 @@ internal class RumVitalAppLaunchEventHelper(
                 configuration = VitalAppLaunchEvent.Configuration(sessionSampleRate = sampleRate),
                 profiling = VitalAppLaunchEvent.Profiling(
                     status = profilingStatus,
-                    quotaReason = profilingQuotaReason
+                    quotaReason = profilingQuotaReason,
+                    clockDrift = if (profilingStatus != null) datadogContext.time.serverTimeOffsetMs else null
                 )
             ),
             application = VitalAppLaunchEvent.Application(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
@@ -701,6 +701,16 @@ internal class ErrorEventAssert(actual: ErrorEvent) :
         return this
     }
 
+    fun hasProfilingClockDrift(expected: Number?): ErrorEventAssert {
+        assertThat(actual.dd.profiling?.clockDrift)
+            .overridingErrorMessage(
+                "Expected RUM event to have profiling clock_drift: $expected" +
+                    " but instead was: ${actual.dd.profiling?.clockDrift}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
     fun hasNoProfiling(): ErrorEventAssert {
         assertThat(actual.dd.profiling)
             .overridingErrorMessage(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/LongTaskEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/LongTaskEventAssert.kt
@@ -440,6 +440,16 @@ internal class LongTaskEventAssert(actual: LongTaskEvent) :
         return this
     }
 
+    fun hasProfilingClockDrift(expected: Number?): LongTaskEventAssert {
+        assertThat(actual.dd.profiling?.clockDrift)
+            .overridingErrorMessage(
+                "Expected RUM event to have profiling clock_drift: $expected" +
+                    " but instead was: ${actual.dd.profiling?.clockDrift}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
     fun hasNoProfiling(): LongTaskEventAssert {
         assertThat(actual.dd.profiling)
             .overridingErrorMessage(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -5758,6 +5758,7 @@ internal class RumViewScopeTest {
         argumentCaptor<LongTaskEvent> {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue).hasProfilingStatus(LongTaskEvent.ProfilingStatus.RUNNING)
+            assertThat(firstValue).hasProfilingClockDrift(datadogContext.time.serverTimeOffsetMs)
         }
     }
 
@@ -5916,6 +5917,7 @@ internal class RumViewScopeTest {
         argumentCaptor<ErrorEvent> {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue).hasProfilingStatus(ErrorEvent.ProfilingStatus.RUNNING)
+            assertThat(firstValue).hasProfilingClockDrift(datadogContext.time.serverTimeOffsetMs)
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

Adds a clock-drift check in ProfilingDataWriter before writing a profiling batch. If the absolute server time offset exceeds 1000 ms, a maintainer log is emitted with the actual drift value. The hard drop (return null) is stubbed behind a TODO RUM-16953 comment pending the follow-up ticket

### Motivation

RUM-16713


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

