### PR TITLE
Add write result telemetry to ProfilingDataWriter

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
@@ -13,16 +13,17 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.internal.persistence.file.readBytesSafe
+import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.internal.profiling.ProfilerEvent
 import com.datadog.android.internal.profiling.ProfilingRumContext
 import com.datadog.android.internal.utils.formatIsoUtc
 import com.datadog.android.profiling.internal.domain.ProfilingBatchMetadata
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
+import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetry
 import com.datadog.android.profiling.model.ProfileEvent
 import com.datadog.android.profiling.model.RumMetadataEvent
 import com.google.gson.JsonArray
 import java.io.File
-import java.util.Locale
 import java.util.concurrent.TimeUnit
 import kotlin.math.abs
 
@@ -69,45 +70,118 @@ internal class ProfilingDataWriter(
         anrEvents: List<ProfilerEvent.RumAnrEvent>,
         vitalEvents: List<ProfilerEvent.RumVitalEvent>
     ): RawBatchEvent? {
-        if (longTaskEvents.isEmpty() && anrEvents.isEmpty() && vitalEvents.isEmpty()) return null
-
-        val driftMs = abs(context.time.serverTimeOffsetMs)
-        if (driftMs > MAX_CLOCK_DRIFT_MS) {
-            sdkCore.internalLogger.log(
-                InternalLogger.Level.INFO,
-                InternalLogger.Target.MAINTAINER,
-                {
-                    LOG_PROFILE_DROPPED_CLOCK_DRIFT.format(
-                        Locale.US,
-                        context.time.serverTimeOffsetMs
-                    )
-                }
+        val driftMs = context.time.serverTimeOffsetMs
+        val dropReason = when {
+            longTaskEvents.isEmpty() && anrEvents.isEmpty() && vitalEvents.isEmpty() -> DROP_REASON_NO_RUM_EVENTS
+            profilingResult.startReason != ProfilingStartReason.APPLICATION_LAUNCH &&
+                abs(driftMs) > MAX_CLOCK_DRIFT_MS -> DROP_REASON_CLOCK_DRIFT
+            else -> null
+        }
+        if (dropReason != null) {
+            logWriteResultMetric(
+                dropped = true,
+                dropReason = dropReason,
+                driftMs = driftMs,
+                startReason = profilingResult.startReason.value,
+                longTaskEvents = longTaskEvents,
+                anrEvents = anrEvents,
+                vitalEvents = vitalEvents
             )
-            // TODO RUM-16953: Uncomment the code below to prevent writing the event.
-            // return null
+            return null
         }
 
+        return assembleBatchEvent(context, profilingResult, driftMs, longTaskEvents, anrEvents, vitalEvents)
+    }
+
+    private fun assembleBatchEvent(
+        context: DatadogContext,
+        profilingResult: PerfettoResult,
+        driftMs: Long,
+        longTaskEvents: List<ProfilerEvent.RumLongTaskEvent>,
+        anrEvents: List<ProfilerEvent.RumAnrEvent>,
+        vitalEvents: List<ProfilerEvent.RumVitalEvent>
+    ): RawBatchEvent? {
         val perfettoBytes = readProfilingData(profilingResult.resultFilePath)
         val firstRumContext =
             longTaskEvents.firstOrNull()?.rumContext
                 ?: anrEvents.firstOrNull()?.rumContext
                 ?: vitalEvents.firstOrNull()?.rumContext
-        return if (perfettoBytes == null || perfettoBytes.isEmpty() || firstRumContext == null) {
-            null
-        } else {
-            val profileEvent = createProfileEvent(
-                context = context,
-                rumContext = firstRumContext,
-                profilingResult = profilingResult,
-                longTaskEvents = longTaskEvents,
-                anrEvents = anrEvents,
-                vitalEvents = vitalEvents
-            )
-            val serializedEvent = profileEvent.toJson().toString().toByteArray(Charsets.UTF_8)
-            val rumMobileEventsJson = buildRumMobileEventsJson(longTaskEvents, anrEvents, vitalEvents)
-            val metadata = ProfilingBatchMetadata(perfettoBytes, rumMobileEventsJson).toBytes()
-            RawBatchEvent(data = serializedEvent, metadata = metadata)
+        return when {
+            perfettoBytes == null || perfettoBytes.isEmpty() -> {
+                logWriteResultMetric(
+                    dropped = true,
+                    dropReason = DROP_REASON_PERFETTO_UNREADABLE,
+                    driftMs = driftMs,
+                    startReason = profilingResult.startReason.value,
+                    longTaskEvents = longTaskEvents,
+                    anrEvents = anrEvents,
+                    vitalEvents = vitalEvents
+                )
+                null
+            }
+            firstRumContext == null -> {
+                logWriteResultMetric(
+                    dropped = true,
+                    dropReason = DROP_REASON_NO_RUM_CONTEXT,
+                    driftMs = driftMs,
+                    startReason = profilingResult.startReason.value,
+                    longTaskEvents = longTaskEvents,
+                    anrEvents = anrEvents,
+                    vitalEvents = vitalEvents
+                )
+                null
+            }
+            else -> {
+                val profileEvent = createProfileEvent(
+                    context = context,
+                    rumContext = firstRumContext,
+                    profilingResult = profilingResult,
+                    longTaskEvents = longTaskEvents,
+                    anrEvents = anrEvents,
+                    vitalEvents = vitalEvents
+                )
+                val serializedEvent = profileEvent.toJson().toString().toByteArray(Charsets.UTF_8)
+                val rumMobileEventsJson = buildRumMobileEventsJson(longTaskEvents, anrEvents, vitalEvents)
+                val metadata = ProfilingBatchMetadata(perfettoBytes, rumMobileEventsJson).toBytes()
+                logWriteResultMetric(
+                    dropped = false,
+                    dropReason = null,
+                    driftMs = driftMs,
+                    startReason = profilingResult.startReason.value,
+                    longTaskEvents = longTaskEvents,
+                    anrEvents = anrEvents,
+                    vitalEvents = vitalEvents
+                )
+                RawBatchEvent(data = serializedEvent, metadata = metadata)
+            }
         }
+    }
+
+    private fun logWriteResultMetric(
+        dropped: Boolean,
+        dropReason: String?,
+        driftMs: Long,
+        startReason: String,
+        longTaskEvents: List<ProfilerEvent.RumLongTaskEvent>,
+        anrEvents: List<ProfilerEvent.RumAnrEvent>,
+        vitalEvents: List<ProfilerEvent.RumVitalEvent>
+    ) {
+        sdkCore.internalLogger.logMetric(
+            messageBuilder = { ProfilingTelemetry.TELEMETRY_MSG_PROFILING_SESSION },
+            additionalProperties = mapOf(
+                ProfilingTelemetry.KEY_METRIC_TYPE to METRIC_TYPE_PROFILING_WRITE,
+                KEY_PROFILING_WRITE to mapOf(
+                    KEY_DROPPED to dropped,
+                    KEY_DROP_REASON to dropReason,
+                    KEY_CLIENT_CLOCK_DRIFT to driftMs,
+                    ProfilingTelemetry.KEY_START_REASON to startReason,
+                    KEY_LONG_TASK_COUNT to longTaskEvents.size,
+                    KEY_ANR_COUNT to anrEvents.size,
+                    KEY_VITAL_COUNT to vitalEvents.size
+                )
+            ),
+            samplingRate = MethodCallSamplingRate.ALL.rate
+        )
     }
 
     private fun createProfileEvent(
@@ -252,9 +326,21 @@ internal class ProfilingDataWriter(
 
     companion object {
         internal const val MAX_CLOCK_DRIFT_MS = 1000L
-        private const val LOG_PROFILE_DROPPED_CLOCK_DRIFT =
-            "Profile dropped during write: clock drift %d ms exceeds threshold"
         private const val LOG_FILE_DELETE_FAILED = "Failed to delete Perfetto trace file: %s"
+
+        internal const val METRIC_TYPE_PROFILING_WRITE = "profiling write"
+        internal const val KEY_PROFILING_WRITE = "profiling_write"
+        internal const val KEY_DROPPED = "dropped"
+        internal const val KEY_DROP_REASON = "drop_reason"
+        internal const val KEY_CLIENT_CLOCK_DRIFT = "client_clock_drift_ms"
+        internal const val KEY_LONG_TASK_COUNT = "long_task_count"
+        internal const val KEY_ANR_COUNT = "anr_count"
+        internal const val KEY_VITAL_COUNT = "vital_count"
+        internal const val DROP_REASON_NO_RUM_EVENTS = "no_rum_events"
+        internal const val DROP_REASON_CLOCK_DRIFT = "clock_drift_exceeded"
+        internal const val DROP_REASON_PERFETTO_UNREADABLE = "perfetto_unreadable"
+        internal const val DROP_REASON_NO_RUM_CONTEXT = "no_rum_context"
+
         private const val TAG_KEY_SERVICE = "service"
         private const val TAG_KEY_VERSION = "version"
         private const val TAG_KEY_BUILD_ID = "build_id"

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingDataWriterTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingDataWriterTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.internal.profiling.ProfilerEvent
 import com.datadog.android.internal.utils.formatIsoUtc
 import com.datadog.android.profiling.assertj.ProfileEventAssert.Companion.assertThat
@@ -22,6 +23,7 @@ import com.datadog.android.profiling.assertj.RumMetadataEventsAssert.Companion.a
 import com.datadog.android.profiling.forge.Configurator
 import com.datadog.android.profiling.internal.domain.ProfilingBatchMetadata
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
+import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetry
 import com.datadog.android.profiling.model.ProfileEvent
 import com.datadog.android.profiling.model.RumMetadataEvent
 import com.google.gson.JsonParser
@@ -270,11 +272,29 @@ internal class ProfilingDataWriterTest {
             eq(false),
             isNull()
         )
+        val expectedProps = mapOf(
+            ProfilingTelemetry.KEY_METRIC_TYPE to ProfilingDataWriter.METRIC_TYPE_PROFILING_WRITE,
+            ProfilingDataWriter.KEY_PROFILING_WRITE to mapOf(
+                ProfilingDataWriter.KEY_DROPPED to true,
+                ProfilingDataWriter.KEY_DROP_REASON to ProfilingDataWriter.DROP_REASON_PERFETTO_UNREADABLE,
+                ProfilingDataWriter.KEY_CLIENT_CLOCK_DRIFT to 0L,
+                ProfilingTelemetry.KEY_START_REASON to fakeResult.startReason.value,
+                ProfilingDataWriter.KEY_LONG_TASK_COUNT to fakeLongTasks.size,
+                ProfilingDataWriter.KEY_ANR_COUNT to fakeAnrs.size,
+                ProfilingDataWriter.KEY_VITAL_COUNT to fakeVitals.size
+            )
+        )
+        verify(mockInternalLogger).logMetric(
+            any(),
+            eq(expectedProps),
+            eq(MethodCallSamplingRate.ALL.rate),
+            isNull()
+        )
         verifyNoMoreInteractions(mockEventBatchWriter)
     }
 
     @Test
-    fun `M skip writing W file is empty`(
+    fun `M skip writing and report drop metric W write {file is empty}`(
         @Forgery fakeResult: PerfettoResult,
         @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
         @Forgery fakeLongTasks: List<ProfilerEvent.RumLongTaskEvent>,
@@ -294,11 +314,29 @@ internal class ProfilingDataWriterTest {
 
         // Then
         assertThat(file.exists()).isFalse()
+        val expectedProps = mapOf(
+            ProfilingTelemetry.KEY_METRIC_TYPE to ProfilingDataWriter.METRIC_TYPE_PROFILING_WRITE,
+            ProfilingDataWriter.KEY_PROFILING_WRITE to mapOf(
+                ProfilingDataWriter.KEY_DROPPED to true,
+                ProfilingDataWriter.KEY_DROP_REASON to ProfilingDataWriter.DROP_REASON_PERFETTO_UNREADABLE,
+                ProfilingDataWriter.KEY_CLIENT_CLOCK_DRIFT to 0L,
+                ProfilingTelemetry.KEY_START_REASON to fakeResult.startReason.value,
+                ProfilingDataWriter.KEY_LONG_TASK_COUNT to fakeLongTasks.size,
+                ProfilingDataWriter.KEY_ANR_COUNT to fakeAnrs.size,
+                ProfilingDataWriter.KEY_VITAL_COUNT to fakeVitals.size
+            )
+        )
+        verify(mockInternalLogger).logMetric(
+            any(),
+            eq(expectedProps),
+            eq(MethodCallSamplingRate.ALL.rate),
+            isNull()
+        )
         verifyNoMoreInteractions(mockInternalLogger, mockEventBatchWriter)
     }
 
     @Test
-    fun `M skip writing W write {no rum events}`(
+    fun `M skip writing and report metric W write {no rum events}`(
         @Forgery fakeResult: PerfettoResult,
         forge: Forge
     ) {
@@ -316,6 +354,24 @@ internal class ProfilingDataWriterTest {
 
         // Then
         assertThat(file.exists()).isFalse()
+        val expectedProps = mapOf(
+            ProfilingTelemetry.KEY_METRIC_TYPE to ProfilingDataWriter.METRIC_TYPE_PROFILING_WRITE,
+            ProfilingDataWriter.KEY_PROFILING_WRITE to mapOf(
+                ProfilingDataWriter.KEY_DROPPED to true,
+                ProfilingDataWriter.KEY_DROP_REASON to ProfilingDataWriter.DROP_REASON_NO_RUM_EVENTS,
+                ProfilingDataWriter.KEY_CLIENT_CLOCK_DRIFT to 0L,
+                ProfilingTelemetry.KEY_START_REASON to fakeResult.startReason.value,
+                ProfilingDataWriter.KEY_LONG_TASK_COUNT to 0,
+                ProfilingDataWriter.KEY_ANR_COUNT to 0,
+                ProfilingDataWriter.KEY_VITAL_COUNT to 0
+            )
+        )
+        verify(mockInternalLogger).logMetric(
+            any(),
+            eq(expectedProps),
+            eq(MethodCallSamplingRate.ALL.rate),
+            isNull()
+        )
         verifyNoMoreInteractions(mockInternalLogger, mockEventBatchWriter)
     }
 
@@ -440,7 +496,7 @@ internal class ProfilingDataWriterTest {
     }
 
     @Test
-    fun `M log drift and write W write {drift over threshold positive}`(
+    fun `M drop and report write metric with clock drift reason W write {continuous, drift over threshold positive}`(
         @Forgery fakeResult: PerfettoResult,
         @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
         forge: Forge
@@ -455,26 +511,40 @@ internal class ProfilingDataWriterTest {
 
         // When
         testedDataWriterTest.write(
-            profilingResult = fakeResult.copy(resultFilePath = file.absolutePath),
+            profilingResult = fakeResult.copy(
+                resultFilePath = file.absolutePath,
+                startReason = ProfilingStartReason.CONTINUOUS
+            ),
             vitalEvents = fakeVitals,
             anrEvents = emptyList(),
             longTasks = emptyList()
         )
 
         // Then
-        verify(mockInternalLogger).log(
-            eq(InternalLogger.Level.INFO),
-            eq(InternalLogger.Target.MAINTAINER),
-            any<() -> String>(),
-            isNull(),
-            eq(false),
+        val expectedProps = mapOf(
+            ProfilingTelemetry.KEY_METRIC_TYPE to ProfilingDataWriter.METRIC_TYPE_PROFILING_WRITE,
+            ProfilingDataWriter.KEY_PROFILING_WRITE to mapOf(
+                ProfilingDataWriter.KEY_DROPPED to true,
+                ProfilingDataWriter.KEY_DROP_REASON to ProfilingDataWriter.DROP_REASON_CLOCK_DRIFT,
+                ProfilingDataWriter.KEY_CLIENT_CLOCK_DRIFT to fakeDriftMs,
+                ProfilingTelemetry.KEY_START_REASON to ProfilingStartReason.CONTINUOUS.value,
+                ProfilingDataWriter.KEY_LONG_TASK_COUNT to 0,
+                ProfilingDataWriter.KEY_ANR_COUNT to 0,
+                ProfilingDataWriter.KEY_VITAL_COUNT to fakeVitals.size
+            )
+        )
+        verify(mockInternalLogger).logMetric(
+            any(),
+            eq(expectedProps),
+            eq(MethodCallSamplingRate.ALL.rate),
             isNull()
         )
+        verifyNoInteractions(mockEventBatchWriter)
         assertThat(file.exists()).isFalse()
     }
 
     @Test
-    fun `M log drift and write W write {drift over threshold negative}`(
+    fun `M drop and report write metric with clock drift reason W write {continuous, drift over threshold negative}`(
         @Forgery fakeResult: PerfettoResult,
         @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
         forge: Forge
@@ -489,21 +559,172 @@ internal class ProfilingDataWriterTest {
 
         // When
         testedDataWriterTest.write(
-            profilingResult = fakeResult.copy(resultFilePath = file.absolutePath),
+            profilingResult = fakeResult.copy(
+                resultFilePath = file.absolutePath,
+                startReason = ProfilingStartReason.CONTINUOUS
+            ),
             vitalEvents = fakeVitals,
             anrEvents = emptyList(),
             longTasks = emptyList()
         )
 
         // Then
-        verify(mockInternalLogger).log(
-            eq(InternalLogger.Level.INFO),
-            eq(InternalLogger.Target.MAINTAINER),
-            any<() -> String>(),
-            isNull(),
-            eq(false),
+        val expectedProps = mapOf(
+            ProfilingTelemetry.KEY_METRIC_TYPE to ProfilingDataWriter.METRIC_TYPE_PROFILING_WRITE,
+            ProfilingDataWriter.KEY_PROFILING_WRITE to mapOf(
+                ProfilingDataWriter.KEY_DROPPED to true,
+                ProfilingDataWriter.KEY_DROP_REASON to ProfilingDataWriter.DROP_REASON_CLOCK_DRIFT,
+                ProfilingDataWriter.KEY_CLIENT_CLOCK_DRIFT to fakeDriftMs,
+                ProfilingTelemetry.KEY_START_REASON to ProfilingStartReason.CONTINUOUS.value,
+                ProfilingDataWriter.KEY_LONG_TASK_COUNT to 0,
+                ProfilingDataWriter.KEY_ANR_COUNT to 0,
+                ProfilingDataWriter.KEY_VITAL_COUNT to fakeVitals.size
+            )
+        )
+        verify(mockInternalLogger).logMetric(
+            any(),
+            eq(expectedProps),
+            eq(MethodCallSamplingRate.ALL.rate),
             isNull()
         )
+        verifyNoInteractions(mockEventBatchWriter)
         assertThat(file.exists()).isFalse()
+    }
+
+    @Test
+    fun `M write profile despite clock drift W write {app launch, drift over threshold positive}`(
+        @Forgery fakeResult: PerfettoResult,
+        @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
+        forge: Forge
+    ) {
+        // Given
+        val fakeDriftMs = forge.aLong(min = ProfilingDataWriter.MAX_CLOCK_DRIFT_MS + 1, max = Long.MAX_VALUE / 2)
+        fakeDatadogContext = fakeDatadogContext.copy(
+            time = fakeDatadogContext.time.copy(serverTimeOffsetMs = fakeDriftMs)
+        )
+        val file = tmp.resolve(fakeResult.resultFilePath)
+        file.writeBytes(forge.aString().toByteArray())
+
+        // When
+        testedDataWriterTest.write(
+            profilingResult = fakeResult.copy(
+                resultFilePath = file.absolutePath,
+                startReason = ProfilingStartReason.APPLICATION_LAUNCH
+            ),
+            vitalEvents = fakeVitals,
+            anrEvents = emptyList(),
+            longTasks = emptyList()
+        )
+
+        // Then — profile is written, metric reports dropped=false with no clock-drift drop reason
+        val expectedProps = mapOf(
+            ProfilingTelemetry.KEY_METRIC_TYPE to ProfilingDataWriter.METRIC_TYPE_PROFILING_WRITE,
+            ProfilingDataWriter.KEY_PROFILING_WRITE to mapOf(
+                ProfilingDataWriter.KEY_DROPPED to false,
+                ProfilingDataWriter.KEY_DROP_REASON to null,
+                ProfilingDataWriter.KEY_CLIENT_CLOCK_DRIFT to fakeDriftMs,
+                ProfilingTelemetry.KEY_START_REASON to ProfilingStartReason.APPLICATION_LAUNCH.value,
+                ProfilingDataWriter.KEY_LONG_TASK_COUNT to 0,
+                ProfilingDataWriter.KEY_ANR_COUNT to 0,
+                ProfilingDataWriter.KEY_VITAL_COUNT to fakeVitals.size
+            )
+        )
+        verify(mockInternalLogger).logMetric(
+            any(),
+            eq(expectedProps),
+            eq(MethodCallSamplingRate.ALL.rate),
+            isNull()
+        )
+        verify(mockEventBatchWriter).write(any(), isNull(), eq(EventType.DEFAULT))
+        assertThat(file.exists()).isFalse()
+    }
+
+    @Test
+    fun `M write profile despite clock drift W write {app launch, drift over threshold negative}`(
+        @Forgery fakeResult: PerfettoResult,
+        @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
+        forge: Forge
+    ) {
+        // Given
+        val fakeDriftMs = forge.aLong(min = Long.MIN_VALUE / 2, max = -(ProfilingDataWriter.MAX_CLOCK_DRIFT_MS + 1))
+        fakeDatadogContext = fakeDatadogContext.copy(
+            time = fakeDatadogContext.time.copy(serverTimeOffsetMs = fakeDriftMs)
+        )
+        val file = tmp.resolve(fakeResult.resultFilePath)
+        file.writeBytes(forge.aString().toByteArray())
+
+        // When
+        testedDataWriterTest.write(
+            profilingResult = fakeResult.copy(
+                resultFilePath = file.absolutePath,
+                startReason = ProfilingStartReason.APPLICATION_LAUNCH
+            ),
+            vitalEvents = fakeVitals,
+            anrEvents = emptyList(),
+            longTasks = emptyList()
+        )
+
+        // Then — profile is written, metric reports dropped=false with no clock-drift drop reason
+        val expectedProps = mapOf(
+            ProfilingTelemetry.KEY_METRIC_TYPE to ProfilingDataWriter.METRIC_TYPE_PROFILING_WRITE,
+            ProfilingDataWriter.KEY_PROFILING_WRITE to mapOf(
+                ProfilingDataWriter.KEY_DROPPED to false,
+                ProfilingDataWriter.KEY_DROP_REASON to null,
+                ProfilingDataWriter.KEY_CLIENT_CLOCK_DRIFT to fakeDriftMs,
+                ProfilingTelemetry.KEY_START_REASON to ProfilingStartReason.APPLICATION_LAUNCH.value,
+                ProfilingDataWriter.KEY_LONG_TASK_COUNT to 0,
+                ProfilingDataWriter.KEY_ANR_COUNT to 0,
+                ProfilingDataWriter.KEY_VITAL_COUNT to fakeVitals.size
+            )
+        )
+        verify(mockInternalLogger).logMetric(
+            any(),
+            eq(expectedProps),
+            eq(MethodCallSamplingRate.ALL.rate),
+            isNull()
+        )
+        verify(mockEventBatchWriter).write(any(), isNull(), eq(EventType.DEFAULT))
+        assertThat(file.exists()).isFalse()
+    }
+
+    @Test
+    fun `M report write metric with event counts W write {write successful}`(
+        @Forgery fakeResult: PerfettoResult,
+        @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
+        @Forgery fakeLongTasks: List<ProfilerEvent.RumLongTaskEvent>,
+        @Forgery fakeAnrs: List<ProfilerEvent.RumAnrEvent>,
+        forge: Forge
+    ) {
+        // Given
+        val file = tmp.resolve(fakeResult.resultFilePath)
+        file.writeBytes(forge.aString().toByteArray())
+
+        // When
+        testedDataWriterTest.write(
+            profilingResult = fakeResult.copy(resultFilePath = file.absolutePath),
+            vitalEvents = fakeVitals,
+            anrEvents = fakeAnrs,
+            longTasks = fakeLongTasks
+        )
+
+        // Then
+        val expectedProps = mapOf(
+            ProfilingTelemetry.KEY_METRIC_TYPE to ProfilingDataWriter.METRIC_TYPE_PROFILING_WRITE,
+            ProfilingDataWriter.KEY_PROFILING_WRITE to mapOf(
+                ProfilingDataWriter.KEY_DROPPED to false,
+                ProfilingDataWriter.KEY_DROP_REASON to null,
+                ProfilingDataWriter.KEY_CLIENT_CLOCK_DRIFT to 0L,
+                ProfilingTelemetry.KEY_START_REASON to fakeResult.startReason.value,
+                ProfilingDataWriter.KEY_LONG_TASK_COUNT to fakeLongTasks.size,
+                ProfilingDataWriter.KEY_ANR_COUNT to fakeAnrs.size,
+                ProfilingDataWriter.KEY_VITAL_COUNT to fakeVitals.size
+            )
+        )
+        verify(mockInternalLogger).logMetric(
+            any(),
+            eq(expectedProps),
+            eq(MethodCallSamplingRate.ALL.rate),
+            isNull()
+        )
     }
 }


### PR DESCRIPTION
### What does this PR do?

Adds structured write-result telemetry to ProfilingDataWriter so every call to buildRawBatchEvent emits a logMetric with a consistent shape regardless of outcome.

Three outcomes are now reported under metric_type = "profiling write" / profiling_write:


| Scenario                              | dropped | drop_reason          |  
|---------------------------------------|---------|----------------------|
| No RUM events attached to the profile | true    | no_rum_events        | 
| Server clock drift exceeds 1 000 ms   | true    | clock_drift_exceeded | 
| Profile written successfully          | false   | null                 |  

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

