### PR TITLE
RUM-14814: Use AlwaysFullView as default RumViewEventWriteConfig

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -814,7 +814,7 @@ internal class RumFeature(
             disableJankStats = false,
             insightsCollector = NoOpInsightsCollector(),
             appStartupActivityPredicate = DefaultAppStartupActivityPredicate,
-            rumViewEventWriteConfig = RumViewEventWriteConfig.FullViewOnlyAtStart
+            rumViewEventWriteConfig = RumViewEventWriteConfig.AlwaysFullView
         )
 
         internal const val EVENT_MESSAGE_PROPERTY = "message"

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/AlwaysFullViewWriterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/AlwaysFullViewWriterTest.kt
@@ -1,0 +1,275 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.domain.scope
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.EventWriteScope
+import com.datadog.android.api.storage.DataWriter
+import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
+import com.datadog.android.rum.configuration.RumViewEventWriteConfig
+import com.datadog.android.rum.event.ViewEventMapper
+import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.rum.utils.config.GlobalRumMonitorTestConfiguration
+import com.datadog.android.rum.utils.forge.Configurator
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class AlwaysFullViewWriterTest {
+
+    lateinit var testedWriter: RumViewEventWriter
+
+    @Mock
+    lateinit var mockViewEventMapper: ViewEventMapper
+
+    @Mock
+    lateinit var mockEventWriteScope: EventWriteScope
+
+    @Mock
+    lateinit var mockDataWriter: DataWriter<Any>
+
+    @Mock
+    lateinit var mockEventBatchWriter: EventBatchWriter
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @Forgery
+    lateinit var fakeDatadogContext: DatadogContext
+
+    @Forgery
+    lateinit var fakeEventType: EventType
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(mockEventWriteScope.invoke(any())) doAnswer {
+            val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
+            callback.invoke(mockEventBatchWriter)
+        }
+        whenever(rumMonitor.mockSdkCore.internalLogger) doReturn mockInternalLogger
+        testedWriter = RumViewEventWriterImpl(
+            config = RumViewEventWriteConfig.AlwaysFullView,
+            viewEventMapper = mockViewEventMapper,
+            sdkCore = rumMonitor.mockSdkCore
+        )
+    }
+
+    @Test
+    fun `M write full view event W single write`(
+        @Forgery fakeViewEvent: ViewEvent
+    ) {
+        // Given
+        whenever(mockViewEventMapper.map(fakeViewEvent)) doReturn fakeViewEvent
+        val writtenEvents = mutableListOf<Any>()
+        whenever(mockDataWriter.write(eq(mockEventBatchWriter), any(), eq(fakeEventType))) doAnswer {
+            writtenEvents += it.getArgument<Any>(1)
+            true
+        }
+
+        // When
+        testedWriter.writeViewEvent(
+            viewEvent = fakeViewEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+
+        // Then
+        assertThat(writtenEvents).hasSize(1)
+        assertThat(writtenEvents[0]).isInstanceOf(MappedViewEvent::class.java)
+    }
+
+    @Test
+    fun `M always write full view W two consecutive writes succeed`(
+        @Forgery fakeViewEvent: ViewEvent,
+        forge: Forge
+    ) {
+        // Given
+        val secondEvent = fakeViewEvent.copy(
+            view = fakeViewEvent.view.copy(
+                action = ViewEvent.Action(fakeViewEvent.view.action.count + forge.aPositiveLong(strict = true))
+            )
+        )
+        whenever(mockViewEventMapper.map(fakeViewEvent)) doReturn fakeViewEvent
+        whenever(mockViewEventMapper.map(secondEvent)) doReturn secondEvent
+        val writtenEvents = mutableListOf<Any>()
+        whenever(mockDataWriter.write(eq(mockEventBatchWriter), any(), eq(fakeEventType))) doAnswer {
+            writtenEvents += it.getArgument<Any>(1)
+            true
+        }
+
+        // When
+        testedWriter.writeViewEvent(
+            viewEvent = fakeViewEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+        testedWriter.writeViewEvent(
+            viewEvent = secondEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+
+        // Then
+        assertThat(writtenEvents[0]).isInstanceOf(MappedViewEvent::class.java)
+        assertThat(writtenEvents[1]).isInstanceOf(MappedViewEvent::class.java)
+    }
+
+    @Test
+    fun `M always write full view W previous write failed`(
+        @Forgery fakeViewEvent: ViewEvent,
+        forge: Forge
+    ) {
+        // Given
+        val secondEvent = fakeViewEvent.copy(
+            view = fakeViewEvent.view.copy(
+                action = ViewEvent.Action(fakeViewEvent.view.action.count + forge.aPositiveLong(strict = true))
+            )
+        )
+        whenever(mockViewEventMapper.map(fakeViewEvent)) doReturn fakeViewEvent
+        whenever(mockViewEventMapper.map(secondEvent)) doReturn secondEvent
+        val writtenEvents = mutableListOf<Any>()
+        whenever(mockDataWriter.write(eq(mockEventBatchWriter), any(), eq(fakeEventType))) doAnswer {
+            writtenEvents += it.getArgument<Any>(1)
+            if (writtenEvents.size == 1) {
+                false
+            } else {
+                true
+            }
+        }
+
+        // When
+        testedWriter.writeViewEvent(
+            viewEvent = fakeViewEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+        testedWriter.writeViewEvent(
+            viewEvent = secondEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+
+        // Then
+        assertThat(writtenEvents[0]).isInstanceOf(MappedViewEvent::class.java)
+        assertThat(writtenEvents[1]).isInstanceOf(MappedViewEvent::class.java)
+    }
+
+    @Test
+    fun `M always write full view W many consecutive writes`(
+        @Forgery fakeViewEvent: ViewEvent,
+        forge: Forge
+    ) {
+        // Given
+        val fakeCount = forge.anInt(min = 3, max = 10)
+        val events = (0 until fakeCount).scan(fakeViewEvent) { prev, _ ->
+            prev.copy(
+                view = prev.view.copy(
+                    action = ViewEvent.Action(prev.view.action.count + forge.aPositiveLong(strict = true))
+                )
+            )
+        }
+        events.forEach { event ->
+            whenever(mockViewEventMapper.map(event)) doReturn event
+        }
+        val writtenEvents = mutableListOf<Any>()
+        whenever(mockDataWriter.write(eq(mockEventBatchWriter), any(), eq(fakeEventType))) doAnswer {
+            writtenEvents += it.getArgument<Any>(1)
+            true
+        }
+
+        // When
+        events.forEach { event ->
+            testedWriter.writeViewEvent(
+                viewEvent = event,
+                datadogContext = fakeDatadogContext,
+                writeScope = mockEventWriteScope,
+                writer = mockDataWriter,
+                eventType = fakeEventType
+            )
+        }
+
+        // Then
+        assertThat(writtenEvents).hasSize(events.size)
+        writtenEvents.forEach { written ->
+            assertThat(written).isInstanceOf(MappedViewEvent::class.java)
+        }
+    }
+
+    @Test
+    fun `M fallback to original view event W mapper throws exception`(
+        @Forgery fakeViewEvent: ViewEvent
+    ) {
+        // Given
+        whenever(mockViewEventMapper.map(fakeViewEvent)) doThrow IllegalStateException("mapper failure")
+        val writtenEvents = mutableListOf<Any>()
+        whenever(mockDataWriter.write(eq(mockEventBatchWriter), any(), eq(fakeEventType))) doAnswer {
+            writtenEvents += it.getArgument<Any>(1)
+            true
+        }
+
+        // When
+        testedWriter.writeViewEvent(
+            viewEvent = fakeViewEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+
+        // Then
+        assertThat(writtenEvents).hasSize(1)
+        assertThat(writtenEvents[0]).isEqualTo(MappedViewEvent(fakeViewEvent))
+    }
+
+    companion object {
+        val rumMonitor = GlobalRumMonitorTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(rumMonitor)
+        }
+    }
+}

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
@@ -14,6 +14,8 @@ import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.log.Logger
 import com.datadog.android.log.LogsConfiguration
 import com.datadog.android.rum.RumConfiguration
+import com.datadog.android.rum._RumInternalProxy
+import com.datadog.android.rum.configuration.RumViewEventWriteConfig
 import com.datadog.android.sessionreplay.SessionReplayConfiguration
 import com.datadog.android.trace.DatadogTracing
 import com.datadog.android.trace.TraceConfiguration
@@ -75,6 +77,12 @@ internal object RuntimeConfig {
     fun rumConfigBuilder(): RumConfiguration.Builder {
         return RumConfiguration.Builder(APP_ID)
             .useCustomEndpoint(rumEndpointUrl)
+            .apply {
+                _RumInternalProxy.setRumViewEventWriteConfig(
+                    builder = this@apply,
+                    config = RumViewEventWriteConfig.FullViewOnlyAtStart
+                )
+            }
     }
 
     fun sessionReplayConfigBuilder(sampleRate: Float): SessionReplayConfiguration.Builder {

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ActivityViewTrackingAlwaysFullViewTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ActivityViewTrackingAlwaysFullViewTest.kt
@@ -1,0 +1,172 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.integration
+
+import android.app.Activity
+import android.app.Application
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.core.stub.StubSDKCore
+import com.datadog.android.rum.Rum
+import com.datadog.android.rum.RumConfiguration
+import com.datadog.android.rum._RumInternalProxy
+import com.datadog.android.rum.configuration.RumViewEventWriteConfig
+import com.datadog.android.rum.integration.tests.assertj.hasRumEvent
+import com.datadog.android.rum.integration.tests.elmyr.RumIntegrationForgeConfigurator
+import com.datadog.android.rum.integration.tests.utils.MainLooperTestConfiguration
+import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
+import com.datadog.android.tests.assertj.StubEventsAssert.Companion.assertThat
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.verify
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@ForgeConfiguration(RumIntegrationForgeConfigurator::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ActivityViewTrackingAlwaysFullViewTest {
+
+    private lateinit var stubSdkCore: StubSDKCore
+
+    private lateinit var testedViewTrackingStrategy: ActivityViewTrackingStrategy
+
+    @Mock
+    lateinit var stubActivity: StubActivity
+
+    @Mock
+    lateinit var mockApplicationContext: Application
+
+    @StringForgery
+    private lateinit var fakeApplicationId: String
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        stubSdkCore = StubSDKCore(forge)
+
+        val fakeRumConfiguration = RumConfiguration.Builder(fakeApplicationId)
+            .trackNonFatalAnrs(false) // required to prevent infinite loop in tests
+            .apply {
+                _RumInternalProxy.setRumViewEventWriteConfig(
+                    builder = this@apply,
+                    config = RumViewEventWriteConfig.AlwaysFullView
+                )
+            }
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+
+        testedViewTrackingStrategy = ActivityViewTrackingStrategy(true)
+        testedViewTrackingStrategy.register(stubSdkCore, mockApplicationContext)
+        verify(mockApplicationContext).registerActivityLifecycleCallbacks(testedViewTrackingStrategy)
+    }
+
+    @AfterEach
+    fun `tear down`() {
+        testedViewTrackingStrategy.unregister(mockApplicationContext)
+        verify(mockApplicationContext).unregisterActivityLifecycleCallbacks(testedViewTrackingStrategy)
+    }
+
+    // region Activity Lifecycle
+
+    @RepeatedTest(4)
+    fun `M send RUM View W onActivityResumed()`() {
+        // Given
+
+        // When
+        testedViewTrackingStrategy.onActivityResumed(stubActivity)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(1)
+            .hasRumEvent(index = 0) {
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl("com/datadog/android/rum/integration/ActivityViewTrackingAlwaysFullViewTest/StubActivity")
+                hasViewName("com.datadog.android.rum.integration.ActivityViewTrackingAlwaysFullViewTest.StubActivity")
+            }
+    }
+
+    @RepeatedTest(4)
+    fun `M send RUM View update W onActivityResumed() + onActivityStopped()`() {
+        // Given
+
+        // When
+        testedViewTrackingStrategy.onActivityResumed(stubActivity)
+        testedViewTrackingStrategy.onActivityStopped(stubActivity)
+        Thread.sleep(250L)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(2)
+            .hasRumEvent(index = 0) {
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl("com/datadog/android/rum/integration/ActivityViewTrackingAlwaysFullViewTest/StubActivity")
+                hasViewName("com.datadog.android.rum.integration.ActivityViewTrackingAlwaysFullViewTest.StubActivity")
+            }
+            .hasRumEvent(index = 1) {
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl("com/datadog/android/rum/integration/ActivityViewTrackingAlwaysFullViewTest/StubActivity")
+                hasViewName("com.datadog.android.rum.integration.ActivityViewTrackingAlwaysFullViewTest.StubActivity")
+                hasViewIsActive(false)
+            }
+    }
+
+    @RepeatedTest(4)
+    fun `M not send RUM View update W onActivityStopped() {start not tracked}`() {
+        // Given
+
+        // When
+        testedViewTrackingStrategy.onActivityStopped(stubActivity)
+        Thread.sleep(250L)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten).hasSize(0)
+    }
+
+    // endregion
+
+    class StubActivity : Activity()
+
+    companion object {
+        private val mainLooper = MainLooperTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(mainLooper)
+        }
+    }
+}

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ActivityViewTrackingStrategyTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ActivityViewTrackingStrategyTest.kt
@@ -12,6 +12,8 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.core.stub.StubSDKCore
 import com.datadog.android.rum.Rum
 import com.datadog.android.rum.RumConfiguration
+import com.datadog.android.rum._RumInternalProxy
+import com.datadog.android.rum.configuration.RumViewEventWriteConfig
 import com.datadog.android.rum.integration.tests.assertj.hasRumEvent
 import com.datadog.android.rum.integration.tests.assertj.hasRumViewUpdateEvent
 import com.datadog.android.rum.integration.tests.elmyr.RumIntegrationForgeConfigurator
@@ -65,6 +67,12 @@ class ActivityViewTrackingStrategyTest {
 
         val fakeRumConfiguration = RumConfiguration.Builder(fakeApplicationId)
             .trackNonFatalAnrs(false)
+            .apply {
+                _RumInternalProxy.setRumViewEventWriteConfig(
+                    builder = this@apply,
+                    config = RumViewEventWriteConfig.FullViewOnlyAtStart
+                )
+            }
             .build()
         Rum.enable(fakeRumConfiguration, stubSdkCore)
 

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingAlwaysFullViewRumTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingAlwaysFullViewRumTest.kt
@@ -1,0 +1,947 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.integration
+
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.core.stub.StubSDKCore
+import com.datadog.android.rum.ExperimentalRumApi
+import com.datadog.android.rum.GlobalRumMonitor
+import com.datadog.android.rum.Rum
+import com.datadog.android.rum.RumActionType
+import com.datadog.android.rum.RumConfiguration
+import com.datadog.android.rum.RumErrorSource
+import com.datadog.android.rum.RumResourceKind
+import com.datadog.android.rum.RumResourceMethod
+import com.datadog.android.rum._RumInternalProxy
+import com.datadog.android.rum.configuration.RumViewEventWriteConfig
+import com.datadog.android.rum.integration.tests.assertj.hasRumEvent
+import com.datadog.android.rum.integration.tests.elmyr.RumIntegrationForgeConfigurator
+import com.datadog.android.rum.integration.tests.utils.MainLooperTestConfiguration
+import com.datadog.android.rum.internal.monitor.AdvancedNetworkRumMonitor
+import com.datadog.android.rum.resource.ResourceId
+import com.datadog.android.tests.assertj.StubEventsAssert.Companion.assertThat
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.FloatForgery
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+import java.net.URL
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@ForgeConfiguration(RumIntegrationForgeConfigurator::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ManualTrackingAlwaysFullViewRumTest {
+
+    private lateinit var stubSdkCore: StubSDKCore
+
+    @StringForgery
+    private lateinit var fakeApplicationId: String
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        stubSdkCore = StubSDKCore(forge)
+
+        val fakeRumConfiguration = RumConfiguration.Builder(fakeApplicationId)
+            .trackNonFatalAnrs(false)
+            .apply {
+                _RumInternalProxy.setRumViewEventWriteConfig(
+                    builder = this@apply,
+                    config = RumViewEventWriteConfig.AlwaysFullView
+                )
+            }
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+    }
+
+    // region Feature Init
+
+    @RepeatedTest(16)
+    fun `M create a GlobalRumMonitor W Rum#enable()`() {
+        // Given
+
+        // When
+        val result = GlobalRumMonitor.get(stubSdkCore)
+
+        // Then
+        // We use reflection because that class is marked internal
+        val classDatadogRum = Class.forName("com.datadog.android.rum.internal.monitor.DatadogRumMonitor")
+        assertThat(result).isInstanceOf(classDatadogRum)
+    }
+
+    // endregion
+
+    // region Basic Scenarios
+
+    @RepeatedTest(16)
+    fun `M send view event W startView()`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String
+    ) {
+        // When
+        GlobalRumMonitor.get(stubSdkCore).startView(viewKey, viewName)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(1)
+            .hasRumEvent(index = 0) {
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+            }
+    }
+
+    @RepeatedTest(16)
+    fun `M send view event W startView() + stopView()`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String
+    ) {
+        // Given
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        rumMonitor.startView(viewKey, viewName)
+        rumMonitor.stopView(viewKey)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(2)
+            .hasRumEvent(index = 0) {
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasViewIsActive(true)
+                hasDocumentVersion(2)
+            }
+            .hasRumEvent(index = 1) {
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasViewIsActive(false)
+                hasDocumentVersion(3)
+            }
+    }
+
+    @RepeatedTest(16)
+    fun `M send view event with feature flag W startView() + addFeatureFlagEvaluation()`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String,
+        @StringForgery ffKey: String,
+        @StringForgery ffValue: String
+    ) {
+        // Given
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        rumMonitor.startView(viewKey, viewName)
+        rumMonitor.addFeatureFlagEvaluation(ffKey, ffValue)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        print(eventsWritten[1].eventData)
+        assertThat(eventsWritten)
+            .hasSize(2)
+            .hasRumEvent(index = 0) {
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                doesNotHaveField("feature_flag")
+                hasDocumentVersion(2)
+            }
+            .hasRumEvent(index = 1) {
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasFeatureFlag(ffKey, ffValue)
+                hasDocumentVersion(3)
+            }
+    }
+
+    @RepeatedTest(16)
+    fun `M send view event with action W startView() + addAction()`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String,
+        @StringForgery actionName: String
+    ) {
+        // Given
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        rumMonitor.startView(viewKey, viewName)
+        rumMonitor.addAction(RumActionType.CUSTOM, actionName)
+        rumMonitor.stopView(viewKey)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(4)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionCount(0)
+                hasDocumentVersion(2)
+            }
+            .hasRumEvent(index = 1) {
+                // Custom event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("action")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionName(actionName)
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionCount(1)
+                doesNotHaveField("feature_flag")
+                hasDocumentVersion(3)
+            }
+            .hasRumEvent(index = 3) {
+                // View updated on stopView
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasActionCount(1)
+                hasViewName(viewName)
+                hasDocumentVersion(4)
+            }
+    }
+
+    @Test
+    fun `M send view events with actions W startView() + multiple addAction()`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String,
+        @StringForgery actionName1: String,
+        @StringForgery actionName2: String
+    ) {
+        // Given
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        rumMonitor.startView(viewKey, viewName)
+        // Each CUSTOM action must be written immediately. In particular the last action
+        // must not be lost just because no further event triggers an inactivity timeout.
+        rumMonitor.addAction(RumActionType.CUSTOM, actionName1)
+        rumMonitor.addAction(RumActionType.CUSTOM, actionName2)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(5)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionCount(0)
+                hasDocumentVersion(2)
+            }
+            .hasRumEvent(index = 1) {
+                // First custom action
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("action")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionName(actionName1)
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with first action
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionCount(1)
+                hasDocumentVersion(3)
+            }
+            .hasRumEvent(index = 3) {
+                // Second custom action
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("action")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionName(actionName2)
+            }
+            .hasRumEvent(index = 4) {
+                // View updated with second action
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionCount(2)
+                hasDocumentVersion(4)
+            }
+    }
+
+    @RepeatedTest(16)
+    fun `M send view event with error W startView() + addError()`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String,
+        @StringForgery errorMessage: String,
+        @Forgery errorSource: RumErrorSource,
+        @Forgery exception: Exception
+    ) {
+        // Given
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        rumMonitor.startView(viewKey, viewName)
+        rumMonitor.addError(errorMessage, errorSource, exception)
+        rumMonitor.stopView(viewKey)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(4)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionCount(0)
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // Custom event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("error")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasErrorCount(1)
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 3) {
+                // View updated with FF
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+            }
+    }
+
+    @RepeatedTest(16)
+    fun `M send view event with resource W startView() + startResource() + stopResource()`(
+        @StringForgery key: String,
+        @StringForgery name: String,
+        @StringForgery resourceKey: String,
+        @Forgery resourceUrl: URL,
+        @IntForgery(200, 599) resourceStatus: Int,
+        @LongForgery(0) resourceSize: Long
+    ) {
+        // Given
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        rumMonitor.startView(key, name)
+        rumMonitor.startResource(resourceKey, RumResourceMethod.GET, resourceUrl.toString())
+        stubSdkCore.advanceTimeBy(100)
+        rumMonitor.stopResource(resourceKey, resourceStatus, resourceSize, RumResourceKind.NATIVE)
+        rumMonitor.stopView(key)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(4)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(key)
+                hasViewName(name)
+                hasActionCount(0)
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // Custom event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("resource")
+                hasViewUrl(key)
+                hasViewName(name)
+                hasResourceUrl(resourceUrl.toString())
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(key)
+                hasViewName(name)
+                hasResourceCount(1)
+            }
+            .hasRumEvent(index = 3) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(key)
+                hasViewName(name)
+            }
+    }
+
+    @RepeatedTest(16)
+    fun `M send view event with resource W startView() + startResource() + stopResource() {using ResourceId}`(
+        @StringForgery key: String,
+        @StringForgery name: String,
+        @StringForgery resourceKey: String,
+        @Forgery resourceUuid: UUID,
+        @Forgery resourceUrl: URL,
+        @IntForgery(200, 599) resourceStatus: Int,
+        @LongForgery(0) resourceSize: Long
+    ) {
+        // Given
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore) as AdvancedNetworkRumMonitor
+        val resourceId = ResourceId(resourceKey, resourceUuid.toString())
+
+        // When
+        rumMonitor.startView(key, name)
+        rumMonitor.startResource(resourceId, RumResourceMethod.GET, resourceUrl.toString())
+        stubSdkCore.advanceTimeBy(100)
+        rumMonitor.stopResource(resourceId, resourceStatus, resourceSize, RumResourceKind.NATIVE)
+        rumMonitor.stopView(key)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(4)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(key)
+                hasViewName(name)
+                hasActionCount(0)
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // Custom event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("resource")
+                hasViewUrl(key)
+                hasViewName(name)
+                hasResourceUrl(resourceUrl.toString())
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(key)
+                hasViewName(name)
+                hasResourceCount(1)
+            }
+            .hasRumEvent(index = 3) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(key)
+                hasViewName(name)
+            }
+    }
+
+    // endregion
+
+    // region AddViewLoading time
+
+    @OptIn(ExperimentalRumApi::class)
+    @Test
+    fun `M attach view loading time W addViewLoadingTime { active view available }`(
+        @StringForgery key: String,
+        @StringForgery name: String,
+        @BoolForgery overwrite: Boolean
+    ) {
+        // Given
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+        rumMonitor.startView(key, name)
+
+        // When
+        stubSdkCore.advanceTimeBy(100)
+        val expectedViewLoadingTime = TimeUnit.MILLISECONDS.toNanos(100)
+        rumMonitor.addViewLoadingTime(overwrite)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(2)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(key)
+                hasViewName(name)
+                hasActionCount(0)
+                doesNotHaveViewLoadingTime()
+            }
+            .hasRumEvent(index = 1) {
+                // view updated with loading time
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(key)
+                hasViewName(name)
+                hasViewLoadingTime(
+                    expectedViewLoadingTime,
+                    offset = Offset.offset(TimeUnit.MILLISECONDS.toNanos(5))
+                )
+            }
+    }
+
+    @OptIn(ExperimentalRumApi::class)
+    @Test
+    fun `M not attach view loading time W addViewLoadingTime { view was stopped }`(
+        @StringForgery key: String,
+        @StringForgery name: String,
+        @BoolForgery overwrite: Boolean
+    ) {
+        // Given
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+        rumMonitor.startView(key, name)
+        rumMonitor.stopView(key)
+
+        // When
+        rumMonitor.addViewLoadingTime(overwrite)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(2)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(key)
+                hasViewName(name)
+                hasActionCount(0)
+                doesNotHaveViewLoadingTime()
+            }
+            .hasRumEvent(index = 1) {
+                // view stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(key)
+                hasViewName(name)
+                doesNotHaveViewLoadingTime()
+            }
+    }
+
+    @OptIn(ExperimentalRumApi::class)
+    @Test
+    fun `M renew view loading time W addViewLoadingTime { loading time was already added, overwrite is true }`(
+        @StringForgery key: String,
+        @StringForgery name: String,
+        @BoolForgery overwrite: Boolean
+    ) {
+        // Given
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+        rumMonitor.startView(key, name)
+        stubSdkCore.advanceTimeBy(50)
+        rumMonitor.addViewLoadingTime(overwrite)
+
+        // When
+        stubSdkCore.advanceTimeBy(50)
+        rumMonitor.addViewLoadingTime(true)
+
+        // Then
+        val expectedFirstViewLoadingTime = TimeUnit.MILLISECONDS.toNanos(50)
+        val expectedSecondViewLoadingTime = TimeUnit.MILLISECONDS.toNanos(100)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(3)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(key)
+                hasViewName(name)
+                hasActionCount(0)
+                doesNotHaveViewLoadingTime()
+            }
+            .hasRumEvent(index = 1) {
+                // first view loading time
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(key)
+                hasViewName(name)
+                hasViewLoadingTime(
+                    expectedFirstViewLoadingTime,
+                    offset = Offset.offset(TimeUnit.MILLISECONDS.toNanos(5))
+                )
+            }
+            .hasRumEvent(index = 2) {
+                // second view loading time
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(key)
+                hasViewName(name)
+                hasViewLoadingTime(
+                    expectedSecondViewLoadingTime,
+                    offset = Offset.offset(TimeUnit.MILLISECONDS.toNanos(5))
+                )
+            }
+    }
+
+    @OptIn(ExperimentalRumApi::class)
+    @Test
+    fun `M not renew view loading time W addViewLoadingTime { loading time was already added, overwrite is false }`(
+        @StringForgery key: String,
+        @StringForgery name: String,
+        @BoolForgery overwrite: Boolean
+    ) {
+        // Given
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+        rumMonitor.startView(key, name)
+        stubSdkCore.advanceTimeBy(50)
+        rumMonitor.addViewLoadingTime(overwrite)
+
+        // When
+        stubSdkCore.advanceTimeBy(50)
+        rumMonitor.addViewLoadingTime(false)
+
+        // Then
+        val expectedViewLoadingTime = TimeUnit.MILLISECONDS.toNanos(50)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(2)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(key)
+                hasViewName(name)
+                hasActionCount(0)
+                doesNotHaveViewLoadingTime()
+            }
+            .hasRumEvent(index = 1) {
+                // first view loading time
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(key)
+                hasViewName(name)
+                hasViewLoadingTime(
+                    expectedViewLoadingTime,
+                    offset = Offset.offset(TimeUnit.MILLISECONDS.toNanos(5))
+                )
+            }
+    }
+
+    @Test
+    fun `M send view event with user Info W set user Info`(
+        forge: Forge,
+        @StringForgery key: String,
+        @StringForgery name: String,
+        @StringForgery fakeUserId: String,
+        @StringForgery fakeUserName: String,
+        @StringForgery fakeUserEmail: String
+    ) {
+        // Given
+        val userAdditionalAttributes = forge.aMap {
+            Pair(this.anAlphabeticalString(), this.anAlphabeticalString())
+        }
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore) as AdvancedNetworkRumMonitor
+        stubSdkCore.setUserInfo(
+            fakeUserId,
+            fakeUserName,
+            fakeUserEmail,
+            userAdditionalAttributes
+        )
+
+        // When
+        rumMonitor.startView(key, name)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(1)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(key)
+                hasViewName(name)
+                hasUsrId(fakeUserId)
+                hasUsrName(fakeUserName)
+                hasUsrEmail(fakeUserEmail)
+                userAdditionalAttributes.forEach { key, value ->
+                    hasUsrAdditionalAttributes(key, value)
+                }
+                hasActionCount(0)
+                doesNotHaveField("feature_flag")
+            }
+    }
+
+    @Test
+    fun `M send view event with account Info W set account Info`(
+        forge: Forge,
+        @StringForgery key: String,
+        @StringForgery name: String,
+        @StringForgery fakeAccountId: String,
+        @StringForgery fakeAccountName: String
+    ) {
+        // Given
+        val accountExtraInfo = forge.aMap {
+            Pair(this.anAlphabeticalString(), this.anAlphabeticalString())
+        }
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore) as AdvancedNetworkRumMonitor
+        stubSdkCore.setAccountInfo(fakeAccountId, fakeAccountName, accountExtraInfo)
+
+        // When
+        rumMonitor.startView(key, name)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(1)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(key)
+                hasViewName(name)
+                hasAccountId(fakeAccountId)
+                hasAccountName(fakeAccountName)
+                accountExtraInfo.forEach { key, value ->
+                    hasAccountExtraInfo(key, value)
+                }
+                hasActionCount(0)
+                doesNotHaveField("feature_flag")
+            }
+    }
+    // endregion
+
+    // region Sample Rates
+
+    @RepeatedTest(16)
+    fun `M send view event with sessionReplaySampleRate W startView() + stopView() { SR context set }`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String,
+        @LongForgery(min = 0L, max = 100L) fakeSrSampleRate: Long
+    ) {
+        // Given
+        stubSdkCore.updateFeatureContext(Feature.SESSION_REPLAY_FEATURE_NAME) {
+            it["session_replay_sample_rate"] = fakeSrSampleRate
+        }
+
+        // When
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+        rumMonitor.startView(viewKey, viewName)
+        rumMonitor.stopView(viewKey)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasRumEvent(index = 1) {
+                hasType("view")
+                hasSessionReplaySampleRate(fakeSrSampleRate)
+            }
+    }
+
+    @RepeatedTest(16)
+    fun `M send view event with traceSampleRate W startView() + stopView() { tracing context set }`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String,
+        @FloatForgery(min = 0f, max = 100f) fakeTraceSampleRate: Float
+    ) {
+        // Given
+        stubSdkCore.updateFeatureContext(Feature.TRACING_FEATURE_NAME) {
+            it["okhttp_interceptor_sample_rate"] = fakeTraceSampleRate
+        }
+
+        // When
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+        rumMonitor.startView(viewKey, viewName)
+        rumMonitor.stopView(viewKey)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasRumEvent(index = 1) {
+                hasType("view")
+                hasTraceSampleRate(fakeTraceSampleRate)
+            }
+    }
+
+    @RepeatedTest(16)
+    fun `M send view event with no sample rates W startView() + stopView() { no SR or tracing context }`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String
+    ) {
+        // When
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+        rumMonitor.startView(viewKey, viewName)
+        rumMonitor.stopView(viewKey)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasRumEvent(index = 1) {
+                hasType("view")
+                doesNotHaveSessionReplaySampleRate()
+                doesNotHaveTraceSampleRate()
+            }
+    }
+
+    // endregion
+
+    companion object {
+        private val mainLooper = MainLooperTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(mainLooper)
+        }
+    }
+}

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingRumTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingRumTest.kt
@@ -16,6 +16,8 @@ import com.datadog.android.rum.RumConfiguration
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
+import com.datadog.android.rum._RumInternalProxy
+import com.datadog.android.rum.configuration.RumViewEventWriteConfig
 import com.datadog.android.rum.integration.tests.assertj.hasRumEvent
 import com.datadog.android.rum.integration.tests.assertj.hasRumViewUpdateEvent
 import com.datadog.android.rum.integration.tests.elmyr.RumIntegrationForgeConfigurator
