### PR TITLE
RUM-767: Improve reading-errors telemetry for dropped events

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -201,6 +201,7 @@ interface com.datadog.android.api.storage.DataWriter<T>
   fun write(EventBatchWriter, T, EventType): Boolean
 interface com.datadog.android.api.storage.EventBatchWriter
   fun write(RawBatchEvent, ByteArray?, EventType): Boolean
+fun EventBatchWriter.write(RawBatchEvent, ByteArray?, EventType, com.datadog.android.internal.telemetry.TelemetryContext): Boolean
 enum com.datadog.android.api.storage.EventType
   - DEFAULT
   - CRASH
@@ -338,6 +339,8 @@ fun java.io.File.lengthSafe(com.datadog.android.api.InternalLogger): Long
 fun java.io.File.readTextSafe(java.nio.charset.Charset = Charsets.UTF_8, com.datadog.android.api.InternalLogger): String?
 fun java.io.File.readBytesSafe(com.datadog.android.api.InternalLogger): ByteArray?
 fun java.io.File.readLinesSafe(java.nio.charset.Charset = Charsets.UTF_8, com.datadog.android.api.InternalLogger): List<String>?
+interface com.datadog.android.core.internal.storage.TelemetryAwareEventBatchWriter : com.datadog.android.api.storage.EventBatchWriter
+  fun write(com.datadog.android.api.storage.RawBatchEvent, ByteArray?, com.datadog.android.api.storage.EventType, com.datadog.android.internal.telemetry.TelemetryContext): Boolean
 fun Collection<ByteArray>.join(ByteArray, ByteArray = ByteArray(0), ByteArray = ByteArray(0), com.datadog.android.api.InternalLogger): ByteArray
 fun java.util.concurrent.Executor.executeSafe(String, com.datadog.android.api.InternalLogger, Runnable)
 fun java.util.concurrent.ScheduledExecutorService.scheduleSafe(String, Long, java.util.concurrent.TimeUnit, com.datadog.android.api.InternalLogger, Runnable): java.util.concurrent.ScheduledFuture<*>?

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -580,6 +580,10 @@ public abstract interface class com/datadog/android/api/storage/EventBatchWriter
 	public abstract fun write (Lcom/datadog/android/api/storage/RawBatchEvent;[BLcom/datadog/android/api/storage/EventType;)Z
 }
 
