### PR TITLE
RUM-17017: Aggregate a trace for stats as a single unit

### DIFF
--- a/detekt_custom_safe_calls.yml
+++ b/detekt_custom_safe_calls.yml
@@ -1126,6 +1126,7 @@ datadog:
       - "kotlin.sequences.Sequence.mapNotNull(kotlin.Function1)"
       - "kotlin.sequences.Sequence.reduceOrNull(kotlin.Function2)"
       - "kotlin.sequences.Sequence.sortedBy(kotlin.Function1)"
+      - "kotlin.sequences.Sequence.toList()"
       - "kotlin.sequences.Sequence.iterator()"
       - "kotlin.sequences.SequenceScope.yield(kotlin.Pair)"
       - "kotlin.sequences.SequenceScope.yieldAll(kotlin.sequences.Sequence)"

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
@@ -60,7 +60,7 @@ internal class StatsConcentrator(
     fun record(trace: List<DDSpan>) {
         val metricsFeature = sdkCore.getFeature(Feature.TRACING_CLIENT_STATS_FEATURE_NAME) ?: return
         metricsFeature.withContext { datadogContext ->
-            trace.asSequence()
+            val applicableSpans = trace.asSequence()
                 .filter { shouldComputeMetrics(it) }
                 .mapNotNull { span ->
                     val mapped = eventMapper.map(ddSpanToSpanEventMapper.map(datadogContext, span))
@@ -83,9 +83,9 @@ internal class StatsConcentrator(
                         isTopLevel = span.isTopLevel
                     )
                 }
-                .forEach { snapshot ->
-                    executorService.executeSafe("stats-aggregate", sdkCore.internalLogger) { aggregate(snapshot) }
-                }
+                .toList()
+
+            executorService.executeSafe("stats-aggregate", sdkCore.internalLogger) { aggregate(applicableSpans) }
         }
     }
 
@@ -132,10 +132,14 @@ internal class StatsConcentrator(
         }
     }
 
-    private fun aggregate(s: SpanSnapshot) {
-        val bucketKey = alignTimestamp(bucketSizeNs, s.startTime + s.durationNs).coerceAtLeast(oldestTs)
-        val key = buildAggregationKey(s)
-        buckets.getOrPut(bucketKey) { mutableMapOf() }.getOrPut(key) { GroupedStats() }.add(s)
+    private fun aggregate(spans: List<SpanSnapshot>) {
+        for (span in spans) {
+            val spanEndTime = span.startTime + span.durationNs
+            val bucketKey = alignTimestamp(bucketSizeNs, spanEndTime).coerceAtLeast(oldestTs)
+            val aggregationKey = buildAggregationKey(span)
+            buckets.getOrPut(bucketKey) { mutableMapOf() }
+                .getOrPut(aggregationKey) { GroupedStats() }.add(span)
+        }
     }
 
     private fun drainBuckets(flushAll: Boolean): List<ClientStatsBucket> {


### PR DESCRIPTION
### What does this PR do?
Without this, a flush task could land in the stats executor between two span aggregations from the same trace, splitting the trace's data across incorrect time buckets.

### Motivation
This came out of this codex finding: https://github.com/DataDog/dd-sdk-android/pull/3564#discussion_r3461161647

