### PR TITLE
RUM-16886: Mark sampled-out network spans as droppable while preserving stats

### DIFF
--- a/features/dd-sdk-android-trace/api/apiSurface
+++ b/features/dd-sdk-android-trace/api/apiSurface
@@ -90,13 +90,15 @@ object com.datadog.android.trace.internal._TraceInternalProxy
   fun setSdkV2Compatible(com.datadog.android.trace.api.tracer.DatadogTracerBuilder): com.datadog.android.trace.api.tracer.DatadogTracerBuilder
   fun addThrowable(com.datadog.android.trace.api.span.DatadogSpan, Throwable, Byte)
   fun activateSpan(com.datadog.android.trace.api.tracer.DatadogTracer, com.datadog.android.trace.api.span.DatadogSpan, Boolean): com.datadog.android.trace.api.scope.DatadogScope?
+  fun isDefaultTracer(com.datadog.android.trace.api.tracer.DatadogTracer): Boolean
   fun mergeBaggage(String?, String): String
   fun createApmNetworkInstrumentation(String, com.datadog.android.trace.ApmNetworkInstrumentationConfiguration)
 fun com.datadog.android.core.sampling.Sampler<com.datadog.android.trace.api.span.DatadogSpan>.effectiveSampleRate(com.datadog.android.trace.api.span.DatadogSpan): Float?
+fun com.datadog.android.trace.api.span.DatadogSpan.finishRumAware(Boolean, Boolean, Boolean)
 fun com.datadog.android.trace.api.span.DatadogSpanContext?.isDropped(): Boolean
 fun Int?.isDroppedPriority(): Boolean
 data class com.datadog.android.trace.internal.net.RequestTracingState
-  constructor(com.datadog.android.api.instrumentation.network.HttpRequestInfoBuilder, Boolean = false, com.datadog.android.trace.api.span.DatadogSpan? = null, Float? = null)
+  constructor(com.datadog.android.api.instrumentation.network.HttpRequestInfoBuilder, Boolean = false, com.datadog.android.trace.api.span.DatadogSpan? = null, Float? = null, Boolean)
   fun createRequestInfo(): com.datadog.android.api.instrumentation.network.HttpRequestInfo
 fun RequestTracingState?.toAttributesMap(String, String, String): Map<String, Any?>
 class com.datadog.android.trace.internal.net.SessionRebasedSampler : com.datadog.android.core.sampling.Sampler<com.datadog.android.trace.api.span.DatadogSpan>, SpanAwareSampler

