### PR TITLE
RUM-14050: Fix R8 missing class error caused by dd-javac-plugin annotations

### DIFF
--- a/sample/benchmark/proguard-rules.pro
+++ b/sample/benchmark/proguard-rules.pro
@@ -27,6 +27,9 @@
 -dontwarn reactor.blockhound.integration.BlockHoundIntegration
 # These annotations are introduced by OpenTelemetry API and we need to make sure R8 will not complain about them
 -dontwarn  com.google.**
+# These annotations are injected by dd-java-agent at class-load time for source code profiling.
+# They are not present in the build classpath, so R8 must not treat them as errors.
+-dontwarn datadog.compiler.annotations.**
 
 -keepattributes RuntimeVisibleAnnotations
 -keep class * extends androidx.navigation.Navigator

--- a/sample/kotlin/proguard-rules.pro
+++ b/sample/kotlin/proguard-rules.pro
@@ -32,3 +32,6 @@
 -dontwarn java.lang.management.RuntimeMXBean
 # These annotations are introduced by OpenTelemetry API and we need to make sure R8 will not complain about them
 -dontwarn  com.google.**
+# These annotations are injected by dd-java-agent at class-load time for source code profiling.
+# They are not present in the build classpath, so R8 must not treat them as errors.
+-dontwarn datadog.compiler.annotations.**


### PR DESCRIPTION
### What does this PR do?

Adds `-dontwarn datadog.compiler.annotations.**` to the ProGuard rules for `sample/benchmark` and `sample/kotlin`.

### Why

PR #3583 introduced a `setup-gradle` CI snippet that appends `dd-java-agent` to `org.gradle.jvmargs` across all jobs — intentionally, to get build telemetry. The side effect is that `dd-java-agent` bundles and activates [dd-javac-plugin](https://github.com/DataDog/dd-javac-plugin), a Java compiler plugin that annotates every compiled class with `@SourcePath` and `@SourceLines` for source code integration. The annotation class definitions live in a companion `dd-javac-plugin-client` JAR that is not added to the build classpath.

So R8 sees those annotation references in the compiled classes, can't find the backing class definitions, and fails hard on `minifyReleaseWithR8`.

This has been breaking `test-pyramid:publish-benchmark-synthetics` (and likely the other synthetics publish jobs) on every pipeline since #3583 merged.

### Fix

`-dontwarn` is the standard R8 fix here. These are compiler-injected annotations used only for profiling source correlation — they have no relevance to the output APK and are safe to ignore.

### Review checklist
- [x] No functional change to the app
- [x] Both sample apps that go through R8 release builds are covered