### PR TITLE
RUM-16668: Add wildcard host pattern matching to first-party tracing

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -289,6 +289,7 @@ class com.datadog.android.core.configuration.HostPatternSanitizer
   constructor(com.datadog.android.api.InternalLogger)
   fun validate(List<String>, String): List<String>
 class com.datadog.android.core.configuration.HostsSanitizer
+  constructor(com.datadog.android.api.InternalLogger = unboundInternalLogger)
   fun sanitizeHosts(List<String>, String): List<String>
 enum com.datadog.android.core.configuration.UploadFrequency
   constructor(Long)

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -781,6 +781,8 @@ public final class com/datadog/android/core/configuration/HostPatternSanitizer {
 
 public final class com/datadog/android/core/configuration/HostsSanitizer {
 	public fun <init> ()V
+	public fun <init> (Lcom/datadog/android/api/InternalLogger;)V
+	public synthetic fun <init> (Lcom/datadog/android/api/InternalLogger;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun sanitizeHosts (Ljava/util/List;Ljava/lang/String;)Ljava/util/List;
 }
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -8,11 +8,13 @@ package com.datadog.android.core.configuration
 
 import com.datadog.android.Datadog
 import com.datadog.android.DatadogSite
+import com.datadog.android.core.internal.utils.unboundInternalLogger
 import com.datadog.android.core.persistence.PersistenceStrategy
 import com.datadog.android.security.Encryption
 import com.datadog.android.trace.TracingHeaderType
 import okhttp3.Authenticator
 import java.net.Proxy
+import java.util.Locale
 
 /**
  * An object describing the configuration of the Datadog SDK.
@@ -76,6 +78,7 @@ internal constructor(
         private var version: String? = null
 
         internal var hostsSanitizer = HostsSanitizer()
+        internal var hostPatternSanitizer = HostPatternSanitizer(unboundInternalLogger)
 
         /**
          * Builds a [Configuration] based on the current state of this Builder.
@@ -113,16 +116,21 @@ internal constructor(
         /**
          * Sets the list of first party hosts.
          * Requests made to a URL with any one of these hosts (or any subdomain) will:
-         * - be considered a first party resource and categorised as such in your RUM dashboard;
+         * - be considered a first party resource and categorized as such in your RUM dashboard;
          * - be wrapped in a Span and have DataDog trace id injected to get a full flame-graph in
          * APM in case of OkHttp instrumentation usage.
+         *
+         * Each entry may be a plain host (e.g. `example.com`, which also matches any subdomain such
+         * as `api.example.com`) or a wildcard pattern (e.g. `*.example.com` or
+         * `preview-*.shopist.io`). A wildcard pattern may contain a single `*`, only the characters
+         * `a-z`, `0-9`, `.`, `-` and `*`, and the `*` may only match a subdomain of a registrable
+         * domain: `*.example.com` matches `api.example.com` but not `example.com` (add the plain host
+         * to also match the apex). Overly broad patterns such as `*`, `*.com` or `*example.com` are
+         * dropped and logged.
          * @param hosts a list of all the hosts that you own.
          */
         fun setFirstPartyHosts(hosts: List<String>): Builder {
-            val sanitizedHosts = hostsSanitizer.sanitizeHosts(
-                hosts,
-                NETWORK_REQUESTS_TRACKING_FEATURE_NAME
-            )
+            val sanitizedHosts = sanitizeHostsAndPatterns(hosts)
             coreConfig = coreConfig.copy(
                 firstPartyHostsWithHeaderTypes = sanitizedHosts.associateWith {
                     setOf(
@@ -138,22 +146,38 @@ internal constructor(
          * Sets the list of first party hosts and specifies the type of HTTP headers used for
          * distributed tracing.
          * Requests made to a URL with any one of these hosts (or any subdomain) will:
-         * - be considered a first party resource and categorised as such in your RUM dashboard;
+         * - be considered a first party resource and categorized as such in your RUM dashboard;
          * - be wrapped in a Span and have trace id of the specified types injected to get a
          * full flame-graph in APM. Multiple header types are supported for each host.
+         *
+         * Each key may be a plain host (e.g. `example.com`, which also matches any subdomain such as
+         * `api.example.com`) or a wildcard pattern (e.g. `*.example.com` or `preview-*.shopist.io`).
+         * A wildcard pattern may contain a single `*`, only the characters `a-z`, `0-9`, `.`, `-` and
+         * `*`, and the `*` may only match a subdomain of a registrable domain: `*.example.com`
+         * matches `api.example.com` but not `example.com` (add the plain host to also match the
+         * apex). Overly broad patterns such as `*`, `*.com` or `*example.com` are dropped and logged.
          * @param hostsWithHeaderType a list of all the hosts that you own and the tracing headers
          * to be used for each host.
          * See [DatadogInterceptor]
          */
         fun setFirstPartyHostsWithHeaderType(hostsWithHeaderType: Map<String, Set<TracingHeaderType>>): Builder {
-            val sanitizedHosts = hostsSanitizer.sanitizeHosts(
-                hostsWithHeaderType.keys.toList(),
-                NETWORK_REQUESTS_TRACKING_FEATURE_NAME
-            )
+            val sanitizedHosts = sanitizeHostsAndPatterns(hostsWithHeaderType.keys.toList())
+                .map { it.lowercase(Locale.US) }
+                .toSet()
             coreConfig = coreConfig.copy(
-                firstPartyHostsWithHeaderTypes = hostsWithHeaderType.filterKeys { sanitizedHosts.contains(it) }
+                firstPartyHostsWithHeaderTypes = hostsWithHeaderType.filterKeys {
+                    sanitizedHosts.contains(it.lowercase(Locale.US))
+                }
             )
             return this
+        }
+
+        // Routes wildcard-free entries to [HostsSanitizer] and entries carrying a '*' to
+        // [HostPatternSanitizer].
+        private fun sanitizeHostsAndPatterns(hosts: List<String>): List<String> {
+            val (patterns, plainHosts) = hosts.partition { it.contains('*') }
+            return hostsSanitizer.sanitizeHosts(plainHosts, NETWORK_REQUESTS_TRACKING_FEATURE_NAME) +
+                hostPatternSanitizer.validate(patterns, NETWORK_REQUESTS_TRACKING_FEATURE_NAME)
         }
 
         /**

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -8,13 +8,11 @@ package com.datadog.android.core.configuration
 
 import com.datadog.android.Datadog
 import com.datadog.android.DatadogSite
-import com.datadog.android.core.internal.utils.unboundInternalLogger
 import com.datadog.android.core.persistence.PersistenceStrategy
 import com.datadog.android.security.Encryption
 import com.datadog.android.trace.TracingHeaderType
 import okhttp3.Authenticator
 import java.net.Proxy
-import java.util.Locale
 
 /**
  * An object describing the configuration of the Datadog SDK.
@@ -78,7 +76,6 @@ internal constructor(
         private var version: String? = null
 
         internal var hostsSanitizer = HostsSanitizer()
-        internal var hostPatternSanitizer = HostPatternSanitizer(unboundInternalLogger)
 
         /**
          * Builds a [Configuration] based on the current state of this Builder.
@@ -122,15 +119,17 @@ internal constructor(
          *
          * Each entry may be a plain host (e.g. `example.com`, which also matches any subdomain such
          * as `api.example.com`) or a wildcard pattern (e.g. `*.example.com` or
-         * `preview-*.shopist.io`). A wildcard pattern may contain a single `*`, only the characters
+         * `preview-*.example.com`). A wildcard pattern may contain a single `*`, only the characters
          * `a-z`, `0-9`, `.`, `-` and `*`, and the `*` may only match a subdomain of a registrable
          * domain: `*.example.com` matches `api.example.com` but not `example.com` (add the plain host
-         * to also match the apex). Overly broad patterns such as `*`, `*.com` or `*example.com` are
-         * dropped and logged.
+         * to also match the apex). The `*` must be the last
+         * character of a subdomain label, so `preview-*.example.com` is valid but
+         * `*-preview.example.com` is not. Overly broad patterns such as `*`, `*.com` or
+         * `*example.com` are dropped and logged.
          * @param hosts a list of all the hosts that you own.
          */
         fun setFirstPartyHosts(hosts: List<String>): Builder {
-            val sanitizedHosts = sanitizeHostsAndPatterns(hosts)
+            val sanitizedHosts = hostsSanitizer.sanitizeHosts(hosts, NETWORK_REQUESTS_TRACKING_FEATURE_NAME)
             coreConfig = coreConfig.copy(
                 firstPartyHostsWithHeaderTypes = sanitizedHosts.associateWith {
                     setOf(
@@ -151,7 +150,7 @@ internal constructor(
          * full flame-graph in APM. Multiple header types are supported for each host.
          *
          * Each key may be a plain host (e.g. `example.com`, which also matches any subdomain such as
-         * `api.example.com`) or a wildcard pattern (e.g. `*.example.com` or `preview-*.shopist.io`).
+         * `api.example.com`) or a wildcard pattern (e.g. `*.example.com` or `preview-*.example.com`).
          * A wildcard pattern may contain a single `*`, only the characters `a-z`, `0-9`, `.`, `-` and
          * `*`, and the `*` may only match a subdomain of a registrable domain: `*.example.com`
          * matches `api.example.com` but not `example.com` (add the plain host to also match the
@@ -161,23 +160,14 @@ internal constructor(
          * See [DatadogInterceptor]
          */
         fun setFirstPartyHostsWithHeaderType(hostsWithHeaderType: Map<String, Set<TracingHeaderType>>): Builder {
-            val sanitizedHosts = sanitizeHostsAndPatterns(hostsWithHeaderType.keys.toList())
-                .map { it.lowercase(Locale.US) }
-                .toSet()
+            val sanitizedHosts = hostsSanitizer.sanitizeHosts(
+                hostsWithHeaderType.keys.toList(),
+                NETWORK_REQUESTS_TRACKING_FEATURE_NAME
+            )
             coreConfig = coreConfig.copy(
-                firstPartyHostsWithHeaderTypes = hostsWithHeaderType.filterKeys {
-                    sanitizedHosts.contains(it.lowercase(Locale.US))
-                }
+                firstPartyHostsWithHeaderTypes = hostsWithHeaderType.filterKeys { sanitizedHosts.contains(it) }
             )
             return this
-        }
-
-        // Routes wildcard-free entries to [HostsSanitizer] and entries carrying a '*' to
-        // [HostPatternSanitizer].
-        private fun sanitizeHostsAndPatterns(hosts: List<String>): List<String> {
-            val (patterns, plainHosts) = hosts.partition { it.contains('*') }
-            return hostsSanitizer.sanitizeHosts(plainHosts, NETWORK_REQUESTS_TRACKING_FEATURE_NAME) +
-                hostPatternSanitizer.validate(patterns, NETWORK_REQUESTS_TRACKING_FEATURE_NAME)
         }
 
         /**

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/HostPatternSanitizer.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/HostPatternSanitizer.kt
@@ -15,15 +15,16 @@ import java.util.Locale
  * Utility class to validate wildcard host patterns.
  *
  * A host pattern may contain at most one `*` wildcard and may only use the characters `a-z`, `0-9`,
- * `.`, `-` and `*`. A wildcard may only match subdomains of a registrable domain, so it must sit in
- * a subdomain label and overly broad patterns such as `*`, `*.com`, `*.co.uk` or
- * `*example.com` are rejected while `*.example.com` and `*.example.co.uk` are accepted.
+ * `.`, `-` and `*`. A wildcard may only match subdomains of a registrable domain, so the `*` must be
+ * the last character of a subdomain label. Overly broad patterns (`*`, `*.com`, `*.co.uk`,
+ * `*example.com`) and mis-placed wildcards (`*-preview.example.com`) are rejected, while
+ * `*.example.com`, `*.example.co.uk` and `preview-*.example.com` are accepted.
  *
  * This is the counterpart of [HostsSanitizer] for entries that are allowed to carry a wildcard, and
- * it only enforces the wildcard rules above. Wildcard-free entries are merely lowercased and
- * character-checked, not fully validated as host names (blanks, bare TLDs such as `com`, etc. are
- * returned as-is), so callers should route wildcard-free entries through [HostsSanitizer] for proper
- * host-name validation.
+ * it only enforces the wildcard rules above. Wildcard-free entries are merely character-checked,
+ * not fully validated as host names (blanks, bare TLDs such as `com`, etc. are returned as-is), so
+ * callers should route wildcard-free entries through [HostsSanitizer] for proper host-name
+ * validation.
  *
  * @param internalLogger the logger used to report dropped patterns to the user.
  */
@@ -32,8 +33,9 @@ class HostPatternSanitizer(
 ) {
 
     /**
-     * Validates the given host patterns, returning the valid ones lowercased and in their original
-     * order. Entries containing characters outside `[a-z0-9.*-]`, more than one `*` wildcard or an
+     * Validates the given host patterns, returning the valid ones in their original case and order
+     * (matching is case-insensitive, so the case is preserved for callers and normalized later).
+     * Entries containing characters outside `[a-z0-9.*-]`, more than one `*` wildcard or an
      * overly broad wildcard are dropped and an error is logged.
      *
      * @param patterns Host patterns to validate.
@@ -48,6 +50,8 @@ class HostPatternSanitizer(
     }
 
     private fun validatePattern(pattern: String, feature: String): String? {
+        // Validate on a lowercased copy (host matching is case-insensitive) but return the original
+        // so callers can match it against their unmodified input; the resolver lowercases keys later.
         val lowercased = pattern.lowercase(Locale.US)
         return when {
             lowercased.contains(INVALID_CHARACTER) -> {
@@ -74,7 +78,7 @@ class HostPatternSanitizer(
                 )
                 null
             }
-            else -> lowercased
+            else -> pattern
         }
     }
 
@@ -82,7 +86,7 @@ class HostPatternSanitizer(
      * A wildcard may only match subdomains of a registrable domain. The `*` must therefore sit in a
      * subdomain label (immediately followed by a `.`) and the remainder must contain a registrable
      * domain according to the public suffix list. This keeps `*.example.com`, `*.example.co.uk`,
-     * `*.foo.example.com` and `preview-*.shopist.io` while rejecting match-all (`*`), public-suffix
+     * `*.foo.example.com` and `preview-*.example.com` while rejecting match-all (`*`), public-suffix
      * (`*.com`, `*.co.uk`, `*.github.io`) and cross-domain (`*example.com`, which would also match
      * `evilexample.com`) patterns.
      */

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/HostsSanitizer.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/HostsSanitizer.kt
@@ -16,16 +16,28 @@ import java.util.Locale
 /**
  * Utility class with the goal to perform host sanitization. Not intended for the public use.
  */
-class HostsSanitizer {
+class HostsSanitizer @JvmOverloads constructor(
+    private val internalLogger: InternalLogger = unboundInternalLogger
+) {
 
     /**
-     * Performs hosts sanitization by comparing them with patterns from pre-defined set.
+     * Sanitizes a list of first-party host entries. Wildcard-free entries are validated as host
+     * names (URLs and IPs are tolerated, with a warning for URLs); entries containing a `*` are
+     * validated as wildcard patterns. Invalid entries are dropped and logged.
      *
-     * @param hosts Hosts to sanitize.
+     * @param hosts Hosts and wildcard patterns to sanitize.
      * @param feature SDK feature requesting the sanitization.
      */
     @InternalApi
     fun sanitizeHosts(
+        hosts: List<String>,
+        feature: String
+    ): List<String> {
+        val (patterns, plainHosts) = hosts.partition { it.contains('*') }
+        return sanitizePlainHosts(plainHosts, feature) + sanitizePatterns(patterns, feature)
+    }
+
+    private fun sanitizePlainHosts(
         hosts: List<String>,
         feature: String
     ): List<String> {
@@ -35,7 +47,7 @@ class HostsSanitizer {
             if (it.matches(validUrlRegex)) {
                 try {
                     val parsedUrl = URL(it)
-                    unboundInternalLogger.log(
+                    internalLogger.log(
                         InternalLogger.Level.WARN,
                         InternalLogger.Target.USER,
                         {
@@ -49,7 +61,7 @@ class HostsSanitizer {
                     )
                     parsedUrl.host
                 } catch (e: MalformedURLException) {
-                    unboundInternalLogger.log(
+                    internalLogger.log(
                         InternalLogger.Level.ERROR,
                         InternalLogger.Target.USER,
                         { ERROR_MALFORMED_URL.format(Locale.US, it, feature) },
@@ -63,7 +75,7 @@ class HostsSanitizer {
                 // special rule exception to accept `localhost` as a valid domain name
                 it
             } else {
-                unboundInternalLogger.log(
+                internalLogger.log(
                     InternalLogger.Level.ERROR,
                     InternalLogger.Target.USER,
                     { ERROR_MALFORMED_HOST_IP_ADDRESS.format(Locale.US, it, feature) }
@@ -72,6 +84,10 @@ class HostsSanitizer {
             }
         }
     }
+
+    // Validates entries carrying a '*' as wildcard host patterns.
+    private fun sanitizePatterns(patterns: List<String>, feature: String): List<String> =
+        HostPatternSanitizer(internalLogger).validate(patterns, feature)
 
     internal companion object {
         private const val VALID_IP_REGEX: String =

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/DefaultFirstPartyHostHeaderTypeResolver.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/DefaultFirstPartyHostHeaderTypeResolver.kt
@@ -12,6 +12,16 @@ import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.util.Locale
 
+private const val WILDCARD = '*'
+private const val LABEL_SEPARATOR = "."
+
+// What a "*" expands to: one or more host characters, spanning subdomain labels, so "*.example.com"
+// matches both "api.example.com" and "a.b.example.com".
+private const val WILDCARD_LABEL_SEGMENT = "[a-z0-9.-]+"
+
+// Regex metacharacters (other than '*') that are escaped so any pattern yields a valid regex.
+private const val REGEX_METACHARACTERS = "\\^$.|?+()[]{}"
+
 /**
  * Default implementation of [FirstPartyHostHeaderTypeResolver].
  *
@@ -22,15 +32,19 @@ class DefaultFirstPartyHostHeaderTypeResolver(
     hosts: Map<String, Set<TracingHeaderType>>
 ) : FirstPartyHostHeaderTypeResolver {
 
-    internal var knownHosts = hosts.entries.associate { it.key.lowercase(Locale.US) to it.value }
+    internal var knownHosts: Map<String, Set<TracingHeaderType>> = emptyMap()
         private set
+
+    private var wildcardMatchers: Map<String, Regex> = emptyMap()
+
+    init {
+        updateKnownHosts(hosts.entries.associate { it.key.lowercase(Locale.US) to it.value })
+    }
 
     /** @inheritdoc */
     override fun isFirstPartyUrl(url: HttpUrl): Boolean {
         val host = url.host
-        return knownHosts.keys.any {
-            it == "*" || host == it || host.endsWith(".$it")
-        }
+        return knownHosts.keys.any { matchesHost(host, it) }
     }
 
     /** @inheritdoc */
@@ -50,8 +64,7 @@ class DefaultFirstPartyHostHeaderTypeResolver(
         val host = url.host
 
         return knownHosts[host]
-            ?: knownHosts.entries.firstOrNull { host.endsWith(".${it.key}") }?.value
-            ?: knownHosts["*"]
+            ?: knownHosts.entries.firstOrNull { matchesHost(host, it.key) }?.value
             ?: emptySet()
     }
 
@@ -65,20 +78,50 @@ class DefaultFirstPartyHostHeaderTypeResolver(
         return knownHosts.isEmpty()
     }
 
-    internal fun addKnownHosts(hosts: List<String>) {
-        knownHosts = knownHosts + hosts.associate {
-            it.lowercase(Locale.US) to setOf(
-                TracingHeaderType.DATADOG,
-                TracingHeaderType.TRACECONTEXT
-            )
-        }
-    }
-
     internal fun addKnownHostsWithHeaderTypes(
         hostsWithHeaderTypes: Map<String, Set<TracingHeaderType>>
     ) {
-        knownHosts = knownHosts + hostsWithHeaderTypes.entries.associate {
-            it.key.lowercase(Locale.US) to it.value
+        updateKnownHosts(
+            knownHosts + hostsWithHeaderTypes.entries.associate {
+                it.key.lowercase(Locale.US) to it.value
+            }
+        )
+    }
+
+    private fun updateKnownHosts(newHosts: Map<String, Set<TracingHeaderType>>) {
+        knownHosts = newHosts
+        wildcardMatchers = newHosts.keys
+            .filter { it.isWildcardPattern() }
+            .associateWith { it.toHostMatchingRegex() }
+    }
+
+    // A wildcard pattern has a single "*" at a label boundary (followed by "."). Only these get a
+    // matcher; a bare "*" is excluded so it is never treated as match-all.
+    private fun String.isWildcardPattern(): Boolean =
+        count { it == WILDCARD } == 1 && substringAfter(WILDCARD).startsWith(LABEL_SEPARATOR)
+
+    // A wildcard pattern matches via its precompiled regex; anything else matches itself or any of
+    // its subdomains.
+    private fun matchesHost(host: String, pattern: String): Boolean {
+        val matcher = wildcardMatchers[pattern]
+        return if (matcher != null) {
+            matcher.matchEntire(host) != null
+        } else {
+            host == pattern || host.endsWith(".$pattern")
         }
+    }
+
+    // Turns a wildcard pattern into a regex where "*" matches one or more host characters and every
+    // other metacharacter is escaped, so "*.example.com" matches "api.example.com" but not
+    // "example.com" and any input yields a valid regex.
+    private fun String.toHostMatchingRegex(): Regex {
+        val regexPattern = map { char ->
+            when (char) {
+                WILDCARD -> WILDCARD_LABEL_SEGMENT
+                in REGEX_METACHARACTERS -> "\\$char"
+                else -> char.toString()
+            }
+        }.joinToString(separator = "")
+        return Regex(regexPattern)
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/DefaultFirstPartyHostHeaderTypeResolver.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/DefaultFirstPartyHostHeaderTypeResolver.kt
@@ -63,8 +63,13 @@ class DefaultFirstPartyHostHeaderTypeResolver(
     override fun headerTypesForUrl(url: HttpUrl): Set<TracingHeaderType> {
         val host = url.host
 
+        // Exact host wins; otherwise the most-specific match (longest matching key) wins, so a
+        // more-specific host or pattern can override a broader one for its subtree.
         return knownHosts[host]
-            ?: knownHosts.entries.firstOrNull { matchesHost(host, it.key) }?.value
+            ?: knownHosts.entries
+                .filter { matchesHost(host, it.key) }
+                .maxByOrNull { it.key.length }
+                ?.value
             ?: emptySet()
     }
 
@@ -115,13 +120,15 @@ class DefaultFirstPartyHostHeaderTypeResolver(
     // other metacharacter is escaped, so "*.example.com" matches "api.example.com" but not
     // "example.com" and any input yields a valid regex.
     private fun String.toHostMatchingRegex(): Regex {
-        val regexPattern = map { char ->
-            when (char) {
-                WILDCARD -> WILDCARD_LABEL_SEGMENT
-                in REGEX_METACHARACTERS -> "\\$char"
-                else -> char.toString()
+        val pattern = this
+        return buildString {
+            for (char in pattern) {
+                when (char) {
+                    WILDCARD -> append(WILDCARD_LABEL_SEGMENT)
+                    in REGEX_METACHARACTERS -> append('\\').append(char)
+                    else -> append(char)
+                }
             }
-        }.joinToString(separator = "")
-        return Regex(regexPattern)
+        }.toRegex()
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -257,31 +257,6 @@ internal class ConfigurationBuilderTest {
     }
 
     @Test
-    fun `M route wildcard patterns to pattern sanitizer W setFirstPartyHosts() { mixed }`(
-        @StringForgery(
-            regex = "(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\\.)+" +
-                "([A-Za-z]|[A-Za-z][A-Za-z0-9-]*[A-Za-z0-9])"
-        ) plainHost: String
-    ) {
-        // Given
-        val wildcardPattern = "*.shopist.io"
-        val mockPatternSanitizer: HostPatternSanitizer = mock()
-        testedBuilder.hostPatternSanitizer = mockPatternSanitizer
-
-        // When
-        testedBuilder
-            .setFirstPartyHosts(listOf(plainHost, wildcardPattern))
-            .build()
-
-        // Then
-        verify(mockPatternSanitizer)
-            .validate(
-                listOf(wildcardPattern),
-                Configuration.NETWORK_REQUESTS_TRACKING_FEATURE_NAME
-            )
-    }
-
-    @Test
     fun `M keep plain hosts and wildcard patterns W setFirstPartyHostsWithHeaderType() { mixed }`(
         @StringForgery(
             regex = "(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\\.)+" +
@@ -312,6 +287,23 @@ internal class ConfigurationBuilderTest {
                 wildcardPattern to wildcardHeaderTypes
             )
         )
+    }
+
+    @Test
+    fun `M keep uppercase wildcard pattern W setFirstPartyHostsWithHeaderType() { mixed case }`() {
+        // Given
+        // an uppercase wildcard is a valid case-insensitive pattern; it must survive the map filter
+        val wildcardPattern = "*.EXAMPLE.COM"
+        val hostsWithHeaderTypes = mapOf(wildcardPattern to setOf(TracingHeaderType.DATADOG))
+
+        // When
+        val config = testedBuilder
+            .setFirstPartyHostsWithHeaderType(hostsWithHeaderTypes)
+            .build()
+
+        // Then
+        assertThat(config.coreConfig.firstPartyHostsWithHeaderTypes.keys)
+            .containsExactly(wildcardPattern)
     }
 
     @Test

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -236,6 +236,85 @@ internal class ConfigurationBuilderTest {
     }
 
     @Test
+    fun `M keep plain hosts and wildcard patterns W setFirstPartyHosts() { mixed }`(
+        @StringForgery(
+            regex = "(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\\.)+" +
+                "([A-Za-z]|[A-Za-z][A-Za-z0-9-]*[A-Za-z0-9])"
+        ) plainHost: String
+    ) {
+        // Given
+        val wildcardPattern = "*.shopist.io"
+        val invalidPattern = "*.com"
+
+        // When
+        val config = testedBuilder
+            .setFirstPartyHosts(listOf(plainHost, wildcardPattern, invalidPattern))
+            .build()
+
+        // Then
+        assertThat(config.coreConfig.firstPartyHostsWithHeaderTypes.keys)
+            .containsExactlyInAnyOrder(plainHost, wildcardPattern)
+    }
+
+    @Test
+    fun `M route wildcard patterns to pattern sanitizer W setFirstPartyHosts() { mixed }`(
+        @StringForgery(
+            regex = "(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\\.)+" +
+                "([A-Za-z]|[A-Za-z][A-Za-z0-9-]*[A-Za-z0-9])"
+        ) plainHost: String
+    ) {
+        // Given
+        val wildcardPattern = "*.shopist.io"
+        val mockPatternSanitizer: HostPatternSanitizer = mock()
+        testedBuilder.hostPatternSanitizer = mockPatternSanitizer
+
+        // When
+        testedBuilder
+            .setFirstPartyHosts(listOf(plainHost, wildcardPattern))
+            .build()
+
+        // Then
+        verify(mockPatternSanitizer)
+            .validate(
+                listOf(wildcardPattern),
+                Configuration.NETWORK_REQUESTS_TRACKING_FEATURE_NAME
+            )
+    }
+
+    @Test
+    fun `M keep plain hosts and wildcard patterns W setFirstPartyHostsWithHeaderType() { mixed }`(
+        @StringForgery(
+            regex = "(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\\.)+" +
+                "([A-Za-z]|[A-Za-z][A-Za-z0-9-]*[A-Za-z0-9])"
+        ) plainHost: String,
+        forge: Forge
+    ) {
+        // Given
+        val wildcardPattern = "*.shopist.io"
+        val invalidPattern = "*.com"
+        val plainHeaderTypes = forge.aList { aValueFrom(TracingHeaderType::class.java) }.toSet()
+        val wildcardHeaderTypes = forge.aList { aValueFrom(TracingHeaderType::class.java) }.toSet()
+        val hostsWithHeaderTypes = mapOf(
+            plainHost to plainHeaderTypes,
+            wildcardPattern to wildcardHeaderTypes,
+            invalidPattern to forge.aList { aValueFrom(TracingHeaderType::class.java) }.toSet()
+        )
+
+        // When
+        val config = testedBuilder
+            .setFirstPartyHostsWithHeaderType(hostsWithHeaderTypes)
+            .build()
+
+        // Then
+        assertThat(config.coreConfig.firstPartyHostsWithHeaderTypes).isEqualTo(
+            mapOf(
+                plainHost to plainHeaderTypes,
+                wildcardPattern to wildcardHeaderTypes
+            )
+        )
+    }
+
+    @Test
     fun `M build config with first party hosts and header types W setFirstPartyHostsWithHeaderType() { host names }`(
         @StringForgery(
             regex = "(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\\.)+" +

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/HostPatternSanitizerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/HostPatternSanitizerTest.kt
@@ -191,15 +191,16 @@ internal class HostPatternSanitizerTest {
     }
 
     @Test
-    fun `M lowercase patterns W validate { uppercase }`() {
+    fun `M keep valid uppercase patterns in original case W validate { uppercase }`() {
         // When
+        // matching is case-insensitive, so uppercase patterns are valid and returned unchanged
         val result = testedValidator.validate(
             listOf("*.SHOPIST.IO", "Preview-*.Example.COM"),
             fakeFeature
         )
 
         // Then
-        assertThat(result).containsExactly("*.shopist.io", "preview-*.example.com")
+        assertThat(result).containsExactly("*.SHOPIST.IO", "Preview-*.Example.COM")
     }
 
     @Test

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/HostsSanitizerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/HostsSanitizerTest.kt
@@ -316,6 +316,24 @@ internal class HostsSanitizerTest {
         assertThat(sanitizedHosts).isEmpty()
     }
 
+    @Test
+    fun `M route plain hosts and wildcard patterns W sanitizeHosts()`() {
+        // Given
+        val plainHost = "example.com"
+        val wildcardPattern = "*.shopist.io"
+        val invalidPattern = "*.com"
+        val invalidHost = "not a valid host!"
+
+        // When
+        val result = testedSanitizer.sanitizeHosts(
+            listOf(plainHost, wildcardPattern, invalidPattern, invalidHost),
+            fakeFeature
+        )
+
+        // Then
+        assertThat(result).containsExactlyInAnyOrder(plainHost, wildcardPattern)
+    }
+
     companion object {
         val logger = InternalLoggerTestConfiguration()
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/DefaultFirstPartyHostHeaderTypeResolverTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/DefaultFirstPartyHostHeaderTypeResolverTest.kt
@@ -270,6 +270,47 @@ internal class DefaultFirstPartyHostHeaderTypeResolverTest {
     }
 
     @Test
+    fun `M prefer wildcard header types over apex W headerTypesForUrl(HttpUrl) { apex and wildcard }`() {
+        // Given
+        val apexHeaderTypes = setOf(TracingHeaderType.DATADOG)
+        val wildcardHeaderTypes = setOf(TracingHeaderType.TRACECONTEXT)
+        // apex is inserted first so, without precedence, iteration order would return the apex types
+        testedDetector = DefaultFirstPartyHostHeaderTypeResolver(
+            mapOf(
+                "example.com" to apexHeaderTypes,
+                "*.example.com" to wildcardHeaderTypes
+            )
+        )
+
+        // Then
+        // a subdomain matches both entries; the wildcard (more specific than the apex) wins
+        assertThat(testedDetector.headerTypesForUrl("https://api.example.com")).isEqualTo(wildcardHeaderTypes)
+        // the apex only matches the plain host
+        assertThat(testedDetector.headerTypesForUrl("https://example.com")).isEqualTo(apexHeaderTypes)
+    }
+
+    @Test
+    fun `M prefer most-specific host over broad wildcard W headerTypesForUrl(HttpUrl) { subtree override }`() {
+        // Given
+        val wildcardHeaderTypes = setOf(TracingHeaderType.DATADOG)
+        val specificHeaderTypes = setOf(TracingHeaderType.TRACECONTEXT)
+        // the broad wildcard is inserted first; a more-specific plain host must still be able to
+        // override the header types for its own subtree
+        testedDetector = DefaultFirstPartyHostHeaderTypeResolver(
+            mapOf(
+                "*.example.com" to wildcardHeaderTypes,
+                "api.example.com" to specificHeaderTypes
+            )
+        )
+
+        // Then
+        // both entries match, but the more-specific "api.example.com" wins for its subtree
+        assertThat(testedDetector.headerTypesForUrl("https://foo.api.example.com")).isEqualTo(specificHeaderTypes)
+        // a subdomain not under the specific host falls back to the wildcard
+        assertThat(testedDetector.headerTypesForUrl("https://foo.example.com")).isEqualTo(wildcardHeaderTypes)
+    }
+
+    @Test
     fun `M return false W isFirstParty(String) {unknown host postfixed with valid host}`(
         @StringForgery(regex = "http(s?)") scheme: String,
         @StringForgery(regex = "[a-zA-Z0-9_~-]{1,9}") prefix: String,

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/DefaultFirstPartyHostHeaderTypeResolverTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/DefaultFirstPartyHostHeaderTypeResolverTest.kt
@@ -81,25 +81,6 @@ internal class DefaultFirstPartyHostHeaderTypeResolverTest {
     }
 
     @Test
-    fun `M return true W isFirstParty(HttpUrl) {known hosts list was updated}`(
-        @StringForgery(regex = "http(s?)") scheme: String,
-        @StringForgery(regex = "(/[a-zA-Z0-9_~\\.-]{1,9}){1,4}") path: String,
-        forge: Forge
-    ) {
-        // Given
-        val fakeNewAllowedHosts = forge.aList { forge.aStringMatching(HOST_REGEX) }
-        testedDetector.addKnownHosts(fakeNewAllowedHosts)
-        val host = forge.anElementFrom(fakeNewAllowedHosts)
-        val url = "$scheme://$host$path".toHttpUrl()
-
-        // When
-        val result = testedDetector.isFirstPartyUrl(url)
-
-        // Then
-        assertThat(result).isTrue()
-    }
-
-    @Test
     fun `M return true W isFirstParty(HttpUrl) {valid host subdomain}`(
         @StringForgery(regex = "http(s?)") scheme: String,
         @StringForgery(regex = "[a-zA-Z0-9_~-]{1,9}") subdomain: String,
@@ -191,26 +172,7 @@ internal class DefaultFirstPartyHostHeaderTypeResolverTest {
     }
 
     @Test
-    fun `M return true W isFirstParty(String) {known hosts list was updated}`(
-        @StringForgery(regex = "http(s?)") scheme: String,
-        @StringForgery(regex = "(/[a-zA-Z0-9_~\\.-]{1,9}){1,4}") path: String,
-        forge: Forge
-    ) {
-        // Given
-        val fakeNewAllowedHosts = forge.aList { forge.aStringMatching(HOST_REGEX) }
-        testedDetector.addKnownHosts(fakeNewAllowedHosts)
-        val host = forge.anElementFrom(fakeNewAllowedHosts)
-        val url = "$scheme://$host$path"
-
-        // When
-        val result = testedDetector.isFirstPartyUrl(url)
-
-        // Then
-        assertThat(result).isTrue()
-    }
-
-    @Test
-    fun `M return true isFirstParty(String) { wild card used for known hosts }`(
+    fun `M return false isFirstParty(String) { bare wildcard is not match-all }`(
         @StringForgery(regex = "http(s?)") scheme: String,
         @StringForgery(regex = "(/[a-zA-Z0-9_~\\.-]{1,9}){1,4}") path: String,
         forge: Forge
@@ -225,11 +187,11 @@ internal class DefaultFirstPartyHostHeaderTypeResolverTest {
         val result = testedDetector.isFirstPartyUrl(url)
 
         // THEN
-        assertThat(result).isTrue()
+        assertThat(result).isFalse()
     }
 
     @Test
-    fun `M return true isFirstParty(HttpUrl) { wild card used for known hosts }`(
+    fun `M return false isFirstParty(HttpUrl) { bare wildcard is not match-all }`(
         @StringForgery(regex = "http(s?)") scheme: String,
         @StringForgery(regex = "(/[a-zA-Z0-9_~\\.-]{1,9}){1,4}") path: String,
         forge: Forge
@@ -244,7 +206,67 @@ internal class DefaultFirstPartyHostHeaderTypeResolverTest {
         val result = testedDetector.isFirstPartyUrl(url)
 
         // THEN
-        assertThat(result).isTrue()
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `M not match plain hosts W isFirstParty { bare wildcard is not match-all }`() {
+        // Given
+        testedDetector = DefaultFirstPartyHostHeaderTypeResolver(
+            mapOf("*" to setOf(TracingHeaderType.DATADOG))
+        )
+
+        // Then a bare "*" must never behave as match-all, for any depth of host
+        assertThat(testedDetector.isFirstPartyUrl("https://example.com".toHttpUrl())).isFalse()
+        assertThat(testedDetector.isFirstPartyUrl("https://api.example.com".toHttpUrl())).isFalse()
+        assertThat(testedDetector.isFirstPartyUrl("https://a.b.example.com".toHttpUrl())).isFalse()
+        assertThat(testedDetector.headerTypesForUrl("https://example.com")).isEmpty()
+    }
+
+    @Test
+    fun `M match subdomain W isFirstParty(HttpUrl) { wildcard pattern }`() {
+        // Given
+        testedDetector = DefaultFirstPartyHostHeaderTypeResolver(
+            mapOf("*.example.com" to setOf(TracingHeaderType.DATADOG))
+        )
+
+        // Then
+        assertThat(testedDetector.isFirstPartyUrl("https://api.example.com/path".toHttpUrl())).isTrue()
+        assertThat(testedDetector.isFirstPartyUrl("https://preview-1.example.com".toHttpUrl())).isTrue()
+        // "*" spans labels, so deeper subdomains are also matched
+        assertThat(testedDetector.isFirstPartyUrl("https://a.b.example.com".toHttpUrl())).isTrue()
+        // apex is not matched by "*.example.com" (add the plain host for that)
+        assertThat(testedDetector.isFirstPartyUrl("https://example.com".toHttpUrl())).isFalse()
+        // a sibling registrable domain is not matched
+        assertThat(testedDetector.isFirstPartyUrl("https://api.notexample.com".toHttpUrl())).isFalse()
+    }
+
+    @Test
+    fun `M match partial label W isFirstParty(HttpUrl) { prefix wildcard pattern }`() {
+        // Given
+        testedDetector = DefaultFirstPartyHostHeaderTypeResolver(
+            mapOf("preview-*.shopist.io" to setOf(TracingHeaderType.DATADOG))
+        )
+
+        // Then
+        assertThat(testedDetector.isFirstPartyUrl("https://preview-123.shopist.io".toHttpUrl())).isTrue()
+        // the wildcard must match at least one character
+        assertThat(testedDetector.isFirstPartyUrl("https://preview-.shopist.io".toHttpUrl())).isFalse()
+        // the prefix must be present
+        assertThat(testedDetector.isFirstPartyUrl("https://staging-1.shopist.io".toHttpUrl())).isFalse()
+    }
+
+    @Test
+    fun `M return header types W headerTypesForUrl(HttpUrl) { wildcard pattern }`() {
+        // Given
+        val headerTypes = setOf(TracingHeaderType.TRACECONTEXT)
+        testedDetector = DefaultFirstPartyHostHeaderTypeResolver(
+            mapOf("*.example.com" to headerTypes)
+        )
+
+        // Then
+        assertThat(testedDetector.headerTypesForUrl("https://api.example.com")).isEqualTo(headerTypes)
+        assertThat(testedDetector.headerTypesForUrl("https://example.com")).isEmpty()
     }
 
     @Test
@@ -327,27 +349,6 @@ internal class DefaultFirstPartyHostHeaderTypeResolverTest {
 
         // Then
         assertThat(testedDetector.getAllHeaderTypes()).isEqualTo(allUsedHeaderTraces)
-    }
-
-    @Test
-    fun `M use datadog and tracecontext header types W addKnownHosts(String)`(
-        @StringForgery(regex = "http(s?)") scheme: String,
-        forge: Forge
-    ) {
-        // Given
-        val fakeHosts = forge.aList { forge.aStringMatching(HOST_REGEX) }
-        val fakeUrls = fakeHosts.map { "$scheme://$it" }
-        testedDetector.addKnownHosts(fakeHosts)
-
-        // When + Then
-        val expectedHeaderTypes = setOf(
-            TracingHeaderType.DATADOG,
-            TracingHeaderType.TRACECONTEXT
-        )
-        fakeUrls.forEach {
-            val headerTypes = testedDetector.headerTypesForUrl(it)
-            assertThat(headerTypes).isEqualTo(expectedHeaderTypes)
-        }
     }
 
     @Test

--- a/detekt_custom_safe_calls_third_party.yml
+++ b/detekt_custom_safe_calls_third_party.yml
@@ -504,6 +504,7 @@ datadog:
       - "kotlin.collections.List.map(kotlin.Function1)"
       - "kotlin.collections.List.mapIndexed(kotlin.Function2)"
       - "kotlin.collections.List.mapNotNull(kotlin.Function1)"
+      - "kotlin.collections.List.maxByOrNull(kotlin.Function1)"
       - "kotlin.collections.List.maxOrNull()"
       - "kotlin.collections.List.orEmpty()"
       - "kotlin.collections.List.partition(kotlin.Function1)"

--- a/detekt_custom_safe_calls_third_party.yml
+++ b/detekt_custom_safe_calls_third_party.yml
@@ -706,6 +706,7 @@ datadog:
       - "kotlin.collections.Set.map(kotlin.Function1)"
       - "kotlin.collections.Set.none(kotlin.Function1)"
       - "kotlin.collections.Set.orEmpty()"
+      - "kotlin.collections.Set.partition(kotlin.Function1)"
       - "kotlin.collections.Set.plus(kotlin.collections.Iterable)"
       - "kotlin.collections.Set.toHashSet()"
       - "kotlin.collections.Set.toSet()"

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/ApmNetworkInstrumentationConfiguration.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/ApmNetworkInstrumentationConfiguration.kt
@@ -6,9 +6,7 @@
 package com.datadog.android.trace
 
 import androidx.annotation.FloatRange
-import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
-import com.datadog.android.core.configuration.HostPatternSanitizer
 import com.datadog.android.core.configuration.HostsSanitizer
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.sampling.Sampler
@@ -17,7 +15,6 @@ import com.datadog.android.trace.api.tracer.DatadogTracer
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation
 import com.datadog.android.trace.internal.net.SessionRebasedSampler
 import com.datadog.android.trace.internal.net.TracerProvider
-import java.util.Locale
 
 /**
  * Configuration for APM distributed tracing of network requests.
@@ -26,7 +23,10 @@ import java.util.Locale
  * with distributed tracing headers and optional client-side APM spans.
  *
  * At minimum, you must provide a list of first-party hosts (or a map of hosts
- * to [TracingHeaderType]s) so that the SDK knows which requests to instrument.
+ * to [TracingHeaderType]s) so that the SDK knows which requests to instrument. Each entry may be a
+ * plain host (e.g. `example.com`, which also matches subdomains such as `api.example.com`) or a
+ * wildcard pattern such as `*.example.com` or `preview-*.example.com` (the `*` must be the last
+ * character of a subdomain label, so `*-preview.example.com` is not accepted).
  *
  * Example usage:
  * ```kotlin
@@ -291,16 +291,13 @@ class ApmNetworkInstrumentationConfiguration internal constructor(
         private fun resolveHosts(
             tracedHosts: Map<String, Set<TracingHeaderType>>
         ): Map<String, Set<TracingHeaderType>> {
-            val (patterns, plainHosts) = tracedHosts.keys.partition { it.contains('*') }
-            val sanitizedHosts = (
-                HostsSanitizer().sanitizeHosts(plainHosts, NETWORK_REQUESTS_TRACKING_FEATURE_NAME) +
-                    HostPatternSanitizer(InternalLogger.UNBOUND)
-                        .validate(patterns, NETWORK_REQUESTS_TRACKING_FEATURE_NAME)
-                )
-                .map { it.lowercase(Locale.US) }
-                .toSet()
+            val sanitizer = HostsSanitizer()
+            val sanitizedHosts = sanitizer.sanitizeHosts(
+                tracedHosts.keys.toList(),
+                NETWORK_REQUESTS_TRACKING_FEATURE_NAME
+            )
 
-            return tracedHosts.filterKeys { sanitizedHosts.contains(it.lowercase(Locale.US)) }
+            return tracedHosts.filterKeys { sanitizedHosts.contains(it) }
         }
 
         private fun Map<String, Set<TracingHeaderType>>.deepCopy() = mapValues { (_, v) -> v.toSet() }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/ApmNetworkInstrumentationConfiguration.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/ApmNetworkInstrumentationConfiguration.kt
@@ -6,7 +6,9 @@
 package com.datadog.android.trace
 
 import androidx.annotation.FloatRange
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
+import com.datadog.android.core.configuration.HostPatternSanitizer
 import com.datadog.android.core.configuration.HostsSanitizer
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.sampling.Sampler
@@ -15,6 +17,7 @@ import com.datadog.android.trace.api.tracer.DatadogTracer
 import com.datadog.android.trace.internal.ApmNetworkInstrumentation
 import com.datadog.android.trace.internal.net.SessionRebasedSampler
 import com.datadog.android.trace.internal.net.TracerProvider
+import java.util.Locale
 
 /**
  * Configuration for APM distributed tracing of network requests.
@@ -288,13 +291,16 @@ class ApmNetworkInstrumentationConfiguration internal constructor(
         private fun resolveHosts(
             tracedHosts: Map<String, Set<TracingHeaderType>>
         ): Map<String, Set<TracingHeaderType>> {
-            val sanitizer = HostsSanitizer()
-            val sanitizedHosts = sanitizer.sanitizeHosts(
-                tracedHosts.keys.toList(),
-                NETWORK_REQUESTS_TRACKING_FEATURE_NAME
-            )
+            val (patterns, plainHosts) = tracedHosts.keys.partition { it.contains('*') }
+            val sanitizedHosts = (
+                HostsSanitizer().sanitizeHosts(plainHosts, NETWORK_REQUESTS_TRACKING_FEATURE_NAME) +
+                    HostPatternSanitizer(InternalLogger.UNBOUND)
+                        .validate(patterns, NETWORK_REQUESTS_TRACKING_FEATURE_NAME)
+                )
+                .map { it.lowercase(Locale.US) }
+                .toSet()
 
-            return tracedHosts.filterKeys { sanitizedHosts.contains(it) }
+            return tracedHosts.filterKeys { sanitizedHosts.contains(it.lowercase(Locale.US)) }
         }
 
         private fun Map<String, Set<TracingHeaderType>>.deepCopy() = mapValues { (_, v) -> v.toSet() }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmInstrumentationConfigurationTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmInstrumentationConfigurationTest.kt
@@ -230,6 +230,30 @@ internal class ApmInstrumentationConfigurationTest {
     }
 
     @Test
+    fun `M keep wildcard patterns W build() {plain, wildcard and invalid patterns}`() {
+        // Given
+        val plainHost = "example.com"
+        val wildcardPattern = "*.shopist.io"
+        val invalidPattern = "*.com"
+        val mixedHosts = mapOf(
+            plainHost to setOf(TracingHeaderType.DATADOG),
+            wildcardPattern to setOf(TracingHeaderType.TRACECONTEXT),
+            invalidPattern to setOf(TracingHeaderType.B3)
+        )
+        testedBuilder = ApmNetworkInstrumentationConfiguration(mixedHosts)
+
+        // When
+        val resolver = testedBuilder.createInstrumentation(fakeNetworkLibraryName)
+            .localFirstPartyHostHeaderTypeResolver
+
+        // Then
+        assertThat(resolver.isFirstPartyUrl("https://$plainHost/path")).isTrue()
+        assertThat(resolver.isFirstPartyUrl("https://api.shopist.io/path")).isTrue()
+        // overly broad "*.com" is dropped
+        assertThat(resolver.isFirstPartyUrl("https://anything.com/path")).isFalse()
+    }
+
+    @Test
     fun `M set scope W setTraceScope()`(forge: Forge) {
         // Given
         val fakeScope = forge.aValueFrom(ApmNetworkTracingScope::class.java)

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/WebViewTracking.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/WebViewTracking.kt
@@ -60,14 +60,14 @@ object WebViewTracking {
      *
      * Each entry may be a plain host name (e.g. `example.com`) or a wildcard pattern containing a
      * single `*`. A wildcard may only match subdomains of a registrable domain:
-     * - accepted: `*.example.com`, `preview-*.shopist.io`, `*.example.co.uk`
-     * - rejected: `*`, `*.com`, `*example.com` (too broad)
+     * - accepted: `*.example.com`, `preview-*.example.com`, `*.example.co.uk`
+     * - rejected: `*`, `*.com`, `*example.com` (too broad), `*-preview.example.com` (the `*` must end a label)
      *
      * Invalid entries are dropped and the reason is logged.
      *
      * @param webView the webView on which to attach the bridge.
      * @param allowedHosts a list of all the hosts (plain host names or wildcard patterns) that you want
-     * to track when loaded in the WebView (e.g.: `listOf("example.com", "*.example.net", "preview-*.shopist.io")`).
+     * to track when loaded in the WebView (e.g.: `listOf("example.com", "*.example.net", "preview-*.example.com")`).
      * @param logsSampleRate the sample rate for logs coming from the WebView, in percent. A value of `30` means we'll
      * send 30% of the logs. If value is `0`, no logs will be sent to Datadog. Default is 100.0 (ie: all logs are sent).
      * @param sdkCore SDK instance on which to attach the bridge.

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/DatadogEventBridge.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/DatadogEventBridge.kt
@@ -8,7 +8,6 @@ package com.datadog.android.webview.internal
 
 import android.webkit.JavascriptInterface
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.core.configuration.HostPatternSanitizer
 import com.datadog.android.core.configuration.HostsSanitizer
 import com.datadog.android.core.sampling.DeterministicSampler
 import com.datadog.android.internal.sampling.DeterministicSampling
@@ -31,8 +30,7 @@ internal class DatadogEventBridge(
     internalLogger: InternalLogger
 ) {
 
-    private val hostsSanitizer = HostsSanitizer()
-    private val hostPatternSanitizer = HostPatternSanitizer(internalLogger)
+    private val hostsSanitizer = HostsSanitizer(internalLogger)
 
     // region Bridge
 
@@ -55,19 +53,9 @@ internal class DatadogEventBridge(
     fun getAllowedWebViewHosts(): String {
         // We need to use a JsonArray here otherwise it cannot be parsed on the JS side
         val origins = JsonArray()
-        val (wildcardPatterns, plainHosts) = allowedHosts.partition { host ->
-            host.any { it == WILDCARD }
-        }
         hostsSanitizer
-            .sanitizeHosts(plainHosts, WEB_VIEW_TRACKING_FEATURE_NAME)
-            .forEach {
-                origins.add(it)
-            }
-        hostPatternSanitizer
-            .validate(wildcardPatterns, WEB_VIEW_TRACKING_FEATURE_NAME)
-            .forEach {
-                origins.add(it)
-            }
+            .sanitizeHosts(allowedHosts, WEB_VIEW_TRACKING_FEATURE_NAME)
+            .forEach { origins.add(it) }
         return origins.toString()
     }
 
@@ -123,8 +111,6 @@ internal class DatadogEventBridge(
 
     companion object {
         internal const val WEB_VIEW_TRACKING_FEATURE_NAME = "WebView"
-
-        private const val WILDCARD = '*'
 
         private const val SESSION_ID_KEY = "session_id"
         private const val SESSION_STATE_KEY = "session_state"

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -759,7 +759,9 @@ internal constructor(
     /**
      * A Builder class for the [TracingInterceptor].
      * @param tracedHostsWithHeaderType a list of all the hosts and header types that you want to
-     * be automatically tracked by this interceptor. If registering a [GlobalDatadogTracer], the tracer must be
+     * be automatically tracked by this interceptor. Each host may be a plain host (e.g. `example.com`,
+     * which also matches subdomains such as `api.example.com`) or a wildcard pattern such as
+     * `*.example.com` or `preview-*.example.com`. If registering a [GlobalDatadogTracer], the tracer must be
      * configured with [com.datadog.android.trace.api.tracer.DatadogTracerBuilder.withTracingHeadersTypes] containing all the necessary
      * header types configured for OkHttp tracking.
      * If no hosts are provided (via this argument or global configuration

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -96,8 +96,8 @@ import java.util.UUID
 class SampleApplication : Application() {
 
     private val tracedHosts = listOf(
-        "datadoghq.com",
-        "127.0.0.1"
+        "127.0.0.1",
+        "*.datadoghq.com"
     )
 
     @OptIn(ExperimentalRumApi::class, ExperimentalTraceApi::class)


### PR DESCRIPTION
### What does this PR do?

- Adds wildcard pattern support to `setFirstPartyHosts` and `setFirstPartyHostsWithHeaderType` inside `Configuration`, which extends to `ApmNetworkInstrumentationConfiguration` and `TracingInterceptor`. Entries can now be a plain host (e.g. `example.com`) or a wildcard pattern such as `*.example.com`.
- Routes wildcard entries to `HostPatternSanitizer` and plain entries to `HostsSanitizer`.
- Matches hosts in `DefaultFirstPartyHostHeaderTypeResolver` against a precompiled regex per pattern. A `*` matches one or more host characters and may span subdomain labels, so `*.example.com` matches `api.example.com` and `a.b.example.com` but not the apex `example.com`.
- **Change:** a bare `*` is no longer allowed as match-all. There were some tests on this, but it was actually unreachable in production as `HostsSanitizer` already dropped entries with `*` before the resolver.
- Remove unused `addKnownHosts` function, as it was only used in tests.

### Motivation

- First-party host configuration previously only supported exact hosts and their subdomains, so dynamic subdomains had to be enumerated explicitly.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

