### PR TITLE
RUM-14050: Disable auto-cancel on develop and feature branches

### DIFF
--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -12,6 +12,8 @@ workflow:
       auto_cancel:
         on_new_commit: interruptible # short-lived branches cancel on new commits
     - when: always # develop, master, feature/*, tags: never auto-canceled
+      auto_cancel:
+        on_new_commit: none
 
 stages:
   - ci-image


### PR DESCRIPTION
### What does this PR do?
Follow up to #3584

Change the fallback for auto-cancel to be `none` instead of the project setting

### Motivation
I did not enough enough permissions in Gitlab to see that the project has auto-cancel turned on at the project level. CI Infra confirmed it is on. This means that when jobs were marked as interruptible, we started cancelling them on the develop and feature branches which was not the intention of #3584. This PR overrides the project setting to be `none` which restores our old behavior