### PR TITLE
RUM-16958: When client side stats is enabled, mark each span to disable server side stats

### DIFF
--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/Trace.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/Trace.kt
@@ -31,7 +31,8 @@ object Trace {
             sdkCore = sdkCore as FeatureSdkCore,
             customEndpointUrl = traceConfiguration.customEndpointUrl,
             spanEventMapper = traceConfiguration.eventMapper,
-            networkInfoEnabled = traceConfiguration.networkInfoEnabled
+            networkInfoEnabled = traceConfiguration.networkInfoEnabled,
+            clientSideStatsEnabled = traceConfiguration.statsComputationEnabled
         )
 
         sdkCore.registerFeature(tracingFeature)

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ClientStatsFeature.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ClientStatsFeature.kt
@@ -49,7 +49,10 @@ internal class ClientStatsFeature(
 
         StatsConcentrator(
             sdkCore,
-            ddSpanToSpanEventMapper = CoreTracerSpanToSpanEventMapper(networkInfoEnabled),
+            ddSpanToSpanEventMapper = CoreTracerSpanToSpanEventMapper(
+                networkInfoEnabled,
+                clientSideStatsEnabled = true
+            ),
             eventMapper = SpanEventMapperWrapper(spanEventMapper, sdkCore.internalLogger),
             statsExecutor,
             BatchStatsWriter(sdkCore, runtimeID),

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/TracingFeature.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/TracingFeature.kt
@@ -30,7 +30,8 @@ internal class TracingFeature(
     private val sdkCore: FeatureSdkCore,
     customEndpointUrl: String?,
     internal val spanEventMapper: SpanEventMapper,
-    internal val networkInfoEnabled: Boolean
+    internal val networkInfoEnabled: Boolean,
+    private val clientSideStatsEnabled: Boolean
 ) : InternalCoreWriterProvider, StorageBackedFeature {
 
     internal var coreTracerDataWriter: Writer = NoOpWriter()
@@ -71,7 +72,7 @@ internal class TracingFeature(
         val internalLogger = sdkCore.internalLogger
         return CoreTraceWriter(
             sdkCore,
-            ddSpanToSpanEventMapper = CoreTracerSpanToSpanEventMapper(networkInfoEnabled),
+            ddSpanToSpanEventMapper = CoreTracerSpanToSpanEventMapper(networkInfoEnabled, clientSideStatsEnabled),
             eventMapper = SpanEventMapperWrapper(spanEventMapper, internalLogger),
             serializer = SpanEventSerializer(internalLogger),
             internalLogger = internalLogger

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/event/CoreTracerSpanToSpanEventMapper.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/event/CoreTracerSpanToSpanEventMapper.kt
@@ -20,7 +20,8 @@ import com.google.gson.JsonObject
 
 @Suppress("TooManyFunctions")
 internal class CoreTracerSpanToSpanEventMapper(
-    internal val networkInfoEnabled: Boolean
+    internal val networkInfoEnabled: Boolean,
+    internal val clientSideStatsEnabled: Boolean
 ) : BaseSpanEventMapper<DDSpan>() {
 
     // region Mapper
@@ -100,6 +101,14 @@ internal class CoreTracerSpanToSpanEventMapper(
         meta.putAll(tags)
         meta[TRACE_ID_META_KEY] = mostSignificantTraceId
         meta[APPLICATION_VARIANT_KEY] = datadogContext.variant
+
+        if (clientSideStatsEnabled) {
+            meta[COMPUTE_STATS_META_KEY] = "0"
+        } else {
+            // Prevent a user from altering the logic by providing the tag manually
+            meta.remove(COMPUTE_STATS_META_KEY)
+        }
+
         resolveSpanLinks(event)?.let { meta[SPAN_LINKS_KEY] = it }
         return SpanEvent.Meta(
             version = datadogContext.version,

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/event/MetaKeys.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/event/MetaKeys.kt
@@ -8,3 +8,4 @@ package com.datadog.android.trace.internal.domain.event
 
 internal const val TRACE_ID_META_KEY = "_dd.p.id"
 internal const val APPLICATION_VARIANT_KEY = "variant"
+internal const val COMPUTE_STATS_META_KEY = "_dd.compute_stats"

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/assertj/SpanEventAssert.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/assertj/SpanEventAssert.kt
@@ -11,6 +11,7 @@ import com.datadog.android.api.context.DeviceInfo
 import com.datadog.android.api.context.DeviceType
 import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.api.context.UserInfo
+import com.datadog.android.trace.internal.domain.event.COMPUTE_STATS_META_KEY
 import com.datadog.android.trace.internal.domain.event.CoreTracerSpanToSpanEventMapper
 import com.datadog.android.trace.internal.domain.event.TRACE_ID_META_KEY
 import com.datadog.android.trace.model.SpanEvent
@@ -117,6 +118,17 @@ internal class SpanEventAssert(actual: SpanEvent) :
                     " but instead was: ${actual.meta.dd.source}"
             )
             .isEqualTo(spanSource)
+        return this
+    }
+
+    fun hasComputeStats(computeStats: String?): SpanEventAssert {
+        val actual = actual.meta.additionalProperties[COMPUTE_STATS_META_KEY]
+        assertThat(actual)
+            .overridingErrorMessage(
+                "Expected SpanEvent to have _dd.compute_stats: $computeStats" +
+                    " but instead was: $actual"
+            )
+            .isEqualTo(computeStats)
         return this
     }
 

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/TracingFeatureTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/TracingFeatureTest.kt
@@ -58,6 +58,9 @@ internal class TracingFeatureTest {
     @BoolForgery
     var fakeNetworkInfoEnabled: Boolean = false
 
+    @BoolForgery
+    var fakeClientStatsEnabled: Boolean = false
+
     @BeforeEach
     fun `set up`() {
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
@@ -66,7 +69,8 @@ internal class TracingFeatureTest {
             mockSdkCore,
             fakeEndpointUrl,
             mockSpanEventMapper,
-            fakeNetworkInfoEnabled
+            fakeNetworkInfoEnabled,
+            fakeClientStatsEnabled
         )
     }
 
@@ -78,9 +82,10 @@ internal class TracingFeatureTest {
         // Then
         val traceWriter = testedFeature.coreTracerDataWriter as CoreTraceWriter
         val ddSpanToSpanEventMapper = traceWriter.ddSpanToSpanEventMapper
-        assertThat(ddSpanToSpanEventMapper).isInstanceOf(CoreTracerSpanToSpanEventMapper::class.java)
-        assertThat((ddSpanToSpanEventMapper as CoreTracerSpanToSpanEventMapper).networkInfoEnabled)
-            .isEqualTo(fakeNetworkInfoEnabled)
+        assertThat(ddSpanToSpanEventMapper).isInstanceOfSatisfying(CoreTracerSpanToSpanEventMapper::class.java) {
+            assertThat(it.networkInfoEnabled).isEqualTo(fakeNetworkInfoEnabled)
+            assertThat(it.clientSideStatsEnabled).isEqualTo(fakeClientStatsEnabled)
+        }
     }
 
     @Test

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/event/CoreTracerSpanToSpanEventMapperTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/event/CoreTracerSpanToSpanEventMapperTest.kt
@@ -49,7 +49,7 @@ internal class CoreTracerSpanToSpanEventMapperTest {
 
     @BeforeEach
     fun `set up`() {
-        testedMapper = CoreTracerSpanToSpanEventMapper(fakeNetworkInfoEnabled)
+        testedMapper = CoreTracerSpanToSpanEventMapper(fakeNetworkInfoEnabled, clientSideStatsEnabled = false)
     }
 
     @Test
@@ -186,6 +186,53 @@ internal class CoreTracerSpanToSpanEventMapperTest {
 
         // Then
         assertThat(event).isNotTopSpan()
+    }
+
+    @Test
+    fun `M set computeStats to 0 W map() { clientSideStatsEnabled is true }`(
+        @Forgery fakeSpan: DDSpan
+    ) {
+        // Given
+        testedMapper = CoreTracerSpanToSpanEventMapper(fakeNetworkInfoEnabled, clientSideStatsEnabled = true)
+
+        // When
+        val event = testedMapper.map(fakeDatadogContext, fakeSpan)
+
+        // Then
+        assertThat(event).hasComputeStats("0")
+    }
+
+    @Test
+    fun `M set computeStats to null W map() { clientSideStatsEnabled is false }`(
+        @Forgery fakeSpan: DDSpan
+    ) {
+        // Given
+        testedMapper = CoreTracerSpanToSpanEventMapper(fakeNetworkInfoEnabled, clientSideStatsEnabled = false)
+
+        // When
+        val event = testedMapper.map(fakeDatadogContext, fakeSpan)
+
+        // Then
+        assertThat(event).hasComputeStats(null)
+    }
+
+    @Test
+    fun `M remove computeStats W map() { clientSideStatsEnabled is false, tag set manually }`(
+        @Forgery fakeSpan: DDSpan,
+        @StringForgery fakeComputeStats: String
+    ) {
+        // Given
+        testedMapper = CoreTracerSpanToSpanEventMapper(fakeNetworkInfoEnabled, clientSideStatsEnabled = false)
+        val tags = fakeSpan.tags.toMutableMap().apply {
+            this[COMPUTE_STATS_META_KEY] = fakeComputeStats
+        }
+        whenever(fakeSpan.tags).thenReturn(tags)
+
+        // When
+        val event = testedMapper.map(fakeDatadogContext, fakeSpan)
+
+        // Then
+        assertThat(event).hasComputeStats(null)
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?
New _dd tag which instructs the backend to ignore the span and to not calculate any APM metrics for it since the SDK is calculating them and uploading them itself

See linked ticket for the corresponding backend change
iOS: https://github.com/DataDog/dd-sdk-ios/pull/3010/

### Motivation
This prevents double counting of spans due to the client and server both calculating the APM metrics for the span