@@ -71,6 +73,12 @@ class ManualTrackingRumTest {
 
         val fakeRumConfiguration = RumConfiguration.Builder(fakeApplicationId)
             .trackNonFatalAnrs(false)
+            .apply {
+                _RumInternalProxy.setRumViewEventWriteConfig(
+                    builder = this@apply,
+                    config = RumViewEventWriteConfig.FullViewOnlyAtStart
+                )
+            }
             .build()
         Rum.enable(fakeRumConfiguration, stubSdkCore)
     }

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/RumResourceInputStreamAlwaysFullViewTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/RumResourceInputStreamAlwaysFullViewTest.kt
@@ -1,0 +1,189 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.integration
+
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.core.stub.StubSDKCore
+import com.datadog.android.rum.GlobalRumMonitor
+import com.datadog.android.rum.Rum
+import com.datadog.android.rum.RumConfiguration
+import com.datadog.android.rum._RumInternalProxy
+import com.datadog.android.rum.configuration.RumViewEventWriteConfig
+import com.datadog.android.rum.integration.tests.assertj.hasRumEvent
+import com.datadog.android.rum.integration.tests.elmyr.RumIntegrationForgeConfigurator
+import com.datadog.android.rum.integration.tests.utils.MainLooperTestConfiguration
+import com.datadog.android.rum.resource.RumResourceInputStream
+import com.datadog.android.tests.assertj.StubEventsAssert.Companion.assertThat
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mockito.mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@ForgeConfiguration(RumIntegrationForgeConfigurator::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RumResourceInputStreamAlwaysFullViewTest {
+
+    private lateinit var stubSdkCore: StubSDKCore
+
+    @StringForgery
+    private lateinit var fakeApplicationId: String
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        stubSdkCore = StubSDKCore(forge)
+        val fakeRumConfiguration = RumConfiguration.Builder(fakeApplicationId)
+            .trackNonFatalAnrs(false)
+            .apply {
+                _RumInternalProxy.setRumViewEventWriteConfig(
+                    builder = this@apply,
+                    config = RumViewEventWriteConfig.AlwaysFullView
+                )
+            }
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+    }
+
+    @RepeatedTest(4)
+    fun `M report RUM Resource W asRumResource()`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String,
+        @StringForgery resourceUrl: String,
+        @StringForgery data: String
+    ) {
+        // Given
+        GlobalRumMonitor.get(stubSdkCore).startView(viewKey, viewName)
+        val input = data.toByteArray()
+        val inputStream = input.inputStream()
+        val rumResourceInputStream = RumResourceInputStream(inputStream, resourceUrl, stubSdkCore)
+        val outputStream = ByteArrayOutputStream(input.size)
+
+        // When
+        rumResourceInputStream.use {
+            it.transferTo(outputStream)
+        }
+
+        // Then
+        assertThat(outputStream.toByteArray()).isEqualTo(input)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten).hasSize(3)
+            .hasRumEvent(index = 0) {
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewName(viewName)
+                hasResourceCount(0)
+            }
+            .hasRumEvent(index = 1) {
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("resource")
+                hasViewName(viewName)
+                hasResourceUrl(resourceUrl)
+            }
+            .hasRumEvent(index = 2) {
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewName(viewName)
+                hasResourceCount(1)
+            }
+    }
+
+    @RepeatedTest(4)
+    fun `M report RUM Error W asRumResource() + read()`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String,
+        @StringForgery resourceUrl: String,
+        @Forgery error: Throwable
+    ) {
+        // Given
+        GlobalRumMonitor.get(stubSdkCore).startView(viewKey, viewName)
+        val inputStream: InputStream = mock()
+        val rumResourceInputStream = RumResourceInputStream(inputStream, resourceUrl, stubSdkCore)
+        whenever(inputStream.read()) doThrow error
+
+        // When
+        var forwardedError: Throwable? = null
+        try {
+            rumResourceInputStream.read()
+        } catch (e: Throwable) {
+            forwardedError = e
+        }
+
+        // Then
+        assertThat(forwardedError).isEqualTo(error)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten).hasSize(3)
+            .hasRumEvent(index = 0) {
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewName(viewName)
+                hasResourceCount(0)
+                hasErrorCount(0)
+            }
+            .hasRumEvent(index = 1) {
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("error")
+                hasViewName(viewName)
+                hasErrorType(error.javaClass.name)
+            }
+            .hasRumEvent(index = 2) {
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewName(viewName)
+                hasResourceCount(0)
+                hasErrorCount(1)
+            }
+    }
+
+    companion object {
+        private val mainLooper = MainLooperTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(mainLooper)
+        }
+    }
+}

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/RumResourceInputStreamTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/RumResourceInputStreamTest.kt
@@ -11,6 +11,8 @@ import com.datadog.android.core.stub.StubSDKCore
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.Rum
 import com.datadog.android.rum.RumConfiguration
