### PR TITLE
Fix `FileMoverTest` flaky test

### DIFF
--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/FileMoverTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/FileMoverTest.kt
@@ -184,11 +184,13 @@ internal class FileMoverTest {
 
     @Test
     fun `M move all files and return true W moveFiles()`(
-        @StringForgery fileNames: List<String>
+        @StringForgery fileNamesInput: List<String>
     ) {
         // Given
         fakeSrcDir.mkdirs()
         fakeDstDir.mkdirs()
+        // on case-insensitive file systems, deduplicate names to avoid collisions
+        val fileNames = fileNamesInput.distinctBy { it.lowercase(Locale.US) }
         fileNames.forEach { name ->
             File(fakeSrcDir, name).writeText(name.reversed())
         }
@@ -231,7 +233,7 @@ internal class FileMoverTest {
         fakeSrcDir.mkdirs()
         assumeFalse(fakeDstDir.exists())
 
-        // in case of file system is not case-sensitive, we need to drop all duplicates
+        // on case-insensitive file systems, deduplicate names to avoid collisions
         val fileNames = fileNamesInput.distinctBy { it.lowercase(Locale.US) }
         fileNames.forEach { name ->
             File(fakeSrcDir, name).writeText(name.reversed())


### PR DESCRIPTION
This was something on my todo list from a failed pipeline I saw some weeks ago. It just aligns with the other test which was already removing duplicates.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

