### PR TITLE
RUM-14050: Cancel stale PR pipeline runs in Gitlab

### DIFF
--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -3,6 +3,16 @@ include:
 
 # SETUP
 
+default:
+  interruptible: true # default all jobs to be interruptable
+
+workflow:
+  rules:
+    - if: "$CI_COMMIT_BRANCH && $CI_COMMIT_BRANCH !~ /^(develop|master)$|^feature\//"
+      auto_cancel:
+        on_new_commit: interruptible # short-lived branches cancel on new commits
+    - when: always # develop, master, feature/*, tags: never auto-canceled
+
 stages:
   - ci-image
   - security
@@ -99,6 +109,7 @@ ci-image:
   when: manual
   except: [ tags, schedules ]
   tags: [ "arch:amd64" ]
+  interruptible: false
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:24.0.4-jammy
   script:
     - docker buildx build --tag $CI_IMAGE_DOCKER -f ./ci/Dockerfile.gitlab --push .
@@ -109,6 +120,7 @@ create_key:
   stage: security
   when: manual
   tags: [ "arch:amd64" ]
+  interruptible: false
   variables:
     PROJECT_NAME: "dd-sdk-android"
     EXPORT_TO_KEYSERVER: "true"
@@ -547,6 +559,7 @@ test-pyramid:publish-benchmark-synthetics:
 
 publish:release-all:
   tags: [ "arch:amd64" ]
+  interruptible: false
   only:
     - tags
     - develop
@@ -567,6 +580,7 @@ publish:release-all:
 
 notify:publish-develop-success:
   extends: .slack-notifier-base
+  interruptible: false
   stage: notify
   when: on_success
   only:
@@ -577,6 +591,7 @@ notify:publish-develop-success:
 
 notify:publish-develop-failure:
   extends: .slack-notifier-base
+  interruptible: false
   stage: notify
   when: on_failure
   only:
@@ -588,6 +603,7 @@ notify:publish-develop-failure:
 
 notify:publish-release-success:
   extends: .slack-notifier-base
+  interruptible: false
   stage: notify
   when: on_success
   only:
@@ -599,6 +615,7 @@ notify:publish-release-success:
 
 notify:publish-release-failure:
   extends: .slack-notifier-base
+  interruptible: false
   stage: notify
   when: on_failure
   only:
@@ -610,6 +627,7 @@ notify:publish-release-failure:
 
 notify:dogfood-app:
   tags: [ "arch:amd64" ]
+  interruptible: false
   only:
     - tags
   image: $CI_IMAGE_DOCKER
@@ -625,6 +643,7 @@ notify:dogfood-app:
 
 notify:dogfood-demo:
   tags: [ "arch:amd64" ]
+  interruptible: false
   only:
     - tags
   image: $CI_IMAGE_DOCKER
@@ -640,6 +659,7 @@ notify:dogfood-demo:
 
 notify:dogfood-gradle-plugin:
   tags: [ "arch:amd64" ]
+  interruptible: false
   only:
     - tags
   image: $CI_IMAGE_DOCKER
@@ -655,6 +675,7 @@ notify:dogfood-gradle-plugin:
 
 notify:merge-verification-metadata:
   tags: [ "arch:amd64" ]
+  interruptible: false
   only:
     - tags
   image: $CI_IMAGE_DOCKER


### PR DESCRIPTION
### What does this PR do?
Since we have a limited size of Mac runners, kill off pipeline jobs for PRs if a newer commit is pushed

Docs: https://support.gitlab.com/hc/en-us/articles/22118112967068-How-to-auto-cancel-redundant-pipelines

### Motivation
Try to reduce the amount of time waiting on our test-pyramid jobs due to stale runs