+import com.datadog.android.rum._RumInternalProxy
+import com.datadog.android.rum.configuration.RumViewEventWriteConfig
 import com.datadog.android.rum.integration.tests.assertj.hasRumEvent
 import com.datadog.android.rum.integration.tests.assertj.hasRumViewUpdateEvent
 import com.datadog.android.rum.integration.tests.elmyr.RumIntegrationForgeConfigurator
@@ -59,6 +61,12 @@ class RumResourceInputStreamTest {
         stubSdkCore = StubSDKCore(forge)
         val fakeRumConfiguration = RumConfiguration.Builder(fakeApplicationId)
             .trackNonFatalAnrs(false)
+            .apply {
+                _RumInternalProxy.setRumViewEventWriteConfig(
+                    builder = this@apply,
+                    config = RumViewEventWriteConfig.FullViewOnlyAtStart
+                )
+            }
             .build()
         Rum.enable(fakeRumConfiguration, stubSdkCore)
     }

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ViewLoadingTimeMetricsAlwaysFullViewTests.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ViewLoadingTimeMetricsAlwaysFullViewTests.kt
@@ -1,0 +1,1450 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.integration
+
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.core.stub.StubSDKCore
+import com.datadog.android.rum.GlobalRumMonitor
+import com.datadog.android.rum.Rum
+import com.datadog.android.rum.RumActionType
+import com.datadog.android.rum.RumConfiguration
+import com.datadog.android.rum.RumErrorSource
+import com.datadog.android.rum.RumMonitor
+import com.datadog.android.rum.RumResourceKind
+import com.datadog.android.rum.RumResourceMethod
+import com.datadog.android.rum._RumInternalProxy
+import com.datadog.android.rum.configuration.RumViewEventWriteConfig
+import com.datadog.android.rum.integration.tests.assertj.hasRumEvent
+import com.datadog.android.rum.integration.tests.elmyr.RumIntegrationForgeConfigurator
+import com.datadog.android.rum.integration.tests.utils.MainLooperTestConfiguration
+import com.datadog.android.rum.metric.interactiontonextview.LastInteractionIdentifier
+import com.datadog.android.rum.metric.interactiontonextview.PreviousViewLastInteractionContext
+import com.datadog.android.rum.metric.interactiontonextview.TimeBasedInteractionIdentifier
+import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
+import com.datadog.android.rum.metric.networksettled.NetworkSettledResourceContext
+import com.datadog.android.rum.metric.networksettled.TimeBasedInitialResourceIdentifier
+import com.datadog.android.tests.assertj.StubEventsAssert.Companion.assertThat
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.data.Offset
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+import java.util.concurrent.TimeUnit
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@ForgeConfiguration(RumIntegrationForgeConfigurator::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ViewLoadingTimeMetricsAlwaysFullViewTests {
+
+    private lateinit var stubSdkCore: StubSDKCore
+
+    @StringForgery
+    private lateinit var fakeApplicationId: String
+
+    @StringForgery
+    private lateinit var viewKey: String
+
+    @StringForgery
+    private lateinit var viewName: String
+
+    @StringForgery
+    private lateinit var previousViewKey: String
+
+    @StringForgery
+    private lateinit var previousViewName: String
+
+    @StringForgery
+    private lateinit var resourceKey: String
+
+    @StringForgery(regex = "https://[a-z]+/[a-z]+\\.com")
+    private lateinit var resourceUrl: String
+
+    @StringForgery
+    private lateinit var lastInteractionName: String
+
+    @IntForgery(200, 599)
+    private var resourceStatus: Int = 0
+
+    @LongForgery(0)
+    var resourceSize: Long = 0L
+
+    @Forgery
+    private lateinit var rumResourceMethod: RumResourceMethod
+
+    @Forgery
+    private lateinit var rumResourceKind: RumResourceKind
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        stubSdkCore = StubSDKCore(forge)
+    }
+
+    // region Time to network settle
+
+    @RepeatedTest(10)
+    fun `M provide the TTNS metric for each view W initial resource was stopped and sent`() {
+        // Given
+        val fakeRumConfiguration = configurationBuilder()
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val monitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        monitor.startView(viewKey, viewName)
+        monitor.startResource(resourceKey, rumResourceMethod, resourceUrl)
+        stubSdkCore.advanceTimeBy(100)
+        monitor.stopResource(resourceKey, resourceStatus, resourceSize, rumResourceKind)
+        monitor.stopView(viewKey)
+        val appExpectedTtnsTime = TimeUnit.MILLISECONDS.toNanos(100)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(4)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionCount(0)
+                doesNotHaveNetworkSettledTime()
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // Custom event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("resource")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasResourceUrl(resourceUrl)
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasNetworkSettledTime(appExpectedTtnsTime, TTNS_METRIC_OFFSET_IN_NANOSECONDS)
+                hasResourceCount(1)
+            }
+            .hasRumEvent(index = 3) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasNetworkSettledTime(appExpectedTtnsTime, TTNS_METRIC_OFFSET_IN_NANOSECONDS)
+                hasViewName(viewName)
+            }
+    }
+
+    @RepeatedTest(10)
+    fun `M provide consistent TTNS metric for each view event W view updated multiple times`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeRumConfiguration = configurationBuilder()
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val monitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        monitor.startView(viewKey, viewName)
+        monitor.startResource(resourceKey, rumResourceMethod, resourceUrl)
+        stubSdkCore.advanceTimeBy(100)
+        monitor.stopResource(resourceKey, resourceStatus, resourceSize, rumResourceKind)
+        monitor.addTiming(forge.anAlphabeticalString())
+        stubSdkCore.advanceTimeBy(100)
+        monitor.addTiming(forge.anAlphabeticalString())
+        monitor.stopView(viewKey)
+        val appExpectedTtnsTime = TimeUnit.MILLISECONDS.toNanos(100)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(6)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionCount(0)
+                doesNotHaveNetworkSettledTime()
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // Custom event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("resource")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasResourceUrl(resourceUrl)
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasNetworkSettledTime(appExpectedTtnsTime, TTNS_METRIC_OFFSET_IN_NANOSECONDS)
+                hasResourceCount(1)
+            }
+            .hasRumEvent(index = 3) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasNetworkSettledTime(appExpectedTtnsTime, TTNS_METRIC_OFFSET_IN_NANOSECONDS)
+                hasResourceCount(1)
+            }
+            .hasRumEvent(index = 4) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasNetworkSettledTime(appExpectedTtnsTime, TTNS_METRIC_OFFSET_IN_NANOSECONDS)
+                hasResourceCount(1)
+            }
+            .hasRumEvent(index = 5) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasNetworkSettledTime(appExpectedTtnsTime, TTNS_METRIC_OFFSET_IN_NANOSECONDS)
+                hasViewName(viewName)
+            }
+    }
+
+    @RepeatedTest(10)
+    fun `M provide the TTNS metric for each view event W initial resource stopped with error`(
+        @StringForgery errorMessage: String,
+        @Forgery errorSource: RumErrorSource,
+        @Forgery throwable: Throwable
+    ) {
+        // Given
+        val fakeRumConfiguration = configurationBuilder()
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val monitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        monitor.startView(viewKey, viewName)
+        monitor.startResource(resourceKey, rumResourceMethod, resourceUrl)
+        stubSdkCore.advanceTimeBy(100)
+        monitor.stopResourceWithError(resourceKey, resourceStatus, errorMessage, errorSource, throwable)
+        monitor.stopView(viewKey)
+        val appExpectedTtnsTime = TimeUnit.MILLISECONDS.toNanos(100)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(4)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionCount(0)
+                doesNotHaveNetworkSettledTime()
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // Custom event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("error")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasErrorCount(1)
+                hasNetworkSettledTime(appExpectedTtnsTime, TTNS_METRIC_OFFSET_IN_NANOSECONDS)
+                hasResourceCount(0)
+            }
+            .hasRumEvent(index = 3) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasErrorCount(1)
+                hasNetworkSettledTime(appExpectedTtnsTime, TTNS_METRIC_OFFSET_IN_NANOSECONDS)
+                hasViewName(viewName)
+            }
+    }
+
+    @RepeatedTest(10)
+    fun `M not provide the TTNS metric for each view event W resource stopped with error, error dropped by mapper`(
+        @StringForgery errorMessage: String,
+        @Forgery errorSource: RumErrorSource,
+        @Forgery throwable: Throwable
+    ) {
+        // Given
+        val fakeRumConfiguration = configurationBuilder()
+            .setErrorEventMapper { null }
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val monitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        monitor.startView(viewKey, viewName)
+        monitor.startResource(resourceKey, rumResourceMethod, resourceUrl)
+        stubSdkCore.advanceTimeBy(100)
+        monitor.stopResourceWithError(resourceKey, resourceStatus, errorMessage, errorSource, throwable)
+        monitor.stopView(viewKey)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(2)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionCount(0)
+                doesNotHaveNetworkSettledTime()
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasErrorCount(0)
+                doesNotHaveNetworkSettledTime()
+                hasViewName(viewName)
+            }
+    }
+
+    @RepeatedTest(10)
+    fun `M not provide the TTNS metric W initial resource dropped through mapper`() {
+        // Given
+        val fakeRumConfiguration = configurationBuilder()
+            .setResourceEventMapper({ null })
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val monitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        monitor.startView(viewKey, viewName)
+        monitor.startResource(resourceKey, rumResourceMethod, resourceUrl)
+        stubSdkCore.advanceTimeBy(100)
+        monitor.stopResource(resourceKey, resourceStatus, resourceSize, rumResourceKind)
+        monitor.stopView(viewKey)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(2)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionCount(0)
+                doesNotHaveNetworkSettledTime()
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                doesNotHaveNetworkSettledTime()
+                hasViewName(viewName)
+                hasResourceCount(0)
+            }
+    }
+
+    @RepeatedTest(10)
+    fun `M not provide TTNS metric W default identifier, resource dropped`() {
+        // Given
+        val fakeRumConfiguration = configurationBuilder()
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val monitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        monitor.startView(viewKey, viewName)
+        // wait for more than the default threshold in the default identifier (100ms)
+        stubSdkCore.advanceTimeBy(110)
+        monitor.startResource(resourceKey, rumResourceMethod, resourceUrl)
+        stubSdkCore.advanceTimeBy(100)
+        monitor.stopResource(resourceKey, resourceStatus, resourceSize, rumResourceKind)
+        monitor.stopView(viewKey)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(4)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionCount(0)
+                doesNotHaveNetworkSettledTime()
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // Custom event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("resource")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasResourceUrl(resourceUrl.toString())
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                doesNotHaveNetworkSettledTime()
+                hasResourceCount(1)
+            }
+            .hasRumEvent(index = 3) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                doesNotHaveNetworkSettledTime()
+                hasViewName(viewName)
+            }
+    }
+
+    @RepeatedTest(10)
+    fun `M not provide TTNS metric W default identifier, custom threshold, resource dropped`(
+        @LongForgery(min = 100, max = 400) resourceIdentifierThresholdMs: Long
+    ) {
+        // Given
+        val fakeRumConfiguration = configurationBuilder()
+            .setInitialResourceIdentifier(TimeBasedInitialResourceIdentifier(resourceIdentifierThresholdMs))
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val monitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        monitor.startView(viewKey, viewName)
+        // wait for more than the custom threshold
+        stubSdkCore.advanceTimeBy(resourceIdentifierThresholdMs + 10)
+        monitor.startResource(resourceKey, rumResourceMethod, resourceUrl)
+        stubSdkCore.advanceTimeBy(100)
+        monitor.stopResource(resourceKey, resourceStatus, resourceSize, rumResourceKind)
+        monitor.stopView(viewKey)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(4)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionCount(0)
+                doesNotHaveNetworkSettledTime()
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // Custom event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("resource")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasResourceUrl(resourceUrl)
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                doesNotHaveNetworkSettledTime()
+                hasResourceCount(1)
+            }
+            .hasRumEvent(index = 3) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                doesNotHaveNetworkSettledTime()
+                hasViewName(viewName)
+            }
+    }
+
+    @RepeatedTest(10)
+    fun `M not provide TNS metric W custom identifier, not valid resource`() {
+        // Given
+        val fakeRumConfiguration = configurationBuilder()
+            .setInitialResourceIdentifier(object : InitialResourceIdentifier {
+                override fun validate(context: NetworkSettledResourceContext): Boolean {
+                    return false
+                }
+            })
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val monitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        monitor.startView(viewKey, viewName)
+        monitor.startResource(resourceKey, rumResourceMethod, resourceUrl)
+        stubSdkCore.advanceTimeBy(100)
+        monitor.stopResource(resourceKey, resourceStatus, resourceSize, rumResourceKind)
+        monitor.stopView(viewKey)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(4)
+            .hasRumEvent(index = 0) {
+                // Initial view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasActionCount(0)
+                doesNotHaveNetworkSettledTime()
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // Custom event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("resource")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasResourceUrl(resourceUrl)
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                doesNotHaveNetworkSettledTime()
+                hasResourceCount(1)
+            }
+            .hasRumEvent(index = 3) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                doesNotHaveNetworkSettledTime()
+                hasViewName(viewName)
+            }
+    }
+
+    // endregion
+
+    // region Interaction to next view
+
+    @ParameterizedTest
+    @MethodSource("getValidLastInteractionTypes")
+    fun `M provide the ITNV metric for current view W last action on previous view was sent { valid type }`(
+        validActionType: RumActionType
+    ) {
+        // Given
+        val fakeRumConfiguration = configurationBuilder().build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val monitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        val appExpectedItnvTime = runSuccessfulItnvTestScenario(monitor, validActionType)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(6)
+            .hasRumEvent(index = 0) {
+                // Initial previous view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewName(previousViewName)
+                doesNotHaveInteractionToNextViewTime()
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // Action event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("action")
+                hasActionName(lastInteractionName)
+                hasViewName(previousViewName)
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewName(previousViewName)
+                doesNotHaveInteractionToNextViewTime()
+                hasActionCount(1)
+            }
+            .hasRumEvent(index = 3) {
+                // Previous view stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                doesNotHaveInteractionToNextViewTime()
+                hasViewName(previousViewName)
+                hasActionCount(1)
+            }
+            .hasRumEvent(index = 4) {
+                // New View Event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasInteractionToNextViewTime(appExpectedItnvTime, ITNV_METRIC_OFFSET_IN_NANOSECONDS)
+            }
+            .hasRumEvent(index = 5) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasInteractionToNextViewTime(appExpectedItnvTime, ITNV_METRIC_OFFSET_IN_NANOSECONDS)
+                hasViewName(viewName)
+            }
+    }
+
+    @ParameterizedTest
+    @MethodSource("getNonValidLastInteractionTypes")
+    fun `M not provide the ITNV metric for current view W last action on previous view was sent { invalid type }`(
+        invalidActionType: RumActionType
+    ) {
+        // Given
+        val fakeRumConfiguration = configurationBuilder().build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val monitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        runSuccessfulItnvTestScenario(monitor, invalidActionType)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(6)
+            .hasRumEvent(index = 0) {
+                // Initial previous view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewName(previousViewName)
+                doesNotHaveInteractionToNextViewTime()
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // Action event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("action")
+                hasActionName(lastInteractionName)
+                hasViewName(previousViewName)
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewName(previousViewName)
+                doesNotHaveInteractionToNextViewTime()
+                hasActionCount(1)
+            }
+            .hasRumEvent(index = 3) {
+                // Previous view stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                doesNotHaveInteractionToNextViewTime()
+                hasActionCount(1)
+                hasViewName(previousViewName)
+            }
+            .hasRumEvent(index = 4) {
+                // New View Event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                doesNotHaveInteractionToNextViewTime()
+            }
+            .hasRumEvent(index = 5) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                doesNotHaveInteractionToNextViewTime()
+                hasViewName(viewName)
+            }
+    }
+
+    @RepeatedTest(10)
+    fun `M not provide the ITNV metric for current view W last action on previous view was dropped`(
+        forge: Forge
+    ) {
+        // Given
+        val validActionType = forge.aValidLastInteractionActionType()
+        val fakeRumConfiguration = configurationBuilder()
+            .setActionEventMapper { null }
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val monitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        runSuccessfulItnvTestScenario(monitor, validActionType)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(4)
+            .hasRumEvent(index = 0) {
+                // Initial previous view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewName(previousViewName)
+                doesNotHaveInteractionToNextViewTime()
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // Previous view stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                doesNotHaveInteractionToNextViewTime()
+                hasActionCount(0)
+                hasViewName(previousViewName)
+            }
+            .hasRumEvent(index = 2) {
+                // New View Event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                doesNotHaveInteractionToNextViewTime()
+            }
+            .hasRumEvent(index = 3) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                doesNotHaveInteractionToNextViewTime()
+                hasViewName(viewName)
+            }
+    }
+
+    @RepeatedTest(10)
+    fun `M provide the ITNV metric for current view W using custom identifier, action validated`(
+        forge: Forge
+    ) {
+        // Given
+        val validActionType = forge.aValidLastInteractionActionType()
+        val fakeRumConfiguration = configurationBuilder()
+            .setLastInteractionIdentifier(object : LastInteractionIdentifier {
+                override fun validate(context: PreviousViewLastInteractionContext): Boolean {
+                    return true
+                }
+            })
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val monitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        val appExpectedItnvTime = runSuccessfulItnvTestScenario(monitor, validActionType)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(6)
+            .hasRumEvent(index = 0) {
+                // Initial previous view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewName(previousViewName)
+                doesNotHaveInteractionToNextViewTime()
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // Action event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("action")
+                hasActionName(lastInteractionName)
+                hasViewName(previousViewName)
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewName(previousViewName)
+                doesNotHaveInteractionToNextViewTime()
+                hasActionCount(1)
+            }
+            .hasRumEvent(index = 3) {
+                // Previous view stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                doesNotHaveInteractionToNextViewTime()
+                hasActionCount(1)
+                hasViewName(previousViewName)
+            }
+            .hasRumEvent(index = 4) {
+                // New View Event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasInteractionToNextViewTime(appExpectedItnvTime, ITNV_METRIC_OFFSET_IN_NANOSECONDS)
+            }
+            .hasRumEvent(index = 5) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasInteractionToNextViewTime(appExpectedItnvTime, ITNV_METRIC_OFFSET_IN_NANOSECONDS)
+                hasViewName(viewName)
+            }
+    }
+
+    @RepeatedTest(10)
+    fun `M not provide the ITNV metric for current view W using custom identifier, action not validated`(
+        forge: Forge
+    ) {
+        // Given
+        val validActionType = forge.aValidLastInteractionActionType()
+        val fakeRumConfiguration = configurationBuilder()
+            .setLastInteractionIdentifier(object : LastInteractionIdentifier {
+                override fun validate(context: PreviousViewLastInteractionContext): Boolean {
+                    return false
+                }
+            })
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val monitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        runUnsuccessfulItnvTestScenario(monitor, validActionType)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(6)
+            .hasRumEvent(index = 0) {
+                // Initial previous view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewName(previousViewName)
+                doesNotHaveInteractionToNextViewTime()
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // Action event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("action")
+                hasActionName(lastInteractionName)
+                hasViewName(previousViewName)
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewName(previousViewName)
+                doesNotHaveInteractionToNextViewTime()
+                hasActionCount(1)
+            }
+            .hasRumEvent(index = 3) {
+                // Previous view stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                doesNotHaveInteractionToNextViewTime()
+                hasActionCount(1)
+                hasViewName(previousViewName)
+            }
+            .hasRumEvent(index = 4) {
+                // New View Event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                doesNotHaveInteractionToNextViewTime()
+            }
+            .hasRumEvent(index = 5) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                doesNotHaveInteractionToNextViewTime()
+                hasViewName(viewName)
+            }
+    }
+
+    @RepeatedTest(10)
+    fun `M provide the ITNV metric for current view W using time based identifier, threshold respected`(
+        forge: Forge
+    ) {
+        // Given
+        val validActionType = forge.aValidLastInteractionActionType()
+        val fakeRumConfiguration = configurationBuilder()
+            .setLastInteractionIdentifier(TimeBasedInteractionIdentifier())
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val monitor = GlobalRumMonitor.get(stubSdkCore)
+        val appExpectedItnvTime = runSuccessfulItnvTestScenario(monitor, validActionType)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(6)
+            .hasRumEvent(index = 0) {
+                // Initial previous view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewName(previousViewName)
+                doesNotHaveInteractionToNextViewTime()
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // Action event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("action")
+                hasActionName(lastInteractionName)
+                hasViewName(previousViewName)
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewName(previousViewName)
+                doesNotHaveInteractionToNextViewTime()
+                hasActionCount(1)
+            }
+            .hasRumEvent(index = 3) {
+                // Previous view stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                doesNotHaveInteractionToNextViewTime()
+                hasActionCount(1)
+                hasViewName(previousViewName)
+            }
+            .hasRumEvent(index = 4) {
+                // New View Event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                hasInteractionToNextViewTime(appExpectedItnvTime, ITNV_METRIC_OFFSET_IN_NANOSECONDS)
+            }
+            .hasRumEvent(index = 5) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasInteractionToNextViewTime(appExpectedItnvTime, ITNV_METRIC_OFFSET_IN_NANOSECONDS)
+                hasViewName(viewName)
+            }
+    }
+
+    @RepeatedTest(2)
+    fun `M not provide the ITNV metric for current view W using time based identifier, threshold surpassed`(
+        forge: Forge
+    ) {
+        // Given
+        val validActionType = forge.aValidLastInteractionActionType()
+        val fakeRumConfiguration = configurationBuilder()
+            .setLastInteractionIdentifier(TimeBasedInteractionIdentifier())
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val monitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        monitor.startView(previousViewKey, previousViewName)
+        monitor.startAction(validActionType, lastInteractionName)
+        stubSdkCore.advanceTimeBy(100)
+        monitor.stopAction(validActionType, lastInteractionName)
+        monitor.stopView(previousViewKey)
+        // Wait for more than the default threshold in the default identifier (3000ms)
+        stubSdkCore.advanceTimeBy(3010)
+        monitor.startView(viewKey, viewName)
+        stubSdkCore.advanceTimeBy(100)
+        monitor.stopView(viewKey)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(6)
+            .hasRumEvent(index = 0) {
+                // Initial previous view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewName(previousViewName)
+                doesNotHaveInteractionToNextViewTime()
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // Action event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("action")
+                hasActionName(lastInteractionName)
+                hasViewName(previousViewName)
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewName(previousViewName)
+                doesNotHaveInteractionToNextViewTime()
+                hasActionCount(1)
+            }
+            .hasRumEvent(index = 3) {
+                // Previous view stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                doesNotHaveInteractionToNextViewTime()
+                hasActionCount(1)
+                hasViewName(previousViewName)
+            }
+            .hasRumEvent(index = 4) {
+                // New View Event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                doesNotHaveInteractionToNextViewTime()
+            }
+            .hasRumEvent(index = 5) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                doesNotHaveInteractionToNextViewTime()
+                hasViewName(viewName)
+            }
+    }
+
+    @RepeatedTest(2)
+    fun `M not provide the ITNV metric for current view W using time based identifier {custom threshold, failed}`(
+        forge: Forge
+    ) {
+        // Given
+        val customThreshold = forge.aLong(min = 300, max = 4000)
+        val validActionType = forge.aValidLastInteractionActionType()
+        val fakeRumConfiguration = configurationBuilder()
+            .setLastInteractionIdentifier(TimeBasedInteractionIdentifier(customThreshold))
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val monitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        monitor.startView(previousViewKey, previousViewName)
+        monitor.startAction(validActionType, lastInteractionName)
+        stubSdkCore.advanceTimeBy(100)
+        monitor.stopAction(validActionType, lastInteractionName)
+        monitor.stopView(previousViewKey)
+        // Wait for more than the custom threshold
+        stubSdkCore.advanceTimeBy(customThreshold + 10)
+        monitor.startView(viewKey, viewName)
+        stubSdkCore.advanceTimeBy(100)
+        monitor.stopView(viewKey)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
+        assertThat(eventsWritten)
+            .hasSize(6)
+            .hasRumEvent(index = 0) {
+                // Initial previous view
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewName(previousViewName)
+                doesNotHaveInteractionToNextViewTime()
+                doesNotHaveField("feature_flag")
+            }
+            .hasRumEvent(index = 1) {
+                // Action event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("action")
+                hasActionName(lastInteractionName)
+                hasViewName(previousViewName)
+            }
+            .hasRumEvent(index = 2) {
+                // View updated with event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewName(previousViewName)
+                doesNotHaveInteractionToNextViewTime()
+                hasActionCount(1)
+            }
+            .hasRumEvent(index = 3) {
+                // Previous view stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                doesNotHaveInteractionToNextViewTime()
+                hasActionCount(1)
+                hasViewName(previousViewName)
+            }
+            .hasRumEvent(index = 4) {
+                // New View Event
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewName(viewName)
+                doesNotHaveInteractionToNextViewTime()
+            }
+            .hasRumEvent(index = 5) {
+                // View stopped
+                hasService(stubSdkCore.getDatadogContext().service)
+                hasApplicationId(fakeApplicationId)
+                hasSessionType("user")
+                hasSource("android")
+                hasType("view")
+                hasViewUrl(viewKey)
+                doesNotHaveInteractionToNextViewTime()
+                hasViewName(viewName)
+            }
+    }
+
+    // endregion
+
+    // region internals
+
+    private fun Forge.aValidLastInteractionActionType(): RumActionType {
+        return aValueFrom(RumActionType::class.java, exclude = listOf(RumActionType.CUSTOM, RumActionType.SCROLL))
+    }
+
+    private fun runSuccessfulItnvTestScenario(monitor: RumMonitor, rumActionType: RumActionType): Long {
+        monitor.startView(previousViewKey, previousViewName)
+        monitor.startAction(rumActionType, lastInteractionName)
+        stubSdkCore.advanceTimeBy(100)
+        monitor.stopAction(rumActionType, lastInteractionName)
+        monitor.stopView(previousViewKey)
+        stubSdkCore.advanceTimeBy(100)
+        monitor.startView(viewKey, viewName)
+        stubSdkCore.advanceTimeBy(100)
+        monitor.stopView(viewKey)
+        return TimeUnit.MILLISECONDS.toNanos(100)
+    }
+
+    private fun runUnsuccessfulItnvTestScenario(monitor: RumMonitor, rumActionType: RumActionType) {
+        monitor.startView(previousViewKey, previousViewName)
+        monitor.startAction(rumActionType, lastInteractionName)
+        stubSdkCore.advanceTimeBy(100)
+        monitor.stopAction(rumActionType, lastInteractionName)
+        monitor.stopView(previousViewKey)
+        monitor.startView(viewKey, viewName)
+        stubSdkCore.advanceTimeBy(100)
+        monitor.stopView(viewKey)
+    }
+
+    private fun configurationBuilder() = RumConfiguration.Builder(fakeApplicationId)
+        .trackNonFatalAnrs(false)
+        .apply {
+            _RumInternalProxy.setRumViewEventWriteConfig(
+                builder = this@apply,
+                config = RumViewEventWriteConfig.AlwaysFullView
+            )
+        }
+
+    // endregion
+
+    companion object {
+        private val mainLooper = MainLooperTestConfiguration()
+
+        private val TTNS_METRIC_OFFSET_IN_NANOSECONDS = Offset.offset(TimeUnit.MILLISECONDS.toNanos(10))
+        private val ITNV_METRIC_OFFSET_IN_NANOSECONDS = Offset.offset(TimeUnit.MILLISECONDS.toNanos(10))
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(mainLooper)
+        }
+
+        @JvmStatic
+        fun getValidLastInteractionTypes(): List<RumActionType> {
+            return listOf(
+                RumActionType.TAP,
+                RumActionType.SWIPE,
+                RumActionType.CLICK,
+                RumActionType.BACK
+            )
+        }
+
+        @JvmStatic
+        fun getNonValidLastInteractionTypes(): List<RumActionType> {
+            return listOf(
+                RumActionType.SCROLL,
+                RumActionType.CUSTOM
+            )
+        }
+    }
+}

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ViewLoadingTimeMetricsTests.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ViewLoadingTimeMetricsTests.kt
@@ -16,6 +16,8 @@ import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
+import com.datadog.android.rum._RumInternalProxy
+import com.datadog.android.rum.configuration.RumViewEventWriteConfig
 import com.datadog.android.rum.integration.tests.assertj.hasRumEvent
 import com.datadog.android.rum.integration.tests.assertj.hasRumViewUpdateEvent
 import com.datadog.android.rum.integration.tests.elmyr.RumIntegrationForgeConfigurator
