### PR TITLE
RUM-17092: Add UK1 site

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -22,6 +22,7 @@ enum com.datadog.android.DatadogSite
   - EU1
   - AP1
   - AP2
+  - UK1
   - US1_FED
   - US2_FED
   - STAGING

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -62,6 +62,7 @@ public final class com/datadog/android/DatadogSite : java/lang/Enum {
 	public static final field AP2 Lcom/datadog/android/DatadogSite;
 	public static final field EU1 Lcom/datadog/android/DatadogSite;
 	public static final field STAGING Lcom/datadog/android/DatadogSite;
+	public static final field UK1 Lcom/datadog/android/DatadogSite;
 	public static final field US1 Lcom/datadog/android/DatadogSite;
 	public static final field US1_FED Lcom/datadog/android/DatadogSite;
 	public static final field US2_FED Lcom/datadog/android/DatadogSite;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/DatadogSite.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/DatadogSite.kt
@@ -46,6 +46,11 @@ enum class DatadogSite private constructor(internal val siteName: String, privat
     AP2("ap2"),
 
     /**
+     *  The UK1 site: [uk1.datadoghq.com](https://uk1.datadoghq.com).
+     */
+    UK1("uk1"),
+
+    /**
      *  The US1_FED site (FedRAMP compatible): [app.ddog-gov.com](https://app.ddog-gov.com).
      */
     US1_FED("us1_fed", "browser-intake-ddog-gov.com"),

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/DatadogSiteTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/DatadogSiteTest.kt
@@ -66,6 +66,11 @@ internal class DatadogSiteTest {
     }
 
     @Test
+    fun `M return intake endpoint W intakeEndpoint {UK1}`() {
+        assertThat(DatadogSite.UK1.intakeEndpoint).isEqualTo("https://browser-intake-uk1-datadoghq.com")
+    }
+
+    @Test
     fun `M return intake endpoint W intakeEndpoint {STAGING}`() {
         assertThat(DatadogSite.STAGING.intakeEndpoint).isEqualTo("https://browser-intake-datad0g.com")
     }

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/DatadogSiteExtensions.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/DatadogSiteExtensions.kt
@@ -36,6 +36,7 @@ private fun DatadogSite.flagsHost(customerDomain: String): String? = when (this)
     DatadogSite.US5 -> buildFlagsHostString(customerDomain, dc = "us5", tld = "com")
     DatadogSite.AP1 -> buildFlagsHostString(customerDomain, dc = "ap1", tld = "com")
     DatadogSite.AP2 -> buildFlagsHostString(customerDomain, dc = "ap2", tld = "com")
+    DatadogSite.UK1 -> buildFlagsHostString(customerDomain, dc = "uk1", tld = "com")
 }
 
 private fun buildFlagsHostString(customerDomain: String, dc: String? = null, tld: String = "com"): String {

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/DatadogSiteExtensionsTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/DatadogSiteExtensionsTest.kt
@@ -98,6 +98,7 @@ internal class DatadogSiteExtensionsTest {
             Arguments.of(DatadogSite.US5, "ff-cdn.us5.datadoghq.com"),
             Arguments.of(DatadogSite.AP1, "ff-cdn.ap1.datadoghq.com"),
             Arguments.of(DatadogSite.AP2, "ff-cdn.ap2.datadoghq.com"),
+            Arguments.of(DatadogSite.UK1, "ff-cdn.uk1.datadoghq.com"),
             Arguments.of(DatadogSite.EU1, "ff-cdn.datadoghq.eu"),
             Arguments.of(DatadogSite.STAGING, "ff-cdn.datad0g.com")
         )

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/webview/DatadogSiteExt.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/webview/DatadogSiteExt.kt
@@ -31,6 +31,7 @@ private fun DatadogSite?.browserSite(): String {
         DatadogSite.EU1 -> "datadoghq.eu"
         DatadogSite.AP1 -> "ap1.datadoghq.com"
         DatadogSite.AP2 -> "ap2.datadoghq.com"
+        DatadogSite.UK1 -> "uk1.datadoghq.com"
         DatadogSite.US1_FED -> "ddog-gov.com"
         DatadogSite.US2_FED -> "us2.ddog-gov.com"
     }


### PR DESCRIPTION
### What does this PR do?
Adds the UK1 site

Intake url in browser SDK: 
https://github.com/DataDog/dd-trace-js/blob/a4a3beb1637769b74e0095cc64dfe9c7a774f712/packages/dd-trace/src/exporters/agentless/intake.js#L14

