### PR TITLE
RUM-16389: Add remote configuration schemas and Configuration.Builder API

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/FlavorBuildConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/FlavorBuildConfig.kt
@@ -86,6 +86,11 @@ fun configureFlavorForSampleApp(
     )
     flavor.buildConfigField(
         "String",
+        "DD_REMOTE_CONFIGURATION_ID",
+        "\"${config.remoteConfigurationId}\""
+    )
+    flavor.buildConfigField(
+        "String",
         "DD_CLIENT_TOKEN",
         "\"${config.token}\""
     )

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/SampleAppConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/SampleAppConfig.kt
@@ -14,5 +14,6 @@ data class SampleAppConfig(
     val token: String = "",
     val rumApplicationId: String = "",
     val apiKey: String = "",
-    val applicationKey: String = ""
+    val applicationKey: String = "",
+    val remoteConfigurationId: String = ""
 )

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/JsonDefinition.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/JsonDefinition.kt
@@ -24,6 +24,7 @@ data class JsonDefinition(
     @SerializedName("anyOf") val anyOf: List<JsonDefinition>?,
     @SerializedName("properties") val properties: Map<String, JsonDefinition>?,
     @SerializedName("definitions") val definitions: Map<String, JsonDefinition>?,
+    @SerializedName("\$defs") val defs: Map<String, JsonDefinition>?,
     @SerializedName("readOnly") val readOnly: Boolean?,
     @SerializedName("additionalProperties") val additionalProperties: Any?,
     @SerializedName("default") val default: Any?
@@ -46,6 +47,7 @@ data class JsonDefinition(
             anyOf = null,
             properties = null,
             definitions = null,
+            defs = null,
             readOnly = null,
             additionalProperties = null,
             default = null
@@ -67,6 +69,7 @@ data class JsonDefinition(
             anyOf = null,
             properties = null,
             definitions = null,
+            defs = null,
             readOnly = null,
             additionalProperties = null,
             default = null

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReader.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReader.kt
@@ -77,7 +77,11 @@ class JsonSchemaReader(
         val match = knownSchemas[fromFile]
             ?.let {
                 // only explicit properties lookup supported
-                if (type == REF_TYPE_PROPERTIES) it.properties else it.definitions
+                if (type == REF_TYPE_PROPERTIES) {
+                    it.properties
+                } else {
+                    it.definitions.orEmpty() + it.defs.orEmpty()
+                }
             }
             ?.entries
             ?.firstOrNull { matcher(it.key, it.value) } ?: return null
@@ -426,8 +430,10 @@ class JsonSchemaReader(
     companion object {
         private const val REF_TYPE_PROPERTIES = "properties"
         private const val REF_TYPE_DEFINITIONS = "definitions"
+        private const val REF_TYPE_DEFS = "\$defs"
 
-        private val REF_NAME_REGEX = Regex("#/($REF_TYPE_DEFINITIONS|$REF_TYPE_PROPERTIES)/([\\w]+)")
+        private val REF_NAME_REGEX =
+            Regex("#/($REF_TYPE_DEFINITIONS|\\$REF_TYPE_DEFS|$REF_TYPE_PROPERTIES)/([\\w]+)")
         private val REF_ID_REGEX = Regex("#[\\w]+")
         private val REF_FILE_REGEX = Regex("(file:)?(([^/]+/)*([^/]+)\\.json)(#(.*))?")
     }

--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -284,6 +284,7 @@ data class com.datadog.android.core.configuration.Configuration
     fun setBackpressureStrategy(BackPressureStrategy): Builder
     fun setUploadSchedulerStrategy(UploadSchedulerStrategy?): Builder
     fun setVersion(String): Builder
+    fun setRemoteConfigurationId(String): Builder
   companion object 
 class com.datadog.android.core.configuration.HostPatternSanitizer
   constructor(com.datadog.android.api.InternalLogger)

--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -483,3 +483,82 @@ enum com.datadog.android.trace.TracingHeaderType
   - B3
   - B3MULTI
   - TRACECONTEXT
+data class com.datadog.android.core.`internal`.remote.model.Android
+  constructor(Rum? = null, SessionReplay? = null, Profiling? = null, Trace? = null)
+  val platform: kotlin.String
+  fun toJson(): com.google.gson.JsonElement
+  companion object 
+    fun fromJson(kotlin.String): Android
+    fun fromJsonObject(com.google.gson.JsonObject): Android
+  data class Rum
+    constructor(kotlin.String, kotlin.String? = null, kotlin.String? = null, kotlin.Number? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Number? = null, VitalsUpdateFrequency? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Rum
+      fun fromJsonObject(com.google.gson.JsonObject): Rum
+  data class SessionReplay
+    constructor(kotlin.Number? = null, kotlin.Boolean? = null, TextAndInputPrivacy? = null, TouchPrivacy? = null, ImagePrivacy? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): SessionReplay
+      fun fromJsonObject(com.google.gson.JsonObject): SessionReplay
+  data class Profiling
+    constructor(kotlin.Number? = null, kotlin.Number? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Profiling
+      fun fromJsonObject(com.google.gson.JsonObject): Profiling
+  data class Trace
+    constructor(kotlin.Number? = null, TraceContextInjection? = null, kotlin.collections.List<kotlin.String>? = null, kotlin.collections.List<TracingHeaderType>? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Trace
+      fun fromJsonObject(com.google.gson.JsonObject): Trace
+  enum VitalsUpdateFrequency
+    constructor(kotlin.String)
+    - FREQUENT
+    - AVERAGE
+    - RARE
+    - NEVER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): VitalsUpdateFrequency
+  enum TextAndInputPrivacy
+    constructor(kotlin.String)
+    - MASK_SENSITIVE_INPUTS
+    - MASK_ALL_INPUTS
+    - MASK_ALL
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TextAndInputPrivacy
+  enum TouchPrivacy
+    constructor(kotlin.String)
+    - SHOW
+    - HIDE
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TouchPrivacy
+  enum ImagePrivacy
+    constructor(kotlin.String)
+    - MASK_NONE
+    - MASK_LARGE_ONLY
+    - MASK_ALL
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ImagePrivacy
+  enum TraceContextInjection
+    constructor(kotlin.String)
+    - ALL
+    - SAMPLED
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TraceContextInjection
+  enum TracingHeaderType
+    constructor(kotlin.String)
+    - DATADOG
+    - B3
+    - B3MULTI
+    - TRACECONTEXT
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TracingHeaderType

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -764,6 +764,7 @@ public final class com/datadog/android/core/configuration/Configuration$Builder 
 	public final fun setFirstPartyHostsWithHeaderType (Ljava/util/Map;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setPersistenceStrategyFactory (Lcom/datadog/android/core/persistence/PersistenceStrategy$Factory;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setProxy (Ljava/net/Proxy;Lokhttp3/Authenticator;)Lcom/datadog/android/core/configuration/Configuration$Builder;
+	public final fun setRemoteConfigurationId (Ljava/lang/String;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setUploadFrequency (Lcom/datadog/android/core/configuration/UploadFrequency;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setUploadSchedulerStrategy (Lcom/datadog/android/core/configuration/UploadSchedulerStrategy;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setUseDeveloperModeWhenDebuggable (Z)Lcom/datadog/android/core/configuration/Configuration$Builder;

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -886,6 +886,254 @@ public final class com/datadog/android/core/internal/persistence/file/FileExtKt 
 	public static synthetic fun readTextSafe$default (Ljava/io/File;Ljava/nio/charset/Charset;Lcom/datadog/android/api/InternalLogger;ILjava/lang/Object;)Ljava/lang/String;
 }
 
+public final class com/datadog/android/core/internal/remote/model/Android {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/datadog/android/core/internal/remote/model/Android$Rum;Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;Lcom/datadog/android/core/internal/remote/model/Android$Profiling;Lcom/datadog/android/core/internal/remote/model/Android$Trace;)V
+	public synthetic fun <init> (Lcom/datadog/android/core/internal/remote/model/Android$Rum;Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;Lcom/datadog/android/core/internal/remote/model/Android$Profiling;Lcom/datadog/android/core/internal/remote/model/Android$Trace;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/core/internal/remote/model/Android$Rum;
+	public final fun component2 ()Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;
+	public final fun component3 ()Lcom/datadog/android/core/internal/remote/model/Android$Profiling;
+	public final fun component4 ()Lcom/datadog/android/core/internal/remote/model/Android$Trace;
+	public final fun copy (Lcom/datadog/android/core/internal/remote/model/Android$Rum;Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;Lcom/datadog/android/core/internal/remote/model/Android$Profiling;Lcom/datadog/android/core/internal/remote/model/Android$Trace;)Lcom/datadog/android/core/internal/remote/model/Android;
+	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/Android;Lcom/datadog/android/core/internal/remote/model/Android$Rum;Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;Lcom/datadog/android/core/internal/remote/model/Android$Profiling;Lcom/datadog/android/core/internal/remote/model/Android$Trace;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/Android;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android;
+	public final fun getPlatform ()Ljava/lang/String;
+	public final fun getProfiling ()Lcom/datadog/android/core/internal/remote/model/Android$Profiling;
+	public final fun getRum ()Lcom/datadog/android/core/internal/remote/model/Android$Rum;
+	public final fun getSessionReplay ()Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;
+	public final fun getTrace ()Lcom/datadog/android/core/internal/remote/model/Android$Trace;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$ImagePrivacy : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy$Companion;
+	public static final field MASK_ALL Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
+	public static final field MASK_LARGE_ONLY Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
+	public static final field MASK_NONE Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
+	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$ImagePrivacy$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$Profiling {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$Profiling$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;)V
+	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Number;
+	public final fun component2 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/core/internal/remote/model/Android$Profiling;
+	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/Android$Profiling;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/Android$Profiling;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$Profiling;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android$Profiling;
+	public final fun getApplicationLaunchSampleRate ()Ljava/lang/Number;
+	public final fun getContinuousSampleRate ()Ljava/lang/Number;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$Profiling$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$Profiling;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android$Profiling;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$Rum {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$Rum$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/Number;
+	public final fun component11 ()Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
+	public final fun component12 ()Ljava/lang/Boolean;
+	public final fun component13 ()Ljava/lang/Boolean;
+	public final fun component14 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Number;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8 ()Ljava/lang/Boolean;
+	public final fun component9 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lcom/datadog/android/core/internal/remote/model/Android$Rum;
+	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/Android$Rum;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/Android$Rum;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$Rum;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android$Rum;
+	public final fun getApplicationId ()Ljava/lang/String;
+	public final fun getCrashReportsEnabled ()Ljava/lang/Boolean;
+	public final fun getEnv ()Ljava/lang/String;
+	public final fun getLongTaskThresholdMs ()Ljava/lang/Number;
+	public final fun getService ()Ljava/lang/String;
+	public final fun getTelemetrySampleRate ()Ljava/lang/Number;
+	public final fun getTrackAnonymousUser ()Ljava/lang/Boolean;
+	public final fun getTrackBackgroundEvents ()Ljava/lang/Boolean;
+	public final fun getTrackFrustrations ()Ljava/lang/Boolean;
+	public final fun getTrackNonFatalAnrs ()Ljava/lang/Boolean;
+	public final fun getTrackResources ()Ljava/lang/Boolean;
+	public final fun getTrackSlowFrames ()Ljava/lang/Boolean;
+	public final fun getTrackUserInteractions ()Ljava/lang/Boolean;
+	public final fun getVitalsUpdateFrequency ()Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$Rum$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$Rum;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android$Rum;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$SessionReplay {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Boolean;Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;)V
+	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Boolean;Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Number;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
+	public final fun component4 ()Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;
+	public final fun component5 ()Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Boolean;Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;)Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;
+	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;Ljava/lang/Number;Ljava/lang/Boolean;Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;
+	public final fun getImagePrivacy ()Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
+	public final fun getSampleRate ()Ljava/lang/Number;
+	public final fun getStartRecordingImmediately ()Ljava/lang/Boolean;
+	public final fun getTextAndInputPrivacy ()Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
+	public final fun getTouchPrivacy ()Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$SessionReplay$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy$Companion;
+	public static final field MASK_ALL Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
+	public static final field MASK_ALL_INPUTS Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
+	public static final field MASK_SENSITIVE_INPUTS Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
+	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$TouchPrivacy : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy$Companion;
+	public static final field HIDE Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;
+	public static final field SHOW Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;
+	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$TouchPrivacy$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$Trace {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$Trace$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Number;
+	public final fun component2 ()Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;Ljava/util/List;Ljava/util/List;)Lcom/datadog/android/core/internal/remote/model/Android$Trace;
+	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/Android$Trace;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/Android$Trace;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$Trace;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android$Trace;
+	public final fun getSampleRate ()Ljava/lang/Number;
+	public final fun getTraceContextInjection ()Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;
+	public final fun getTracedHosts ()Ljava/util/List;
+	public final fun getTracingHeaderTypes ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$Trace$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$Trace;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android$Trace;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$TraceContextInjection : java/lang/Enum {
+	public static final field ALL Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection$Companion;
+	public static final field SAMPLED Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;
+	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$TraceContextInjection$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$TracingHeaderType : java/lang/Enum {
+	public static final field B3 Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType;
+	public static final field B3MULTI Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType;
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType$Companion;
+	public static final field DATADOG Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType;
+	public static final field TRACECONTEXT Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType;
+	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$TracingHeaderType$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency : java/lang/Enum {
+	public static final field AVERAGE Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency$Companion;
+	public static final field FREQUENT Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
+	public static final field NEVER Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
+	public static final field RARE Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
+	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
+}
+
+public final class com/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
+}
+
 public final class com/datadog/android/core/internal/utils/ByteArrayExtKt {
 	public static final fun join (Ljava/util/Collection;[B[B[BLcom/datadog/android/api/InternalLogger;)[B
 	public static synthetic fun join$default (Ljava/util/Collection;[B[B[BLcom/datadog/android/api/InternalLogger;ILjava/lang/Object;)[B

--- a/dd-sdk-android-core/build.gradle.kts
+++ b/dd-sdk-android-core/build.gradle.kts
@@ -15,6 +15,7 @@ import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
 import com.datadog.gradle.config.publishingConfig
+import com.datadog.gradle.utils.createJsonModelsGenerationTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -41,6 +42,12 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+}
+
+createJsonModelsGenerationTask("generateRemoteConfigModelsFromJson") {
+    inputDirPath = "src/main/json/rc"
+    targetPackageName = "com.datadog.android.core.internal.remote.model"
+    ignoredFiles = listOf("mobile.json")
 }
 
 /**

--- a/dd-sdk-android-core/src/main/json/rc/android.json
+++ b/dd-sdk-android-core/src/main/json/rc/android.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "rum-sdk-config-android",
+  "description": "Android RUM SDK Remote Configuration",
+  "type": "object",
+  "required": ["platform"],
+  "additionalProperties": false,
+  "properties": {
+    "platform": { "type": "string", "const": "android" },
+    "rum": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "mobile.json#/$defs/rum" },
+        {
+          "type": "object",
+          "properties": {
+            "crashReportsEnabled": { "type": "boolean" },
+            "trackNonFatalAnrs": { "type": "boolean" }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "sessionReplay": {
+      "type": "object",
+      "allOf": [
+        { "$ref": "mobile.json#/$defs/sessionReplay" },
+        {
+          "type": "object",
+          "properties": {
+            "imagePrivacy": {
+              "type": "string",
+              "description": "Session Replay image masking level",
+              "enum": ["mask_none", "mask_large_only", "mask_all"]
+            }
+          }
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "profiling": { "$ref": "mobile.json#/$defs/profiling" },
+    "trace": { "$ref": "mobile.json#/$defs/trace" }
+  }
+}

--- a/dd-sdk-android-core/src/main/json/rc/mobile.json
+++ b/dd-sdk-android-core/src/main/json/rc/mobile.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "rum-sdk-config-mobile",
+  "description": "Shared definitions for the iOS and Android RUM SDK configs",
+  "$defs": {
+    "rum": {
+      "type": "object",
+      "required": ["applicationId"],
+      "properties": {
+        "applicationId": {
+          "type": "string",
+          "description": "UUID of the RUM application",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
+        },
+        "service": { "type": "string" },
+        "env": { "type": "string" },
+        "telemetrySampleRate": { "type": "number", "minimum": 0, "maximum": 100 },
+        "trackAnonymousUser": { "type": "boolean" },
+        "trackUserInteractions": { "type": "boolean" },
+        "trackResources": { "type": "boolean" },
+        "trackBackgroundEvents": { "type": "boolean" },
+        "trackFrustrations": { "type": "boolean" },
+        "longTaskThresholdMs": {
+          "type": "number",
+          "minimum": 100,
+          "description": "Minimum main-thread task duration to report as a long task"
+        },
+        "vitalsUpdateFrequency": {
+          "type": "string",
+          "enum": ["frequent", "average", "rare", "never"]
+        },
+        "trackSlowFrames": { "type": "boolean" }
+      }
+    },
+    "sessionReplay": {
+      "type": "object",
+      "properties": {
+        "sampleRate": { "type": "number", "minimum": 0, "maximum": 100 },
+        "startRecordingImmediately": {
+          "type": "boolean",
+          "description": "Whether Session Replay starts recording as soon as the SDK initializes"
+        },
+        "textAndInputPrivacy": {
+          "type": "string",
+          "enum": ["mask_sensitive_inputs", "mask_all_inputs", "mask_all"]
+        },
+        "touchPrivacy": {
+          "type": "string",
+          "enum": ["show", "hide"]
+        }
+      }
+    },
+    "profiling": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "continuousSampleRate": { "type": "number", "minimum": 0, "maximum": 100 },
+        "applicationLaunchSampleRate": { "type": "number", "minimum": 0, "maximum": 100 }
+      }
+    },
+    "trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sampleRate": { "type": "number", "minimum": 0, "maximum": 100 },
+        "traceContextInjection": { "type": "string", "enum": ["all", "sampled"] },
+        "tracedHosts": {
+          "type": "array",
+          "description": "Hostnames for which distributed tracing headers are injected",
+          "items": { "type": "string" }
+        },
+        "tracingHeaderTypes": {
+          "type": "array",
+          "description": "Tracing header formats injected on requests to all traced hosts",
+          "items": { "type": "string", "enum": ["datadog", "b3", "b3multi", "tracecontext"] }
+        }
+      }
+    }
+  }
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -44,7 +44,8 @@ internal constructor(
         val batchProcessingLevel: BatchProcessingLevel,
         val persistenceStrategyFactory: PersistenceStrategy.Factory?,
         val backpressureStrategy: BackPressureStrategy,
-        val uploadSchedulerStrategy: UploadSchedulerStrategy?
+        val uploadSchedulerStrategy: UploadSchedulerStrategy?,
+        val remoteConfigurationId: String?
     )
 
     // region Builder
@@ -285,6 +286,17 @@ internal constructor(
             return this
         }
 
+        /**
+         * Sets the remote configuration ID used to fetch SDK settings from the Datadog CDN.
+         *
+         * @param remoteConfigurationId the opaque identifier assigned during application
+         * onboarding in the Datadog UI.
+         */
+        fun setRemoteConfigurationId(remoteConfigurationId: String): Builder {
+            coreConfig = coreConfig.copy(remoteConfigurationId = remoteConfigurationId)
+            return this
+        }
+
         internal fun allowClearTextHttp(): Builder {
             coreConfig = coreConfig.copy(
                 needsClearTextHttp = true
@@ -324,7 +336,8 @@ internal constructor(
             batchProcessingLevel = BatchProcessingLevel.MEDIUM,
             persistenceStrategyFactory = null,
             backpressureStrategy = DEFAULT_BACKPRESSURE_STRATEGY,
-            uploadSchedulerStrategy = null
+            uploadSchedulerStrategy = null,
+            remoteConfigurationId = null
         )
 
         internal const val NETWORK_REQUESTS_TRACKING_FEATURE_NAME = "Network requests"

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -77,6 +77,7 @@ internal class ConfigurationBuilderTest {
         assertThat(config.coreConfig.backpressureStrategy.backpressureMitigation)
             .isEqualTo(BackPressureMitigation.IGNORE_NEWEST)
         assertThat(config.coreConfig.backpressureStrategy.capacity).isEqualTo(1024)
+        assertThat(config.coreConfig.remoteConfigurationId).isNull()
         assertThat(config.crashReportsEnabled).isTrue
         assertThat(config.additionalConfig).isEmpty()
     }
@@ -445,6 +446,23 @@ internal class ConfigurationBuilderTest {
         assertThat(config.coreConfig).isEqualTo(
             Configuration.DEFAULT_CORE_CONFIG.copy(
                 uploadSchedulerStrategy = mockUploadSchedulerStrategy
+            )
+        )
+    }
+
+    @Test
+    fun `M build config with remote configuration id W setRemoteConfigurationId() and build()`(
+        @StringForgery remoteConfigurationId: String
+    ) {
+        // When
+        val config = testedBuilder
+            .setRemoteConfigurationId(remoteConfigurationId)
+            .build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(
+            Configuration.DEFAULT_CORE_CONFIG.copy(
+                remoteConfigurationId = remoteConfigurationId
             )
         )
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCoreForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCoreForgeryFactory.kt
@@ -60,7 +60,8 @@ internal class ConfigurationCoreForgeryFactory :
                 mock(),
                 forge.aValueFrom(BackPressureMitigation::class.java)
             ),
-            uploadSchedulerStrategy = forge.aNullable { mock() }
+            uploadSchedulerStrategy = forge.aNullable { mock() },
+            remoteConfigurationId = forge.aNullable { anAlphabeticalString() }
         )
     }
 }

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -1932,7 +1932,7 @@ data class com.datadog.android.rum.model.ViewEvent
       fun fromJson(kotlin.String): DdSession
       fun fromJsonObject(com.google.gson.JsonObject): DdSession
   data class Configuration
-    constructor(kotlin.Number, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Boolean? = null)
+    constructor(kotlin.Number, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.String? = null, kotlin.Boolean? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Configuration

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -5147,19 +5147,21 @@ public final class com/datadog/android/rum/model/ViewEvent$Companion {
 
 public final class com/datadog/android/rum/model/ViewEvent$Configuration {
 	public static final field Companion Lcom/datadog/android/rum/model/ViewEvent$Configuration$Companion;
-	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/String;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Number;
 	public final fun component2 ()Ljava/lang/Number;
 	public final fun component3 ()Ljava/lang/Number;
 	public final fun component4 ()Ljava/lang/Number;
-	public final fun component5 ()Ljava/lang/Boolean;
-	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Boolean;)Lcom/datadog/android/rum/model/ViewEvent$Configuration;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewEvent$Configuration;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewEvent$Configuration;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/datadog/android/rum/model/ViewEvent$Configuration;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ViewEvent$Configuration;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/Number;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ViewEvent$Configuration;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$Configuration;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ViewEvent$Configuration;
 	public final fun getProfilingSampleRate ()Ljava/lang/Number;
+	public final fun getRemoteConfigurationId ()Ljava/lang/String;
 	public final fun getSessionReplaySampleRate ()Ljava/lang/Number;
 	public final fun getSessionSampleRate ()Ljava/lang/Number;
 	public final fun getStartSessionReplayRecordingManually ()Ljava/lang/Boolean;

--- a/features/dd-sdk-android-rum/src/main/json/rum/_view-properties-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/_view-properties-schema.json
@@ -461,6 +461,25 @@
           "readOnly": true
         }
       }
+    },
+    "_dd": {
+      "type": "object",
+      "description": "Internal properties",
+      "readOnly": true,
+      "properties": {
+        "configuration": {
+          "type": "object",
+          "description": "Subset of the SDK configuration options in use during its execution",
+          "readOnly": true,
+          "properties": {
+            "remote_configuration_id": {
+              "type": "string",
+              "description": "The id of the remote configuration applied to the SDK, if any",
+              "readOnly": true
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -441,6 +441,11 @@ class SampleApplication : Application() {
             .setFirstPartyHosts(tracedHosts)
             .setBatchSize(BatchSize.SMALL)
             .setUploadFrequency(UploadFrequency.FREQUENT)
+            .apply {
+                if (BuildConfig.DD_REMOTE_CONFIGURATION_ID.isNotBlank()) {
+                    setRemoteConfigurationId(BuildConfig.DD_REMOTE_CONFIGURATION_ID)
+                }
+            }
 
         try {
             configBuilder.useSite(DatadogSite.valueOf(BuildConfig.DD_SITE_NAME))


### PR DESCRIPTION
### What does this PR do?

First PR of the Remote Configuration feature. It lays the schema and public API foundation:

- **RC schema files** (`android.json`, `mobile.json`) added to `dd-sdk-android-core/src/main/json/rc/`, sourced from `dd-go`. The JSON schema generator (`JsonDefinition`, `JsonSchemaReader`) was extended to support `$defs` (JSON Schema 2020-12) alongside the existing `definitions` keyword.
- **Gradle model generation task** wired in `dd-sdk-android-core`, generating the internal `Android` typed model under `com.datadog.android.core.internal.remote.model`.
- **`remote_configuration_id` field** added to `_view-properties-schema.json` under `_dd.configuration`, in sync with `rum-events-format`.
- **`Configuration.Builder.setRemoteConfigurationId(String)`** — opt-in public API. Default is `null` — no behavioural change for existing users.
- **Sample app** wired to call `setRemoteConfigurationId()` via `BuildConfig`.

### Motivation

The generated model and new builder method are not yet consumed at runtime — fetch/cache and feature consumption follow in subsequent PRs.

### Additional Notes

The `$defs` fix to the JSON schema generator is a general improvement for any future schema in the codebase.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)