@@ -1909,6 +1911,12 @@ class ViewLoadingTimeMetricsTests {
 
     private fun configurationBuilder() = RumConfiguration.Builder(fakeApplicationId)
         .trackNonFatalAnrs(false)
+        .apply {
+            _RumInternalProxy.setRumViewEventWriteConfig(
+                builder = this@apply,
+                config = RumViewEventWriteConfig.FullViewOnlyAtStart
+            )
+        }
 
     // endregion
 


### PR DESCRIPTION
### What does this PR do?

Switches the default `RumViewEventWriteConfig` in `RumFeature` from `FullViewOnlyAtStart` to `AlwaysFullView`, so every view update sends a complete `ViewEvent` payload by default. All tests that rely on partial view update behaviour (`ViewUpdateEvent`) are explicitly opted into `FullViewOnlyAtStart` via `_RumInternalProxy`. Parallel `AlwaysFullView` test variants are added for the reliability single-fit suite so both paths have full coverage and the `FullViewOnlyAtStart` tests can be deleted as a unit when that mode is eventually removed.

### Motivation

The dogfooding branch needs `AlwaysFullView` as the default to simplify validation — full view payloads are easier to inspect and don't require partial-update reconstruction on the backend side. `FullViewOnlyAtStart` remains available for explicit opt-in and will become the default once backend reconstruction is fully validated.

### Additional Notes

- **No API surface changes** — `RumViewEventWriteConfig` sealed interface is unchanged; the default is an internal implementation detail.
- **Tests that assert on `ViewUpdateEvent`** (`ManualTrackingRumTest`, `ViewLoadingTimeMetricsTests`, `ActivityViewTrackingStrategyTest`, `RumResourceInputStreamTest`, instrumented `RuntimeConfig`) now explicitly opt into `FullViewOnlyAtStart` via `_RumInternalProxy.setRumViewEventWriteConfig(...)` — they will continue to work correctly.
- **New `AlwaysFullView` test files** (`ManualTrackingAlwaysFullViewRumTest`, `ActivityViewTrackingAlwaysFullViewTest`, `RumResourceInputStreamAlwaysFullViewTest`, `ViewLoadingTimeMetricsAlwaysFullViewTests`) are copies of the develop-branch versions (full `ViewEvent` assertions). They are designed to be deleted as a unit when `FullViewOnlyAtStart` is removed. Same applies to `AlwaysFullViewWriterTest` at the unit level.
- **`RumViewEventWriterTest`** (existing unit tests) cover `FullViewOnlyAtStart` path and are unchanged.

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)