### PR TITLE
RUM-17103: Decrease client stats flush interval to 30s

### DIFF
--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
@@ -314,7 +314,7 @@ internal class StatsConcentrator(
         private const val KEY_SVC_SRC = "_dd.svc_src"
         private const val DEFAULT_BUFFER_SIZE = 2
         private val DEFAULT_BUCKET_LENGTH = 10.seconds
-        private const val FLUSH_INTERVAL_SECS = 10L
+        private const val FLUSH_INTERVAL_SECS = 30L
 
         private val ELIGIBLE_SPAN_KINDS = setOf(
             Tags.SPAN_KIND_SERVER,

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentratorTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentratorTest.kt
@@ -134,7 +134,7 @@ internal class StatsConcentratorTest {
         )
 
         // Then
-        verify(mockExecutorService).schedule(any<Runnable>(), eq(10L), eq(TimeUnit.SECONDS))
+        verify(mockExecutorService).schedule(any<Runnable>(), eq(30L), eq(TimeUnit.SECONDS))
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?
Align the stats flush interval to 30s to align with [iOS](https://github.com/DataDog/dd-sdk-ios/blob/7ac8c21a72ea86f5fd828834082d6dffee1d521b/DatadogTrace/Sources/Feature/ClientStatsFeature.swift#L34) 