+public final class com/datadog/android/api/storage/EventBatchWriterKt {
+	public static final fun write (Lcom/datadog/android/api/storage/EventBatchWriter;Lcom/datadog/android/api/storage/RawBatchEvent;[BLcom/datadog/android/api/storage/EventType;Lcom/datadog/android/internal/telemetry/TelemetryContext;)Z
+}
+
 public final class com/datadog/android/api/storage/EventType : java/lang/Enum {
 	public static final field CRASH Lcom/datadog/android/api/storage/EventType;
 	public static final field DEFAULT Lcom/datadog/android/api/storage/EventType;
@@ -885,6 +889,10 @@ public final class com/datadog/android/core/internal/persistence/file/FileExtKt 
 	public static synthetic fun readLinesSafe$default (Ljava/io/File;Ljava/nio/charset/Charset;Lcom/datadog/android/api/InternalLogger;ILjava/lang/Object;)Ljava/util/List;
 	public static final fun readTextSafe (Ljava/io/File;Ljava/nio/charset/Charset;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/String;
 	public static synthetic fun readTextSafe$default (Ljava/io/File;Ljava/nio/charset/Charset;Lcom/datadog/android/api/InternalLogger;ILjava/lang/Object;)Ljava/lang/String;
+}
+
+public abstract interface class com/datadog/android/core/internal/storage/TelemetryAwareEventBatchWriter : com/datadog/android/api/storage/EventBatchWriter {
+	public abstract fun write (Lcom/datadog/android/api/storage/RawBatchEvent;[BLcom/datadog/android/api/storage/EventType;Lcom/datadog/android/internal/telemetry/TelemetryContext;)Z
 }
 
 public final class com/datadog/android/core/internal/utils/ByteArrayExtKt {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/EventBatchWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/EventBatchWriter.kt
@@ -7,6 +7,9 @@
 package com.datadog.android.api.storage
 
 import androidx.annotation.WorkerThread
+import com.datadog.android.core.internal.storage.TelemetryAwareEventBatchWriter
+import com.datadog.android.internal.telemetry.TelemetryContext
+import com.datadog.android.lint.InternalApi
 
 /**
  * Writer allowing [FeatureScope] to write events in the storage.
@@ -28,3 +31,23 @@ interface EventBatchWriter {
         eventType: EventType
     ): Boolean
 }
+
+/**
+ * Writes an event, forwarding [telemetryContext] when the underlying writer supports
+ * dropped-event telemetry, otherwise falling back to the plain [EventBatchWriter.write].
+ * @param event the event to write (content + metadata)
+ * @param batchMetadata the optional updated batch metadata
+ * @param eventType additional information about the event data
+ * @param telemetryContext metadata attached to dropped-event telemetry
+ * @return true if event was written, false otherwise.
+ */
+@InternalApi
+@WorkerThread
+fun EventBatchWriter.write(
+    event: RawBatchEvent,
+    batchMetadata: ByteArray?,
+    eventType: EventType,
+    telemetryContext: TelemetryContext
+): Boolean = (this as? TelemetryAwareEventBatchWriter)
+    ?.write(event, batchMetadata, eventType, telemetryContext)
+    ?: write(event, batchMetadata, eventType)

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -20,6 +20,7 @@ import com.datadog.android.BuildConfig
 import com.datadog.android.Datadog
 import com.datadog.android.DatadogSite
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.configuration.BackPressureStrategy
 import com.datadog.android.core.configuration.BatchProcessingLevel
@@ -74,6 +75,7 @@ import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.core.persistence.PersistenceStrategy
 import com.datadog.android.core.thread.FlushableExecutorService
 import com.datadog.android.internal.system.BuildSdkVersionProvider
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.internal.utils.allowThreadDiskReads
@@ -386,8 +388,17 @@ internal class CoreFeature(
 
     @WorkerThread
     internal fun writeLastViewEvent(data: ByteArray) {
-        val serialized = lastViewEventFileWriter.serializeToBytes(RawBatchEvent(data = data)) ?: return
-        lastViewEventFileWriter.writeBinaryData(lastViewEventFile, serialized, false)
+        val telemetryContext = TelemetryContext(featureName = Feature.RUM_FEATURE_NAME)
+        val serialized = lastViewEventFileWriter.serializeToBytes(
+            RawBatchEvent(data = data),
+            telemetryContext
+        ) ?: return
+        lastViewEventFileWriter.writeBinaryData(
+            lastViewEventFile,
+            serialized,
+            append = false,
+            telemetryContext
+        )
     }
 
     @WorkerThread
@@ -437,7 +448,10 @@ internal class CoreFeature(
 
         val reader =
             BatchFileReaderWriter.create(internalLogger, localDataEncryption)
-        val content = reader.readData(lastViewEventFile)
+        val content = reader.readData(
+            lastViewEventFile,
+            TelemetryContext(featureName = Feature.RUM_FEATURE_NAME)
+        )
         return if (content.isEmpty()) {
             null
         } else {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -443,6 +443,7 @@ internal class SdkFeature(
         )
 
         dataStore = DataStoreFileHandler(
+            featureName = featureName,
             executorService = coreFeature.persistenceExecutorService,
             internalLogger = internalLogger,
             dataStoreFileReader = dataStoreFileReader,
@@ -461,6 +462,7 @@ internal class SdkFeature(
             BatchFileReaderWriter.create(internalLogger, coreFeature.localDataEncryption),
             FileReaderWriter.create(internalLogger, coreFeature.localDataEncryption),
             FileMover(internalLogger),
+            wrappedFeature.name,
             internalLogger
         )
         flusher.flush(uploader)

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataFlusher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataFlusher.kt
@@ -14,6 +14,7 @@ import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.FileReader
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileReader
 import com.datadog.android.core.internal.persistence.file.existsSafe
+import com.datadog.android.internal.telemetry.TelemetryContext
 
 internal class DataFlusher(
     internal val contextProvider: ContextProvider,
@@ -21,6 +22,7 @@ internal class DataFlusher(
     internal val fileReader: BatchFileReader,
     internal val metadataFileReader: FileReader<ByteArray>,
     internal val fileMover: FileMover,
+    private val featureName: String,
     private val internalLogger: InternalLogger
 ) : Flusher {
 
@@ -30,10 +32,11 @@ internal class DataFlusher(
 
         val toUploadFiles = fileOrchestrator.getFlushableFiles()
         toUploadFiles.forEach {
-            val batch = fileReader.readData(it)
+            val telemetryContext = TelemetryContext(featureName)
+            val batch = fileReader.readData(it, telemetryContext)
             val metaFile = fileOrchestrator.getMetadataFile(it)
             val meta = if (metaFile != null && metaFile.existsSafe(internalLogger)) {
-                metadataFileReader.readData(metaFile)
+                metadataFileReader.readData(metaFile, telemetryContext)
             } else {
                 null
             }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
@@ -23,6 +23,7 @@ import com.datadog.android.core.internal.persistence.file.batch.BatchFileReaderW
 import com.datadog.android.core.internal.persistence.file.existsSafe
 import com.datadog.android.core.internal.persistence.file.lengthSafe
 import com.datadog.android.core.internal.utils.executeSafe
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.privacy.TrackingConsent
 import java.io.File
 import java.util.Locale
@@ -60,6 +61,7 @@ internal class ConsentAwareStorage(
             return AsyncEventWriteScope(executorService, NoOpEventBatchWriter(), writeLock, featureName, internalLogger)
         }
         val writer = FileEventBatchWriter(
+            featureName = featureName,
             fileOrchestrator = orchestrator,
             eventsWriter = batchEventsReaderWriter,
             metadataReaderWriter = batchMetadataReaderWriter,
@@ -83,12 +85,16 @@ internal class ConsentAwareStorage(
         }
 
         val batchId = BatchId.fromFile(batchFile)
+        val telemetryContext = TelemetryContext(featureName = featureName)
         val batchMetadata = if (metaFile == null || !metaFile.existsSafe(internalLogger)) {
             null
         } else {
-            batchMetadataReaderWriter.readData(metaFile)
+            batchMetadataReaderWriter.readData(metaFile, telemetryContext)
         }
-        val batchData = batchEventsReaderWriter.readData(batchFile)
+        val batchData = batchEventsReaderWriter.readData(
+            batchFile,
+            telemetryContext
+        )
 
         return BatchData(id = batchId, data = batchData, metadata = batchMetadata)
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriter.kt
@@ -8,60 +8,76 @@ package com.datadog.android.core.internal.persistence
 
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileReaderWriter
+import com.datadog.android.core.internal.storage.TelemetryAwareEventBatchWriter
+import com.datadog.android.internal.telemetry.TelemetryContext
 import java.io.File
 import java.util.Locale
 
 internal class FileEventBatchWriter(
+    private val featureName: String,
     private val fileOrchestrator: FileOrchestrator,
     private val eventsWriter: BatchFileReaderWriter,
     private val metadataReaderWriter: FileReaderWriter,
     private val filePersistenceConfig: FilePersistenceConfig,
     private val batchWriteEventListener: BatchWriteEventListener,
     private val internalLogger: InternalLogger
-) : EventBatchWriter {
+) : TelemetryAwareEventBatchWriter {
+
+    @WorkerThread
+    override fun write(
+        event: RawBatchEvent,
+        batchMetadata: ByteArray?,
+        eventType: EventType
+    ) = write(
+        event,
+        batchMetadata,
+        eventType,
+        TelemetryContext(featureName = featureName)
+    )
 
     @WorkerThread
     @Suppress("ReturnCount")
     override fun write(
         event: RawBatchEvent,
         batchMetadata: ByteArray?,
-        eventType: EventType
+        eventType: EventType,
+        telemetryContext: TelemetryContext
     ): Boolean {
         // prevent useless operation for empty event
         if (event.data.isEmpty()) {
             return true
         }
-        if (!checkEventSize(event.data.size)) {
+        if (!checkEventSize(event.data.size, telemetryContext)) {
             return false
         }
 
         // Serialize once (TLV-wrapped, encrypted if configured) so the exact on-disk size is known
         // before asking the orchestrator for a file with enough room to hold it.
-        val serializedEvent = eventsWriter.serializeToBytes(event) ?: return false
+        val serializedEvent = eventsWriter.serializeToBytes(event, telemetryContext) ?: return false
 
         val batchFile = fileOrchestrator.getWritableFile(serializedEvent.size.toLong())
         if (batchFile == null) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
                 targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-                { NO_BATCH_FILE_AVAILABLE }
+                { NO_BATCH_FILE_AVAILABLE },
+                additionalProperties = telemetryContext.asAttributesMap(bytesLost = event.data.size)
             )
             return false
         }
 
         val metadataFile = fileOrchestrator.getMetadataFile(batchFile)
 
-        return if (eventsWriter.writeBinaryData(batchFile, serializedEvent, true)) {
+        return if (eventsWriter.writeBinaryData(batchFile, serializedEvent, true, telemetryContext)) {
             batchWriteEventListener.onWriteEvent(event.data.size.toLong())
             if (batchMetadata?.isNotEmpty() == true && metadataFile != null) {
-                writeBatchMetadata(metadataFile, batchMetadata)
+                writeBatchMetadata(metadataFile, batchMetadata, telemetryContext)
             }
             true
         } else {
@@ -69,18 +85,19 @@ internal class FileEventBatchWriter(
         }
     }
 
-    private fun checkEventSize(eventSize: Int): Boolean {
+    private fun checkEventSize(eventSize: Int, telemetryContext: TelemetryContext): Boolean {
         if (eventSize > filePersistenceConfig.maxItemSize) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
-                InternalLogger.Target.USER,
-                {
+                targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+                messageBuilder = {
                     ERROR_LARGE_DATA.format(
                         Locale.US,
                         eventSize,
                         filePersistenceConfig.maxItemSize
                     )
-                }
+                },
+                additionalProperties = telemetryContext.asAttributesMap(bytesLost = eventSize)
             )
             return false
         }
@@ -88,22 +105,28 @@ internal class FileEventBatchWriter(
     }
 
     @WorkerThread
-    private fun writeBatchMetadata(metadataFile: File, metadata: ByteArray) {
+    private fun writeBatchMetadata(
+        metadataFile: File,
+        metadata: ByteArray,
+        telemetryContext: TelemetryContext
+    ) {
         val result = metadataReaderWriter.writeData(
             metadataFile,
             metadata,
-            false
+            false,
+            telemetryContext
         )
         if (!result) {
             internalLogger.log(
                 InternalLogger.Level.WARN,
-                InternalLogger.Target.USER,
+                listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
                 {
                     WARNING_METADATA_WRITE_FAILED.format(
                         Locale.US,
                         metadataFile.path
                     )
-                }
+                },
+                additionalProperties = telemetryContext.asAttributesMap(bytesLost = metadata.size)
             )
         }
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriter.kt
@@ -90,14 +90,11 @@ internal class FileEventBatchWriter(
             internalLogger.log(
                 InternalLogger.Level.ERROR,
                 targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-                messageBuilder = {
-                    ERROR_LARGE_DATA.format(
-                        Locale.US,
-                        eventSize,
-                        filePersistenceConfig.maxItemSize
-                    )
-                },
-                additionalProperties = telemetryContext.asAttributesMap(bytesLost = eventSize)
+                messageBuilder = { ERROR_LARGE_DATA },
+                additionalProperties = telemetryContext.asAttributesMap(
+                    bytesLost = eventSize,
+                    TelemetryContext.TELEMETRY_DATA_LIMIT to filePersistenceConfig.maxItemSize
+                )
             )
             return false
         }
@@ -119,21 +116,15 @@ internal class FileEventBatchWriter(
         if (!result) {
             internalLogger.log(
                 InternalLogger.Level.WARN,
-                listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-                {
-                    WARNING_METADATA_WRITE_FAILED.format(
-                        Locale.US,
-                        metadataFile.path
-                    )
-                },
-                additionalProperties = telemetryContext.asAttributesMap(bytesLost = metadata.size)
+                InternalLogger.Target.USER,
+                { WARNING_METADATA_WRITE_FAILED.format(Locale.US, metadataFile.path) }
             )
         }
     }
 
     companion object {
         internal const val WARNING_METADATA_WRITE_FAILED = "Unable to write metadata file: %s"
-        internal const val ERROR_LARGE_DATA = "Can't write data with size %d (max item size is %d)"
+        internal const val ERROR_LARGE_DATA = "Can't write data - too big."
         internal const val NO_BATCH_FILE_AVAILABLE = "No batch file available"
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileHandler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileHandler.kt
@@ -13,9 +13,11 @@ import com.datadog.android.api.storage.datastore.DataStoreWriteCallback
 import com.datadog.android.core.internal.persistence.Deserializer
 import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.core.persistence.Serializer
+import com.datadog.android.internal.telemetry.TelemetryContext
 import java.util.concurrent.ExecutorService
 
 internal class DataStoreFileHandler(
+    private val featureName: String,
     private val executorService: ExecutorService,
     private val internalLogger: InternalLogger,
     private val dataStoreFileReader: DatastoreFileReader,
@@ -30,7 +32,7 @@ internal class DataStoreFileHandler(
         serializer: Serializer<T>
     ) {
         executorService.executeSafe("dataStoreWrite", internalLogger) {
-            datastoreFileWriter.write(key, data, serializer, callback, version)
+            datastoreFileWriter.write(key, data, serializer, callback, version, TelemetryContext(featureName))
         }
     }
 
@@ -53,7 +55,7 @@ internal class DataStoreFileHandler(
         deserializer: Deserializer<String, T>
     ) {
         executorService.executeSafe("dataStoreRead", internalLogger) {
-            dataStoreFileReader.read(key, deserializer, version, callback)
+            dataStoreFileReader.read(key, deserializer, version, callback, TelemetryContext(featureName))
         }
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/DatastoreFileReader.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/DatastoreFileReader.kt
@@ -16,6 +16,7 @@ import com.datadog.android.core.internal.persistence.tlvformat.TLVBlockFileReade
 import com.datadog.android.core.internal.persistence.tlvformat.TLVBlockType
 import com.datadog.android.core.internal.utils.toInt
 import com.datadog.android.core.persistence.datastore.DataStoreContent
+import com.datadog.android.internal.telemetry.TelemetryContext
 import java.io.File
 import java.util.Locale
 
@@ -31,7 +32,8 @@ internal class DatastoreFileReader(
         key: String,
         deserializer: Deserializer<String, T>,
         version: Int? = null,
-        callback: DataStoreReadCallback<T>
+        callback: DataStoreReadCallback<T>,
+        telemetryContext: TelemetryContext
     ) {
         val datastoreFile = dataStoreFileHelper.getDataStoreFile(
             storageDir = storageDir,
@@ -44,7 +46,7 @@ internal class DatastoreFileReader(
             return
         }
 
-        readFromDataStoreFile(datastoreFile, deserializer, tlvBlockFileReader, version, callback)
+        readFromDataStoreFile(datastoreFile, deserializer, tlvBlockFileReader, version, callback, telemetryContext)
     }
 
     @Suppress("ReturnCount", "ThreadSafety")
@@ -53,9 +55,10 @@ internal class DatastoreFileReader(
         deserializer: Deserializer<String, T>,
         tlvBlockFileReader: TLVBlockFileReader,
         requestedVersion: Int?,
-        callback: DataStoreReadCallback<T>
+        callback: DataStoreReadCallback<T>,
+        telemetryContext: TelemetryContext
     ) {
-        val tlvBlocks = tlvBlockFileReader.read(datastoreFile)
+        val tlvBlocks = tlvBlockFileReader.read(datastoreFile, telemetryContext)
 
         // there should be as many blocks read as there are block types
         val numberBlocksFound = tlvBlocks.size

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/DatastoreFileWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/DatastoreFileWriter.kt
@@ -18,6 +18,7 @@ import com.datadog.android.core.internal.persistence.tlvformat.TLVBlockType
 import com.datadog.android.core.internal.utils.join
 import com.datadog.android.core.internal.utils.toByteArray
 import com.datadog.android.core.persistence.Serializer
+import com.datadog.android.internal.telemetry.TelemetryContext
 import java.io.File
 
 internal class DatastoreFileWriter(
@@ -33,7 +34,8 @@ internal class DatastoreFileWriter(
         data: T,
         serializer: Serializer<T>,
         callback: DataStoreWriteCallback?,
-        version: Int
+        version: Int,
+        telemetryContext: TelemetryContext
     ) {
         val datastoreFile = dataStoreFileHelper.getDataStoreFile(
             storageDir = storageDir,
@@ -58,7 +60,8 @@ internal class DatastoreFileWriter(
         val result = fileReaderWriter.writeData(
             file = datastoreFile,
             data = dataToWrite,
-            append = false
+            append = false,
+            telemetryContext = telemetryContext
         )
 
         if (result) {
@@ -115,7 +118,7 @@ internal class DatastoreFileWriter(
             internalLogger = internalLogger
         )
 
-        return dataBlock.serialize()
+        return dataBlock.serialize(TelemetryContext(featureName = featureName))
     }
 
     private fun getVersionCodeBlock(version: Int): ByteArray? {
@@ -126,7 +129,7 @@ internal class DatastoreFileWriter(
             internalLogger = internalLogger
         )
 
-        return versionBlock.serialize()
+        return versionBlock.serialize(TelemetryContext(featureName = featureName))
     }
 
     private fun logFailedToSerializeDataError() {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/EncryptedFileReaderWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/EncryptedFileReaderWriter.kt
@@ -8,6 +8,7 @@ package com.datadog.android.core.internal.persistence.file
 
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.security.Encryption
 import java.io.File
 
@@ -22,7 +23,8 @@ internal class EncryptedFileReaderWriter(
     override fun writeData(
         file: File,
         data: ByteArray,
-        append: Boolean
+        append: Boolean,
+        telemetryContext: TelemetryContext
     ): Boolean {
         if (append) {
             internalLogger.log(
@@ -44,18 +46,15 @@ internal class EncryptedFileReaderWriter(
             return false
         }
 
-        return delegate.writeData(
-            file,
-            encryptedData,
-            append
-        )
+        return delegate.writeData(file, encryptedData, append, telemetryContext)
     }
 
     @WorkerThread
     override fun readData(
-        file: File
+        file: File,
+        telemetryContext: TelemetryContext
     ): ByteArray {
-        return encryption.decrypt(delegate.readData(file))
+        return encryption.decrypt(delegate.readData(file, telemetryContext))
     }
 
     companion object {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileReader.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileReader.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.core.internal.persistence.file
 
 import androidx.annotation.WorkerThread
+import com.datadog.android.internal.telemetry.TelemetryContext
 import java.io.File
 
 internal interface FileReader<T> {
@@ -14,8 +15,9 @@ internal interface FileReader<T> {
     /**
      * Reads data from the given file.
      *  @param file the file to read from
+     *  @param telemetryContext context used to report telemetry if the read fails
      *  @return the data
      */
     @WorkerThread
-    fun readData(file: File): T
+    fun readData(file: File, telemetryContext: TelemetryContext): T
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileWriter.kt
@@ -7,22 +7,25 @@
 package com.datadog.android.core.internal.persistence.file
 
 import androidx.annotation.WorkerThread
+import com.datadog.android.internal.telemetry.TelemetryContext
 import java.io.File
 
 internal interface FileWriter<T> {
 
     /**
      * Writes data as a [T] into a file.
-     * @type T type of the data to write
+     * @typeParam T type of the data to write
      * @param file the file to write to
      * @param data the data to write
      * @param append whether to append data at the end of the file or overwrite
+     * @param telemetryContext optional telemetry metadata for dropped-event diagnostics
      * @return whether the write operation was successful
      */
     @WorkerThread
     fun writeData(
         file: File,
         data: T,
-        append: Boolean
+        append: Boolean,
+        telemetryContext: TelemetryContext
     ): Boolean
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/PlainFileReaderWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/PlainFileReaderWriter.kt
@@ -11,10 +11,10 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.utils.use
 import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.internal.telemetry.TelemetryContext.Companion.BYTE_LOST_UNKNOWN
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_FILE_PATH
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
-import java.util.Locale
 
 /**
  * Stores data as-is. Use for any non-RUM/Trace/Logs data.
@@ -39,18 +39,24 @@ internal class PlainFileReaderWriter(
             internalLogger.log(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                { ERROR_WRITE.format(Locale.US, file.path) },
+                { ERROR_WRITE },
                 e,
-                additionalProperties = telemetryContext.asAttributesMap(bytesLost = data.size)
+                additionalProperties = telemetryContext.asAttributesMap(
+                    bytesLost = data.size,
+                    TELEMETRY_FILE_PATH to file.path
+                )
             )
             false
         } catch (e: SecurityException) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                { ERROR_WRITE.format(Locale.US, file.path) },
+                { ERROR_WRITE },
                 e,
-                additionalProperties = telemetryContext.asAttributesMap(bytesLost = data.size)
+                additionalProperties = telemetryContext.asAttributesMap(
+                    bytesLost = data.size,
+                    TELEMETRY_FILE_PATH to file.path
+                )
             )
             false
         }
@@ -66,16 +72,22 @@ internal class PlainFileReaderWriter(
                 internalLogger.log(
                     InternalLogger.Level.ERROR,
                     listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                    { ERROR_READ.format(Locale.US, file.path) },
-                    additionalProperties = telemetryContext.asAttributesMap(bytesLost = BYTE_LOST_UNKNOWN)
+                    { ERROR_READ },
+                    additionalProperties = telemetryContext.asAttributesMap(
+                        bytesLost = BYTE_LOST_UNKNOWN,
+                        TELEMETRY_FILE_PATH to file.path
+                    )
                 )
                 EMPTY_BYTE_ARRAY
             } else if (file.isDirectory) {
                 internalLogger.log(
                     InternalLogger.Level.ERROR,
                     listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                    { ERROR_READ.format(Locale.US, file.path) },
-                    additionalProperties = telemetryContext.asAttributesMap(bytesLost = BYTE_LOST_UNKNOWN)
+                    { ERROR_READ },
+                    additionalProperties = telemetryContext.asAttributesMap(
+                        bytesLost = BYTE_LOST_UNKNOWN,
+                        TELEMETRY_FILE_PATH to file.path
+                    )
                 )
                 EMPTY_BYTE_ARRAY
             } else {
@@ -86,18 +98,24 @@ internal class PlainFileReaderWriter(
             internalLogger.log(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                { ERROR_READ.format(Locale.US, file.path) },
+                { ERROR_READ },
                 e,
-                additionalProperties = telemetryContext.asAttributesMap(bytesLost = BYTE_LOST_UNKNOWN)
+                additionalProperties = telemetryContext.asAttributesMap(
+                    bytesLost = BYTE_LOST_UNKNOWN,
+                    TELEMETRY_FILE_PATH to file.path
+                )
             )
             EMPTY_BYTE_ARRAY
         } catch (e: SecurityException) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                { ERROR_READ.format(Locale.US, file.path) },
+                { ERROR_READ },
                 e,
-                additionalProperties = telemetryContext.asAttributesMap(bytesLost = BYTE_LOST_UNKNOWN)
+                additionalProperties = telemetryContext.asAttributesMap(
+                    bytesLost = BYTE_LOST_UNKNOWN,
+                    TELEMETRY_FILE_PATH to file.path
+                )
             )
             EMPTY_BYTE_ARRAY
         }
@@ -126,7 +144,7 @@ internal class PlainFileReaderWriter(
     companion object {
 
         private val EMPTY_BYTE_ARRAY = ByteArray(0)
-        internal const val ERROR_WRITE = "Unable to write data to file: %s"
-        internal const val ERROR_READ = "Unable to read data from file: %s"
+        internal const val ERROR_WRITE = "Unable to write data to file."
+        internal const val ERROR_READ = "Unable to read data from file."
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/PlainFileReaderWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/PlainFileReaderWriter.kt
@@ -9,6 +9,8 @@ package com.datadog.android.core.internal.persistence.file
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.utils.use
+import com.datadog.android.internal.telemetry.TelemetryContext
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.BYTE_LOST_UNKNOWN
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -27,7 +29,8 @@ internal class PlainFileReaderWriter(
     override fun writeData(
         file: File,
         data: ByteArray,
-        append: Boolean
+        append: Boolean,
+        telemetryContext: TelemetryContext
     ): Boolean {
         return try {
             lockFileAndWriteData(file, append, data)
@@ -37,7 +40,8 @@ internal class PlainFileReaderWriter(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
                 { ERROR_WRITE.format(Locale.US, file.path) },
-                e
+                e,
+                additionalProperties = telemetryContext.asAttributesMap(bytesLost = data.size)
             )
             false
         } catch (e: SecurityException) {
@@ -45,7 +49,8 @@ internal class PlainFileReaderWriter(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
                 { ERROR_WRITE.format(Locale.US, file.path) },
-                e
+                e,
+                additionalProperties = telemetryContext.asAttributesMap(bytesLost = data.size)
             )
             false
         }
@@ -53,21 +58,24 @@ internal class PlainFileReaderWriter(
 
     @WorkerThread
     override fun readData(
-        file: File
+        file: File,
+        telemetryContext: TelemetryContext
     ): ByteArray {
         return try {
             if (!file.exists()) {
                 internalLogger.log(
                     InternalLogger.Level.ERROR,
                     listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                    { ERROR_READ.format(Locale.US, file.path) }
+                    { ERROR_READ.format(Locale.US, file.path) },
+                    additionalProperties = telemetryContext.asAttributesMap(bytesLost = BYTE_LOST_UNKNOWN)
                 )
                 EMPTY_BYTE_ARRAY
             } else if (file.isDirectory) {
                 internalLogger.log(
                     InternalLogger.Level.ERROR,
                     listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                    { ERROR_READ.format(Locale.US, file.path) }
+                    { ERROR_READ.format(Locale.US, file.path) },
+                    additionalProperties = telemetryContext.asAttributesMap(bytesLost = BYTE_LOST_UNKNOWN)
                 )
                 EMPTY_BYTE_ARRAY
             } else {
@@ -79,7 +87,8 @@ internal class PlainFileReaderWriter(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
                 { ERROR_READ.format(Locale.US, file.path) },
-                e
+                e,
+                additionalProperties = telemetryContext.asAttributesMap(bytesLost = BYTE_LOST_UNKNOWN)
             )
             EMPTY_BYTE_ARRAY
         } catch (e: SecurityException) {
@@ -87,7 +96,8 @@ internal class PlainFileReaderWriter(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
                 { ERROR_READ.format(Locale.US, file.path) },
-                e
+                e,
+                additionalProperties = telemetryContext.asAttributesMap(bytesLost = BYTE_LOST_UNKNOWN)
             )
             EMPTY_BYTE_ARRAY
         }
@@ -116,7 +126,6 @@ internal class PlainFileReaderWriter(
     companion object {
 
         private val EMPTY_BYTE_ARRAY = ByteArray(0)
-
         internal const val ERROR_WRITE = "Unable to write data to file: %s"
         internal const val ERROR_READ = "Unable to read data from file: %s"
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileReader.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileReader.kt
@@ -8,6 +8,7 @@ package com.datadog.android.core.internal.persistence.file.batch
 
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.internal.telemetry.TelemetryContext
 import java.io.File
 
 internal interface BatchFileReader {
@@ -15,10 +16,12 @@ internal interface BatchFileReader {
     /**
      * Reads data from the given file.
      *  @param file the file to read from
+     *  @param telemetryContext telemetry metadata for dropped-event diagnostics
      *  @return the list of events as [RawBatchEvent] data stored in a file.
      */
     @WorkerThread
     fun readData(
-        file: File
+        file: File,
+        telemetryContext: TelemetryContext
     ): List<RawBatchEvent>
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileReaderWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileReaderWriter.kt
@@ -9,6 +9,7 @@ package com.datadog.android.core.internal.persistence.file.batch
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.security.Encryption
 import java.io.File
 
@@ -19,37 +20,43 @@ internal interface BatchFileReaderWriter : BatchFileReader {
      * and encrypted if encryption is configured). The size of the returned array is the exact number
      * of bytes [writeBinaryData] would append for this event.
      * @param data the event to serialize
+     * @param telemetryContext metadata attached to dropped-event telemetry if serialization fails
      * @return the on-disk binary representation of the event, or null if the event could not be
      * serialized (e.g. encryption produced an empty result for non-empty data). Callers must skip
      * the write when null is returned.
      */
-    fun serializeToBytes(data: RawBatchEvent): ByteArray?
+    fun serializeToBytes(data: RawBatchEvent, telemetryContext: TelemetryContext): ByteArray?
 
     /**
      * Writes a pre-serialized payload (as returned by [serializeToBytes]) to a file.
      * @param file the file to write to
      * @param bytes the pre-serialized payload to write
      * @param append whether to append data at the end of the file or overwrite
+     * @param telemetryContext metadata attached to dropped-event telemetry if the write fails
      * @return whether the write operation was successful
      */
     @WorkerThread
-    fun writeBinaryData(file: File, bytes: ByteArray, append: Boolean): Boolean
+    fun writeBinaryData(
+        file: File,
+        bytes: ByteArray,
+        append: Boolean,
+        telemetryContext: TelemetryContext
+    ): Boolean
 
     companion object {
         /**
          * Creates either plain [PlainBatchFileReaderWriter] or [PlainBatchFileReaderWriter] wrapped in
          * [EncryptedBatchReaderWriter] if encryption is provided.
          */
-        fun create(internalLogger: InternalLogger, encryption: Encryption?): BatchFileReaderWriter {
+        fun create(
+            internalLogger: InternalLogger,
+            encryption: Encryption?
+        ): BatchFileReaderWriter {
             val readerWriter = PlainBatchFileReaderWriter(internalLogger)
             return if (encryption == null) {
                 readerWriter
             } else {
-                EncryptedBatchReaderWriter(
-                    encryption,
-                    readerWriter,
-                    internalLogger
-                )
+                EncryptedBatchReaderWriter(encryption, readerWriter, internalLogger)
             }
         }
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/EncryptedBatchReaderWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/EncryptedBatchReaderWriter.kt
@@ -9,6 +9,7 @@ package com.datadog.android.core.internal.persistence.file.batch
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.security.Encryption
 import java.io.File
 
@@ -18,14 +19,18 @@ internal class EncryptedBatchReaderWriter(
     private val internalLogger: InternalLogger
 ) : BatchFileReaderWriter by delegate {
 
-    override fun serializeToBytes(data: RawBatchEvent): ByteArray? {
+    override fun serializeToBytes(
+        data: RawBatchEvent,
+        telemetryContext: TelemetryContext
+    ): ByteArray? {
         val encryptedData = encryption.encrypt(data.data)
 
         if (data.data.isNotEmpty() && encryptedData.isEmpty()) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
-                InternalLogger.Target.USER,
-                { BAD_ENCRYPTION_RESULT_MESSAGE }
+                listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+                { BAD_ENCRYPTION_RESULT_MESSAGE },
+                additionalProperties = telemetryContext.asAttributesMap(bytesLost = data.data.size)
             )
             return null
         }
@@ -34,19 +39,25 @@ internal class EncryptedBatchReaderWriter(
             data = encryptedData,
             metadata = encryption.encrypt(data.metadata)
         )
-        return delegate.serializeToBytes(encryptedRawBatchEvent)
+        return delegate.serializeToBytes(encryptedRawBatchEvent, telemetryContext)
     }
 
     @WorkerThread
-    override fun writeBinaryData(file: File, bytes: ByteArray, append: Boolean): Boolean {
-        return delegate.writeBinaryData(file, bytes, append)
+    override fun writeBinaryData(
+        file: File,
+        bytes: ByteArray,
+        append: Boolean,
+        telemetryContext: TelemetryContext
+    ): Boolean {
+        return delegate.writeBinaryData(file, bytes, append, telemetryContext)
     }
 
     @WorkerThread
     override fun readData(
-        file: File
+        file: File,
+        telemetryContext: TelemetryContext
     ): List<RawBatchEvent> {
-        return delegate.readData(file)
+        return delegate.readData(file, telemetryContext)
             .map {
                 RawBatchEvent(
                     data = if (it.data.isNotEmpty()) encryption.decrypt(it.data) else it.data,

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriter.kt
@@ -12,6 +12,13 @@ import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.internal.persistence.file.lengthSafe
 import com.datadog.android.core.internal.utils.use
 import com.datadog.android.internal.telemetry.TelemetryContext
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_BATCH_BYTES_ACTUAL
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_BATCH_BYTES_EXPECTED
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_BATCH_OPERATION
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_BLOCK_TYPE_ACTUAL_IDENTIFIER
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_BLOCK_TYPE_EXPECTED
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_BLOCK_TYPE_EXPECTED_IDENTIFIER
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_FILE_PATH
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
@@ -61,18 +68,24 @@ internal class PlainBatchFileReaderWriter(
             internalLogger.log(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                { ERROR_WRITE.format(Locale.US, file.path) },
+                { ERROR_WRITE },
                 e,
-                additionalProperties = telemetryContext.asAttributesMap(bytesLost = bytes.size)
+                additionalProperties = telemetryContext.asAttributesMap(
+                    bytesLost = bytes.size,
+                    TELEMETRY_FILE_PATH to file.path
+                )
             )
             false
         } catch (e: SecurityException) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                { ERROR_WRITE.format(Locale.US, file.path) },
+                { ERROR_WRITE },
                 e,
-                additionalProperties = telemetryContext.asAttributesMap(bytesLost = bytes.size)
+                additionalProperties = telemetryContext.asAttributesMap(
+                    bytesLost = bytes.size,
+                    TELEMETRY_FILE_PATH to file.path
+                )
             )
             false
         }
@@ -94,18 +107,24 @@ internal class PlainBatchFileReaderWriter(
             internalLogger.log(
                 level = InternalLogger.Level.ERROR,
                 targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                messageBuilder = { ERROR_READ.format(Locale.US, file.path) },
+                messageBuilder = { ERROR_READ },
                 throwable = e,
-                additionalProperties = telemetryContext.asAttributesMap(bytesLost = inputLength)
+                additionalProperties = telemetryContext.asAttributesMap(
+                    bytesLost = inputLength,
+                    TELEMETRY_FILE_PATH to file.path
+                )
             )
             emptyList()
         } catch (e: SecurityException) {
             internalLogger.log(
                 level = InternalLogger.Level.ERROR,
                 targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                messageBuilder = { ERROR_READ.format(Locale.US, file.path) },
+                messageBuilder = { ERROR_READ },
                 throwable = e,
-                additionalProperties = telemetryContext.asAttributesMap(inputLength)
+                additionalProperties = telemetryContext.asAttributesMap(
+                    bytesLost = inputLength,
+                    TELEMETRY_FILE_PATH to file.path
+                )
             )
             emptyList()
         }
@@ -170,26 +189,15 @@ internal class PlainBatchFileReaderWriter(
 
         // Read file iteratively
         var remaining = inputLength
-        // Snapshot of `remaining` at the start of the current iteration, i.e. the same value already
-        // reported to the readBlock/checkReadExpected telemetry above on failure. Used only for the
-        // summary log below, since `remaining` itself gets decremented by the partial bytes consumed
-        // by a failed read, which would otherwise under-report what this method actually drops.
-        var remainingAtIterationStart = remaining
         file.inputStream().buffered().use {
             while (remaining > 0) {
-                remainingAtIterationStart = remaining
                 val metaReadResult = readBlock(it, BlockType.META, telemetryContext, remaining)
                 if (metaReadResult.data == null) {
                     remaining -= metaReadResult.bytesRead
                     break
                 }
 
-                val eventReadResult = readBlock(
-                    it,
-                    BlockType.EVENT,
-                    telemetryContext,
-                    remaining
-                )
+                val eventReadResult = readBlock(it, BlockType.EVENT, telemetryContext, remaining)
                 remaining -= metaReadResult.bytesRead + eventReadResult.bytesRead
 
                 if (eventReadResult.data == null) break
@@ -199,12 +207,10 @@ internal class PlainBatchFileReaderWriter(
         }
 
         if (remaining != 0 || (inputLength > 0 && result.isEmpty())) {
-            val droppedBytes = if (result.isEmpty()) inputLength else remainingAtIterationStart
             internalLogger.log(
                 InternalLogger.Level.ERROR,
-                listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-                { WARNING_NOT_ALL_DATA_READ.format(Locale.US, file.path) },
-                additionalProperties = telemetryContext.asAttributesMap(bytesLost = droppedBytes)
+                listOf(InternalLogger.Target.USER, InternalLogger.Target.MAINTAINER),
+                { WARNING_NOT_ALL_DATA_READ.format(Locale.US, file.path) }
             )
         }
 
@@ -241,11 +247,13 @@ internal class PlainBatchFileReaderWriter(
             internalLogger.log(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                {
-                    "Unexpected block type identifier=$blockType met," +
-                        " was expecting $expectedBlockType(${expectedBlockType.identifier})"
-                },
-                additionalProperties = telemetryContext.asAttributesMap(bytesLost = remaining)
+                { ERROR_UNEXPECTED_BLOCK_TYPE_MET },
+                additionalProperties = telemetryContext.asAttributesMap(
+                    bytesLost = remaining,
+                    TELEMETRY_BLOCK_TYPE_ACTUAL_IDENTIFIER to blockType,
+                    TELEMETRY_BLOCK_TYPE_EXPECTED_IDENTIFIER to expectedBlockType.identifier,
+                    TELEMETRY_BLOCK_TYPE_EXPECTED to expectedBlockType.name
+                )
             )
             // in theory, we could continue reading, because we still know data size,
             // but unexpected type says that at least relationship between blocks is broken,
@@ -285,18 +293,23 @@ internal class PlainBatchFileReaderWriter(
                 internalLogger.log(
                     InternalLogger.Level.ERROR,
                     listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                    {
-                        "Number of bytes read for operation='$operation' doesn't" +
-                            " match with expected: expected=$expected, actual=$actual"
-                    },
-                    additionalProperties = telemetryContext.asAttributesMap(bytesLost = bytesLost)
+                    { ERROR_UNEXPECTED_NUMBERS_OF_BYTES },
+                    additionalProperties = telemetryContext.asAttributesMap(
+                        bytesLost = bytesLost,
+                        TELEMETRY_BATCH_OPERATION to operation,
+                        TELEMETRY_BATCH_BYTES_EXPECTED to expected,
+                        TELEMETRY_BATCH_BYTES_ACTUAL to actual
+                    )
                 )
             } else {
                 internalLogger.log(
                     InternalLogger.Level.ERROR,
                     listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                    { "Unexpected EOF at the operation=$operation" },
-                    additionalProperties = telemetryContext.asAttributesMap(bytesLost = bytesLost)
+                    { ERROR_UNEXPECTED_EOF },
+                    additionalProperties = telemetryContext.asAttributesMap(
+                        bytesLost = bytesLost,
+                        TELEMETRY_BATCH_OPERATION to operation
+                    )
                 )
             }
             false
@@ -338,10 +351,13 @@ internal class PlainBatchFileReaderWriter(
         internal const val LENGTH_SIZE_BYTES: Int = 4
         internal const val HEADER_SIZE_BYTES: Int = TYPE_SIZE_BYTES + LENGTH_SIZE_BYTES
 
-        internal const val ERROR_WRITE = "Unable to write data to file: %s"
+        internal const val ERROR_WRITE = "Unable to write data to file."
         internal const val ERROR_WRITE_FALLBACK = "Unable to restore file after failed write: %s"
-        internal const val ERROR_READ = "Unable to read data from file: %s"
+        internal const val ERROR_READ = "Unable to read data from file."
 
+        internal const val ERROR_UNEXPECTED_EOF = "Unexpected EOF"
+        internal const val ERROR_UNEXPECTED_BLOCK_TYPE_MET = "Unexpected block type identifier met"
+        internal const val ERROR_UNEXPECTED_NUMBERS_OF_BYTES = "Number of bytes read doesn't match with expected"
         internal const val WARNING_NOT_ALL_DATA_READ =
             "File %s is probably corrupted, not all content was read."
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriter.kt
@@ -11,6 +11,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.internal.persistence.file.lengthSafe
 import com.datadog.android.core.internal.utils.use
+import com.datadog.android.internal.telemetry.TelemetryContext
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
@@ -28,8 +29,11 @@ internal class PlainBatchFileReaderWriter(
 
     // region BatchFileReaderWriter
 
-    @Suppress("UnsafeThirdPartyFunctionCall")
-    override fun serializeToBytes(data: RawBatchEvent): ByteArray {
+    @Suppress("UnsafeThirdPartyFunctionCall", "UNUSED_PARAMETER")
+    override fun serializeToBytes(
+        data: RawBatchEvent,
+        telemetryContext: TelemetryContext
+    ): ByteArray {
         val meta = data.metadata
         val metaBlockSize = TYPE_SIZE_BYTES + LENGTH_SIZE_BYTES + meta.size
         val dataBlockSize = TYPE_SIZE_BYTES + LENGTH_SIZE_BYTES + data.data.size
@@ -47,7 +51,8 @@ internal class PlainBatchFileReaderWriter(
     override fun writeBinaryData(
         file: File,
         bytes: ByteArray,
-        append: Boolean
+        append: Boolean,
+        telemetryContext: TelemetryContext
     ): Boolean {
         return try {
             lockFileAndWriteData(file, append, bytes)
@@ -55,9 +60,10 @@ internal class PlainBatchFileReaderWriter(
         } catch (e: IOException) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
-                listOf(InternalLogger.Target.MAINTAINER),
+                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
                 { ERROR_WRITE.format(Locale.US, file.path) },
-                e
+                e,
+                additionalProperties = telemetryContext.asAttributesMap(bytesLost = bytes.size)
             )
             false
         } catch (e: SecurityException) {
@@ -65,7 +71,8 @@ internal class PlainBatchFileReaderWriter(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
                 { ERROR_WRITE.format(Locale.US, file.path) },
-                e
+                e,
+                additionalProperties = telemetryContext.asAttributesMap(bytesLost = bytes.size)
             )
             false
         }
@@ -77,24 +84,28 @@ internal class PlainBatchFileReaderWriter(
 
     @WorkerThread
     override fun readData(
-        file: File
+        file: File,
+        telemetryContext: TelemetryContext
     ): List<RawBatchEvent> {
+        val inputLength = file.lengthSafe(internalLogger).toInt()
         return try {
-            readFileData(file)
+            readFileData(file, inputLength, telemetryContext)
         } catch (e: IOException) {
             internalLogger.log(
-                InternalLogger.Level.ERROR,
-                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                { ERROR_READ.format(Locale.US, file.path) },
-                e
+                level = InternalLogger.Level.ERROR,
+                targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                messageBuilder = { ERROR_READ.format(Locale.US, file.path) },
+                throwable = e,
+                additionalProperties = telemetryContext.asAttributesMap(bytesLost = inputLength)
             )
             emptyList()
         } catch (e: SecurityException) {
             internalLogger.log(
-                InternalLogger.Level.ERROR,
-                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                { ERROR_READ.format(Locale.US, file.path) },
-                e
+                level = InternalLogger.Level.ERROR,
+                targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                messageBuilder = { ERROR_READ.format(Locale.US, file.path) },
+                throwable = e,
+                additionalProperties = telemetryContext.asAttributesMap(inputLength)
             )
             emptyList()
         }
@@ -151,23 +162,34 @@ internal class PlainBatchFileReaderWriter(
     @Suppress("UnsafeThirdPartyFunctionCall", "ComplexMethod", "LoopWithTooManyJumpStatements")
     // Called within a try/catch block
     private fun readFileData(
-        file: File
+        file: File,
+        inputLength: Int,
+        telemetryContext: TelemetryContext
     ): List<RawBatchEvent> {
-        val inputLength = file.lengthSafe(internalLogger).toInt()
-
         val result = mutableListOf<RawBatchEvent>()
 
         // Read file iteratively
         var remaining = inputLength
+        // Snapshot of `remaining` at the start of the current iteration, i.e. the same value already
+        // reported to the readBlock/checkReadExpected telemetry above on failure. Used only for the
+        // summary log below, since `remaining` itself gets decremented by the partial bytes consumed
+        // by a failed read, which would otherwise under-report what this method actually drops.
+        var remainingAtIterationStart = remaining
         file.inputStream().buffered().use {
             while (remaining > 0) {
-                val metaReadResult = readBlock(it, BlockType.META)
+                remainingAtIterationStart = remaining
+                val metaReadResult = readBlock(it, BlockType.META, telemetryContext, remaining)
                 if (metaReadResult.data == null) {
                     remaining -= metaReadResult.bytesRead
                     break
                 }
 
-                val eventReadResult = readBlock(it, BlockType.EVENT)
+                val eventReadResult = readBlock(
+                    it,
+                    BlockType.EVENT,
+                    telemetryContext,
+                    remaining
+                )
                 remaining -= metaReadResult.bytesRead + eventReadResult.bytesRead
 
                 if (eventReadResult.data == null) break
@@ -177,10 +199,12 @@ internal class PlainBatchFileReaderWriter(
         }
 
         if (remaining != 0 || (inputLength > 0 && result.isEmpty())) {
+            val droppedBytes = if (result.isEmpty()) inputLength else remainingAtIterationStart
             internalLogger.log(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-                { WARNING_NOT_ALL_DATA_READ.format(Locale.US, file.path) }
+                { WARNING_NOT_ALL_DATA_READ.format(Locale.US, file.path) },
+                additionalProperties = telemetryContext.asAttributesMap(bytesLost = droppedBytes)
             )
         }
 
@@ -189,7 +213,12 @@ internal class PlainBatchFileReaderWriter(
 
     @Suppress("ReturnCount")
     @Throws(IOException::class)
-    private fun readBlock(stream: InputStream, expectedBlockType: BlockType): BlockReadResult {
+    private fun readBlock(
+        stream: InputStream,
+        expectedBlockType: BlockType,
+        telemetryContext: TelemetryContext,
+        remaining: Int
+    ): BlockReadResult {
         @Suppress("UnsafeThirdPartyFunctionCall") // allocation size is always positive
         val headerBuffer = ByteBuffer.allocate(HEADER_SIZE_BYTES)
 
@@ -199,7 +228,9 @@ internal class PlainBatchFileReaderWriter(
         if (!checkReadExpected(
                 HEADER_SIZE_BYTES,
                 headerReadBytes,
-                "Block(${expectedBlockType.name}): Header read"
+                "Block(${expectedBlockType.name}): Header read",
+                telemetryContext,
+                remaining
             )
         ) {
             return BlockReadResult(null, max(0, headerReadBytes))
@@ -209,11 +240,12 @@ internal class PlainBatchFileReaderWriter(
         if (blockType != expectedBlockType.identifier) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
-                InternalLogger.Target.MAINTAINER,
+                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
                 {
                     "Unexpected block type identifier=$blockType met," +
                         " was expecting $expectedBlockType(${expectedBlockType.identifier})"
-                }
+                },
+                additionalProperties = telemetryContext.asAttributesMap(bytesLost = remaining)
             )
             // in theory, we could continue reading, because we still know data size,
             // but unexpected type says that at least relationship between blocks is broken,
@@ -230,7 +262,9 @@ internal class PlainBatchFileReaderWriter(
         return if (checkReadExpected(
                 dataSize,
                 dataReadBytes,
-                "Block(${expectedBlockType.name}):Data read"
+                "Block(${expectedBlockType.name}):Data read",
+                telemetryContext,
+                remaining
             )
         ) {
             BlockReadResult(dataBuffer, headerReadBytes + dataReadBytes)
@@ -239,22 +273,30 @@ internal class PlainBatchFileReaderWriter(
         }
     }
 
-    private fun checkReadExpected(expected: Int, actual: Int, operation: String): Boolean {
+    private fun checkReadExpected(
+        expected: Int,
+        actual: Int,
+        operation: String,
+        telemetryContext: TelemetryContext,
+        bytesLost: Int
+    ): Boolean {
         return if (expected != actual) {
             if (actual != -1) {
                 internalLogger.log(
                     InternalLogger.Level.ERROR,
-                    InternalLogger.Target.MAINTAINER,
+                    listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
                     {
                         "Number of bytes read for operation='$operation' doesn't" +
                             " match with expected: expected=$expected, actual=$actual"
-                    }
+                    },
+                    additionalProperties = telemetryContext.asAttributesMap(bytesLost = bytesLost)
                 )
             } else {
                 internalLogger.log(
                     InternalLogger.Level.ERROR,
-                    InternalLogger.Target.MAINTAINER,
-                    { "Unexpected EOF at the operation=$operation" }
+                    listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                    { "Unexpected EOF at the operation=$operation" },
+                    additionalProperties = telemetryContext.asAttributesMap(bytesLost = bytesLost)
                 )
             }
             false

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleItemDataWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleItemDataWriter.kt
@@ -14,6 +14,7 @@ import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.FileWriter
 import com.datadog.android.core.persistence.Serializer
 import com.datadog.android.core.persistence.serializeToByteArray
+import com.datadog.android.internal.telemetry.TelemetryContext
 import java.util.Locale
 
 internal open class SingleItemDataWriter<T : Any>(
@@ -21,7 +22,8 @@ internal open class SingleItemDataWriter<T : Any>(
     internal val serializer: Serializer<T>,
     internal val fileWriter: FileWriter<ByteArray>,
     internal val internalLogger: InternalLogger,
-    internal val filePersistenceConfig: FilePersistenceConfig
+    internal val filePersistenceConfig: FilePersistenceConfig,
+    internal val telemetryContext: TelemetryContext
 ) : DataWriter<T> {
 
     // region DataWriter
@@ -55,7 +57,7 @@ internal open class SingleItemDataWriter<T : Any>(
     private fun writeData(byteArray: ByteArray): Boolean {
         if (!checkEventSize(byteArray.size)) return false
         val file = fileOrchestrator.getWritableFile(byteArray.size.toLong()) ?: return false
-        return fileWriter.writeData(file, byteArray, false)
+        return fileWriter.writeData(file, byteArray, false, telemetryContext)
     }
 
     private fun checkEventSize(eventSize: Int): Boolean {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/tlvformat/TLVBlock.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/tlvformat/TLVBlock.kt
@@ -8,8 +8,10 @@ package com.datadog.android.core.internal.persistence.tlvformat
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.telemetry.TelemetryContext
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_TLV_SIZE
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_TLV_SIZE_LIMIT
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_TLV_TYPE
 import java.nio.ByteBuffer
-import java.util.Locale
 
 internal class TLVBlock(
     val type: TLVBlockType,
@@ -30,7 +32,18 @@ internal class TLVBlock(
         val entrySize = typeFieldSize + dataLengthFieldSize + dataFieldSize
 
         if (entrySize > maxEntrySize) {
-            logEntrySizeExceededError(entrySize, maxEntrySize, telemetryContext)
+            internalLogger.log(
+                level = InternalLogger.Level.ERROR,
+                targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+                messageBuilder = { BYTE_LENGTH_EXCEEDED_ERROR },
+                additionalProperties = telemetryContext.asAttributesMap(
+                    bytesLost = entrySize,
+                    TELEMETRY_TLV_SIZE_LIMIT to maxEntrySize,
+                    TELEMETRY_TLV_SIZE to entrySize,
+                    TELEMETRY_TLV_TYPE to type
+                )
+
+            )
             return null
         }
 
@@ -47,23 +60,9 @@ internal class TLVBlock(
             .array()
     }
 
-    private fun logEntrySizeExceededError(
-        entrySize: Int,
-        maxEntrySize: Int,
-        telemetryContext: TelemetryContext
-    ) {
-        internalLogger.log(
-            level = InternalLogger.Level.ERROR,
-            targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-            messageBuilder = { BYTE_LENGTH_EXCEEDED_ERROR.format(Locale.US, maxEntrySize, entrySize) },
-            additionalProperties = telemetryContext.asAttributesMap(bytesLost = entrySize)
-        )
-    }
-
     internal companion object {
         // The maximum length of data (Value) in TLV block defining key data.
         internal const val MAXIMUM_DATA_SIZE_MB = 10 * 1024 * 1024 // 10 mb
-        internal const val BYTE_LENGTH_EXCEEDED_ERROR =
-            "DataBlock length exceeds limit of %s bytes, was %s"
+        internal const val BYTE_LENGTH_EXCEEDED_ERROR = "DataBlock length exceeds limit."
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/tlvformat/TLVBlock.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/tlvformat/TLVBlock.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.core.internal.persistence.tlvformat
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.internal.telemetry.TelemetryContext
 import java.nio.ByteBuffer
 import java.util.Locale
 
@@ -16,7 +17,10 @@ internal class TLVBlock(
     val internalLogger: InternalLogger
 ) {
     @Suppress("ReturnCount")
-    internal fun serialize(maxEntrySize: Int = MAXIMUM_DATA_SIZE_MB): ByteArray? {
+    internal fun serialize(
+        telemetryContext: TelemetryContext,
+        maxEntrySize: Int = MAXIMUM_DATA_SIZE_MB
+    ): ByteArray? {
         if (data.isEmpty()) return null
 
         val typeFieldSize = Short.SIZE_BYTES
@@ -26,7 +30,7 @@ internal class TLVBlock(
         val entrySize = typeFieldSize + dataLengthFieldSize + dataFieldSize
 
         if (entrySize > maxEntrySize) {
-            logEntrySizeExceededError(entrySize, maxEntrySize)
+            logEntrySizeExceededError(entrySize, maxEntrySize, telemetryContext)
             return null
         }
 
@@ -43,17 +47,22 @@ internal class TLVBlock(
             .array()
     }
 
-    private fun logEntrySizeExceededError(entrySize: Int, maxEntrySize: Int) {
+    private fun logEntrySizeExceededError(
+        entrySize: Int,
+        maxEntrySize: Int,
+        telemetryContext: TelemetryContext
+    ) {
         internalLogger.log(
-            target = InternalLogger.Target.MAINTAINER,
-            level = InternalLogger.Level.WARN,
-            messageBuilder = { BYTE_LENGTH_EXCEEDED_ERROR.format(Locale.US, maxEntrySize, entrySize) }
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            messageBuilder = { BYTE_LENGTH_EXCEEDED_ERROR.format(Locale.US, maxEntrySize, entrySize) },
+            additionalProperties = telemetryContext.asAttributesMap(bytesLost = entrySize)
         )
     }
 
     internal companion object {
         // The maximum length of data (Value) in TLV block defining key data.
-        private const val MAXIMUM_DATA_SIZE_MB = 10 * 1024 * 1024 // 10 mb
+        internal const val MAXIMUM_DATA_SIZE_MB = 10 * 1024 * 1024 // 10 mb
         internal const val BYTE_LENGTH_EXCEEDED_ERROR =
             "DataBlock length exceeds limit of %s bytes, was %s"
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/tlvformat/TLVBlockFileReader.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/tlvformat/TLVBlockFileReader.kt
@@ -13,8 +13,12 @@ import com.datadog.android.core.internal.utils.copyOfRangeSafe
 import com.datadog.android.core.internal.utils.toInt
 import com.datadog.android.core.internal.utils.toShort
 import com.datadog.android.internal.telemetry.TelemetryContext
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_TLV_DATA_LENGTH
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_TLV_DATA_LENGTH_LIMIT
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_TLV_HEADER_LENGTH
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_TLV_HEADER_LENGTH_LIMIT
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_TLV_TYPE
 import java.io.File
-import java.util.Locale
 
 internal class TLVBlockFileReader(
     val internalLogger: InternalLogger,
@@ -71,7 +75,16 @@ internal class TLVBlockFileReader(
         newIndex += typeBlockSize
 
         if (newIndex > inputArray.size) {
-            internalLogger.logFailedToDeserializeError(telemetryContext, bytesLost = inputArray.size - currentIndex)
+            internalLogger.log(
+                level = InternalLogger.Level.WARN,
+                targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+                messageBuilder = { WARN_CORRUPT_HEADER_LENGTH_ERROR },
+                additionalProperties = telemetryContext.asAttributesMap(
+                    inputArray.size - currentIndex,
+                    TELEMETRY_TLV_HEADER_LENGTH to typeBlockSize,
+                    TELEMETRY_TLV_HEADER_LENGTH_LIMIT to (inputArray.size - currentIndex)
+                )
+            )
             return null
         }
 
@@ -85,8 +98,11 @@ internal class TLVBlockFileReader(
             internalLogger.log(
                 level = InternalLogger.Level.WARN,
                 targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                messageBuilder = { CORRUPT_TLV_HEADER_TYPE_ERROR.format(Locale.US, shortValue) },
-                additionalProperties = telemetryContext.asAttributesMap(bytesLost = inputArray.size - currentIndex)
+                messageBuilder = { WARN_CORRUPT_TLV_HEADER_TYPE },
+                additionalProperties = telemetryContext.asAttributesMap(
+                    bytesLost = inputArray.size - currentIndex,
+                    TELEMETRY_TLV_TYPE to shortValue
+                )
             )
             return null
         }
@@ -108,7 +124,17 @@ internal class TLVBlockFileReader(
         var newIndex = currentIndex + lengthBlockSize
 
         if (newIndex > inputArray.size) {
-            internalLogger.logFailedToDeserializeError(telemetryContext, bytesLost = bytesLeft)
+            internalLogger.log(
+                level = InternalLogger.Level.WARN,
+                targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+                messageBuilder = { WARN_CORRUPT_DATA_LENGTH_ERROR },
+                additionalProperties = telemetryContext.asAttributesMap(
+                    bytesLost = bytesLeft,
+                    TELEMETRY_TLV_DATA_LENGTH to lengthBlockSize,
+                    TELEMETRY_TLV_DATA_LENGTH_LIMIT to (inputArray.size - currentIndex)
+                )
+            )
+
             return null
         }
 
@@ -117,12 +143,25 @@ internal class TLVBlockFileReader(
             internalLogger.log(
                 level = InternalLogger.Level.ERROR,
                 targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-                messageBuilder = { CORRUPT_DATA_LENGTH_ERROR.format(Locale.US, maxEntrySize, lengthData) },
-                additionalProperties = telemetryContext.asAttributesMap(bytesLeft)
+                messageBuilder = { WARN_CORRUPT_DATA_LENGTH_ERROR },
+                additionalProperties = telemetryContext.asAttributesMap(
+                    bytesLeft,
+                    TELEMETRY_TLV_DATA_LENGTH to lengthData,
+                    TELEMETRY_TLV_DATA_LENGTH_LIMIT to maxEntrySize
+                )
             )
             return null
         } else if (newIndex + lengthData > inputArray.size) {
-            internalLogger.logFailedToDeserializeError(telemetryContext, bytesLost = bytesLeft)
+            internalLogger.log(
+                level = InternalLogger.Level.ERROR,
+                targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+                messageBuilder = { WARN_CORRUPT_DATA_LENGTH_ERROR },
+                additionalProperties = telemetryContext.asAttributesMap(
+                    bytesLeft,
+                    TELEMETRY_TLV_DATA_LENGTH to lengthData,
+                    TELEMETRY_TLV_DATA_LENGTH_LIMIT to inputArray.size - newIndex
+                )
+            )
             return null
         }
 
@@ -139,19 +178,10 @@ internal class TLVBlockFileReader(
     )
 
     internal companion object {
-        internal const val CORRUPT_TLV_HEADER_TYPE_ERROR = "TLV header corrupt. Invalid type %s"
-        internal const val FAILED_TO_DESERIALIZE_ERROR = "Failed to deserialize TLV data length"
-        internal const val CORRUPT_DATA_LENGTH_ERROR =
-            "DataBlock length read from file is invalid or exceeds limit of %s bytes, was %s"
-
-        private fun InternalLogger.logFailedToDeserializeError(
-            telemetryContext: TelemetryContext,
-            bytesLost: Int
-        ) = log(
-            level = InternalLogger.Level.WARN,
-            targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-            messageBuilder = { FAILED_TO_DESERIALIZE_ERROR },
-            additionalProperties = telemetryContext.asAttributesMap(bytesLost)
-        )
+        internal const val WARN_CORRUPT_TLV_HEADER_TYPE = "TLV header corrupt. Invalid type."
+        internal const val WARN_CORRUPT_HEADER_LENGTH_ERROR =
+            "Header block length read from file is invalid or exceeds limit"
+        internal const val WARN_CORRUPT_DATA_LENGTH_ERROR =
+            "Data block length read from file is invalid or exceeds limit"
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/tlvformat/TLVBlockFileReader.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/tlvformat/TLVBlockFileReader.kt
@@ -12,23 +12,26 @@ import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.utils.copyOfRangeSafe
 import com.datadog.android.core.internal.utils.toInt
 import com.datadog.android.core.internal.utils.toShort
+import com.datadog.android.internal.telemetry.TelemetryContext
 import java.io.File
 import java.util.Locale
 
 internal class TLVBlockFileReader(
     val internalLogger: InternalLogger,
-    val fileReaderWriter: FileReaderWriter
+    val fileReaderWriter: FileReaderWriter,
+    private val maxEntrySize: Int = TLVBlock.MAXIMUM_DATA_SIZE_MB
 ) {
     @WorkerThread
     internal fun read(
-        file: File
+        file: File,
+        telemetryContext: TelemetryContext
     ): List<TLVBlock> {
-        val byteArray = fileReaderWriter.readData(file)
+        val byteArray = fileReaderWriter.readData(file, telemetryContext)
         val blocks = mutableListOf<TLVBlock>()
         var currentIndex = 0
 
         while (currentIndex < byteArray.size) {
-            val result = readBlock(byteArray, currentIndex) ?: break
+            val result = readBlock(byteArray, currentIndex, telemetryContext) ?: break
             blocks.add(result.data)
             currentIndex = result.newIndex
         }
@@ -37,9 +40,18 @@ internal class TLVBlockFileReader(
     }
 
     @Suppress("ReturnCount")
-    private fun readBlock(inputArray: ByteArray, currentIndex: Int): TLVResult<TLVBlock>? {
-        val typeResult = readType(inputArray, currentIndex) ?: return null
-        val data = readData(inputArray, typeResult.newIndex) ?: return null
+    private fun readBlock(
+        inputArray: ByteArray,
+        currentIndex: Int,
+        telemetryContext: TelemetryContext
+    ): TLVResult<TLVBlock>? {
+        val typeResult = readType(inputArray, currentIndex, telemetryContext) ?: return null
+        val data = readData(
+            inputArray = inputArray,
+            currentIndex = typeResult.newIndex,
+            bytesLeft = inputArray.size - currentIndex,
+            telemetryContext = telemetryContext
+        ) ?: return null
 
         val block = TLVBlock(typeResult.data, data.data, internalLogger)
         return TLVResult(
@@ -49,13 +61,17 @@ internal class TLVBlockFileReader(
     }
 
     @Suppress("ReturnCount")
-    private fun readType(inputArray: ByteArray, currentIndex: Int): TLVResult<TLVBlockType>? {
+    private fun readType(
+        inputArray: ByteArray,
+        currentIndex: Int,
+        telemetryContext: TelemetryContext
+    ): TLVResult<TLVBlockType>? {
         val typeBlockSize = UShort.SIZE_BYTES
         var newIndex = currentIndex
         newIndex += typeBlockSize
 
         if (newIndex > inputArray.size) {
-            logFailedToDeserializeError()
+            internalLogger.logFailedToDeserializeError(telemetryContext, bytesLost = inputArray.size - currentIndex)
             return null
         }
 
@@ -66,7 +82,12 @@ internal class TLVBlockFileReader(
         val tlvHeader = TLVBlockType.fromValue(shortValue.toUShort())
 
         if (tlvHeader == null) {
-            logTypeCorruptionError(shortValue)
+            internalLogger.log(
+                level = InternalLogger.Level.WARN,
+                targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                messageBuilder = { CORRUPT_TLV_HEADER_TYPE_ERROR.format(Locale.US, shortValue) },
+                additionalProperties = telemetryContext.asAttributesMap(bytesLost = inputArray.size - currentIndex)
+            )
             return null
         }
 
@@ -76,49 +97,40 @@ internal class TLVBlockFileReader(
         )
     }
 
-    private fun readData(inputArray: ByteArray, currentIndex: Int): TLVResult<ByteArray>? {
+    @Suppress("ReturnCount")
+    private fun readData(
+        inputArray: ByteArray,
+        currentIndex: Int,
+        bytesLeft: Int,
+        telemetryContext: TelemetryContext
+    ): TLVResult<ByteArray>? {
         val lengthBlockSize = Int.SIZE_BYTES
         var newIndex = currentIndex + lengthBlockSize
 
         if (newIndex > inputArray.size) {
-            logFailedToDeserializeError()
+            internalLogger.logFailedToDeserializeError(telemetryContext, bytesLost = bytesLeft)
             return null
         }
 
-        val lengthInBytes = inputArray.copyOfRangeSafe(currentIndex, newIndex)
+        val lengthData = inputArray.copyOfRangeSafe(currentIndex, newIndex).toInt()
+        if (lengthData !in 0..maxEntrySize) {
+            internalLogger.log(
+                level = InternalLogger.Level.ERROR,
+                targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+                messageBuilder = { CORRUPT_DATA_LENGTH_ERROR.format(Locale.US, maxEntrySize, lengthData) },
+                additionalProperties = telemetryContext.asAttributesMap(bytesLeft)
+            )
+            return null
+        } else if (newIndex + lengthData > inputArray.size) {
+            internalLogger.logFailedToDeserializeError(telemetryContext, bytesLost = bytesLeft)
+            return null
+        }
 
-        val lengthData = lengthInBytes.toInt()
-
-        val dataBytes =
-            inputArray.copyOfRangeSafe(newIndex, newIndex + lengthData)
+        val dataBytes = inputArray.copyOfRangeSafe(newIndex, newIndex + lengthData)
 
         newIndex += lengthData
 
-        return TLVResult(
-            data = dataBytes,
-            newIndex = newIndex
-        )
-    }
-
-    private fun logTypeCorruptionError(shortValue: Short) {
-        internalLogger.log(
-            target = InternalLogger.Target.MAINTAINER,
-            level = InternalLogger.Level.WARN,
-            messageBuilder = {
-                CORRUPT_TLV_HEADER_TYPE_ERROR.format(
-                    Locale.US,
-                    shortValue
-                )
-            }
-        )
-    }
-
-    private fun logFailedToDeserializeError() {
-        internalLogger.log(
-            target = InternalLogger.Target.MAINTAINER,
-            level = InternalLogger.Level.WARN,
-            messageBuilder = { FAILED_TO_DESERIALIZE_ERROR }
-        )
+        return TLVResult(data = dataBytes, newIndex = newIndex)
     }
 
     private data class TLVResult<T : Any>(
@@ -129,5 +141,17 @@ internal class TLVBlockFileReader(
     internal companion object {
         internal const val CORRUPT_TLV_HEADER_TYPE_ERROR = "TLV header corrupt. Invalid type %s"
         internal const val FAILED_TO_DESERIALIZE_ERROR = "Failed to deserialize TLV data length"
+        internal const val CORRUPT_DATA_LENGTH_ERROR =
+            "DataBlock length read from file is invalid or exceeds limit of %s bytes, was %s"
+
+        private fun InternalLogger.logFailedToDeserializeError(
+            telemetryContext: TelemetryContext,
+            bytesLost: Int
+        ) = log(
+            level = InternalLogger.Level.WARN,
+            targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            messageBuilder = { FAILED_TO_DESERIALIZE_ERROR },
+            additionalProperties = telemetryContext.asAttributesMap(bytesLost)
+        )
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/storage/TelemetryAwareEventBatchWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/storage/TelemetryAwareEventBatchWriter.kt
@@ -1,0 +1,42 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.storage
+
+import androidx.annotation.WorkerThread
+import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
+import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.internal.telemetry.TelemetryContext
+import com.datadog.android.lint.InternalApi
+
+/**
+ * SDK-internal extension of [EventBatchWriter] that lets the SDK's own [DataWriter] implementations
+ * attach dropped-event telemetry metadata to a write call. This is not part of the supported public
+ * API: third-party code must never implement this interface; only the SDK's internal [EventBatchWriter]
+ * implementations do, and only the SDK's internal [DataWriter] implementations should check for it
+ * (e.g. via `writer as? TelemetryAwareEventBatchWriter`) before falling back to the plain
+ * [EventBatchWriter.write].
+ */
+@InternalApi
+interface TelemetryAwareEventBatchWriter : EventBatchWriter {
+    /**
+     * Write a raw event with telemetry metadata for dropped-event tracking.
+     *
+     * @param event the raw batch event to write
+     * @param batchMetadata optional batch metadata
+     * @param eventType the type of the event being written
+     * @param telemetryContext telemetry metadata to attach to this write call
+     * @return `true` if the event was written successfully, `false` otherwise
+     */
+    @WorkerThread
+    fun write(
+        event: RawBatchEvent,
+        batchMetadata: ByteArray?,
+        eventType: EventType,
+        telemetryContext: TelemetryContext
+    ): Boolean
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/api/storage/RawBatchEventTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/api/storage/RawBatchEventTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.api.storage
+
+import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class RawBatchEventTest {
+
+    @Test
+    fun `M return true W equals() {same data and metadata}`(
+        @StringForgery fakeData: String,
+        @StringForgery fakeMetadata: String
+    ) {
+        // Given
+        val event = RawBatchEvent(
+            fakeData.toByteArray(),
+            fakeMetadata.toByteArray()
+        )
+        val other = RawBatchEvent(
+            fakeData.toByteArray(),
+            fakeMetadata.toByteArray()
+        )
+
+        // When
+        val result = event == other
+
+        // Then
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `M return false W equals() {different data}`(
+        @StringForgery fakeData: String,
+        @StringForgery fakeMetadata: String
+    ) {
+        // Given
+        val event = RawBatchEvent(
+            fakeData.toByteArray(),
+            fakeMetadata.toByteArray()
+        )
+        val other = RawBatchEvent(
+            (fakeData + "x").toByteArray(),
+            fakeMetadata.toByteArray()
+        )
+
+        // When
+        val result = event == other
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `M return same value W hashCode() {same data and metadata}`(
+        @StringForgery fakeData: String,
+        @StringForgery fakeMetadata: String
+    ) {
+        // Given
+        val event = RawBatchEvent(
+            fakeData.toByteArray(),
+            fakeMetadata.toByteArray()
+        )
+        val other = RawBatchEvent(
+            fakeData.toByteArray(),
+            fakeMetadata.toByteArray()
+        )
+
+        // When
+        val result = event.hashCode()
+
+        // Then
+        assertThat(result).isEqualTo(other.hashCode())
+    }
+
+    @Test
+    fun `M return different value W hashCode() {different data}`(
+        @StringForgery fakeData: String,
+        @StringForgery fakeMetadata: String
+    ) {
+        // Given
+        val event = RawBatchEvent(
+            fakeData.toByteArray(),
+            fakeMetadata.toByteArray()
+        )
+        val other = RawBatchEvent(
+            (fakeData + "x").toByteArray(),
+            fakeMetadata.toByteArray()
+        )
+
+        // When
+        val result = event.hashCode()
+
+        // Then
+        assertThat(result).isNotEqualTo(other.hashCode())
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -37,6 +37,7 @@ import com.datadog.android.core.internal.user.NoOpMutableUserInfoProvider
 import com.datadog.android.core.persistence.PersistenceStrategy
 import com.datadog.android.core.thread.FlushableExecutorService
 import com.datadog.android.internal.system.BuildSdkVersionProvider
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.ndk.internal.DatadogNdkCrashHandler
 import com.datadog.android.ndk.internal.NoOpNdkCrashHandler
@@ -145,6 +146,9 @@ internal class CoreFeatureTest {
 
     @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL)
     lateinit var fakeVersion: String
+
+    @Forgery
+    lateinit var fakeTelemetryContext: TelemetryContext
 
     @BeforeEach
     fun `set up`() {
@@ -1284,12 +1288,16 @@ internal class CoreFeatureTest {
         val legacyNdkViewEventFile = DatadogNdkCrashHandler.getLastViewEventFile(tempDir)
         legacyNdkViewEventFile.parentFile?.mkdirs()
 
-        val fixtureWriter = BatchFileReaderWriter.create(internalLogger = mock(), encryption = null)
+        val fixtureWriter = BatchFileReaderWriter.create(
+            internalLogger = mock(),
+            encryption = null
+        )
         val fixtureEvent = RawBatchEvent(fakeViewEvent.toString().toByteArray())
         fixtureWriter.writeBinaryData(
             legacyNdkViewEventFile,
-            checkNotNull(fixtureWriter.serializeToBytes(fixtureEvent)),
-            append = false
+            checkNotNull(fixtureWriter.serializeToBytes(fixtureEvent, fakeTelemetryContext)),
+            append = false,
+            fakeTelemetryContext
         )
 
         // When

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataFlusherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataFlusherTest.kt
@@ -14,9 +14,11 @@ import com.datadog.android.core.internal.persistence.file.FileMover
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.FileReader
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileReader
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.junit.jupiter.api.BeforeEach
@@ -26,7 +28,9 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -67,8 +71,14 @@ internal class DataFlusherTest {
     @Forgery
     lateinit var fakeContext: DatadogContext
 
+    @StringForgery
+    lateinit var fakeFeatureName: String
+
+    private lateinit var fakeTelemetryContext: TelemetryContext
+
     @BeforeEach
     fun `set up`() {
+        fakeTelemetryContext = TelemetryContext(featureName = fakeFeatureName)
         whenever(mockContextProvider.getContext(emptySet())) doReturn fakeContext
 
         testedFlusher = DataFlusher(
@@ -77,6 +87,7 @@ internal class DataFlusherTest {
             mockFileReader,
             mockMetaFileReader,
             mockFileMover,
+            fakeFeatureName,
             mockInternalLogger
         )
     }
@@ -103,14 +114,14 @@ internal class DataFlusherTest {
         whenever(mockFileOrchestrator.getFlushableFiles()).thenReturn(fakeFiles)
         fakeFiles.forEachIndexed { index, file ->
             whenever(
-                mockFileReader.readData(file)
+                mockFileReader.readData(eq(file), any())
             ).thenReturn(fakeBatches[index])
             val fakeMetaFile = fakeMetaFiles[index]
             whenever(
                 mockFileOrchestrator.getMetadataFile(file)
             ).thenReturn(fakeMetaFile)
             if (fakeMetaFile != null) {
-                whenever(mockMetaFileReader.readData(fakeMetaFile)).thenReturn(fakeMeta[index])
+                whenever(mockMetaFileReader.readData(eq(fakeMetaFile), any())).thenReturn(fakeMeta[index])
             }
         }
 
@@ -143,7 +154,7 @@ internal class DataFlusherTest {
         whenever(mockFileOrchestrator.getFlushableFiles()).thenReturn(fakeFiles)
         fakeFiles.forEachIndexed { index, file ->
             whenever(
-                mockFileReader.readData(file)
+                mockFileReader.readData(eq(file), any())
             ).thenReturn(fakeBatches[index])
             whenever(
                 mockFileOrchestrator.getMetadataFile(file)
@@ -179,7 +190,7 @@ internal class DataFlusherTest {
         whenever(mockFileOrchestrator.getFlushableFiles()).thenReturn(fakeFiles)
         fakeFiles.forEachIndexed { index, file ->
             whenever(
-                mockFileReader.readData(file)
+                mockFileReader.readData(eq(file), any())
             ).thenReturn(fakeBatches[index])
             val fakeBatchFile =
                 forge.aNullable { mock<File>().apply { whenever(exists()) doReturn false } }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
@@ -20,6 +20,7 @@ import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileReaderWriter
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
@@ -113,8 +114,11 @@ internal class ConsentAwareStorageTest {
     @IntForgery(min = 0, max = 100)
     var fakePendingBatches: Int = 0
 
+    private lateinit var fakeTelemetryContext: TelemetryContext
+
     @BeforeEach
     fun `set up`() {
+        fakeTelemetryContext = TelemetryContext(featureName = fakeFeatureName)
         whenever(mockPendingOrchestrator.getRootDir()) doReturn File(mockPendingRootParentFile, fakeRootDirName)
         whenever(mockGrantedOrchestrator.getRootDir()) doReturn File(mockGrantedRootParentFile, fakeRootDirName)
         whenever((mockGrantedOrchestrator).decrementAndGetPendingFilesCount())
@@ -260,7 +264,7 @@ internal class ConsentAwareStorageTest {
     ) {
         // Given
         whenever(mockGrantedOrchestrator.getReadableFile(any())) doReturn batchFile
-        whenever(mockBatchReaderWriter.readData(batchFile)) doReturn fakeData
+        whenever(mockBatchReaderWriter.readData(batchFile, fakeTelemetryContext)) doReturn fakeData
 
         val mockMetaFile = mock<File>().apply {
             whenever(exists()) doReturn true
@@ -268,7 +272,7 @@ internal class ConsentAwareStorageTest {
 
         whenever(mockGrantedOrchestrator.getMetadataFile(batchFile)) doReturn mockMetaFile
         val mockMetadata = metadata.toByteArray()
-        whenever(mockMetaReaderWriter.readData(mockMetaFile)) doReturn mockMetadata
+        whenever(mockMetaReaderWriter.readData(mockMetaFile, fakeTelemetryContext)) doReturn mockMetadata
 
         // Whenever
         val batchData = testedStorage.readNextBatch()
@@ -287,7 +291,7 @@ internal class ConsentAwareStorageTest {
     ) {
         // Given
         whenever(mockGrantedOrchestrator.getReadableFile(any())) doReturn batchFile
-        whenever(mockBatchReaderWriter.readData(batchFile)) doReturn fakeData
+        whenever(mockBatchReaderWriter.readData(batchFile, fakeTelemetryContext)) doReturn fakeData
         whenever(mockGrantedOrchestrator.getMetadataFile(batchFile)) doReturn null
 
         // Whenever
@@ -307,7 +311,7 @@ internal class ConsentAwareStorageTest {
     ) {
         // Given
         whenever(mockGrantedOrchestrator.getReadableFile(any())) doReturn batchFile
-        whenever(mockBatchReaderWriter.readData(batchFile)) doReturn fakeData
+        whenever(mockBatchReaderWriter.readData(batchFile, fakeTelemetryContext)) doReturn fakeData
 
         val mockMetaFile = mock<File>().apply {
             whenever(exists()) doReturn false

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriterTest.kt
@@ -17,6 +17,7 @@ import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileReaderWriter
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.Forge
@@ -81,9 +82,16 @@ internal class FileEventBatchWriterTest {
     @Forgery
     lateinit var fakeEventType: EventType
 
+    @StringForgery
+    lateinit var fakeFeatureName: String
+
+    private lateinit var fakeTelemetryContext: TelemetryContext
+
     @BeforeEach
     fun `set up`() {
+        fakeTelemetryContext = TelemetryContext(featureName = fakeFeatureName)
         testedWriter = FileEventBatchWriter(
+            featureName = fakeFeatureName,
             fileOrchestrator = mockFileOrchestrator,
             eventsWriter = mockBatchWriter,
             metadataReaderWriter = mockMetaReaderWriter,
@@ -94,7 +102,9 @@ internal class FileEventBatchWriterTest {
         whenever(mockFilePersistenceConfig.maxItemSize) doReturn Long.MAX_VALUE
         whenever(mockFileOrchestrator.getWritableFile(any())) doReturn fakeBatchFile
         whenever(mockFileOrchestrator.getMetadataFile(fakeBatchFile)) doReturn fakeBatchMetadataFile
-        whenever(mockBatchWriter.serializeToBytes(any())) doAnswer { it.getArgument<RawBatchEvent>(0).data }
+        whenever(mockBatchWriter.serializeToBytes(any(), any())) doAnswer {
+            it.getArgument<RawBatchEvent>(0).data
+        }
     }
 
     // region write
@@ -106,9 +116,9 @@ internal class FileEventBatchWriterTest {
     ) {
         // Given
         val serializedMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
-        whenever(mockMetaReaderWriter.readData(fakeBatchMetadataFile)) doReturn serializedMetadata
+        whenever(mockMetaReaderWriter.readData(fakeBatchMetadataFile, fakeTelemetryContext)) doReturn serializedMetadata
         whenever(
-            mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true)
+            mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true, fakeTelemetryContext)
         ) doReturn true
 
         // When
@@ -117,16 +127,18 @@ internal class FileEventBatchWriterTest {
         // Then
         assertThat(result).isTrue()
 
-        verify(mockBatchWriter).serializeToBytes(batchEvent)
+        verify(mockBatchWriter).serializeToBytes(batchEvent, fakeTelemetryContext)
         verify(mockBatchWriter).writeBinaryData(
             fakeBatchFile,
             batchEvent.data,
-            append = true
+            append = true,
+            fakeTelemetryContext
         )
         verify(mockMetaReaderWriter).writeData(
             fakeBatchMetadataFile,
             serializedMetadata,
-            append = false
+            append = false,
+            fakeTelemetryContext
         )
 
         verifyNoMoreInteractions(
@@ -173,7 +185,8 @@ internal class FileEventBatchWriterTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-            NO_BATCH_FILE_AVAILABLE
+            NO_BATCH_FILE_AVAILABLE,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = batchEvent.data.size)
         )
     }
 
@@ -184,7 +197,7 @@ internal class FileEventBatchWriterTest {
     ) {
         // Given
         val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
-        whenever(mockBatchWriter.serializeToBytes(batchEvent)) doReturn null
+        whenever(mockBatchWriter.serializeToBytes(batchEvent, fakeTelemetryContext)) doReturn null
 
         // When
         val result = testedWriter.write(batchEvent, serializedBatchMetadata, fakeEventType)
@@ -213,12 +226,9 @@ internal class FileEventBatchWriterTest {
 
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
-            InternalLogger.Target.USER,
-            ERROR_LARGE_DATA.format(
-                Locale.US,
-                batchEvent.data.size,
-                maxItemSize
-            )
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            ERROR_LARGE_DATA.format(Locale.US, batchEvent.data.size, maxItemSize),
+            additionalProperties = fakeTelemetryContext.asAttributesMap(batchEvent.data.size)
         )
     }
 
@@ -229,7 +239,9 @@ internal class FileEventBatchWriterTest {
     ) {
         // Given
         val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
-        whenever(mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true)) doReturn false
+        whenever(
+            mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true, fakeTelemetryContext)
+        ) doReturn false
 
         // When
         val result = testedWriter.write(batchEvent, serializedBatchMetadata, fakeEventType)
@@ -248,7 +260,9 @@ internal class FileEventBatchWriterTest {
 
         val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
 
-        whenever(mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true)) doReturn true
+        whenever(
+            mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true, fakeTelemetryContext)
+        ) doReturn true
 
         // When
         val result = testedWriter.write(batchEvent, serializedBatchMetadata, fakeEventType)
@@ -265,7 +279,9 @@ internal class FileEventBatchWriterTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true)) doReturn true
+        whenever(
+            mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true, fakeTelemetryContext)
+        ) doReturn true
 
         // When
         val result = testedWriter.write(batchEvent, forge.aNullable { ByteArray(0) }, fakeEventType)
@@ -273,11 +289,12 @@ internal class FileEventBatchWriterTest {
         // Then
         assertThat(result).isTrue
 
-        verify(mockBatchWriter).serializeToBytes(batchEvent)
+        verify(mockBatchWriter).serializeToBytes(batchEvent, fakeTelemetryContext)
         verify(mockBatchWriter).writeBinaryData(
             fakeBatchFile,
             batchEvent.data,
-            true
+            append = true,
+            fakeTelemetryContext
         )
         verifyNoMoreInteractions(mockBatchWriter)
         verifyNoInteractions(mockMetaReaderWriter)
@@ -310,7 +327,7 @@ internal class FileEventBatchWriterTest {
         // Given
         val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         whenever(
-            mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true)
+            mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true, fakeTelemetryContext)
         ) doReturn false
 
         // When
@@ -330,10 +347,15 @@ internal class FileEventBatchWriterTest {
         // Given
         val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         whenever(
-            mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true)
+            mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true, fakeTelemetryContext)
         ) doReturn true
         whenever(
-            mockMetaReaderWriter.writeData(fakeBatchMetadataFile, serializedBatchMetadata, false)
+            mockMetaReaderWriter.writeData(
+                fakeBatchMetadataFile,
+                serializedBatchMetadata,
+                false,
+                fakeTelemetryContext
+            )
         ) doReturn false
 
         // When
@@ -344,11 +366,12 @@ internal class FileEventBatchWriterTest {
 
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
-            InternalLogger.Target.USER,
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
             WARNING_METADATA_WRITE_FAILED.format(
                 Locale.US,
                 fakeBatchMetadataFile
-            )
+            ),
+            additionalProperties = fakeTelemetryContext.asAttributesMap(serializedBatchMetadata.size)
         )
     }
 
@@ -364,10 +387,15 @@ internal class FileEventBatchWriterTest {
         // Given
         val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         whenever(
-            mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true)
+            mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true, fakeTelemetryContext)
         ) doReturn true
         whenever(
-            mockMetaReaderWriter.writeData(fakeBatchMetadataFile, serializedBatchMetadata, false)
+            mockMetaReaderWriter.writeData(
+                fakeBatchMetadataFile,
+                serializedBatchMetadata,
+                false,
+                fakeTelemetryContext
+            )
         ) doReturn false
 
         // When

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriterTest.kt
@@ -227,8 +227,11 @@ internal class FileEventBatchWriterTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-            ERROR_LARGE_DATA.format(Locale.US, batchEvent.data.size, maxItemSize),
-            additionalProperties = fakeTelemetryContext.asAttributesMap(batchEvent.data.size)
+            ERROR_LARGE_DATA,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(
+                bytesLost = batchEvent.data.size,
+                TelemetryContext.TELEMETRY_DATA_LIMIT to maxItemSize.toLong()
+            )
         )
     }
 
@@ -366,12 +369,11 @@ internal class FileEventBatchWriterTest {
 
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
-            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            InternalLogger.Target.USER,
             WARNING_METADATA_WRITE_FAILED.format(
                 Locale.US,
                 fakeBatchMetadataFile
-            ),
-            additionalProperties = fakeTelemetryContext.asAttributesMap(serializedBatchMetadata.size)
+            )
         )
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileHandlerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileHandlerTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.storage.datastore.DataStoreWriteCallback
 import com.datadog.android.core.internal.persistence.Deserializer
 import com.datadog.android.core.persistence.Serializer
 import com.datadog.android.core.persistence.datastore.DataStoreContent
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -71,10 +72,14 @@ internal class DataStoreFileHandlerTest {
     @StringForgery
     lateinit var fakeDataString: String
 
+    private lateinit var fakeTelemetryContext: TelemetryContext
+
     private lateinit var fileCallback: DataStoreReadCallback<ByteArray>
 
     @BeforeEach
     fun setup() {
+        fakeTelemetryContext = TelemetryContext(featureName = fakeFeatureName)
+
         whenever(mockExecutorService.execute(any())) doAnswer {
             it.getArgument<Runnable>(0).run()
         }
@@ -85,6 +90,7 @@ internal class DataStoreFileHandlerTest {
         }
 
         testedDataStoreHandler = DataStoreFileHandler(
+            featureName = fakeFeatureName,
             executorService = mockExecutorService,
             internalLogger = mockInternalLogger,
             dataStoreFileReader = mockDataStoreFileReader,
@@ -105,7 +111,8 @@ internal class DataStoreFileHandlerTest {
         verify(mockDataStoreFileReader).read(
             key = fakeKey,
             deserializer = mockDeserializer,
-            callback = fileCallback
+            callback = fileCallback,
+            telemetryContext = fakeTelemetryContext
         )
     }
 
@@ -126,7 +133,8 @@ internal class DataStoreFileHandlerTest {
             key = fakeKey,
             deserializer = mockDeserializer,
             version = fakeVersion,
-            callback = fileCallback
+            callback = fileCallback,
+            telemetryContext = fakeTelemetryContext
         )
     }
 
@@ -149,7 +157,8 @@ internal class DataStoreFileHandlerTest {
             data = fakeDataString,
             serializer = mockSerializer,
             callback = mockDataStoreWriteCallback,
-            version = fakeVersion
+            version = fakeVersion,
+            telemetryContext = fakeTelemetryContext
         )
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileReaderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileReaderTest.kt
@@ -16,8 +16,10 @@ import com.datadog.android.core.internal.persistence.tlvformat.TLVBlock
 import com.datadog.android.core.internal.persistence.tlvformat.TLVBlockFileReader
 import com.datadog.android.core.internal.persistence.tlvformat.TLVBlockType
 import com.datadog.android.core.persistence.datastore.DataStoreContent
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -81,6 +83,9 @@ internal class DataStoreFileReaderTest {
     @StringForgery
     lateinit var fakeKey: String
 
+    @Forgery
+    lateinit var fakeTelemetryContext: TelemetryContext
+
     private lateinit var fakeDataBytes: ByteArray
     private lateinit var versionBlock: TLVBlock
     private lateinit var dataBlock: TLVBlock
@@ -107,7 +112,7 @@ internal class DataStoreFileReaderTest {
         versionBlock = createVersionBlock(true)
         dataBlock = createDataBlock()
         blocksReturned = arrayListOf(versionBlock, dataBlock)
-        whenever(mockTLVBlockFileReader.read(mockDataStoreFile)).thenReturn(blocksReturned)
+        whenever(mockTLVBlockFileReader.read(mockDataStoreFile, fakeTelemetryContext)).thenReturn(blocksReturned)
 
         testedDatastoreFileReader = DatastoreFileReader(
             dataStoreFileHelper = mockDataStoreFileHelper,
@@ -128,7 +133,8 @@ internal class DataStoreFileReaderTest {
         testedDatastoreFileReader.read(
             key = fakeKey,
             deserializer = mockDeserializer,
-            callback = mockCallback
+            callback = mockCallback,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -153,7 +159,8 @@ internal class DataStoreFileReaderTest {
         testedDatastoreFileReader.read(
             key = fakeKey,
             deserializer = mockDeserializer,
-            callback = mockCallback
+            callback = mockCallback,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -176,7 +183,8 @@ internal class DataStoreFileReaderTest {
             key = fakeKey,
             version = 99,
             callback = mockCallback,
-            deserializer = mockDeserializer
+            deserializer = mockDeserializer,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -199,7 +207,8 @@ internal class DataStoreFileReaderTest {
         testedDatastoreFileReader.read(
             key = fakeKey,
             deserializer = mockDeserializer,
-            callback = mockCallback
+            callback = mockCallback,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -222,7 +231,8 @@ internal class DataStoreFileReaderTest {
         testedDatastoreFileReader.read(
             key = fakeKey,
             deserializer = mockDeserializer,
-            callback = mockCallback
+            callback = mockCallback,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -240,14 +250,15 @@ internal class DataStoreFileReaderTest {
         // Given
         blocksReturned.clear()
         blocksReturned.addAll(listOf(dataBlock, versionBlock))
-        whenever(mockTLVBlockFileReader.read(mockDataStoreFile)).thenReturn(blocksReturned)
+        whenever(mockTLVBlockFileReader.read(mockDataStoreFile, fakeTelemetryContext)).thenReturn(blocksReturned)
         val mockCallback = mock<DataStoreReadCallback<ByteArray>>()
 
         // When
         testedDatastoreFileReader.read(
             key = fakeKey,
             deserializer = mockDeserializer,
-            callback = mockCallback
+            callback = mockCallback,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileWriterTest.kt
@@ -13,8 +13,10 @@ import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.deleteSafe
 import com.datadog.android.core.internal.persistence.file.existsSafe
 import com.datadog.android.core.persistence.Serializer
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -27,6 +29,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -77,6 +80,9 @@ internal class DataStoreFileWriterTest {
     @StringForgery
     lateinit var fakeKey: String
 
+    @Forgery
+    lateinit var fakeTelemetryContext: TelemetryContext
+
     private lateinit var fakeDataBytes: ByteArray
 
     @BeforeEach
@@ -115,7 +121,8 @@ internal class DataStoreFileWriterTest {
             serializer = mockSerializer,
             data = fakeDataString,
             callback = mockDataStoreWriteCallback,
-            version = 0
+            version = 0,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -133,7 +140,8 @@ internal class DataStoreFileWriterTest {
             data = fakeDataString,
             serializer = mockSerializer,
             callback = mockDataStoreWriteCallback,
-            version = 0
+            version = 0,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -152,14 +160,16 @@ internal class DataStoreFileWriterTest {
             data = fakeDataString,
             serializer = mockSerializer,
             callback = mockDataStoreWriteCallback,
-            version = 0
+            version = 0,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
         verify(mockFileReaderWriter).writeData(
             eq(mockDataStoreFile),
             any(),
-            eq(false)
+            eq(false),
+            anyOrNull()
         )
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/EncryptedFileReaderWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/EncryptedFileReaderWriterTest.kt
@@ -7,9 +7,11 @@
 package com.datadog.android.core.internal.persistence.file
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.security.Encryption
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -22,6 +24,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -53,11 +56,14 @@ internal class EncryptedFileReaderWriterTest {
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
+    @Forgery
+    lateinit var fakeTelemetryContext: TelemetryContext
+
     private lateinit var testedReaderWriter: EncryptedFileReaderWriter
 
     @BeforeEach
     fun setUp() {
-        whenever(mockFileReaderWriterDelegate.writeData(any(), any(), any())) doReturn true
+        whenever(mockFileReaderWriterDelegate.writeData(any(), any(), any(), anyOrNull())) doReturn true
 
         whenever(mockEncryption.encrypt(any())) doAnswer {
             val bytes = it.getArgument<ByteArray>(0)
@@ -85,7 +91,8 @@ internal class EncryptedFileReaderWriterTest {
         val result = testedReaderWriter.writeData(
             mockFile,
             data.toByteArray(),
-            append = false
+            append = false,
+            telemetryContext = fakeTelemetryContext
         )
         val encryptedData = encrypt(data.toByteArray())
 
@@ -93,9 +100,10 @@ internal class EncryptedFileReaderWriterTest {
         assertThat(result).isTrue()
         verify(mockFileReaderWriterDelegate)
             .writeData(
-                mockFile,
-                encryptedData,
-                false
+                eq(mockFile),
+                eq(encryptedData),
+                eq(false),
+                anyOrNull()
             )
 
         verifyNoInteractions(mockInternalLogger)
@@ -112,7 +120,8 @@ internal class EncryptedFileReaderWriterTest {
         val result = testedReaderWriter.writeData(
             mockFile,
             data.toByteArray(),
-            append = false
+            append = false,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -135,7 +144,8 @@ internal class EncryptedFileReaderWriterTest {
         val result = testedReaderWriter.writeData(
             mockFile,
             data.toByteArray(),
-            append = true
+            append = true,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -160,11 +170,11 @@ internal class EncryptedFileReaderWriterTest {
     ) {
         // Given
         whenever(
-            mockFileReaderWriterDelegate.readData(mockFile)
+            mockFileReaderWriterDelegate.readData(mockFile, fakeTelemetryContext)
         ) doReturn encrypt(data.toByteArray())
 
         // When
-        val result = testedReaderWriter.readData(mockFile)
+        val result = testedReaderWriter.readData(mockFile, fakeTelemetryContext)
 
         // Then
         assertThat(result).isEqualTo(data.toByteArray())
@@ -185,7 +195,8 @@ internal class EncryptedFileReaderWriterTest {
             mockFileReaderWriterDelegate.writeData(
                 eq(mockFile),
                 any(),
-                eq(false)
+                eq(false),
+                anyOrNull()
             )
         ) doAnswer {
             storage = it.getArgument(1)
@@ -193,12 +204,12 @@ internal class EncryptedFileReaderWriterTest {
         }
 
         whenever(
-            mockFileReaderWriterDelegate.readData(mockFile)
+            mockFileReaderWriterDelegate.readData(mockFile, fakeTelemetryContext)
         ) doAnswer { storage }
 
         // When
-        val writeResult = testedReaderWriter.writeData(mockFile, data.toByteArray(), false)
-        val readResult = testedReaderWriter.readData(mockFile)
+        val writeResult = testedReaderWriter.writeData(mockFile, data.toByteArray(), false, fakeTelemetryContext)
+        val readResult = testedReaderWriter.readData(mockFile, fakeTelemetryContext)
 
         // Then
         assertThat(writeResult).isTrue()

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/PlainFileReaderWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/PlainFileReaderWriterTest.kt
@@ -7,10 +7,13 @@
 package com.datadog.android.core.internal.persistence.file
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.internal.telemetry.TelemetryContext
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.BYTE_LOST_UNKNOWN
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -51,6 +54,9 @@ internal class PlainFileReaderWriterTest {
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
+    @Forgery
+    lateinit var fakeTelemetryContext: TelemetryContext
+
     private lateinit var fakeSrcDir: File
     private lateinit var fakeDstDir: File
 
@@ -77,7 +83,8 @@ internal class PlainFileReaderWriterTest {
         val result = testedFileReaderWriter.writeData(
             file,
             contentBytes,
-            append = false
+            append = false,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -99,7 +106,8 @@ internal class PlainFileReaderWriterTest {
         val result = testedFileReaderWriter.writeData(
             file,
             contentBytes,
-            append = false
+            append = false,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -122,7 +130,8 @@ internal class PlainFileReaderWriterTest {
         val result = testedFileReaderWriter.writeData(
             file,
             contentBytes,
-            append = false
+            append = false,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -146,7 +155,8 @@ internal class PlainFileReaderWriterTest {
         val result = testedFileReaderWriter.writeData(
             file,
             contentBytes,
-            append = true
+            append = true,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -171,7 +181,8 @@ internal class PlainFileReaderWriterTest {
         val result = testedFileReaderWriter.writeData(
             file,
             content.toByteArray(),
-            append = append
+            append = append,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -181,7 +192,8 @@ internal class PlainFileReaderWriterTest {
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
             PlainFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path),
-            IOException::class.java
+            IOException::class.java,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = content.toByteArray().size)
         )
     }
 
@@ -199,7 +211,8 @@ internal class PlainFileReaderWriterTest {
         val result = testedFileReaderWriter.writeData(
             file,
             content.toByteArray(),
-            append = append
+            append = append,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -208,7 +221,8 @@ internal class PlainFileReaderWriterTest {
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
             PlainFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path),
-            IOException::class.java
+            IOException::class.java,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = content.toByteArray().size)
         )
     }
 
@@ -225,7 +239,7 @@ internal class PlainFileReaderWriterTest {
         assumeFalse(file.exists())
 
         // When
-        val result = testedFileReaderWriter.readData(file)
+        val result = testedFileReaderWriter.readData(file, fakeTelemetryContext)
 
         // Then
         assertThat(result).isEmpty()
@@ -234,7 +248,8 @@ internal class PlainFileReaderWriterTest {
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
             PlainFileReaderWriter.ERROR_READ.format(Locale.US, file.path),
-            null
+            null,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = BYTE_LOST_UNKNOWN)
         )
     }
 
@@ -244,10 +259,11 @@ internal class PlainFileReaderWriterTest {
     ) {
         // Given
         val file = File(fakeRootDirectory, fileName)
-        assumeFalse(file.exists())
+        file.mkdirs()
+        assumeFalse(file.isFile)
 
         // When
-        val result = testedFileReaderWriter.readData(file)
+        val result = testedFileReaderWriter.readData(file, fakeTelemetryContext)
 
         // Then
         assertThat(result).isEmpty()
@@ -255,7 +271,8 @@ internal class PlainFileReaderWriterTest {
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
             PlainFileReaderWriter.ERROR_READ.format(Locale.US, file.path),
-            null
+            null,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = BYTE_LOST_UNKNOWN)
         )
     }
 
@@ -270,7 +287,7 @@ internal class PlainFileReaderWriterTest {
         file.writeBytes(eventBytes)
 
         // When
-        val result = testedFileReaderWriter.readData(file)
+        val result = testedFileReaderWriter.readData(file, fakeTelemetryContext)
 
         // Then
         assertThat(result).isEqualTo(eventBytes)
@@ -290,7 +307,7 @@ internal class PlainFileReaderWriterTest {
         file.writeBytes(data)
 
         // When
-        val result = testedFileReaderWriter.readData(file)
+        val result = testedFileReaderWriter.readData(file, fakeTelemetryContext)
 
         // Then
         assertThat(result).isEqualTo(data)
@@ -309,8 +326,8 @@ internal class PlainFileReaderWriterTest {
         val file = File(fakeRootDirectory, fileName)
 
         // When
-        val writeResult = testedFileReaderWriter.writeData(file, content.toByteArray(), false)
-        val readResult = testedFileReaderWriter.readData(file)
+        val writeResult = testedFileReaderWriter.writeData(file, content.toByteArray(), false, fakeTelemetryContext)
+        val readResult = testedFileReaderWriter.readData(file, fakeTelemetryContext)
 
         // Then
         assertThat(writeResult).isTrue()
@@ -335,10 +352,11 @@ internal class PlainFileReaderWriterTest {
             writeResult = writeResult && testedFileReaderWriter.writeData(
                 file,
                 it,
-                true
+                true,
+                fakeTelemetryContext
             )
         }
-        val readResult = testedFileReaderWriter.readData(file)
+        val readResult = testedFileReaderWriter.readData(file, fakeTelemetryContext)
 
         // Then
         assertThat(writeResult).isTrue()

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/PlainFileReaderWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/PlainFileReaderWriterTest.kt
@@ -30,7 +30,6 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
 import java.io.File
 import java.io.IOException
-import java.util.Locale
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -191,9 +190,12 @@ internal class PlainFileReaderWriterTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            PlainFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path),
+            PlainFileReaderWriter.ERROR_WRITE,
             IOException::class.java,
-            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = content.toByteArray().size)
+            additionalProperties = fakeTelemetryContext.asAttributesMap(
+                bytesLost = content.toByteArray().size,
+                TelemetryContext.TELEMETRY_FILE_PATH to file.path
+            )
         )
     }
 
@@ -220,9 +222,12 @@ internal class PlainFileReaderWriterTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            PlainFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path),
+            PlainFileReaderWriter.ERROR_WRITE,
             IOException::class.java,
-            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = content.toByteArray().size)
+            additionalProperties = fakeTelemetryContext.asAttributesMap(
+                bytesLost = content.toByteArray().size,
+                TelemetryContext.TELEMETRY_FILE_PATH to file.path
+            )
         )
     }
 
@@ -247,9 +252,12 @@ internal class PlainFileReaderWriterTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            PlainFileReaderWriter.ERROR_READ.format(Locale.US, file.path),
+            PlainFileReaderWriter.ERROR_READ,
             null,
-            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = BYTE_LOST_UNKNOWN)
+            additionalProperties = fakeTelemetryContext.asAttributesMap(
+                bytesLost = BYTE_LOST_UNKNOWN,
+                TelemetryContext.TELEMETRY_FILE_PATH to file.path
+            )
         )
     }
 
@@ -270,9 +278,12 @@ internal class PlainFileReaderWriterTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            PlainFileReaderWriter.ERROR_READ.format(Locale.US, file.path),
+            PlainFileReaderWriter.ERROR_READ,
             null,
-            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = BYTE_LOST_UNKNOWN)
+            additionalProperties = fakeTelemetryContext.asAttributesMap(
+                bytesLost = BYTE_LOST_UNKNOWN,
+                TelemetryContext.TELEMETRY_FILE_PATH to file.path
+            )
         )
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileReaderWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileReaderWriterTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.core.internal.persistence.file.batch
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.security.Encryption
 import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -31,6 +32,9 @@ internal class BatchFileReaderWriterTest {
 
     @Mock
     lateinit var mockInternalLogger: InternalLogger
+
+    @StringForgery
+    lateinit var fakeFeatureName: String
 
     @Test
     fun `M create BatchFileReaderWriter W create() { without encryption }`() {

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/EncryptedBatchReaderWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/EncryptedBatchReaderWriterTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.core.internal.persistence.file.batch
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.security.Encryption
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
@@ -57,11 +58,17 @@ internal class EncryptedBatchReaderWriterTest {
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
+    @StringForgery
+    lateinit var fakeFeatureName: String
+
+    @Forgery
+    lateinit var fakeTelemetryContext: TelemetryContext
+
     private lateinit var testedReaderWriter: EncryptedBatchReaderWriter
 
     @BeforeEach
     fun setUp() {
-        whenever(mockBatchFileReaderWriter.writeBinaryData(any(), any(), any())) doReturn true
+        whenever(mockBatchFileReaderWriter.writeBinaryData(any(), any(), any(), any())) doReturn true
 
         whenever(mockEncryption.encrypt(any())) doAnswer {
             val bytes = it.getArgument<ByteArray>(0)
@@ -72,12 +79,11 @@ internal class EncryptedBatchReaderWriterTest {
             decrypt(bytes)
         }
 
-        testedReaderWriter =
-            EncryptedBatchReaderWriter(
-                mockEncryption,
-                mockBatchFileReaderWriter,
-                mockInternalLogger
-            )
+        testedReaderWriter = EncryptedBatchReaderWriter(
+            mockEncryption,
+            mockBatchFileReaderWriter,
+            mockInternalLogger
+        )
     }
 
     // region BatchFileReaderWriter#serializeToBytes tests
@@ -91,15 +97,16 @@ internal class EncryptedBatchReaderWriterTest {
         val serializedBytes = fakeSerialized.toByteArray()
         val encryptedData = encrypt(batchEvent.data)
         val encryptedMetadata = encrypt(batchEvent.metadata)
-        whenever(mockBatchFileReaderWriter.serializeToBytes(any())) doReturn serializedBytes
+        whenever(mockBatchFileReaderWriter.serializeToBytes(any(), any())) doReturn serializedBytes
 
         // When
-        val result = testedReaderWriter.serializeToBytes(batchEvent)
+        val result = testedReaderWriter.serializeToBytes(batchEvent, fakeTelemetryContext)
 
         // Then
         assertThat(result).isEqualTo(serializedBytes)
         verify(mockBatchFileReaderWriter).serializeToBytes(
-            RawBatchEvent(data = encryptedData, metadata = encryptedMetadata)
+            RawBatchEvent(data = encryptedData, metadata = encryptedMetadata),
+            fakeTelemetryContext
         )
     }
 
@@ -113,17 +120,18 @@ internal class EncryptedBatchReaderWriterTest {
         whenever(mockEncryption.encrypt(nonEmptyEvent.data)) doReturn ByteArray(0)
 
         // When
-        val result = testedReaderWriter.serializeToBytes(nonEmptyEvent)
+        val result = testedReaderWriter.serializeToBytes(nonEmptyEvent, fakeTelemetryContext)
 
         // Then
         assertThat(result).isNull()
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
-            InternalLogger.Target.USER,
-            EncryptedBatchReaderWriter.BAD_ENCRYPTION_RESULT_MESSAGE
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            EncryptedBatchReaderWriter.BAD_ENCRYPTION_RESULT_MESSAGE,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = 4)
         )
         verifyNoMoreInteractions(mockInternalLogger)
-        verify(mockBatchFileReaderWriter, never()).serializeToBytes(any())
+        verify(mockBatchFileReaderWriter, never()).serializeToBytes(any(), any())
     }
 
     // endregion
@@ -137,14 +145,16 @@ internal class EncryptedBatchReaderWriterTest {
     ) {
         // Given
         val bytes = fakeContent.toByteArray()
-        whenever(mockBatchFileReaderWriter.writeBinaryData(mockFile, bytes, append)) doReturn true
+        whenever(
+            mockBatchFileReaderWriter.writeBinaryData(mockFile, bytes, append, fakeTelemetryContext)
+        ) doReturn true
 
         // When
-        val result = testedReaderWriter.writeBinaryData(mockFile, bytes, append)
+        val result = testedReaderWriter.writeBinaryData(mockFile, bytes, append, fakeTelemetryContext)
 
         // Then
         assertThat(result).isTrue()
-        verify(mockBatchFileReaderWriter).writeBinaryData(mockFile, bytes, append)
+        verify(mockBatchFileReaderWriter).writeBinaryData(mockFile, bytes, append, fakeTelemetryContext)
     }
 
     // endregion
@@ -157,11 +167,11 @@ internal class EncryptedBatchReaderWriterTest {
     ) {
         // Given
         whenever(
-            mockBatchFileReaderWriter.readData(mockFile)
+            mockBatchFileReaderWriter.readData(eq(mockFile), any())
         ) doReturn events.map { RawBatchEvent(encrypt(it.data), encrypt(it.metadata)) }
 
         // When
-        val result = testedReaderWriter.readData(mockFile)
+        val result = testedReaderWriter.readData(mockFile, fakeTelemetryContext)
 
         // Then
         assertThat(result).containsExactlyElementsOf(events)
@@ -183,7 +193,7 @@ internal class EncryptedBatchReaderWriterTest {
         val storage = mutableListOf<RawBatchEvent>()
 
         whenever(
-            mockBatchFileReaderWriter.serializeToBytes(any())
+            mockBatchFileReaderWriter.serializeToBytes(any(), any())
         ) doAnswer {
             val encryptedEvent = it.getArgument<RawBatchEvent>(0)
             val bytes = encryptedEvent.data
@@ -192,7 +202,12 @@ internal class EncryptedBatchReaderWriterTest {
         }
 
         whenever(
-            mockBatchFileReaderWriter.writeBinaryData(eq(mockFile), any(), eq(true))
+            mockBatchFileReaderWriter.writeBinaryData(
+                eq(mockFile),
+                any(),
+                eq(true),
+                any()
+            )
         ) doAnswer {
             val bytes = it.getArgument<ByteArray>(1)
             encryptedEventByBytes[bytes]?.also { event -> storage.add(event) }
@@ -200,16 +215,21 @@ internal class EncryptedBatchReaderWriterTest {
         }
 
         whenever(
-            mockBatchFileReaderWriter.readData(mockFile)
+            mockBatchFileReaderWriter.readData(eq(mockFile), any())
         ) doAnswer { storage.toList() }
 
         // When
         var writeResult = true
         events.forEach {
-            val bytes = checkNotNull(testedReaderWriter.serializeToBytes(it))
-            writeResult = writeResult && testedReaderWriter.writeBinaryData(mockFile, bytes, true)
+            val bytes = checkNotNull(testedReaderWriter.serializeToBytes(it, fakeTelemetryContext))
+            writeResult = writeResult && testedReaderWriter.writeBinaryData(
+                mockFile,
+                bytes,
+                append = true,
+                fakeTelemetryContext
+            )
         }
-        val readResult = testedReaderWriter.readData(mockFile)
+        val readResult = testedReaderWriter.readData(mockFile, fakeTelemetryContext)
 
         // Then
         assertThat(writeResult).isTrue()

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriterTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.core.internal.persistence.file.batch
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.Forge
@@ -34,9 +35,11 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.io.File
+import java.io.FileInputStream
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.RandomAccessFile
@@ -67,6 +70,12 @@ internal class PlainBatchFileReaderWriterTest {
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
+    @StringForgery
+    lateinit var fakeFeatureName: String
+
+    @Forgery
+    lateinit var fakeTelemetryContext: TelemetryContext
+
     private lateinit var fakeSrcDir: File
     private lateinit var fakeDstDir: File
 
@@ -92,7 +101,8 @@ internal class PlainBatchFileReaderWriterTest {
         val result = testedReaderWriter.writeBinaryData(
             file,
             encode(event),
-            append = false
+            append = false,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -114,7 +124,8 @@ internal class PlainBatchFileReaderWriterTest {
         val result = testedReaderWriter.writeBinaryData(
             file,
             encode(event),
-            append = false
+            append = false,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -136,7 +147,8 @@ internal class PlainBatchFileReaderWriterTest {
         val result = testedReaderWriter.writeBinaryData(
             file,
             encode(event),
-            append = true
+            append = true,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -161,7 +173,8 @@ internal class PlainBatchFileReaderWriterTest {
         val result = testedReaderWriter.writeBinaryData(
             file,
             encode(event),
-            append = append
+            append = append,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
@@ -169,9 +182,10 @@ internal class PlainBatchFileReaderWriterTest {
         assertThat(file).doesNotExist()
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
-            listOf(InternalLogger.Target.MAINTAINER),
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
             PlainBatchFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path),
-            FileNotFoundException::class.java
+            FileNotFoundException::class.java,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = encode(event).size)
         )
     }
 
@@ -189,16 +203,18 @@ internal class PlainBatchFileReaderWriterTest {
         val result = testedReaderWriter.writeBinaryData(
             file,
             encode(event),
-            append = append
+            append = append,
+            telemetryContext = fakeTelemetryContext
         )
 
         // Then
         assertThat(result).isFalse()
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
-            listOf(InternalLogger.Target.MAINTAINER),
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
             PlainBatchFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path),
-            FileNotFoundException::class.java
+            FileNotFoundException::class.java,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = encode(event).size)
         )
     }
 
@@ -226,7 +242,8 @@ internal class PlainBatchFileReaderWriterTest {
             val result = testedReaderWriter.writeBinaryData(
                 file,
                 encode(event),
-                append = append
+                append = append,
+                telemetryContext = fakeTelemetryContext
             )
 
             // Then
@@ -235,9 +252,10 @@ internal class PlainBatchFileReaderWriterTest {
             verify(mockChannel, times(2)).truncate(expectedRollbackLength)
             mockInternalLogger.verifyLog(
                 InternalLogger.Level.ERROR,
-                listOf(InternalLogger.Target.MAINTAINER),
+                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
                 PlainBatchFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path),
-                IOException::class.java
+                IOException::class.java,
+                additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = encode(event).size)
             )
         }
     }
@@ -251,7 +269,7 @@ internal class PlainBatchFileReaderWriterTest {
         @Forgery event: RawBatchEvent
     ) {
         // When
-        val result = testedReaderWriter.serializeToBytes(event)
+        val result = testedReaderWriter.serializeToBytes(event, fakeTelemetryContext)
 
         // Then
         assertThat(result).isEqualTo(encode(event))
@@ -262,6 +280,22 @@ internal class PlainBatchFileReaderWriterTest {
     // region readData
 
     @Test
+    fun `M return empty list W readData() { empty file }`(
+        @StringForgery(regex = "[a-z]+") fileName: String
+    ) {
+        // Given
+        val file = File(fakeRootDirectory, fileName)
+        file.createNewFile()
+
+        // When
+        val result = testedReaderWriter.readData(file, fakeTelemetryContext)
+
+        // Then
+        assertThat(result).isEmpty()
+        verifyNoInteractions(mockInternalLogger)
+    }
+
+    @Test
     fun `M return empty list and warn W readData() {file does not exist}`(
         @StringForgery fileName: String
     ) {
@@ -270,7 +304,7 @@ internal class PlainBatchFileReaderWriterTest {
         assumeFalse(file.exists())
 
         // When
-        val result = testedReaderWriter.readData(file)
+        val result = testedReaderWriter.readData(file, fakeTelemetryContext)
 
         // Then
         assertThat(result).isEmpty()
@@ -279,7 +313,8 @@ internal class PlainBatchFileReaderWriterTest {
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
             PlainBatchFileReaderWriter.ERROR_READ.format(Locale.US, file.path),
-            FileNotFoundException::class.java
+            FileNotFoundException::class.java,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = 0)
         )
     }
 
@@ -292,7 +327,7 @@ internal class PlainBatchFileReaderWriterTest {
         assumeFalse(file.exists())
 
         // When
-        val result = testedReaderWriter.readData(file)
+        val result = testedReaderWriter.readData(file, fakeTelemetryContext)
 
         // Then
         assertThat(result).isEmpty()
@@ -300,7 +335,8 @@ internal class PlainBatchFileReaderWriterTest {
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
             PlainBatchFileReaderWriter.ERROR_READ.format(Locale.US, file.path),
-            FileNotFoundException::class.java
+            FileNotFoundException::class.java,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = 0)
         )
     }
 
@@ -311,17 +347,20 @@ internal class PlainBatchFileReaderWriterTest {
     ) {
         // Given
         val file = File(fakeRootDirectory, fileName)
-        file.writeBytes(content.toByteArray())
+        val contentBytes = content.toByteArray()
+        file.writeBytes(contentBytes)
 
         // When
-        val result = testedReaderWriter.readData(file)
+        val result = testedReaderWriter.readData(file, fakeTelemetryContext)
 
         // Then
         assertThat(result).isEmpty()
+        // whole file is unreadable -> file-level warning to USER+TELEMETRY with the full size dropped
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-            PlainBatchFileReaderWriter.WARNING_NOT_ALL_DATA_READ.format(Locale.US, file.path)
+            PlainBatchFileReaderWriter.WARNING_NOT_ALL_DATA_READ.format(Locale.US, file.path),
+            additionalProperties = droppedBytesTelemetry(contentBytes.size)
         )
     }
 
@@ -349,10 +388,50 @@ internal class PlainBatchFileReaderWriterTest {
         )
 
         // When
-        val result = testedReaderWriter.readData(file)
+        val result = testedReaderWriter.readData(file, fakeTelemetryContext)
 
         // Then
         assertThat(result).containsExactlyElementsOf(events.take(events.size - 1))
+    }
+
+    @Test
+    fun `M return valid events and report telemetry W readData() { data block shorter than declared }`(
+        @StringForgery fileName: String,
+        @Forgery validEvent: RawBatchEvent,
+        @StringForgery fakeCorruptedMetadata: String,
+        @StringForgery fakeCorruptedEventData: String,
+        forge: Forge
+    ) {
+        // Given
+        val file = File(fakeRootDirectory, fileName)
+        val corruptedMetadataBytes = metaBytesAsTlv(fakeCorruptedMetadata.toByteArray())
+        val corruptedEventData = fakeCorruptedEventData.toByteArray()
+        // header declares more data than is actually present -> partial data read (actual != -1)
+        val declaredEventDataSize = corruptedEventData.size + forge.anInt(min = 1, max = 128)
+        val corruptedEventBytes = ByteBuffer.allocate(
+            PlainBatchFileReaderWriter.HEADER_SIZE_BYTES + corruptedEventData.size
+        )
+            .putShort(0x00)
+            .putInt(declaredEventDataSize)
+            .put(corruptedEventData)
+            .array()
+        file.writeBytes(encode(validEvent) + corruptedMetadataBytes + corruptedEventBytes)
+
+        // When
+        val result = testedReaderWriter.readData(file, fakeTelemetryContext)
+
+        // Then
+        assertThat(result).containsExactly(validEvent)
+        // the corrupted data block is read up to the declared (but absent) tail, consuming the
+        // rest of the file, so `remaining` lands exactly on 0 and the file-level warning stays silent
+        val droppedBytes = corruptedMetadataBytes.size + corruptedEventBytes.size
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            "Number of bytes read for operation='Block(EVENT):Data read' doesn't match with expected: " +
+                "expected=$declaredEventDataSize, actual=${corruptedEventData.size}",
+            additionalProperties = droppedBytesTelemetry(droppedBytes)
+        )
     }
 
     @Test
@@ -365,47 +444,151 @@ internal class PlainBatchFileReaderWriterTest {
         val file = File(fakeRootDirectory, fileName)
 
         val badEventIndex = forge.anInt(min = 0, max = events.size)
+        val isBadBlockTypeInMeta = forge.aBool()
+        // block type is the 2nd header byte (big-endian short, high byte 0x00); META identifier
+        // is 1 and EVENT identifier is 0, so pick any value that differs from the expected one
+        val badBlockType = if (isBadBlockTypeInMeta) {
+            forge.anElementFrom(0, forge.anInt(min = 2, max = Byte.MAX_VALUE + 1))
+        } else {
+            forge.anInt(min = 1, max = Byte.MAX_VALUE + 1)
+        }
         file.writeBytes(
             events.mapIndexed { index, item ->
                 val metaBytes = metaBytesAsTlv(item.metadata)
                 val eventBytes = dataBytesAsTlv(item.data)
-                if (index == badEventIndex) {
-                    val isBadBlockTypeInMeta = forge.aBool()
-                    if (isBadBlockTypeInMeta) {
-                        metaBytes.apply {
-                            set(
-                                1,
-                                // first 2 bytes of meta should be 1, so to generate
-                                // wrong block we need any value != 1
-                                forge.anElementFrom(
-                                    0,
-                                    forge.anInt(min = 2, max = Byte.MAX_VALUE + 1)
-                                ).toByte()
-                            )
-                        } + eventBytes
+                when {
+                    index == badEventIndex -> if (isBadBlockTypeInMeta) {
+                        metaBytes.apply { set(1, badBlockType.toByte()) } + eventBytes
                     } else {
-                        // first 2 bytes of event should be 0, so to generate
-                        // wrong block we need any value != 0
-                        metaBytes + eventBytes.apply {
-                            set(1, forge.anInt(min = 1, max = Byte.MAX_VALUE + 1).toByte())
-                        }
+                        metaBytes + eventBytes.apply { set(1, badBlockType.toByte()) }
                     }
-                } else {
-                    metaBytes + eventBytes
+                    else -> metaBytes + eventBytes
                 }
             }.reduce { acc, bytes -> acc + bytes }
         )
 
         // When
-        val result = testedReaderWriter.readData(file)
+        val result = testedReaderWriter.readData(file, fakeTelemetryContext)
 
         // Then
         assertThat(result).containsExactlyElementsOf(events.take(badEventIndex))
 
+        // an unexpected block type is a block-level (MAINTAINER) diagnostic, and the file-level
+        // (USER) summary warning must report the same dropped byte count, not a partially
+        // decremented one, since everything from the bad block to EOF is discarded
+        val expectedBlockName = if (isBadBlockTypeInMeta) "META" else "EVENT"
+        val expectedIdentifier = if (isBadBlockTypeInMeta) 1 else 0
+        val droppedBytes =
+            events.drop(badEventIndex).sumOf { metaBytesAsTlv(it.metadata).size + dataBytesAsTlv(it.data).size }
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            "Unexpected block type identifier=$badBlockType met," +
+                " was expecting $expectedBlockName($expectedIdentifier)",
+            additionalProperties = droppedBytesTelemetry(droppedBytes)
+        )
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-            PlainBatchFileReaderWriter.WARNING_NOT_ALL_DATA_READ.format(Locale.US, file.path)
+            PlainBatchFileReaderWriter.WARNING_NOT_ALL_DATA_READ.format(Locale.US, file.path),
+            additionalProperties = droppedBytesTelemetry(droppedBytes)
+        )
+    }
+
+    @Test
+    fun `M report telemetry W readData() { unexpected EOF on data block }`(
+        @StringForgery fileName: String,
+        @Forgery validEvent: RawBatchEvent,
+        @StringForgery fakeMetadata: String,
+        forge: Forge
+    ) {
+        // Given
+        val file = File(fakeRootDirectory, fileName)
+        val metaBytes = metaBytesAsTlv(fakeMetadata.toByteArray())
+        // valid event header declaring data, but no data bytes follow -> EOF (actual == -1)
+        val eventHeaderOnly = ByteBuffer.allocate(PlainBatchFileReaderWriter.HEADER_SIZE_BYTES)
+            .putShort(0x00)
+            .putInt(forge.anInt(min = 1, max = 128))
+            .array()
+        file.writeBytes(encode(validEvent) + metaBytes + eventHeaderOnly)
+
+        // When
+        testedReaderWriter.readData(file, fakeTelemetryContext)
+
+        // Then
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            "Unexpected EOF at the operation=Block(EVENT):Data read",
+            additionalProperties = droppedBytesTelemetry(
+                metaBytes.size + eventHeaderOnly.size
+            )
+        )
+    }
+
+    @Test
+    fun `M report telemetry W readData() { IOException while reading }`(
+        @StringForgery(regex = "[a-z]+") fileName: String,
+        @StringForgery(regex = "[a-z]+") content: String,
+        @StringForgery errorMessage: String
+    ) {
+        // Given
+        val file = File(fakeRootDirectory, fileName)
+        val contentBytes = content.toByteArray()
+        // real, non-empty file so inputLength > 0 and the read actually starts
+        file.writeBytes(contentBytes)
+
+        Mockito.mockConstruction(FileInputStream::class.java) { mock, _ ->
+            whenever(mock.read(any(), any(), any())) doThrow IOException(errorMessage)
+        }.use {
+            // When
+            val result = testedReaderWriter.readData(file, fakeTelemetryContext)
+
+            // Then
+            assertThat(result).isEmpty()
+            mockInternalLogger.verifyLog(
+                InternalLogger.Level.ERROR,
+                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                PlainBatchFileReaderWriter.ERROR_READ.format(Locale.US, file.path),
+                IOException::class.java,
+                additionalProperties = droppedBytesTelemetry(contentBytes.size)
+            )
+        }
+    }
+
+    @Test
+    fun `M report telemetry W readData() { data block larger than declared }`(
+        @StringForgery fileName: String,
+        @StringForgery fakeMetadata: String,
+        @StringForgery fakeEventData: String,
+        forge: Forge
+    ) {
+        // Given
+        val file = File(fakeRootDirectory, fileName)
+        val metaBytes = metaBytesAsTlv(fakeMetadata.toByteArray())
+        val eventData = fakeEventData.toByteArray()
+        // header under-declares the payload: the reader consumes `eventData.size` bytes as the
+        // event and the surplus (< header size) is then misread as the next block's header
+        val surplus = forge.anInt(min = 1, max = PlainBatchFileReaderWriter.HEADER_SIZE_BYTES)
+        val oversizedEventBytes = ByteBuffer.allocate(
+            PlainBatchFileReaderWriter.HEADER_SIZE_BYTES + eventData.size + surplus
+        )
+            .putShort(0x00)
+            .putInt(eventData.size)
+            .put(eventData + ByteArray(surplus))
+            .array()
+        file.writeBytes(metaBytes + oversizedEventBytes)
+
+        // When
+        testedReaderWriter.readData(file, fakeTelemetryContext)
+
+        // Then: surplus bytes are misread as the next META header -> block-level (MAINTAINER) mismatch
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            "Number of bytes read for operation='Block(META): Header read' doesn't match with expected: " +
+                "expected=${PlainBatchFileReaderWriter.HEADER_SIZE_BYTES}, actual=$surplus",
+            additionalProperties = droppedBytesTelemetry(surplus)
         )
     }
 
@@ -419,7 +602,7 @@ internal class PlainBatchFileReaderWriterTest {
         file.writeBytes(encode(event))
 
         // When
-        val result = testedReaderWriter.readData(file)
+        val result = testedReaderWriter.readData(file, fakeTelemetryContext)
 
         // Then
         assertThat(result).containsExactlyElementsOf(listOf(event))
@@ -435,7 +618,7 @@ internal class PlainBatchFileReaderWriterTest {
         file.writeBytes(events.map { encode(it) }.reduce { acc, bytes -> acc + bytes })
 
         // When
-        val result = testedReaderWriter.readData(file)
+        val result = testedReaderWriter.readData(file, fakeTelemetryContext)
 
         // Then
         assertThat(result).containsExactlyElementsOf(events)
@@ -456,10 +639,11 @@ internal class PlainBatchFileReaderWriterTest {
         // When
         val writeResult = testedReaderWriter.writeBinaryData(
             file,
-            testedReaderWriter.serializeToBytes(event),
-            false
+            testedReaderWriter.serializeToBytes(event, fakeTelemetryContext),
+            append = false,
+            telemetryContext = fakeTelemetryContext
         )
-        val readResult = testedReaderWriter.readData(file)
+        val readResult = testedReaderWriter.readData(file, fakeTelemetryContext)
 
         // Then
         assertThat(writeResult).isTrue()
@@ -479,11 +663,12 @@ internal class PlainBatchFileReaderWriterTest {
         events.forEach {
             writeResult = writeResult && testedReaderWriter.writeBinaryData(
                 file,
-                testedReaderWriter.serializeToBytes(it),
-                true
+                testedReaderWriter.serializeToBytes(it, fakeTelemetryContext),
+                append = true,
+                fakeTelemetryContext
             )
         }
-        val readResult = testedReaderWriter.readData(file)
+        val readResult = testedReaderWriter.readData(file, fakeTelemetryContext)
 
         // Then
         assertThat(writeResult).isTrue()
@@ -507,7 +692,7 @@ internal class PlainBatchFileReaderWriterTest {
         )
 
         // When
-        val readResult = testedReaderWriter.readData(file)
+        val readResult = testedReaderWriter.readData(file, fakeTelemetryContext)
 
         // Then
         assertThat(readResult).hasSize(2)
@@ -543,6 +728,9 @@ internal class PlainBatchFileReaderWriterTest {
             .put(data)
             .array()
     }
+
+    private fun droppedBytesTelemetry(droppedBytes: Int): Map<String, Any> =
+        fakeTelemetryContext.asAttributesMap(bytesLost = droppedBytes)
 
     // endregion
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriterTest.kt
@@ -33,6 +33,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -183,9 +184,12 @@ internal class PlainBatchFileReaderWriterTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            PlainBatchFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path),
+            PlainBatchFileReaderWriter.ERROR_WRITE,
             FileNotFoundException::class.java,
-            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = encode(event).size)
+            additionalProperties = fakeTelemetryContext.asAttributesMap(
+                bytesLost = encode(event).size,
+                TelemetryContext.TELEMETRY_FILE_PATH to file.path
+            )
         )
     }
 
@@ -212,9 +216,12 @@ internal class PlainBatchFileReaderWriterTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            PlainBatchFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path),
+            PlainBatchFileReaderWriter.ERROR_WRITE,
             FileNotFoundException::class.java,
-            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = encode(event).size)
+            additionalProperties = fakeTelemetryContext.asAttributesMap(
+                bytesLost = encode(event).size,
+                TelemetryContext.TELEMETRY_FILE_PATH to file.path
+            )
         )
     }
 
@@ -253,9 +260,12 @@ internal class PlainBatchFileReaderWriterTest {
             mockInternalLogger.verifyLog(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                PlainBatchFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path),
+                PlainBatchFileReaderWriter.ERROR_WRITE,
                 IOException::class.java,
-                additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = encode(event).size)
+                additionalProperties = fakeTelemetryContext.asAttributesMap(
+                    bytesLost = encode(event).size,
+                    TelemetryContext.TELEMETRY_FILE_PATH to file.path
+                )
             )
         }
     }
@@ -312,9 +322,12 @@ internal class PlainBatchFileReaderWriterTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            PlainBatchFileReaderWriter.ERROR_READ.format(Locale.US, file.path),
+            PlainBatchFileReaderWriter.ERROR_READ,
             FileNotFoundException::class.java,
-            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = 0)
+            additionalProperties = fakeTelemetryContext.asAttributesMap(
+                bytesLost = 0,
+                TelemetryContext.TELEMETRY_FILE_PATH to file.path
+            )
         )
     }
 
@@ -334,16 +347,19 @@ internal class PlainBatchFileReaderWriterTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            PlainBatchFileReaderWriter.ERROR_READ.format(Locale.US, file.path),
+            PlainBatchFileReaderWriter.ERROR_READ,
             FileNotFoundException::class.java,
-            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = 0)
+            additionalProperties = fakeTelemetryContext.asAttributesMap(
+                bytesLost = 0,
+                TelemetryContext.TELEMETRY_FILE_PATH to file.path
+            )
         )
     }
 
     @Test
     fun `M return empty list and warn user W readData() { corrupted data }`(
         @StringForgery fileName: String,
-        @StringForgery content: String
+        @StringForgery(regex = "[a-z]{1,5}") content: String
     ) {
         // Given
         val file = File(fakeRootDirectory, fileName)
@@ -355,12 +371,23 @@ internal class PlainBatchFileReaderWriterTest {
 
         // Then
         assertThat(result).isEmpty()
-        // whole file is unreadable -> file-level warning to USER+TELEMETRY with the full size dropped
+        // header is shorter than HEADER_SIZE_BYTES -> block-level (MAINTAINER) diagnostic
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
-            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-            PlainBatchFileReaderWriter.WARNING_NOT_ALL_DATA_READ.format(Locale.US, file.path),
-            additionalProperties = droppedBytesTelemetry(contentBytes.size)
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            PlainBatchFileReaderWriter.ERROR_UNEXPECTED_NUMBERS_OF_BYTES,
+            additionalProperties = droppedBytesTelemetry(
+                contentBytes.size,
+                TelemetryContext.TELEMETRY_BATCH_OPERATION to "Block(META): Header read",
+                TelemetryContext.TELEMETRY_BATCH_BYTES_EXPECTED to PlainBatchFileReaderWriter.HEADER_SIZE_BYTES,
+                TelemetryContext.TELEMETRY_BATCH_BYTES_ACTUAL to contentBytes.size
+            )
+        )
+
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.MAINTAINER),
+            PlainBatchFileReaderWriter.WARNING_NOT_ALL_DATA_READ.format(Locale.US, file.path)
         )
     }
 
@@ -423,14 +450,18 @@ internal class PlainBatchFileReaderWriterTest {
         // Then
         assertThat(result).containsExactly(validEvent)
         // the corrupted data block is read up to the declared (but absent) tail, consuming the
-        // rest of the file, so `remaining` lands exactly on 0 and the file-level warning stays silent
+        // rest of the file
         val droppedBytes = corruptedMetadataBytes.size + corruptedEventBytes.size
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            "Number of bytes read for operation='Block(EVENT):Data read' doesn't match with expected: " +
-                "expected=$declaredEventDataSize, actual=${corruptedEventData.size}",
-            additionalProperties = droppedBytesTelemetry(droppedBytes)
+            PlainBatchFileReaderWriter.ERROR_UNEXPECTED_NUMBERS_OF_BYTES,
+            additionalProperties = droppedBytesTelemetry(
+                droppedBytes,
+                TelemetryContext.TELEMETRY_BATCH_OPERATION to "Block(EVENT):Data read",
+                TelemetryContext.TELEMETRY_BATCH_BYTES_EXPECTED to declaredEventDataSize,
+                TelemetryContext.TELEMETRY_BATCH_BYTES_ACTUAL to corruptedEventData.size
+            )
         )
     }
 
@@ -473,9 +504,8 @@ internal class PlainBatchFileReaderWriterTest {
         // Then
         assertThat(result).containsExactlyElementsOf(events.take(badEventIndex))
 
-        // an unexpected block type is a block-level (MAINTAINER) diagnostic, and the file-level
-        // (USER) summary warning must report the same dropped byte count, not a partially
-        // decremented one, since everything from the bad block to EOF is discarded
+        // an unexpected block type is a block-level (MAINTAINER) diagnostic; everything from the
+        // bad block to EOF is discarded
         val expectedBlockName = if (isBadBlockTypeInMeta) "META" else "EVENT"
         val expectedIdentifier = if (isBadBlockTypeInMeta) 1 else 0
         val droppedBytes =
@@ -483,15 +513,13 @@ internal class PlainBatchFileReaderWriterTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            "Unexpected block type identifier=$badBlockType met," +
-                " was expecting $expectedBlockName($expectedIdentifier)",
-            additionalProperties = droppedBytesTelemetry(droppedBytes)
-        )
-        mockInternalLogger.verifyLog(
-            InternalLogger.Level.ERROR,
-            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-            PlainBatchFileReaderWriter.WARNING_NOT_ALL_DATA_READ.format(Locale.US, file.path),
-            additionalProperties = droppedBytesTelemetry(droppedBytes)
+            PlainBatchFileReaderWriter.ERROR_UNEXPECTED_BLOCK_TYPE_MET,
+            additionalProperties = droppedBytesTelemetry(
+                droppedBytes,
+                TelemetryContext.TELEMETRY_BLOCK_TYPE_ACTUAL_IDENTIFIER to badBlockType.toShort(),
+                TelemetryContext.TELEMETRY_BLOCK_TYPE_EXPECTED_IDENTIFIER to expectedIdentifier.toShort(),
+                TelemetryContext.TELEMETRY_BLOCK_TYPE_EXPECTED to expectedBlockName
+            )
         )
     }
 
@@ -519,9 +547,10 @@ internal class PlainBatchFileReaderWriterTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            "Unexpected EOF at the operation=Block(EVENT):Data read",
+            PlainBatchFileReaderWriter.ERROR_UNEXPECTED_EOF,
             additionalProperties = droppedBytesTelemetry(
-                metaBytes.size + eventHeaderOnly.size
+                metaBytes.size + eventHeaderOnly.size,
+                TelemetryContext.TELEMETRY_BATCH_OPERATION to "Block(EVENT):Data read"
             )
         )
     }
@@ -549,9 +578,12 @@ internal class PlainBatchFileReaderWriterTest {
             mockInternalLogger.verifyLog(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                PlainBatchFileReaderWriter.ERROR_READ.format(Locale.US, file.path),
+                PlainBatchFileReaderWriter.ERROR_READ,
                 IOException::class.java,
-                additionalProperties = droppedBytesTelemetry(contentBytes.size)
+                additionalProperties = droppedBytesTelemetry(
+                    contentBytes.size,
+                    TelemetryContext.TELEMETRY_FILE_PATH to file.path
+                )
             )
         }
     }
@@ -586,9 +618,42 @@ internal class PlainBatchFileReaderWriterTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            "Number of bytes read for operation='Block(META): Header read' doesn't match with expected: " +
-                "expected=${PlainBatchFileReaderWriter.HEADER_SIZE_BYTES}, actual=$surplus",
-            additionalProperties = droppedBytesTelemetry(surplus)
+            PlainBatchFileReaderWriter.ERROR_UNEXPECTED_NUMBERS_OF_BYTES,
+            additionalProperties = droppedBytesTelemetry(
+                surplus,
+                TelemetryContext.TELEMETRY_BATCH_OPERATION to "Block(META): Header read",
+                TelemetryContext.TELEMETRY_BATCH_BYTES_EXPECTED to PlainBatchFileReaderWriter.HEADER_SIZE_BYTES,
+                TelemetryContext.TELEMETRY_BATCH_BYTES_ACTUAL to surplus
+            )
+        )
+    }
+
+    @Test
+    fun `M log warning W readData() { bad block type leaves trailing bytes unread }`(
+        @StringForgery fileName: String,
+        @Forgery validEvent: RawBatchEvent,
+        @StringForgery(regex = "[a-z]{1,10}") fakeTrailingData: String
+    ) {
+        // Given
+        val file = File(fakeRootDirectory, fileName)
+        val trailingBytes = fakeTrailingData.toByteArray()
+        // header declares the EVENT identifier where a META block is expected -> block type
+        // mismatch is detected right after the header, so the trailing bytes are never read
+        val corruptedMetaHeader = ByteBuffer.allocate(PlainBatchFileReaderWriter.HEADER_SIZE_BYTES)
+            .putShort(0x00)
+            .putInt(trailingBytes.size)
+            .array()
+        file.writeBytes(encode(validEvent) + corruptedMetaHeader + trailingBytes)
+
+        // When
+        val result = testedReaderWriter.readData(file, fakeTelemetryContext)
+
+        // Then
+        assertThat(result).containsExactly(validEvent)
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.MAINTAINER),
+            PlainBatchFileReaderWriter.WARNING_NOT_ALL_DATA_READ.format(Locale.US, file.path)
         )
     }
 
@@ -622,6 +687,12 @@ internal class PlainBatchFileReaderWriterTest {
 
         // Then
         assertThat(result).containsExactlyElementsOf(events)
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.MAINTAINER),
+            PlainBatchFileReaderWriter.WARNING_NOT_ALL_DATA_READ.format(Locale.US, file.path),
+            mode = never()
+        )
     }
 
     // endregion
@@ -729,8 +800,8 @@ internal class PlainBatchFileReaderWriterTest {
             .array()
     }
 
-    private fun droppedBytesTelemetry(droppedBytes: Int): Map<String, Any> =
-        fakeTelemetryContext.asAttributesMap(bytesLost = droppedBytes)
+    private fun droppedBytesTelemetry(droppedBytes: Int, vararg customFields: Pair<String, Any>): Map<String, Any> =
+        fakeTelemetryContext.asAttributesMap(bytesLost = droppedBytes, *customFields)
 
     // endregion
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleItemDataWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleItemDataWriterTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.FileWriter
 import com.datadog.android.core.persistence.Serializer
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.annotation.Forgery
@@ -59,6 +60,9 @@ internal class SingleItemDataWriterTest {
     lateinit var mockInternalLogger: InternalLogger
 
     @Forgery
+    lateinit var fakeTelemetryContext: TelemetryContext
+
+    @Forgery
     lateinit var fakeThrowable: Throwable
 
     @Forgery
@@ -83,7 +87,8 @@ internal class SingleItemDataWriterTest {
             mockSerializer,
             mockFileWriter,
             mockInternalLogger,
-            fakeFilePersistenceConfig.copy(maxItemSize = Long.MAX_VALUE)
+            fakeFilePersistenceConfig.copy(maxItemSize = Long.MAX_VALUE),
+            fakeTelemetryContext
         )
     }
 
@@ -104,7 +109,8 @@ internal class SingleItemDataWriterTest {
             .writeData(
                 file,
                 serialized,
-                append = false
+                append = false,
+                telemetryContext = fakeTelemetryContext
             )
     }
 
@@ -125,7 +131,8 @@ internal class SingleItemDataWriterTest {
             .writeData(
                 file,
                 lastSerialized,
-                append = false
+                append = false,
+                telemetryContext = fakeTelemetryContext
             )
     }
 
@@ -177,9 +184,8 @@ internal class SingleItemDataWriterTest {
             mockSerializer,
             mockFileWriter,
             mockInternalLogger,
-            fakeFilePersistenceConfig.copy(
-                maxItemSize = maxLimit
-            )
+            fakeFilePersistenceConfig.copy(maxItemSize = maxLimit),
+            fakeTelemetryContext
         )
 
         // When

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/tlvformat/TLVBlockFileReaderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/tlvformat/TLVBlockFileReaderTest.kt
@@ -9,8 +9,10 @@ package com.datadog.android.core.internal.persistence.tlvformat
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.tlvformat.TLVBlockFileReader.Companion.FAILED_TO_DESERIALIZE_ERROR
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -31,6 +33,7 @@ import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.io.File
 import java.nio.ByteBuffer
+import java.util.Locale
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -53,6 +56,9 @@ internal class TLVBlockFileReaderTest {
     @StringForgery
     private lateinit var fakeDataString: String
 
+    @Forgery
+    private lateinit var fakeTelemetryContext: TelemetryContext
+
     private lateinit var fakeVersionBytes: ByteArray
     private lateinit var fakeDataBytes: ByteArray
     private lateinit var fakeBufferBytes: ByteArray
@@ -63,7 +69,7 @@ internal class TLVBlockFileReaderTest {
         val dataBytes = createDataBytes()
         val dataToWrite = versionBytes + dataBytes
 
-        whenever(mockFileReaderWriter.readData(mockFile)).thenReturn(dataToWrite)
+        whenever(mockFileReaderWriter.readData(mockFile, fakeTelemetryContext)).thenReturn(dataToWrite)
 
         testedReader = TLVBlockFileReader(
             fileReaderWriter = mockFileReaderWriter,
@@ -72,52 +78,86 @@ internal class TLVBlockFileReaderTest {
     }
 
     @Test
-    fun `M return empty collection W read() { invalid TLV type }`() {
+    fun `M return empty collection W read() { input shorter than TLV type }`(
+        @IntForgery(min = 0, max = 1) fakeSize: Int
+    ) {
         // Given
-        fakeBufferBytes = fakeDataString.toByteArray(Charsets.UTF_8)
-        whenever(mockFileReaderWriter.readData(mockFile))
+        fakeBufferBytes = ByteArray(fakeSize)
+        whenever(mockFileReaderWriter.readData(mockFile, fakeTelemetryContext))
             .thenReturn(fakeBufferBytes)
 
         // When
-        val readBytes = testedReader.read(file = mockFile)
+        val readBytes = testedReader.read(file = mockFile, telemetryContext = fakeTelemetryContext)
 
         // Then
         assertThat(readBytes).isEmpty()
     }
 
     @Test
-    fun `M log error W read() { invalid TLV type }`() {
+    fun `M return empty collection W read() { invalid TLV type }`(
+        @StringForgery(regex = "[a-zA-Z0-9]{2,32}") fakeInvalidTypeString: String
+    ) {
         // Given
-        fakeBufferBytes = fakeDataString.toByteArray(Charsets.UTF_8)
-        whenever(mockFileReaderWriter.readData(mockFile))
+        fakeBufferBytes = fakeInvalidTypeString.toByteArray(Charsets.UTF_8)
+        whenever(mockFileReaderWriter.readData(mockFile, fakeTelemetryContext))
             .thenReturn(fakeBufferBytes)
 
         // When
-        testedReader.read(file = mockFile)
+        val readBytes = testedReader.read(file = mockFile, telemetryContext = fakeTelemetryContext)
 
         // Then
-        val expectedMessage = if (fakeDataString.length >= 2) {
-            "TLV header corrupt. Invalid type"
-        } else {
-            "Failed to deserialize TLV data length"
-        }
+        assertThat(readBytes).isEmpty()
+    }
+
+    @Test
+    fun `M log error W read() { input shorter than TLV type }`() {
+        // Given
+        fakeBufferBytes = ByteArray(1)
+        whenever(mockFileReaderWriter.readData(mockFile, fakeTelemetryContext))
+            .thenReturn(fakeBufferBytes)
+
+        // When
+        testedReader.read(file = mockFile, telemetryContext = fakeTelemetryContext)
+
+        // Then
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.WARN,
+            targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            message = FAILED_TO_DESERIALIZE_ERROR,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = fakeBufferBytes.size)
+        )
+    }
+
+    @Test
+    fun `M log error W read() { invalid TLV type }`(
+        @StringForgery(regex = "[a-zA-Z0-9]{2,32}") fakeInvalidTypeString: String
+    ) {
+        // Given
+        fakeBufferBytes = fakeInvalidTypeString.toByteArray(Charsets.UTF_8)
+        whenever(mockFileReaderWriter.readData(mockFile, fakeTelemetryContext))
+            .thenReturn(fakeBufferBytes)
+
+        // When
+        testedReader.read(file = mockFile, telemetryContext = fakeTelemetryContext)
+
+        // Then
         val captor = argumentCaptor<() -> String>()
         verify(mockInternalLogger).log(
             level = eq(InternalLogger.Level.WARN),
-            target = eq(InternalLogger.Target.MAINTAINER),
+            targets = eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
             captor.capture(),
             anyOrNull(),
             anyOrNull(),
-            anyOrNull()
+            eq(fakeTelemetryContext.asAttributesMap(bytesLost = fakeBufferBytes.size))
         )
         assertThat(captor.firstValue.invoke())
-            .startsWith(expectedMessage)
+            .startsWith("TLV header corrupt. Invalid type")
     }
 
     @Test
     fun `M return valid object W read() { valid TLV format }`() {
         // When
-        val tlvArray = testedReader.read(file = mockFile)
+        val tlvArray = testedReader.read(file = mockFile, telemetryContext = fakeTelemetryContext)
 
         // Then
         assertThat(tlvArray).hasSize(2)
@@ -134,17 +174,18 @@ internal class TLVBlockFileReaderTest {
     fun `M return empty array W read() { invalid type length }`() {
         // Given
         val fakeByteArray = ByteBuffer.allocate(1).array()
-        whenever(mockFileReaderWriter.readData(mockFile)).thenReturn(fakeByteArray)
+        whenever(mockFileReaderWriter.readData(mockFile, fakeTelemetryContext)).thenReturn(fakeByteArray)
 
         // When
-        val result = testedReader.read(mockFile)
+        val result = testedReader.read(mockFile, fakeTelemetryContext)
 
         // Then
         assertThat(result).isEmpty()
         mockInternalLogger.verifyLog(
             level = InternalLogger.Level.WARN,
-            target = InternalLogger.Target.MAINTAINER,
-            message = FAILED_TO_DESERIALIZE_ERROR
+            targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            message = FAILED_TO_DESERIALIZE_ERROR,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = fakeByteArray.size)
         )
     }
 
@@ -153,17 +194,106 @@ internal class TLVBlockFileReaderTest {
         // Given
         val fakeBuffer = ByteBuffer.allocate(3)
         val fakeArray = fakeBuffer.putShort(TLVBlockType.DATA.rawValue.toShort()).array()
-        whenever(mockFileReaderWriter.readData(mockFile)).thenReturn(fakeArray)
+        whenever(mockFileReaderWriter.readData(mockFile, fakeTelemetryContext)).thenReturn(fakeArray)
 
         // When
-        val result = testedReader.read(mockFile)
+        val result = testedReader.read(mockFile, fakeTelemetryContext)
 
         // Then
         assertThat(result).isEmpty()
         mockInternalLogger.verifyLog(
             level = InternalLogger.Level.WARN,
-            target = InternalLogger.Target.MAINTAINER,
-            message = FAILED_TO_DESERIALIZE_ERROR
+            targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            message = FAILED_TO_DESERIALIZE_ERROR,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = fakeArray.size)
+        )
+    }
+
+    @Test
+    fun `M return empty array and log error W read() { declared block length exceeds limit }`(
+        @IntForgery(min = 1, max = 8) fakeMaxEntrySize: Int,
+        @IntForgery(min = 9) fakeDeclaredLength: Int
+    ) {
+        // Given
+        val fakeBlock = ByteBuffer.allocate(Short.SIZE_BYTES + Int.SIZE_BYTES)
+            .putShort(TLVBlockType.DATA.rawValue.toShort())
+            .putInt(fakeDeclaredLength)
+            .array()
+        whenever(mockFileReaderWriter.readData(mockFile, fakeTelemetryContext)).thenReturn(fakeBlock)
+        testedReader = TLVBlockFileReader(
+            fileReaderWriter = mockFileReaderWriter,
+            internalLogger = mockInternalLogger,
+            maxEntrySize = fakeMaxEntrySize
+        )
+
+        // When
+        val result = testedReader.read(mockFile, fakeTelemetryContext)
+
+        // Then
+        assertThat(result).isEmpty()
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            message = TLVBlockFileReader.CORRUPT_DATA_LENGTH_ERROR
+                .format(Locale.US, fakeMaxEntrySize, fakeDeclaredLength),
+            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = fakeBlock.size)
+        )
+    }
+
+    @Test
+    fun `M return empty array and log error W read() { declared block length is negative }`(
+        @IntForgery(min = 1) fakeMaxEntrySize: Int,
+        @IntForgery(max = 0) fakeNegativeLength: Int
+    ) {
+        // Given
+        val fakeBlock = ByteBuffer.allocate(Short.SIZE_BYTES + Int.SIZE_BYTES)
+            .putShort(TLVBlockType.DATA.rawValue.toShort())
+            .putInt(fakeNegativeLength)
+            .array()
+        whenever(mockFileReaderWriter.readData(mockFile, fakeTelemetryContext)).thenReturn(fakeBlock)
+        testedReader = TLVBlockFileReader(
+            fileReaderWriter = mockFileReaderWriter,
+            internalLogger = mockInternalLogger,
+            maxEntrySize = fakeMaxEntrySize
+        )
+
+        // When
+        val result = testedReader.read(mockFile, fakeTelemetryContext)
+
+        // Then
+        assertThat(result).isEmpty()
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            message = TLVBlockFileReader.CORRUPT_DATA_LENGTH_ERROR
+                .format(Locale.US, fakeMaxEntrySize, fakeNegativeLength),
+            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = fakeBlock.size)
+        )
+    }
+
+    @Test
+    fun `M return empty array and log error W read() { declared length exceeds available bytes }`(
+        @IntForgery(min = 1, max = 10) fakeAvailableDataSize: Int,
+        @IntForgery(min = 11, max = 1000) fakeDeclaredLength: Int
+    ) {
+        // Given
+        val fakeBlock = ByteBuffer.allocate(Short.SIZE_BYTES + Int.SIZE_BYTES + fakeAvailableDataSize)
+            .putShort(TLVBlockType.DATA.rawValue.toShort())
+            .putInt(fakeDeclaredLength)
+            .put(ByteArray(fakeAvailableDataSize))
+            .array()
+        whenever(mockFileReaderWriter.readData(mockFile, fakeTelemetryContext)).thenReturn(fakeBlock)
+
+        // When
+        val result = testedReader.read(mockFile, fakeTelemetryContext)
+
+        // Then
+        assertThat(result).isEmpty()
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.WARN,
+            targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            message = FAILED_TO_DESERIALIZE_ERROR,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = fakeBlock.size)
         )
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/tlvformat/TLVBlockFileReaderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/tlvformat/TLVBlockFileReaderTest.kt
@@ -8,8 +8,13 @@ package com.datadog.android.core.internal.persistence.tlvformat
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
-import com.datadog.android.core.internal.persistence.tlvformat.TLVBlockFileReader.Companion.FAILED_TO_DESERIALIZE_ERROR
+import com.datadog.android.core.internal.utils.toShort
 import com.datadog.android.internal.telemetry.TelemetryContext
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_TLV_DATA_LENGTH
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_TLV_DATA_LENGTH_LIMIT
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_TLV_HEADER_LENGTH
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_TLV_HEADER_LENGTH_LIMIT
+import com.datadog.android.internal.telemetry.TelemetryContext.Companion.TELEMETRY_TLV_TYPE
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.annotation.Forgery
@@ -25,15 +30,10 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
-import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.io.File
 import java.nio.ByteBuffer
-import java.util.Locale
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -123,8 +123,12 @@ internal class TLVBlockFileReaderTest {
         mockInternalLogger.verifyLog(
             level = InternalLogger.Level.WARN,
             targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-            message = FAILED_TO_DESERIALIZE_ERROR,
-            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = fakeBufferBytes.size)
+            message = TLVBlockFileReader.WARN_CORRUPT_HEADER_LENGTH_ERROR,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(
+                bytesLost = fakeBufferBytes.size,
+                TELEMETRY_TLV_HEADER_LENGTH to Short.SIZE_BYTES,
+                TELEMETRY_TLV_HEADER_LENGTH_LIMIT to fakeBufferBytes.size
+            )
         )
     }
 
@@ -141,17 +145,16 @@ internal class TLVBlockFileReaderTest {
         testedReader.read(file = mockFile, telemetryContext = fakeTelemetryContext)
 
         // Then
-        val captor = argumentCaptor<() -> String>()
-        verify(mockInternalLogger).log(
-            level = eq(InternalLogger.Level.WARN),
-            targets = eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
-            captor.capture(),
-            anyOrNull(),
-            anyOrNull(),
-            eq(fakeTelemetryContext.asAttributesMap(bytesLost = fakeBufferBytes.size))
+        val actualType = fakeBufferBytes.copyOfRange(0, Short.SIZE_BYTES).toShort()
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.WARN,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            message = TLVBlockFileReader.WARN_CORRUPT_TLV_HEADER_TYPE,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(
+                bytesLost = fakeBufferBytes.size,
+                TELEMETRY_TLV_TYPE to actualType
+            )
         )
-        assertThat(captor.firstValue.invoke())
-            .startsWith("TLV header corrupt. Invalid type")
     }
 
     @Test
@@ -184,8 +187,12 @@ internal class TLVBlockFileReaderTest {
         mockInternalLogger.verifyLog(
             level = InternalLogger.Level.WARN,
             targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-            message = FAILED_TO_DESERIALIZE_ERROR,
-            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = fakeByteArray.size)
+            message = TLVBlockFileReader.WARN_CORRUPT_HEADER_LENGTH_ERROR,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(
+                bytesLost = fakeByteArray.size,
+                TELEMETRY_TLV_HEADER_LENGTH to Short.SIZE_BYTES,
+                TELEMETRY_TLV_HEADER_LENGTH_LIMIT to fakeByteArray.size
+            )
         )
     }
 
@@ -201,11 +208,16 @@ internal class TLVBlockFileReaderTest {
 
         // Then
         assertThat(result).isEmpty()
+        // 2 bytes of type consumed, only 1 byte left for the 4-byte length field
         mockInternalLogger.verifyLog(
             level = InternalLogger.Level.WARN,
             targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-            message = FAILED_TO_DESERIALIZE_ERROR,
-            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = fakeArray.size)
+            message = TLVBlockFileReader.WARN_CORRUPT_DATA_LENGTH_ERROR,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(
+                fakeArray.size,
+                TELEMETRY_TLV_DATA_LENGTH to Int.SIZE_BYTES,
+                TELEMETRY_TLV_DATA_LENGTH_LIMIT to (fakeArray.size - Short.SIZE_BYTES)
+            )
         )
     }
 
@@ -234,9 +246,12 @@ internal class TLVBlockFileReaderTest {
         mockInternalLogger.verifyLog(
             level = InternalLogger.Level.ERROR,
             targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-            message = TLVBlockFileReader.CORRUPT_DATA_LENGTH_ERROR
-                .format(Locale.US, fakeMaxEntrySize, fakeDeclaredLength),
-            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = fakeBlock.size)
+            message = TLVBlockFileReader.WARN_CORRUPT_DATA_LENGTH_ERROR,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(
+                fakeBlock.size,
+                TELEMETRY_TLV_DATA_LENGTH to fakeDeclaredLength,
+                TELEMETRY_TLV_DATA_LENGTH_LIMIT to fakeMaxEntrySize
+            )
         )
     }
 
@@ -265,9 +280,12 @@ internal class TLVBlockFileReaderTest {
         mockInternalLogger.verifyLog(
             level = InternalLogger.Level.ERROR,
             targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-            message = TLVBlockFileReader.CORRUPT_DATA_LENGTH_ERROR
-                .format(Locale.US, fakeMaxEntrySize, fakeNegativeLength),
-            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = fakeBlock.size)
+            message = TLVBlockFileReader.WARN_CORRUPT_DATA_LENGTH_ERROR,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(
+                fakeBlock.size,
+                TELEMETRY_TLV_DATA_LENGTH to fakeNegativeLength,
+                TELEMETRY_TLV_DATA_LENGTH_LIMIT to fakeMaxEntrySize
+            )
         )
     }
 
@@ -290,10 +308,14 @@ internal class TLVBlockFileReaderTest {
         // Then
         assertThat(result).isEmpty()
         mockInternalLogger.verifyLog(
-            level = InternalLogger.Level.WARN,
+            level = InternalLogger.Level.ERROR,
             targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-            message = FAILED_TO_DESERIALIZE_ERROR,
-            additionalProperties = fakeTelemetryContext.asAttributesMap(bytesLost = fakeBlock.size)
+            message = TLVBlockFileReader.WARN_CORRUPT_DATA_LENGTH_ERROR,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(
+                fakeBlock.size,
+                TELEMETRY_TLV_DATA_LENGTH to fakeDeclaredLength,
+                TELEMETRY_TLV_DATA_LENGTH_LIMIT to fakeAvailableDataSize
+            )
         )
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/tlvformat/TLVBlockTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/tlvformat/TLVBlockTest.kt
@@ -7,7 +7,9 @@
 package com.datadog.android.core.internal.persistence.tlvformat
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -42,6 +44,9 @@ internal class TLVBlockTest {
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
+    @Forgery
+    lateinit var fakeTelemetryContext: TelemetryContext
+
     @Test
     fun `M return null W serialize() { empty data }`() {
         // Given
@@ -52,7 +57,7 @@ internal class TLVBlockTest {
         )
 
         // When
-        val block = testedTLVBlock.serialize()
+        val block = testedTLVBlock.serialize(fakeTelemetryContext)
 
         // Then
         assertThat(block).isNull()
@@ -75,7 +80,7 @@ internal class TLVBlockTest {
         )
 
         // When
-        val block = testedTLVBlock.serialize()
+        val block = testedTLVBlock.serialize(fakeTelemetryContext)
 
         // Then
         checkNotNull(block)
@@ -107,18 +112,24 @@ internal class TLVBlockTest {
         )
 
         // When
-        testedTLVBlock.serialize(1)
+        testedTLVBlock.serialize(fakeTelemetryContext, 1)
 
         // Then
         val stringCaptor = argumentCaptor<() -> String>()
+        val propertiesCaptor = argumentCaptor<Map<String, Any>>()
         verify(mockInternalLogger).log(
-            level = eq(InternalLogger.Level.WARN),
-            target = eq(InternalLogger.Target.MAINTAINER),
+            level = eq(InternalLogger.Level.ERROR),
+            targets = eq(listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY)),
             stringCaptor.capture(),
             anyOrNull(),
             anyOrNull(),
-            anyOrNull()
+            propertiesCaptor.capture()
         )
         assertThat(stringCaptor.firstValue.invoke()).startsWith("DataBlock length exceeds limit")
+        assertThat(propertiesCaptor.firstValue).isEqualTo(
+            fakeTelemetryContext.asAttributesMap(
+                bytesLost = fakeByteArray.size + 6
+            )
+        )
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/tlvformat/TLVBlockTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/tlvformat/TLVBlockTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.core.internal.persistence.tlvformat
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -21,10 +22,6 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
-import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.nio.ByteBuffer
@@ -115,20 +112,15 @@ internal class TLVBlockTest {
         testedTLVBlock.serialize(fakeTelemetryContext, 1)
 
         // Then
-        val stringCaptor = argumentCaptor<() -> String>()
-        val propertiesCaptor = argumentCaptor<Map<String, Any>>()
-        verify(mockInternalLogger).log(
-            level = eq(InternalLogger.Level.ERROR),
-            targets = eq(listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY)),
-            stringCaptor.capture(),
-            anyOrNull(),
-            anyOrNull(),
-            propertiesCaptor.capture()
-        )
-        assertThat(stringCaptor.firstValue.invoke()).startsWith("DataBlock length exceeds limit")
-        assertThat(propertiesCaptor.firstValue).isEqualTo(
-            fakeTelemetryContext.asAttributesMap(
-                bytesLost = fakeByteArray.size + 6
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            TLVBlock.BYTE_LENGTH_EXCEEDED_ERROR,
+            additionalProperties = fakeTelemetryContext.asAttributesMap(
+                bytesLost = fakeByteArray.size + 6,
+                TelemetryContext.TELEMETRY_TLV_SIZE_LIMIT to 1,
+                TelemetryContext.TELEMETRY_TLV_SIZE to fakeByteArray.size + 6,
+                TelemetryContext.TELEMETRY_TLV_TYPE to mockTLVBlockType
             )
         )
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/ndk/internal/DatadogNdkCrashHandlerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/ndk/internal/DatadogNdkCrashHandlerTest.kt
@@ -94,7 +94,7 @@ internal class DatadogNdkCrashHandlerTest {
     @BeforeEach
     fun `set up`() {
         fakeNdkCacheDir = File(tempDir, DatadogNdkCrashHandler.NDK_CRASH_REPORTS_FOLDER_NAME)
-        whenever(mockEnvFileReader.readData(any())) doAnswer {
+        whenever(mockEnvFileReader.readData(any(), any())) doAnswer {
             it.getArgument<File>(0).readBytes()
         }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.utils.forge
 
 import com.datadog.android.internal.tests.elmyr.InternalTelemetryApiUsageForgeryFactory
+import com.datadog.android.internal.tests.elmyr.TelemetryContextFactory
 import com.datadog.android.internal.tests.elmyr.TracingHeaderTypesSetForgeryFactory
 import com.datadog.android.test.elmyr.PersistenceStrategyBatchForgeryFactory
 import com.datadog.android.tests.elmyr.useCoreFactories
@@ -75,5 +76,6 @@ internal class Configurator :
         // telemetry
         forge.addFactory(InternalTelemetryApiUsageForgeryFactory())
         forge.addFactory(TracingHeaderTypesSetForgeryFactory())
+        forge.addFactory(TelemetryContextFactory())
     }
 }

--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -253,6 +253,12 @@ sealed class com.datadog.android.internal.telemetry.InternalTelemetryEvent
     enum Mode
       - DEFAULT_HEADERS
       - CUSTOM
+data class com.datadog.android.internal.telemetry.TelemetryContext
+  constructor(String, String? = null)
+  fun asAttributesMap(Int): Map<String, Any>
+  companion object 
+    const val BYTE_LOST_UNKNOWN: Int
+    fun asAttributesMap(String, Int? = null, String? = null): Map<String, Any>
 enum com.datadog.android.internal.telemetry.TracingHeaderType
   - DATADOG
   - B3

--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -255,10 +255,25 @@ sealed class com.datadog.android.internal.telemetry.InternalTelemetryEvent
       - CUSTOM
 data class com.datadog.android.internal.telemetry.TelemetryContext
   constructor(String, String? = null)
-  fun asAttributesMap(Int): Map<String, Any>
+  fun asAttributesMap(Int, Pair<String, Any> = emptyArray()): Map<String, Any>
   companion object 
     const val BYTE_LOST_UNKNOWN: Int
-    fun asAttributesMap(String, Int? = null, String? = null): Map<String, Any>
+    const val TELEMETRY_DATA_LIMIT: String
+    const val TELEMETRY_FILE_PATH: String
+    const val TELEMETRY_BATCH_OPERATION: String
+    const val TELEMETRY_BATCH_BYTES_EXPECTED: String
+    const val TELEMETRY_BATCH_BYTES_ACTUAL: String
+    const val TELEMETRY_BLOCK_TYPE_ACTUAL_IDENTIFIER: String
+    const val TELEMETRY_BLOCK_TYPE_EXPECTED: String
+    const val TELEMETRY_BLOCK_TYPE_EXPECTED_IDENTIFIER: String
+    const val TELEMETRY_TLV_TYPE: String
+    const val TELEMETRY_TLV_SIZE: String
+    const val TELEMETRY_TLV_SIZE_LIMIT: String
+    const val TELEMETRY_TLV_DATA_LENGTH: String
+    const val TELEMETRY_TLV_DATA_LENGTH_LIMIT: String
+    const val TELEMETRY_TLV_HEADER_LENGTH: String
+    const val TELEMETRY_TLV_HEADER_LENGTH_LIMIT: String
+    fun asAttributesMap(String, Int? = null, String? = null, Pair<String, Any> = emptyArray()): Map<String, Any>
 enum com.datadog.android.internal.telemetry.TracingHeaderType
   - DATADOG
   - B3

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -622,9 +622,25 @@ public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent
 public final class com/datadog/android/internal/telemetry/TelemetryContext {
 	public static final field BYTE_LOST_UNKNOWN I
 	public static final field Companion Lcom/datadog/android/internal/telemetry/TelemetryContext$Companion;
+	public static final field TELEMETRY_BATCH_BYTES_ACTUAL Ljava/lang/String;
+	public static final field TELEMETRY_BATCH_BYTES_EXPECTED Ljava/lang/String;
+	public static final field TELEMETRY_BATCH_OPERATION Ljava/lang/String;
+	public static final field TELEMETRY_BLOCK_TYPE_ACTUAL_IDENTIFIER Ljava/lang/String;
+	public static final field TELEMETRY_BLOCK_TYPE_EXPECTED Ljava/lang/String;
+	public static final field TELEMETRY_BLOCK_TYPE_EXPECTED_IDENTIFIER Ljava/lang/String;
+	public static final field TELEMETRY_DATA_LIMIT Ljava/lang/String;
+	public static final field TELEMETRY_FILE_PATH Ljava/lang/String;
+	public static final field TELEMETRY_TLV_DATA_LENGTH Ljava/lang/String;
+	public static final field TELEMETRY_TLV_DATA_LENGTH_LIMIT Ljava/lang/String;
+	public static final field TELEMETRY_TLV_HEADER_LENGTH Ljava/lang/String;
+	public static final field TELEMETRY_TLV_HEADER_LENGTH_LIMIT Ljava/lang/String;
+	public static final field TELEMETRY_TLV_SIZE Ljava/lang/String;
+	public static final field TELEMETRY_TLV_SIZE_LIMIT Ljava/lang/String;
+	public static final field TELEMETRY_TLV_TYPE Ljava/lang/String;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun asAttributesMap (I)Ljava/util/Map;
+	public final fun asAttributesMap (I[Lkotlin/Pair;)Ljava/util/Map;
+	public static synthetic fun asAttributesMap$default (Lcom/datadog/android/internal/telemetry/TelemetryContext;I[Lkotlin/Pair;ILjava/lang/Object;)Ljava/util/Map;
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/internal/telemetry/TelemetryContext;
@@ -637,8 +653,8 @@ public final class com/datadog/android/internal/telemetry/TelemetryContext {
 }
 
 public final class com/datadog/android/internal/telemetry/TelemetryContext$Companion {
-	public final fun asAttributesMap (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;)Ljava/util/Map;
-	public static synthetic fun asAttributesMap$default (Lcom/datadog/android/internal/telemetry/TelemetryContext$Companion;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/Map;
+	public final fun asAttributesMap (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;[Lkotlin/Pair;)Ljava/util/Map;
+	public static synthetic fun asAttributesMap$default (Lcom/datadog/android/internal/telemetry/TelemetryContext$Companion;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;[Lkotlin/Pair;ILjava/lang/Object;)Ljava/util/Map;
 }
 
 public final class com/datadog/android/internal/telemetry/TracingHeaderType : java/lang/Enum {

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -619,6 +619,28 @@ public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent
 	public static fun values ()[Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ResourceHeadersTrackingConfigured$Mode;
 }
 
+public final class com/datadog/android/internal/telemetry/TelemetryContext {
+	public static final field BYTE_LOST_UNKNOWN I
+	public static final field Companion Lcom/datadog/android/internal/telemetry/TelemetryContext$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun asAttributesMap (I)Ljava/util/Map;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/internal/telemetry/TelemetryContext;
+	public static synthetic fun copy$default (Lcom/datadog/android/internal/telemetry/TelemetryContext;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/internal/telemetry/TelemetryContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEventType ()Ljava/lang/String;
+	public final fun getFeatureName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/internal/telemetry/TelemetryContext$Companion {
+	public final fun asAttributesMap (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;)Ljava/util/Map;
+	public static synthetic fun asAttributesMap$default (Lcom/datadog/android/internal/telemetry/TelemetryContext$Companion;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/Map;
+}
+
 public final class com/datadog/android/internal/telemetry/TracingHeaderType : java/lang/Enum {
 	public static final field B3 Lcom/datadog/android/internal/telemetry/TracingHeaderType;
 	public static final field B3MULTI Lcom/datadog/android/internal/telemetry/TracingHeaderType;

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/telemetry/TelemetryContext.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/telemetry/TelemetryContext.kt
@@ -28,22 +28,68 @@ data class TelemetryContext(
      * ingestion by the telemetry batch.
      */
     fun asAttributesMap(
-        bytesLost: Int
-    ): Map<String, Any> = asAttributesMap(featureName, bytesLost, eventType)
+        bytesLost: Int,
+        vararg customFields: Pair<String, Any> = emptyArray()
+    ): Map<String, Any> = asAttributesMap(featureName, bytesLost, eventType, *customFields)
 
     companion object {
         /** Sentinel value used when the number of bytes lost for a dropped event is not known. */
         const val BYTE_LOST_UNKNOWN: Int = -1
 
         /** Name of the feature ("rum", "logs", "tracing", ...) whose event was affected. */
-        internal const val FEATURE_NAME: String = "event.feature_name"
+        internal const val FEATURE_NAME: String = "telemetry.feature_name"
 
         /** Serialized size, in bytes, of an event that was dropped because it exceeded the size limit. */
-        internal const val EVENT_DROPPED_BYTES: String = "event.dropped_bytes"
+        internal const val EVENT_DROPPED_BYTES: String = "telemetry.dropped_bytes"
 
         /** Category of the dropped event, in a feature-specific format (e.g. RUM uses its model
          * event type such as "view", "action", "error") — when known. */
-        internal const val EVENT_TYPE: String = "event.type"
+        internal const val EVENT_TYPE: String = "telemetry.event.type"
+
+        /** Configured limit, in bytes, that the persisted data exceeded. */
+        const val TELEMETRY_DATA_LIMIT: String = "telemetry.data.limit"
+
+        /** Path of the file involved in the telemetry event. */
+        const val TELEMETRY_FILE_PATH: String = "telemetry.file.path"
+
+        /** Batch operation being performed when the telemetry event was recorded. */
+        const val TELEMETRY_BATCH_OPERATION: String = "telemetry.batch.operation"
+
+        /** Number of bytes expected to be read or written for the batch operation. */
+        const val TELEMETRY_BATCH_BYTES_EXPECTED: String = "telemetry.batch.bytes_expected"
+
+        /** Number of bytes actually read or written for the batch operation. */
+        const val TELEMETRY_BATCH_BYTES_ACTUAL: String = "telemetry.batch.bytes_actual"
+
+        /** Identifier of the TLV block type that was actually read. */
+        const val TELEMETRY_BLOCK_TYPE_ACTUAL_IDENTIFIER: String = "telemetry.block.type.actual_identifier"
+
+        /** TLV block type that was expected to be read. */
+        const val TELEMETRY_BLOCK_TYPE_EXPECTED: String = "telemetry.block.type.expected"
+
+        /** Identifier of the TLV block type that was expected to be read. */
+        const val TELEMETRY_BLOCK_TYPE_EXPECTED_IDENTIFIER: String = "telemetry.block.type.expected_identifier"
+
+        /** Type of TLV entry, whether captured while writing it or while reading it back. */
+        const val TELEMETRY_TLV_TYPE: String = "telemetry.tlv.type"
+
+        /** Size, in bytes, of the TLV entry involved in the telemetry event. */
+        const val TELEMETRY_TLV_SIZE: String = "telemetry.tlv.size"
+
+        /** Configured size limit, in bytes, that the TLV entry exceeded. */
+        const val TELEMETRY_TLV_SIZE_LIMIT: String = "telemetry.tlv.limit"
+
+        /** Length, in bytes, of the TLV entry's data block. */
+        const val TELEMETRY_TLV_DATA_LENGTH: String = "telemetry.tlv.data.length"
+
+        /** Configured length limit, in bytes, that the TLV entry's data block exceeded. */
+        const val TELEMETRY_TLV_DATA_LENGTH_LIMIT: String = "telemetry.tlv.data.limit"
+
+        /** Length, in bytes, of the TLV entry's header block. */
+        const val TELEMETRY_TLV_HEADER_LENGTH: String = "telemetry.tlv.header.length"
+
+        /** Configured length limit, in bytes, that the TLV entry's header block exceeded. */
+        const val TELEMETRY_TLV_HEADER_LENGTH_LIMIT: String = "telemetry.tlv.header.limit"
 
         /**
          * Builds a map of telemetry attributes from the provided feature name,
@@ -52,11 +98,13 @@ data class TelemetryContext(
         fun asAttributesMap(
             featureName: String,
             bytesLost: Int? = null,
-            eventType: String? = null
+            eventType: String? = null,
+            vararg customFields: Pair<String, Any> = emptyArray()
         ): Map<String, Any> = buildMap {
             put(FEATURE_NAME, featureName)
             bytesLost?.let { put(EVENT_DROPPED_BYTES, it) }
             eventType?.let { put(EVENT_TYPE, it) }
+            customFields.forEach { put(it.first, it.second) }
         }
     }
 }

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/telemetry/TelemetryContext.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/telemetry/TelemetryContext.kt
@@ -1,0 +1,62 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.telemetry
+
+/**
+ * Telemetry metadata for dropped-event diagnostics. Instances are converted to an
+ * `additionalProperties` map via [asAttributesMap] and attached to internal telemetry error events so that
+ * dropped-event diagnostics stay consistent and queryable across features and across the read/write
+ * persistence paths.
+ */
+data class TelemetryContext(
+    /**
+     * Name of the feature ("rum", "logs", "tracing", ...) whose event was affected.
+     */
+    val featureName: String,
+    /**
+     * Category of the dropped event, in a feature-specific format (e.g. RUM uses its model event
+     * type such as "view", "action", "error") — when known.
+     */
+    val eventType: String? = null
+) {
+    /**
+     * Converts this metadata instance into a map of telemetry attributes suitable for
+     * ingestion by the telemetry batch.
+     */
+    fun asAttributesMap(
+        bytesLost: Int
+    ): Map<String, Any> = asAttributesMap(featureName, bytesLost, eventType)
+
+    companion object {
+        /** Sentinel value used when the number of bytes lost for a dropped event is not known. */
+        const val BYTE_LOST_UNKNOWN: Int = -1
+
+        /** Name of the feature ("rum", "logs", "tracing", ...) whose event was affected. */
+        internal const val FEATURE_NAME: String = "event.feature_name"
+
+        /** Serialized size, in bytes, of an event that was dropped because it exceeded the size limit. */
+        internal const val EVENT_DROPPED_BYTES: String = "event.dropped_bytes"
+
+        /** Category of the dropped event, in a feature-specific format (e.g. RUM uses its model
+         * event type such as "view", "action", "error") — when known. */
+        internal const val EVENT_TYPE: String = "event.type"
+
+        /**
+         * Builds a map of telemetry attributes from the provided feature name,
+         * optional dropped bytes, and optional event type.
+         */
+        fun asAttributesMap(
+            featureName: String,
+            bytesLost: Int? = null,
+            eventType: String? = null
+        ): Map<String, Any> = buildMap {
+            put(FEATURE_NAME, featureName)
+            bytesLost?.let { put(EVENT_DROPPED_BYTES, it) }
+            eventType?.let { put(EVENT_TYPE, it) }
+        }
+    }
+}

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/telemetry/TelemetryContextTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/telemetry/TelemetryContextTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.telemetry
+
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class TelemetryContextTest {
+
+    @Test
+    fun `M return map with both keys W asAttributesMap() { non-null dropped bytes }`(
+        @StringForgery fakeFeatureName: String,
+        @IntForgery fakeDroppedBytes: Int
+    ) {
+        val result = TelemetryContext(featureName = fakeFeatureName)
+            .asAttributesMap(bytesLost = fakeDroppedBytes)
+
+        assertThat(result).containsEntry(TelemetryContext.FEATURE_NAME, fakeFeatureName)
+        assertThat(result).containsEntry(TelemetryContext.EVENT_DROPPED_BYTES, fakeDroppedBytes)
+        assertThat(result).doesNotContainKey(TelemetryContext.EVENT_TYPE)
+    }
+
+    @Test
+    fun `M include EVENT_TYPE W asAttributesMap() { non-null event type }`(
+        @StringForgery fakeFeatureName: String,
+        @IntForgery fakeDroppedBytes: Int,
+        @StringForgery fakeEventType: String
+    ) {
+        val result = TelemetryContext(featureName = fakeFeatureName, eventType = fakeEventType)
+            .asAttributesMap(bytesLost = fakeDroppedBytes)
+
+        assertThat(result).containsEntry(TelemetryContext.FEATURE_NAME, fakeFeatureName)
+        assertThat(result).containsEntry(TelemetryContext.EVENT_DROPPED_BYTES, fakeDroppedBytes)
+        assertThat(result).containsEntry(TelemetryContext.EVENT_TYPE, fakeEventType)
+    }
+
+    @Test
+    fun `M return map without EVENT_DROPPED_BYTES key W Companion#asAttributesMap() { null dropped bytes }`(
+        @StringForgery fakeFeatureName: String
+    ) {
+        val result = TelemetryContext.asAttributesMap(
+            featureName = fakeFeatureName,
+            bytesLost = null
+        )
+
+        assertThat(result).containsEntry(TelemetryContext.FEATURE_NAME, fakeFeatureName)
+        assertThat(result).doesNotContainKey(TelemetryContext.EVENT_DROPPED_BYTES)
+    }
+}

--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/TelemetryContextFactory.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/TelemetryContextFactory.kt
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.tests.elmyr
+
+import com.datadog.android.internal.telemetry.TelemetryContext
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+class TelemetryContextFactory : ForgeryFactory<TelemetryContext> {
+    override fun getForgery(forge: Forge): TelemetryContext {
+        return TelemetryContext(
+            featureName = forge.anAlphabeticalString(),
+            eventType = forge.aNullable { anAlphabeticalString() }
+        )
+    }
+}

--- a/detekt_custom_safe_calls_third_party.yml
+++ b/detekt_custom_safe_calls_third_party.yml
@@ -413,6 +413,7 @@ datadog:
       - "kotlin.lazy(kotlin.Function0)"
       - "kotlin.lazy(kotlin.LazyThreadSafetyMode, kotlin.Function0)"
       - "kotlin.repeat(kotlin.Int, kotlin.Function1)"
+      - "kotlin.runCatching(kotlin.Function0)"
       - "kotlin.synchronized(kotlin.Any, kotlin.Function0)"
       - "kotlin.ReplaceWith.constructor(kotlin.String, kotlin.Array)"
       - "kotlin.Result.failure(kotlin.Throwable)"

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/storage/EvaluationEventRecordWriter.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/storage/EvaluationEventRecordWriter.kt
@@ -10,8 +10,10 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.api.storage.write
 import com.datadog.android.flags.internal.EvaluationEventWriter
 import com.datadog.android.flags.internal.aggregation.EvaluationAggregationStats
+import com.datadog.android.internal.telemetry.TelemetryContext
 
 /**
  * Persists serialized flag evaluation events to SDK Core storage.
@@ -23,7 +25,8 @@ internal class EvaluationEventRecordWriter(private val sdkCore: FeatureSdkCore) 
     override fun writeAll(events: List<EvaluationAggregationStats>) {
         if (events.isEmpty()) return
 
-        sdkCore.getFeature(Feature.FLAGS_EVALUATIONS_FEATURE_NAME)
+        val featureName = Feature.FLAGS_EVALUATIONS_FEATURE_NAME
+        sdkCore.getFeature(featureName)
             ?.withWriteContext { datadogContext, writeScope ->
                 writeScope { batchWriter ->
                     for (event in events) {
@@ -35,7 +38,8 @@ internal class EvaluationEventRecordWriter(private val sdkCore: FeatureSdkCore) 
                         batchWriter.write(
                             event = rawBatchEvent,
                             batchMetadata = null,
-                            eventType = EventType.DEFAULT
+                            eventType = EventType.DEFAULT,
+                            TelemetryContext(featureName)
                         )
                     }
                 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
@@ -7,15 +7,28 @@
 package com.datadog.android.rum.internal.domain
 
 import androidx.annotation.WorkerThread
+import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.api.storage.write
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.persistence.Serializer
 import com.datadog.android.core.persistence.serializeToByteArray
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.rum.internal.domain.event.RumEventMeta
+import com.datadog.android.rum.model.ActionEvent
+import com.datadog.android.rum.model.ErrorEvent
+import com.datadog.android.rum.model.LongTaskEvent
+import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.rum.model.VitalAppLaunchEvent
+import com.datadog.android.rum.model.VitalOperationStepEvent
+import com.datadog.android.telemetry.model.TelemetryConfigurationEvent
+import com.datadog.android.telemetry.model.TelemetryDebugEvent
+import com.datadog.android.telemetry.model.TelemetryErrorEvent
+import com.datadog.android.telemetry.model.TelemetryUsageEvent
 
 internal class RumDataWriter(
     internal val eventSerializer: Serializer<Any>,
@@ -26,23 +39,21 @@ internal class RumDataWriter(
     // region DataWriter
 
     @WorkerThread
+    @Suppress("ReturnCount")
     override fun write(writer: EventBatchWriter, element: Any, eventType: EventType): Boolean {
-        val byteArray = eventSerializer.serializeToByteArray(
-            element,
-            sdkCore.internalLogger
-        ) ?: return false
+        val byteArray = eventSerializer.serializeToByteArray(element, sdkCore.internalLogger)
+            ?: return false
 
         val batchEvent = if (element is ViewEvent) {
-            val hasAccessibility = element.view.accessibility != null
-
             val eventMeta = RumEventMeta.View(
                 viewId = element.view.id,
                 documentVersion = element.dd.documentVersion,
-                hasAccessibility = hasAccessibility
+                hasAccessibility = element.view.accessibility != null
             )
-            val serializedEventMeta =
-                eventMetaSerializer.serializeToByteArray(eventMeta, sdkCore.internalLogger)
-                    ?: EMPTY_BYTE_ARRAY
+
+            val serializedEventMeta = eventMetaSerializer.serializeToByteArray(eventMeta, sdkCore.internalLogger)
+                ?: EMPTY_BYTE_ARRAY
+
             RawBatchEvent(
                 data = byteArray,
                 metadata = serializedEventMeta
@@ -52,7 +63,12 @@ internal class RumDataWriter(
         }
 
         synchronized(this) {
-            val result = writer.write(batchEvent, null, eventType)
+            val telemetryContext = TelemetryContext(
+                featureName = Feature.RUM_FEATURE_NAME,
+                eventType = resolveEventType(element)
+            )
+
+            val result = writer.write(batchEvent, null, eventType, telemetryContext)
             if (result) {
                 onDataWritten(element, byteArray)
             }
@@ -75,5 +91,22 @@ internal class RumDataWriter(
 
     companion object {
         val EMPTY_BYTE_ARRAY = ByteArray(0)
+
+        private const val UNKNOWN_EVENT_TYPE = "unknown"
+
+        private fun resolveEventType(event: Any): String = when (event) {
+            is ActionEvent -> event.type
+            is ErrorEvent -> event.type
+            is LongTaskEvent -> event.type
+            is ResourceEvent -> event.type
+            is ViewEvent -> event.type
+            is VitalAppLaunchEvent -> event.type
+            is VitalOperationStepEvent -> event.type
+            is TelemetryConfigurationEvent -> event.type
+            is TelemetryDebugEvent -> event.type
+            is TelemetryErrorEvent -> event.type
+            is TelemetryUsageEvent -> event.type
+            else -> UNKNOWN_EVENT_TYPE
+        }
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
@@ -7,10 +7,11 @@
 package com.datadog.android.rum.internal.domain
 
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.core.internal.storage.TelemetryAwareEventBatchWriter
 import com.datadog.android.core.persistence.Serializer
+import com.datadog.android.internal.telemetry.TelemetryContext
 import com.datadog.android.rum.internal.domain.event.RumEventMeta
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
@@ -19,6 +20,10 @@ import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.rum.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.rum.utils.forge.Configurator
+import com.datadog.android.telemetry.model.TelemetryConfigurationEvent
+import com.datadog.android.telemetry.model.TelemetryDebugEvent
+import com.datadog.android.telemetry.model.TelemetryErrorEvent
+import com.datadog.android.telemetry.model.TelemetryUsageEvent
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
@@ -36,9 +41,12 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -65,7 +73,7 @@ internal class RumDataWriterTest {
     lateinit var mockInternalLogger: InternalLogger
 
     @Mock
-    lateinit var mockEventBatchWriter: EventBatchWriter
+    lateinit var mockEventBatchWriter: TelemetryAwareEventBatchWriter
 
     @StringForgery
     lateinit var fakeSerializedEvent: String
@@ -81,9 +89,17 @@ internal class RumDataWriterTest {
 
         whenever(
             mockEventBatchWriter.write(
-                RawBatchEvent(data = fakeSerializedData),
-                null,
-                fakeEventType
+                any<RawBatchEvent>(),
+                anyOrNull<ByteArray>(),
+                any<EventType>(),
+                any<TelemetryContext>()
+            )
+        ) doReturn true
+        whenever(
+            mockEventBatchWriter.write(
+                any<RawBatchEvent>(),
+                anyOrNull<ByteArray>(),
+                any<EventType>()
             )
         ) doReturn true
         whenever(rumMonitor.mockSdkCore.internalLogger) doReturn mockInternalLogger
@@ -116,11 +132,76 @@ internal class RumDataWriterTest {
         // Then
         assertThat(result).isTrue
 
+        val captor = argumentCaptor<RawBatchEvent>()
         verify(mockEventBatchWriter).write(
-            RawBatchEvent(data = fakeSerializedData),
-            null,
-            fakeEventType
+            captor.capture(),
+            anyOrNull<ByteArray>(),
+            any<EventType>(),
+            any<TelemetryContext>()
         )
+        assertThat(captor.firstValue.data).isEqualTo(fakeSerializedData)
+    }
+
+    @Test
+    fun `M resolve event type W write() { telemetry models }`(forge: Forge) {
+        // Given
+        val fakeConfigurationEvent = forge.getForgery(TelemetryConfigurationEvent::class.java)
+        val fakeDebugEvent = forge.getForgery(TelemetryDebugEvent::class.java)
+        val fakeErrorEvent = forge.getForgery(TelemetryErrorEvent::class.java)
+        val fakeUsageEvent = forge.getForgery(TelemetryUsageEvent::class.java)
+        val fakeEvents = listOf<Any>(
+            fakeConfigurationEvent,
+            fakeDebugEvent,
+            fakeErrorEvent,
+            fakeUsageEvent
+        )
+        val expectedEventTypes = listOf(
+            fakeConfigurationEvent.type,
+            fakeDebugEvent.type,
+            fakeErrorEvent.type,
+            fakeUsageEvent.type
+        )
+        fakeEvents.forEach {
+            whenever(mockSerializer.serialize(it)) doReturn fakeSerializedEvent
+        }
+
+        // When
+        fakeEvents.forEach {
+            testedWriter.write(mockEventBatchWriter, it, fakeEventType)
+        }
+
+        // Then
+        val captor = argumentCaptor<TelemetryContext>()
+        verify(mockEventBatchWriter, times(fakeEvents.size)).write(
+            any(),
+            anyOrNull<ByteArray>(),
+            any<EventType>(),
+            captor.capture()
+        )
+        assertThat(captor.allValues.map { it.eventType })
+            .containsExactlyElementsOf(expectedEventTypes)
+    }
+
+    @Test
+    fun `M resolve unknown event type W write() { event class has no type property }`(
+        @StringForgery fakeValue: String
+    ) {
+        // Given
+        val fakeEvent = FakeEventWithoutType(fakeValue)
+        whenever(mockSerializer.serialize(fakeEvent)) doReturn fakeSerializedEvent
+
+        // When
+        testedWriter.write(mockEventBatchWriter, fakeEvent, fakeEventType)
+
+        // Then
+        val captor = argumentCaptor<TelemetryContext>()
+        verify(mockEventBatchWriter).write(
+            any(),
+            anyOrNull<ByteArray>(),
+            any<EventType>(),
+            captor.capture()
+        )
+        assertThat(captor.firstValue.eventType).isEqualTo("unknown")
     }
 
     @Test
@@ -143,14 +224,15 @@ internal class RumDataWriterTest {
         testedWriter.write(mockEventBatchWriter, fakeViewEvent, fakeEventType)
 
         // Then
+        val captor = argumentCaptor<RawBatchEvent>()
         verify(mockEventBatchWriter).write(
-            RawBatchEvent(
-                data = fakeSerializedData,
-                metadata = fakeSerializedViewEventMeta.toByteArray(Charsets.UTF_8)
-            ),
-            null,
-            fakeEventType
+            captor.capture(),
+            anyOrNull<ByteArray>(),
+            any<EventType>(),
+            any<TelemetryContext>()
         )
+        assertThat(captor.firstValue.data).isEqualTo(fakeSerializedData)
+        assertThat(captor.firstValue.metadata).isEqualTo(fakeSerializedViewEventMeta.toByteArray(Charsets.UTF_8))
     }
 
     @Test
@@ -172,11 +254,15 @@ internal class RumDataWriterTest {
         testedWriter.write(mockEventBatchWriter, fakeViewEvent, fakeEventType)
 
         // Then
+        val captor = argumentCaptor<RawBatchEvent>()
         verify(mockEventBatchWriter).write(
-            RawBatchEvent(data = fakeSerializedData),
-            null,
-            fakeEventType
+            captor.capture(),
+            anyOrNull<ByteArray>(),
+            any<EventType>(),
+            any<TelemetryContext>()
         )
+        assertThat(captor.firstValue.data).isEqualTo(fakeSerializedData)
+        assertThat(captor.firstValue.metadata).isEmpty()
     }
 
     @Test
@@ -217,7 +303,14 @@ internal class RumDataWriterTest {
         )
 
         whenever(mockSerializer.serialize(fakeEvent)) doReturn fakeSerializedEvent
-        whenever(mockEventBatchWriter.write(RawBatchEvent(fakeSerializedData), null, fakeEventType)) doReturn false
+        whenever(
+            mockEventBatchWriter.write(
+                any<RawBatchEvent>(),
+                anyOrNull<ByteArray>(),
+                any<EventType>(),
+                any<TelemetryContext>()
+            )
+        ) doReturn false
 
         // When
         val result = testedWriter.write(mockEventBatchWriter, fakeEvent, fakeEventType)
@@ -317,3 +410,5 @@ internal class RumDataWriterTest {
         }
     }
 }
+
+private data class FakeEventWithoutType(val value: String)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/net/ResourceRequestBodyFactoryTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/net/ResourceRequestBodyFactoryTest.kt
@@ -254,6 +254,7 @@ internal class ResourceRequestBodyFactoryTest {
         fakeMetadata.addProperty(APPLICATION_ID_KEY, forge.getForgery<UUID>().toString())
         fakeMetadata.addProperty(FILENAME_KEY, forge.getForgery<UUID>().toString())
         return fakeEvent.copy(
+            data = fakeEvent.data,
             metadata = fakeMetadata.toString().toByteArray(Charsets.UTF_8)
         )
     }


### PR DESCRIPTION
### What does this PR do?

Improves internal telemetry for events dropped during file read/write on the persistence layer:
- Adds `TelemetryAttributes` (`feature.name`, `event.dropped_bytes`) so dropped-event error telemetry carries consistent, queryable attributes across features (RUM, logs, tracing) and across read/write paths.
- Threads these attributes through `RumDataWriter`, `FileEventBatchWriter`, `BatchFileReaderWriter`/`PlainBatchFileReaderWriter`, `TLVBlock`/`TLVBlockFileReader`, `CoreFeature`, and `SdkFeature` so telemetry errors report which feature and how many bytes were involved when an event is dropped.
- Fixes a detekt violation introduced by the above changes.

### Motivation

When events are dropped during persistence (e.g. oversized batches), the existing telemetry lacked enough context to diagnose which feature was affected and how large the dropped payload was. RUM-767 tracks improving this visibility.

### Additional Notes

- New/updated unit tests for `TLVBlockFileReader`, `RumDataWriter`, `FileEventBatchWriter`, `BatchFileReaderWriter`/`PlainBatchFileReaderWriter`, `TLVBlock`.
- `dd-sdk-android-internal` public API surface updated (`apiSurface` / `.api` files) for the new `TelemetryAttributes` object.
- Draft PR — pushed directly per request; full local_ci (tests/lint/apiSurface regen) has not been re-run as part of this push.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)