### PR TITLE
RUM-17112: Remove default `= Time()` from `RumRawEvent` subclasses

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/Time.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/Time.kt
@@ -6,31 +6,38 @@
 
 package com.datadog.android.rum.internal.domain
 
+import com.datadog.android.internal.time.TimeProvider
 import java.util.concurrent.TimeUnit
 
 internal data class Time(
-    val timestamp: Long = System.currentTimeMillis(),
-    val nanoTime: Long = System.nanoTime()
-)
+    val timestamp: Long,
+    val nanoTime: Long
+) {
+    companion object {
+        fun now(timeProvider: TimeProvider): Time {
+            return Time(
+                timeProvider.getDeviceTimestampMillis(),
+                timeProvider.getDeviceElapsedTimeNanos()
+            )
+        }
 
-/**
- * Convert a value obtained from [System.currentTimeMillis] to [Time].
- */
-internal fun Long.asTime(): Time {
-    // Because nanoTime only measures the nanoseconds since the beginning
-    // of the current JVM lifetime, we need to approximate the nanotime we want.
-    // We simply convert the delay between the desired and real timestamp and
-    // apply it to the measured nanotime
-    val now = Time()
-    val offset = this - now.timestamp
-    return Time(this, TimeUnit.MILLISECONDS.toNanos(offset) + now.nanoTime)
-}
+        fun fromTimestampMillis(timestamp: Long, timeProvider: TimeProvider): Time {
+            // Because nanoTime only measures the nanoseconds since the beginning
+            // of the current JVM lifetime, we need to approximate the nanoTime we want.
+            // We convert the delay between the desired and current timestamp and
+            // apply it to the currently measured nanoTime.
+            val now = now(timeProvider)
+            val offset = timestamp - now.timestamp
+            return Time(timestamp, now.nanoTime + TimeUnit.MILLISECONDS.toNanos(offset))
+        }
 
-/**
- * Convert a value obtained from [System.nanoTime] to [Time].
- */
-internal fun Long.asTimeNs(): Time {
-    val now = Time()
-    val offset = this - now.nanoTime
-    return Time(TimeUnit.NANOSECONDS.toMillis(offset) + now.timestamp, this)
+        fun fromNanoTime(nanoTime: Long, timeProvider: TimeProvider): Time {
+            // Symmetric to [fromTimestampMillis]: we have a nanoTime reading and
+            // approximate the matching wall-clock timestamp by applying the delay
+            // between the desired and current nanoTime to the current timestamp.
+            val now = now(timeProvider)
+            val offset = nanoTime - now.nanoTime
+            return Time(now.timestamp + TimeUnit.NANOSECONDS.toMillis(offset), nanoTime)
+        }
+    }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
@@ -64,7 +64,7 @@ internal class RumApplicationScope(
 
     private var rumContext = RumContext(applicationId = applicationId)
 
-    internal val childScopes = mutableListOf<RumSessionScope>(
+    internal val childScopes = mutableListOf(
         RumSessionScope(
             parentScope = this,
             sdkCore = sdkCore,
@@ -218,7 +218,8 @@ internal class RumApplicationScope(
             lastActiveViewInfo?.let {
                 val startViewEvent = RumRawEvent.StartView(
                     key = it.key,
-                    attributes = it.attributes
+                    attributes = it.attributes,
+                    eventTime = Time.now(sdkCore.timeProvider)
                 )
                 newSession.handleEvent(startViewEvent, datadogContext, writeScope, writer)
             }
@@ -259,7 +260,7 @@ internal class RumApplicationScope(
             )
             val startupTime = eventTime.nanoTime - processStartTimeNs
             val appStartedEvent =
-                RumRawEvent.ApplicationStarted(applicationLaunchViewTime, startupTime)
+                RumRawEvent.ApplicationStarted(startupTime, applicationLaunchViewTime)
             delegateToChildren(appStartedEvent, datadogContext, writeScope, writer)
             isAppStartedEventSent = true
         }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -30,23 +30,23 @@ internal sealed class RumRawEvent {
     internal data class StartView(
         val key: RumScopeKey,
         val attributes: Map<String, Any?>,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class StopView(
         val key: RumScopeKey,
         val attributes: Map<String, Any?>,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class StartAction(
         val type: RumActionType,
         val name: String,
         val waitForStop: Boolean,
+        override val eventTime: Time,
         val nativeHeatmapActionData: NativeHeatmapActionData? = null,
         val crossPlatformHeatmapActionData: CrossPlatformHeatmapActionData? = null,
         val appPackageName: String? = null,
-        override val eventTime: Time = Time(),
         val attributes: Map<String, Any?> = emptyMap()
     ) : RumRawEvent()
 
@@ -54,7 +54,7 @@ internal sealed class RumRawEvent {
         val type: RumActionType?,
         val name: String?,
         val attributes: Map<String, Any?>,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class StartResource(
@@ -62,18 +62,18 @@ internal sealed class RumRawEvent {
         val url: String,
         val method: RumResourceMethod,
         val attributes: Map<String, Any?>,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class WaitForResourceTiming(
         val key: Any,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class AddResourceTiming(
         val key: Any,
         val timing: ResourceTiming,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class StopResource(
@@ -82,7 +82,7 @@ internal sealed class RumRawEvent {
         val size: Long?,
         val kind: RumResourceKind,
         val attributes: Map<String, Any?>,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class StopResourceWithError(
@@ -92,7 +92,7 @@ internal sealed class RumRawEvent {
         val source: RumErrorSource,
         val throwable: Throwable,
         val attributes: Map<String, Any?>,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class StopResourceWithStackTrace(
@@ -103,7 +103,7 @@ internal sealed class RumRawEvent {
         val stackTrace: String,
         val errorType: String?,
         val attributes: Map<String, Any?>,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class AddError(
@@ -113,10 +113,10 @@ internal sealed class RumRawEvent {
         val stacktrace: String?,
         val isFatal: Boolean,
         val attributes: Map<String, Any?>,
-        override val eventTime: Time = Time(),
+        val threads: List<ThreadDump>,
+        override val eventTime: Time,
         val type: String? = null,
         val sourceType: RumErrorSourceType = RumErrorSourceType.ANDROID,
-        val threads: List<ThreadDump>,
         val timeSinceAppStartNs: Long? = null
     ) : RumRawEvent()
 
@@ -124,7 +124,7 @@ internal sealed class RumRawEvent {
         val viewId: String,
         val resourceId: String,
         val resourceEndTimestampInNanos: Long,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class ActionSent(
@@ -132,160 +132,160 @@ internal sealed class RumRawEvent {
         val frustrationCount: Int,
         val type: ActionEvent.ActionEventActionType,
         val eventEndTimestampInNanos: Long,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class ErrorSent(
         val viewId: String,
+        override val eventTime: Time,
         val resourceId: String? = null,
-        val resourceEndTimestampInNanos: Long? = null,
-        override val eventTime: Time = Time()
+        val resourceEndTimestampInNanos: Long? = null
     ) : RumRawEvent()
 
     internal data class LongTaskSent(
         val viewId: String,
-        val isFrozenFrame: Boolean = false,
-        override val eventTime: Time = Time()
+        override val eventTime: Time,
+        val isFrozenFrame: Boolean = false
     ) : RumRawEvent()
 
     internal data class ResourceDropped(
         val viewId: String,
         val resourceId: String,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class ActionDropped(
         val viewId: String,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class ErrorDropped(
         val viewId: String,
-        val resourceId: String? = null,
-        override val eventTime: Time = Time()
+        override val eventTime: Time,
+        val resourceId: String? = null
     ) : RumRawEvent()
 
     internal data class LongTaskDropped(
         val viewId: String,
-        val isFrozenFrame: Boolean = false,
-        override val eventTime: Time = Time()
+        override val eventTime: Time,
+        val isFrozenFrame: Boolean = false
     ) : RumRawEvent()
 
     internal data class ResetSession(
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class ApplicationStarted(
-        override val eventTime: Time,
-        val applicationStartupNanos: Long
+        val applicationStartupNanos: Long,
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class AddCustomTiming(
         val name: String,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class AddViewLoadingTime(
         val overwrite: Boolean,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class AddViewAttributes(
         val attributes: Map<String, Any?>,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class RemoveViewAttributes(
         val attributes: Collection<String>,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class AddLongTask(
         val durationNs: Long,
         val target: String,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class SendCustomActionNow(
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class AddFeatureFlagEvaluation(
         val name: String,
         val value: Any,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class AddFeatureFlagEvaluations(
         val featureFlags: Map<String, Any>,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class StopSession(
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class UpdatePerformanceMetric(
         val metric: RumPerformanceMetric,
         val value: Double,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class UpdateExternalRefreshRate(
         val frameTimeSeconds: Double,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class SetInternalViewAttribute(
         val key: String,
         val value: Any?,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class SetSyntheticsTestAttribute(
         val testId: String,
         val resultId: String,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
-    internal data class WebViewEvent(override val eventTime: Time = Time()) : RumRawEvent()
+    internal data class WebViewEvent(override val eventTime: Time) : RumRawEvent()
 
     internal data class TelemetryEventWrapper(
         val event: InternalTelemetryEvent,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class SdkInit(
         val isAppInForeground: Boolean,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class StartOperation(
         val name: String,
         val operationKey: String?,
         val attributes: Map<String, Any?>,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal data class StopOperation(
         val name: String,
         val operationKey: String?,
         val attributes: Map<String, Any?>,
-        val failureReason: FailureReason? = null,
-        override val eventTime: Time = Time()
+        override val eventTime: Time,
+        val failureReason: FailureReason? = null
     ) : RumRawEvent()
 
     internal class AppStartEvent(
         val scenario: RumStartupScenario,
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal class AppStartTTIDEvent(
-        override val eventTime: Time = Time(),
-        val info: RumTTIDInfo
+        val info: RumTTIDInfo,
+        override val eventTime: Time
     ) : RumRawEvent()
 
     internal class AppStartTTFDEvent(
-        override val eventTime: Time = Time()
+        override val eventTime: Time
     ) : RumRawEvent()
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -618,7 +618,12 @@ internal open class RumViewScope(
                 heatmapIdentifierRegistry = heatmapIdentifierRegistry
             )
             pendingActionCount++
-            customActionScope.handleEvent(RumRawEvent.SendCustomActionNow(), datadogContext, writeScope, writer)
+            customActionScope.handleEvent(
+                RumRawEvent.SendCustomActionNow(Time.now(sdkCore.timeProvider)),
+                datadogContext,
+                writeScope,
+                writer
+            )
             return
         }
 
@@ -963,7 +968,7 @@ internal open class RumViewScope(
             val entry = iterator.next()
             val scope = entry.value.handleEvent(event, datadogContext, writeScope, writer)
             if (scope == null) {
-                // if we finalized this scope and it was by error, we won't have resource
+                // if we finalized this scope, and it was by error, we won't have resource
                 // event written, but error event instead
                 if (event is RumRawEvent.StopResourceWithError ||
                     event is RumRawEvent.StopResourceWithStackTrace
@@ -1753,7 +1758,7 @@ internal open class RumViewScope(
          * This function is used to inverse frame times metrics into frame rates.
          *
          * As we take the inverse, the min of the inverse is the inverse of the max and
-         * vice-versa.
+         * vice versa.
          * For instance, if the min frame time is 20ms (50 fps) and the max is 500ms (2 fps),
          * the max frame rate is 50 fps (1/minValue) and the min is 2 fps (1/maxValue).
          *

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -52,7 +52,6 @@ import com.datadog.android.rum.internal.domain.InfoProvider
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.accessibility.AccessibilitySnapshotManager
-import com.datadog.android.rum.internal.domain.asTime
 import com.datadog.android.rum.internal.domain.battery.BatteryInfo
 import com.datadog.android.rum.internal.domain.display.DisplayInfo
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
@@ -457,9 +456,9 @@ internal class DatadogRumMonitor(
                 null,
                 false,
                 mutableAttributes,
+                threads.orEmpty(),
                 eventTime,
-                errorType,
-                threads = threads.orEmpty()
+                errorType
             )
         )
     }
@@ -481,10 +480,10 @@ internal class DatadogRumMonitor(
                 stacktrace,
                 false,
                 attributes.toMap(),
+                emptyList(),
                 eventTime,
                 errorType,
-                errorSourceType,
-                threads = emptyList()
+                errorSourceType
             )
         )
     }
@@ -493,27 +492,28 @@ internal class DatadogRumMonitor(
         handleEvent(
             RumRawEvent.AddFeatureFlagEvaluation(
                 name,
-                value
+                value,
+                now()
             )
         )
     }
 
     override fun addFeatureFlagEvaluations(featureFlags: Map<String, Any>) {
         handleEvent(
-            RumRawEvent.AddFeatureFlagEvaluations(featureFlags)
+            RumRawEvent.AddFeatureFlagEvaluations(featureFlags, now())
         )
     }
 
     override fun stopSession() {
         handleEvent(
-            RumRawEvent.StopSession()
+            RumRawEvent.StopSession(now())
         )
     }
 
     @ExperimentalRumApi
     override fun reportAppFullyDisplayed() {
         handleEvent(
-            RumRawEvent.AppStartTTFDEvent()
+            RumRawEvent.AppStartTTFDEvent(now())
         )
     }
 
@@ -546,12 +546,12 @@ internal class DatadogRumMonitor(
     // region AdvancedRumMonitor
 
     override fun sendWebViewEvent() {
-        handleEvent(RumRawEvent.WebViewEvent())
+        handleEvent(RumRawEvent.WebViewEvent(now()))
     }
 
     override fun resetSession() {
         handleEvent(
-            RumRawEvent.ResetSession()
+            RumRawEvent.ResetSession(now())
         )
     }
 
@@ -560,19 +560,19 @@ internal class DatadogRumMonitor(
         val isAppInForeground = processImportance ==
             ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
         handleEvent(
-            RumRawEvent.SdkInit(isAppInForeground)
+            RumRawEvent.SdkInit(isAppInForeground, now())
         )
     }
 
     override fun waitForResourceTiming(key: Any) {
         handleEvent(
-            RumRawEvent.WaitForResourceTiming(key)
+            RumRawEvent.WaitForResourceTiming(key, now())
         )
     }
 
     override fun addResourceTiming(key: Any, timing: ResourceTiming) {
         handleEvent(
-            RumRawEvent.AddResourceTiming(key, timing)
+            RumRawEvent.AddResourceTiming(key, timing, now())
         )
     }
 
@@ -582,7 +582,7 @@ internal class DatadogRumMonitor(
         throwable: Throwable,
         threads: List<ThreadDump>
     ) {
-        val now = getCurrentTime()
+        val now = now()
         val timeSinceAppStartNs = now.nanoTime - sdkCore.appStartTimeNs
         handleEvent(
             RumRawEvent.AddError(
@@ -601,30 +601,30 @@ internal class DatadogRumMonitor(
 
     override fun addTiming(name: String) {
         handleEvent(
-            RumRawEvent.AddCustomTiming(name)
+            RumRawEvent.AddCustomTiming(name, now())
         )
     }
 
     @ExperimentalRumApi
     override fun addViewLoadingTime(overwrite: Boolean) {
-        handleEvent(RumRawEvent.AddViewLoadingTime(overwrite = overwrite, getCurrentTime()))
+        handleEvent(RumRawEvent.AddViewLoadingTime(overwrite = overwrite, now()))
     }
 
     override fun addViewAttributes(attributes: Map<String, Any?>) {
         handleEvent(
-            RumRawEvent.AddViewAttributes(attributes)
+            RumRawEvent.AddViewAttributes(attributes, now())
         )
     }
 
     override fun removeViewAttributes(attributes: Collection<String>) {
         handleEvent(
-            RumRawEvent.RemoveViewAttributes(attributes)
+            RumRawEvent.RemoveViewAttributes(attributes, now())
         )
     }
 
     override fun addLongTask(durationNs: Long, target: String) {
         handleEvent(
-            RumRawEvent.AddLongTask(durationNs, target)
+            RumRawEvent.AddLongTask(durationNs, target, now())
         )
     }
 
@@ -635,7 +635,8 @@ internal class DatadogRumMonitor(
                     viewId,
                     event.frustrationCount,
                     event.type,
-                    event.eventEndTimestampInNanos
+                    event.eventEndTimestampInNanos,
+                    now()
                 )
             )
 
@@ -643,20 +644,22 @@ internal class DatadogRumMonitor(
                 RumRawEvent.ResourceSent(
                     viewId,
                     event.resourceId,
-                    event.resourceStopTimestampInNanos
+                    event.resourceStopTimestampInNanos,
+                    now()
                 )
             )
 
             is StorageEvent.Error -> handleEvent(
                 RumRawEvent.ErrorSent(
                     viewId,
+                    now(),
                     event.resourceId,
                     event.resourceStopTimestampInNanos
                 )
             )
 
-            is StorageEvent.LongTask -> handleEvent(RumRawEvent.LongTaskSent(viewId, false))
-            is StorageEvent.FrozenFrame -> handleEvent(RumRawEvent.LongTaskSent(viewId, true))
+            is StorageEvent.LongTask -> handleEvent(RumRawEvent.LongTaskSent(viewId, now(), false))
+            is StorageEvent.FrozenFrame -> handleEvent(RumRawEvent.LongTaskSent(viewId, now(), true))
             is StorageEvent.View -> {
                 // Nothing to do
             }
@@ -665,11 +668,11 @@ internal class DatadogRumMonitor(
 
     override fun eventDropped(viewId: String, event: StorageEvent) {
         when (event) {
-            is StorageEvent.Action -> handleEvent(RumRawEvent.ActionDropped(viewId))
-            is StorageEvent.Resource -> handleEvent(RumRawEvent.ResourceDropped(viewId, event.resourceId))
-            is StorageEvent.Error -> handleEvent(RumRawEvent.ErrorDropped(viewId, event.resourceId))
-            is StorageEvent.LongTask -> handleEvent(RumRawEvent.LongTaskDropped(viewId, false))
-            is StorageEvent.FrozenFrame -> handleEvent(RumRawEvent.LongTaskDropped(viewId, true))
+            is StorageEvent.Action -> handleEvent(RumRawEvent.ActionDropped(viewId, now()))
+            is StorageEvent.Resource -> handleEvent(RumRawEvent.ResourceDropped(viewId, event.resourceId, now()))
+            is StorageEvent.Error -> handleEvent(RumRawEvent.ErrorDropped(viewId, now(), event.resourceId))
+            is StorageEvent.LongTask -> handleEvent(RumRawEvent.LongTaskDropped(viewId, now(), false))
+            is StorageEvent.FrozenFrame -> handleEvent(RumRawEvent.LongTaskDropped(viewId, now(), true))
             is StorageEvent.View -> {
                 // Nothing to do
             }
@@ -690,7 +693,7 @@ internal class DatadogRumMonitor(
 
     override fun notifyInterceptorInstantiated() {
         handleEvent(
-            RumRawEvent.TelemetryEventWrapper(InternalTelemetryEvent.InterceptorInstantiated)
+            RumRawEvent.TelemetryEventWrapper(InternalTelemetryEvent.InterceptorInstantiated, now())
         )
     }
 
@@ -702,27 +705,27 @@ internal class DatadogRumMonitor(
         mode: InternalTelemetryEvent.ResourceHeadersTrackingConfigured.Mode
     ) {
         handleEvent(
-            RumRawEvent.TelemetryEventWrapper(InternalTelemetryEvent.ResourceHeadersTrackingConfigured(mode))
+            RumRawEvent.TelemetryEventWrapper(InternalTelemetryEvent.ResourceHeadersTrackingConfigured(mode), now())
         )
     }
 
     override fun updatePerformanceMetric(metric: RumPerformanceMetric, value: Double) {
-        handleEvent(RumRawEvent.UpdatePerformanceMetric(metric, value))
+        handleEvent(RumRawEvent.UpdatePerformanceMetric(metric, value, now()))
     }
 
     override fun updateExternalRefreshRate(frameTimeSeconds: Double) {
-        handleEvent(RumRawEvent.UpdateExternalRefreshRate(frameTimeSeconds))
+        handleEvent(RumRawEvent.UpdateExternalRefreshRate(frameTimeSeconds, now()))
     }
 
     override fun setInternalViewAttribute(key: String, value: Any?) {
-        handleEvent(RumRawEvent.SetInternalViewAttribute(key, value))
+        handleEvent(RumRawEvent.SetInternalViewAttribute(key, value, now()))
     }
 
     override fun setSyntheticsAttribute(
         testId: String,
         resultId: String
     ) {
-        handleEvent(RumRawEvent.SetSyntheticsTestAttribute(testId, resultId))
+        handleEvent(RumRawEvent.SetSyntheticsTestAttribute(testId, resultId, now()))
     }
 
     override fun _getInternal(): _RumInternalProxy {
@@ -730,7 +733,7 @@ internal class DatadogRumMonitor(
     }
 
     override fun sendTelemetryEvent(telemetryEvent: InternalTelemetryEvent) {
-        handleEvent(RumRawEvent.TelemetryEventWrapper(telemetryEvent))
+        handleEvent(RumRawEvent.TelemetryEventWrapper(telemetryEvent, now()))
     }
 
     override fun enableJankStatsTracking(activity: Activity) {
@@ -744,7 +747,8 @@ internal class DatadogRumMonitor(
     ) {
         handleEvent(
             RumRawEvent.AppStartTTIDEvent(
-                info = info
+                info = info,
+                eventTime = now()
             )
         )
     }
@@ -752,7 +756,8 @@ internal class DatadogRumMonitor(
     override fun sendAppStartEvent(scenario: RumStartupScenario) {
         handleEvent(
             RumRawEvent.AppStartEvent(
-                scenario = scenario
+                scenario = scenario,
+                eventTime = now()
             )
         )
     }
@@ -1042,12 +1047,12 @@ internal class DatadogRumMonitor(
         }
     }
 
-    private fun getEventTime(attributes: Map<String, Any?>): Time {
-        return (attributes[RumAttributes.INTERNAL_TIMESTAMP] as? Long)?.asTime() ?: getCurrentTime()
-    }
+    private fun getEventTime(attributes: Map<String, Any?>): Time =
+        (attributes[RumAttributes.INTERNAL_TIMESTAMP] as? Long)
+            ?.let { Time.fromTimestampMillis(it, sdkCore.timeProvider) }
+            ?: now()
 
-    private fun getCurrentTime() =
-        Time(sdkCore.timeProvider.getDeviceTimestampMillis(), sdkCore.timeProvider.getDeviceElapsedTimeNanos())
+    private fun now(): Time = Time.now(sdkCore.timeProvider)
 
     private fun getErrorType(attributes: Map<String, Any?>): String? {
         return attributes[RumAttributes.INTERNAL_ERROR_TYPE] as? String

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetector.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetector.kt
@@ -11,7 +11,6 @@ import androidx.annotation.UiThread
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.rum.internal.domain.Time
-import com.datadog.android.rum.internal.domain.asTimeNs
 import com.datadog.android.rum.startup.AppStartupActivityPredicate
 
 internal interface RumAppStartupDetector {
@@ -38,8 +37,8 @@ internal interface RumAppStartupDetector {
             return RumAppStartupDetectorImpl(
                 application = application,
                 buildSdkVersionProvider = BuildSdkVersionProvider.DEFAULT,
-                appStartupTimeProvider = { sdkCore.appStartTimeNs.asTimeNs() },
-                timeProvider = { Time() },
+                appStartupTime = { Time.fromNanoTime(sdkCore.appStartTimeNs, sdkCore.timeProvider) },
+                currentTime = { Time.now(sdkCore.timeProvider) },
                 listener = listener,
                 appStartupActivityPredicate = appStartupActivityPredicate,
                 rumFirstDrawTimeReporter = rumFirstDrawTimeReporter

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImpl.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImpl.kt
@@ -21,8 +21,8 @@ import kotlin.time.Duration.Companion.seconds
 internal class RumAppStartupDetectorImpl(
     private val application: Application,
     private val buildSdkVersionProvider: BuildSdkVersionProvider,
-    private val appStartupTimeProvider: () -> Time,
-    private val timeProvider: () -> Time,
+    private val appStartupTime: () -> Time,
+    private val currentTime: () -> Time,
     private val listener: RumAppStartupDetector.Listener,
     private val appStartupActivityPredicate: AppStartupActivityPredicate,
     private val rumFirstDrawTimeReporter: RumFirstDrawTimeReporter
@@ -82,7 +82,7 @@ internal class RumAppStartupDetectorImpl(
     @Suppress("LongMethod")
     private fun onBeforeActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
         numberOfActivities++
-        val now = timeProvider()
+        val now = currentTime()
 
         val shouldTrackStartup = appStartupActivityPredicate.shouldTrackStartup(activity)
 
@@ -106,7 +106,7 @@ internal class RumAppStartupDetectorImpl(
                 pendingScenario == null
 
         if (isFirstTrackedActivityWithNoPendingStartup) {
-            val processStartTime = appStartupTimeProvider()
+            val processStartTime = appStartupTime()
 
             val gapNs = now.nanoTime - processStartTime.nanoTime
             val hasSavedInstanceStateBundle = savedInstanceState != null

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureStartupDetectorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureStartupDetectorTest.kt
@@ -66,6 +66,9 @@ internal class RumFeatureStartupDetectorTest {
     @Forgery
     lateinit var fakeConfiguration: RumFeature.Configuration
 
+    @Forgery
+    lateinit var fakeTime: Time
+
     @Mock
     lateinit var mockSdkCore: InternalSdkCore
 
@@ -117,7 +120,6 @@ internal class RumFeatureStartupDetectorTest {
         val listener = extractStartupDetectorListener()
 
         val fakeActivity = mock<Activity>()
-        val fakeTime = Time(nanoTime = 100_000L)
         val fakeScenario = RumStartupScenario.Cold(
             hasSavedInstanceStateBundle = false,
             activity = WeakReference(fakeActivity),
@@ -143,7 +145,6 @@ internal class RumFeatureStartupDetectorTest {
         GlobalRumMonitor.registerIfAbsent(mock<RumMonitor>(), mockSdkCore)
 
         val fakeActivity = mock<Activity>()
-        val fakeTime = Time(nanoTime = 100_000L)
         val fakeScenario = RumStartupScenario.Cold(
             hasSavedInstanceStateBundle = false,
             activity = WeakReference(fakeActivity),
@@ -170,7 +171,6 @@ internal class RumFeatureStartupDetectorTest {
         val listener = extractStartupDetectorListener()
 
         val fakeActivity = mock<Activity>()
-        val fakeTime = Time(nanoTime = 100_000L)
         val fakeScenario = RumStartupScenario.Cold(
             hasSavedInstanceStateBundle = false,
             activity = WeakReference(fakeActivity),
@@ -200,7 +200,6 @@ internal class RumFeatureStartupDetectorTest {
         val listener = extractStartupDetectorListener()
 
         val fakeActivity = mock<Activity>()
-        val fakeTime = Time(nanoTime = 100_000L)
         val fakeScenario = RumStartupScenario.Cold(
             hasSavedInstanceStateBundle = false,
             activity = WeakReference(fakeActivity),
@@ -236,7 +235,7 @@ internal class RumFeatureStartupDetectorTest {
             hasSavedInstanceStateBundle = false,
             activity = WeakReference(mock()),
             appStartActivityOnCreateGapNs = 0L,
-            initialTime = Time(nanoTime = 100_000L)
+            initialTime = fakeTime
         )
 
         // When

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/TimeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/TimeTest.kt
@@ -6,12 +6,14 @@
 
 package com.datadog.android.rum.internal.domain
 
+import com.datadog.android.internal.tests.stub.StubTimeProvider
 import com.datadog.android.rum.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.data.Offset.offset
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.util.concurrent.TimeUnit
@@ -20,55 +22,55 @@ import java.util.concurrent.TimeUnit
 @ForgeConfiguration(Configurator::class)
 internal class TimeTest {
 
-    @Test
-    fun `creates Time with current millis and nanos`() {
-        val startMs = System.currentTimeMillis()
-        val startNs = System.nanoTime()
+    private lateinit var stubTimeProvider: StubTimeProvider
 
-        val time = Time()
-
-        val endNs = System.nanoTime()
-        val endMs = System.currentTimeMillis()
-
-        assertThat(time.timestamp).isBetween(startMs, endMs)
-        assertThat(time.nanoTime).isBetween(startNs, endNs)
-    }
-
-    @Test
-    fun `M convert timestamp to Time W asTime()`(
-        @LongForgery(1000000000000, 2000000000000) timestamp: Long
-    ) {
-        val startMs = System.currentTimeMillis()
-        val startNs = System.nanoTime()
-        val time = timestamp.asTime()
-        val endNs = System.nanoTime()
-        val endMs = System.currentTimeMillis()
-
-        assertThat(time.timestamp).isEqualTo(timestamp)
-        val nanoOffset = time.nanoTime - ((startNs + endNs) / 2)
-        val milliOffset = time.timestamp - ((startMs + endMs) / 2)
-        assertThat(TimeUnit.NANOSECONDS.toMillis(nanoOffset)).isCloseTo(
-            milliOffset,
-            offset(2L)
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        stubTimeProvider = StubTimeProvider(
+            deviceTimestampMs = forge.aLong(min = 1000000000000, max = 2000000000000),
+            elapsedTimeNs = forge.aLong(min = 1000000000000, max = 2000000000000)
         )
     }
 
     @Test
-    fun `M convert nanoTime to Time W asTimeNs()`(
-        @LongForgery(1000000000000, 2000000000000) nanoTime: Long
-    ) {
-        val startMs = System.currentTimeMillis()
-        val startNs = System.nanoTime()
-        val time = nanoTime.asTimeNs()
-        val endNs = System.nanoTime()
-        val endMs = System.currentTimeMillis()
+    fun `M read current time from provider W now()`() {
+        // When
+        val time = Time.now(stubTimeProvider)
 
-        assertThat(time.nanoTime).isEqualTo(nanoTime)
-        val nanoOffset = time.nanoTime - ((startNs + endNs) / 2)
-        val milliOffset = time.timestamp - ((startMs + endMs) / 2)
-        assertThat(TimeUnit.NANOSECONDS.toMillis(nanoOffset)).isCloseTo(
-            milliOffset,
-            offset(2L)
-        )
+        // Then
+        assertThat(time.timestamp).isEqualTo(stubTimeProvider.deviceTimestampMs)
+        assertThat(time.nanoTime).isEqualTo(stubTimeProvider.elapsedTimeNs)
+    }
+
+    @Test
+    fun `M convert timestamp to Time W fromTimestampMillis()`(
+        @LongForgery(1000000000000, 2000000000000) fakeTimestampMs: Long
+    ) {
+        // Given
+        val expectedNanoTime = stubTimeProvider.elapsedTimeNs +
+            TimeUnit.MILLISECONDS.toNanos(fakeTimestampMs - stubTimeProvider.deviceTimestampMs)
+
+        // When
+        val time = Time.fromTimestampMillis(fakeTimestampMs, stubTimeProvider)
+
+        // Then
+        assertThat(time.timestamp).isEqualTo(fakeTimestampMs)
+        assertThat(time.nanoTime).isEqualTo(expectedNanoTime)
+    }
+
+    @Test
+    fun `M convert nanoTime to Time W fromNanoTime()`(
+        @LongForgery(1000000000000, 2000000000000) fakeNanoTime: Long
+    ) {
+        // Given
+        val expectedTimestamp = stubTimeProvider.deviceTimestampMs +
+            TimeUnit.NANOSECONDS.toMillis(fakeNanoTime - stubTimeProvider.elapsedTimeNs)
+
+        // When
+        val time = Time.fromNanoTime(fakeNanoTime, stubTimeProvider)
+
+        // Then
+        assertThat(time.nanoTime).isEqualTo(fakeNanoTime)
+        assertThat(time.timestamp).isEqualTo(expectedTimestamp)
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeAttributePropagationTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeAttributePropagationTest.kt
@@ -113,6 +113,7 @@ internal class RumActionScopeAttributePropagationTest {
     @Forgery
     lateinit var fakeParentContext: RumContext
 
+    @Forgery
     lateinit var fakeEventTime: Time
 
     lateinit var fakeEvent: RumRawEvent
@@ -148,8 +149,6 @@ internal class RumActionScopeAttributePropagationTest {
 
     @BeforeEach
     fun `set up`(forge: Forge) {
-        fakeEventTime = Time()
-
         fakeParentAttributes = forge.exhaustiveAttributes()
         fakeActionAttributes = forge.exhaustiveAttributes()
         whenever(mockParentScope.getCustomAttributes()) doReturn fakeParentAttributes.toMutableMap()

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
@@ -121,6 +121,7 @@ internal class RumActionScopeTest {
 
     private var fakeSampleRate: Float = 0f
 
+    @Forgery
     lateinit var fakeEventTime: Time
 
     lateinit var fakeEvent: RumRawEvent
@@ -152,7 +153,6 @@ internal class RumActionScopeTest {
 
         fakeParentContext = fakeParentContext.copy(syntheticsTestId = null, syntheticsResultId = null)
 
-        fakeEventTime = Time()
         val maxLimit = 1000L
         val minLimit = -1000L
         fakeServerOffset =
@@ -604,7 +604,7 @@ internal class RumActionScopeTest {
         @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
         // Given
-        var key: Any? = Object()
+        var key: Any? = Any()
         val keyRef = WeakReference(key)
 
         // When
@@ -1000,7 +1000,7 @@ internal class RumActionScopeTest {
         testedScope.resourceCount = count
 
         // When
-        fakeEvent = RumRawEvent.StartView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = startViewEvent()
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1063,7 +1063,7 @@ internal class RumActionScopeTest {
         testedScope.longTaskCount = count
 
         // When
-        fakeEvent = RumRawEvent.StartView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = startViewEvent()
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1126,7 +1126,7 @@ internal class RumActionScopeTest {
         testedScope.errorCount = count
 
         // When
-        fakeEvent = RumRawEvent.StartView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = startViewEvent()
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1198,7 +1198,7 @@ internal class RumActionScopeTest {
         testedScope.crashCount = fatalCount
 
         // When
-        fakeEvent = RumRawEvent.StartView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = startViewEvent()
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1267,7 +1267,7 @@ internal class RumActionScopeTest {
         testedScope.resourceCount = count
 
         // When
-        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = stopViewEvent()
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1330,7 +1330,7 @@ internal class RumActionScopeTest {
         testedScope.longTaskCount = count
 
         // When
-        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = stopViewEvent()
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1393,7 +1393,7 @@ internal class RumActionScopeTest {
         testedScope.errorCount = count
 
         // When
-        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = stopViewEvent()
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1464,7 +1464,7 @@ internal class RumActionScopeTest {
         testedScope.crashCount = fatalCount
 
         // When
-        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = stopViewEvent()
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1533,7 +1533,7 @@ internal class RumActionScopeTest {
         testedScope.resourceCount = count
 
         // When
-        fakeEvent = RumRawEvent.StopSession()
+        fakeEvent = stopSessionEvent()
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1596,7 +1596,7 @@ internal class RumActionScopeTest {
         testedScope.longTaskCount = count
 
         // When
-        fakeEvent = RumRawEvent.StopSession()
+        fakeEvent = stopSessionEvent()
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1659,7 +1659,7 @@ internal class RumActionScopeTest {
         testedScope.errorCount = count
 
         // When
-        fakeEvent = RumRawEvent.StopSession()
+        fakeEvent = stopSessionEvent()
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1730,7 +1730,7 @@ internal class RumActionScopeTest {
         testedScope.crashCount = fatalCount
 
         // When
-        fakeEvent = RumRawEvent.StopSession()
+        fakeEvent = stopSessionEvent()
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -2410,7 +2410,7 @@ internal class RumActionScopeTest {
         testedScope.resourceCount = 0
         testedScope.errorCount = 0
         testedScope.crashCount = 0
-        fakeEvent = RumRawEvent.StartView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = startViewEvent()
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -2474,7 +2474,7 @@ internal class RumActionScopeTest {
         testedScope.errorCount = 0
         testedScope.crashCount = 0
         testedScope.longTaskCount = 0
-        fakeEvent = RumRawEvent.StartView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = startViewEvent()
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -2538,7 +2538,7 @@ internal class RumActionScopeTest {
         testedScope.resourceCount = 0
         testedScope.errorCount = 0
         testedScope.crashCount = 0
-        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = stopViewEvent()
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -2602,7 +2602,7 @@ internal class RumActionScopeTest {
         testedScope.errorCount = 0
         testedScope.crashCount = 0
         testedScope.longTaskCount = 0
-        fakeEvent = RumRawEvent.StopSession()
+        fakeEvent = stopSessionEvent()
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -2964,7 +2964,7 @@ internal class RumActionScopeTest {
     fun `M send Action W handleEvent(SendCustomActionNow)`() {
         // When
         testedScope.type = RumActionType.CUSTOM
-        val event = RumRawEvent.SendCustomActionNow()
+        val event = sendCustomActionNowEvent()
         val result = testedScope.handleEvent(event, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -3126,7 +3126,7 @@ internal class RumActionScopeTest {
     @Test
     fun `M notify about success W handleEvent() { write succeeded }`() {
         // Given
-        val event = RumRawEvent.SendCustomActionNow()
+        val event = sendCustomActionNowEvent()
 
         // When
         testedScope.type = RumActionType.CUSTOM
@@ -3143,7 +3143,7 @@ internal class RumActionScopeTest {
     @Test
     fun `M notify about error W handleEvent() { write failed }`() {
         // Given
-        val event = RumRawEvent.SendCustomActionNow()
+        val event = sendCustomActionNowEvent()
 
         // When
         testedScope.type = RumActionType.CUSTOM
@@ -3163,7 +3163,7 @@ internal class RumActionScopeTest {
         forge: Forge
     ) {
         // Given
-        val event = RumRawEvent.SendCustomActionNow()
+        val event = sendCustomActionNowEvent()
 
         // When
         testedScope.type = RumActionType.CUSTOM
@@ -3631,9 +3631,22 @@ internal class RumActionScopeTest {
         return fakeEventTime.timestamp + fakeServerOffset
     }
 
+    private fun startViewEvent() =
+        RumRawEvent.StartView(RumScopeKey.from(Any()), emptyMap(), timeWithOffset(TEST_ACTION_DURATION_MS))
+
+    private fun stopViewEvent() =
+        RumRawEvent.StopView(RumScopeKey.from(Any()), emptyMap(), timeWithOffset(TEST_ACTION_DURATION_MS))
+
+    private fun stopSessionEvent() =
+        RumRawEvent.StopSession(timeWithOffset(TEST_ACTION_DURATION_MS))
+
+    private fun sendCustomActionNowEvent() =
+        RumRawEvent.SendCustomActionNow(timeWithOffset(TEST_ACTION_DURATION_MS))
+
     // endregion
 
     companion object {
+        internal const val TEST_ACTION_DURATION_MS = 10L
         internal const val TEST_INACTIVITY_MS = 50L
         internal const val TEST_MAX_DURATION_MS = 500L
         internal val TEST_MAX_DURATION_NS = TimeUnit.MILLISECONDS.toNanos(TEST_MAX_DURATION_MS)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeAttributePropagationTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeAttributePropagationTest.kt
@@ -58,7 +58,6 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
-import java.util.concurrent.TimeUnit
 import kotlin.math.max
 import kotlin.math.min
 
@@ -136,6 +135,7 @@ internal class RumApplicationScopeAttributePropagationTest {
     @Mock
     lateinit var mockSessionSampler: Sampler<String>
 
+    @Forgery
     lateinit var fakeEventTime: Time
 
     lateinit var fakeEvent: RumRawEvent
@@ -176,19 +176,14 @@ internal class RumApplicationScopeAttributePropagationTest {
             source = forge.aValueFrom(ViewEvent.ViewEventSource::class.java).toJson().asString
         )
 
-        val fakeOffset = -forge.aLong(1000, 50000)
-        val fakeTimestamp = System.currentTimeMillis() + fakeOffset
-        val fakeNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(fakeOffset)
-        val maxLimit = max(Long.MAX_VALUE - fakeTimestamp, Long.MAX_VALUE)
-        val minLimit = min(-fakeTimestamp, maxLimit)
+        val maxLimit = max(Long.MAX_VALUE - fakeEventTime.timestamp, Long.MAX_VALUE)
+        val minLimit = min(-fakeEventTime.timestamp, maxLimit)
 
         fakeDatadogContext = fakeDatadogContext.copy(
             time = fakeTimeInfoAtScopeStart.copy(
                 serverTimeOffsetMs = forge.aLong(min = minLimit, max = maxLimit)
             )
         )
-        fakeEventTime = Time(fakeTimestamp, fakeNanos)
-
         whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
             val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(1)
             callback.invoke(fakeDatadogContext, mockEventWriteScope)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -22,6 +22,7 @@ import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.domain.InfoProvider
+import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.accessibility.AccessibilitySnapshotManager
 import com.datadog.android.rum.internal.domain.battery.BatteryInfo
 import com.datadog.android.rum.internal.domain.display.DisplayInfo
@@ -29,7 +30,6 @@ import com.datadog.android.rum.internal.domain.state.ViewUIPerformanceReport
 import com.datadog.android.rum.internal.instrumentation.insights.InsightsCollector
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
-import com.datadog.android.rum.internal.startup.RumAppStartupTelemetryReporter
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.metric.interactiontonextview.LastInteractionIdentifier
 import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
@@ -101,9 +101,6 @@ internal class RumApplicationScopeTest {
     lateinit var mockDisplayInfoProvider: InfoProvider<DisplayInfo>
 
     @Mock
-    lateinit var mockRumAppStartupTelemetryReporter: RumAppStartupTelemetryReporter
-
-    @Mock
     private lateinit var mockInsightsCollector: InsightsCollector
 
     @Mock
@@ -161,6 +158,9 @@ internal class RumApplicationScopeTest {
     lateinit var viewUIPerformanceReport: ViewUIPerformanceReport
 
     private var fakeRumSessionType: RumSessionType? = null
+
+    @Forgery
+    private lateinit var fakeEventTime: Time
 
     @BeforeEach
     fun `set up`(forge: Forge) {
@@ -236,7 +236,7 @@ internal class RumApplicationScopeTest {
         @StringForgery fakeResultId: String
     ) {
         // Given
-        val event = RumRawEvent.SetSyntheticsTestAttribute(fakeTestId, fakeResultId)
+        val event = RumRawEvent.SetSyntheticsTestAttribute(fakeTestId, fakeResultId, fakeEventTime)
 
         // When
         val result = testedScope.handleEvent(event, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -325,7 +325,12 @@ internal class RumApplicationScopeTest {
     @Test
     fun `M have no active session W stopping current session`() {
         // When
-        testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        testedScope.handleEvent(
+            RumRawEvent.StopSession(fakeEventTime),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
 
         // Then
         val activeSession = testedScope.activeSession
@@ -338,7 +343,7 @@ internal class RumApplicationScopeTest {
         val mockSession: RumSessionScope = mock()
         testedScope.childScopes.clear()
         testedScope.childScopes.add(mockSession)
-        val stopEvent = RumRawEvent.StopSession()
+        val stopEvent = RumRawEvent.StopSession(fakeEventTime)
         whenever(
             mockSession.handleEvent(
                 any(),
@@ -363,11 +368,17 @@ internal class RumApplicationScopeTest {
     ) {
         // Given
         val initialSession = testedScope.childScopes.first()
-        testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        testedScope.handleEvent(
+            RumRawEvent.StopSession(fakeEventTime),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
         testedScope.handleEvent(
             RumRawEvent.StartView(
                 key = RumScopeKey.from(viewKey, viewName),
-                attributes = mapOf()
+                attributes = mapOf(),
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
@@ -395,13 +406,19 @@ internal class RumApplicationScopeTest {
         testedScope.handleEvent(
             RumRawEvent.StartView(
                 key = fakeKey,
-                attributes = mockAttributes
+                attributes = mockAttributes,
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
-        testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        testedScope.handleEvent(
+            RumRawEvent.StopSession(fakeEventTime),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
 
         // When
         testedScope.handleEvent(
@@ -409,7 +426,8 @@ internal class RumApplicationScopeTest {
                 type = RumActionType.TAP,
                 name = "MockAction",
                 waitForStop = false,
-                attributes = mapOf()
+                attributes = mapOf(),
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -108,6 +108,7 @@ internal class RumContinuousActionScopeTest {
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
+    @Forgery
     private lateinit var fakeEventTime: Time
 
     private lateinit var fakeEvent: RumRawEvent
@@ -138,7 +139,6 @@ internal class RumContinuousActionScopeTest {
 
         fakeParentContext = fakeParentContext.copy(syntheticsTestId = null, syntheticsResultId = null)
 
-        fakeEventTime = Time()
         val maxLimit = Long.MAX_VALUE - fakeEventTime.timestamp
         val minLimit = -fakeEventTime.timestamp
         fakeServerOffset =
@@ -474,7 +474,7 @@ internal class RumContinuousActionScopeTest {
         @Forgery kind: RumResourceKind
     ) {
         // When
-        fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
+        fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap(), fakeEventTime)
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         fakeEvent = RumRawEvent.StopAction(fakeType, fakeName, emptyMap(), fakeEventTime)
         val expectedStoppedTimestamp = fakeEvent.eventTime.nanoTime
@@ -560,7 +560,7 @@ internal class RumContinuousActionScopeTest {
         @Forgery throwable: Throwable
     ) {
         // When
-        fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
+        fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap(), fakeEventTime)
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         fakeEvent = RumRawEvent.StopAction(fakeType, fakeName, emptyMap(), fakeEventTime)
         val expectedStoppedTimestamp = fakeEvent.eventTime.nanoTime
@@ -667,7 +667,7 @@ internal class RumContinuousActionScopeTest {
         val errorType = forge.aNullable { anAlphabeticalString() }
 
         // When
-        fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
+        fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap(), fakeEventTime)
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         fakeEvent = RumRawEvent.StopAction(fakeType, fakeName, emptyMap(), fakeEventTime)
         val expectedStoppedTimestamp = fakeEvent.eventTime.nanoTime
@@ -764,10 +764,10 @@ internal class RumContinuousActionScopeTest {
         @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
         // Given
-        var key: Any? = Object()
+        var key: Any? = Any()
 
         // When
-        fakeEvent = RumRawEvent.StartResource(key.toString(), url, method, emptyMap())
+        fakeEvent = RumRawEvent.StartResource(key.toString(), url, method, emptyMap(), fakeEventTime)
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         fakeEvent = RumRawEvent.StopAction(fakeType, fakeName, emptyMap(), fakeEventTime)
         val expectedStoppedTimestamp = fakeEvent.eventTime.nanoTime
@@ -851,7 +851,8 @@ internal class RumContinuousActionScopeTest {
             stacktrace = null,
             isFatal = false,
             threads = emptyList(),
-            attributes = emptyMap()
+            attributes = emptyMap(),
+            eventTime = fakeEventTime
         )
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         val stopActionDelay = TEST_INACTIVITY_MS * 2
@@ -948,7 +949,8 @@ internal class RumContinuousActionScopeTest {
             stacktrace = null,
             isFatal = true,
             threads = emptyList(),
-            attributes = emptyMap()
+            attributes = emptyMap(),
+            eventTime = fakeEventTime
         )
         val expectedFrustrationCount = if (fakeType == RumActionType.TAP) {
             1
@@ -1032,7 +1034,8 @@ internal class RumContinuousActionScopeTest {
             stacktrace = null,
             isFatal = false,
             threads = emptyList(),
-            attributes = emptyMap()
+            attributes = emptyMap(),
+            eventTime = fakeEventTime
         )
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         fakeEvent = RumRawEvent.AddError(
@@ -1042,7 +1045,8 @@ internal class RumContinuousActionScopeTest {
             stacktrace = null,
             isFatal = true,
             threads = emptyList(),
-            attributes = emptyMap()
+            attributes = emptyMap(),
+            eventTime = fakeEventTime
         )
         val expectedFrustrationCount = if (fakeType == RumActionType.TAP) {
             1
@@ -1116,7 +1120,7 @@ internal class RumContinuousActionScopeTest {
     fun `M send Action immediately W handleEvent(StopView) {viewTreeChangeCount != 0}`() {
         // When
         val expectedStoppedTimestamp = fakeEventTime.nanoTime
-        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Any()), emptyMap(), timeWithOffset(10L))
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1184,7 +1188,7 @@ internal class RumContinuousActionScopeTest {
         testedScope.resourceCount = count
 
         // When
-        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Any()), emptyMap(), timeWithOffset(10L))
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1252,7 +1256,7 @@ internal class RumContinuousActionScopeTest {
         testedScope.longTaskCount = count
 
         // When
-        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Any()), emptyMap(), timeWithOffset(10L))
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1325,7 +1329,7 @@ internal class RumContinuousActionScopeTest {
         }
 
         // When
-        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Any()), emptyMap(), timeWithOffset(10L))
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1406,7 +1410,7 @@ internal class RumContinuousActionScopeTest {
         }
 
         // When
-        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Any()), emptyMap(), timeWithOffset(10L))
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1475,7 +1479,7 @@ internal class RumContinuousActionScopeTest {
     fun `M send Action immediately W handleEvent(StopSession) {viewTreeChangeCount != 0}`() {
         // When
         val expectedStoppedTimestamp = fakeEventTime.nanoTime
-        fakeEvent = RumRawEvent.StopSession()
+        fakeEvent = RumRawEvent.StopSession(timeWithOffset(10L))
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1543,7 +1547,7 @@ internal class RumContinuousActionScopeTest {
         testedScope.resourceCount = count
 
         // When
-        fakeEvent = RumRawEvent.StopSession()
+        fakeEvent = RumRawEvent.StopSession(timeWithOffset(10L))
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1611,7 +1615,7 @@ internal class RumContinuousActionScopeTest {
         testedScope.longTaskCount = count
 
         // When
-        fakeEvent = RumRawEvent.StopSession()
+        fakeEvent = RumRawEvent.StopSession(timeWithOffset(10L))
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -1679,7 +1683,7 @@ internal class RumContinuousActionScopeTest {
         testedScope.errorCount = count
 
         // When
-        fakeEvent = RumRawEvent.StopSession()
+        fakeEvent = RumRawEvent.StopSession(timeWithOffset(10L))
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         val expectedFrustrationCount = if (fakeType == RumActionType.TAP) {
             1
@@ -1765,7 +1769,7 @@ internal class RumContinuousActionScopeTest {
         }
 
         // When
-        fakeEvent = RumRawEvent.StopSession()
+        fakeEvent = RumRawEvent.StopSession(timeWithOffset(10L))
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then
@@ -2514,7 +2518,7 @@ internal class RumContinuousActionScopeTest {
         testedScope.errorCount = 0
         testedScope.crashCount = 0
         testedScope.longTaskCount = 0
-        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Any()), emptyMap(), timeWithOffset(10L))
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -2583,7 +2587,7 @@ internal class RumContinuousActionScopeTest {
         testedScope.errorCount = 0
         testedScope.crashCount = 0
         testedScope.longTaskCount = 0
-        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Object()), emptyMap())
+        fakeEvent = RumRawEvent.StopView(RumScopeKey.from(Any()), emptyMap(), timeWithOffset(10L))
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -2650,7 +2654,7 @@ internal class RumContinuousActionScopeTest {
         testedScope.errorCount = 0
         testedScope.crashCount = 0
         testedScope.longTaskCount = 0
-        fakeEvent = RumRawEvent.StopSession()
+        fakeEvent = RumRawEvent.StopSession(timeWithOffset(10L))
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -2720,7 +2724,7 @@ internal class RumContinuousActionScopeTest {
         testedScope.errorCount = 0
         testedScope.crashCount = 0
         testedScope.longTaskCount = 0
-        fakeEvent = RumRawEvent.StopSession()
+        fakeEvent = RumRawEvent.StopSession(timeWithOffset(10L))
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -2819,7 +2823,7 @@ internal class RumContinuousActionScopeTest {
         @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
         // When
-        fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
+        fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap(), fakeEventTime)
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         val result2 = testedScope.handleEvent(
             mockEvent(TEST_INACTIVITY_MS * 2),
@@ -2841,7 +2845,7 @@ internal class RumContinuousActionScopeTest {
         @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
         // When
-        fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
+        fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap(), fakeEventTime)
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         val stopActionDelay = TEST_INACTIVITY_MS * 2
         fakeEvent = RumRawEvent.StopAction(fakeType, fakeName, emptyMap(), timeWithOffset(stopActionDelay))
@@ -2937,7 +2941,7 @@ internal class RumContinuousActionScopeTest {
         @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
         // When
-        fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
+        fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap(), fakeEventTime)
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         val stopActionDelay = TEST_INACTIVITY_MS * 2
         fakeEvent = RumRawEvent.StopAction(fakeType, fakeName, emptyMap(), timeWithOffset(stopActionDelay))
@@ -3008,7 +3012,7 @@ internal class RumContinuousActionScopeTest {
     fun `M send Action W handleEvent(SendCustomActionNow)`() {
         // When
         testedScope.type = RumActionType.CUSTOM
-        val event = RumRawEvent.SendCustomActionNow()
+        val event = RumRawEvent.SendCustomActionNow(timeWithOffset(10L))
         val result = testedScope.handleEvent(event, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // Then

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
@@ -28,7 +28,7 @@ internal fun Forge.interactiveRumRawEvent(): RumRawEvent {
     )
 }
 
-internal fun Forge.startViewEvent(eventTime: Time = Time()): RumRawEvent.StartView {
+internal fun Forge.startViewEvent(eventTime: Time = getForgery()): RumRawEvent.StartView {
     return RumRawEvent.StartView(
         key = getForgery(),
         attributes = exhaustiveAttributes(),
@@ -39,13 +39,14 @@ internal fun Forge.startViewEvent(eventTime: Time = Time()): RumRawEvent.StartVi
 internal fun Forge.stopViewEvent(): RumRawEvent.StopView {
     return RumRawEvent.StopView(
         key = getForgery(),
-        attributes = exhaustiveAttributes()
+        attributes = exhaustiveAttributes(),
+        eventTime = getForgery()
     )
 }
 
 internal fun Forge.startActionEvent(
     continuous: Boolean? = null,
-    eventTime: Time = Time(),
+    eventTime: Time = getForgery(),
     nativeHeatmapActionData: NativeHeatmapActionData? = null
 ): RumRawEvent.StartAction {
     return RumRawEvent.StartAction(
@@ -62,7 +63,8 @@ internal fun Forge.stopActionEvent(): RumRawEvent.StopAction {
     return RumRawEvent.StopAction(
         type = aValueFrom(RumActionType::class.java),
         name = anAlphabeticalString(),
-        attributes = exhaustiveAttributes()
+        attributes = exhaustiveAttributes(),
+        eventTime = getForgery()
     )
 }
 
@@ -71,7 +73,8 @@ internal fun Forge.startResourceEvent(): RumRawEvent.StartResource {
         key = anAlphabeticalString(),
         url = getForgery<URL>().toString(),
         method = aValueFrom(RumResourceMethod::class.java),
-        attributes = exhaustiveAttributes()
+        attributes = exhaustiveAttributes(),
+        eventTime = getForgery()
     )
 }
 
@@ -81,7 +84,8 @@ internal fun Forge.stopResourceEvent(): RumRawEvent.StopResource {
         statusCode = aNullable { aLong(100, 600) },
         size = aNullable { aPositiveLong() },
         kind = aValueFrom(RumResourceKind::class.java),
-        attributes = exhaustiveAttributes()
+        attributes = exhaustiveAttributes(),
+        eventTime = getForgery()
     )
 }
 
@@ -89,7 +93,8 @@ internal fun Forge.startOperationEvent(): RumRawEvent.StartOperation {
     return RumRawEvent.StartOperation(
         name = anAlphabeticalString(),
         operationKey = aNullable { anAlphabeticalString() },
-        attributes = exhaustiveAttributes()
+        attributes = exhaustiveAttributes(),
+        eventTime = getForgery()
     )
 }
 
@@ -97,8 +102,9 @@ internal fun Forge.stopOperationEvent(): RumRawEvent.StopOperation {
     return RumRawEvent.StopOperation(
         name = anAlphabeticalString(),
         operationKey = aNullable { anAlphabeticalString() },
-        failureReason = aNullable { aValueFrom(FailureReason::class.java) },
-        attributes = exhaustiveAttributes()
+        attributes = exhaustiveAttributes(),
+        eventTime = getForgery(),
+        failureReason = aNullable { aValueFrom(FailureReason::class.java) }
     )
 }
 
@@ -109,7 +115,8 @@ internal fun Forge.stopResourceWithErrorEvent(): RumRawEvent.StopResourceWithErr
         source = aValueFrom(RumErrorSource::class.java),
         message = anAlphabeticalString(),
         throwable = aThrowable(),
-        attributes = exhaustiveAttributes()
+        attributes = exhaustiveAttributes(),
+        eventTime = getForgery()
     )
 }
 
@@ -121,7 +128,8 @@ internal fun Forge.stopResourceWithStacktraceEvent(): RumRawEvent.StopResourceWi
         message = anAlphabeticalString(),
         stackTrace = anAlphabeticalString(),
         errorType = aNullable { anAlphabeticalString() },
-        attributes = exhaustiveAttributes()
+        attributes = exhaustiveAttributes(),
+        eventTime = getForgery()
     )
 }
 
@@ -135,23 +143,25 @@ internal fun Forge.addErrorEvent(): RumRawEvent.AddError {
         isFatal = isFatal,
         threads = if (isFatal) aList { getForgery() } else emptyList(),
         timeSinceAppStartNs = if (isFatal) aPositiveLong() else null,
-        attributes = exhaustiveAttributes()
+        attributes = exhaustiveAttributes(),
+        eventTime = getForgery()
     )
 }
 
 internal fun Forge.addViewLoadingTimeEvent(): RumRawEvent.AddViewLoadingTime {
-    return RumRawEvent.AddViewLoadingTime(overwrite = aBool())
+    return RumRawEvent.AddViewLoadingTime(overwrite = aBool(), eventTime = getForgery())
 }
 
 internal fun Forge.addLongTaskEvent(): RumRawEvent.AddLongTask {
     return RumRawEvent.AddLongTask(
         durationNs = aLong(min = 1),
-        target = anAlphabeticalString()
+        target = anAlphabeticalString(),
+        eventTime = getForgery()
     )
 }
 
 internal fun Forge.applicationStartedEvent(): RumRawEvent.ApplicationStarted {
-    val time = Time()
+    val time = getForgery<Time>()
     return RumRawEvent.ApplicationStarted(
         eventTime = time,
         applicationStartupNanos = aLong(min = 0L, max = time.nanoTime)
@@ -159,44 +169,39 @@ internal fun Forge.applicationStartedEvent(): RumRawEvent.ApplicationStarted {
 }
 
 internal fun Forge.sdkInitEvent(): RumRawEvent.SdkInit {
-    val time = Time()
     return RumRawEvent.SdkInit(
         isAppInForeground = aBool(),
-        eventTime = time
+        eventTime = getForgery()
     )
 }
 
 internal fun Forge.updatePerformanceMetricEvent(): RumRawEvent.UpdatePerformanceMetric {
-    val time = Time()
     return RumRawEvent.UpdatePerformanceMetric(
         metric = getForgery(),
         value = aDouble(),
-        eventTime = time
+        eventTime = getForgery()
     )
 }
 
 internal fun Forge.updateExternalRefreshRateEvent(): RumRawEvent.UpdateExternalRefreshRate {
-    val time = Time()
     return RumRawEvent.UpdateExternalRefreshRate(
         frameTimeSeconds = aDouble(),
-        eventTime = time
+        eventTime = getForgery()
     )
 }
 
 internal fun Forge.addFeatureFlagEvaluationEvent(): RumRawEvent.AddFeatureFlagEvaluation {
-    val time = Time()
     return RumRawEvent.AddFeatureFlagEvaluation(
         name = anAlphabeticalString(),
         value = anElementFrom(aString(), anInt(), Any()),
-        eventTime = time
+        eventTime = getForgery()
     )
 }
 
 internal fun Forge.addCustomTimingEvent(): RumRawEvent.AddCustomTiming {
-    val time = Time()
     return RumRawEvent.AddCustomTiming(
         name = anAlphabeticalString(),
-        eventTime = time
+        eventTime = getForgery()
     )
 }
 
@@ -227,22 +232,22 @@ internal fun Forge.invalidBackgroundEvent(): RumRawEvent {
 
 internal fun Forge.anyRumEvent(excluding: List<KClass<out RumRawEvent>> = listOf()): RumRawEvent {
     fun <T : RumRawEvent> strictSameTypePair(key: KClass<T>, value: () -> T) = key to value
-    val allEventsFactories = mapOf<KClass<out RumRawEvent>, () -> RumRawEvent>(
-        strictSameTypePair(RumRawEvent.StartView::class, { startViewEvent() }),
-        strictSameTypePair(RumRawEvent.StopView::class, { stopViewEvent() }),
-        strictSameTypePair(RumRawEvent.StartAction::class, { startActionEvent() }),
-        strictSameTypePair(RumRawEvent.StopAction::class, { stopActionEvent() }),
-        strictSameTypePair(RumRawEvent.StartResource::class, { startResourceEvent() }),
-        strictSameTypePair(RumRawEvent.StopResource::class, { stopResourceEvent() }),
-        strictSameTypePair(RumRawEvent.StopResourceWithError::class, { stopResourceWithErrorEvent() }),
-        strictSameTypePair(RumRawEvent.StopResourceWithStackTrace::class, { stopResourceWithStacktraceEvent() }),
-        strictSameTypePair(RumRawEvent.AddError::class, { addErrorEvent() }),
-        strictSameTypePair(RumRawEvent.AddLongTask::class, { addLongTaskEvent() }),
-        strictSameTypePair(RumRawEvent.AddFeatureFlagEvaluation::class, { addFeatureFlagEvaluationEvent() }),
-        strictSameTypePair(RumRawEvent.AddCustomTiming::class, { addCustomTimingEvent() }),
-        strictSameTypePair(RumRawEvent.UpdatePerformanceMetric::class, { updatePerformanceMetricEvent() }),
-        strictSameTypePair(RumRawEvent.UpdateExternalRefreshRate::class, { updateExternalRefreshRateEvent() }),
-        strictSameTypePair(RumRawEvent.AddViewLoadingTime::class, { addViewLoadingTimeEvent() })
+    val allEventsFactories = mapOf(
+        strictSameTypePair(RumRawEvent.StartView::class) { startViewEvent() },
+        strictSameTypePair(RumRawEvent.StopView::class) { stopViewEvent() },
+        strictSameTypePair(RumRawEvent.StartAction::class) { startActionEvent() },
+        strictSameTypePair(RumRawEvent.StopAction::class) { stopActionEvent() },
+        strictSameTypePair(RumRawEvent.StartResource::class) { startResourceEvent() },
+        strictSameTypePair(RumRawEvent.StopResource::class) { stopResourceEvent() },
+        strictSameTypePair(RumRawEvent.StopResourceWithError::class) { stopResourceWithErrorEvent() },
+        strictSameTypePair(RumRawEvent.StopResourceWithStackTrace::class) { stopResourceWithStacktraceEvent() },
+        strictSameTypePair(RumRawEvent.AddError::class) { addErrorEvent() },
+        strictSameTypePair(RumRawEvent.AddLongTask::class) { addLongTaskEvent() },
+        strictSameTypePair(RumRawEvent.AddFeatureFlagEvaluation::class) { addFeatureFlagEvaluationEvent() },
+        strictSameTypePair(RumRawEvent.AddCustomTiming::class) { addCustomTimingEvent() },
+        strictSameTypePair(RumRawEvent.UpdatePerformanceMetric::class) { updatePerformanceMetricEvent() },
+        strictSameTypePair(RumRawEvent.UpdateExternalRefreshRate::class) { updateExternalRefreshRateEvent() },
+        strictSameTypePair(RumRawEvent.AddViewLoadingTime::class) { addViewLoadingTimeEvent() }
     )
     return this.anElementFrom(
         allEventsFactories
@@ -252,45 +257,9 @@ internal fun Forge.anyRumEvent(excluding: List<KClass<out RumRawEvent>> = listOf
     ).invoke()
 }
 
-internal fun Forge.invalidAppLaunchEvent(): RumRawEvent {
-    return this.anElementFrom(
-        listOf(
-            stopActionEvent(),
-            stopResourceEvent(),
-            stopResourceWithErrorEvent(),
-            stopResourceWithStacktraceEvent()
-        )
-    )
-}
-
-internal fun Forge.silentOrphanEvent(): RumRawEvent {
-    val fakeId = getForgery<UUID>().toString()
-
-    return this.anElementFrom(
-        listOf(
-            RumRawEvent.ApplicationStarted(Time(), aLong()),
-            RumRawEvent.ResetSession(),
-            RumRawEvent.StopView(getForgery(), emptyMap()),
-            RumRawEvent.ActionSent(
-                fakeId,
-                aPositiveInt(),
-                aValueFrom(ActionEvent.ActionEventActionType::class.java),
-                aPositiveLong()
-            ),
-            RumRawEvent.ErrorSent(fakeId),
-            RumRawEvent.LongTaskSent(fakeId),
-            RumRawEvent.ResourceSent(fakeId, getForgery<UUID>().toString(), aPositiveLong()),
-            RumRawEvent.ActionDropped(fakeId),
-            RumRawEvent.ErrorDropped(fakeId),
-            RumRawEvent.LongTaskDropped(fakeId),
-            RumRawEvent.ResourceDropped(fakeId, getForgery<UUID>().toString())
-        )
-    )
-}
-
 internal fun Forge.eventSent(
     viewId: String,
-    eventTime: Time = Time()
+    eventTime: Time = getForgery()
 ): RumRawEvent {
     return this.anElementFrom(
         listOf(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeAttributePropagationTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeAttributePropagationTest.kt
@@ -120,6 +120,7 @@ internal class RumResourceScopeAttributePropagationTest {
     @Forgery
     lateinit var fakeParentContext: RumContext
 
+    @Forgery
     lateinit var fakeEventTime: Time
 
     lateinit var fakeEvent: RumRawEvent
@@ -161,8 +162,6 @@ internal class RumResourceScopeAttributePropagationTest {
 
     @BeforeEach
     fun `set up`(forge: Forge) {
-        fakeEventTime = Time()
-
         fakeParentAttributes = forge.exhaustiveAttributes()
         fakeResourceAttributes = forge.exhaustiveAttributes()
         fakeErrorAttributes = forge.exhaustiveAttributes()
@@ -232,7 +231,14 @@ internal class RumResourceScopeAttributePropagationTest {
         expectedAttributes.putAll(fakeParentAttributes)
         expectedAttributes.putAll(fakeResourceAttributes)
         expectedAttributes.putAll(stopResourceAttributes)
-        val fakeEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, stopResourceAttributes)
+        val fakeEvent = RumRawEvent.StopResource(
+            fakeKey,
+            statusCode,
+            size,
+            kind,
+            stopResourceAttributes,
+            timeWithOffset(RESOURCE_DURATION_MS)
+        )
 
         // When
         testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -263,7 +269,8 @@ internal class RumResourceScopeAttributePropagationTest {
             message,
             source,
             throwable,
-            fakeErrorAttributes
+            fakeErrorAttributes,
+            eventTime = fakeEventTime
         )
 
         // When

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -145,7 +145,8 @@ internal class RumResourceScopeTest {
     private var fakeServerOffset: Long = 0L
     private var fakeSampleRate: Float = 0.0f
 
-    private lateinit var fakeEventTime: Time
+    @Forgery
+    lateinit var fakeEventTime: Time
     private var fakeSourceResourceEvent: ResourceEvent.ResourceEventSource? = null
     private var fakeSourceErrorEvent: ErrorEvent.ErrorEventSource? = null
 
@@ -187,7 +188,6 @@ internal class RumResourceScopeTest {
             null
         }
 
-        fakeEventTime = Time()
         val maxLimit = Long.MAX_VALUE - fakeEventTime.timestamp
         val minLimit = -fakeEventTime.timestamp
         fakeServerOffset =
@@ -1115,7 +1115,7 @@ internal class RumResourceScopeTest {
         expectedAttributes.putAll(attributes)
 
         // When
-        mockEvent = RumRawEvent.AddResourceTiming(fakeKey, timing)
+        mockEvent = RumRawEvent.AddResourceTiming(fakeKey, timing, eventTime = fakeEventTime)
         val resultTiming = testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         mockEvent =
             RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
@@ -1194,7 +1194,7 @@ internal class RumResourceScopeTest {
         expectedAttributes.putAll(attributes)
 
         // When
-        mockEvent = RumRawEvent.AddResourceTiming("not_the_$fakeKey", timing)
+        mockEvent = RumRawEvent.AddResourceTiming("not_the_$fakeKey", timing, eventTime = fakeEventTime)
         val resultTiming = testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         mockEvent =
             RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
@@ -2545,7 +2545,7 @@ internal class RumResourceScopeTest {
         expectedAttributes.putAll(fakeResourceAttributes)
         expectedAttributes.putAll(attributes)
 
-        mockEvent = RumRawEvent.WaitForResourceTiming(fakeKey)
+        mockEvent = RumRawEvent.WaitForResourceTiming(fakeKey, eventTime = fakeEventTime)
         val resultWaitForTiming =
             testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         mockEvent =
@@ -2573,7 +2573,7 @@ internal class RumResourceScopeTest {
         expectedAttributes.putAll(fakeResourceAttributes)
         expectedAttributes.putAll(attributes)
 
-        mockEvent = RumRawEvent.WaitForResourceTiming("not_the_$fakeKey")
+        mockEvent = RumRawEvent.WaitForResourceTiming("not_the_$fakeKey", eventTime = fakeEventTime)
         val resultWaitForTiming =
             testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         mockEvent =
@@ -2645,10 +2645,10 @@ internal class RumResourceScopeTest {
         expectedAttributes.putAll(fakeResourceAttributes)
         expectedAttributes.putAll(attributes)
 
-        mockEvent = RumRawEvent.WaitForResourceTiming(fakeKey)
+        mockEvent = RumRawEvent.WaitForResourceTiming(fakeKey, eventTime = fakeEventTime)
         val resultWaitForTiming =
             testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
-        mockEvent = RumRawEvent.AddResourceTiming(fakeKey, timing)
+        mockEvent = RumRawEvent.AddResourceTiming(fakeKey, timing, eventTime = fakeEventTime)
         val resultTiming = testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         mockEvent =
             RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
@@ -2720,10 +2720,10 @@ internal class RumResourceScopeTest {
         expectedAttributes.putAll(fakeResourceAttributes)
         expectedAttributes.putAll(attributes)
 
-        mockEvent = RumRawEvent.WaitForResourceTiming(fakeKey)
+        mockEvent = RumRawEvent.WaitForResourceTiming(fakeKey, eventTime = fakeEventTime)
         val resultWaitForTiming =
             testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, eventTime = fakeEventTime)
         val resultStop = testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         mockEvent = RumRawEvent.AddResourceTiming(fakeKey, timing, timeWithOffset(RESOURCE_DURATION_MS))
         val resultTiming = testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -2797,12 +2797,13 @@ internal class RumResourceScopeTest {
                     to forge.getForgery(ResourceTiming::class.java).asTimingsPayload()
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope
             .handleEvent(
-                RumRawEvent.AddResourceTiming(fakeKey, timing = timing),
+                RumRawEvent.AddResourceTiming(fakeKey, timing = timing, eventTime = fakeEventTime),
                 fakeDatadogContext,
                 mockEventWriteScope,
                 mockWriter
@@ -2828,7 +2829,8 @@ internal class RumResourceScopeTest {
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeResourceAttributes.keys) +
             mapOf("_dd.resource_timings" to timing.asTimingsPayload())
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3006,7 +3008,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.GRAPHQL_VARIABLES to variables
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3040,7 +3043,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.GRAPHQL_VARIABLES to variables
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3078,7 +3082,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.GRAPHQL_PAYLOAD to originalPayload
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3119,7 +3124,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.GRAPHQL_VARIABLES to variables
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3152,7 +3158,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.GRAPHQL_VARIABLES to variables
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3189,7 +3196,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.GRAPHQL_VARIABLES to variables
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3227,7 +3235,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.GRAPHQL_VARIABLES to variables
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3252,7 +3261,7 @@ internal class RumResourceScopeTest {
         val operationName = forge.aNullable { aString() }
         val variables = forge.aNullable { aString() }
 
-        // Create a payload with multi-byte UTF-8 characters that exceeds the limit
+        // Create a payload with multibyte UTF-8 characters that exceeds the limit
         // Create base payload that's close to but under the byte limit (leave room for emojis)
         val baseSizeBytes = RumResourceScope.MAX_GRAPHQL_PAYLOAD_SIZE_BYTES - 150
         val basePayload = forge.aString(size = baseSizeBytes) // 1 byte per char in UTF-8
@@ -3276,7 +3285,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.GRAPHQL_VARIABLES to variables
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3295,7 +3305,7 @@ internal class RumResourceScopeTest {
             assertThat(actualPayload.toByteArray(Charsets.UTF_8).size)
                 .isLessThanOrEqualTo(RumResourceScope.MAX_GRAPHQL_PAYLOAD_SIZE_BYTES)
 
-            // Verify the truncated string is valid UTF-8 (no broken multi-byte sequences)
+            // Verify the truncated string is valid UTF-8 (no broken multibyte sequences)
             assertThat(actualPayload.toByteArray(Charsets.UTF_8).toString(Charsets.UTF_8))
                 .isEqualTo(actualPayload)
 
@@ -3342,7 +3352,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.GRAPHQL_VARIABLES to variables
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3404,11 +3415,11 @@ internal class RumResourceScopeTest {
         // Miscellaneous Symbols and Pictographs block (4 bytes per char in UTF-8)
         val emojiStart = 0x1F300 // 🌀
         val emojiEnd = 0x1F5FF // 🗿
-        val emoji = (1..5).map {
+        val emoji = (1..5).joinToString("") {
             String(
                 Character.toChars(forge.anInt(min = emojiStart, max = emojiEnd))
             )
-        }.joinToString("")
+        }
         val mixedSuffix = ascii + accented + cjk + emoji
         val originalPayload = basePayload + mixedSuffix.repeat(10) // Repeat to ensure we exceed limit
 
@@ -3420,7 +3431,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.GRAPHQL_VARIABLES to variables
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3478,7 +3490,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.GRAPHQL_VARIABLES to variables
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3513,7 +3526,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.GRAPHQL_ERRORS to errorsJson
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3555,7 +3569,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.GRAPHQL_ERRORS to errorsJson
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3591,7 +3606,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.GRAPHQL_VARIABLES to variables
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3623,7 +3639,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.GRAPHQL_ERRORS to ""
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3655,7 +3672,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.GRAPHQL_ERRORS to "not valid json"
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3855,9 +3873,8 @@ internal class RumResourceScopeTest {
         // Given
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeResourceAttributes.keys)
 
-        // Wait to ensure duration > 0
-        Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3872,7 +3889,7 @@ internal class RumResourceScopeTest {
 
     private fun mockEvent(): RumRawEvent {
         val event: RumRawEvent = mock()
-        whenever(event.eventTime) doReturn Time()
+        whenever(event.eventTime) doReturn fakeEventTime
         return event
     }
 
@@ -3925,7 +3942,8 @@ internal class RumResourceScopeTest {
                 }
         }
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3956,7 +3974,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.REQUEST_HEADERS to requestHeaders,
                 RumAttributes.RESPONSE_HEADERS to responseHeaders
             )
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3979,7 +3998,8 @@ internal class RumResourceScopeTest {
     ) {
         // Given
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeResourceAttributes.keys)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -4008,7 +4028,8 @@ internal class RumResourceScopeTest {
                 RumAttributes.REQUEST_HEADERS to requestHeaders,
                 RumAttributes.RESPONSE_HEADERS to responseHeaders
             )
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent =
+            RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes, timeWithOffset(RESOURCE_DURATION_MS))
 
         // When
         testedScope.handleEvent(mockEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeAttributePropagationTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeAttributePropagationTest.kt
@@ -20,14 +20,12 @@ import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.FeaturesContextResolver
 import com.datadog.android.rum.internal.domain.InfoProvider
 import com.datadog.android.rum.internal.domain.RumContext
-import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.accessibility.AccessibilitySnapshotManager
 import com.datadog.android.rum.internal.domain.battery.BatteryInfo
 import com.datadog.android.rum.internal.domain.display.DisplayInfo
 import com.datadog.android.rum.internal.instrumentation.insights.InsightsCollector
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
-import com.datadog.android.rum.internal.startup.RumAppStartupTelemetryReporter
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.metric.interactiontonextview.LastInteractionIdentifier
 import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
@@ -107,9 +105,6 @@ internal class RumSessionScopeAttributePropagationTest {
     lateinit var mockDisplayInfoProvider: InfoProvider<DisplayInfo>
 
     @Mock
-    lateinit var mockRumAppStartupTelemetryReporter: RumAppStartupTelemetryReporter
-
-    @Mock
     private lateinit var mockInsightsCollector: InsightsCollector
 
     @Mock
@@ -137,8 +132,6 @@ internal class RumSessionScopeAttributePropagationTest {
 
     @Forgery
     lateinit var fakeParentContext: RumContext
-
-    lateinit var fakeEventTime: Time
 
     lateinit var fakeEvent: RumRawEvent
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -34,7 +34,6 @@ import com.datadog.android.rum.internal.domain.display.DisplayInfo
 import com.datadog.android.rum.internal.instrumentation.insights.InsightsCollector
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
-import com.datadog.android.rum.internal.startup.RumAppStartupTelemetryReporter
 import com.datadog.android.rum.internal.startup.RumSessionScopeStartupManager
 import com.datadog.android.rum.internal.startup.RumStartupScenario
 import com.datadog.android.rum.internal.startup.RumTTIDInfo
@@ -121,9 +120,6 @@ internal class RumSessionScopeTest {
 
     @Mock
     lateinit var mockDisplayInfoProvider: InfoProvider<DisplayInfo>
-
-    @Mock
-    lateinit var mockRumAppStartupTelemetryReporter: RumAppStartupTelemetryReporter
 
     @Mock
     private lateinit var mockInsightsCollector: InsightsCollector
@@ -345,7 +341,12 @@ internal class RumSessionScopeTest {
 
         // When
         val result =
-            testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+            testedScope.handleEvent(
+                RumRawEvent.StopSession(eventTime = currentFakeTime()),
+                fakeDatadogContext,
+                mockEventWriteScope,
+                mockWriter
+            )
 
         // Then
         assertThat(result).isNull()
@@ -356,7 +357,12 @@ internal class RumSessionScopeTest {
     fun `M update context W handleEvent { StopSession }`() {
         // When
         val initialContext = testedScope.getRumContext()
-        testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        testedScope.handleEvent(
+            RumRawEvent.StopSession(eventTime = currentFakeTime()),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
 
         // Then
         val context = testedScope.getRumContext()
@@ -377,7 +383,12 @@ internal class RumSessionScopeTest {
 
         // When
         val result =
-            testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+            testedScope.handleEvent(
+                RumRawEvent.StopSession(eventTime = currentFakeTime()),
+                fakeDatadogContext,
+                mockEventWriteScope,
+                mockWriter
+            )
 
         // Then
         assertThat(result).isSameAs(testedScope)
@@ -387,7 +398,7 @@ internal class RumSessionScopeTest {
     @Test
     fun `M return null from handleEvent W stopped { completed child scopes }`() {
         // Given
-        val stopEvent = RumRawEvent.StopSession()
+        val stopEvent = RumRawEvent.StopSession(eventTime = currentFakeTime())
         val fakeEvent: RumRawEvent = mock()
         whenever(
             mockChildScope.handleEvent(
@@ -987,7 +998,12 @@ internal class RumSessionScopeTest {
 
         // When
         val result =
-            testedScope.handleEvent(RumRawEvent.ResetSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+            testedScope.handleEvent(
+                RumRawEvent.ResetSession(eventTime = currentFakeTime()),
+                fakeDatadogContext,
+                mockEventWriteScope,
+                mockWriter
+            )
         val context = testedScope.getRumContext()
 
         // Then
@@ -1122,7 +1138,7 @@ internal class RumSessionScopeTest {
         val initialContext = testedScope.getRumContext()
 
         // When
-        val resetEvent = RumRawEvent.ResetSession()
+        val resetEvent = RumRawEvent.ResetSession(eventTime = currentFakeTime())
         val result = testedScope.handleEvent(resetEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         testedScope.handleEvent(forge.startViewEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
         val context = testedScope.getRumContext()
@@ -1206,7 +1222,12 @@ internal class RumSessionScopeTest {
 
         // When
         val result =
-            testedScope.handleEvent(RumRawEvent.ResetSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+            testedScope.handleEvent(
+                RumRawEvent.ResetSession(eventTime = currentFakeTime()),
+                fakeDatadogContext,
+                mockEventWriteScope,
+                mockWriter
+            )
         testedScope.handleEvent(forge.startViewEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
         val context = testedScope.getRumContext()
 
@@ -1403,7 +1424,7 @@ internal class RumSessionScopeTest {
         val firstSessionId = testedScope.getRumContext().sessionId
 
         // When
-        val resetEvent = RumRawEvent.ResetSession()
+        val resetEvent = RumRawEvent.ResetSession(eventTime = currentFakeTime())
         testedScope.handleEvent(resetEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         testedScope.handleEvent(forge.startViewEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -1546,7 +1567,7 @@ internal class RumSessionScopeTest {
         val firstSessionId = testedScope.getRumContext().sessionId
 
         // When
-        val resetEvent = RumRawEvent.ResetSession()
+        val resetEvent = RumRawEvent.ResetSession(eventTime = currentFakeTime())
         testedScope.handleEvent(resetEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
         testedScope.handleEvent(forge.startViewEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
         val secondSessionId = testedScope.getRumContext().sessionId
@@ -1609,7 +1630,8 @@ internal class RumSessionScopeTest {
     ) {
         // Given
         val event = RumRawEvent.AppStartEvent(
-            scenario = scenario
+            scenario = scenario,
+            eventTime = currentFakeTime()
         )
 
         testedScope.handleEvent(
@@ -1645,7 +1667,7 @@ internal class RumSessionScopeTest {
             durationNs = forge.aLong(min = 0, max = 10000)
         )
 
-        val event = RumRawEvent.AppStartTTIDEvent(info = info)
+        val event = RumRawEvent.AppStartTTIDEvent(info = info, eventTime = currentFakeTime())
 
         testedScope.handleEvent(
             event = fakeInitialViewEvent,
@@ -1710,7 +1732,7 @@ internal class RumSessionScopeTest {
     @Test
     fun `M call onTTFDEvent W handleEvent { AppStartTTFDEvent }`() {
         // Given
-        val event = RumRawEvent.AppStartTTFDEvent()
+        val event = RumRawEvent.AppStartTTFDEvent(eventTime = currentFakeTime())
 
         testedScope.handleEvent(
             event = fakeInitialViewEvent,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeAttributePropagationTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeAttributePropagationTest.kt
@@ -18,7 +18,6 @@ import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.FeaturesContextResolver
 import com.datadog.android.rum.internal.domain.InfoProvider
 import com.datadog.android.rum.internal.domain.RumContext
-import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.accessibility.AccessibilitySnapshotManager
 import com.datadog.android.rum.internal.domain.battery.BatteryInfo
 import com.datadog.android.rum.internal.domain.display.DisplayInfo
@@ -120,8 +119,6 @@ internal class RumViewManagerScopeAttributePropagationTest {
 
     @Forgery
     lateinit var fakeParentContext: RumContext
-
-    lateinit var fakeEventTime: Time
 
     lateinit var fakeEvent: RumRawEvent
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -133,6 +133,9 @@ internal class RumViewManagerScopeTest {
     lateinit var fakeViewUIPerformanceReport: ViewUIPerformanceReport
 
     @Forgery
+    lateinit var fakeEventTime: Time
+
+    @Forgery
     lateinit var fakeTime: TimeInfo
 
     @Mock
@@ -208,7 +211,6 @@ internal class RumViewManagerScopeTest {
     fun `M delegate to child scope W handleEvent()`() {
         // Given
         val fakeEvent: RumRawEvent = mock()
-        whenever(fakeEvent.eventTime) doReturn Time()
         testedScope.childrenScopes.add(mockChildScope)
 
         // When
@@ -335,7 +337,8 @@ internal class RumViewManagerScopeTest {
         testedScope.handleEvent(
             RumRawEvent.AddFeatureFlagEvaluation(
                 forge.anAlphabeticalString(),
-                forge.anAlphaNumericalString()
+                forge.anAlphaNumericalString(),
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
@@ -360,17 +363,16 @@ internal class RumViewManagerScopeTest {
         forge: Forge
     ) {
         // Given
-        val baseTime = Time()
-        val firstViewEvent = forge.startViewEvent(eventTime = baseTime)
+        val firstViewEvent = forge.startViewEvent(eventTime = fakeEventTime)
         testedScope.applicationDisplayed = true
         testedScope.handleEvent(firstViewEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
-        val stopFirstViewEvent = RumRawEvent.StopView(firstViewEvent.key, emptyMap(), baseTime)
+        val stopFirstViewEvent = RumRawEvent.StopView(firstViewEvent.key, emptyMap(), fakeEventTime)
         testedScope.handleEvent(stopFirstViewEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // When
         val secondViewTime = Time(
-            baseTime.timestamp + fakeGapMs,
-            baseTime.nanoTime + TimeUnit.MILLISECONDS.toNanos(fakeGapMs)
+            fakeEventTime.timestamp + fakeGapMs,
+            fakeEventTime.nanoTime + TimeUnit.MILLISECONDS.toNanos(fakeGapMs)
         )
         val secondViewEvent = forge.startViewEvent(eventTime = secondViewTime)
         testedScope.handleEvent(secondViewEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -398,15 +400,14 @@ internal class RumViewManagerScopeTest {
         forge: Forge
     ) {
         // Given
-        val baseTime = Time()
-        val firstViewEvent = forge.startViewEvent(eventTime = baseTime)
+        val firstViewEvent = forge.startViewEvent(eventTime = fakeEventTime)
         testedScope.applicationDisplayed = true
         testedScope.handleEvent(firstViewEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // When
         val secondViewTime = Time(
-            baseTime.timestamp + 15,
-            baseTime.nanoTime + TimeUnit.MILLISECONDS.toNanos(15)
+            fakeEventTime.timestamp + 15,
+            fakeEventTime.nanoTime + TimeUnit.MILLISECONDS.toNanos(15)
         )
         val secondViewEvent = forge.startViewEvent(eventTime = secondViewTime)
         testedScope.handleEvent(secondViewEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -551,7 +552,8 @@ internal class RumViewManagerScopeTest {
             throwable = ANRException(Thread.currentThread()),
             isFatal = false,
             threads = emptyList(),
-            attributes = emptyMap()
+            attributes = emptyMap(),
+            eventTime = fakeEventTime
         )
 
         // When
@@ -828,7 +830,12 @@ internal class RumViewManagerScopeTest {
 
         // When
         val result =
-            testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+            testedScope.handleEvent(
+                RumRawEvent.StopSession(eventTime = fakeEventTime),
+                fakeDatadogContext,
+                mockEventWriteScope,
+                mockWriter
+            )
 
         // Then
         assertThat(result).isNull()
@@ -851,7 +858,12 @@ internal class RumViewManagerScopeTest {
 
         // When
         val result =
-            testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+            testedScope.handleEvent(
+                RumRawEvent.StopSession(eventTime = fakeEventTime),
+                fakeDatadogContext,
+                mockEventWriteScope,
+                mockWriter
+            )
 
         // Then
         assertThat(result).isSameAs(testedScope)
@@ -862,7 +874,7 @@ internal class RumViewManagerScopeTest {
         // Given
         testedScope.applicationDisplayed = true
         testedScope.childrenScopes.add(mockChildScope)
-        val stopEvent = RumRawEvent.StopSession()
+        val stopEvent = RumRawEvent.StopSession(eventTime = fakeEventTime)
         val fakeEvent: RumRawEvent = mock()
         whenever(
             mockChildScope.handleEvent(
@@ -894,7 +906,12 @@ internal class RumViewManagerScopeTest {
     fun `M not display application W stopped`() {
         // When
         val result =
-            testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+            testedScope.handleEvent(
+                RumRawEvent.StopSession(eventTime = fakeEventTime),
+                fakeDatadogContext,
+                mockEventWriteScope,
+                mockWriter
+            )
 
         assertThat(result).isNull()
         assertThat(testedScope.applicationDisplayed).isFalse
@@ -906,7 +923,12 @@ internal class RumViewManagerScopeTest {
         forge: Forge
     ) {
         // Given
-        testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        testedScope.handleEvent(
+            RumRawEvent.StopSession(eventTime = fakeEventTime),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
         val fakeEvent = forge.startViewEvent()
 
         // When
@@ -922,7 +944,12 @@ internal class RumViewManagerScopeTest {
     ) {
         // Given
         testedScope.applicationDisplayed = true
-        testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        testedScope.handleEvent(
+            RumRawEvent.StopSession(eventTime = fakeEventTime),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
         val fakeEvent = forge.startViewEvent()
 
         // When
@@ -987,10 +1014,9 @@ internal class RumViewManagerScopeTest {
     @Test
     fun `M renew all the child scopes W renewViewScopes`(forge: Forge) {
         // Given
-        val eventTime = Time()
         repeat(forge.aSmallInt()) {
             testedScope.handleEvent(
-                forge.startViewEvent(eventTime),
+                forge.startViewEvent(fakeEventTime),
                 fakeDatadogContext,
                 mockEventWriteScope,
                 mockWriter
@@ -999,7 +1025,7 @@ internal class RumViewManagerScopeTest {
 
         // When
         val oldScopes = testedScope.childrenScopes.toList()
-        testedScope.renewViewScopes(eventTime)
+        testedScope.renewViewScopes(fakeEventTime)
 
         // Then
         assertThat(testedScope.childrenScopes).isNotEqualTo(oldScopes)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeAttributePropagationTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeAttributePropagationTest.kt
@@ -77,7 +77,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
-import java.util.concurrent.TimeUnit
 import kotlin.math.max
 import kotlin.math.min
 
@@ -149,6 +148,7 @@ internal class RumViewScopeAttributePropagationTest {
     @Forgery
     lateinit var fakeParentContext: RumContext
 
+    @Forgery
     lateinit var fakeEventTime: Time
 
     lateinit var fakeEvent: RumRawEvent
@@ -220,11 +220,8 @@ internal class RumViewScopeAttributePropagationTest {
         fakeParentContext =
             fakeParentContext.copy(syntheticsTestId = null, syntheticsResultId = null)
 
-        val fakeOffset = -forge.aLong(1000, 50000)
-        val fakeTimestamp = System.currentTimeMillis() + fakeOffset
-        val fakeNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(fakeOffset)
-        val maxLimit = max(Long.MAX_VALUE - fakeTimestamp, Long.MAX_VALUE)
-        val minLimit = min(-fakeTimestamp, maxLimit)
+        val maxLimit = max(Long.MAX_VALUE - fakeEventTime.timestamp, Long.MAX_VALUE)
+        val minLimit = min(-fakeEventTime.timestamp, maxLimit)
         fakeSampleRate = forge.aFloat(min = 0.0f, max = 100.0f)
 
         fakeDatadogContext = fakeDatadogContext.copy(
@@ -232,7 +229,6 @@ internal class RumViewScopeAttributePropagationTest {
                 serverTimeOffsetMs = forge.aLong(min = minLimit, max = maxLimit)
             )
         )
-        fakeEventTime = Time(fakeTimestamp, fakeNanos)
         fakeParentAttributes = forge.exhaustiveAttributes()
         fakeViewAttributes = forge.exhaustiveAttributes()
         fakeChildAttributes = forge.exhaustiveAttributes()
@@ -276,11 +272,11 @@ internal class RumViewScopeAttributePropagationTest {
         expectedAttributes.putAll(fakeParentAttributes)
         expectedAttributes.putAll(fakeViewAttributes)
         testedScope = newRumViewScope(initialAttributes = fakeViewAttributes)
-        val fakeEvent = RumRawEvent.ErrorSent(testedScope.viewId)
+        val fakeEvent = RumRawEvent.ErrorSent(testedScope.viewId, eventTime = fakeEventTime)
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -310,14 +306,14 @@ internal class RumViewScopeAttributePropagationTest {
 
         // When
         val result = testedScope.handleEvent(
-            RumRawEvent.AddViewAttributes(fakeViewAttributes),
+            RumRawEvent.AddViewAttributes(fakeViewAttributes, eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
 
         testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -346,14 +342,14 @@ internal class RumViewScopeAttributePropagationTest {
 
         // When
         val result = testedScope.handleEvent(
-            RumRawEvent.RemoveViewAttributes(fakeViewAttributes.keys),
+            RumRawEvent.RemoveViewAttributes(fakeViewAttributes.keys, eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
 
         testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -394,7 +390,8 @@ internal class RumViewScopeAttributePropagationTest {
             isFatal = fakeIsFatal,
             attributes = fakeChildAttributes,
             type = fakeType,
-            threads = emptyList()
+            threads = emptyList(),
+            eventTime = fakeEventTime
         )
 
         // When
@@ -433,7 +430,8 @@ internal class RumViewScopeAttributePropagationTest {
             isFatal = fakeIsFatal,
             attributes = fakeChildAttributes,
             type = fakeType,
-            threads = emptyList()
+            threads = emptyList(),
+            eventTime = fakeEventTime
         )
 
         // When
@@ -473,7 +471,8 @@ internal class RumViewScopeAttributePropagationTest {
             isFatal = fakeIsFatal,
             attributes = fakeChildAttributes,
             type = fakeType,
-            threads = emptyList()
+            threads = emptyList(),
+            eventTime = fakeEventTime
         )
 
         // When
@@ -503,7 +502,7 @@ internal class RumViewScopeAttributePropagationTest {
         expectedAttributes.putAll(fakeParentAttributes)
         expectedAttributes.put(RumAttributes.LONG_TASK_TARGET, fakeTarget)
         testedScope = newRumViewScope(initialAttributes = emptyMap())
-        val fakeEvent = RumRawEvent.AddLongTask(fakeDuration, fakeTarget)
+        val fakeEvent = RumRawEvent.AddLongTask(fakeDuration, fakeTarget, eventTime = fakeEventTime)
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -529,7 +528,7 @@ internal class RumViewScopeAttributePropagationTest {
         expectedAttributes.putAll(fakeViewAttributes)
         expectedAttributes.put(RumAttributes.LONG_TASK_TARGET, fakeTarget)
         testedScope = newRumViewScope(initialAttributes = fakeViewAttributes)
-        val fakeEvent = RumRawEvent.AddLongTask(fakeDuration, fakeTarget)
+        val fakeEvent = RumRawEvent.AddLongTask(fakeDuration, fakeTarget, eventTime = fakeEventTime)
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -555,7 +554,7 @@ internal class RumViewScopeAttributePropagationTest {
         val expectedAttributes = overriddenAttributes.toMutableMap()
         expectedAttributes.put(RumAttributes.LONG_TASK_TARGET, fakeTarget)
         testedScope = newRumViewScope(initialAttributes = overriddenAttributes)
-        val fakeEvent = RumRawEvent.AddLongTask(fakeDuration, fakeTarget)
+        val fakeEvent = RumRawEvent.AddLongTask(fakeDuration, fakeTarget, eventTime = fakeEventTime)
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -584,7 +583,7 @@ internal class RumViewScopeAttributePropagationTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -615,7 +614,7 @@ internal class RumViewScopeAttributePropagationTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StartView(newViewKey, emptyMap()),
+            RumRawEvent.StartView(newViewKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -381,6 +381,7 @@ internal class RumViewScopeTest {
         whenever(rumMonitorConfiguration.mockSdkCore.time) doReturn fakeTimeInfoAtScopeStart
         whenever(rumMonitorConfiguration.mockSdkCore.networkInfo) doReturn fakeNetworkInfoAtScopeStart
         whenever(rumMonitorConfiguration.mockSdkCore.internalLogger) doReturn mockInternalLogger
+        whenever(rumMonitorConfiguration.mockSdkCore.timeProvider) doReturn mock()
         whenever(mockEventWriteScope.invoke(any())) doAnswer {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
@@ -451,7 +452,7 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         // Given
-        val fakeEvent = RumRawEvent.StopView(fakeKey, forge.exhaustiveAttributes())
+        val fakeEvent = RumRawEvent.StopView(fakeKey, forge.exhaustiveAttributes(), eventTime = fakeEventTime)
         testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
         // When
@@ -492,7 +493,7 @@ internal class RumViewScopeTest {
             )
         ) doReturn fakeHasReplay
         testedScope.handleEvent(fakeEvent, datadogContextWithReplay, mockEventWriteScope, mockWriter)
-        val fakeStopEvent = RumRawEvent.StopView(fakeKey, forge.exhaustiveAttributes())
+        val fakeStopEvent = RumRawEvent.StopView(fakeKey, forge.exhaustiveAttributes(), eventTime = fakeEventTime)
         val stopViewContext = fakeDatadogContext.copy(
             featuresContext = fakeDatadogContext.featuresContext +
                 mapOf(Feature.SESSION_REPLAY_FEATURE_NAME to mapOf("has_replay" to false))
@@ -563,7 +564,7 @@ internal class RumViewScopeTest {
 
         // When
         val result = testedScope.handleEvent(
-            RumRawEvent.StartView(key, emptyMap()),
+            RumRawEvent.StartView(key, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -580,7 +581,7 @@ internal class RumViewScopeTest {
     ) {
         // When
         val result = testedScope.handleEvent(
-            RumRawEvent.StartView(key, emptyMap()),
+            RumRawEvent.StartView(key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -660,13 +661,13 @@ internal class RumViewScopeTest {
     ) {
         // When
         val result = testedScope.handleEvent(
-            RumRawEvent.StartView(key, emptyMap()),
+            RumRawEvent.StartView(key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
         val result2 = testedScope.handleEvent(
-            RumRawEvent.StartView(key2, emptyMap()),
+            RumRawEvent.StartView(key2, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -750,7 +751,7 @@ internal class RumViewScopeTest {
 
         // When
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, attributes),
+            RumRawEvent.StopView(fakeKey, attributes, eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -840,7 +841,7 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
             contextWithSr,
             mockEventWriteScope,
             mockWriter
@@ -874,7 +875,7 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
             contextWithTracing,
             mockEventWriteScope,
             mockWriter
@@ -897,7 +898,7 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -929,7 +930,7 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
             contextWithNullSrRate,
             mockEventWriteScope,
             mockWriter
@@ -960,7 +961,7 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
             contextWithNullTraceRate,
             mockEventWriteScope,
             mockWriter
@@ -996,7 +997,7 @@ internal class RumViewScopeTest {
 
         // When
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, attributes),
+            RumRawEvent.StopView(fakeKey, attributes, eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -1086,7 +1087,7 @@ internal class RumViewScopeTest {
 
         // When
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, attributes),
+            RumRawEvent.StopView(fakeKey, attributes, eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -1172,7 +1173,7 @@ internal class RumViewScopeTest {
 
         // When
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, attributes),
+            RumRawEvent.StopView(fakeKey, attributes, eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -1246,7 +1247,7 @@ internal class RumViewScopeTest {
     fun `M send event with user extra attributes W handleEvent(StopView) on active view`() {
         // When
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -1334,7 +1335,7 @@ internal class RumViewScopeTest {
 
         // When
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -1429,7 +1430,7 @@ internal class RumViewScopeTest {
 
         // When
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -1514,13 +1515,13 @@ internal class RumViewScopeTest {
 
         // When
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, attributes),
+            RumRawEvent.StopView(fakeKey, attributes, eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
         val result2 = testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, attributes),
+            RumRawEvent.StopView(fakeKey, attributes, eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -1600,7 +1601,7 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         // Given
-        testedScope.activeResourceScopes.put(key, mockChildScope)
+        testedScope.activeResourceScopes[key] = mockChildScope
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
@@ -1608,7 +1609,7 @@ internal class RumViewScopeTest {
 
         // When
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, attributes),
+            RumRawEvent.StopView(fakeKey, attributes, eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -1690,7 +1691,7 @@ internal class RumViewScopeTest {
 
         // When
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(key, attributes),
+            RumRawEvent.StopView(key, attributes, eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -1714,7 +1715,7 @@ internal class RumViewScopeTest {
 
         // When
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, attributes),
+            RumRawEvent.StopView(fakeKey, attributes, eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -1730,7 +1731,7 @@ internal class RumViewScopeTest {
         @LongForgery(1) pending: Long
     ) {
         // Given
-        fakeEvent = RumRawEvent.ErrorSent(testedScope.viewId)
+        fakeEvent = RumRawEvent.ErrorSent(testedScope.viewId, eventTime = laterEventTime())
         testedScope.pendingErrorCount = pending
 
         // When
@@ -1809,7 +1810,7 @@ internal class RumViewScopeTest {
         // Given
         val viewId = viewUuid.toString()
         assumeTrue(viewId != testedScope.viewId)
-        fakeEvent = RumRawEvent.ErrorSent(viewId)
+        fakeEvent = RumRawEvent.ErrorSent(viewId, eventTime = fakeEventTime)
         testedScope.pendingErrorCount = pending
 
         // When
@@ -1935,7 +1936,13 @@ internal class RumViewScopeTest {
         @LongForgery(0) actionEventTimestamp: Long
     ) {
         // Given
-        fakeEvent = RumRawEvent.ActionSent(testedScope.viewId, frustrationCount, actionType, actionEventTimestamp)
+        fakeEvent = RumRawEvent.ActionSent(
+            testedScope.viewId,
+            frustrationCount,
+            actionType,
+            actionEventTimestamp,
+            eventTime = laterEventTime()
+        )
         testedScope.pendingActionCount = pending
 
         // When
@@ -2017,7 +2024,14 @@ internal class RumViewScopeTest {
         // Given
         val viewId = viewUuid.toString()
         assumeTrue(viewId != testedScope.viewId)
-        fakeEvent = RumRawEvent.ActionSent(viewId, frustrationCount, actionType, actionEventTimestamp)
+        fakeEvent =
+            RumRawEvent.ActionSent(
+                viewId,
+                frustrationCount,
+                actionType,
+                actionEventTimestamp,
+                eventTime = fakeEventTime
+            )
         testedScope.pendingActionCount = pending
 
         // When
@@ -2035,7 +2049,7 @@ internal class RumViewScopeTest {
         @LongForgery(1) pendingFrozenFrame: Long
     ) {
         // Given
-        fakeEvent = RumRawEvent.LongTaskSent(testedScope.viewId)
+        fakeEvent = RumRawEvent.LongTaskSent(testedScope.viewId, eventTime = laterEventTime())
         testedScope.pendingLongTaskCount = pendingLongTask
         testedScope.pendingFrozenFrameCount = pendingFrozenFrame
 
@@ -2114,7 +2128,7 @@ internal class RumViewScopeTest {
         @LongForgery(1) pendingFrozenFrame: Long
     ) {
         // Given
-        fakeEvent = RumRawEvent.LongTaskSent(testedScope.viewId, true)
+        fakeEvent = RumRawEvent.LongTaskSent(testedScope.viewId, eventTime = laterEventTime(), isFrozenFrame = true)
         testedScope.pendingLongTaskCount = pendingLongTask
         testedScope.pendingFrozenFrameCount = pendingFrozenFrame
 
@@ -2195,7 +2209,7 @@ internal class RumViewScopeTest {
         // Given
         val viewId = viewUuid.toString()
         assumeTrue(viewId != testedScope.viewId)
-        fakeEvent = RumRawEvent.LongTaskSent(viewId)
+        fakeEvent = RumRawEvent.LongTaskSent(viewId, eventTime = fakeEventTime)
         testedScope.pendingLongTaskCount = pending
 
         // When
@@ -2215,7 +2229,7 @@ internal class RumViewScopeTest {
         testedScope.stopped = true
         testedScope.stoppedNanos = fakeEventTime.nanoTime + durationNs
         testedScope.pendingErrorCount = 1
-        fakeEvent = RumRawEvent.ErrorSent(testedScope.viewId)
+        fakeEvent = RumRawEvent.ErrorSent(testedScope.viewId, eventTime = fakeEventTime)
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -2299,7 +2313,7 @@ internal class RumViewScopeTest {
         testedScope.pendingErrorCount = pending
         val viewId = viewUuid.toString()
         assumeTrue(viewId != testedScope.viewId)
-        fakeEvent = RumRawEvent.ErrorSent(viewId)
+        fakeEvent = RumRawEvent.ErrorSent(viewId, eventTime = fakeEventTime)
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -2433,7 +2447,13 @@ internal class RumViewScopeTest {
         testedScope.stopped = true
         testedScope.stoppedNanos = fakeEventTime.nanoTime + durationNs
         testedScope.pendingActionCount = 1
-        fakeEvent = RumRawEvent.ActionSent(testedScope.viewId, frustrationCount, actionType, actionEventTimestamp)
+        fakeEvent = RumRawEvent.ActionSent(
+            testedScope.viewId,
+            frustrationCount,
+            actionType,
+            actionEventTimestamp,
+            eventTime = fakeEventTime
+        )
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -2520,7 +2540,14 @@ internal class RumViewScopeTest {
         testedScope.pendingActionCount = pending
         val viewId = viewUuid.toString()
         assumeTrue(viewId != testedScope.viewId)
-        fakeEvent = RumRawEvent.ActionSent(viewId, frustrationCount, actionType, actionEventTimestamp)
+        fakeEvent =
+            RumRawEvent.ActionSent(
+                viewId,
+                frustrationCount,
+                actionType,
+                actionEventTimestamp,
+                eventTime = fakeEventTime
+            )
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -2539,7 +2566,7 @@ internal class RumViewScopeTest {
         testedScope.stopped = true
         testedScope.stoppedNanos = fakeEventTime.nanoTime + durationNs
         testedScope.pendingLongTaskCount = 1
-        fakeEvent = RumRawEvent.LongTaskSent(testedScope.viewId)
+        fakeEvent = RumRawEvent.LongTaskSent(testedScope.viewId, eventTime = fakeEventTime)
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -2623,7 +2650,7 @@ internal class RumViewScopeTest {
         testedScope.pendingLongTaskCount = pending
         val viewId = viewUuid.toString()
         assumeTrue(viewId != testedScope.viewId)
-        fakeEvent = RumRawEvent.LongTaskSent(viewId)
+        fakeEvent = RumRawEvent.LongTaskSent(viewId, eventTime = fakeEventTime)
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -2779,7 +2806,7 @@ internal class RumViewScopeTest {
 
         // When
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, attributes),
+            RumRawEvent.StopView(fakeKey, attributes, eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -2872,6 +2899,7 @@ internal class RumViewScopeTest {
             type = type,
             name = name,
             waitForStop = waitForStop,
+            eventTime = fakeEventTime,
             attributes = attributes
         )
         val result = testedScope.handleEvent(
@@ -2910,6 +2938,7 @@ internal class RumViewScopeTest {
             type = type,
             name = name,
             waitForStop = waitForStop,
+            eventTime = fakeEventTime,
             nativeHeatmapActionData = fakeHeatmapData,
             attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         )
@@ -2931,7 +2960,13 @@ internal class RumViewScopeTest {
 
         // When
         val fakeStartActionEvent =
-            RumRawEvent.StartAction(RumActionType.CUSTOM, name, waitForStop = true, attributes = attributes)
+            RumRawEvent.StartAction(
+                RumActionType.CUSTOM,
+                name,
+                waitForStop = true,
+                eventTime = fakeEventTime,
+                attributes = attributes
+            )
         val result = testedScope.handleEvent(
             fakeStartActionEvent,
             fakeDatadogContext,
@@ -2960,7 +2995,14 @@ internal class RumViewScopeTest {
     ) {
         // Given
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
-        fakeEvent = RumRawEvent.StartAction(RumActionType.CUSTOM, name, false, attributes = attributes)
+        fakeEvent =
+            RumRawEvent.StartAction(
+                RumActionType.CUSTOM,
+                name,
+                false,
+                eventTime = fakeEventTime,
+                attributes = attributes
+            )
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3005,6 +3047,7 @@ internal class RumViewScopeTest {
             type = actionType,
             name = name,
             waitForStop = waitForStop,
+            eventTime = fakeEventTime,
             attributes = attributes
         )
         whenever(
@@ -3049,6 +3092,7 @@ internal class RumViewScopeTest {
                 type = RumActionType.CUSTOM,
                 name = name,
                 waitForStop = true,
+                eventTime = fakeEventTime,
                 attributes = attributes
             )
         whenever(
@@ -3092,6 +3136,7 @@ internal class RumViewScopeTest {
             type = RumActionType.CUSTOM,
             name = name,
             waitForStop = false,
+            eventTime = fakeEventTime,
             attributes = attributes
         )
         whenever(
@@ -3173,6 +3218,7 @@ internal class RumViewScopeTest {
             type = RumActionType.CUSTOM,
             name = name,
             waitForStop = false,
+            eventTime = fakeEventTime,
             attributes = attributes
         )
         whenever(
@@ -3259,6 +3305,7 @@ internal class RumViewScopeTest {
             type = type,
             name = name,
             waitForStop = waitForStop,
+            eventTime = fakeEventTime,
             attributes = attributes
         )
 
@@ -3336,6 +3383,7 @@ internal class RumViewScopeTest {
             type = type,
             name = name,
             waitForStop = waitForStop,
+            eventTime = fakeEventTime,
             attributes = emptyMap()
         )
 
@@ -3351,7 +3399,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.pendingActionCount = pending
-        fakeEvent = RumRawEvent.ActionDropped(testedScope.viewId)
+        fakeEvent = RumRawEvent.ActionDropped(testedScope.viewId, eventTime = fakeEventTime)
 
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
@@ -3363,7 +3411,7 @@ internal class RumViewScopeTest {
     fun `M decrease pending Action W handleEvent(ActionDropped) on stopped view`() {
         // Given
         testedScope.pendingActionCount = 1
-        fakeEvent = RumRawEvent.ActionDropped(testedScope.viewId)
+        fakeEvent = RumRawEvent.ActionDropped(testedScope.viewId, eventTime = fakeEventTime)
         testedScope.stopped = true
 
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3381,7 +3429,7 @@ internal class RumViewScopeTest {
         val viewId = viewUuid.toString()
         assumeTrue(viewId != testedScope.viewId)
         testedScope.pendingActionCount = pending
-        fakeEvent = RumRawEvent.ActionDropped(viewId)
+        fakeEvent = RumRawEvent.ActionDropped(viewId, eventTime = fakeEventTime)
 
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
@@ -3398,7 +3446,7 @@ internal class RumViewScopeTest {
         val viewId = viewUuid.toString()
         assumeTrue(viewId != testedScope.viewId)
         testedScope.pendingActionCount = pending
-        fakeEvent = RumRawEvent.ActionDropped(viewId)
+        fakeEvent = RumRawEvent.ActionDropped(viewId, eventTime = fakeEventTime)
         testedScope.stopped = true
 
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3422,7 +3470,7 @@ internal class RumViewScopeTest {
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
 
         // When
-        val fakeEvent = RumRawEvent.StartResource(key, url, method, attributes)
+        val fakeEvent = RumRawEvent.StartResource(key, url, method, attributes, eventTime = fakeEventTime)
         val result = testedScope.handleEvent(
             fakeEvent,
             fakeDatadogContext,
@@ -3459,7 +3507,7 @@ internal class RumViewScopeTest {
         // Given
         testedScope.activeActionScope = mockActionScope
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
-        fakeEvent = RumRawEvent.StartResource(key, url, method, attributes)
+        fakeEvent = RumRawEvent.StartResource(key, url, method, attributes, eventTime = fakeEventTime)
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3565,7 +3613,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.pendingResourceCount = 0
-        fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
+        fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap(), eventTime = fakeEventTime)
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3582,7 +3630,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.pendingResourceCount = pending
-        val fakeResourceDrooped = forge.getForgery<RumRawEvent.ResourceDropped>().copy(testedScope.viewId)
+        val fakeResourceDrooped = forge.getForgery<RumRawEvent.ResourceDropped>().copy(viewId = testedScope.viewId)
 
         // When
         val result = testedScope.handleEvent(fakeResourceDrooped, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -3715,6 +3763,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace,
             isFatal = false,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes
         )
@@ -3796,6 +3845,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace,
             isFatal = false,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes
         )
@@ -3880,6 +3930,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace,
             isFatal = false,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes
         )
@@ -3958,6 +4009,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace,
             isFatal = false,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes
         )
@@ -4038,6 +4090,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace,
             isFatal = false,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes
         )
@@ -4120,6 +4173,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace,
             isFatal = false,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes
         )
@@ -4198,6 +4252,7 @@ internal class RumViewScopeTest {
             throwable = null,
             stacktrace,
             isFatal = false,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes
         )
@@ -4256,6 +4311,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace = null,
             isFatal = false,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes,
             sourceType = sourceType
@@ -4340,6 +4396,7 @@ internal class RumViewScopeTest {
             throwable = null,
             stacktrace = null,
             isFatal = false,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes,
             sourceType = sourceType
@@ -4425,6 +4482,7 @@ internal class RumViewScopeTest {
             throwable = null,
             stacktrace = null,
             isFatal = true,
+            eventTime = laterEventTime(),
             threads = threads,
             attributes = attributes,
             sourceType = sourceType,
@@ -4573,6 +4631,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace,
             isFatal = false,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = fullAttributes
         )
@@ -4652,6 +4711,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace = null,
             isFatal = true,
+            eventTime = laterEventTime(),
             threads = threads,
             attributes = attributes,
             sourceType = sourceType,
@@ -4796,6 +4856,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace = null,
             isFatal = false,
+            eventTime = laterEventTime(),
             // empty list, because _dd.error.is_crash is coming from Cross Platform, this not a native crash
             threads = emptyList(),
             attributes = attributesWithCrash,
@@ -4809,6 +4870,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace = null,
             isFatal = true,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes,
             sourceType = sourceType,
@@ -4954,6 +5016,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace = null,
             isFatal = false,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributesWithCrash,
             sourceType = sourceType
@@ -5038,6 +5101,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace = null,
             isFatal = false,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes,
             type = errorType,
@@ -5124,6 +5188,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace = null,
             isFatal = fatal,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes
         )
@@ -5154,6 +5219,7 @@ internal class RumViewScopeTest {
             throwable = null,
             stacktrace,
             fatal,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes
         )
@@ -5181,6 +5247,7 @@ internal class RumViewScopeTest {
             throwable = null,
             stacktrace,
             isFatal = false,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = emptyMap()
         )
@@ -5205,6 +5272,7 @@ internal class RumViewScopeTest {
             throwable = null,
             stacktrace,
             isFatal = true,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = emptyMap()
         )
@@ -5221,7 +5289,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.pendingErrorCount = pending
-        fakeEvent = RumRawEvent.ErrorDropped(testedScope.viewId)
+        fakeEvent = RumRawEvent.ErrorDropped(testedScope.viewId, eventTime = fakeEventTime)
 
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
@@ -5233,7 +5301,7 @@ internal class RumViewScopeTest {
     fun `M decrease pending Error W handleEvent(ErrorDropped) on stopped view`() {
         // Given
         testedScope.pendingErrorCount = 1
-        fakeEvent = RumRawEvent.ErrorDropped(testedScope.viewId)
+        fakeEvent = RumRawEvent.ErrorDropped(testedScope.viewId, eventTime = fakeEventTime)
         testedScope.stopped = true
 
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -5251,7 +5319,7 @@ internal class RumViewScopeTest {
         val viewId = viewUuid.toString()
         assumeTrue(viewId != testedScope.viewId)
         testedScope.pendingErrorCount = pending
-        fakeEvent = RumRawEvent.ErrorDropped(viewId)
+        fakeEvent = RumRawEvent.ErrorDropped(viewId, eventTime = fakeEventTime)
 
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
@@ -5268,7 +5336,7 @@ internal class RumViewScopeTest {
         val viewId = viewUuid.toString()
         assumeTrue(viewId != testedScope.viewId)
         testedScope.pendingErrorCount = pending
-        fakeEvent = RumRawEvent.ErrorDropped(viewId)
+        fakeEvent = RumRawEvent.ErrorDropped(viewId, eventTime = fakeEventTime)
         testedScope.stopped = true
 
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -5288,7 +5356,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeActionScope = null
-        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target, eventTime = fakeEventTime)
         val durationMs = TimeUnit.NANOSECONDS.toMillis(durationNs)
 
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -5349,7 +5417,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeActionScope = null
-        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target, eventTime = fakeEventTime)
         val durationMs = TimeUnit.NANOSECONDS.toMillis(durationNs)
 
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -5412,7 +5480,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeActionScope = null
-        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target, eventTime = fakeEventTime)
         val durationMs = TimeUnit.NANOSECONDS.toMillis(durationNs)
         fakeParentContext = fakeParentContext.copy(
             syntheticsTestId = fakeTestId,
@@ -5484,7 +5552,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeActionScope = null
-        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target, eventTime = fakeEventTime)
         val durationMs = TimeUnit.NANOSECONDS.toMillis(durationNs)
         fakeParentContext = fakeParentContext.copy(
             syntheticsTestId = fakeTestId,
@@ -5556,7 +5624,7 @@ internal class RumViewScopeTest {
         // Given
         testedScope.activeActionScope = mockActionScope
         testedScope.pendingLongTaskCount = pending
-        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target, eventTime = fakeEventTime)
         testedScope.stopped = true
 
         // When
@@ -5575,7 +5643,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.pendingLongTaskCount = 0
-        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target, eventTime = fakeEventTime)
 
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
@@ -5591,7 +5659,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.pendingLongTaskCount = 0
-        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target, eventTime = fakeEventTime)
 
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
@@ -5608,7 +5676,7 @@ internal class RumViewScopeTest {
         // Given
         testedScope.pendingLongTaskCount = pendingLongTask
         testedScope.pendingFrozenFrameCount = pendingFrozenFrame
-        fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, false)
+        fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, eventTime = fakeEventTime, isFrozenFrame = false)
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -5627,7 +5695,7 @@ internal class RumViewScopeTest {
         // Given
         testedScope.pendingLongTaskCount = pendingLongTask
         testedScope.pendingFrozenFrameCount = pendingFrozenFrame
-        fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, true)
+        fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, eventTime = fakeEventTime, isFrozenFrame = true)
 
         // When
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -5643,7 +5711,7 @@ internal class RumViewScopeTest {
         // Given
         testedScope.pendingLongTaskCount = 1
         testedScope.pendingFrozenFrameCount = 0
-        fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, false)
+        fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, eventTime = fakeEventTime, isFrozenFrame = false)
         testedScope.stopped = true
 
         // When
@@ -5660,7 +5728,7 @@ internal class RumViewScopeTest {
         // Given
         testedScope.pendingLongTaskCount = 1
         testedScope.pendingFrozenFrameCount = 1
-        fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, true)
+        fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, eventTime = fakeEventTime, isFrozenFrame = true)
         testedScope.stopped = true
 
         // When
@@ -5682,7 +5750,7 @@ internal class RumViewScopeTest {
         val viewId = viewUuid.toString()
         assumeTrue(viewId != testedScope.viewId)
         testedScope.pendingLongTaskCount = pending
-        fakeEvent = RumRawEvent.LongTaskDropped(viewId, isFrozenFrame)
+        fakeEvent = RumRawEvent.LongTaskDropped(viewId, eventTime = fakeEventTime, isFrozenFrame = isFrozenFrame)
 
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
 
@@ -5700,7 +5768,7 @@ internal class RumViewScopeTest {
         val viewId = viewUuid.toString()
         assumeTrue(viewId != testedScope.viewId)
         testedScope.pendingLongTaskCount = pending
-        fakeEvent = RumRawEvent.LongTaskDropped(viewId, isFrozenFrame)
+        fakeEvent = RumRawEvent.LongTaskDropped(viewId, eventTime = fakeEventTime, isFrozenFrame = isFrozenFrame)
         testedScope.stopped = true
 
         val result = testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -5722,7 +5790,7 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.AddCustomTiming(fakeTimingKey),
+            RumRawEvent.AddCustomTiming(fakeTimingKey, eventTime = Time(System.currentTimeMillis(), System.nanoTime())),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -5804,14 +5872,20 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.AddCustomTiming(fakeTimingKey1),
+            RumRawEvent.AddCustomTiming(
+                fakeTimingKey1,
+                eventTime = Time(System.currentTimeMillis(), System.nanoTime())
+            ),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
         val customTiming1EstimatedDuration = System.nanoTime() - fakeEventTime.nanoTime
         testedScope.handleEvent(
-            RumRawEvent.AddCustomTiming(fakeTimingKey2),
+            RumRawEvent.AddCustomTiming(
+                fakeTimingKey2,
+                eventTime = Time(System.currentTimeMillis(), System.nanoTime())
+            ),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -5957,7 +6031,7 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.AddCustomTiming(fakeTimingKey),
+            RumRawEvent.AddCustomTiming(fakeTimingKey, eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -5977,7 +6051,10 @@ internal class RumViewScopeTest {
         @BoolForgery fakeOverwrite: Boolean
     ) {
         // Given
-        val viewLoadingTimeEvent = RumRawEvent.AddViewLoadingTime(overwrite = fakeOverwrite)
+        val viewLoadingTimeEvent = RumRawEvent.AddViewLoadingTime(
+            overwrite = fakeOverwrite,
+            eventTime = laterEventTime()
+        )
         val expectedViewLoadingTime = viewLoadingTimeEvent.eventTime.nanoTime - fakeEventTime.nanoTime
 
         // When
@@ -6075,7 +6152,7 @@ internal class RumViewScopeTest {
         // Given
         val previousLoadingTime = forge.aPositiveLong()
         testedScope.viewLoadingTime = previousLoadingTime
-        val newViewLoadingTime = RumRawEvent.AddViewLoadingTime(overwrite = true)
+        val newViewLoadingTime = RumRawEvent.AddViewLoadingTime(overwrite = true, eventTime = laterEventTime())
         val expectedViewLoadingTime = newViewLoadingTime.eventTime.nanoTime - fakeEventTime.nanoTime
 
         // When
@@ -6174,7 +6251,9 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         // Given
-        val viewLoadingTimeEvents = forge.aList { RumRawEvent.AddViewLoadingTime(overwrite = true) }
+        val viewLoadingTimeEvents = forge.aList {
+            RumRawEvent.AddViewLoadingTime(overwrite = true, eventTime = laterEventTime())
+        }
         val expectedViewLoadingTime = viewLoadingTimeEvents.last().eventTime.nanoTime - fakeEventTime.nanoTime
 
         // When
@@ -6257,7 +6336,9 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         // Given
-        val viewLoadingTimeEvents = forge.aList { RumRawEvent.AddViewLoadingTime(overwrite = false) }
+        val viewLoadingTimeEvents = forge.aList {
+            RumRawEvent.AddViewLoadingTime(overwrite = false, eventTime = laterEventTime())
+        }
         val expectedViewLoadingTime = viewLoadingTimeEvents.first().eventTime.nanoTime - fakeEventTime.nanoTime
 
         // When
@@ -6344,7 +6425,7 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.AddViewLoadingTime(overwrite = fakeOverwrite),
+            RumRawEvent.AddViewLoadingTime(overwrite = fakeOverwrite, eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -6365,7 +6446,12 @@ internal class RumViewScopeTest {
         @LongForgery(0) resourceStopTimestampInNanos: Long
     ) {
         // Given
-        fakeEvent = RumRawEvent.ErrorSent(testedScope.viewId, resourceId, resourceStopTimestampInNanos)
+        fakeEvent = RumRawEvent.ErrorSent(
+            testedScope.viewId,
+            eventTime = fakeEventTime,
+            resourceId = resourceId,
+            resourceEndTimestampInNanos = resourceStopTimestampInNanos
+        )
 
         // When
         testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -6384,7 +6470,7 @@ internal class RumViewScopeTest {
         @StringForgery resourceId: String
     ) {
         // Given
-        fakeEvent = RumRawEvent.ErrorDropped(testedScope.viewId, resourceId)
+        fakeEvent = RumRawEvent.ErrorDropped(testedScope.viewId, eventTime = fakeEventTime, resourceId = resourceId)
 
         // When
         testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -6396,7 +6482,7 @@ internal class RumViewScopeTest {
     @Test
     fun `M not interact with networkSettledMetricResolver W handleEvent(ErrorSent) { resource info not present }`() {
         // Given
-        fakeEvent = RumRawEvent.ErrorSent(testedScope.viewId)
+        fakeEvent = RumRawEvent.ErrorSent(testedScope.viewId, eventTime = fakeEventTime)
 
         // When
         testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -6408,7 +6494,7 @@ internal class RumViewScopeTest {
     @Test
     fun `M not interact with networkSettledMetricResolver W handleEvent(ErrorDropped) { resource info not present }`() {
         // Given
-        fakeEvent = RumRawEvent.ErrorSent(testedScope.viewId)
+        fakeEvent = RumRawEvent.ErrorSent(testedScope.viewId, eventTime = fakeEventTime)
 
         // When
         testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -6421,7 +6507,7 @@ internal class RumViewScopeTest {
     fun `M notify the networkSettledMetricResolver W view was stopped`() {
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -6440,7 +6526,7 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeOtherKey, emptyMap()),
+            RumRawEvent.StopView(fakeOtherKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -6457,7 +6543,7 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -6548,7 +6634,7 @@ internal class RumViewScopeTest {
             listener.onVitalUpdate(VitalInfo(index + 1, 0.0, value, value / 2.0))
         }
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -6639,7 +6725,7 @@ internal class RumViewScopeTest {
         listener.onVitalUpdate(VitalInfo(1, 0.0, 0.0, 0.0))
         listener.onVitalUpdate(VitalInfo(1, 0.0, cpuTicks, cpuTicks / 2.0))
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -6723,7 +6809,7 @@ internal class RumViewScopeTest {
         // When
         vitals.forEach { listener.onVitalUpdate(it) }
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -6817,7 +6903,7 @@ internal class RumViewScopeTest {
             listener.onVitalUpdate(VitalInfo(count, min, max, sum / count))
         }
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -6911,7 +6997,7 @@ internal class RumViewScopeTest {
             listener.onVitalUpdate(VitalInfo(count, min, max, sum / count))
         }
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -6991,7 +7077,7 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7012,7 +7098,7 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeOtherKey, emptyMap()),
+            RumRawEvent.StopView(fakeOtherKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7032,7 +7118,7 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StartView(fakeOtherKey, emptyMap()),
+            RumRawEvent.StartView(fakeOtherKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7049,7 +7135,12 @@ internal class RumViewScopeTest {
         // Given
 
         // When
-        testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        testedScope.handleEvent(
+            RumRawEvent.StopSession(eventTime = fakeEventTime),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
 
         // Then
         verify(mockCpuVitalMonitor).unregister(testedScope.cpuVitalListener)
@@ -7063,13 +7154,13 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7090,13 +7181,13 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
         testedScope.handleEvent(
-            RumRawEvent.StartView(fakeOtherKey, emptyMap()),
+            RumRawEvent.StartView(fakeOtherKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7114,12 +7205,17 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
-        testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        testedScope.handleEvent(
+            RumRawEvent.StopSession(eventTime = fakeEventTime),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
 
         // Then
         verify(mockCpuVitalMonitor).unregister(testedScope.cpuVitalListener)
@@ -7136,13 +7232,13 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StartView(fakeOtherKey, emptyMap()),
+            RumRawEvent.StartView(fakeOtherKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7166,13 +7262,13 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StartView(fakeOtherKey1, emptyMap()),
+            RumRawEvent.StartView(fakeOtherKey1, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
         testedScope.handleEvent(
-            RumRawEvent.StartView(fakeOtherKey2, emptyMap()),
+            RumRawEvent.StartView(fakeOtherKey2, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7193,12 +7289,17 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StartView(fakeOtherKey, emptyMap()),
+            RumRawEvent.StartView(fakeOtherKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
-        testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        testedScope.handleEvent(
+            RumRawEvent.StopSession(eventTime = fakeEventTime),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
 
         // Then
         verify(mockCpuVitalMonitor).unregister(testedScope.cpuVitalListener)
@@ -7214,9 +7315,14 @@ internal class RumViewScopeTest {
         assumeFalse(fakeOtherKey == fakeKey)
 
         // When
-        testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopSession(eventTime = fakeEventTime),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+        testedScope.handleEvent(
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7236,9 +7342,14 @@ internal class RumViewScopeTest {
         assumeFalse(fakeOtherKey == fakeKey)
 
         // When
-        testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
         testedScope.handleEvent(
-            RumRawEvent.StartView(fakeOtherKey, emptyMap()),
+            RumRawEvent.StopSession(eventTime = fakeEventTime),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+        testedScope.handleEvent(
+            RumRawEvent.StartView(fakeOtherKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7258,8 +7369,18 @@ internal class RumViewScopeTest {
         assumeFalse(fakeOtherKey == fakeKey)
 
         // When
-        testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
-        testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        testedScope.handleEvent(
+            RumRawEvent.StopSession(eventTime = fakeEventTime),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+        testedScope.handleEvent(
+            RumRawEvent.StopSession(eventTime = fakeEventTime),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
 
         // Then
         verify(mockCpuVitalMonitor).unregister(testedScope.cpuVitalListener)
@@ -7282,14 +7403,15 @@ internal class RumViewScopeTest {
         val result = testedScope.handleEvent(
             RumRawEvent.UpdatePerformanceMetric(
                 metric = RumPerformanceMetric.FLUTTER_BUILD_TIME,
-                value = value
+                value = value,
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
         testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7320,14 +7442,15 @@ internal class RumViewScopeTest {
         val result = testedScope.handleEvent(
             RumRawEvent.UpdatePerformanceMetric(
                 metric = RumPerformanceMetric.FLUTTER_RASTER_TIME,
-                value = value
+                value = value,
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
         testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7359,14 +7482,15 @@ internal class RumViewScopeTest {
         val result = testedScope.handleEvent(
             RumRawEvent.UpdatePerformanceMetric(
                 metric = RumPerformanceMetric.JS_FRAME_TIME,
-                value = value
+                value = value,
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
         testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7407,7 +7531,8 @@ internal class RumViewScopeTest {
             testedScope.handleEvent(
                 RumRawEvent.UpdatePerformanceMetric(
                     metric = RumPerformanceMetric.FLUTTER_BUILD_TIME,
-                    value = flutterBuildTimes[i]
+                    value = flutterBuildTimes[i],
+                    eventTime = fakeEventTime
                 ),
                 fakeDatadogContext,
                 mockEventWriteScope,
@@ -7416,7 +7541,8 @@ internal class RumViewScopeTest {
             testedScope.handleEvent(
                 RumRawEvent.UpdatePerformanceMetric(
                     metric = RumPerformanceMetric.FLUTTER_RASTER_TIME,
-                    value = flutterRasterTimes[i]
+                    value = flutterRasterTimes[i],
+                    eventTime = fakeEventTime
                 ),
                 fakeDatadogContext,
                 mockEventWriteScope,
@@ -7425,7 +7551,8 @@ internal class RumViewScopeTest {
             testedScope.handleEvent(
                 RumRawEvent.UpdatePerformanceMetric(
                     metric = RumPerformanceMetric.JS_FRAME_TIME,
-                    value = jsFrameTimes[i]
+                    value = jsFrameTimes[i],
+                    eventTime = fakeEventTime
                 ),
                 fakeDatadogContext,
                 mockEventWriteScope,
@@ -7433,7 +7560,7 @@ internal class RumViewScopeTest {
             )
         }
         testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7484,17 +7611,16 @@ internal class RumViewScopeTest {
         // GIVEN
         val frameTimeSeconds = forge.aDouble(min = 0.001, max = 0.05) // 1ms to 50ms
         val expectedRefreshRate = 1.0 / frameTimeSeconds
-        val expectedRefreshRateMin = expectedRefreshRate
 
         // WHEN
         val result = testedScope.handleEvent(
-            RumRawEvent.UpdateExternalRefreshRate(frameTimeSeconds),
+            RumRawEvent.UpdateExternalRefreshRate(frameTimeSeconds, eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
         testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7504,7 +7630,7 @@ internal class RumViewScopeTest {
         argumentCaptor<ViewEvent> {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
-                .hasRefreshRateMetric(expectedRefreshRate, expectedRefreshRateMin)
+                .hasRefreshRateMetric(expectedRefreshRate, expectedRefreshRate)
         }
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
@@ -7534,7 +7660,7 @@ internal class RumViewScopeTest {
             max = max(max, refreshRate)
 
             result = testedScope.handleEvent(
-                RumRawEvent.UpdateExternalRefreshRate(frameTime),
+                RumRawEvent.UpdateExternalRefreshRate(frameTime, eventTime = fakeEventTime),
                 fakeDatadogContext,
                 mockEventWriteScope,
                 mockWriter
@@ -7542,7 +7668,7 @@ internal class RumViewScopeTest {
         }
 
         testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7563,13 +7689,13 @@ internal class RumViewScopeTest {
     fun `M ignore invalid frame time W handleEvent(UpdateExternalRefreshRate+StopView) { zero frame time }`() {
         // WHEN
         val result = testedScope.handleEvent(
-            RumRawEvent.UpdateExternalRefreshRate(0.0),
+            RumRawEvent.UpdateExternalRefreshRate(0.0, eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
         testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7601,7 +7727,7 @@ internal class RumViewScopeTest {
 
         // WHEN
         val result = testedScope.handleEvent(
-            RumRawEvent.UpdateExternalRefreshRate(externalFrameTime),
+            RumRawEvent.UpdateExternalRefreshRate(externalFrameTime, eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7611,7 +7737,7 @@ internal class RumViewScopeTest {
         vitalListener.onVitalUpdate(VitalInfo(1, internalRefreshRate, internalRefreshRate, internalRefreshRate))
 
         testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7642,7 +7768,7 @@ internal class RumViewScopeTest {
         vitalListener.onVitalUpdate(VitalInfo(1, internalRefreshRate, internalRefreshRate, internalRefreshRate))
 
         val result = testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7664,7 +7790,7 @@ internal class RumViewScopeTest {
     ) {
         // GIVEN
         testedScope.handleEvent(
-            RumRawEvent.StopView(fakeKey, emptyMap()),
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7673,7 +7799,7 @@ internal class RumViewScopeTest {
 
         // WHEN
         val result = testedScope.handleEvent(
-            RumRawEvent.UpdateExternalRefreshRate(frameTimeSeconds),
+            RumRawEvent.UpdateExternalRefreshRate(frameTimeSeconds, eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7700,26 +7826,26 @@ internal class RumViewScopeTest {
 
         // WHEN
         testedScope.handleEvent(
-            RumRawEvent.UpdateExternalRefreshRate(frameTime1),
+            RumRawEvent.UpdateExternalRefreshRate(frameTime1, eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
         testedScope.handleEvent(
-            RumRawEvent.UpdateExternalRefreshRate(frameTime2),
+            RumRawEvent.UpdateExternalRefreshRate(frameTime2, eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
         val result = testedScope.handleEvent(
-            RumRawEvent.UpdateExternalRefreshRate(frameTime3),
+            RumRawEvent.UpdateExternalRefreshRate(frameTime3, eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
 
         testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7750,14 +7876,15 @@ internal class RumViewScopeTest {
         val result = testedScope.handleEvent(
             RumRawEvent.SetInternalViewAttribute(
                 key = RumAttributes.FLUTTER_FIRST_BUILD_COMPLETE,
-                value = fbc
+                value = fbc,
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
         testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7790,14 +7917,15 @@ internal class RumViewScopeTest {
         val result = testedScope.handleEvent(
             RumRawEvent.SetInternalViewAttribute(
                 key = RumAttributes.CUSTOM_INV_VALUE,
-                value = customInv
+                value = customInv,
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
         )
         testedScope.handleEvent(
-            RumRawEvent.StopView(testedScope.key, emptyMap()),
+            RumRawEvent.StopView(testedScope.key, emptyMap(), eventTime = laterEventTime()),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -7826,7 +7954,8 @@ internal class RumViewScopeTest {
         testedScope.handleEvent(
             RumRawEvent.AddFeatureFlagEvaluation(
                 name = flagName,
-                value = flagValue
+                value = flagValue,
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
@@ -7849,7 +7978,8 @@ internal class RumViewScopeTest {
         testedScope.handleEvent(
             RumRawEvent.AddFeatureFlagEvaluation(
                 name = flagName,
-                value = flagValue
+                value = flagValue,
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
@@ -7858,7 +7988,8 @@ internal class RumViewScopeTest {
         testedScope.handleEvent(
             RumRawEvent.AddFeatureFlagEvaluation(
                 name = flagName,
-                value = flagValue
+                value = flagValue,
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
@@ -7884,7 +8015,8 @@ internal class RumViewScopeTest {
         testedScope.handleEvent(
             RumRawEvent.AddFeatureFlagEvaluation(
                 name = flagName,
-                value = flagValue
+                value = flagValue,
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
@@ -7906,7 +8038,8 @@ internal class RumViewScopeTest {
         testedScope.handleEvent(
             RumRawEvent.AddFeatureFlagEvaluation(
                 name = flagName,
-                value = oldFlagValue
+                value = oldFlagValue,
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
@@ -7917,7 +8050,8 @@ internal class RumViewScopeTest {
         testedScope.handleEvent(
             RumRawEvent.AddFeatureFlagEvaluation(
                 name = flagName,
-                value = flagValue
+                value = flagValue,
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
@@ -7941,7 +8075,8 @@ internal class RumViewScopeTest {
         testedScope.handleEvent(
             RumRawEvent.AddFeatureFlagEvaluation(
                 name = flagName,
-                value = flagValue
+                value = flagValue,
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
@@ -7956,6 +8091,7 @@ internal class RumViewScopeTest {
                 throwable = null,
                 stacktrace = null,
                 isFatal = false,
+                eventTime = fakeEventTime,
                 threads = emptyList(),
                 attributes = emptyMap()
             ),
@@ -7989,7 +8125,8 @@ internal class RumViewScopeTest {
         // WHEN
         testedScope.handleEvent(
             RumRawEvent.AddFeatureFlagEvaluations(
-                mapOf(flagName1 to flagValue1, flagName2 to flagValue2, flagName3 to flagValue3)
+                mapOf(flagName1 to flagValue1, flagName2 to flagValue2, flagName3 to flagValue3),
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
@@ -8017,7 +8154,8 @@ internal class RumViewScopeTest {
         // WHEN
         testedScope.handleEvent(
             RumRawEvent.AddFeatureFlagEvaluations(
-                mapOf(flagName1 to flagValue1, flagName2 to flagValue2, flagName3 to flagValue3)
+                mapOf(flagName1 to flagValue1, flagName2 to flagValue2, flagName3 to flagValue3),
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
@@ -8025,7 +8163,8 @@ internal class RumViewScopeTest {
         )
         testedScope.handleEvent(
             RumRawEvent.AddFeatureFlagEvaluations(
-                mapOf(flagName1 to flagValue1, flagName2 to flagValue2, flagName3 to flagValue3)
+                mapOf(flagName1 to flagValue1, flagName2 to flagValue2, flagName3 to flagValue3),
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
@@ -8051,7 +8190,7 @@ internal class RumViewScopeTest {
 
         // WHEN
         testedScope.handleEvent(
-            RumRawEvent.AddFeatureFlagEvaluations(mapOf(flagName to flagValue)),
+            RumRawEvent.AddFeatureFlagEvaluations(mapOf(flagName to flagValue), eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -8077,7 +8216,8 @@ internal class RumViewScopeTest {
         // GIVEN
         testedScope.handleEvent(
             RumRawEvent.AddFeatureFlagEvaluations(
-                mapOf(flagName1 to oldFlagValue1, flagName2 to oldFlagValue2, flagName3 to oldFlagValue3)
+                mapOf(flagName1 to oldFlagValue1, flagName2 to oldFlagValue2, flagName3 to oldFlagValue3),
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
@@ -8087,7 +8227,8 @@ internal class RumViewScopeTest {
         // WHEN
         testedScope.handleEvent(
             RumRawEvent.AddFeatureFlagEvaluations(
-                mapOf(flagName1 to flagValue1, flagName2 to flagValue2, flagName3 to flagValue3)
+                mapOf(flagName1 to flagValue1, flagName2 to flagValue2, flagName3 to flagValue3),
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
@@ -8116,7 +8257,8 @@ internal class RumViewScopeTest {
         // GIVEN
         testedScope.handleEvent(
             RumRawEvent.AddFeatureFlagEvaluations(
-                mapOf(flagName1 to flagValue1, flagName2 to flagValue2, flagName3 to flagValue3)
+                mapOf(flagName1 to flagValue1, flagName2 to flagValue2, flagName3 to flagValue3),
+                eventTime = fakeEventTime
             ),
             fakeDatadogContext,
             mockEventWriteScope,
@@ -8131,6 +8273,7 @@ internal class RumViewScopeTest {
                 throwable = null,
                 stacktrace = null,
                 isFatal = false,
+                eventTime = fakeEventTime,
                 threads = emptyList(),
                 attributes = emptyMap()
             ),
@@ -8162,7 +8305,7 @@ internal class RumViewScopeTest {
 
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopSession(),
+            RumRawEvent.StopSession(eventTime = fakeEventTime),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -8201,6 +8344,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace,
             isFatal = false,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes
         )
@@ -8230,6 +8374,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace,
             isFatal = false,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes
         )
@@ -8260,6 +8405,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace,
             isFatal = false,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes
         )
@@ -8292,6 +8438,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace,
             isFatal = true,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes
         )
@@ -8321,6 +8468,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace,
             isFatal = true,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes
         )
@@ -8351,6 +8499,7 @@ internal class RumViewScopeTest {
             throwable,
             stacktrace,
             isFatal = true,
+            eventTime = fakeEventTime,
             threads = emptyList(),
             attributes = attributes
         )
@@ -8373,7 +8522,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeActionScope = mockActionScope
-        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target, eventTime = fakeEventTime)
 
         // When
         testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -8390,7 +8539,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeActionScope = mockActionScope
-        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target, eventTime = fakeEventTime)
         whenever(mockWriter.write(eq(mockEventBatchWriter), isA<LongTaskEvent>(), eq(EventType.DEFAULT))) doReturn false
 
         // When
@@ -8409,7 +8558,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeActionScope = mockActionScope
-        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target, eventTime = fakeEventTime)
         whenever(
             mockWriter.write(eq(mockEventBatchWriter), isA<LongTaskEvent>(), eq(EventType.DEFAULT))
         ) doThrow forge.anException()
@@ -8429,7 +8578,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeActionScope = mockActionScope
-        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target, eventTime = fakeEventTime)
 
         // When
         testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -8446,7 +8595,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeActionScope = mockActionScope
-        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target, eventTime = fakeEventTime)
         whenever(mockWriter.write(eq(mockEventBatchWriter), isA<LongTaskEvent>(), eq(EventType.DEFAULT))) doReturn false
 
         // When
@@ -8465,7 +8614,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeActionScope = mockActionScope
-        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target, eventTime = fakeEventTime)
         whenever(
             mockWriter.write(eq(mockEventBatchWriter), isA<LongTaskEvent>(), eq(EventType.DEFAULT))
         ) doThrow forge.anException()
@@ -8632,7 +8781,7 @@ internal class RumViewScopeTest {
         @StringForgery target: String
     ) {
         // Given
-        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target, eventTime = fakeEventTime)
 
         // When
         testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -8649,7 +8798,10 @@ internal class RumViewScopeTest {
         fakeEvent = RumRawEvent.StopView(
             key = testedScope.key,
             attributes = forge.exhaustiveAttributes(),
-            eventTime = Time(nanoTime = fakeEventTime.nanoTime + fakeViewDurationNs)
+            eventTime = Time(
+                timestamp = fakeEventTime.timestamp,
+                nanoTime = fakeEventTime.nanoTime + fakeViewDurationNs
+            )
         )
 
         // When
@@ -8665,7 +8817,13 @@ internal class RumViewScopeTest {
     ) {
         // When
         testedScope.handleEvent(
-            forge.startViewEvent(eventTime = Time(nanoTime = fakeEventTime.nanoTime + fakeViewDurationNs)),
+            forge.startViewEvent(
+                eventTime = Time(
+                    timestamp = fakeEventTime.timestamp,
+                    nanoTime =
+                    fakeEventTime.nanoTime + fakeViewDurationNs
+                )
+            ),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -8679,7 +8837,13 @@ internal class RumViewScopeTest {
     fun `M call resolveReport(viewId, true, Long) of slowFramesListener W handleEvent(StopSession)`() {
         // When
         testedScope.handleEvent(
-            RumRawEvent.StopSession(eventTime = Time(nanoTime = fakeEventTime.nanoTime + fakeViewDurationNs)),
+            RumRawEvent.StopSession(
+                eventTime = Time(
+                    timestamp = fakeEventTime.timestamp,
+                    nanoTime =
+                    fakeEventTime.nanoTime + fakeViewDurationNs
+                )
+            ),
             fakeDatadogContext,
             mockEventWriteScope,
             mockWriter
@@ -8811,7 +8975,12 @@ internal class RumViewScopeTest {
         testedScope = newRumViewScope()
 
         // When
-        testedScope.handleEvent(RumRawEvent.StopSession(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+        testedScope.handleEvent(
+            RumRawEvent.StopSession(eventTime = fakeEventTime),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
 
         // Then
         mockViewEndedMetricDispatcher.sendViewEnded(fakeInvState, fakeTnsState)
@@ -8820,7 +8989,13 @@ internal class RumViewScopeTest {
     @Test
     fun `M onDurationResolved W closing scope(StopSession)`(@LongForgery(min = 1) expectedDuration: Long) {
         // Given
-        val stopEvent = RumRawEvent.StopSession(eventTime = Time(nanoTime = fakeEventTime.nanoTime + expectedDuration))
+        val stopEvent = RumRawEvent.StopSession(
+            eventTime = Time(
+                timestamp = fakeEventTime.timestamp,
+                nanoTime =
+                fakeEventTime.nanoTime + expectedDuration
+            )
+        )
         testedScope = newRumViewScope()
 
         // When
@@ -8835,7 +9010,7 @@ internal class RumViewScopeTest {
         // Given
         val stopEvent = RumRawEvent.AddViewLoadingTime(
             overwrite = false,
-            eventTime = Time(nanoTime = fakeEventTime.nanoTime + expectedDuration)
+            eventTime = Time(timestamp = fakeEventTime.timestamp, nanoTime = fakeEventTime.nanoTime + expectedDuration)
         )
         testedScope = newRumViewScope()
 
@@ -8849,7 +9024,7 @@ internal class RumViewScopeTest {
     @Test
     fun `M return a new RumViewScope W renew the current one`() {
         // Given
-        val expectedTime = Time(nanoTime = fakeEventTime.nanoTime)
+        val expectedTime = Time(timestamp = fakeEventTime.timestamp, nanoTime = fakeEventTime.nanoTime)
 
         // When
         val newScope = testedScope.renew(expectedTime)
@@ -9448,7 +9623,7 @@ internal class RumViewScopeTest {
         @StringForgery target: String
     ) {
         // Given
-        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target, eventTime = fakeEventTime)
 
         // When
         testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
@@ -9505,9 +9680,16 @@ internal class RumViewScopeTest {
 
     private fun mockEvent(): RumRawEvent {
         val event: RumRawEvent = mock()
-        whenever(event.eventTime) doReturn Time()
+        whenever(event.eventTime) doReturn fakeEventTime
         return event
     }
+
+    // Builds an event time that is strictly after the scope start (fakeEventTime), so that the
+    // resolved view duration is positive. Used by tests that assert a non-zero view duration.
+    private fun laterEventTime(offsetMs: Long = 10L) = Time(
+        timestamp = fakeEventTime.timestamp + offsetMs,
+        nanoTime = fakeEventTime.nanoTime + TimeUnit.MILLISECONDS.toNanos(offsetMs)
+    )
 
     private fun forgeGlobalAttributes(
         forge: Forge,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -56,7 +56,6 @@ import com.datadog.android.rum.internal.metric.slowframes.SlowFramesListener
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor.Companion.OPERATION_ERROR_INVALID_NAME
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor.Companion.OPERATION_ERROR_INVALID_NAME_CHARACTERS
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor.Companion.OPERATION_ERROR_INVALID_OPERATION_KEY
-import com.datadog.android.rum.internal.startup.RumAppStartupTelemetryReporter
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.metric.interactiontonextview.LastInteractionIdentifier
 import com.datadog.android.rum.metric.networksettled.InitialResourceIdentifier
@@ -146,9 +145,6 @@ internal class DatadogRumMonitorTest {
 
     @Mock
     lateinit var mockDisplayInfoProvider: InfoProvider<DisplayInfo>
-
-    @Mock
-    lateinit var mockRumAppStartupTelemetryReporter: RumAppStartupTelemetryReporter
 
     @Mock
     private lateinit var mockInsightsCollector: InsightsCollector
@@ -651,7 +647,7 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
-    fun `M return null W getCurrentViewUrl() { session exists but has NULL_UUID — not yet sampled in }`(
+    fun `M return null W getCurrentViewUrl() { session exists but has NULL_UUID, not yet sampled in }`(
         @Forgery fakeRumContext: RumContext,
         @Forgery type: RumActionType,
         @StringForgery name: String
@@ -2179,7 +2175,7 @@ internal class DatadogRumMonitorTest {
         @StringForgery name: String,
         @StringForgery value: String
     ) {
-        val batch = mapOf(name to value)
+        val batch: Map<String, Any> = mapOf(name to value)
         testedMonitor.addFeatureFlagEvaluations(batch)
 
         argumentCaptor<RumRawEvent> {
@@ -2697,17 +2693,20 @@ internal class DatadogRumMonitorTest {
                         throwable = forge.aThrowable(),
                         stacktrace = forge.anAlphaNumericalString(),
                         threads = emptyList(),
-                        attributes = emptyMap()
+                        attributes = emptyMap(),
+                        eventTime = forge.getForgery()
                     ),
                     RumRawEvent.StartAction(
                         type = forge.aValueFrom(RumActionType::class.java),
                         name = forge.anAlphaNumericalString(),
                         waitForStop = forge.aBool(),
-                        attributes = emptyMap()
+                        attributes = emptyMap(),
+                        eventTime = forge.getForgery()
                     ),
                     RumRawEvent.StartView(
                         key = forge.getForgery(),
-                        attributes = emptyMap()
+                        attributes = emptyMap(),
+                        eventTime = forge.getForgery()
                     )
                 )
                 testedMonitor.handleEvent(event)
@@ -3249,7 +3248,7 @@ internal class DatadogRumMonitorTest {
     @Test
     fun `M warn but still emit W startOperation { operation name contains emoji }`() {
         // Like the non-ASCII case above, an emoji must fail the `[\w.@$-]*`
-        // regex. This additionally pins surrogate-pair / multi-byte handling
+        // regex. This additionally pins surrogate-pair / multibyte handling
         // (mirrors iOS PR #2864 / Browser PR #4525, spec test VAL-09).
         val invalidName = "login🔐"
         val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImplTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumAppStartupDetectorImplTest.kt
@@ -986,8 +986,8 @@ internal class RumAppStartupDetectorImplTest {
         val detector = RumAppStartupDetectorImpl(
             application = application,
             buildSdkVersionProvider = buildSdkVersionProvider,
-            appStartupTimeProvider = { Time(0, 0) },
-            timeProvider = {
+            appStartupTime = { Time(0, 0) },
+            currentTime = {
                 Time(
                     timestamp = currentTime.inWholeMilliseconds,
                     nanoTime = currentTime.inWholeNanoseconds

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManagerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumSessionScopeStartupManagerTest.kt
@@ -224,7 +224,8 @@ internal class RumSessionScopeStartupManagerTest {
         )
 
         val event = RumRawEvent.AppStartTTIDEvent(
-            info = info
+            info = info,
+            eventTime = scenario.initialTime
         )
 
         // When
@@ -263,7 +264,8 @@ internal class RumSessionScopeStartupManagerTest {
         )
 
         val event = RumRawEvent.AppStartTTIDEvent(
-            info = info
+            info = info,
+            eventTime = scenario.initialTime
         )
         val mockProfilingFeatureScope = mock<FeatureScope>()
         whenever(
@@ -314,7 +316,8 @@ internal class RumSessionScopeStartupManagerTest {
         )
 
         val event1 = RumRawEvent.AppStartTTIDEvent(
-            info = info1
+            info = info1,
+            eventTime = scenario1.initialTime
         )
 
         val info2 = RumTTIDInfo(
@@ -323,7 +326,8 @@ internal class RumSessionScopeStartupManagerTest {
         )
 
         val event2 = RumRawEvent.AppStartTTIDEvent(
-            info = info2
+            info = info2,
+            eventTime = scenario2.initialTime
         )
 
         // When
@@ -373,12 +377,12 @@ internal class RumSessionScopeStartupManagerTest {
             durationNs = forge.aLong(min = 0, max = 10000)
         )
 
-        val ttidEvent = RumRawEvent.AppStartTTIDEvent(info = info)
+        val ttidEvent = RumRawEvent.AppStartTTIDEvent(info = info, eventTime = scenario.initialTime)
 
         val ttfdEvent = forge.createTTFDEvent(scenario.initialTime)
 
         // When
-        manager.onAppStartEvent(RumRawEvent.AppStartEvent(scenario = scenario))
+        manager.onAppStartEvent(RumRawEvent.AppStartEvent(scenario = scenario, eventTime = scenario.initialTime))
 
         manager.onTTIDEvent(
             event = ttidEvent,
@@ -421,8 +425,8 @@ internal class RumSessionScopeStartupManagerTest {
         forge: Forge
     ) {
         // Given
-        val appStartEvent1 = RumRawEvent.AppStartEvent(scenario = scenario1)
-        val appStartEvent2 = RumRawEvent.AppStartEvent(scenario = scenario2)
+        val appStartEvent1 = RumRawEvent.AppStartEvent(scenario = scenario1, eventTime = scenario1.initialTime)
+        val appStartEvent2 = RumRawEvent.AppStartEvent(scenario = scenario2, eventTime = scenario2.initialTime)
 
         val info1 = RumTTIDInfo(
             scenario = scenario1,
@@ -434,8 +438,8 @@ internal class RumSessionScopeStartupManagerTest {
             durationNs = forge.aLong(min = 0, max = 10000)
         )
 
-        val ttidEvent1 = RumRawEvent.AppStartTTIDEvent(info = info1)
-        val ttidEvent2 = RumRawEvent.AppStartTTIDEvent(info = info2)
+        val ttidEvent1 = RumRawEvent.AppStartTTIDEvent(info = info1, eventTime = scenario1.initialTime)
+        val ttidEvent2 = RumRawEvent.AppStartTTIDEvent(info = info2, eventTime = scenario2.initialTime)
 
         val ttfdEvent1 = forge.createTTFDEvent(scenario1.initialTime)
         val ttfdEvent2 = forge.createTTFDEvent(scenario2.initialTime)
@@ -501,7 +505,7 @@ internal class RumSessionScopeStartupManagerTest {
     fun `M log W onTTFDEvent { if called before onAppStartEvent }`() {
         // When
         manager.onTTFDEvent(
-            event = RumRawEvent.AppStartTTFDEvent(),
+            event = RumRawEvent.AppStartTTFDEvent(eventTime = Time(timestamp = 0L, nanoTime = 0L)),
             datadogContext = fakeDatadogContext,
             writeScope = mockEventWriteScope,
             writer = mockWriter,
@@ -529,10 +533,10 @@ internal class RumSessionScopeStartupManagerTest {
         scenario: RumStartupScenario
     ) {
         // When
-        manager.onAppStartEvent(RumRawEvent.AppStartEvent(scenario = scenario))
+        manager.onAppStartEvent(RumRawEvent.AppStartEvent(scenario = scenario, eventTime = scenario.initialTime))
 
         manager.onTTFDEvent(
-            event = RumRawEvent.AppStartTTFDEvent(),
+            event = RumRawEvent.AppStartTTFDEvent(eventTime = scenario.initialTime),
             datadogContext = fakeDatadogContext,
             writeScope = mockEventWriteScope,
             writer = mockWriter,
@@ -568,13 +572,14 @@ internal class RumSessionScopeStartupManagerTest {
         )
 
         val ttidEvent = RumRawEvent.AppStartTTIDEvent(
-            info = info
+            info = info,
+            eventTime = scenario.initialTime
         )
 
-        val ttfdEvent = RumRawEvent.AppStartTTFDEvent()
+        val ttfdEvent = RumRawEvent.AppStartTTFDEvent(eventTime = scenario.initialTime)
 
         // When
-        manager.onAppStartEvent(RumRawEvent.AppStartEvent(scenario = scenario))
+        manager.onAppStartEvent(RumRawEvent.AppStartEvent(scenario = scenario, eventTime = scenario.initialTime))
 
         manager.onTTFDEvent(
             event = ttfdEvent,
@@ -626,11 +631,12 @@ internal class RumSessionScopeStartupManagerTest {
         )
 
         val ttidEvent = RumRawEvent.AppStartTTIDEvent(
-            info = info
+            info = info,
+            eventTime = scenario.initialTime
         )
 
         // When
-        manager.onAppStartEvent(RumRawEvent.AppStartEvent(scenario = scenario))
+        manager.onAppStartEvent(RumRawEvent.AppStartEvent(scenario = scenario, eventTime = scenario.initialTime))
 
         manager.onTTIDEvent(
             event = ttidEvent,
@@ -666,7 +672,7 @@ internal class RumSessionScopeStartupManagerTest {
             durationNs = forge.aLong(min = 0, max = 10000)
         )
 
-        val ttidEvent = RumRawEvent.AppStartTTIDEvent(info = info)
+        val ttidEvent = RumRawEvent.AppStartTTIDEvent(info = info, eventTime = scenario.initialTime)
 
         val ttfdEvent = forge.createTTFDEvent(
             initialTime = scenario.initialTime,
@@ -674,7 +680,7 @@ internal class RumSessionScopeStartupManagerTest {
         )
 
         // When
-        manager.onAppStartEvent(RumRawEvent.AppStartEvent(scenario = scenario))
+        manager.onAppStartEvent(RumRawEvent.AppStartEvent(scenario = scenario, eventTime = scenario.initialTime))
 
         manager.onTTIDEvent(
             event = ttidEvent,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ActionSentForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ActionSentForgeryFactory.kt
@@ -18,7 +18,8 @@ internal class ActionSentForgeryFactory : ForgeryFactory<RumRawEvent.ActionSent>
             viewId = forge.getForgery<UUID>().toString(),
             frustrationCount = forge.anInt(min = 0),
             type = forge.aValueFrom(ActionEvent.ActionEventActionType::class.java),
-            eventEndTimestampInNanos = forge.aPositiveLong()
+            eventEndTimestampInNanos = forge.aPositiveLong(),
+            eventTime = forge.getForgery()
         )
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/AddCustomTimingEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/AddCustomTimingEventForgeryFactory.kt
@@ -12,7 +12,8 @@ import fr.xgouchet.elmyr.ForgeryFactory
 internal class AddCustomTimingEventForgeryFactory : ForgeryFactory<RumRawEvent.AddCustomTiming> {
     override fun getForgery(forge: Forge): RumRawEvent.AddCustomTiming {
         return RumRawEvent.AddCustomTiming(
-            name = forge.aString()
+            name = forge.aString(),
+            eventTime = forge.getForgery()
         )
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/AddErrorEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/AddErrorEventForgeryFactory.kt
@@ -24,6 +24,7 @@ internal class AddErrorEventForgeryFactory : ForgeryFactory<RumRawEvent.AddError
         attributes = forge.exhaustiveAttributes(),
         type = forge.aNullable { aString() },
         threads = forge.aList { getForgery() },
-        timeSinceAppStartNs = forge.aNullable { aPositiveLong() }
+        timeSinceAppStartNs = forge.aNullable { aPositiveLong() },
+        eventTime = forge.getForgery()
     )
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/AddFeatureFlagEvaluationForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/AddFeatureFlagEvaluationForgeryFactory.kt
@@ -12,6 +12,7 @@ import fr.xgouchet.elmyr.ForgeryFactory
 internal class AddFeatureFlagEvaluationForgeryFactory : ForgeryFactory<RumRawEvent.AddFeatureFlagEvaluation> {
     override fun getForgery(forge: Forge) = RumRawEvent.AddFeatureFlagEvaluation(
         name = forge.aString(),
-        value = forge.aString()
+        value = forge.aString(),
+        eventTime = forge.getForgery()
     )
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
@@ -43,6 +43,7 @@ internal class Configurator : BaseConfigurator() {
         forge.addFactory(ViewEventMetaForgeryFactory())
         forge.addFactory(RumScopeKeyForgeryFactory())
         forge.addFactory(ResourceIdForgeryFactory())
+        forge.addFactory(TimeForgeryFactory())
         forge.addFactory(InternalResourceContextFactory())
         forge.addFactory(NetworkSettledResourceContextFactory())
         forge.addFactory(InternalInteractionContextFactory())

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ErrorSentForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ErrorSentForgeryFactory.kt
@@ -13,6 +13,7 @@ internal class ErrorSentForgeryFactory : ForgeryFactory<RumRawEvent.ErrorSent> {
     override fun getForgery(forge: Forge) = RumRawEvent.ErrorSent(
         viewId = forge.aString(),
         resourceId = forge.aNullable { aString() },
-        resourceEndTimestampInNanos = forge.aNullable { aPositiveLong() }
+        resourceEndTimestampInNanos = forge.aNullable { aPositiveLong() },
+        eventTime = forge.getForgery()
     )
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/LongTaskSentForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/LongTaskSentForgeryFactory.kt
@@ -12,6 +12,7 @@ import fr.xgouchet.elmyr.ForgeryFactory
 internal class LongTaskSentForgeryFactory : ForgeryFactory<RumRawEvent.LongTaskSent> {
     override fun getForgery(forge: Forge) = RumRawEvent.LongTaskSent(
         viewId = forge.aString(),
-        isFrozenFrame = forge.aBool()
+        isFrozenFrame = forge.aBool(),
+        eventTime = forge.getForgery()
     )
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ResourceDroppedForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ResourceDroppedForgeryFactory.kt
@@ -15,7 +15,8 @@ internal class ResourceDroppedForgeryFactory : ForgeryFactory<RumRawEvent.Resour
     override fun getForgery(forge: Forge): RumRawEvent.ResourceDropped {
         return RumRawEvent.ResourceDropped(
             viewId = forge.getForgery<UUID>().toString(),
-            resourceId = forge.getForgery<UUID>().toString()
+            resourceId = forge.getForgery<UUID>().toString(),
+            eventTime = forge.getForgery()
         )
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ResourceSentForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ResourceSentForgeryFactory.kt
@@ -16,7 +16,8 @@ internal class ResourceSentForgeryFactory : ForgeryFactory<RumRawEvent.ResourceS
         return RumRawEvent.ResourceSent(
             viewId = forge.getForgery<UUID>().toString(),
             resourceId = forge.getForgery<UUID>().toString(),
-            resourceEndTimestampInNanos = forge.aPositiveLong()
+            resourceEndTimestampInNanos = forge.aPositiveLong(),
+            eventTime = forge.getForgery()
         )
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/TimeForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/TimeForgeryFactory.kt
@@ -3,15 +3,16 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
  * Copyright 2016-Present Datadog, Inc.
  */
+
 package com.datadog.android.rum.utils.forge
 
-import com.datadog.android.rum.internal.domain.scope.RumRawEvent
+import com.datadog.android.rum.internal.domain.Time
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
-internal class AddFeatureFlagEvaluationsForgeryFactory : ForgeryFactory<RumRawEvent.AddFeatureFlagEvaluations> {
-    override fun getForgery(forge: Forge) = RumRawEvent.AddFeatureFlagEvaluations(
-        featureFlags = forge.aMap { aString() to aString() },
-        eventTime = forge.getForgery()
+internal class TimeForgeryFactory : ForgeryFactory<Time> {
+    override fun getForgery(forge: Forge): Time = Time(
+        timestamp = forge.aLong(min = 1_000_000_000_000L, max = 2_000_000_000_000L),
+        nanoTime = forge.aLong(min = 1_000_000_000_000L, max = 2_000_000_000_000L)
     )
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -23,6 +23,7 @@ import com.datadog.android.internal.telemetry.TracingHeaderTypesSet
 import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.RumContext
+import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.scope.RumRawEvent
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.metric.interactiontonextview.LastInteractionIdentifier
@@ -165,6 +166,9 @@ internal class TelemetryEventHandlerTest {
 
     private var fakeServerOffset: Long = 0L
 
+    @Forgery
+    lateinit var fakeEventTime: Time
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         whenever(mockDeviceInfo.architecture).thenReturn(fakeDeviceArchitecture)
@@ -176,7 +180,6 @@ internal class TelemetryEventHandlerTest {
         whenever(mockDeviceInfo.architecture).thenReturn(fakeDeviceArchitecture)
 
         fakeServerOffset = forge.aLong(-50000, 50000)
-
         fakeDatadogContext = fakeDatadogContext.copy(
             source = "android",
             featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
@@ -239,7 +242,7 @@ internal class TelemetryEventHandlerTest {
     @Test
     fun `M create debug event W handleEvent(Log Debug)`(@Forgery fakeLogDebugEvent: InternalTelemetryEvent.Log.Debug) {
         // Given
-        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeLogDebugEvent)
+        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeLogDebugEvent, eventTime = fakeEventTime)
 
         // When
         testedTelemetryHandler.handleEvent(fakeWrappedEvent, mockWriter)
@@ -261,7 +264,7 @@ internal class TelemetryEventHandlerTest {
         @Forgery fakeLogDebugEvent: InternalTelemetryEvent.Log.Debug
     ) {
         // Given
-        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeLogDebugEvent)
+        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeLogDebugEvent, eventTime = fakeEventTime)
         fakeDatadogContext = fakeDatadogContext.copy(
             featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
                 remove(Feature.RUM_FEATURE_NAME)
@@ -304,7 +307,7 @@ internal class TelemetryEventHandlerTest {
             stacktrace = expectedStackTrace,
             kind = null
         )
-        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeLogErrorEvent)
+        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeLogErrorEvent, eventTime = fakeEventTime)
         fakeDatadogContext = fakeDatadogContext.copy(
             featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
                 remove(Feature.RUM_FEATURE_NAME)
@@ -345,7 +348,7 @@ internal class TelemetryEventHandlerTest {
             stacktrace = null,
             kind = expectedKind
         )
-        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeLogErrorEvent)
+        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeLogErrorEvent, eventTime = fakeEventTime)
         fakeDatadogContext = fakeDatadogContext.copy(
             featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
                 remove(Feature.RUM_FEATURE_NAME)
@@ -387,7 +390,7 @@ internal class TelemetryEventHandlerTest {
             stacktrace = expectedStacktrace,
             kind = expectedKind
         )
-        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeLogErrorEvent)
+        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeLogErrorEvent, eventTime = fakeEventTime)
         fakeDatadogContext = fakeDatadogContext.copy(
             featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
                 remove(Feature.RUM_FEATURE_NAME)
@@ -430,7 +433,7 @@ internal class TelemetryEventHandlerTest {
             stacktrace = null,
             kind = null
         )
-        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeLogErrorEvent)
+        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeLogErrorEvent, eventTime = fakeEventTime)
         fakeDatadogContext = fakeDatadogContext.copy(
             featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
                 remove(Feature.RUM_FEATURE_NAME)
@@ -473,7 +476,7 @@ internal class TelemetryEventHandlerTest {
             stacktrace = expectedStacktrace,
             kind = expectedKind
         )
-        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeLogErrorEvent)
+        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeLogErrorEvent, eventTime = fakeEventTime)
         fakeDatadogContext = fakeDatadogContext.copy(
             featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
                 remove(Feature.RUM_FEATURE_NAME)
@@ -512,7 +515,7 @@ internal class TelemetryEventHandlerTest {
         @Forgery fakeConfigurationEvent: InternalTelemetryEvent.Configuration
     ) {
         // Given
-        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeConfigurationEvent)
+        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeConfigurationEvent, eventTime = fakeEventTime)
 
         // When
         testedTelemetryHandler.handleEvent(fakeWrappedEvent, mockWriter)
@@ -534,7 +537,7 @@ internal class TelemetryEventHandlerTest {
         @Forgery fakeConfigurationEvent: InternalTelemetryEvent.Configuration
     ) {
         // Given
-        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeConfigurationEvent)
+        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeConfigurationEvent, eventTime = fakeEventTime)
         fakeDatadogContext = fakeDatadogContext.copy(
             featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
                 remove(Feature.RUM_FEATURE_NAME)
@@ -572,7 +575,7 @@ internal class TelemetryEventHandlerTest {
         whenever(mockRumFeature.configuration) doReturn fakeRumConfiguration
         whenever(mockRumFeatureScope.unwrap<RumFeature>()) doReturn mockRumFeature
 
-        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfigurationEvent)
+        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfigurationEvent, eventTime = fakeEventTime)
 
         val expectedViewTrackingStrategy = when (fakeRumConfiguration.viewTrackingStrategy) {
             is ActivityViewTrackingStrategy -> VTS.ACTIVITYVIEWTRACKINGSTRATEGY
@@ -618,7 +621,7 @@ internal class TelemetryEventHandlerTest {
         @Forgery fakeConfiguration: InternalTelemetryEvent.Configuration
     ) {
         // Given
-        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration)
+        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration, eventTime = fakeEventTime)
         if (useTracer) {
             whenever(mockSdkCore.getFeature(Feature.TRACING_FEATURE_NAME)) doReturn mock()
             if (tracerApi == TelemetryEventHandler.TracerApi.OpenTracing) {
@@ -661,12 +664,15 @@ internal class TelemetryEventHandlerTest {
     ) {
         // Given
         val trackNetworkRequests = forge.aBool()
-        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration)
+        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration, eventTime = fakeEventTime)
 
         // When
         if (trackNetworkRequests) {
             testedTelemetryHandler.handleEvent(
-                RumRawEvent.TelemetryEventWrapper(InternalTelemetryEvent.InterceptorInstantiated),
+                RumRawEvent.TelemetryEventWrapper(
+                    InternalTelemetryEvent.InterceptorInstantiated,
+                    eventTime = fakeEventTime
+                ),
                 mockWriter
             )
         }
@@ -691,7 +697,7 @@ internal class TelemetryEventHandlerTest {
         @Forgery fakeConfiguration: InternalTelemetryEvent.Configuration
     ) {
         // Given
-        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration)
+        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration, eventTime = fakeEventTime)
 
         // When
         testedTelemetryHandler.handleEvent(configRawEvent, mockWriter)
@@ -708,14 +714,15 @@ internal class TelemetryEventHandlerTest {
         @Forgery fakeConfiguration: InternalTelemetryEvent.Configuration
     ) {
         // Given
-        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration)
+        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration, eventTime = fakeEventTime)
 
         // When
         testedTelemetryHandler.handleEvent(
             RumRawEvent.TelemetryEventWrapper(
                 InternalTelemetryEvent.ResourceHeadersTrackingConfigured(
                     InternalTelemetryEvent.ResourceHeadersTrackingConfigured.Mode.DEFAULT_HEADERS
-                )
+                ),
+                eventTime = fakeEventTime
             ),
             mockWriter
         )
@@ -735,14 +742,15 @@ internal class TelemetryEventHandlerTest {
         @Forgery fakeConfiguration: InternalTelemetryEvent.Configuration
     ) {
         // Given
-        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration)
+        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration, eventTime = fakeEventTime)
 
         // When
         testedTelemetryHandler.handleEvent(
             RumRawEvent.TelemetryEventWrapper(
                 InternalTelemetryEvent.ResourceHeadersTrackingConfigured(
                     InternalTelemetryEvent.ResourceHeadersTrackingConfigured.Mode.CUSTOM
-                )
+                ),
+                eventTime = fakeEventTime
             ),
             mockWriter
         )
@@ -762,7 +770,7 @@ internal class TelemetryEventHandlerTest {
         @Forgery fakeConfiguration: InternalTelemetryEvent.Configuration
     ) {
         // Given
-        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration)
+        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration, eventTime = fakeEventTime)
 
         // When
         testedTelemetryHandler.handleEvent(configRawEvent, mockWriter)
@@ -803,7 +811,7 @@ internal class TelemetryEventHandlerTest {
                 )
             }
         )
-        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration)
+        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration, eventTime = fakeEventTime)
 
         // When
         testedTelemetryHandler.handleEvent(configRawEvent, mockWriter)
@@ -827,15 +835,15 @@ internal class TelemetryEventHandlerTest {
     ) {
         // Given
         val fakeSampleRate = forge.aNullable { aString() }
-        val fakeSessionReplayIsStartedImmediatley = forge.aNullable { aString() }
+        val fakeSessionReplayIsStartedImmediately = forge.aNullable { aString() }
         val fakeSessionReplayContext = mutableMapOf<String, Any?>(
             TelemetryEventHandler.SESSION_REPLAY_START_IMMEDIATE_RECORDING_KEY to
-                fakeSessionReplayIsStartedImmediatley,
+                fakeSessionReplayIsStartedImmediately,
             TelemetryEventHandler.SESSION_REPLAY_SAMPLE_RATE_KEY to fakeSampleRate
         )
         whenever(mockSdkCore.getFeatureContext(Feature.SESSION_REPLAY_FEATURE_NAME)) doReturn
             fakeSessionReplayContext
-        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration)
+        val configRawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration, eventTime = fakeEventTime)
 
         // When
         testedTelemetryHandler.handleEvent(configRawEvent, mockWriter)
@@ -860,7 +868,7 @@ internal class TelemetryEventHandlerTest {
     fun `M not write event W handleEvent() { event is not sampled }`(forge: Forge) {
         // Given
         val fakeInternalTelemetryEvent = forge.forgeWritableInternalTelemetryEvent()
-        val rawEvent = RumRawEvent.TelemetryEventWrapper(fakeInternalTelemetryEvent)
+        val rawEvent = RumRawEvent.TelemetryEventWrapper(fakeInternalTelemetryEvent, eventTime = fakeEventTime)
         whenever(mockSampler.sample(any())) doReturn false
 
         // When
@@ -879,7 +887,7 @@ internal class TelemetryEventHandlerTest {
             forge.getForgery<InternalTelemetryEvent.Log.Error>(),
             forge.getForgery<InternalTelemetryEvent.Log.Debug>()
         )
-        val rawEvent = RumRawEvent.TelemetryEventWrapper(logeEvent)
+        val rawEvent = RumRawEvent.TelemetryEventWrapper(logeEvent, eventTime = fakeEventTime)
         whenever(mockSampler.sample(any())) doReturn true
         whenever(mockConfigurationSampler.sample(any())) doReturn false
 
@@ -902,7 +910,7 @@ internal class TelemetryEventHandlerTest {
         @Forgery fakeConfiguration: InternalTelemetryEvent.Configuration
     ) {
         // Given
-        val rawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration)
+        val rawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration, eventTime = fakeEventTime)
         whenever(mockSampler.sample(any())) doReturn true
         whenever(mockConfigurationSampler.sample(any())) doReturn false
 
@@ -922,7 +930,7 @@ internal class TelemetryEventHandlerTest {
             forge.getForgery<InternalTelemetryEvent.Log.Error>(),
             forge.getForgery<InternalTelemetryEvent.Log.Debug>()
         )
-        val rawEvent = RumRawEvent.TelemetryEventWrapper(internalTelemetryEvent)
+        val rawEvent = RumRawEvent.TelemetryEventWrapper(internalTelemetryEvent, eventTime = fakeEventTime)
         val anotherEvent = rawEvent.copy()
 
         // When
@@ -973,8 +981,8 @@ internal class TelemetryEventHandlerTest {
         @Forgery fakeMetricEvent: InternalTelemetryEvent.Metric
     ) {
         // Given
-        val rawEvent = RumRawEvent.TelemetryEventWrapper(fakeMetricEvent)
-        val events = listOf(rawEvent, RumRawEvent.TelemetryEventWrapper(fakeMetricEvent))
+        val rawEvent = RumRawEvent.TelemetryEventWrapper(fakeMetricEvent, eventTime = fakeEventTime)
+        val events = listOf(rawEvent, RumRawEvent.TelemetryEventWrapper(fakeMetricEvent, eventTime = fakeEventTime))
 
         // When
         testedTelemetryHandler.handleEvent(events[0], mockWriter)
@@ -1006,7 +1014,10 @@ internal class TelemetryEventHandlerTest {
 
         // When
         events.forEach {
-            testedTelemetryHandler.handleEvent(RumRawEvent.TelemetryEventWrapper(it), mockWriter)
+            testedTelemetryHandler.handleEvent(
+                RumRawEvent.TelemetryEventWrapper(it, eventTime = fakeEventTime),
+                mockWriter
+            )
         }
 
         // Then
@@ -1023,10 +1034,10 @@ internal class TelemetryEventHandlerTest {
         // important because non-metric events can only be seen once
         val eventsInOldSession = (0..MAX_EVENTS_PER_SESSION_TEST / 2).map {
             forge.getForgery<InternalTelemetryEvent.Metric>()
-        }.map { RumRawEvent.TelemetryEventWrapper(it) }
+        }.map { RumRawEvent.TelemetryEventWrapper(it, eventTime = fakeEventTime) }
         val eventsInNewSession = (0..MAX_EVENTS_PER_SESSION_TEST / 2).map {
             forge.getForgery<InternalTelemetryEvent.Metric>()
-        }.map { RumRawEvent.TelemetryEventWrapper(it) }
+        }.map { RumRawEvent.TelemetryEventWrapper(it, eventTime = fakeEventTime) }
 
         eventsInOldSession.forEach {
             testedTelemetryHandler.handleEvent(it, mockWriter)
@@ -1060,7 +1071,7 @@ internal class TelemetryEventHandlerTest {
         ) { forge.forgeWritableInternalTelemetryEvent(InternalTelemetryEvent.Configuration::class) }
             // remove unwanted identity collisions
             .groupBy { it.identity }
-            .map { RumRawEvent.TelemetryEventWrapper(it.value.first()) }
+            .map { RumRawEvent.TelemetryEventWrapper(it.value.first(), eventTime = fakeEventTime) }
             .take(MAX_EVENTS_PER_SESSION_TEST * 2)
 
         assumeTrue(events.size == MAX_EVENTS_PER_SESSION_TEST * 2)
@@ -1099,8 +1110,8 @@ internal class TelemetryEventHandlerTest {
             kind = null
         )
         val events = listOf(
-            RumRawEvent.TelemetryEventWrapper(fakeLogErrorEventNoKindNoThrowable),
-            RumRawEvent.TelemetryEventWrapper(fakeLogErrorEventNoKindWithThrowable)
+            RumRawEvent.TelemetryEventWrapper(fakeLogErrorEventNoKindNoThrowable, eventTime = fakeEventTime),
+            RumRawEvent.TelemetryEventWrapper(fakeLogErrorEventNoKindWithThrowable, eventTime = fakeEventTime)
         )
 
         // When
@@ -1133,7 +1144,7 @@ internal class TelemetryEventHandlerTest {
         @Forgery fakeApiUsageEvent: InternalTelemetryEvent.ApiUsage
     ) {
         // Given
-        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeApiUsageEvent)
+        val fakeWrappedEvent = RumRawEvent.TelemetryEventWrapper(fakeApiUsageEvent, eventTime = fakeEventTime)
 
         // When
         testedTelemetryHandler.handleEvent(fakeWrappedEvent, mockWriter)
@@ -1155,8 +1166,8 @@ internal class TelemetryEventHandlerTest {
         @Forgery fakeApiUsageEvent: InternalTelemetryEvent.ApiUsage
     ) {
         // Given
-        val rawEvent = RumRawEvent.TelemetryEventWrapper(fakeApiUsageEvent)
-        val events = listOf(rawEvent, RumRawEvent.TelemetryEventWrapper(fakeApiUsageEvent))
+        val rawEvent = RumRawEvent.TelemetryEventWrapper(fakeApiUsageEvent, eventTime = fakeEventTime)
+        val events = listOf(rawEvent, RumRawEvent.TelemetryEventWrapper(fakeApiUsageEvent, eventTime = fakeEventTime))
 
         // When
         testedTelemetryHandler.handleEvent(events[0], mockWriter)
@@ -1188,7 +1199,10 @@ internal class TelemetryEventHandlerTest {
 
         // When
         events.forEach {
-            testedTelemetryHandler.handleEvent(RumRawEvent.TelemetryEventWrapper(it), mockWriter)
+            testedTelemetryHandler.handleEvent(
+                RumRawEvent.TelemetryEventWrapper(it, eventTime = fakeEventTime),
+                mockWriter
+            )
         }
 
         // Then
@@ -1207,12 +1221,15 @@ internal class TelemetryEventHandlerTest {
         // Given
         repeat(MAX_EVENTS_PER_SESSION_TEST + 1) {
             val event = forge.getForgery<InternalTelemetryEvent.Metric>()
-            testedTelemetryHandler.handleEvent(RumRawEvent.TelemetryEventWrapper(event), mockWriter)
+            testedTelemetryHandler.handleEvent(
+                RumRawEvent.TelemetryEventWrapper(event, eventTime = fakeEventTime),
+                mockWriter
+            )
         }
 
         // When
         testedTelemetryHandler.handleEvent(
-            RumRawEvent.TelemetryEventWrapper(fakeConfigurationEvent),
+            RumRawEvent.TelemetryEventWrapper(fakeConfigurationEvent, eventTime = fakeEventTime),
             mockWriter
         )
 
@@ -1233,14 +1250,17 @@ internal class TelemetryEventHandlerTest {
     ) {
         // Given
         testedTelemetryHandler.handleEvent(
-            RumRawEvent.TelemetryEventWrapper(fakeConfigurationEvent),
+            RumRawEvent.TelemetryEventWrapper(fakeConfigurationEvent, eventTime = fakeEventTime),
             mockWriter
         )
 
         // When
         repeat(MAX_EVENTS_PER_SESSION_TEST) {
             testedTelemetryHandler.handleEvent(
-                RumRawEvent.TelemetryEventWrapper(forge.getForgery<InternalTelemetryEvent.Metric>()),
+                RumRawEvent.TelemetryEventWrapper(
+                    forge.getForgery<InternalTelemetryEvent.Metric>(),
+                    eventTime = fakeEventTime
+                ),
                 mockWriter
             )
         }
@@ -1264,7 +1284,10 @@ internal class TelemetryEventHandlerTest {
         }
 
         // When
-        testedTelemetryHandler.handleEvent(RumRawEvent.TelemetryEventWrapper(fakeApiUsageEvent), mockWriter)
+        testedTelemetryHandler.handleEvent(
+            RumRawEvent.TelemetryEventWrapper(fakeApiUsageEvent, eventTime = fakeEventTime),
+            mockWriter
+        )
 
         // Then
         argumentCaptor<Any> {
@@ -1291,7 +1314,10 @@ internal class TelemetryEventHandlerTest {
         )
 
         // When
-        testedTelemetryHandler.handleEvent(RumRawEvent.TelemetryEventWrapper(fakeMetricEvent), mockWriter)
+        testedTelemetryHandler.handleEvent(
+            RumRawEvent.TelemetryEventWrapper(fakeMetricEvent, eventTime = fakeEventTime),
+            mockWriter
+        )
 
         // Then
         argumentCaptor<Any> {
@@ -1318,7 +1344,10 @@ internal class TelemetryEventHandlerTest {
         )
 
         // When
-        testedTelemetryHandler.handleEvent(RumRawEvent.TelemetryEventWrapper(fakeLogDebugEvent), mockWriter)
+        testedTelemetryHandler.handleEvent(
+            RumRawEvent.TelemetryEventWrapper(fakeLogDebugEvent, eventTime = fakeEventTime),
+            mockWriter
+        )
 
         // Then
         argumentCaptor<Any> {
@@ -1345,7 +1374,10 @@ internal class TelemetryEventHandlerTest {
         )
 
         // When
-        testedTelemetryHandler.handleEvent(RumRawEvent.TelemetryEventWrapper(fakeLogDebugEvent), mockWriter)
+        testedTelemetryHandler.handleEvent(
+            RumRawEvent.TelemetryEventWrapper(fakeLogDebugEvent, eventTime = fakeEventTime),
+            mockWriter
+        )
 
         // Then
         argumentCaptor<Any> {
@@ -1374,7 +1406,10 @@ internal class TelemetryEventHandlerTest {
         }
 
         // When
-        testedTelemetryHandler.handleEvent(RumRawEvent.TelemetryEventWrapper(fakeApiUsageEvent), mockWriter)
+        testedTelemetryHandler.handleEvent(
+            RumRawEvent.TelemetryEventWrapper(fakeApiUsageEvent, eventTime = fakeEventTime),
+            mockWriter
+        )
 
         // Then
         argumentCaptor<Any> {
@@ -1411,7 +1446,10 @@ internal class TelemetryEventHandlerTest {
         )
 
         // When
-        testedTelemetryHandler.handleEvent(RumRawEvent.TelemetryEventWrapper(fakeMetricEvent), mockWriter)
+        testedTelemetryHandler.handleEvent(
+            RumRawEvent.TelemetryEventWrapper(fakeMetricEvent, eventTime = fakeEventTime),
+            mockWriter
+        )
 
         // Then
         argumentCaptor<Any> {
@@ -1447,7 +1485,10 @@ internal class TelemetryEventHandlerTest {
         )
 
         // When
-        testedTelemetryHandler.handleEvent(RumRawEvent.TelemetryEventWrapper(fakeDebugEvent), mockWriter)
+        testedTelemetryHandler.handleEvent(
+            RumRawEvent.TelemetryEventWrapper(fakeDebugEvent, eventTime = fakeEventTime),
+            mockWriter
+        )
 
         // Then
         argumentCaptor<Any> {
@@ -1483,7 +1524,10 @@ internal class TelemetryEventHandlerTest {
         )
 
         // When
-        testedTelemetryHandler.handleEvent(RumRawEvent.TelemetryEventWrapper(fakeErrorEvent), mockWriter)
+        testedTelemetryHandler.handleEvent(
+            RumRawEvent.TelemetryEventWrapper(fakeErrorEvent, eventTime = fakeEventTime),
+            mockWriter
+        )
 
         // Then
         argumentCaptor<Any> {
@@ -1509,7 +1553,10 @@ internal class TelemetryEventHandlerTest {
 
         val fakeConfigurationEvent = forge.getForgery<InternalTelemetryEvent.Configuration>()
         // When
-        testedTelemetryHandler.handleEvent(RumRawEvent.TelemetryEventWrapper(fakeConfigurationEvent), mockWriter)
+        testedTelemetryHandler.handleEvent(
+            RumRawEvent.TelemetryEventWrapper(fakeConfigurationEvent, eventTime = fakeEventTime),
+            mockWriter
+        )
 
         // Then
         argumentCaptor<Any> {

--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/sdk/PreferTimeProvider.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/sdk/PreferTimeProvider.kt
@@ -94,7 +94,6 @@ class PreferTimeProvider(
     internal companion object {
         internal val DEFAULT_ALLOWED_FILES = listOf(
             ".*DdRumContentProvider.*",
-            ".*Time\\.kt",
             ".*TimeProvider.*"
         )
 


### PR DESCRIPTION
### What does this PR do?

- Removes the `= Time()` default from all `RumRawEvent` subclasses and makes `eventTime` an explicit constructor argument, sourced through the injected `TimeProvider`.
- Adds companion factories `Time.now(timeProvider)`; `Time.fromTimestampMillis(timestamp, timeProvider)` and `Time.fromNanoTime(nanoTime, timeProvider)` replace the old extensions.
- Adds a `TimeForgeryFactory` and reuses it in tests.

### Motivation

The no-arg `Time()` called `System.currentTimeMillis()` and `System.nanoTime()` apis directly, bypassing `TimeProvider`. This finished the goal of https://github.com/DataDog/dd-sdk-android/pull/3011 and makes RUM event timing fully deterministic and testable.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

