### PR TITLE
Fix TTFD report during warm start after session expiration

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -249,15 +249,18 @@ internal class RumSessionScope(
 
         val isInteraction = (event is RumRawEvent.StartView) || (event is RumRawEvent.StartAction)
         val isBackgroundEvent = event.javaClass in RumViewManagerScope.validBackgroundEventTypes
+
         val isSdkInitInForeground = event is RumRawEvent.SdkInit && event.isAppInForeground
         val isSdkInitInBackground = event is RumRawEvent.SdkInit && !event.isAppInForeground
+
+        val isAppStart = event is RumRawEvent.AppStartEvent
 
         // When the session is expired, time-out or stopSession API is called, session ended metric should be sent
         if (isExpired || isTimedOut || isActive.not()) {
             sessionEndedMetricDispatcher.endMetric(sessionId, sdkCore.time.serverTimeOffsetMs)
         }
 
-        if (isInteraction || isSdkInitInForeground) {
+        if (isInteraction || isSdkInitInForeground || isAppStart) {
             if (isNewSession || isExpired || isTimedOut) {
                 val reason = if (isNewSession) {
                     StartReason.USER_APP_LAUNCH

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -1742,6 +1742,69 @@ internal class RumSessionScopeTest {
         verifyNoMoreInteractions(mockRumSessionScopeStartupManager)
     }
 
+    @ParameterizedTest
+    @MethodSource("testScenarios")
+    fun `M record TTID and TTFD W handleEvent { session previously expired }`(
+        scenario: RumStartupScenario,
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(
+            event = fakeInitialViewEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter
+        )
+        advanceTimeByMs(TEST_INACTIVITY_MS)
+
+        val appStartEvent = RumRawEvent.AppStartEvent(scenario = scenario)
+        testedScope.handleEvent(
+            event = appStartEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter
+        )
+
+        // When
+        val info = RumTTIDInfo(scenario = scenario, durationNs = forge.aLong(min = 0, max = 10000))
+        val ttidEvent = RumRawEvent.AppStartTTIDEvent(info = info)
+        testedScope.handleEvent(
+            event = ttidEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter
+        )
+
+        val ttfdEvent = RumRawEvent.AppStartTTFDEvent()
+        val result = testedScope.handleEvent(
+            event = ttfdEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter
+        )
+        val rumContext = checkNotNull(result).getRumContext()
+
+        // Then
+        verify(mockRumSessionScopeStartupManager).onAppStartEvent(event = eq(appStartEvent))
+        verify(mockRumSessionScopeStartupManager).onTTIDEvent(
+            event = ttidEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter,
+            rumContext = rumContext,
+            customAttributes = fakeParentAttributes
+        )
+        verify(mockRumSessionScopeStartupManager).onTTFDEvent(
+            event = ttfdEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockWriter,
+            rumContext = rumContext,
+            customAttributes = fakeParentAttributes
+        )
+        verifyNoMoreInteractions(mockRumSessionScopeStartupManager)
+    }
+
     // endregion
 
     // region Internal


### PR DESCRIPTION
### What does this PR do?

TTFD for warm start was not reported.

Steps to reproduce:
1. Turn on "don't keep Activities" in the developer settings of the device so that activity gets destroyed when you go to home screen (without killing the app).
2. Set [this](https://github.com/DataDog/dd-sdk-android/blob/221f45b8267d701a915e736dbce4ff7519d99e41/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt#L328) to some small value, for example 10 seconds, so that you don't have to wait for a long time before reopening the app. Otherwise you need to wait for 15 minutes.
3. Launch the app.
4. Go to home screen of your phone.
5. wait > 10 seconds.
6. launch again, it will be a warm start. TTFD will not be reported.

The problem is that when [this](https://github.com/DataDog/dd-sdk-android/blob/fbb456951d300c1a4b4d8ccb124ef7f920575499/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt#L182) place is called during warm start, the session is in the EXPIRED state, it hasn't been renewed yet. The solution is to renew the session for the `AppStartEvent` event.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

