### PR TITLE
RUM-17106: Test Only Flush Client-Side-Stats before shared write executor shuts down

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -341,6 +341,7 @@ fun java.util.concurrent.ScheduledExecutorService.scheduleSafe(String, Long, jav
 fun java.util.concurrent.ExecutorService.submitSafe(String, com.datadog.android.api.InternalLogger, Runnable): java.util.concurrent.Future<*>?
 fun <T> java.util.concurrent.ExecutorService.submitSafe(String, com.datadog.android.api.InternalLogger, java.util.concurrent.Callable<T>): java.util.concurrent.Future<T>?
 fun <T> java.util.concurrent.Future<T>?.getSafe(String, com.datadog.android.api.InternalLogger): T?
+fun <T> java.util.concurrent.Future<T>?.getSafe(String, Long, java.util.concurrent.TimeUnit, com.datadog.android.api.InternalLogger): T?
 object com.datadog.android.core.internal.utils.JsonSerializer
   fun toJsonElement(Any?): com.google.gson.JsonElement
   fun Map<String, Any?>.safeMapValuesToJson(com.datadog.android.api.InternalLogger): Map<String, com.google.gson.JsonElement>

--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -342,8 +342,8 @@ fun java.util.concurrent.Executor.executeSafe(String, com.datadog.android.api.In
 fun java.util.concurrent.ScheduledExecutorService.scheduleSafe(String, Long, java.util.concurrent.TimeUnit, com.datadog.android.api.InternalLogger, Runnable): java.util.concurrent.ScheduledFuture<*>?
 fun java.util.concurrent.ExecutorService.submitSafe(String, com.datadog.android.api.InternalLogger, Runnable): java.util.concurrent.Future<*>?
 fun <T> java.util.concurrent.ExecutorService.submitSafe(String, com.datadog.android.api.InternalLogger, java.util.concurrent.Callable<T>): java.util.concurrent.Future<T>?
-fun <T> java.util.concurrent.Future<T>?.getSafe(String, com.datadog.android.api.InternalLogger): T?
-fun <T> java.util.concurrent.Future<T>?.getSafe(String, Long, java.util.concurrent.TimeUnit, com.datadog.android.api.InternalLogger): T?
+fun <T> java.util.concurrent.Future<T>.getSafe(String, com.datadog.android.api.InternalLogger): T?
+fun <T> java.util.concurrent.Future<T>.getSafe(String, Long, java.util.concurrent.TimeUnit, com.datadog.android.api.InternalLogger): T?
 object com.datadog.android.core.internal.utils.JsonSerializer
   fun toJsonElement(Any?): com.google.gson.JsonElement
   fun Map<String, Any?>.safeMapValuesToJson(com.datadog.android.api.InternalLogger): Map<String, com.google.gson.JsonElement>

--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -243,6 +243,8 @@ interface com.datadog.android.core.InternalSdkCore : com.datadog.android.api.fea
   fun getPersistenceExecutorService(): java.util.concurrent.ExecutorService
   fun getAllFeatures(): List<com.datadog.android.api.feature.FeatureScope>
   fun getDatadogContext(Set<String> = emptySet()): com.datadog.android.api.context.DatadogContext?
+  fun flushContextThread()
+  fun flushStoredData()
 class com.datadog.android.core.SdkReference
   constructor(String? = null, (com.datadog.android.api.SdkCore) -> Unit = {})
   fun get(): com.datadog.android.api.SdkCore?

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -889,6 +889,7 @@ public final class com/datadog/android/core/internal/utils/ByteArrayExtKt {
 
 public final class com/datadog/android/core/internal/utils/ConcurrencyExtKt {
 	public static final fun executeSafe (Ljava/util/concurrent/Executor;Ljava/lang/String;Lcom/datadog/android/api/InternalLogger;Ljava/lang/Runnable;)V
+	public static final fun getSafe (Ljava/util/concurrent/Future;Ljava/lang/String;JLjava/util/concurrent/TimeUnit;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Object;
 	public static final fun getSafe (Ljava/util/concurrent/Future;Ljava/lang/String;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Object;
 	public static final fun scheduleSafe (Ljava/util/concurrent/ScheduledExecutorService;Ljava/lang/String;JLjava/util/concurrent/TimeUnit;Lcom/datadog/android/api/InternalLogger;Ljava/lang/Runnable;)Ljava/util/concurrent/ScheduledFuture;
 	public static final fun submitSafe (Ljava/util/concurrent/ExecutorService;Ljava/lang/String;Lcom/datadog/android/api/InternalLogger;Ljava/lang/Runnable;)Ljava/util/concurrent/Future;

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -662,6 +662,8 @@ public abstract interface class com/datadog/android/api/storage/datastore/DataSt
 
 public abstract interface class com/datadog/android/core/InternalSdkCore : com/datadog/android/api/feature/FeatureSdkCore {
 	public abstract fun deleteLastViewEvent ()V
+	public abstract fun flushContextThread ()V
+	public abstract fun flushStoredData ()V
 	public abstract fun getAllFeatures ()Ljava/util/List;
 	public abstract fun getAppStartTimeNs ()J
 	public abstract fun getAppUptimeNs ()J

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -14,6 +14,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.context.UserInfo
 import com.datadog.android.api.feature.Feature
+import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.DatadogCore
 import com.datadog.android.core.internal.HashGenerator
@@ -404,7 +405,7 @@ object Datadog {
         // we need to drain, execute and flush from a background thread or ensure we're
         // not in the main thread!
         synchronized(registry) {
-            val sdkCore = registry.getInstance() as? DatadogCore
+            val sdkCore = registry.getInstance() as? InternalSdkCore
             if (sdkCore != null) {
                 // Flush the context thread in case any features are blocked waiting on the context thread
                 sdkCore.flushContextThread()

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -14,7 +14,6 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.context.UserInfo
 import com.datadog.android.api.feature.Feature
-import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.DatadogCore
 import com.datadog.android.core.internal.HashGenerator
@@ -405,15 +404,23 @@ object Datadog {
         // we need to drain, execute and flush from a background thread or ensure we're
         // not in the main thread!
         synchronized(registry) {
-            val sdkCore = registry.getInstance() as? FeatureSdkCore
+            val sdkCore = registry.getInstance() as? DatadogCore
             if (sdkCore != null) {
+                // Flush the context thread in case any features are blocked waiting on the context thread
+                sdkCore.flushContextThread()
                 sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
                     ?.sendEvent(
                         mapOf(
                             "type" to "flush_and_stop_monitor"
                         )
                     )
-                (sdkCore as? DatadogCore)?.flushStoredData()
+                sdkCore.getFeature(Feature.TRACING_CLIENT_STATS_FEATURE_NAME)
+                    ?.sendEvent(
+                        mapOf(
+                            "type" to "flush_and_stop_stats"
+                        )
+                    )
+                sdkCore.flushStoredData()
             }
         }
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/InternalSdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/InternalSdkCore.kt
@@ -132,4 +132,18 @@ interface InternalSdkCore : FeatureSdkCore {
      */
     @InternalApi
     fun getDatadogContext(withFeatureContexts: Set<String> = emptySet()): DatadogContext?
+
+    /**
+     * Flushes all currently pending tasks on the context thread and executes them synchronously on the calling thread
+     *
+     * You should not use this method in production code.
+     */
+    @InternalApi
+    fun flushContextThread()
+
+    /**
+     * Flushes all stored data (send everything right now).
+     */
+    @InternalApi
+    fun flushStoredData()
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -72,6 +72,8 @@ import com.datadog.android.core.internal.user.DatadogUserInfoProvider
 import com.datadog.android.core.internal.user.MutableUserInfoProvider
 import com.datadog.android.core.internal.user.NoOpMutableUserInfoProvider
 import com.datadog.android.core.internal.utils.executeSafe
+import com.datadog.android.core.internal.utils.getSafe
+import com.datadog.android.core.internal.utils.submitSafe
 import com.datadog.android.core.persistence.PersistenceStrategy
 import com.datadog.android.core.thread.FlushableExecutorService
 import com.datadog.android.internal.system.BuildSdkVersionProvider
@@ -349,6 +351,12 @@ internal class CoreFeature(
                 return client.newCall(request)
             }
         }
+    }
+
+    fun flushContextThread() {
+        contextExecutorService
+            .submitSafe("context-drain-fence", internalLogger) {}
+            ?.getSafe("context-drain-fence", DRAIN_WAIT_SECONDS, TimeUnit.SECONDS, internalLogger)
     }
 
     @Throws(UnsupportedOperationException::class, InterruptedException::class)

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -708,23 +708,13 @@ internal class DatadogCore(
         removeShutdownHook()
     }
 
-    /**
-     * Flushes all currently pending tasks on the context thread and executes them synchronously on the calling thread
-     *
-     * You should not use this method in production code.
-     */
     @WorkerThread
-    internal fun flushContextThread() {
-        // We need to drain and shutdown the executors first to make sure we avoid duplicated
-        // data due to async operations.
+    override fun flushContextThread() {
         coreFeature.flushContextThread()
     }
 
-    /**
-     * Flushes all stored data (send everything right now).
-     */
     @WorkerThread
-    internal fun flushStoredData() {
+    override fun flushStoredData() {
         // We need to drain and shutdown the executors first to make sure we avoid duplicated
         // data due to async operations.
         coreFeature.drainAndShutdownExecutors()

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -709,6 +709,18 @@ internal class DatadogCore(
     }
 
     /**
+     * Flushes all currently pending tasks on the context thread and executes them synchronously on the calling thread
+     *
+     * You should not use this method in production code.
+     */
+    @WorkerThread
+    internal fun flushContextThread() {
+        // We need to drain and shutdown the executors first to make sure we avoid duplicated
+        // data due to async operations.
+        coreFeature.flushContextThread()
+    }
+
+    /**
      * Flushes all stored data (send everything right now).
      */
     @WorkerThread

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -270,7 +270,7 @@ internal class DatadogCore(
                     internalLogger,
                     callable
                 )
-                .getSafe("DatadogCore.getFeatureContext-$featureName", internalLogger)
+                ?.getSafe("DatadogCore.getFeatureContext-$featureName", internalLogger)
                 .orEmpty()
         } else {
             @Suppress("UnsafeThirdPartyFunctionCall") // not 3rd party
@@ -365,7 +365,7 @@ internal class DatadogCore(
                 Callable {
                     coreFeature.trackingConsentProvider.getConsent()
                 }
-            ).getSafe("getTrackingConsent", internalLogger) ?: TrackingConsent.NOT_GRANTED
+            )?.getSafe("getTrackingConsent", internalLogger) ?: TrackingConsent.NOT_GRANTED
         }
 
     override val rootStorageDir: File
@@ -429,7 +429,7 @@ internal class DatadogCore(
                     with(contextProvider) { if (this is NoOpContextProvider) null else getContext(withFeatureContexts) }
                 }
             )
-            .getSafe("getDatadogContext", internalLogger)
+            ?.getSafe("getDatadogContext", internalLogger)
     }
 
     // endregion

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/NoOpInternalSdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/NoOpInternalSdkCore.kt
@@ -200,6 +200,10 @@ internal object NoOpInternalSdkCore : InternalSdkCore {
 
     override fun getDatadogContext(withFeatureContexts: Set<String>): DatadogContext? = null
 
+    override fun flushContextThread() {}
+
+    override fun flushStoredData() {}
+
     // endregion
 
     class NoOpExecutorService : ExecutorService {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -226,7 +226,7 @@ internal class SdkFeature(
                     context to eventBatchWriteScope
                 }
             )
-            .getSafe(operationName, internalLogger)
+            ?.getSafe(operationName, internalLogger)
     }
 
     override fun sendEvent(event: Any) {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/ConcurrencyExt.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/ConcurrencyExt.kt
@@ -24,6 +24,7 @@ import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 internal const val ERROR_TASK_REJECTED = "Unable to schedule %s task on the executor"
 internal const val ERROR_FUTURE_GET_FAILED = "Unable to get result of the %s task"
@@ -183,6 +184,60 @@ fun <T> Future<T>?.getSafe(
         )
         null
     } catch (e: ExecutionException) {
+        internalLogger.log(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            { ERROR_FUTURE_GET_FAILED.format(Locale.US, operationName) },
+            e
+        )
+        null
+    }
+}
+
+/**
+ * Safely unwraps [Future] result with a timeout without throwing any exception.
+ *
+ * @param T Task result type.
+ * @param operationName Name of the task.
+ * @param timeout Maximum time to wait.
+ * @param unit Time unit of the timeout.
+ * @param internalLogger Internal logger.
+ */
+@InternalApi
+fun <T> Future<T>?.getSafe(
+    operationName: String,
+    timeout: Long,
+    unit: TimeUnit,
+    internalLogger: InternalLogger
+): T? {
+    return try {
+        @Suppress("UnsafeThirdPartyFunctionCall") // timeout args are caller-controlled
+        this?.get(timeout, unit)
+    } catch (e: InterruptedException) {
+        internalLogger.log(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            { ERROR_FUTURE_GET_FAILED.format(Locale.US, operationName) },
+            e
+        )
+        null
+    } catch (e: CancellationException) {
+        internalLogger.log(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            { ERROR_FUTURE_GET_FAILED.format(Locale.US, operationName) },
+            e
+        )
+        null
+    } catch (e: ExecutionException) {
+        internalLogger.log(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            { ERROR_FUTURE_GET_FAILED.format(Locale.US, operationName) },
+            e
+        )
+        null
+    } catch (e: TimeoutException) {
         internalLogger.log(
             InternalLogger.Level.ERROR,
             listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/ConcurrencyExt.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/ConcurrencyExt.kt
@@ -161,12 +161,12 @@ fun <T> ExecutorService.submitSafe(
  * @param internalLogger Internal logger.
  */
 @InternalApi
-fun <T> Future<T>?.getSafe(
+fun <T> Future<T>.getSafe(
     operationName: String,
     internalLogger: InternalLogger
 ): T? {
     return try {
-        this?.get()
+        get()
     } catch (e: InterruptedException) {
         internalLogger.log(
             InternalLogger.Level.ERROR,
@@ -204,7 +204,7 @@ fun <T> Future<T>?.getSafe(
  * @param internalLogger Internal logger.
  */
 @InternalApi
-fun <T> Future<T>?.getSafe(
+fun <T> Future<T>.getSafe(
     operationName: String,
     timeout: Long,
     unit: TimeUnit,
@@ -212,7 +212,7 @@ fun <T> Future<T>?.getSafe(
 ): T? {
     return try {
         @Suppress("UnsafeThirdPartyFunctionCall") // timeout args are caller-controlled
-        this?.get(timeout, unit)
+        get(timeout, unit)
     } catch (e: InterruptedException) {
         internalLogger.log(
             InternalLogger.Level.ERROR,

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/InternalProxyTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/InternalProxyTest.kt
@@ -143,4 +143,44 @@ internal class InternalProxyTest {
         // Then
         verify(mockCoreFeature).metricTelemetrySampleRateBypass = fakeSampleRate
     }
+
+    @Test
+    fun `M send flush_and_stop_monitor event to RUM feature W flushAndShutdownExecutors()`() {
+        // Given
+        val mockSdkCore = mock<DatadogCore>()
+        val mockRumFeatureScope = mock<FeatureScope>()
+        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
+        Datadog.registry.register(null, mockSdkCore)
+        val proxy = _InternalProxy(mockSdkCore)
+
+        try {
+            // When
+            proxy.flushAndShutdownExecutors()
+
+            // Then
+            verify(mockRumFeatureScope).sendEvent(mapOf("type" to "flush_and_stop_monitor"))
+        } finally {
+            Datadog.registry.clear()
+        }
+    }
+
+    @Test
+    fun `M send flush_and_stop_stats event to Client Stats feature W flushAndShutdownExecutors()`() {
+        // Given
+        val mockSdkCore = mock<DatadogCore>()
+        val mockStatsFeatureScope = mock<FeatureScope>()
+        whenever(mockSdkCore.getFeature(Feature.TRACING_CLIENT_STATS_FEATURE_NAME)) doReturn mockStatsFeatureScope
+        Datadog.registry.register(null, mockSdkCore)
+        val proxy = _InternalProxy(mockSdkCore)
+
+        try {
+            // When
+            proxy.flushAndShutdownExecutors()
+
+            // Then
+            verify(mockStatsFeatureScope).sendEvent(mapOf("type" to "flush_and_stop_stats"))
+        } finally {
+            Datadog.registry.clear()
+        }
+    }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/ConcurrencyExtTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/ConcurrencyExtTest.kt
@@ -43,6 +43,7 @@ import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -299,6 +300,53 @@ internal class ConcurrencyExtTest {
 
         // When
         val result = future.getSafe(operationName, mockInternalLogger)
+
+        // Then
+        assertThat(result).isNull()
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            message = "Unable to get result of the $operationName task",
+            throwable = fakeException
+        )
+    }
+
+    @Test
+    fun `M return result W getSafe() { with timeout }`(
+        @StringForgery operationName: String,
+        @LongForgery(min = 1L) fakeTimeout: Long
+    ) {
+        // Given
+        val future = mock<Future<Any>>()
+        val fakeResult = Any()
+        whenever(future.get(fakeTimeout, TimeUnit.SECONDS)) doReturn fakeResult
+
+        // When
+        val result = future.getSafe(operationName, fakeTimeout, TimeUnit.SECONDS, mockInternalLogger)
+
+        // Then
+        assertThat(result).isSameAs(fakeResult)
+        verifyNoInteractions(mockInternalLogger)
+    }
+
+    @Test
+    fun `M log error W getSafe() { with timeout, exception thrown }`(
+        @StringForgery operationName: String,
+        @LongForgery(min = 1L) fakeTimeout: Long,
+        forge: Forge
+    ) {
+        // Given
+        val future = mock<Future<Any>>()
+        val fakeException = forge.anElementFrom(
+            ExecutionException(forge.aThrowable()),
+            CancellationException(),
+            InterruptedException(),
+            TimeoutException()
+        )
+        whenever(future.get(fakeTimeout, TimeUnit.SECONDS)) doThrow fakeException
+
+        // When
+        val result = future.getSafe(operationName, fakeTimeout, TimeUnit.SECONDS, mockInternalLogger)
 
         // Then
         assertThat(result).isNull()

--- a/detekt_custom_unsafe_calls.yml
+++ b/detekt_custom_unsafe_calls.yml
@@ -135,6 +135,7 @@ datadog:
       - "java.util.concurrent.LinkedBlockingQueue.offer(kotlin.Any?):java.lang.NullPointerException"
       - "java.util.concurrent.LinkedBlockingQueue.offer(kotlin.Any?, kotlin.Long, java.util.concurrent.TimeUnit?):java.lang.NullPointerException"
       - "java.util.concurrent.ScheduledExecutorService.schedule(java.lang.Runnable, kotlin.Long, java.util.concurrent.TimeUnit):java.util.concurrent.RejectedExecutionException,java.lang.NullPointerException"
+      - "java.util.concurrent.ScheduledExecutorService.awaitTermination(kotlin.Long, java.util.concurrent.TimeUnit?):java.lang.InterruptedException"
       - "java.util.concurrent.ScheduledThreadPoolExecutor.awaitTermination(kotlin.Long, java.util.concurrent.TimeUnit?):java.lang.InterruptedException"
       - "java.util.concurrent.ScheduledThreadPoolExecutor.constructor(kotlin.Int):java.lang.IllegalArgumentException"
       - "java.util.concurrent.ScheduledThreadPoolExecutor.schedule(java.lang.Runnable, kotlin.Long, java.util.concurrent.TimeUnit):java.util.concurrent.RejectedExecutionException,java.lang.NullPointerException"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -964,7 +964,7 @@ internal class DatadogRumMonitor(
                                 }
                             }
                         )
-                        val rumContext = future.getSafe("Rum get context", sdkCore.internalLogger)
+                        val rumContext = future?.getSafe("Rum get context", sdkCore.internalLogger)
                         // we are on the context thread already, so useContextThread=false
                         sdkCore.updateFeatureContext(Feature.RUM_FEATURE_NAME, useContextThread = false) {
                             it.clear()

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ClientStatsFeature.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ClientStatsFeature.kt
@@ -7,7 +7,9 @@
 package com.datadog.android.trace.internal
 
 import android.content.Context
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureEventReceiver
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.feature.StorageBackedFeature
 import com.datadog.android.api.storage.FeatureStorageConfiguration
@@ -24,6 +26,7 @@ import com.datadog.android.trace.internal.net.ClientStatsRequestFactory
 import com.datadog.trace.api.Config
 import com.datadog.trace.common.metrics.MetricsAggregator
 import com.datadog.trace.common.metrics.NoOpMetricsAggregator
+import java.util.Locale
 import java.util.concurrent.ScheduledExecutorService
 
 internal class ClientStatsFeature(
@@ -31,7 +34,7 @@ internal class ClientStatsFeature(
     customEndpointUrl: String?,
     private val spanEventMapper: SpanEventMapper,
     private val networkInfoEnabled: Boolean
-) : StorageBackedFeature, TrackingConsentProviderCallback {
+) : StorageBackedFeature, TrackingConsentProviderCallback, FeatureEventReceiver {
     override val name = Feature.TRACING_CLIENT_STATS_FEATURE_NAME
 
     override val storageConfiguration = FeatureStorageConfiguration(
@@ -70,9 +73,12 @@ internal class ClientStatsFeature(
         statsConcentrator = concentrator
         statsExecutor = executor
         aggregator = ClientStatsAdapter(concentrator)
+
+        sdkCore.setEventReceiver(name, this)
     }
 
     override fun onStop() {
+        sdkCore.removeEventReceiver(name)
         statsConcentrator?.stop()
         statsExecutor?.shutdown()
     }
@@ -82,5 +88,37 @@ internal class ClientStatsFeature(
         newConsent: TrackingConsent
     ) {
         statsConcentrator?.onConsentUpdated(newConsent)
+    }
+
+    override fun onReceive(event: Any) {
+        if (event !is Map<*, *>) {
+            sdkCore.internalLogger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.USER,
+                { UNSUPPORTED_EVENT_TYPE.format(Locale.US, event::class.java.canonicalName) }
+            )
+            return
+        }
+
+        when (event["type"]) {
+            FLUSH_AND_STOP_STATS_MESSAGE_TYPE -> statsConcentrator?.drainAndFlush()
+
+            else -> {
+                sdkCore.internalLogger.log(
+                    InternalLogger.Level.WARN,
+                    InternalLogger.Target.USER,
+                    { UNKNOWN_EVENT_TYPE_PROPERTY_VALUE.format(Locale.US, event["type"]) }
+                )
+            }
+        }
+    }
+
+    internal companion object {
+        internal const val FLUSH_AND_STOP_STATS_MESSAGE_TYPE = "flush_and_stop_stats"
+
+        internal const val UNSUPPORTED_EVENT_TYPE =
+            "Client Stats feature received an event of unsupported type=%s."
+        internal const val UNKNOWN_EVENT_TYPE_PROPERTY_VALUE =
+            "Client Stats feature received an event with unknown value of \"type\" property=%s."
     }
 }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
@@ -10,7 +10,9 @@ import androidx.annotation.VisibleForTesting
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.internal.utils.executeSafe
+import com.datadog.android.core.internal.utils.getSafe
 import com.datadog.android.core.internal.utils.scheduleSafe
+import com.datadog.android.core.internal.utils.submitSafe
 import com.datadog.android.event.EventMapper
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.privacy.TrackingConsent
@@ -21,6 +23,7 @@ import com.datadog.android.trace.model.SpanEvent
 import com.datadog.trace.bootstrap.instrumentation.api.Tags
 import com.datadog.trace.core.DDSpan
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -66,7 +69,7 @@ internal class StatsConcentrator(
     fun record(trace: List<DDSpan>) {
         // Possible rare race when consent switches from NOT_GRANTED to PENDING/GRANTED or vice versa but
         // the rare and small data loss is worth it for the performance gain
-        if (currentConsent == TrackingConsent.NOT_GRANTED) {
+        if (currentConsent == TrackingConsent.NOT_GRANTED || isStopped) {
             return
         }
 
@@ -110,6 +113,35 @@ internal class StatsConcentrator(
     fun stop() {
         isStopped = true
         scheduleFlush(flushAll = true)
+    }
+
+    /**
+     * Synchronously drains any pending tasks queued on [executorService], shuts the executor down,
+     * awaits its termination, runs the drained tasks on the calling thread, and finally performs a
+     * synchronous flush-all of the in-memory buckets so [statsWriter] is invoked while the shared
+     * core write executor is still guaranteed to be alive.
+     *
+     * Unlike [stop], which only schedules a flush asynchronously on [executorService] (and is
+     * therefore unsafe to use right before that executor — or the shared core write executor — gets
+     * shut down), this method blocks the calling thread until the flush has actually completed.
+     *
+     * It should only be used by tests.
+     */
+    @Suppress("UnsafeThirdPartyFunctionCall") // Used in tests only
+    fun drainAndFlush() {
+        isStopped = true
+
+        (executorService as? ScheduledThreadPoolExecutor)?.let {
+            // Don't let not-yet-due delayed tasks (e.g. the periodic flush) run after shutdown.
+            it.executeExistingDelayedTasksAfterShutdownPolicy = false
+        }
+        // Submit the final flush ON the executor thread so it queues after any in-flight
+        // aggregation tasks and runs on the thread that owns buckets/oldestTs.
+        executorService
+            .submitSafe("stats-drain-flush", sdkCore.internalLogger) { flushBuckets(flushAll = true) }
+            ?.getSafe("stats-drain-flush", DRAIN_WAIT_SECONDS, TimeUnit.SECONDS, sdkCore.internalLogger)
+        executorService.shutdown()
+        executorService.awaitTermination(DRAIN_WAIT_SECONDS, TimeUnit.SECONDS)
     }
 
     private fun schedulePeriodicFlush() {
@@ -315,6 +347,7 @@ internal class StatsConcentrator(
         private const val DEFAULT_BUFFER_SIZE = 2
         private val DEFAULT_BUCKET_LENGTH = 10.seconds
         private const val FLUSH_INTERVAL_SECS = 30L
+        private const val DRAIN_WAIT_SECONDS = 10L
 
         private val ELIGIBLE_SPAN_KINDS = setOf(
             Tags.SPAN_KIND_SERVER,

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.trace.internal.domain.metrics
 
 import androidx.annotation.VisibleForTesting
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.internal.utils.executeSafe
@@ -124,10 +125,7 @@ internal class StatsConcentrator(
      * Unlike [stop], which only schedules a flush asynchronously on [executorService] (and is
      * therefore unsafe to use right before that executor — or the shared core write executor — gets
      * shut down), this method blocks the calling thread until the flush has actually completed.
-     *
-     * It should only be used by tests.
      */
-    @Suppress("UnsafeThirdPartyFunctionCall") // Used in tests only
     fun drainAndFlush() {
         isStopped = true
 
@@ -141,7 +139,21 @@ internal class StatsConcentrator(
             .submitSafe("stats-drain-flush", sdkCore.internalLogger) { flushBuckets(flushAll = true) }
             ?.getSafe("stats-drain-flush", DRAIN_WAIT_SECONDS, TimeUnit.SECONDS, sdkCore.internalLogger)
         executorService.shutdown()
-        executorService.awaitTermination(DRAIN_WAIT_SECONDS, TimeUnit.SECONDS)
+        try {
+            executorService.awaitTermination(DRAIN_WAIT_SECONDS, TimeUnit.SECONDS)
+        } catch (_: InterruptedException) {
+            try {
+                // Restore the interrupted status
+                Thread.currentThread().interrupt()
+            } catch (se: SecurityException) {
+                sdkCore.internalLogger.log(
+                    InternalLogger.Level.ERROR,
+                    InternalLogger.Target.MAINTAINER,
+                    { "Thread was unable to set its own interrupted state" },
+                    se
+                )
+            }
+        }
     }
 
     private fun schedulePeriodicFlush() {

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/ClientStatsFeatureTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/ClientStatsFeatureTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.trace.event.SpanEventMapper
 import com.datadog.android.trace.internal.domain.metrics.ClientStatsAdapter
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -29,11 +30,14 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.Locale
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ScheduledExecutorService
 
 @Extensions(
@@ -193,6 +197,72 @@ internal class ClientStatsFeatureTest {
     fun `M expose ClientStatsAdapter W aggregator`() {
         // When + Then
         assertThat(testedFeature.aggregator).isInstanceOf(ClientStatsAdapter::class.java)
+    }
+
+    // endregion
+
+    // region onReceive
+
+    @Test
+    fun `M register itself as event receiver W onInitialize()`() {
+        // Then
+        verify(mockSdkCore).setEventReceiver(Feature.TRACING_CLIENT_STATS_FEATURE_NAME, testedFeature)
+    }
+
+    @Test
+    fun `M remove event receiver W onStop()`() {
+        // When
+        testedFeature.onStop()
+
+        // Then
+        verify(mockSdkCore).removeEventReceiver(Feature.TRACING_CLIENT_STATS_FEATURE_NAME)
+    }
+
+    @Test
+    fun `M drain and flush concentrator W onReceive() { flush_and_stop_stats }`() {
+        // Given
+        whenever(mockStatsExecutor.execute(any())) doAnswer { it.getArgument<Runnable>(0).run() }
+        whenever(mockStatsExecutor.submit(any())) doAnswer {
+            it.getArgument<Runnable>(0).run()
+            CompletableFuture.completedFuture(Unit)
+        }
+
+        // When
+        testedFeature.onReceive(mapOf("type" to ClientStatsFeature.FLUSH_AND_STOP_STATS_MESSAGE_TYPE))
+
+        // Then
+        verify(mockStatsExecutor).shutdown()
+        verify(mockStatsExecutor).awaitTermination(any(), any())
+    }
+
+    @Test
+    fun `M log warning W onReceive() { unknown map event type }`(
+        @StringForgery fakeType: String
+    ) {
+        // When
+        testedFeature.onReceive(mapOf("type" to fakeType))
+
+        // Then
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            ClientStatsFeature.UNKNOWN_EVENT_TYPE_PROPERTY_VALUE.format(Locale.US, fakeType)
+        )
+    }
+
+    @Test
+    fun `M log warning W onReceive() { unsupported event type }`(
+        @StringForgery fakeEvent: String
+    ) {
+        // When
+        testedFeature.onReceive(fakeEvent)
+
+        // Then
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            ClientStatsFeature.UNSUPPORTED_EVENT_TYPE.format(Locale.US, fakeEvent::class.java.canonicalName)
+        )
     }
 
     // endregion

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentratorTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentratorTest.kt
@@ -47,8 +47,11 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -698,6 +701,71 @@ internal class StatsConcentratorTest {
 
         // Then: schedule was called exactly once (initial), never re-scheduled after stop
         verify(mockExecutorService, times(1)).schedule(any<Runnable>(), any(), any())
+    }
+
+    // endregion
+
+    // region drainAndFlush
+
+    @Test
+    fun `M shut down executor W drainAndFlush()`() {
+        // Given
+        whenever(mockExecutorService.submit(any())) doAnswer {
+            it.getArgument<Runnable>(0).run()
+            CompletableFuture.completedFuture(Unit)
+        }
+
+        // When
+        testedConcentrator.drainAndFlush()
+
+        // Then
+        verify(mockExecutorService).shutdown()
+        verify(mockExecutorService).awaitTermination(any(), any())
+    }
+
+    @Test
+    fun `M flush all buckets synchronously W drainAndFlush()`(forge: Forge) {
+        // Given
+        whenever(mockExecutorService.submit(any())) doAnswer {
+            it.getArgument<Runnable>(0).run()
+            CompletableFuture.completedFuture(Unit)
+        }
+
+        val (span) = forge.makeEligibleSpan()
+        testedConcentrator.record(listOf(span))
+        stubNow(farFuture())
+
+        // When
+        testedConcentrator.drainAndFlush()
+
+        // Then
+        assertThat(captureBuckets()).hasSize(1)
+    }
+
+    @Test
+    fun `M run queued tasks W drainAndFlush() { tasks queued in real ScheduledThreadPoolExecutor }`() {
+        // Given
+        val taskRan = AtomicBoolean(false)
+        val realExecutor = ScheduledThreadPoolExecutor(1)
+        val concentrator = StatsConcentrator(
+            sdkCore = mockSdkCore,
+            ddSpanToSpanEventMapper = mockSpanEventMapper,
+            eventMapper = mockEventMapper,
+            bufferLen = fakeBufferLen,
+            bucketSizeNs = fakeBucketSizeNs,
+            executorService = realExecutor,
+            statsWriter = mockStatsWriter,
+            timeProvider = mockTimeProvider,
+            initialConsent = TrackingConsent.GRANTED,
+            startPeriodicFlush = false
+        )
+        realExecutor.execute { taskRan.set(true) }
+
+        // When
+        concentrator.drainAndFlush()
+
+        // Then
+        assertThat(taskRan.get()).isTrue()
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?
Add StatsConcentrator.drainAndFlush() and wire it into flushAndShutdownExecutors() via a new "flush_and_stop_stats" event, so CSS buckets are synchronously flushed before the shared write executor is shut down instead of being dropped when the periodic timer hasn't fired yet.

This follows the pattern that RUM Monitor [established](https://github.com/DataDog/dd-sdk-android/blob/948c2cfba329ca99aa557d95b8fd7d734d1d1345/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt#L901-L913)

### Motivation
This is used by RUM Fit to flush the CSS data during test runs