### PR TITLE
RUM-15483: Fix clock mismatch in DefaultAppStartTimeProvider app start time computation

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/time/DefaultAppStartTimeProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/time/DefaultAppStartTimeProvider.kt
@@ -22,7 +22,7 @@ internal class DefaultAppStartTimeProvider(
         when {
             buildSdkVersionProvider.isAtLeastN -> {
                 val timeProvider = timeProviderFactory()
-                val diffMs = timeProvider.getDeviceElapsedRealtimeMillis() - Process.getStartElapsedRealtime()
+                val diffMs = timeProvider.getDeviceUptimeMillis() - Process.getStartUptimeMillis()
                 val computedAppStartTimeNs =
                     timeProvider.getDeviceElapsedTimeNanos() - TimeUnit.MILLISECONDS.toNanos(diffMs)
                 val contentProviderCreateTimeNs = DdRumContentProvider.createTimeNs
@@ -32,9 +32,8 @@ internal class DefaultAppStartTimeProvider(
                         PROCESS_START_TO_CP_START_DIFF_THRESHOLD_NS
 
                 /**
-                 * Occasionally [Process.getStartElapsedRealtime] returns buggy values. We filter them and fall back
-                 * to the time of creation of [DdRumContentProvider].
-                 * Two directions are guarded:
+                 * Guard against unexpected values from [Process.getStartUptimeMillis].
+                 * Two directions are checked and fall back to [DdRumContentProvider] creation time:
                  * - computedAppStartTimeNs > createTimeNs: app start appears to be after content provider init,
                  * which is impossible.
                  * - computedAppStartTimeNs is more than the threshold before createTimeNs: app start appears

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/time/DefaultAppStartTimeProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/time/DefaultAppStartTimeProviderTest.kt
@@ -53,7 +53,7 @@ class DefaultAppStartTimeProviderTest {
         // GIVEN
         whenever(mockBuildSdkVersionProvider.isAtLeastN) doReturn true
         whenever(mockTimeProvider.getDeviceElapsedTimeNanos()) doReturn fakeCurrentTimeNs
-        val diffMs = stubAndGetElapsedRealtimeMs() - Process.getStartElapsedRealtime()
+        val diffMs = stubAndGetUptimeMs() - Process.getStartUptimeMillis()
         val startTimeNs = fakeCurrentTimeNs - TimeUnit.MILLISECONDS.toNanos(diffMs)
         DdRumContentProvider.createTimeNs = startTimeNs +
             forge.aLong(min = 0, max = DefaultAppStartTimeProvider.PROCESS_START_TO_CP_START_DIFF_THRESHOLD_NS)
@@ -66,14 +66,14 @@ class DefaultAppStartTimeProviderTest {
     }
 
     @Test
-    fun `M fall back to DdRumContentProvider W appStartTime { N+ getStartElapsedRealtime returns buggy value }`(
+    fun `M fall back to DdRumContentProvider W appStartTime { N+ getStartUptimeMillis returns buggy value }`(
         @LongForgery(min = 0L) fakeCurrentTimeNs: Long,
         forge: Forge
     ) {
         // GIVEN
         whenever(mockBuildSdkVersionProvider.isAtLeastN) doReturn true
         whenever(mockTimeProvider.getDeviceElapsedTimeNanos()) doReturn fakeCurrentTimeNs
-        val diffMs = stubAndGetElapsedRealtimeMs() - Process.getStartElapsedRealtime()
+        val diffMs = stubAndGetUptimeMs() - Process.getStartUptimeMillis()
         val startTimeNs = fakeCurrentTimeNs - TimeUnit.MILLISECONDS.toNanos(diffMs)
         DdRumContentProvider.createTimeNs = startTimeNs +
             forge.aLong(min = DefaultAppStartTimeProvider.PROCESS_START_TO_CP_START_DIFF_THRESHOLD_NS)
@@ -91,14 +91,14 @@ class DefaultAppStartTimeProviderTest {
     ) {
         // GIVEN
         whenever(mockBuildSdkVersionProvider.isAtLeastN) doReturn true
-        val diffMs = stubAndGetElapsedRealtimeMs() - Process.getStartElapsedRealtime()
+        val diffMs = stubAndGetUptimeMs() - Process.getStartUptimeMillis()
         val fakeCurrentTimeNs = fakeComputedAppStartTimeNs + TimeUnit.MILLISECONDS.toNanos(diffMs)
         whenever(mockTimeProvider.getDeviceElapsedTimeNanos()) doReturn fakeCurrentTimeNs
 
         val computedAppStartTimeNs = fakeCurrentTimeNs - TimeUnit.MILLISECONDS.toNanos(diffMs)
         // Set createTimeNs strictly before computedAppStartTimeNs, simulating a buggy
-        // getStartElapsedRealtime()
-        // that makes the computed app start time appear to be after the content provider was created.
+        // getStartUptimeMillis() that makes the computed app start time appear to be after
+        // the content provider was created.
         DdRumContentProvider.createTimeNs = computedAppStartTimeNs - 1L
 
         // WHEN
@@ -236,14 +236,18 @@ class DefaultAppStartTimeProviderTest {
         assertThat(uptime2).isGreaterThan(uptime1)
     }
 
-    private fun stubAndGetElapsedRealtimeMs(): Long {
-        val elapsedRealtimeMs = SystemClock.elapsedRealtime()
-        whenever(mockTimeProvider.getDeviceElapsedRealtimeMillis()) doReturn elapsedRealtimeMs
-        return elapsedRealtimeMs
+    // region helpers
+
+    private fun stubAndGetUptimeMs(): Long {
+        val uptimeMs = SystemClock.uptimeMillis()
+        whenever(mockTimeProvider.getDeviceUptimeMillis()) doReturn uptimeMs
+        return uptimeMs
     }
 
     private fun computeCurrentTimeNsForStartTime(fakeStartTimeNs: Long): Long {
-        val diffMs = stubAndGetElapsedRealtimeMs() - Process.getStartElapsedRealtime()
+        val diffMs = stubAndGetUptimeMs() - Process.getStartUptimeMillis()
         return fakeStartTimeNs + TimeUnit.MILLISECONDS.toNanos(diffMs)
     }
+
+    // endregion
 }

--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -256,10 +256,12 @@ interface com.datadog.android.internal.time.TimeProvider
   fun getServerOffsetNanos(): Long
   fun getServerOffsetMillis(): Long
   fun getDeviceElapsedRealtimeMillis(): Long
+  fun getDeviceUptimeMillis(): Long
 abstract class com.datadog.android.internal.time.BaseTimeProvider : TimeProvider
   override fun getDeviceTimestampMillis(): Long
   override fun getDeviceElapsedTimeNanos(): Long
   override fun getDeviceElapsedRealtimeMillis(): Long
+  override fun getDeviceUptimeMillis(): Long
 fun ByteArray.toHexString(): String
 fun <T> android.content.Context.getSystemServiceAs(String): T?
 interface com.datadog.android.internal.utils.DDCoreSubscription<T: Any>

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -565,6 +565,7 @@ public abstract class com/datadog/android/internal/time/BaseTimeProvider : com/d
 	public final fun getDeviceElapsedRealtimeMillis ()J
 	public final fun getDeviceElapsedTimeNanos ()J
 	public final fun getDeviceTimestampMillis ()J
+	public final fun getDeviceUptimeMillis ()J
 }
 
 public final class com/datadog/android/internal/time/DefaultTimeProvider : com/datadog/android/internal/time/BaseTimeProvider {
@@ -578,6 +579,7 @@ public abstract interface class com/datadog/android/internal/time/TimeProvider {
 	public abstract fun getDeviceElapsedRealtimeMillis ()J
 	public abstract fun getDeviceElapsedTimeNanos ()J
 	public abstract fun getDeviceTimestampMillis ()J
+	public abstract fun getDeviceUptimeMillis ()J
 	public abstract fun getServerOffsetMillis ()J
 	public abstract fun getServerOffsetNanos ()J
 	public abstract fun getServerTimestampMillis ()J

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/time/TimeProvider.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/time/TimeProvider.kt
@@ -47,6 +47,15 @@ interface TimeProvider {
      * This is implemented in [BaseTimeProvider] as [SystemClock.elapsedRealtime].
      */
     fun getDeviceElapsedRealtimeMillis(): Long
+
+    /**
+     * Returns the time since boot in milliseconds, NOT including time spent in sleep.
+     * This is implemented in [BaseTimeProvider] as [SystemClock.uptimeMillis].
+     * Uses [CLOCK_MONOTONIC] — the same clock domain as [System.nanoTime] and
+     * [getDeviceElapsedTimeNanos], making it safe to use together with those methods
+     * for duration calculations that should exclude device sleep time.
+     */
+    fun getDeviceUptimeMillis(): Long
 }
 
 /**
@@ -56,4 +65,5 @@ abstract class BaseTimeProvider : TimeProvider {
     final override fun getDeviceTimestampMillis(): Long = System.currentTimeMillis()
     final override fun getDeviceElapsedTimeNanos(): Long = System.nanoTime()
     final override fun getDeviceElapsedRealtimeMillis(): Long = SystemClock.elapsedRealtime()
+    final override fun getDeviceUptimeMillis(): Long = SystemClock.uptimeMillis()
 }

--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/stub/StubTimeProvider.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/stub/StubTimeProvider.kt
@@ -17,6 +17,7 @@ import com.datadog.android.internal.time.TimeProvider
  * @property serverOffsetNs The server time offset in nanoseconds. Defaults to `0`.
  * @property serverOffsetMs The server time offset in milliseconds. Defaults to `0`.
  * @property elapsedRealtimeMs The elapsed realtime in milliseconds (includes time in sleep). Defaults to `0`.
+ * @property uptimeMs The uptime in milliseconds (excludes time in sleep). Defaults to `0`.
  */
 class StubTimeProvider(
     var deviceTimestampMs: Long = 0L,
@@ -24,7 +25,8 @@ class StubTimeProvider(
     var elapsedTimeNs: Long = 0L,
     var serverOffsetNs: Long = 0L,
     var serverOffsetMs: Long = 0L,
-    var elapsedRealtimeMs: Long = 0L
+    var elapsedRealtimeMs: Long = 0L,
+    var uptimeMs: Long = 0L
 ) : TimeProvider {
 
     override fun getDeviceTimestampMillis(): Long = deviceTimestampMs
@@ -38,4 +40,6 @@ class StubTimeProvider(
     override fun getServerOffsetMillis(): Long = serverOffsetMs
 
     override fun getDeviceElapsedRealtimeMillis(): Long = elapsedRealtimeMs
+
+    override fun getDeviceUptimeMillis(): Long = uptimeMs
 }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -927,5 +927,6 @@ class PerfettoProfilerTest {
         override fun getServerOffsetMillis(): Long = 0L
 
         override fun getDeviceElapsedRealtimeMillis(): Long = 0L
+        override fun getDeviceUptimeMillis(): Long = 0L
     }
 }

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
@@ -181,6 +181,7 @@ class StubSDKCore(
         override fun getServerOffsetNanos(): Long = 0L
         override fun getServerOffsetMillis(): Long = 0L
         override fun getDeviceElapsedRealtimeMillis(): Long = SystemClock.elapsedRealtime()
+        override fun getDeviceUptimeMillis(): Long = SystemClock.uptimeMillis()
     }
 
     override fun registerFeature(feature: Feature) {


### PR DESCRIPTION
### What does this PR do?
Fixes a clock-domain mismatch in `DefaultAppStartTimeProvider` where the app start time computation mixed `CLOCK_BOOTTIME` (`elapsedRealtime` / `Process.getStartElapsedRealtime()`) with `CLOCK_MONOTONIC` (`System.nanoTime()`). The fix replaces the `CLOCK_BOOTTIME` pair with a fully `CLOCK_MONOTONIC` computation using `SystemClock.uptimeMillis()` / `Process.getStartUptimeMillis()`.

To support this, `getDeviceUptimeMillis()` is added to the `TimeProvider` interface and implemented in `BaseTimeProvider` as `SystemClock.uptimeMillis()`.

### Motivation
On devices that sleep between process start and the first lazy access of `appStartTimeNs` (background launches, OEM battery optimization), the old formula produced a value that was too small by exactly the sleep duration. This silently inflated TTID, app startup duration, `timeSinceAppStartNs` on fatal/ANR errors, and NDK crash timestamps. The bug was identified while investigating the CI flake fixed in RUM-15269 (PR #3339).

### Additional Notes
- `Process.getStartUptimeMillis()` is available from API 24+ (confirmed from AOSP source) — no API level branching is required. It is already pre-approved in `detekt_custom_safe_calls_android.yml`.

Related to: https://github.com/DataDog/dd-sdk-android/pull/3339

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)