### PR TITLE
RUM-16470: Bump `latest-api` instrumented test jobs to Android API 37

### DIFF
--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -72,10 +72,12 @@ stages:
     - !reference [ .snippets, setup-gradle ]
     - !reference [ .snippets, setup-dd-ci-cli ]
     - !reference [ .snippets, install-android-api-components ]
+  start-emulator:
+    - $ANDROID_HOME/emulator/emulator -avd "$EMULATOR_NAME" -grpc-use-jwt -no-snapstorage -no-audio -no-window -no-boot-anim -verbose -qemu -machine virt &
   run-legacy-integration-instrumented:
     - set +e
     - exit_code=0
-    - $ANDROID_HOME/emulator/emulator -avd "$EMULATOR_NAME" -grpc-use-jwt -no-snapstorage -no-audio -no-window -no-boot-anim -verbose -qemu -machine virt &
+    - !reference [ .snippets, start-emulator ]
     - DD_TAGS="test.configuration.android_api:$ANDROID_API" ./gradlew :instrumented:integration:connectedDebugAndroidTest $( (( $ANDROID_API <= 23 )) && echo "-Puse-api21-java-backport -Puse-desugaring" ) || exit_code=$?
     - $ANDROID_HOME/platform-tools/adb emu kill
     - datadog-ci junit upload --service dd-sdk-android --tags test.configuration.android_api:$ANDROID_API --xpath-tag test.suite=/testcase/@classname instrumented/integration/build/outputs/androidTest-results/connected/debug/
@@ -84,7 +86,7 @@ stages:
   run-core-it-instrumented:
     - set +e
     - exit_code=0
-    - $ANDROID_HOME/emulator/emulator -avd "$EMULATOR_NAME" -grpc-use-jwt -no-snapstorage -no-audio -no-window -no-boot-anim -verbose -qemu -machine virt &
+    - !reference [ .snippets, start-emulator ]
     - DD_TAGS="test.configuration.android_api:$ANDROID_API" ./gradlew :reliability:core-it:connectedDebugAndroidTest $( (( $ANDROID_API <= 23 )) && echo "-Puse-api21-java-backport -Puse-desugaring" ) || exit_code=$?
     - $ANDROID_HOME/platform-tools/adb emu kill
     - datadog-ci junit upload --service dd-sdk-android --tags test.configuration.android_api:$ANDROID_API --xpath-tag test.suite=/testcase/@classname reliability/core-it/build/outputs/androidTest-results/connected/debug/
@@ -93,7 +95,7 @@ stages:
   run-ndk-instrumented:
     - set +e
     - exit_code=0
-    - $ANDROID_HOME/emulator/emulator -avd "$EMULATOR_NAME" -grpc-use-jwt -no-snapstorage -no-audio -no-window -no-boot-anim -verbose -qemu -machine virt &
+    - !reference [ .snippets, start-emulator ]
     - DD_TAGS="test.configuration.android_api:$ANDROID_API" ./gradlew :features:dd-sdk-android-ndk:connectedDebugAndroidTest $( (( $ANDROID_API <= 23 )) && echo "-Puse-api21-java-backport -Puse-desugaring" ) || exit_code=$?
     - $ANDROID_HOME/platform-tools/adb emu kill
     - datadog-ci junit upload --service dd-sdk-android --tags test.configuration.android_api:$ANDROID_API --xpath-tag test.suite=/testcase/@classname features/dd-sdk-android-ndk/build/outputs/androidTest-results/connected/debug/
@@ -275,9 +277,9 @@ test-pyramid:core-it-latest-api:
   stage: test-pyramid
   timeout: 1h
   variables:
-    ANDROID_API: "36"
-    ANDROID_EMULATOR_IMAGE: "system-images;android-$ANDROID_API;google_apis;${ANDROID_ARCH}"
-    ANDROID_PLATFORM: "platforms;android-$ANDROID_API"
+    ANDROID_API: "37"
+    ANDROID_EMULATOR_IMAGE: "system-images;android-$ANDROID_API.0;google_apis_ps16k;${ANDROID_ARCH}"
+    ANDROID_PLATFORM: "platforms;android-$ANDROID_API.0"
     ANDROID_BUILD_TOOLS: "build-tools;$ANDROID_API.0.0"
   script:
     - !reference [.snippets, setup-macos-ami-runner]
@@ -390,9 +392,9 @@ test-pyramid:legacy-integration-instrumented-latest-api:
   stage: test-pyramid
   timeout: 1h
   variables:
-    ANDROID_API: "36"
-    ANDROID_EMULATOR_IMAGE: "system-images;android-$ANDROID_API;google_apis;${ANDROID_ARCH}"
-    ANDROID_PLATFORM: "platforms;android-$ANDROID_API"
+    ANDROID_API: "37"
+    ANDROID_EMULATOR_IMAGE: "system-images;android-$ANDROID_API.0;google_apis_ps16k;${ANDROID_ARCH}"
+    ANDROID_PLATFORM: "platforms;android-$ANDROID_API.0"
     ANDROID_BUILD_TOOLS: "build-tools;$ANDROID_API.0.0"
   script:
     - !reference [.snippets, setup-macos-ami-runner]
@@ -420,9 +422,9 @@ test-pyramid:ndk-instrumented-latest-api:
   stage: test-pyramid
   timeout: 1h
   variables:
-    ANDROID_API: "36"
-    ANDROID_EMULATOR_IMAGE: "system-images;android-$ANDROID_API;google_apis;${ANDROID_ARCH}"
-    ANDROID_PLATFORM: "platforms;android-$ANDROID_API"
+    ANDROID_API: "37"
+    ANDROID_EMULATOR_IMAGE: "system-images;android-$ANDROID_API.0;google_apis_ps16k;${ANDROID_ARCH}"
+    ANDROID_PLATFORM: "platforms;android-$ANDROID_API.0"
     ANDROID_BUILD_TOOLS: "build-tools;$ANDROID_API.0.0"
   script:
     - !reference [.snippets, setup-macos-ami-runner]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,7 @@ androidXJunitRunner = "1.5.0"
 androidXJunitRules = "1.5.0"
 androidXExtJunit = "1.1.5"
 androidXJunitCore = "1.5.0"
-espresso = "3.5.1"
+espresso = "3.7.0"
 
 # Tests Tools
 assertJ = "3.27.7"


### PR DESCRIPTION
- Use emulator image with API 37 that was created here: https://github.com/DataDog/ci-platform-machine-images/pull/793.
- Bump `espresso` to the latest `3.7.0`, as tests were failing because this library was using the removed API `InputManager.getInstance()`.

The emulator was failing to run because of an old `cmdline-tools` version not being able to read XML v4, which is a warning I also see locally when running `local_ci.sh` actually. It was impossible to understand this was the root cause in the ci logs, but thankfully the infra team helped and discovered it, fixing it here: https://github.com/DataDog/ci-platform-machine-images/pull/820.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

