### PR TITLE
RUM-16955: Do not aggregate stats if we lack consent

### DIFF
--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ClientStatsFeature.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ClientStatsFeature.kt
@@ -11,6 +11,9 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.feature.StorageBackedFeature
 import com.datadog.android.api.storage.FeatureStorageConfiguration
+import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.privacy.TrackingConsentProviderCallback
 import com.datadog.android.trace.event.SpanEventMapper
 import com.datadog.android.trace.internal.domain.event.CoreTracerSpanToSpanEventMapper
 import com.datadog.android.trace.internal.domain.event.SpanEventMapperWrapper
@@ -19,14 +22,16 @@ import com.datadog.android.trace.internal.domain.metrics.ClientStatsAdapter
 import com.datadog.android.trace.internal.domain.metrics.StatsConcentrator
 import com.datadog.android.trace.internal.net.ClientStatsRequestFactory
 import com.datadog.trace.api.Config
+import com.datadog.trace.common.metrics.MetricsAggregator
+import com.datadog.trace.common.metrics.NoOpMetricsAggregator
 import java.util.concurrent.ScheduledExecutorService
 
 internal class ClientStatsFeature(
     private val sdkCore: FeatureSdkCore,
     customEndpointUrl: String?,
-    spanEventMapper: SpanEventMapper,
-    networkInfoEnabled: Boolean
-) : StorageBackedFeature {
+    private val spanEventMapper: SpanEventMapper,
+    private val networkInfoEnabled: Boolean
+) : StorageBackedFeature, TrackingConsentProviderCallback {
     override val name = Feature.TRACING_CLIENT_STATS_FEATURE_NAME
 
     override val storageConfiguration = FeatureStorageConfiguration(
@@ -39,35 +44,40 @@ internal class ClientStatsFeature(
         oldBatchThreshold = 18L * 60L * 60L * 1000L
     )
 
-    private val statsExecutor: ScheduledExecutorService by lazy {
-        sdkCore.createScheduledExecutorService("client-side-stats-aggregator")
-    }
-    private val statsConcentrator by lazy {
-        // runtimeId is static and encapsulated in Tracer core's Config. There is no way to get it except via the root
-        // span's tags or this Config object
-        val runtimeID = Config.get().runtimeId
+    @Volatile
+    internal var aggregator: MetricsAggregator = NoOpMetricsAggregator()
 
-        StatsConcentrator(
-            sdkCore,
-            ddSpanToSpanEventMapper = CoreTracerSpanToSpanEventMapper(networkInfoEnabled),
-            eventMapper = SpanEventMapperWrapper(spanEventMapper, sdkCore.internalLogger),
-            statsExecutor,
-            BatchStatsWriter(sdkCore, runtimeID),
-            sdkCore.timeProvider
-        )
-    }
-
-    internal val aggregator by lazy {
-        ClientStatsAdapter(statsConcentrator)
-    }
+    private var statsConcentrator: StatsConcentrator? = null
+    private var statsExecutor: ScheduledExecutorService? = null
 
     override val requestFactory = ClientStatsRequestFactory(customEndpointUrl)
 
-    override fun onInitialize(appContext: Context) {}
+    override fun onInitialize(appContext: Context) {
+        val internalSdkCore = sdkCore as InternalSdkCore
+        val executor = sdkCore.createScheduledExecutorService("client-side-stats-aggregator")
+        val concentrator = StatsConcentrator(
+            sdkCore = internalSdkCore,
+            ddSpanToSpanEventMapper = CoreTracerSpanToSpanEventMapper(networkInfoEnabled),
+            eventMapper = SpanEventMapperWrapper(spanEventMapper, sdkCore.internalLogger),
+            executorService = executor,
+            statsWriter = BatchStatsWriter(sdkCore, Config.get().runtimeId),
+            timeProvider = internalSdkCore.timeProvider,
+            initialConsent = internalSdkCore.trackingConsent
+        )
+        statsConcentrator = concentrator
+        statsExecutor = executor
+        aggregator = ClientStatsAdapter(concentrator)
+    }
 
     override fun onStop() {
-        statsConcentrator.stop()
+        statsConcentrator?.stop()
+        statsExecutor?.shutdown()
+    }
 
-        statsExecutor.shutdown()
+    override fun onConsentUpdated(
+        previousConsent: TrackingConsent,
+        newConsent: TrackingConsent
+    ) {
+        statsConcentrator?.onConsentUpdated(newConsent)
     }
 }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.core.internal.utils.scheduleSafe
 import com.datadog.android.event.EventMapper
 import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.trace.api.DatadogTracingConstants
 import com.datadog.android.trace.internal.ddsketch.DDSketch
 import com.datadog.android.trace.internal.domain.event.ContextAwareMapper
@@ -24,6 +25,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
+@Suppress("TooManyFunctions")
 internal class StatsConcentrator(
     private val sdkCore: FeatureSdkCore,
     private val ddSpanToSpanEventMapper: ContextAwareMapper<DDSpan, SpanEvent>,
@@ -34,6 +36,7 @@ internal class StatsConcentrator(
     private val executorService: ScheduledExecutorService,
     private val statsWriter: StatsWriter,
     private val timeProvider: TimeProvider,
+    initialConsent: TrackingConsent,
     /**
      * The number of stats buckets we keep in memory before flushing them.
      * It means that we can compute stats only for the last `bufferLen * bucketSizeNs` and that we
@@ -44,6 +47,9 @@ internal class StatsConcentrator(
     private val bucketSizeNs: Long = DEFAULT_BUCKET_LENGTH.inWholeNanoseconds,
     startPeriodicFlush: Boolean = true
 ) {
+    @Volatile
+    private var currentConsent: TrackingConsent = initialConsent
+
     // These fields below are confined to executorService; never access them from another thread.
     private var oldestTs: Long = 0L
     private val buckets = mutableMapOf<Long, MutableMap<AggregationKey, GroupedStats>>()
@@ -85,7 +91,13 @@ internal class StatsConcentrator(
                 }
                 .toList()
 
-            executorService.executeSafe("stats-aggregate", sdkCore.internalLogger) { aggregate(applicableSpans) }
+            executorService.executeSafe("stats-aggregate", sdkCore.internalLogger) {
+                if (currentConsent == TrackingConsent.NOT_GRANTED) {
+                    return@executeSafe
+                }
+
+                aggregate(applicableSpans)
+            }
         }
     }
 
@@ -154,31 +166,35 @@ internal class StatsConcentrator(
         // Update the oldest allowed timestamp that older events will fall into
         oldestTs = (alignTimestamp(bucketSizeNs, now) - (bufferLen - 1) * bucketSizeNs).coerceAtLeast(oldestTs)
 
-        return closedBuckets.map { (bucketStart, groups) ->
-            ClientStatsBucket(
-                start = bucketStart + timeProvider.getServerOffsetNanos(),
-                duration = bucketSizeNs,
-                stats = groups.map { (key, stats) ->
-                    ClientGroupedStats(
-                        service = key.service,
-                        name = key.operation,
-                        resource = key.resource,
-                        httpStatusCode = key.httpStatusCode,
-                        type = key.type,
-                        spanKind = key.spanKind,
-                        isTraceRoot = key.isTraceRoot,
-                        hits = stats.hits,
-                        errors = stats.errors,
-                        duration = stats.duration,
-                        topLevelHits = stats.topLevelHits,
-                        okSummary = stats.okSummary.serialize(),
-                        errorSummary = stats.errSummary.serialize(),
-                        isSynthetic = key.synthetics,
-                        peerTags = key.peerTags,
-                        serviceSource = key.serviceSource
-                    )
-                }
-            )
+        return if (currentConsent == TrackingConsent.NOT_GRANTED) {
+            emptyList()
+        } else {
+            closedBuckets.map { (bucketStart, groups) ->
+                ClientStatsBucket(
+                    start = bucketStart + timeProvider.getServerOffsetNanos(),
+                    duration = bucketSizeNs,
+                    stats = groups.map { (key, stats) ->
+                        ClientGroupedStats(
+                            service = key.service,
+                            name = key.operation,
+                            resource = key.resource,
+                            httpStatusCode = key.httpStatusCode,
+                            type = key.type,
+                            spanKind = key.spanKind,
+                            isTraceRoot = key.isTraceRoot,
+                            hits = stats.hits,
+                            errors = stats.errors,
+                            duration = stats.duration,
+                            topLevelHits = stats.topLevelHits,
+                            okSummary = stats.okSummary.serialize(),
+                            errorSummary = stats.errSummary.serialize(),
+                            isSynthetic = key.synthetics,
+                            peerTags = key.peerTags,
+                            serviceSource = key.serviceSource
+                        )
+                    }
+                )
+            }
         }
     }
 
@@ -213,6 +229,18 @@ internal class StatsConcentrator(
         return PEER_TAG_KEYS
             .mapNotNull { key -> spanTags[key]?.let { value -> "$key:$value" } }
             .sorted()
+    }
+
+    fun onConsentUpdated(newConsent: TrackingConsent) {
+        executorService.executeSafe("stats-consent-change", sdkCore.internalLogger) {
+            currentConsent = newConsent
+            // Only flush when revoking consent. PENDING <-> GRANTED transitions are both recording
+            // states and need no boundary flush. Consent is set first so drainBuckets discards
+            // the in-memory buffer rather than forwarding it to the writer.
+            if (newConsent == TrackingConsent.NOT_GRANTED) {
+                flushBuckets(flushAll = true)
+            }
+        }
     }
 
     private data class AggregationKey(

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/ClientStatsFeatureTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/ClientStatsFeatureTest.kt
@@ -6,10 +6,12 @@
 
 package com.datadog.android.trace.internal
 
+import android.content.Context
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
-import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.trace.event.SpanEventMapper
 import com.datadog.android.trace.internal.domain.metrics.ClientStatsAdapter
 import com.datadog.android.utils.forge.Configurator
@@ -45,7 +47,10 @@ internal class ClientStatsFeatureTest {
     private lateinit var testedFeature: ClientStatsFeature
 
     @Mock
-    lateinit var mockSdkCore: FeatureSdkCore
+    lateinit var mockSdkCore: InternalSdkCore
+
+    @Mock
+    lateinit var mockContext: Context
 
     @Mock
     lateinit var mockInternalLogger: InternalLogger
@@ -72,6 +77,7 @@ internal class ClientStatsFeatureTest {
     fun `set up`() {
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockSdkCore.timeProvider) doReturn mockTimeProvider
+        whenever(mockSdkCore.trackingConsent) doReturn TrackingConsent.GRANTED
         whenever(mockTimeProvider.getDeviceTimestampMillis()) doReturn fakeTimestampMillis
         whenever(mockSdkCore.createScheduledExecutorService(any())) doReturn mockStatsExecutor
 
@@ -81,6 +87,7 @@ internal class ClientStatsFeatureTest {
             spanEventMapper = mockSpanEventMapper,
             networkInfoEnabled = fakeNetworkInfoEnabled
         )
+        testedFeature.onInitialize(mockContext)
     }
 
     // region name

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentratorTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentratorTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.event.EventMapper
 import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.trace.api.DatadogTracingConstants
 import com.datadog.android.trace.internal.domain.event.ContextAwareMapper
 import com.datadog.android.trace.internal.domain.metrics.StatsConcentrator.Companion.alignTimestamp
@@ -109,6 +110,7 @@ internal class StatsConcentratorTest {
             executorService = mockExecutorService,
             statsWriter = mockStatsWriter,
             timeProvider = mockTimeProvider,
+            initialConsent = TrackingConsent.GRANTED,
             startPeriodicFlush = false
         )
     }
@@ -127,6 +129,7 @@ internal class StatsConcentratorTest {
             executorService = mockExecutorService,
             statsWriter = mockStatsWriter,
             timeProvider = mockTimeProvider,
+            initialConsent = TrackingConsent.GRANTED,
             startPeriodicFlush = true
         )
 
@@ -684,6 +687,7 @@ internal class StatsConcentratorTest {
             executorService = mockExecutorService,
             statsWriter = mockStatsWriter,
             timeProvider = mockTimeProvider,
+            initialConsent = TrackingConsent.GRANTED,
             startPeriodicFlush = true
         )
         verify(mockExecutorService).schedule(runnableCaptor.capture(), any(), any())
@@ -732,7 +736,140 @@ internal class StatsConcentratorTest {
 
     // endregion
 
+    // region Consent
+
+    @Test
+    fun `M drop all spans W record() { initialConsent = NOT_GRANTED }`(forge: Forge) {
+        // Given
+        val concentrator = makeConcentrator(initialConsent = TrackingConsent.NOT_GRANTED)
+        val (span) = forge.makeEligibleSpan()
+
+        // When
+        concentrator.record(listOf(span))
+        concentrator.scheduleFlush(flushAll = true)
+
+        // Then
+        verifyNoInteractions(mockStatsWriter)
+    }
+
+    @Test
+    fun `M aggregate spans W record() { initialConsent = PENDING }`(forge: Forge) {
+        // Given
+        val concentrator = makeConcentrator(initialConsent = TrackingConsent.PENDING)
+        val (span) = forge.makeEligibleSpan()
+
+        // When
+        concentrator.record(listOf(span))
+        concentrator.scheduleFlush(flushAll = true)
+
+        // Then
+        assertThat(captureBuckets()).hasSize(1)
+    }
+
+    @Test
+    fun `M discard buffered data W onConsentUpdated() { GRANTED to NOT_GRANTED }`(
+        forge: Forge
+    ) {
+        // Given: record a span while consent is GRANTED
+        val (span) = forge.makeEligibleSpan()
+        testedConcentrator.record(listOf(span))
+
+        // When: consent is revoked
+        testedConcentrator.onConsentUpdated(TrackingConsent.NOT_GRANTED)
+
+        // Then
+        verifyNoInteractions(mockStatsWriter)
+    }
+
+    @Test
+    fun `M drop spans recorded after consent revoked W onConsentUpdated() { GRANTED to NOT_GRANTED }`(
+        forge: Forge
+    ) {
+        // Given: flush any existing data, then revoke consent
+        testedConcentrator.onConsentUpdated(TrackingConsent.NOT_GRANTED)
+        val (span) = forge.makeEligibleSpan()
+
+        // When: record a span after revocation
+        testedConcentrator.record(listOf(span))
+        testedConcentrator.scheduleFlush(flushAll = true)
+
+        // Then
+        verifyNoInteractions(mockStatsWriter)
+    }
+
+    @Test
+    fun `M not flush buffered data W onConsentUpdated() { GRANTED to PENDING }`(forge: Forge) {
+        // Given: record a span while consent is GRANTED
+        val (span) = forge.makeEligibleSpan()
+        testedConcentrator.record(listOf(span))
+
+        // When: consent moves to PENDING — both are recording states, no boundary flush needed
+        testedConcentrator.onConsentUpdated(TrackingConsent.PENDING)
+
+        // Then: no flush triggered by the consent change itself
+        verifyNoInteractions(mockStatsWriter)
+    }
+
+    @Test
+    fun `M not flush buffered data W onConsentUpdated() { PENDING to GRANTED }`(forge: Forge) {
+        // Given
+        val concentrator = makeConcentrator(initialConsent = TrackingConsent.PENDING)
+        val (span) = forge.makeEligibleSpan()
+        concentrator.record(listOf(span))
+
+        // When
+        concentrator.onConsentUpdated(TrackingConsent.GRANTED)
+
+        // Then: no flush triggered by the consent change itself
+        verifyNoInteractions(mockStatsWriter)
+    }
+
+    @Test
+    fun `M resume recording W onConsentUpdated() { NOT_GRANTED to GRANTED }`(forge: Forge) {
+        // Given: start with no consent
+        val concentrator = makeConcentrator(initialConsent = TrackingConsent.NOT_GRANTED)
+        val (span) = forge.makeEligibleSpan()
+
+        // When: grant consent then record
+        concentrator.onConsentUpdated(TrackingConsent.GRANTED)
+        concentrator.record(listOf(span))
+        concentrator.scheduleFlush(flushAll = true)
+
+        // Then
+        assertThat(captureBuckets()).hasSize(1)
+    }
+
+    @Test
+    fun `M resume recording W onConsentUpdated() { NOT_GRANTED to PENDING }`(forge: Forge) {
+        // Given: start with no consent
+        val concentrator = makeConcentrator(initialConsent = TrackingConsent.NOT_GRANTED)
+        val (span) = forge.makeEligibleSpan()
+
+        // When: update to pending then record
+        concentrator.onConsentUpdated(TrackingConsent.PENDING)
+        concentrator.record(listOf(span))
+        concentrator.scheduleFlush(flushAll = true)
+
+        // Then
+        assertThat(captureBuckets()).hasSize(1)
+    }
+
+    // endregion
+
     // region Helpers
+
+    private fun makeConcentrator(initialConsent: TrackingConsent) = StatsConcentrator(
+        sdkCore = mockSdkCore,
+        ddSpanToSpanEventMapper = mockSpanEventMapper,
+        eventMapper = mockEventMapper,
+        bufferLen = fakeBufferLen,
+        bucketSizeNs = fakeBucketSizeNs,
+        executorService = mockExecutorService,
+        statsWriter = mockStatsWriter,
+        timeProvider = mockTimeProvider,
+        initialConsent = initialConsent,
+        startPeriodicFlush = false
+    )
 
     /** Creates a matched (DDSpan, SpanEvent) pair and wires the mapper stub. */
     private fun Forge.makeEligibleSpan(


### PR DESCRIPTION
### What does this PR do?
Drops spans for calculation if we lack consent
When consent is switched to not granted, we will also flush all the buckets which will drop the data by the storage layer as well

Also changed how the feature is init-ed so we can safely grab the consent during the init phase