### PR TITLE
dogfooding: use AlwaysFullView as default RumViewEventWriteConfig

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -929,7 +929,7 @@ internal class RumFeature(
             insightsCollector = NoOpInsightsCollector(),
             appStartupActivityPredicate = DefaultAppStartupActivityPredicate,
             timeseriesConfiguration = null,
-            rumViewEventWriteConfig = RumViewEventWriteConfig.FullViewOnlyAtStart
+            rumViewEventWriteConfig = RumViewEventWriteConfig.AlwaysFullView
         )
 
         internal const val EVENT_MESSAGE_PROPERTY = "message"

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
@@ -14,6 +14,8 @@ import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.log.Logger
 import com.datadog.android.log.LogsConfiguration
 import com.datadog.android.rum.RumConfiguration
+import com.datadog.android.rum._RumInternalProxy
+import com.datadog.android.rum.configuration.RumViewEventWriteConfig
 import com.datadog.android.sessionreplay.SessionReplayConfiguration
 import com.datadog.android.trace.DatadogTracing
 import com.datadog.android.trace.TraceConfiguration
@@ -75,6 +77,12 @@ internal object RuntimeConfig {
     fun rumConfigBuilder(): RumConfiguration.Builder {
         return RumConfiguration.Builder(APP_ID)
             .useCustomEndpoint(rumEndpointUrl)
+            .apply {
+                _RumInternalProxy.setRumViewEventWriteConfig(
+                    builder = this@apply,
+                    config = RumViewEventWriteConfig.FullViewOnlyAtStart
+                )
+            }
     }
 
     fun sessionReplayConfigBuilder(sampleRate: Float): SessionReplayConfiguration.Builder {

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ActivityViewTrackingStrategyTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ActivityViewTrackingStrategyTest.kt
@@ -12,6 +12,8 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.core.stub.StubSDKCore
 import com.datadog.android.rum.Rum
 import com.datadog.android.rum.RumConfiguration
+import com.datadog.android.rum._RumInternalProxy
+import com.datadog.android.rum.configuration.RumViewEventWriteConfig
 import com.datadog.android.rum.integration.tests.assertj.hasRumEvent
 import com.datadog.android.rum.integration.tests.assertj.hasRumViewUpdateEvent
 import com.datadog.android.rum.integration.tests.elmyr.RumIntegrationForgeConfigurator
@@ -65,6 +67,12 @@ class ActivityViewTrackingStrategyTest {
 
         val fakeRumConfiguration = RumConfiguration.Builder(fakeApplicationId)
             .trackNonFatalAnrs(false)
+            .apply {
+                _RumInternalProxy.setRumViewEventWriteConfig(
+                    builder = this@apply,
+                    config = RumViewEventWriteConfig.FullViewOnlyAtStart
+                )
+            }
             .build()
         Rum.enable(fakeRumConfiguration, stubSdkCore)
 

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingRumTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingRumTest.kt
@@ -16,6 +16,8 @@ import com.datadog.android.rum.RumConfiguration
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
+import com.datadog.android.rum._RumInternalProxy
+import com.datadog.android.rum.configuration.RumViewEventWriteConfig
 import com.datadog.android.rum.integration.tests.assertj.hasRumEvent
 import com.datadog.android.rum.integration.tests.assertj.hasRumViewUpdateEvent
 import com.datadog.android.rum.integration.tests.elmyr.RumIntegrationForgeConfigurator
@@ -71,6 +73,12 @@ class ManualTrackingRumTest {
 
         val fakeRumConfiguration = RumConfiguration.Builder(fakeApplicationId)
             .trackNonFatalAnrs(false)
+            .apply {
+                _RumInternalProxy.setRumViewEventWriteConfig(
+                    builder = this@apply,
+                    config = RumViewEventWriteConfig.FullViewOnlyAtStart
+                )
+            }
             .build()
         Rum.enable(fakeRumConfiguration, stubSdkCore)
     }

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/RumResourceInputStreamTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/RumResourceInputStreamTest.kt
@@ -11,6 +11,8 @@ import com.datadog.android.core.stub.StubSDKCore
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.Rum
 import com.datadog.android.rum.RumConfiguration
+import com.datadog.android.rum._RumInternalProxy
+import com.datadog.android.rum.configuration.RumViewEventWriteConfig
 import com.datadog.android.rum.integration.tests.assertj.hasRumEvent
 import com.datadog.android.rum.integration.tests.assertj.hasRumViewUpdateEvent
 import com.datadog.android.rum.integration.tests.elmyr.RumIntegrationForgeConfigurator
@@ -59,6 +61,12 @@ class RumResourceInputStreamTest {
         stubSdkCore = StubSDKCore(forge)
         val fakeRumConfiguration = RumConfiguration.Builder(fakeApplicationId)
             .trackNonFatalAnrs(false)
+            .apply {
+                _RumInternalProxy.setRumViewEventWriteConfig(
+                    builder = this@apply,
+                    config = RumViewEventWriteConfig.FullViewOnlyAtStart
+                )
+            }
             .build()
         Rum.enable(fakeRumConfiguration, stubSdkCore)
     }

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ViewLoadingTimeMetricsTests.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ViewLoadingTimeMetricsTests.kt
@@ -16,6 +16,8 @@ import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
+import com.datadog.android.rum._RumInternalProxy
+import com.datadog.android.rum.configuration.RumViewEventWriteConfig
 import com.datadog.android.rum.integration.tests.assertj.hasRumEvent
 import com.datadog.android.rum.integration.tests.assertj.hasRumViewUpdateEvent
 import com.datadog.android.rum.integration.tests.elmyr.RumIntegrationForgeConfigurator
@@ -1909,6 +1911,12 @@ class ViewLoadingTimeMetricsTests {
 
     private fun configurationBuilder() = RumConfiguration.Builder(fakeApplicationId)
         .trackNonFatalAnrs(false)
+        .apply {
+            _RumInternalProxy.setRumViewEventWriteConfig(
+                builder = this@apply,
+                config = RumViewEventWriteConfig.FullViewOnlyAtStart
+            )
+        }
 
     // endregion
 


### PR DESCRIPTION
### What does this PR do?
Switches the default `RumViewEventWriteConfig` in `RumFeature` from`FullViewOnlyAtStart` to `AlwaysFullView`.

### Motivation
We want full view events to be sent by default for dogfooding. Apps that want to use partial view updates will need to explicitly set `RumViewEventWriteConfig.FullViewOnlyAtStart` in their RUM configuration.

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)