--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -167,6 +167,7 @@ public final class com/datadog/android/trace/internal/_TraceInternalProxy {
 	public static final fun addThrowable (Lcom/datadog/android/trace/api/span/DatadogSpan;Ljava/lang/Throwable;B)V
 	public final fun createApmNetworkInstrumentation (Ljava/lang/String;Lcom/datadog/android/trace/ApmNetworkInstrumentationConfiguration;)Lcom/datadog/android/trace/internal/ApmNetworkInstrumentation;
 	public final fun getPropagationHelper ()Lcom/datadog/android/trace/internal/DatadogPropagationHelper;
+	public final fun isDefaultTracer (Lcom/datadog/android/trace/api/tracer/DatadogTracer;)Z
 	public final fun mergeBaggage (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public final fun setSdkV2Compatible (Lcom/datadog/android/trace/api/tracer/DatadogTracerBuilder;)Lcom/datadog/android/trace/api/tracer/DatadogTracerBuilder;
 	public final fun setTraceId128BitGenerationEnabled (Lcom/datadog/android/trace/api/tracer/DatadogTracerBuilder;)Lcom/datadog/android/trace/api/tracer/DatadogTracerBuilder;
@@ -175,25 +176,28 @@ public final class com/datadog/android/trace/internal/_TraceInternalProxy {
 
 public final class com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExtKt {
 	public static final fun effectiveSampleRate (Lcom/datadog/android/core/sampling/Sampler;Lcom/datadog/android/trace/api/span/DatadogSpan;)Ljava/lang/Float;
+	public static final fun finishRumAware (Lcom/datadog/android/trace/api/span/DatadogSpan;ZZZ)V
 	public static final fun isDropped (Lcom/datadog/android/trace/api/span/DatadogSpanContext;)Z
 	public static final fun isDroppedPriority (Ljava/lang/Integer;)Z
 }
 
 public final class com/datadog/android/trace/internal/net/RequestTracingState {
-	public fun <init> (Lcom/datadog/android/api/instrumentation/network/HttpRequestInfoBuilder;ZLcom/datadog/android/trace/api/span/DatadogSpan;Ljava/lang/Float;)V
-	public synthetic fun <init> (Lcom/datadog/android/api/instrumentation/network/HttpRequestInfoBuilder;ZLcom/datadog/android/trace/api/span/DatadogSpan;Ljava/lang/Float;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/datadog/android/api/instrumentation/network/HttpRequestInfoBuilder;ZLcom/datadog/android/trace/api/span/DatadogSpan;Ljava/lang/Float;Z)V
+	public synthetic fun <init> (Lcom/datadog/android/api/instrumentation/network/HttpRequestInfoBuilder;ZLcom/datadog/android/trace/api/span/DatadogSpan;Ljava/lang/Float;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/datadog/android/api/instrumentation/network/HttpRequestInfoBuilder;
 	public final fun component2 ()Z
 	public final fun component3 ()Lcom/datadog/android/trace/api/span/DatadogSpan;
 	public final fun component4 ()Ljava/lang/Float;
-	public final fun copy (Lcom/datadog/android/api/instrumentation/network/HttpRequestInfoBuilder;ZLcom/datadog/android/trace/api/span/DatadogSpan;Ljava/lang/Float;)Lcom/datadog/android/trace/internal/net/RequestTracingState;
-	public static synthetic fun copy$default (Lcom/datadog/android/trace/internal/net/RequestTracingState;Lcom/datadog/android/api/instrumentation/network/HttpRequestInfoBuilder;ZLcom/datadog/android/trace/api/span/DatadogSpan;Ljava/lang/Float;ILjava/lang/Object;)Lcom/datadog/android/trace/internal/net/RequestTracingState;
+	public final fun component5 ()Z
+	public final fun copy (Lcom/datadog/android/api/instrumentation/network/HttpRequestInfoBuilder;ZLcom/datadog/android/trace/api/span/DatadogSpan;Ljava/lang/Float;Z)Lcom/datadog/android/trace/internal/net/RequestTracingState;
+	public static synthetic fun copy$default (Lcom/datadog/android/trace/internal/net/RequestTracingState;Lcom/datadog/android/api/instrumentation/network/HttpRequestInfoBuilder;ZLcom/datadog/android/trace/api/span/DatadogSpan;Ljava/lang/Float;ZILjava/lang/Object;)Lcom/datadog/android/trace/internal/net/RequestTracingState;
 	public final fun createRequestInfo ()Lcom/datadog/android/api/instrumentation/network/HttpRequestInfo;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getRequestInfoBuilder ()Lcom/datadog/android/api/instrumentation/network/HttpRequestInfoBuilder;
 	public final fun getSampleRate ()Ljava/lang/Float;
 	public final fun getSpan ()Lcom/datadog/android/trace/api/span/DatadogSpan;
 	public fun hashCode ()I
+	public final fun isDefaultTracer ()Z
 	public final fun isSampled ()Z
 	public fun toString ()Ljava/lang/String;
 }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ApmNetworkInstrumentation.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ApmNetworkInstrumentation.kt
@@ -115,7 +115,7 @@ class ApmNetworkInstrumentation internal constructor(
         }
 
         if (sdkCore == null) {
-            return RequestTracingState(requestInfoBuilder)
+            return RequestTracingState(requestInfoBuilder = requestInfoBuilder, isDefaultTracer = false)
         }
 
         val tracer = tracerProvider.provideTracer(
@@ -125,7 +125,7 @@ class ApmNetworkInstrumentation internal constructor(
         )
 
         if (tracer == null || !request.isTraceable(sdkCore)) {
-            return RequestTracingState(requestInfoBuilder)
+            return RequestTracingState(requestInfoBuilder = requestInfoBuilder, isDefaultTracer = false)
         }
 
         val span = tracer.buildSpan(
@@ -155,7 +155,8 @@ class ApmNetworkInstrumentation internal constructor(
             span = span,
             isSampled = isSampled,
             sampleRate = traceSampler.effectiveSampleRate(span),
-            requestInfoBuilder = tracedRequestInfoBuilder
+            requestInfoBuilder = tracedRequestInfoBuilder,
+            isDefaultTracer = tracer is DatadogTracerAdapter
         )
     }
 
@@ -167,17 +168,19 @@ class ApmNetworkInstrumentation internal constructor(
      * @param response the HTTP response information.
      */
     fun onResponseSucceeded(requestTracingState: RequestTracingState, response: HttpResponseInfo) {
-        if (requestTracingState.isSampled) {
-            requestTracingState.span?.setTag(DatadogTracingConstants.Tags.KEY_HTTP_STATUS, response.statusCode)
-            if (response.statusCode in HttpURLConnection.HTTP_BAD_REQUEST until HttpURLConnection.HTTP_INTERNAL_ERROR) {
-                requestTracingState.span?.isError = true
-            }
-            if (response.statusCode == HttpURLConnection.HTTP_NOT_FOUND && redacted404ResourceName) {
-                requestTracingState.span?.resourceName = RESOURCE_NAME_404
-            }
+        requestTracingState.span?.setTag(DatadogTracingConstants.Tags.KEY_HTTP_STATUS, response.statusCode)
+        if (response.statusCode in HttpURLConnection.HTTP_BAD_REQUEST until HttpURLConnection.HTTP_INTERNAL_ERROR) {
+            requestTracingState.span?.isError = true
+        }
+        if (response.statusCode == HttpURLConnection.HTTP_NOT_FOUND && redacted404ResourceName) {
+            requestTracingState.span?.resourceName = RESOURCE_NAME_404
         }
         requestTracingState.onRequestIntercepted(response, null)
-        requestTracingState.span?.finishRumAware(requestTracingState.isSampled, canSendSpan)
+        requestTracingState.span?.finishRumAware(
+            requestTracingState.isSampled,
+            canSendSpan,
+            requestTracingState.isDefaultTracer
+        )
     }
 
     /**
@@ -188,8 +191,8 @@ class ApmNetworkInstrumentation internal constructor(
      * @param throwable the exception that caused the failure.
      */
     fun onResponseFailed(requestTracingState: RequestTracingState, throwable: Throwable) {
+        requestTracingState.span?.isError = true
         if (requestTracingState.isSampled) {
-            requestTracingState.span?.isError = true
             requestTracingState.span?.setTag(DatadogTracingConstants.Tags.KEY_ERROR_MSG, throwable.message)
             requestTracingState.span?.setTag(DatadogTracingConstants.Tags.KEY_ERROR_TYPE, throwable.javaClass.name)
             requestTracingState.span?.setTag(
@@ -198,7 +201,11 @@ class ApmNetworkInstrumentation internal constructor(
             )
         }
         requestTracingState.onRequestIntercepted(null, throwable)
-        requestTracingState.span?.finishRumAware(requestTracingState.isSampled, canSendSpan)
+        requestTracingState.span?.finishRumAware(
+            requestTracingState.isSampled,
+            canSendSpan,
+            requestTracingState.isDefaultTracer
+        )
     }
 
     /**

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/_TraceInternalProxy.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/_TraceInternalProxy.kt
@@ -94,6 +94,13 @@ object _TraceInternalProxy {
     }
 
     /**
+     * Returns true if [tracer] is the SDK's built-in tracer, meaning it routes spans through
+     * CoreTraceWriter which honors the FORCE_DROP_SPAN tag. Custom tracer implementations
+     * do not honor that tag, so callers must call drop() instead of setTag+finish() for them.
+     */
+    fun isDefaultTracer(tracer: DatadogTracer): Boolean = tracer is DatadogTracerAdapter
+
+    /**
      * Merges two baggage headers into a single string representation. The [oldHeader] represents the
      * previously existing baggage header, and the [newHeader] represents the new baggage information
      * to be merged with the old one.

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/data/CoreTraceWriter.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/data/CoreTraceWriter.kt
@@ -19,6 +19,7 @@ import com.datadog.android.event.NoOpEventMapper
 import com.datadog.android.trace.internal.RumContextPropagator
 import com.datadog.android.trace.internal.RumContextPropagator.Companion.extractRumContext
 import com.datadog.android.trace.internal.domain.event.ContextAwareMapper
+import com.datadog.android.trace.internal.domain.event.FORCE_DROP_SPAN
 import com.datadog.android.trace.internal.storage.ContextAwareSerializer
 import com.datadog.android.trace.model.SpanEvent
 import com.datadog.trace.api.sampling.PrioritySampling
@@ -45,7 +46,10 @@ internal class CoreTraceWriter(
         sdkCore.getFeature(Feature.TRACING_FEATURE_NAME)
             ?.withWriteContext { datadogContext, writeScope ->
                 val writeSpans = trace
-                    .filter { it.getTraceSamplingPriority() !in DROP_SAMPLING_PRIORITIES }
+                    .filter {
+                        it.getTraceSamplingPriority() !in DROP_SAMPLING_PRIORITIES &&
+                            it.getTag(FORCE_DROP_SPAN) == null
+                    }
                     .map { it.extractRumContext(rumContextPropagator) }
                 // TODO RUM-4092 Add the capability in the serializer to handle multiple spans in one payload
                 writeScope {

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/event/MetaKeys.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/event/MetaKeys.kt
@@ -6,6 +6,10 @@
 
 package com.datadog.android.trace.internal.domain.event
 
+/**
+ * Internal tag which indicates the span should be created locally but never sent to the backend.
+ */
+internal const val FORCE_DROP_SPAN: String = "_dd.local.force_drop"
 internal const val TRACE_ID_META_KEY = "_dd.p.id"
 internal const val APPLICATION_VARIANT_KEY = "variant"
 internal const val COMPUTE_STATS_META_KEY = "_dd.compute_stats"

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExt.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationExt.kt
@@ -23,6 +23,7 @@ import com.datadog.android.trace.internal.ApmNetworkInstrumentation.Companion.ZE
 import com.datadog.android.trace.internal.ParentContextSource
 import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.trace.internal._TraceInternalProxy.propagationHelper
+import com.datadog.android.trace.internal.domain.event.FORCE_DROP_SPAN
 import java.util.Locale
 
 internal val FeatureSdkCore?.isRumEnabled: Boolean
@@ -71,11 +72,18 @@ internal fun DatadogSpan.sample(
     }
 }
 
-internal fun DatadogSpan.finishRumAware(isSampled: Boolean, canSendSpan: Boolean) {
-    if (canSendSpan && isSampled) {
-        finish()
-    } else {
-        drop()
+@SuppressWarnings("UndocumentedPublicFunction")
+@InternalApi
+fun DatadogSpan.finishRumAware(isSampled: Boolean, canSendSpan: Boolean, isDefaultTracer: Boolean) {
+    when {
+        !canSendSpan -> drop()
+        isSampled -> finish()
+        !isSampled && isDefaultTracer -> {
+            // SDK-backed tracer: tag the span so CoreTraceWriter suppresses it instead of calling drop()
+            setTag(FORCE_DROP_SPAN, true)
+            finish()
+        }
+        else -> drop()
     }
 }
 

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/RequestTracingState.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/RequestTracingState.kt
@@ -23,13 +23,15 @@ import com.datadog.android.trace.api.span.DatadogSpan
  * @property isSampled whether the request trace was sampled.
  * @property span the trace span created for this request, or null if not sampled or tracing is disabled.
  * @property sampleRate the sample rate used for the sampling decision.
+ * @property isDefaultTracer whether the tracer is the SDK's built-in implementation
  */
 @InternalApi
 data class RequestTracingState(
     val requestInfoBuilder: HttpRequestInfoBuilder,
     val isSampled: Boolean = false,
     val span: DatadogSpan? = null,
-    val sampleRate: Float? = null
+    val sampleRate: Float? = null,
+    val isDefaultTracer: Boolean
 ) {
 
     /**

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/TraceInternalProxyTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/TraceInternalProxyTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.trace.internal
 
 import com.datadog.android.trace.ApmNetworkInstrumentationConfiguration
 import com.datadog.android.trace.TracingHeaderType
+import com.datadog.android.trace.api.tracer.DatadogTracer
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -18,8 +19,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.mock
 import org.mockito.quality.Strictness
 
 @Extensions(
@@ -29,6 +32,9 @@ import org.mockito.quality.Strictness
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
 internal class TraceInternalProxyTest {
+
+    @Mock
+    lateinit var mockCustomTracer: DatadogTracer
 
     private lateinit var fakeTracedHosts: Map<String, Set<TracingHeaderType>>
 
@@ -82,5 +88,17 @@ internal class TraceInternalProxyTest {
         assertThat(result).isNotNull
         assertThat(result.sdkInstanceName).isEqualTo(fakeSdkInstanceName)
         assertThat(result.traceOrigin).isEqualTo(fakeTraceOrigin)
+    }
+
+    @Test
+    fun `M return false W isDefaultTracer() {custom tracer}`() {
+        assertThat(_TraceInternalProxy.isDefaultTracer(mockCustomTracer)).isFalse()
+    }
+
+    @Test
+    fun `M return true W isDefaultTracer() {SDK DatadogTracerAdapter}`() {
+        val sdkTracer: DatadogTracer = mock<DatadogTracerAdapter>()
+
+        assertThat(_TraceInternalProxy.isDefaultTracer(sdkTracer)).isTrue()
     }
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/CoreTraceWriterTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/CoreTraceWriterTest.kt
@@ -19,6 +19,7 @@ import com.datadog.android.event.EventMapper
 import com.datadog.android.log.LogAttributes
 import com.datadog.android.trace.internal.RumContextPropagator
 import com.datadog.android.trace.internal.domain.event.ContextAwareMapper
+import com.datadog.android.trace.internal.domain.event.FORCE_DROP_SPAN
 import com.datadog.android.trace.internal.storage.ContextAwareSerializer
 import com.datadog.android.trace.model.SpanEvent
 import com.datadog.android.trace.utils.RumContextTestsUtils.RUM_CONTEXT_ACTION_ID
@@ -317,6 +318,22 @@ internal class CoreTraceWriterTest {
         ddSpans.forEach {
             it.finish()
         }
+    }
+
+    @Test
+    fun `M not write spans with force drop tag W write()`(forge: Forge) {
+        // GIVEN
+        val ddSpans = createNonEmptyDdSpans(
+            forge = forge,
+            includeDropSamplingPriority = false
+        )
+        ddSpans.forEach { whenever(it.getTag(FORCE_DROP_SPAN)) doReturn true }
+
+        // WHEN
+        testedWriter.write(ddSpans)
+
+        // THEN
+        verifyNoInteractions(mockEventBatchWriter)
     }
 
     @Test

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationTest.kt
@@ -34,6 +34,7 @@ import com.datadog.android.trace.internal.ApmNetworkInstrumentation
 import com.datadog.android.trace.internal.DatadogPropagationHelper
 import com.datadog.android.trace.internal.ParentContextSource
 import com.datadog.android.trace.internal._TraceInternalProxy
+import com.datadog.android.trace.internal.domain.event.FORCE_DROP_SPAN
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.Forge
@@ -727,7 +728,12 @@ internal class ApmNetworkInstrumentationTest {
             testedInstrumentation.onResponseSucceeded(traceState, mockResponseInfo)
 
             // Then
-            if (fakeIsSampled) verify(mockSpan).finish() else verify(mockSpan).drop()
+            if (fakeIsSampled) {
+                verify(mockSpan, never()).setTag(eq(FORCE_DROP_SPAN), any<Boolean>())
+            } else {
+                verify(mockSpan).setTag(FORCE_DROP_SPAN, true)
+            }
+            verify(mockSpan).finish()
         }
     }
 
@@ -794,7 +800,7 @@ internal class ApmNetworkInstrumentationTest {
     }
 
     @Test
-    fun `M not set error tags W onResponseFailed() {not sampled}`(
+    fun `M set isError but not verbose tags W onResponseFailed() {not sampled}`(
         @Forgery fakeThrowable: Throwable
     ) {
         // Given
@@ -804,8 +810,9 @@ internal class ApmNetworkInstrumentationTest {
             // When
             testedInstrumentation.onResponseFailed(traceState, fakeThrowable)
 
-            // Then
-            verify(mockSpan, never()).isError = true
+            // Then — isError must be set so the APM stats counts this as an error,
+            // but verbose payload tags are omitted for unsampled spans
+            verify(mockSpan).isError = true
             verify(mockSpan, never()).setTag(eq(Tags.KEY_ERROR_MSG), any<String>())
             verify(mockSpan, never()).setTag(eq(Tags.KEY_ERROR_TYPE), any<String>())
             verify(mockSpan, never()).setTag(eq(Tags.KEY_ERROR_STACK), any<String>())
@@ -827,7 +834,63 @@ internal class ApmNetworkInstrumentationTest {
             testedInstrumentation.onResponseFailed(traceState, fakeThrowable)
 
             // Then
-            if (fakeIsSampled) verify(mockSpan).finish() else verify(mockSpan).drop()
+            if (fakeIsSampled) {
+                verify(mockSpan, never()).setTag(eq(FORCE_DROP_SPAN), any<Boolean>())
+            } else {
+                verify(mockSpan).setTag(FORCE_DROP_SPAN, true)
+            }
+            verify(mockSpan).finish()
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `M finish or drop span W onResponseSucceeded() {custom tracer}`(
+        fakeIsSampled: Boolean,
+        @IntForgery(min = 200, max = 299) fakeStatusCode: Int
+    ) {
+        // Given
+        whenever(mockResponseInfo.statusCode) doReturn fakeStatusCode
+        val traceState = createTraceState(isSampled = fakeIsSampled, isDefaultTracer = false)
+
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
+            // When
+            testedInstrumentation.onResponseSucceeded(traceState, mockResponseInfo)
+
+            // Then — custom tracers must call drop() directly; FORCE_DROP_SPAN is SDK-internal
+            verify(mockSpan, never()).setTag(eq(FORCE_DROP_SPAN), any<Boolean>())
+            if (fakeIsSampled) {
+                verify(mockSpan).finish()
+                verify(mockSpan, never()).drop()
+            } else {
+                verify(mockSpan, never()).finish()
+                verify(mockSpan).drop()
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `M finish or drop span W onResponseFailed() {custom tracer}`(
+        fakeIsSampled: Boolean,
+        @Forgery fakeThrowable: Throwable
+    ) {
+        // Given
+        val traceState = createTraceState(isSampled = fakeIsSampled, isDefaultTracer = false)
+
+        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
+            // When
+            testedInstrumentation.onResponseFailed(traceState, fakeThrowable)
+
+            // Then — custom tracers must call drop() directly; FORCE_DROP_SPAN is SDK-internal
+            verify(mockSpan, never()).setTag(eq(FORCE_DROP_SPAN), any<Boolean>())
+            if (fakeIsSampled) {
+                verify(mockSpan).finish()
+                verify(mockSpan, never()).drop()
+            } else {
+                verify(mockSpan, never()).finish()
+                verify(mockSpan).drop()
+            }
         }
     }
 
@@ -854,25 +917,6 @@ internal class ApmNetworkInstrumentationTest {
             // Then
             verify(mockSpan).drop()
             verify(mockSpan, never()).finish()
-        }
-    }
-
-    @Test
-    fun `M finish span W onResponseSucceeded() {APP_LEVEL, canSendSpan=true, RUM enabled, sampled}`(
-        @IntForgery(min = 200, max = 299) fakeStatusCode: Int
-    ) {
-        // Given - canSendSpan=true is set in setUp
-        whenever(mockResponseInfo.statusCode) doReturn fakeStatusCode
-
-        val traceState = createTraceState()
-
-        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
-            // When
-            testedInstrumentation.onResponseSucceeded(traceState, mockResponseInfo)
-
-            // Then
-            verify(mockSpan).finish()
-            verify(mockSpan, never()).drop()
         }
     }
 
@@ -915,23 +959,6 @@ internal class ApmNetworkInstrumentationTest {
             // Then
             verify(mockSpan).drop()
             verify(mockSpan, never()).finish()
-        }
-    }
-
-    @Test
-    fun `M finish span W onResponseFailed() {APP_LEVEL, canSendSpan=true, RUM enabled, sampled}`(
-        @Forgery fakeThrowable: Throwable
-    ) {
-        // Given - canSendSpan=true is set in setUp
-        val traceState = createTraceState()
-
-        _TraceInternalProxy.withMockPropagationHelper(mockPropagationHelper) {
-            // When
-            testedInstrumentation.onResponseFailed(traceState, fakeThrowable)
-
-            // Then
-            verify(mockSpan).finish()
-            verify(mockSpan, never()).drop()
         }
     }
 
@@ -991,7 +1018,12 @@ internal class ApmNetworkInstrumentationTest {
             testedInstrumentation.onResponseSucceeded(traceState, mockResponseInfo)
 
             // Then
-            if (fakeIsSampled) verify(mockSpan).finish() else verify(mockSpan).drop()
+            if (fakeIsSampled) {
+                verify(mockSpan, never()).setTag(eq(FORCE_DROP_SPAN), any<Boolean>())
+            } else {
+                verify(mockSpan).setTag(FORCE_DROP_SPAN, true)
+            }
+            verify(mockSpan).finish()
         }
     }
 
@@ -1010,7 +1042,12 @@ internal class ApmNetworkInstrumentationTest {
             testedInstrumentation.onResponseFailed(traceState, fakeThrowable)
 
             // Then
-            if (fakeIsSampled) verify(mockSpan).finish() else verify(mockSpan).drop()
+            if (fakeIsSampled) {
+                verify(mockSpan, never()).setTag(eq(FORCE_DROP_SPAN), any<Boolean>())
+            } else {
+                verify(mockSpan).setTag(FORCE_DROP_SPAN, true)
+            }
+            verify(mockSpan).finish()
         }
     }
 
@@ -1156,11 +1193,12 @@ internal class ApmNetworkInstrumentationTest {
 
     // endregion
 
-    private fun createTraceState(isSampled: Boolean = true) = RequestTracingState(
+    private fun createTraceState(isSampled: Boolean = true, isDefaultTracer: Boolean = true) = RequestTracingState(
         requestInfoBuilder = mockRequestBuilder,
         isSampled = isSampled,
         span = mockSpan,
-        sampleRate = fakeSampleRate
+        sampleRate = fakeSampleRate,
+        isDefaultTracer = isDefaultTracer
     )
 
     private fun createInstrumentation(

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/RequestTracingStateTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/RequestTracingStateTest.kt
@@ -62,7 +62,7 @@ internal class RequestTracingStateTest {
     fun `M return request info W createRequestInfo()`() {
         // Given
         whenever(mockRequestBuilder.build()) doReturn mockRequestInfo
-        val state = RequestTracingState(requestInfoBuilder = mockRequestBuilder)
+        val state = RequestTracingState(requestInfoBuilder = mockRequestBuilder, isDefaultTracer = false)
 
         // When / Then
         assertThat(state.createRequestInfo()).isSameAs(mockRequestInfo)
@@ -86,7 +86,8 @@ internal class RequestTracingStateTest {
         val state = RequestTracingState(
             requestInfoBuilder = mockRequestBuilder,
             isSampled = true,
-            span = null
+            span = null,
+            isDefaultTracer = false
         )
 
         // When
@@ -102,7 +103,8 @@ internal class RequestTracingStateTest {
         val state = RequestTracingState(
             requestInfoBuilder = mockRequestBuilder,
             isSampled = false,
-            span = mockSpan
+            span = mockSpan,
+            isDefaultTracer = false
         )
 
         // When
@@ -129,7 +131,8 @@ internal class RequestTracingStateTest {
             requestInfoBuilder = mockRequestBuilder,
             isSampled = true,
             span = mockSpan,
-            sampleRate = fakeSampleRate
+            sampleRate = fakeSampleRate,
+            isDefaultTracer = false
         )
 
         // When
@@ -157,7 +160,8 @@ internal class RequestTracingStateTest {
             requestInfoBuilder = mockRequestBuilder,
             isSampled = true,
             span = mockSpan,
-            sampleRate = null
+            sampleRate = null,
+            isDefaultTracer = false
         )
 
         // When

--- a/integrations/dd-sdk-android-cronet/src/main/kotlin/com/datadog/android/cronet/internal/CronetRequestCallback.kt
+++ b/integrations/dd-sdk-android-cronet/src/main/kotlin/com/datadog/android/cronet/internal/CronetRequestCallback.kt
@@ -41,7 +41,12 @@ internal class CronetRequestCallback(
         apmNetworkInstrumentation?.onRequest(finalRequestInfo)
             .also(apmTracingStateHolder::set)
 
-        return distributedTracingState ?: RequestTracingState(initialRequestInfo.newBuilder())
+        // Fallback when no APM instrumentation is registered — no span is created so isDefaultTracer
+        // is never consulted (finishRumAware is a no-op on a null span).
+        return distributedTracingState ?: RequestTracingState(
+            requestInfoBuilder = initialRequestInfo.newBuilder(),
+            isDefaultTracer = false
+        )
     }
 
     override fun onRedirectReceived(

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -39,6 +39,7 @@ import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.api.span.DatadogSpan
 import com.datadog.android.trace.api.tracer.DatadogTracer
+import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.trace.internal.net.SessionRebasedSampler
 import com.datadog.android.trace.internal.net.effectiveSampleRate
 import okhttp3.Interceptor
@@ -92,7 +93,8 @@ open class DatadogInterceptor internal constructor(
     redacted404ResourceName: Boolean,
     localTracerFactory: (SdkCore, Set<TracingHeaderType>) -> DatadogTracer,
     globalTracerProvider: () -> DatadogTracer?,
-    internal val resourceHeadersExtractor: ResourceHeadersExtractor? = null
+    internal val resourceHeadersExtractor: ResourceHeadersExtractor? = null,
+    defaultTracerCheck: (DatadogTracer) -> Boolean = _TraceInternalProxy::isDefaultTracer
 ) : TracingInterceptor(
     sdkInstanceName,
     tracedHosts,
@@ -102,7 +104,8 @@ open class DatadogInterceptor internal constructor(
     traceContextInjection,
     redacted404ResourceName,
     localTracerFactory,
-    globalTracerProvider
+    globalTracerProvider,
+    defaultTracerCheck
 ) {
     internal val rumResourceAttributesProvider: RumResourceAttributesProvider =
         rumResourceAttributesProvider as? NoOpRumResourceAttributesProvider

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/RequestTracingStateRegistry.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/RequestTracingStateRegistry.kt
@@ -59,10 +59,11 @@ internal class RequestTracingStateRegistry(
         }
 
         requestTracingStateByCall[call] = RequestTracingState(
-            call.request()
+            requestInfoBuilder = call.request()
                 .toHttpRequestInfo()
                 .newBuilder()
-                .addTag(UUID::class.java, UUID.randomUUID())
+                .addTag(UUID::class.java, UUID.randomUUID()),
+            isDefaultTracer = false
         )
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -40,6 +40,7 @@ import com.datadog.android.trace.internal.RumContextPropagator.Companion.extract
 import com.datadog.android.trace.internal._TraceInternalProxy
 import com.datadog.android.trace.internal.net.TraceContext
 import com.datadog.android.trace.internal.net.effectiveSampleRate
+import com.datadog.android.trace.internal.net.finishRumAware
 import com.datadog.android.trace.internal.net.isDropped
 import com.datadog.android.trace.internal.net.isDroppedPriority
 import okhttp3.Interceptor
@@ -90,7 +91,8 @@ internal constructor(
     internal val traceContextInjection: TraceContextInjection,
     internal val redacted404ResourceName: Boolean,
     internal val localTracerFactory: (SdkCore, Set<TracingHeaderType>) -> DatadogTracer,
-    private val globalTracerProvider: () -> DatadogTracer?
+    private val globalTracerProvider: () -> DatadogTracer?,
+    internal val defaultTracerCheck: (DatadogTracer) -> Boolean = _TraceInternalProxy::isDefaultTracer
 ) : Interceptor {
 
     private val localTracerReference: AtomicReference<DatadogTracer> = AtomicReference()
@@ -250,6 +252,7 @@ internal constructor(
         request: Request,
         tracer: DatadogTracer
     ): Response {
+        val isDefaultTracer = defaultTracerCheck(tracer)
         val span = buildSpan(tracer, request)
         val isSampled = span.extractRumContext(rumContextPropagator, block = true)
             .sample(request, ignoreLocalDroppedParent = !canSendSpan())
@@ -284,10 +287,10 @@ internal constructor(
 
         try {
             val response = chain.proceed(updatedRequest)
-            handleResponse(sdkCore, request, response, span, isSampled)
+            handleResponse(sdkCore, request, response, span, isSampled, isDefaultTracer)
             return response
         } catch (e: Throwable) {
-            handleThrowable(sdkCore, request, e, span, isSampled)
+            handleThrowable(sdkCore, request, e, span, isSampled, isDefaultTracer)
             throw e
         }
     }
@@ -698,22 +701,23 @@ internal constructor(
         request: Request,
         response: Response,
         span: DatadogSpan,
-        isSampled: Boolean
+        isSampled: Boolean,
+        isDefaultTracer: Boolean
     ) {
-        if (!isSampled) {
-            onRequestIntercepted(sdkCore, request, null, response, null)
-        } else {
-            val statusCode = response.code
-            span.setTag(Tags.KEY_HTTP_STATUS, statusCode)
-            if (statusCode in HttpURLConnection.HTTP_BAD_REQUEST until HttpURLConnection.HTTP_INTERNAL_ERROR) {
-                span.isError = true
-            }
-            if (statusCode == HttpURLConnection.HTTP_NOT_FOUND && redacted404ResourceName) {
-                span.resourceName = RESOURCE_NAME_404
-            }
-            onRequestIntercepted(sdkCore, request, span, response, null)
+        val statusCode = response.code
+        span.setTag(Tags.KEY_HTTP_STATUS, statusCode)
+        if (statusCode in HttpURLConnection.HTTP_BAD_REQUEST until HttpURLConnection.HTTP_INTERNAL_ERROR) {
+            span.isError = true
         }
-        span.finishRumAware(isSampled)
+        if (statusCode == HttpURLConnection.HTTP_NOT_FOUND && redacted404ResourceName) {
+            span.resourceName = RESOURCE_NAME_404
+        }
+        if (isSampled) {
+            onRequestIntercepted(sdkCore, request, span, response, null)
+        } else {
+            onRequestIntercepted(sdkCore, request, null, response, null)
+        }
+        span.finishRumAware(isSampled = isSampled, canSendSpan = canSendSpan(), isDefaultTracer = isDefaultTracer)
     }
 
     private fun handleThrowable(
@@ -721,26 +725,19 @@ internal constructor(
         request: Request,
         throwable: Throwable,
         span: DatadogSpan,
-        isSampled: Boolean
+        isSampled: Boolean,
+        isDefaultTracer: Boolean
     ) {
-        if (!isSampled) {
-            onRequestIntercepted(sdkCore, request, null, null, throwable)
-        } else {
-            span.isError = true
+        span.isError = true
+        if (isSampled) {
             span.setTag(Tags.KEY_ERROR_MSG, throwable.message)
             span.setTag(Tags.KEY_ERROR_TYPE, throwable.javaClass.name)
             span.setTag(Tags.KEY_ERROR_STACK, throwable.loggableStackTrace())
             onRequestIntercepted(sdkCore, request, span, null, throwable)
-        }
-        span.finishRumAware(isSampled)
-    }
-
-    private fun DatadogSpan.finishRumAware(isSampled: Boolean) {
-        if (canSendSpan()) {
-            if (isSampled) finish() else drop()
         } else {
-            drop()
+            onRequestIntercepted(sdkCore, request, null, null, throwable)
         }
+        span.finishRumAware(isSampled = isSampled, canSendSpan = canSendSpan(), isDefaultTracer = isDefaultTracer)
     }
 
     private fun DatadogSpan.sample(request: Request, ignoreLocalDroppedParent: Boolean): Boolean {

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutRumTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutRumTest.kt
@@ -54,6 +54,7 @@ internal class DatadogInterceptorWithoutRumTest : TracingInterceptorTest() {
     override fun instantiateTestedInterceptor(
         tracedHosts: Map<String, Set<TracingHeaderType>>,
         globalTracerProvider: () -> DatadogTracer?,
+        defaultTracerCheck: (DatadogTracer) -> Boolean,
         localTracerFactory: (SdkCore, Set<TracingHeaderType>) -> DatadogTracer
     ): TracingInterceptor {
         return DatadogInterceptor(
@@ -65,7 +66,8 @@ internal class DatadogInterceptorWithoutRumTest : TracingInterceptorTest() {
             traceContextInjection = TraceContextInjection.ALL,
             redacted404ResourceName = fakeRedacted404Resources,
             localTracerFactory = localTracerFactory,
-            globalTracerProvider = globalTracerProvider
+            globalTracerProvider = globalTracerProvider,
+            defaultTracerCheck = defaultTracerCheck
         )
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/ApmInstrumentationOkHttpAdapterTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/ApmInstrumentationOkHttpAdapterTest.kt
@@ -107,7 +107,8 @@ internal class ApmInstrumentationOkHttpAdapterTest {
         val mockRequestBuilder = mockRequestInfoBuilder(modifiedRequestInfo)
         val fakeTracingState = RequestTracingState(
             requestInfoBuilder = mockRequestBuilder,
-            isSampled = true
+            isSampled = true,
+            isDefaultTracer = false
         )
         whenever(mockApmNetworkInstrumentation.onRequest(any())) doReturn fakeTracingState
 
@@ -139,7 +140,8 @@ internal class ApmInstrumentationOkHttpAdapterTest {
         val mockRequestBuilder = mockRequestInfoBuilder(modifiedRequestInfo)
         val fakeTracingState = RequestTracingState(
             requestInfoBuilder = mockRequestBuilder,
-            isSampled = true
+            isSampled = true,
+            isDefaultTracer = false
         )
         whenever(mockApmNetworkInstrumentation.onRequest(any())) doReturn fakeTracingState
 
@@ -199,7 +201,8 @@ internal class ApmInstrumentationOkHttpAdapterTest {
         val mockRequestBuilder = mockRequestInfoBuilder(modifiedRequestInfo)
         val fakeTracingState = RequestTracingState(
             requestInfoBuilder = mockRequestBuilder,
-            isSampled = true
+            isSampled = true,
+            isDefaultTracer = false
         )
         whenever(mockApmNetworkInstrumentation.onRequest(any())) doReturn fakeTracingState
 
@@ -222,7 +225,8 @@ internal class ApmInstrumentationOkHttpAdapterTest {
         val mockRequestBuilder = mockRequestInfoBuilder(null)
         val fakeTracingState = RequestTracingState(
             requestInfoBuilder = mockRequestBuilder,
-            isSampled = true
+            isSampled = true,
+            isDefaultTracer = false
         )
         whenever(mockApmNetworkInstrumentation.onRequest(any())) doReturn fakeTracingState
 
@@ -312,7 +316,8 @@ internal class ApmInstrumentationOkHttpAdapterTest {
         val mockRequestBuilder = mockRequestInfoBuilder(modifiedRequestInfo)
         val fakeTracingState = RequestTracingState(
             requestInfoBuilder = mockRequestBuilder,
-            isSampled = true
+            isSampled = true,
+            isDefaultTracer = false
         )
         whenever(mockApmNetworkInstrumentation.onRequest(any())) doReturn fakeTracingState
         whenever(mockChain.proceed(any())) doReturn forgeResponse(statusCode)
@@ -342,7 +347,8 @@ internal class ApmInstrumentationOkHttpAdapterTest {
         val mockRequestBuilder = mockRequestInfoBuilder(modifiedRequestInfo)
         val fakeTracingState = RequestTracingState(
             requestInfoBuilder = mockRequestBuilder,
-            isSampled = true
+            isSampled = true,
+            isDefaultTracer = false
         )
         whenever(mockApmNetworkInstrumentation.onRequest(any())) doReturn fakeTracingState
 
@@ -380,7 +386,8 @@ internal class ApmInstrumentationOkHttpAdapterTest {
         val mockRequestBuilder = mockRequestInfoBuilder(modifiedRequestInfo)
         val fakeTracingState = RequestTracingState(
             requestInfoBuilder = mockRequestBuilder,
-            isSampled = true
+            isSampled = true,
+            isDefaultTracer = false
         )
         whenever(mockApmNetworkInstrumentation.onRequest(any())) doReturn fakeTracingState
 
@@ -411,7 +418,8 @@ internal class ApmInstrumentationOkHttpAdapterTest {
         val mockRequestBuilder = mockRequestInfoBuilder(tracedRequestInfo)
         val fakeTracingState = RequestTracingState(
             requestInfoBuilder = mockRequestBuilder,
-            isSampled = true
+            isSampled = true,
+            isDefaultTracer = false
         )
         whenever(mockApmNetworkInstrumentation.onRequest(any())) doReturn fakeTracingState
 
@@ -447,7 +455,8 @@ internal class ApmInstrumentationOkHttpAdapterTest {
         val mockRequestBuilder = mockRequestInfoBuilder(modifiedRequestInfo)
         val fakeTracingState = RequestTracingState(
             requestInfoBuilder = mockRequestBuilder,
-            isSampled = true
+            isSampled = true,
+            isDefaultTracer = false
         )
         whenever(mockApmNetworkInstrumentation.onRequest(any())) doReturn fakeTracingState
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/RequestTracingStateRegistryTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/RequestTracingStateRegistryTest.kt
@@ -167,7 +167,8 @@ internal class RequestTracingStateRegistryTest {
         )
         val newState = RequestTracingState(
             requestInfoBuilder = newRequestBuilder,
-            isSampled = true
+            isSampled = true,
+            isDefaultTracer = false
         )
 
         // When
@@ -184,7 +185,8 @@ internal class RequestTracingStateRegistryTest {
             requestInfoBuilder = OkHttpRequestInfoBuilder(
                 Request.Builder().url(fakeUrl)
             ),
-            isSampled = true
+            isSampled = true,
+            isDefaultTracer = false
         )
 
         // When
@@ -206,7 +208,8 @@ internal class RequestTracingStateRegistryTest {
         )
         val newState = RequestTracingState(
             requestInfoBuilder = newRequestBuilder,
-            isSampled = true
+            isSampled = true,
+            isDefaultTracer = false
         )
 
         // When
@@ -226,7 +229,8 @@ internal class RequestTracingStateRegistryTest {
         )
         val newState = RequestTracingState(
             requestInfoBuilder = newRequestBuilder,
-            isSampled = true
+            isSampled = true,
+            isDefaultTracer = false
         )
 
         // When
@@ -320,7 +324,8 @@ internal class RequestTracingStateRegistryTest {
             requestInfoBuilder = newRequestBuilder,
             isSampled = true,
             span = mockSpan,
-            sampleRate = fakeSampleRate
+            sampleRate = fakeSampleRate,
+            isDefaultTracer = false
         )
 
         // When
@@ -366,7 +371,8 @@ internal class RequestTracingStateRegistryTest {
                             requestInfoBuilder = OkHttpRequestInfoBuilder(
                                 Request.Builder().url(call.request().url.toString())
                             ),
-                            isSampled = true
+                            isSampled = true,
+                            isDefaultTracer = false
                         )
                     )
                     testedRegistry.get(call)

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/RumInstrumentationOkHttpAdapterTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/RumInstrumentationOkHttpAdapterTest.kt
@@ -111,7 +111,7 @@ internal class RumInstrumentationOkHttpAdapterTest {
         // Given
         val fakeRequestBuilder = OkHttpRequestInfoBuilder(fakeRequest.newBuilder())
             .addTag(UUID::class.java, fakeUuid)
-        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder)
+        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder, isDefaultTracer = false)
         whenever(mockRegistry.get(mockCall)) doReturn fakeState
         val fakeResponse = forgeResponse(statusCode)
         whenever(mockChain.proceed(any())) doReturn fakeResponse
@@ -134,7 +134,7 @@ internal class RumInstrumentationOkHttpAdapterTest {
         // Given
         val fakeRequestBuilder = OkHttpRequestInfoBuilder(fakeRequest.newBuilder())
             .addTag(UUID::class.java, fakeUuid)
-        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder)
+        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder, isDefaultTracer = false)
         whenever(mockRegistry.get(mockCall)) doReturn fakeState
         val fakeException = IOException("network error")
         whenever(mockChain.proceed(any())) doThrow fakeException
@@ -205,7 +205,7 @@ internal class RumInstrumentationOkHttpAdapterTest {
         // Given
         val fakeRequestBuilder = OkHttpRequestInfoBuilder(fakeRequest.newBuilder())
             .addTag(UUID::class.java, fakeUuid)
-        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder)
+        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder, isDefaultTracer = false)
         whenever(mockRegistry.get(mockCall)) doReturn fakeState
         val fakeResponse = forgeResponse(statusCode)
         whenever(mockChain.proceed(any())) doReturn fakeResponse
@@ -228,7 +228,7 @@ internal class RumInstrumentationOkHttpAdapterTest {
         // Given
         val fakeRequestBuilder = OkHttpRequestInfoBuilder(fakeRequest.newBuilder())
             .addTag(UUID::class.java, fakeUuid)
-        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder)
+        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder, isDefaultTracer = false)
         whenever(mockRegistry.get(mockCall)) doReturn fakeState
         val fakeResponse = forgeResponse(statusCode)
         whenever(mockChain.proceed(any())) doReturn fakeResponse
@@ -255,7 +255,7 @@ internal class RumInstrumentationOkHttpAdapterTest {
         // Given
         val fakeRequestBuilder = OkHttpRequestInfoBuilder(fakeRequest.newBuilder())
             .addTag(UUID::class.java, fakeUuid)
-        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder)
+        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder, isDefaultTracer = false)
         var callCount = 0
         whenever(mockRegistry.get(mockCall)).thenAnswer {
             callCount++
@@ -293,7 +293,7 @@ internal class RumInstrumentationOkHttpAdapterTest {
 
         val fakeRequestBuilder = OkHttpRequestInfoBuilder(fakeRequest.newBuilder())
             .addTag(UUID::class.java, fakeUuid)
-        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder)
+        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder, isDefaultTracer = false)
         whenever(mockRegistry.get(mockCall)) doReturn fakeState
         val fakeResponse = forgeResponse(statusCode)
         whenever(mockChain.proceed(any())) doReturn fakeResponse
@@ -322,7 +322,7 @@ internal class RumInstrumentationOkHttpAdapterTest {
 
         val fakeRequestBuilder = OkHttpRequestInfoBuilder(fakeRequest.newBuilder())
             .addTag(UUID::class.java, fakeUuid)
-        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder)
+        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder, isDefaultTracer = false)
         whenever(mockRegistry.get(mockCall)) doReturn fakeState
         val fakeResponse = forgeResponse(statusCode)
         whenever(mockChain.proceed(any())) doReturn fakeResponse
@@ -349,7 +349,7 @@ internal class RumInstrumentationOkHttpAdapterTest {
 
         val fakeRequestBuilder = OkHttpRequestInfoBuilder(fakeRequest.newBuilder())
             .addTag(UUID::class.java, fakeUuid)
-        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder)
+        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder, isDefaultTracer = false)
         whenever(mockRegistry.get(mockCall)) doReturn fakeState
         val fakeResponse = forgeResponse(statusCode)
         whenever(mockChain.proceed(any())) doReturn fakeResponse
@@ -378,7 +378,7 @@ internal class RumInstrumentationOkHttpAdapterTest {
 
         val fakeRequestBuilder = OkHttpRequestInfoBuilder(fakeRequest.newBuilder())
             .addTag(UUID::class.java, fakeUuid)
-        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder)
+        val fakeState = RequestTracingState(requestInfoBuilder = fakeRequestBuilder, isDefaultTracer = false)
         whenever(mockRegistry.get(mockCall)) doReturn fakeState
         val fakeResponse = forgeResponse(statusCode)
         whenever(mockChain.proceed(any())) doReturn fakeResponse
@@ -409,7 +409,8 @@ internal class RumInstrumentationOkHttpAdapterTest {
         )
         val fakeDistributedTracingState = RequestTracingState(
             requestInfoBuilder = OkHttpRequestInfoBuilder(fakeRequest.newBuilder())
-                .addTag(UUID::class.java, fakeUuid)
+                .addTag(UUID::class.java, fakeUuid),
+            isDefaultTracer = false
         )
         whenever(mockDistributedTracingInstrumentation.onRequest(any())) doReturn fakeDistributedTracingState
         whenever(mockChain.proceed(any())) doReturn forgeResponse(statusCode)
@@ -435,7 +436,8 @@ internal class RumInstrumentationOkHttpAdapterTest {
         val fakeDistributedTracingState = RequestTracingState(
             requestInfoBuilder = OkHttpRequestInfoBuilder(fakeRequest.newBuilder())
                 .addTag(UUID::class.java, fakeUuid)
-                .addHeader("x-datadog-trace-id", fakeTraceId)
+                .addHeader("x-datadog-trace-id", fakeTraceId),
+            isDefaultTracer = false
         )
         whenever(mockDistributedTracingInstrumentation.onRequest(any())) doReturn fakeDistributedTracingState
         whenever(mockChain.proceed(any())) doReturn forgeResponse(statusCode)
@@ -462,7 +464,8 @@ internal class RumInstrumentationOkHttpAdapterTest {
         )
         val fakeDistributedTracingState = RequestTracingState(
             requestInfoBuilder = OkHttpRequestInfoBuilder(fakeRequest.newBuilder())
-                .addTag(UUID::class.java, fakeUuid)
+                .addTag(UUID::class.java, fakeUuid),
+            isDefaultTracer = false
         )
         whenever(mockDistributedTracingInstrumentation.onRequest(any())) doReturn fakeDistributedTracingState
         whenever(mockChain.proceed(any())) doReturn forgeResponse(statusCode)
@@ -487,7 +490,8 @@ internal class RumInstrumentationOkHttpAdapterTest {
         )
         val fakeDistributedTracingState = RequestTracingState(
             requestInfoBuilder = OkHttpRequestInfoBuilder(fakeRequest.newBuilder())
-                .addTag(UUID::class.java, fakeUuid)
+                .addTag(UUID::class.java, fakeUuid),
+            isDefaultTracer = false
         )
         whenever(mockDistributedTracingInstrumentation.onRequest(any())) doReturn fakeDistributedTracingState
         val fakeException = IOException("network error")

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/RumInstrumentationTimingsCounterTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/internal/RumInstrumentationTimingsCounterTest.kt
@@ -92,7 +92,7 @@ internal class RumInstrumentationTimingsCounterTest {
             .build()
 
         whenever(mockRequestBuilder.build()) doReturn mockRequestInfo
-        val fakeTracingState = RequestTracingState(requestInfoBuilder = mockRequestBuilder)
+        val fakeTracingState = RequestTracingState(requestInfoBuilder = mockRequestBuilder, isDefaultTracer = false)
         whenever(mockRequestInfoRegistry.get(mockCall)) doReturn fakeTracingState
 
         whenever(mockSdkCore.time).thenReturn(
@@ -285,7 +285,7 @@ internal class RumInstrumentationTimingsCounterTest {
     fun `M send timing W callEnd() { full request lifecycle }`() {
         // Given
         whenever(mockRequestInfoRegistry.remove(mockCall)) doReturn
-            RequestTracingState(requestInfoBuilder = mockRequestBuilder)
+            RequestTracingState(requestInfoBuilder = mockRequestBuilder, isDefaultTracer = false)
 
         // When
         testedListener.callStart(mockCall)
@@ -325,7 +325,7 @@ internal class RumInstrumentationTimingsCounterTest {
     ) {
         // Given
         whenever(mockRequestInfoRegistry.remove(mockCall)) doReturn
-            RequestTracingState(requestInfoBuilder = mockRequestBuilder)
+            RequestTracingState(requestInfoBuilder = mockRequestBuilder, isDefaultTracer = false)
 
         // When
         testedListener.callStart(mockCall)
@@ -390,7 +390,7 @@ internal class RumInstrumentationTimingsCounterTest {
     fun `M send timing with zeroes for missing phases W callEnd() { reused connection }`() {
         // Given
         whenever(mockRequestInfoRegistry.remove(mockCall)) doReturn
-            RequestTracingState(requestInfoBuilder = mockRequestBuilder)
+            RequestTracingState(requestInfoBuilder = mockRequestBuilder, isDefaultTracer = false)
 
         // When
         testedListener.callStart(mockCall)

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
@@ -67,6 +67,7 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -1022,6 +1023,44 @@ internal open class TracingInterceptorNonDdTracerTest {
         verify(mockSpan).setTag("error.stack", throwable.loggableStackTrace())
         verify(mockSpan).setTag("span.kind", "client")
         verify(mockSpan).finish()
+    }
+
+    @Test
+    fun `M drop span W intercept() {custom global tracer, not sampled, successful request}`(
+        @IntForgery(min = 200, max = 600) statusCode: Int
+    ) {
+        // Given - backwards-compat guarantee: custom tracers do not honour FORCE_DROP_SPAN,
+        // so sampled-out spans must be dropped via drop(), not setTag+finish.
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        verify(mockSpan).drop()
+        verify(mockSpan, never()).finish()
+    }
+
+    @Test
+    fun `M drop span W intercept() {custom global tracer, not sampled, throwing request}`(
+        @Forgery throwable: Throwable
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockChain.request()) doReturn fakeRequest
+        whenever(mockChain.proceed(any())) doThrow throwable
+
+        // When
+        assertThrows<Throwable>(throwable.message.orEmpty()) {
+            testedInterceptor.intercept(mockChain)
+        }
+
+        // Then
+        verify(mockSpan).drop()
+        verify(mockSpan, never()).finish()
     }
 
     @Test

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
@@ -229,6 +229,7 @@ internal open class TracingInterceptorTest {
     open fun instantiateTestedInterceptor(
         tracedHosts: Map<String, Set<TracingHeaderType>> = emptyMap(),
         globalTracerProvider: () -> DatadogTracer? = { null },
+        defaultTracerCheck: (DatadogTracer) -> Boolean = _TraceInternalProxy::isDefaultTracer,
         localTracerFactory: (SdkCore, Set<TracingHeaderType>) -> DatadogTracer
     ): TracingInterceptor {
         return TracingInterceptor(
@@ -240,7 +241,8 @@ internal open class TracingInterceptorTest {
             localTracerFactory = localTracerFactory,
             redacted404ResourceName = fakeRedacted404Resources,
             traceContextInjection = TraceContextInjection.ALL,
-            globalTracerProvider = globalTracerProvider
+            globalTracerProvider = globalTracerProvider,
+            defaultTracerCheck = defaultTracerCheck
         )
     }
 
@@ -1261,6 +1263,108 @@ internal open class TracingInterceptorTest {
         verify(mockSpan).setTag("span.kind", "client")
         verify(mockSpan).resourceName = fakeBaseUrl.lowercase(Locale.US)
         verify(mockSpan).finish()
+    }
+
+    @Test
+    fun `M force drop span W intercept() {not sampled, successful request, SDK-backed tracer}`(
+        @IntForgery(min = 200, max = 600) statusCode: Int
+    ) {
+        // Given
+        testedInterceptor = instantiateTestedInterceptor(
+            fakeLocalHosts,
+            globalTracerProvider = { mockTracer },
+            defaultTracerCheck = { true },
+            localTracerFactory = { _, _ -> mockLocalTracer }
+        )
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
+        stubChain(mockChain, statusCode)
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        verify(mockSpan).setTag("_dd.local.force_drop", true)
+        verify(mockSpan).finish()
+        verify(mockSpan, never()).drop()
+    }
+
+    @Test
+    fun `M drop span W intercept() {not sampled, successful request, custom tracer}`(
+        @IntForgery(min = 200, max = 600) statusCode: Int
+    ) {
+        // Given
+        testedInterceptor = instantiateTestedInterceptor(
+            fakeLocalHosts,
+            globalTracerProvider = { mockTracer },
+            defaultTracerCheck = { false },
+            localTracerFactory = { _, _ -> mockLocalTracer }
+        )
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
+        stubChain(mockChain, statusCode)
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        verify(mockSpan, never()).setTag("_dd.local.force_drop", true)
+        verify(mockSpan, never()).finish()
+        verify(mockSpan).drop()
+    }
+
+    @Test
+    fun `M force drop span W intercept() {not sampled, throwing request, SDK-backed tracer}`(
+        @Forgery throwable: Throwable
+    ) {
+        // Given
+        testedInterceptor = instantiateTestedInterceptor(
+            fakeLocalHosts,
+            globalTracerProvider = { mockTracer },
+            defaultTracerCheck = { true },
+            localTracerFactory = { _, _ -> mockLocalTracer }
+        )
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
+        whenever(mockChain.request()) doReturn fakeRequest
+        whenever(mockChain.proceed(any())) doThrow throwable
+
+        // When
+        assertThrows<Throwable>(throwable.message.orEmpty()) {
+            testedInterceptor.intercept(mockChain)
+        }
+
+        // Then
+        verify(mockSpan).setTag("_dd.local.force_drop", true)
+        verify(mockSpan).finish()
+        verify(mockSpan, never()).drop()
+    }
+
+    @Test
+    fun `M drop span W intercept() {not sampled, throwing request, custom tracer}`(
+        @Forgery throwable: Throwable
+    ) {
+        // Given
+        testedInterceptor = instantiateTestedInterceptor(
+            fakeLocalHosts,
+            globalTracerProvider = { mockTracer },
+            defaultTracerCheck = { false },
+            localTracerFactory = { _, _ -> mockLocalTracer }
+        )
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
+        whenever(mockChain.request()) doReturn fakeRequest
+        whenever(mockChain.proceed(any())) doThrow throwable
+
+        // When
+        assertThrows<Throwable>(throwable.message.orEmpty()) {
+            testedInterceptor.intercept(mockChain)
+        }
+
+        // Then
+        verify(mockSpan, never()).setTag("_dd.local.force_drop", true)
+        verify(mockSpan, never()).finish()
+        verify(mockSpan).drop()
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
CoreTracer needs to see all spans to calculate APM client-side stats. Since network spans have their own sampling rate, sampled-out spans are now finished with the `_dd.local.force_drop` tag instead of being dropped. This tells downstream systems to discard the span while still letting CoreTracer process it for stats calculations.

This only applies when the active tracer is the SDK's own `DatadogTracerAdapter`, which routes through `CoreTraceWriter` — the only implementation that honours `_dd.local.force_drop`. When a custom or global `DatadogTracer` is in use, sampled-out spans are dropped via `drop()` as before, preserving backward compatibility.

Note: Some of this can be cleaned up if we drop OpenTrace and move the OKHttp feature to use the new ApmNetworkInstrumentation in V4

### Motivation
Allows us to capture APM metrics for traces that are sampled out at the request level

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

