### PR TITLE
RUM-16325: Dogfooding fixes

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -312,6 +312,7 @@ class com.datadog.android.rum.timeseries.TimeseriesConfiguration
     fun setIntervalMs(Long): Builder
     fun collectInBackground(Boolean): Builder
     fun useDeltaCompression(Boolean): Builder
+    fun addAttribute(String, String): Builder
     fun build(): TimeseriesConfiguration
   companion object 
     val DEFAULT: TimeseriesConfiguration

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -8645,6 +8645,7 @@ public final class com/datadog/android/rum/timeseries/TimeseriesConfiguration {
 
 public final class com/datadog/android/rum/timeseries/TimeseriesConfiguration$Builder {
 	public fun <init> ()V
+	public final fun addAttribute (Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration$Builder;
 	public final fun build ()Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration;
 	public final fun collectInBackground (Z)Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration$Builder;
 	public final fun setBufferSize (I)Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration$Builder;

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -440,6 +440,7 @@ internal class RumFeature(
         )
     }
 
+    @Suppress("LongMethod")
     internal fun createTimeseriesCollectingFactory(
         configuration: TimeseriesConfiguration,
         totalRamBytes: Long,
@@ -463,9 +464,11 @@ internal class RumFeature(
                         applicationId = applicationId,
                         sessionType = sessionType,
                         timeProvider = sdkCore.timeProvider,
-                        useDeltaCompression = configuration.useDeltaCompression
+                        useDeltaCompression = configuration.useDeltaCompression,
+                        additionalAttributes = configuration.additionalAttributes
                     ),
                     dataWriter = dataWriter,
+                    internalLogger = sdkCore.internalLogger,
                     insightsCollector = insightsCollector
                 ),
                 if (totalRamBytes > 0L) {
@@ -483,9 +486,11 @@ internal class RumFeature(
                             sessionType = sessionType,
                             totalRamBytes = totalRamBytes,
                             timeProvider = sdkCore.timeProvider,
-                            useDeltaCompression = configuration.useDeltaCompression
+                            useDeltaCompression = configuration.useDeltaCompression,
+                            additionalAttributes = configuration.additionalAttributes
                         ),
                         dataWriter = dataWriter,
+                        internalLogger = sdkCore.internalLogger,
                         insightsCollector = insightsCollector
                     )
                 } else {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -298,6 +298,7 @@ internal class RumSessionScope(
                 renewSession(event.eventTime, StartReason.BACKGROUND_LAUNCH)
                 lastUserInteractionNs.set(nanoTime)
             } else {
+                stopTimeseries()
                 sessionState = State.EXPIRED
             }
         } else if (isTimedOut) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/Pipeline.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/Pipeline.kt
@@ -7,6 +7,9 @@
 package com.datadog.android.rum.internal.timeseries
 
 import androidx.annotation.WorkerThread
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.DataWriter
@@ -15,14 +18,17 @@ import com.datadog.android.rum.internal.instrumentation.insights.InsightsCollect
 import com.datadog.android.rum.internal.instrumentation.insights.NoOpInsightsCollector
 import com.datadog.android.rum.internal.timeseries.provider.DataPointsReader
 import com.datadog.android.rum.internal.timeseries.serializer.JsonSerializer
+import com.datadog.android.rum.internal.timeseries.serializer.TimeseriesAttributes
 import com.google.gson.JsonObject
 
+@Suppress("LongParameterList")
 internal class Pipeline<T : Any>(
     private val sdkCore: FeatureSdkCore,
     private val reader: DataPointsReader<T>,
     private val buffer: Buffer<T>,
     private val serializer: JsonSerializer<T>,
     private val dataWriter: DataWriter<Any>,
+    private val internalLogger: InternalLogger,
     private val insightsCollector: InsightsCollector = NoOpInsightsCollector()
 ) {
     val intervalMs: Long get() = reader.intervalMs
@@ -34,22 +40,42 @@ internal class Pipeline<T : Any>(
     }
 
     @WorkerThread
-    fun flush() = buffer.drain()
-        .takeIf { it.isNotEmpty() }
-        ?.let(serializer::serialize)
-        ?.let(::write)
+    fun flush() {
+        val dataPoints = buffer.drain().ifEmpty { return }
+        sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
+            ?.withWriteContext { datadogContext: DatadogContext, writeScope: EventWriteScope ->
+                val json = safeCall(ERROR_SERIALIZATION_FAILED) {
+                    serializer.serialize(datadogContext, dataPoints)
+                } ?: return@withWriteContext
 
-    private fun write(json: JsonObject) = sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
-        ?.withWriteContext { _, writeScope ->
-            writeScope { dataWriter.write(it, json, EventType.DEFAULT) }
-            insightsCollector.onTimeseries(json.timeseriesName())
-        }
+                writeScope { batchWriter ->
+                    safeCall(ERROR_FLUSH_FAILED) {
+                        if (dataWriter.write(batchWriter, json, EventType.DEFAULT)) {
+                            insightsCollector.onTimeseries(json.timeseriesName)
+                        }
+                    }
+                }
+            }
+    }
 
-    private fun JsonObject.timeseriesName(): String =
-        getAsJsonObject(KEY_TIMESERIES)?.get(KEY_NAME)?.asString.orEmpty()
+    private inline fun <R> safeCall(message: String, block: () -> R): R? = try {
+        block()
+    } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+        internalLogger.log(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            messageBuilder = { message },
+            throwable = t
+        )
+        null
+    }
 
     private companion object {
-        private const val KEY_TIMESERIES = "timeseries"
-        private const val KEY_NAME = "name"
+        private const val ERROR_FLUSH_FAILED = "Timeseries flush failed"
+        private const val ERROR_SERIALIZATION_FAILED = "Timeseries serialization failed"
+        private val JsonObject.timeseriesName: String
+            get() = getAsJsonObject(TimeseriesAttributes.KEY_TIMESERIES)
+                ?.get(TimeseriesAttributes.KEY_NAME)
+                ?.asString.orEmpty()
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/RumSessionScopeTimeseries.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/RumSessionScopeTimeseries.kt
@@ -78,13 +78,14 @@ internal class RumSessionScopeTimeseries(
     }
 
     @WorkerThread
-    override fun onViewTypeUpdate(viewType: RumViewType) {
-        val isEnterForeground = currentViewType != RumViewType.FOREGROUND && viewType == RumViewType.FOREGROUND
-        currentViewType = viewType
+    override fun onViewTypeUpdate(newViewType: RumViewType) {
+        if (newViewType == currentViewType) return
+        val isEnterForeground = !currentViewType.isForeground && newViewType.isForeground
+        currentViewType = newViewType
         if (!collectInBackground) {
             if (isEnterForeground && state.compareAndSet(State.SUSPENDED, State.RUNNING)) {
                 startSampling()
-            } else if (viewType != RumViewType.FOREGROUND) {
+            } else if (!newViewType.isForeground) {
                 state.compareAndSet(State.RUNNING, State.SUSPENDED)
             }
         }
@@ -124,8 +125,15 @@ internal class RumSessionScopeTimeseries(
         state.get() == State.RUNNING && currentGeneration.get() == generation
 
     internal companion object {
-        internal const val OPERATION_NAME = "Timeseries sampling"
-        internal const val ERROR_SAMPLING_FAILED = "Timeseries sampling iteration failed; rescheduling next sample."
-        internal const val ERROR_FLUSH_FAILED = "Timeseries flush on session stop failed."
+        const val OPERATION_NAME = "Timeseries sampling"
+        const val ERROR_SAMPLING_FAILED = "Timeseries sampling iteration failed; rescheduling next sample."
+        const val ERROR_FLUSH_FAILED = "Timeseries flush on session stop failed."
+        val RumViewType?.isForeground: Boolean
+            get() = when (this) {
+                RumViewType.FOREGROUND, RumViewType.APPLICATION_LAUNCH -> true
+                RumViewType.BACKGROUND -> false
+                RumViewType.NONE -> false
+                null -> false
+            }
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/Timeseries.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/Timeseries.kt
@@ -14,7 +14,7 @@ import com.datadog.tools.annotation.NoOpImplementation
 internal interface Timeseries {
     fun onSessionStart()
     fun onSessionStop()
-    fun onViewTypeUpdate(viewType: RumViewType)
+    fun onViewTypeUpdate(newViewType: RumViewType)
 
     @NoOpImplementation
     interface Factory {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/serializer/CpuEventSerializer.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/serializer/CpuEventSerializer.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.timeseries.serializer
 
+import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.timeseries.DataPoint
@@ -18,16 +19,18 @@ import com.google.gson.JsonObject
 import java.util.UUID
 import kotlin.math.pow
 
+@Suppress("LongParameterList")
 internal class CpuEventSerializer(
     private val sessionId: String,
     private val applicationId: String,
     private val sessionType: RumSessionType,
     private val timeProvider: TimeProvider,
+    private val additionalAttributes: Map<String, String>,
     private val useDeltaCompression: Boolean = false,
     private val precision: Int = DeltaCompression.PRECISION
 ) : JsonSerializer<Double> {
 
-    override fun serialize(dataPoints: List<DataPoint<Double>>): JsonObject? {
+    override fun serialize(datadogContext: DatadogContext, dataPoints: List<DataPoint<Double>>): JsonObject? {
         if (dataPoints.isEmpty()) return null
         val data = dataPoints.map { sample ->
             TimeseriesCpuEvent.Data(
@@ -52,8 +55,8 @@ internal class CpuEventSerializer(
             ),
             source = TimeseriesCpuEvent.Source.ANDROID,
             date = timeProvider.getDeviceTimestampMillis(),
-            service = null,
-            version = null,
+            version = datadogContext.version,
+            service = datadogContext.service,
             timeseries = TimeseriesCpuEvent.Timeseries(
                 id = UUID.randomUUID().toString(),
                 schema = schema,
@@ -64,12 +67,18 @@ internal class CpuEventSerializer(
         ).toJson().asJsonObject
 
         // <DOGFOODING ONLY>
-        val timeseriesJson = json.getAsJsonObject("timeseries")
+        val timeseriesJson = json.getAsJsonObject(TimeseriesAttributes.KEY_TIMESERIES)
         if (deltaEncoded != null) {
-            timeseriesJson?.remove("data")
-            timeseriesJson?.add("data", deltaEncoded)
+            timeseriesJson?.remove(TimeseriesAttributes.KEY_DATA)
+            timeseriesJson?.add(TimeseriesAttributes.KEY_DATA, deltaEncoded)
         }
-        timeseriesJson?.addProperty("count", data.size)
+        if (additionalAttributes.isNotEmpty()) {
+            timeseriesJson?.add(
+                TimeseriesAttributes.KEY_TAGS,
+                additionalAttributes.toJson()
+            )
+        }
+        timeseriesJson?.addProperty(TimeseriesAttributes.KEY_COUNT, data.size)
         // </DOGFOODING ONLY>
         return json
     }
@@ -84,14 +93,10 @@ internal class CpuEventSerializer(
         }
 
         return JsonObject().apply {
-            addProperty("precision", precision)
-            addProperty("resolution", RESOLUTION_NS)
-            add("ts", ts)
-            add("value", cpuUsageArray)
+            addProperty(TimeseriesAttributes.KEY_PRECISION, precision)
+            addProperty(TimeseriesAttributes.KEY_RESOLUTION, TimeseriesAttributes.NS)
+            add(TimeseriesAttributes.KEY_TS, ts)
+            add(TimeseriesAttributes.KEY_VALUE, cpuUsageArray)
         }
-    }
-
-    companion object {
-        private const val RESOLUTION_NS = "ns"
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/serializer/JsonSerializer.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/serializer/JsonSerializer.kt
@@ -6,9 +6,30 @@
 
 package com.datadog.android.rum.internal.timeseries.serializer
 
+import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.rum.internal.timeseries.DataPoint
 import com.google.gson.JsonObject
 
 internal fun interface JsonSerializer<T : Any> {
-    fun serialize(dataPoints: List<DataPoint<T>>): JsonObject?
+    fun serialize(datadogContext: DatadogContext, dataPoints: List<DataPoint<T>>): JsonObject?
+}
+
+internal object TimeseriesAttributes {
+    const val KEY_TIMESERIES = "timeseries"
+    const val KEY_SCHEMA = "schema"
+    const val KEY_DATA = "data"
+    const val KEY_COUNT = "count"
+    const val KEY_TAGS = "tags"
+    const val KEY_TS = "ts"
+    const val NS = "ns"
+    const val KEY_PRECISION = "precision"
+    const val KEY_RESOLUTION = "resolution"
+    const val KEY_VALUE = "value"
+    const val KEY_NAME = "name"
+    const val KEY_MEMORY_FOOTPRINT = "memory_footprint"
+    const val KEY_MEMORY_PERCENT = "memory_percent"
+}
+
+internal fun Map<String, String>.toJson() = JsonObject().also { json ->
+    entries.forEach { json.addProperty(it.key, it.value) }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/serializer/MemoryEventSerializer.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/serializer/MemoryEventSerializer.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.timeseries.serializer
 
+import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.timeseries.DataPoint
@@ -18,17 +19,19 @@ import com.google.gson.JsonObject
 import java.util.UUID
 import kotlin.math.pow
 
+@Suppress("LongParameterList")
 internal class MemoryEventSerializer(
     private val sessionId: String,
     private val applicationId: String,
     private val sessionType: RumSessionType,
     private val totalRamBytes: Long,
     private val timeProvider: TimeProvider,
+    private val additionalAttributes: Map<String, String>,
     private val useDeltaCompression: Boolean = false,
     private val precision: Int = DeltaCompression.PRECISION
 ) : JsonSerializer<Double> {
 
-    override fun serialize(dataPoints: List<DataPoint<Double>>): JsonObject? {
+    override fun serialize(datadogContext: DatadogContext, dataPoints: List<DataPoint<Double>>): JsonObject? {
         if (totalRamBytes <= 0L || dataPoints.isEmpty()) return null
         val data = dataPoints.map { sample ->
             val memoryPercent = sample.value / totalRamBytes * PERCENT_FACTOR
@@ -54,8 +57,8 @@ internal class MemoryEventSerializer(
             ),
             source = TimeseriesMemoryEvent.Source.ANDROID,
             date = timeProvider.getDeviceTimestampMillis(),
-            service = null,
-            version = null,
+            version = datadogContext.version,
+            service = datadogContext.service,
             timeseries = TimeseriesMemoryEvent.Timeseries(
                 id = UUID.randomUUID().toString(),
                 schema = schema,
@@ -65,12 +68,18 @@ internal class MemoryEventSerializer(
             )
         ).toJson().asJsonObject
         // <DOGFOODING ONLY>
-        val timeseriesJson = json.getAsJsonObject("timeseries")
+        val timeseriesJson = json.getAsJsonObject(TimeseriesAttributes.KEY_TIMESERIES)
         if (deltaEncoded != null) {
-            timeseriesJson?.remove("data")
-            timeseriesJson?.add("data", deltaEncoded)
+            timeseriesJson?.remove(TimeseriesAttributes.KEY_DATA)
+            timeseriesJson?.add(TimeseriesAttributes.KEY_DATA, deltaEncoded)
         }
-        timeseriesJson?.addProperty("count", data.size)
+        timeseriesJson?.addProperty(TimeseriesAttributes.KEY_COUNT, data.size)
+        if (additionalAttributes.isNotEmpty()) {
+            timeseriesJson?.add(
+                TimeseriesAttributes.KEY_TAGS,
+                additionalAttributes.toJson()
+            )
+        }
         // </DOGFOODING ONLY>
         return json
     }
@@ -90,16 +99,15 @@ internal class MemoryEventSerializer(
         }
 
         return JsonObject().apply {
-            addProperty("precision", precision)
-            addProperty("resolution", RESOLUTION_NS)
-            add("ts", ts)
-            add("memory_footprint", memoryFootprintArray)
-            add("memory_percent", memoryPercentArray)
+            addProperty(TimeseriesAttributes.KEY_PRECISION, precision)
+            addProperty(TimeseriesAttributes.KEY_RESOLUTION, TimeseriesAttributes.NS)
+            add(TimeseriesAttributes.KEY_TS, ts)
+            add(TimeseriesAttributes.KEY_MEMORY_FOOTPRINT, memoryFootprintArray)
+            add(TimeseriesAttributes.KEY_MEMORY_PERCENT, memoryPercentArray)
         }
     }
 
     companion object {
         private const val PERCENT_FACTOR = 100.0
-        private const val RESOLUTION_NS = "ns"
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfiguration.kt
@@ -20,7 +20,8 @@ class TimeseriesConfiguration internal constructor(
     internal val bufferSize: Int,
     internal val intervalMs: Long,
     internal val collectInBackground: Boolean,
-    internal val useDeltaCompression: Boolean
+    internal val useDeltaCompression: Boolean,
+    internal val additionalAttributes: Map<String, String>
 ) {
 
     /**
@@ -33,6 +34,7 @@ class TimeseriesConfiguration internal constructor(
         private var intervalMs: Long = DEFAULT_INTERVAL_MS
         private var collectInBackground: Boolean = false
         private var useDeltaCompression: Boolean = false
+        private val additionalAttributes: MutableMap<String, String> = mutableMapOf()
 
         /**
          * Sets the number of samples accumulated per pipeline before sending a batch event.
@@ -72,12 +74,21 @@ class TimeseriesConfiguration internal constructor(
             this.useDeltaCompression = useDeltaCompression
         }
 
+        /**
+         * Adds an attribute to all timeseries events created with this configuration.
+         * The attribute is emitted as a key/value entry in the `timeseries.tags` JSON object.
+         */
+        fun addAttribute(key: String, value: String): Builder = apply {
+            additionalAttributes[key] = value
+        }
+
         /** Builds a [TimeseriesConfiguration] from the current builder state. */
         fun build(): TimeseriesConfiguration = TimeseriesConfiguration(
             bufferSize = bufferSize,
             intervalMs = intervalMs,
             collectInBackground = collectInBackground,
-            useDeltaCompression = useDeltaCompression
+            useDeltaCompression = useDeltaCompression,
+            additionalAttributes = additionalAttributes.toMap()
         )
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/TimeseriesCpuEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/TimeseriesCpuEventAssert.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.assertj
 
+import com.datadog.android.rum.internal.timeseries.serializer.TimeseriesAttributes
 import com.datadog.android.rum.model.TimeseriesCpuEvent
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
@@ -40,6 +41,18 @@ internal class TimeseriesCpuEventAssert private constructor(
     fun hasSessionType(expected: TimeseriesCpuEvent.Type): TimeseriesCpuEventAssert = apply {
         assertThat(actual.session.type)
             .overridingErrorMessage { "Expected event to have session.type $expected but was ${actual.session.type}" }
+            .isEqualTo(expected)
+    }
+
+    fun hasService(expected: String): TimeseriesCpuEventAssert = apply {
+        assertThat(actual.service)
+            .overridingErrorMessage { "Expected event to have service $expected but was ${actual.service}" }
+            .isEqualTo(expected)
+    }
+
+    fun hasVersion(expected: String): TimeseriesCpuEventAssert = apply {
+        assertThat(actual.version)
+            .overridingErrorMessage { "Expected event to have version $expected but was ${actual.version}" }
             .isEqualTo(expected)
     }
 
@@ -102,21 +115,33 @@ internal class TimeseriesCpuEventAssert private constructor(
     // Use assertThatDelta(JsonObject) to enter this path.
 
     fun hasDeltaPrecision(expected: Int): TimeseriesCpuEventAssert = apply {
-        val precision = json.timeseries.getAsJsonObject("data").get("precision").asInt
+        val precision = json.timeseries
+            .getAsJsonObject(TimeseriesAttributes.KEY_DATA)
+            .get(TimeseriesAttributes.KEY_PRECISION)
+            .asInt
+
         assertThat(precision)
             .overridingErrorMessage { "Expected delta data to have precision $expected but was $precision" }
             .isEqualTo(expected)
     }
 
     fun hasDeltaResolution(expected: String): TimeseriesCpuEventAssert = apply {
-        val resolution = json.timeseries.getAsJsonObject("data").get("resolution").asString
+        val resolution = json.timeseries
+            .getAsJsonObject(TimeseriesAttributes.KEY_DATA)
+            .get(TimeseriesAttributes.KEY_RESOLUTION)
+            .asString
+
         assertThat(resolution)
             .overridingErrorMessage { "Expected delta data to have resolution $expected but was $resolution" }
             .isEqualTo(expected)
     }
 
     fun hasDeltaTsValues(vararg expected: Long): TimeseriesCpuEventAssert = apply {
-        val tsArray = json.timeseries.getAsJsonObject("data").get("ts").asJsonArray
+        val tsArray = json.timeseries
+            .getAsJsonObject(TimeseriesAttributes.KEY_DATA)
+            .get(TimeseriesAttributes.KEY_TS)
+            .asJsonArray
+
         expected.forEachIndexed { i, v ->
             assertThat(tsArray[i].asLong)
                 .overridingErrorMessage { "Expected delta ts[$i] to be $v but was ${tsArray[i].asLong}" }
@@ -125,7 +150,11 @@ internal class TimeseriesCpuEventAssert private constructor(
     }
 
     fun hasDeltaValueAt(index: Int, expected: Long): TimeseriesCpuEventAssert = apply {
-        val valueArray = json.timeseries.getAsJsonObject("data").get("value").asJsonArray
+        val valueArray = json.timeseries
+            .getAsJsonObject(TimeseriesAttributes.KEY_DATA)
+            .get(TimeseriesAttributes.KEY_VALUE)
+            .asJsonArray
+
         val actual = valueArray[index].asLong
         assertThat(actual)
             .overridingErrorMessage { "Expected delta value[$index] to be $expected but was $actual" }
@@ -135,7 +164,7 @@ internal class TimeseriesCpuEventAssert private constructor(
     // endregion
 
     companion object {
-        private val JsonObject.timeseries: JsonObject get() = getAsJsonObject("timeseries")
+        private val JsonObject.timeseries: JsonObject get() = getAsJsonObject(TimeseriesAttributes.KEY_TIMESERIES)
 
         internal fun assertThat(event: TimeseriesCpuEvent): TimeseriesCpuEventAssert =
             TimeseriesCpuEventAssert(event, event.toJson() as JsonObject)
@@ -150,7 +179,8 @@ internal class TimeseriesCpuEventAssert private constructor(
          */
         internal fun assertThatDelta(json: JsonObject): TimeseriesCpuEventAssert {
             val patchedJson = json.deepCopy().also {
-                it.getAsJsonObject("timeseries").add("data", JsonArray())
+                it.getAsJsonObject(TimeseriesAttributes.KEY_TIMESERIES)
+                    .add(TimeseriesAttributes.KEY_DATA, JsonArray())
             }
             return TimeseriesCpuEventAssert(TimeseriesCpuEvent.fromJsonObject(patchedJson), json)
         }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -1981,6 +1981,26 @@ internal class RumSessionScopeTest {
     }
 
     @Test
+    fun `M stop timeseries W handleEvent { session expires without renewal }`(forge: Forge) {
+        // Given
+        initializeTestedScope(backgroundTrackingEnabled = false, timeseriesFactory = mockTimeseriesFactory)
+        testedScope.handleEvent(
+            forge.startViewEvent(),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // When
+        advanceTimeByMs(TEST_INACTIVITY_MS)
+        testedScope.handleEvent(mock(), fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        assertThat(testedScope.sessionState).isEqualTo(RumSessionScope.State.EXPIRED)
+        verify(mockTimeseries).onSessionStop()
+    }
+
+    @Test
     fun `M stop timeseries W handleEvent { StopSession }`(forge: Forge) {
         // Given
         initializeTestedScope(timeseriesFactory = mockTimeseriesFactory)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/PipelineTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/PipelineTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.timeseries
 
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
@@ -17,7 +18,10 @@ import com.datadog.android.api.storage.EventType
 import com.datadog.android.rum.internal.instrumentation.insights.InsightsCollector
 import com.datadog.android.rum.internal.timeseries.provider.DataPointsReader
 import com.datadog.android.rum.internal.timeseries.serializer.JsonSerializer
+import com.datadog.android.rum.internal.timeseries.serializer.TimeseriesAttributes
 import com.datadog.android.rum.utils.forge.Configurator
+import com.datadog.android.utils.verifyLog
+import com.datadog.tools.unit.forge.aThrowable
 import com.google.gson.JsonObject
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.IntForgery
@@ -36,7 +40,8 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -74,6 +79,12 @@ internal class PipelineTest {
     @Mock
     lateinit var mockInsightsCollector: InsightsCollector
 
+    @Mock
+    lateinit var mockDatadogContext: DatadogContext
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
     @IntForgery(min = 2, max = 10)
     var fakeBufferSize: Int = 0
 
@@ -85,11 +96,12 @@ internal class PipelineTest {
         whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
         whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
             it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(it.arguments.lastIndex)
-                .invoke(mock(), mockEventWriteScope)
+                .invoke(mockDatadogContext, mockEventWriteScope)
         }
         whenever(mockEventWriteScope.invoke(any())) doAnswer {
             it.getArgument<(EventBatchWriter) -> Unit>(0).invoke(mockEventBatchWriter)
         }
+        whenever(mockDataWriter.write(any(), any(), any())) doReturn true
 
         buffer = Buffer(fakeBufferSize)
         testedPipeline = Pipeline(
@@ -98,6 +110,7 @@ internal class PipelineTest {
             buffer = buffer,
             serializer = mockSerializer,
             dataWriter = mockDataWriter,
+            internalLogger = mockInternalLogger,
             insightsCollector = mockInsightsCollector
         )
     }
@@ -149,7 +162,7 @@ internal class PipelineTest {
         val fakeTimeseriesName = "view.cpu"
         val fakeJson = fakeTimeseriesJson(fakeTimeseriesName)
         whenever(mockReader.read()) doReturn fakePoint
-        whenever(mockSerializer.serialize(any())) doReturn fakeJson
+        whenever(mockSerializer.serialize(any(), any())) doReturn fakeJson
         repeat(fakeBufferSize - 1) { testedPipeline.execute() }
 
         // When
@@ -178,7 +191,7 @@ internal class PipelineTest {
     fun `M not flush W execute() { serializer returns null }`(forge: Forge) {
         // Given
         whenever(mockReader.read()) doReturn forge.getForgery<DataPoint<Double>>()
-        whenever(mockSerializer.serialize(any())) doReturn null
+        whenever(mockSerializer.serialize(any(), any())) doReturn null
         repeat(fakeBufferSize - 1) { testedPipeline.execute() }
 
         // When
@@ -200,7 +213,7 @@ internal class PipelineTest {
         val fakeTimeseriesName = "view.memory"
         val fakeJson = fakeTimeseriesJson(fakeTimeseriesName)
         whenever(mockReader.read()) doReturn fakePoint
-        whenever(mockSerializer.serialize(any())) doReturn fakeJson
+        whenever(mockSerializer.serialize(any(), any())) doReturn fakeJson
         val sampleCount = fakeBufferSize - 1
         repeat(sampleCount) { testedPipeline.execute() }
 
@@ -209,11 +222,71 @@ internal class PipelineTest {
 
         // Then
         val captor = argumentCaptor<List<DataPoint<Double>>>()
-        verify(mockSerializer).serialize(captor.capture())
+        verify(mockSerializer).serialize(any(), captor.capture())
         assertThat(captor.firstValue).hasSize(sampleCount).allMatch { it == fakePoint }
         verify(mockDataWriter).write(mockEventBatchWriter, fakeJson, EventType.DEFAULT)
         verify(mockInsightsCollector).onTimeseries(fakeTimeseriesName)
         assertThat(buffer.drain()).isEmpty()
+    }
+
+    @Test
+    fun `M drain buffer before write context callback W flush()`(forge: Forge) {
+        // Given
+        val fakePoint = forge.getForgery<DataPoint<Double>>()
+        whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer { Unit }
+        whenever(mockSerializer.serialize(any(), any())) doReturn fakeTimeseriesJson("view.cpu")
+        whenever(mockReader.read()) doReturn fakePoint
+        testedPipeline.execute()
+
+        // When
+        testedPipeline.flush()
+
+        // Then
+        assertThat(buffer.drain()).isEmpty()
+        verifyNoInteractions(mockSerializer)
+        verifyNoInteractions(mockDataWriter)
+        verifyNoInteractions(mockInsightsCollector)
+    }
+
+    @Test
+    fun `M pass only pre-flush points to serializer W execute() { point added before write context callback invoked }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakePoint = forge.getForgery<DataPoint<Double>>()
+        val fakeNextPoint = forge.getForgery<DataPoint<Double>>()
+        val callbackCaptor = argumentCaptor<(DatadogContext, EventWriteScope) -> Unit>()
+        whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer { Unit }
+        whenever(mockSerializer.serialize(any(), any())) doReturn fakeTimeseriesJson("view.cpu")
+        whenever(mockReader.read()) doReturn fakePoint
+        testedPipeline.execute()
+        testedPipeline.flush()
+        whenever(mockReader.read()) doReturn fakeNextPoint
+
+        // When
+        testedPipeline.execute()
+        verify(mockRumFeatureScope).withWriteContext(any(), callbackCaptor.capture())
+        callbackCaptor.firstValue.invoke(mockDatadogContext, mockEventWriteScope)
+
+        // Then
+        val dataPointsCaptor = argumentCaptor<List<DataPoint<Double>>>()
+        verify(mockSerializer).serialize(eq(mockDatadogContext), dataPointsCaptor.capture())
+        assertThat(dataPointsCaptor.firstValue).containsExactly(fakePoint)
+        assertThat(buffer.drain()).containsExactly(fakeNextPoint)
+    }
+
+    @Test
+    fun `M pass datadogContext from withWriteContext W flush()`(forge: Forge) {
+        // Given
+        whenever(mockReader.read()) doReturn forge.getForgery<DataPoint<Double>>()
+        whenever(mockSerializer.serialize(any(), any())) doReturn fakeTimeseriesJson("view.cpu")
+        testedPipeline.execute()
+
+        // When
+        testedPipeline.flush()
+
+        // Then
+        verify(mockSerializer).serialize(eq(mockDatadogContext), any())
     }
 
     @Test
@@ -226,11 +299,77 @@ internal class PipelineTest {
         verifyNoInteractions(mockInsightsCollector)
     }
 
+    @Test
+    fun `M log error W flush() { serializer throws }`(forge: Forge) {
+        // Given
+        val fakeThrowable = forge.aThrowable()
+        whenever(mockReader.read()) doReturn forge.getForgery<DataPoint<Double>>()
+        whenever(mockSerializer.serialize(any(), any())) doThrow fakeThrowable
+        testedPipeline.execute()
+
+        // When
+        testedPipeline.flush()
+
+        // Then
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            message = "Timeseries serialization failed",
+            throwable = fakeThrowable
+        )
+        verifyNoInteractions(mockDataWriter)
+        verifyNoInteractions(mockInsightsCollector)
+    }
+
+    @Test
+    fun `M log error W flush() { dataWriter throws }`(forge: Forge) {
+        // Given
+        val fakeThrowable = forge.aThrowable()
+        val fakeJson = fakeTimeseriesJson("view.cpu")
+        val writeBlockCaptor = argumentCaptor<(EventBatchWriter) -> Unit>()
+        whenever(mockReader.read()) doReturn forge.getForgery<DataPoint<Double>>()
+        whenever(mockSerializer.serialize(any(), any())) doReturn fakeJson
+        whenever(mockDataWriter.write(any(), any(), any())) doThrow fakeThrowable
+        whenever(mockEventWriteScope.invoke(any())) doAnswer { Unit }
+        testedPipeline.execute()
+
+        // When
+        testedPipeline.flush()
+        verify(mockEventWriteScope).invoke(writeBlockCaptor.capture())
+        writeBlockCaptor.firstValue.invoke(mockEventBatchWriter)
+
+        // Then
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            message = "Timeseries flush failed",
+            throwable = fakeThrowable
+        )
+        verifyNoInteractions(mockInsightsCollector)
+    }
+
+    @Test
+    fun `M not notify insights W flush() { dataWriter returns false }`(forge: Forge) {
+        // Given
+        val fakeJson = fakeTimeseriesJson("view.cpu")
+        whenever(mockReader.read()) doReturn forge.getForgery<DataPoint<Double>>()
+        whenever(mockSerializer.serialize(any(), any())) doReturn fakeJson
+        whenever(mockDataWriter.write(any(), any(), any())) doReturn false
+        testedPipeline.execute()
+
+        // When
+        testedPipeline.flush()
+
+        // Then
+        verify(mockDataWriter).write(mockEventBatchWriter, fakeJson, EventType.DEFAULT)
+        verifyNoInteractions(mockInsightsCollector)
+    }
+
     // endregion
 
     private fun fakeTimeseriesJson(name: String): JsonObject = JsonObject().apply {
         add(
-            "timeseries",
+            TimeseriesAttributes.KEY_TIMESERIES,
             JsonObject().apply {
                 addProperty("name", name)
             }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/RumSessionScopeTimeseriesFactoryTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/RumSessionScopeTimeseriesFactoryTest.kt
@@ -18,6 +18,7 @@ import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
@@ -92,17 +93,15 @@ internal class RumSessionScopeTimeseriesFactoryTest {
             pipelinesProvider = emptyProvider
         )
 
-        // When
-        val timeseries = testedFactory.create(fakeSessionId, fakeApplicationId, RumSessionType.USER)
-
-        // Then — collectInBackground is private; tick behavior is covered by RumSessionScopeTimeseriesTest.
-        // Here we just assert the instance was built without throwing.
-        assertThat(timeseries).isNotNull
+        // When / Then
+        assertDoesNotThrow {
+            testedFactory.create(fakeSessionId, fakeApplicationId, RumSessionType.USER)
+        }
     }
 
     private fun mockPipeline(): Pipeline<*> {
         val reader = mock<DataPointsReader<Double>>()
         val serializer = mock<JsonSerializer<Double>>()
-        return Pipeline(mockSdkCore, reader, Buffer(1), serializer, mockWriter)
+        return Pipeline(mockSdkCore, reader, Buffer(1), serializer, mockWriter, mockInternalLogger)
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/RumSessionScopeTimeseriesTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/RumSessionScopeTimeseriesTest.kt
@@ -124,8 +124,8 @@ internal class RumSessionScopeTimeseriesTest {
 
         bufferA = Buffer(fakeBufferSize)
         bufferB = Buffer(fakeBufferSize)
-        pipelineA = Pipeline(mockSdkCore, mockReaderA, bufferA, mockSerializerA, mockDataWriter)
-        pipelineB = Pipeline(mockSdkCore, mockReaderB, bufferB, mockSerializerB, mockDataWriter)
+        pipelineA = Pipeline(mockSdkCore, mockReaderA, bufferA, mockSerializerA, mockDataWriter, mockInternalLogger)
+        pipelineB = Pipeline(mockSdkCore, mockReaderB, bufferB, mockSerializerB, mockDataWriter, mockInternalLogger)
 
         testedTimeseries = RumSessionScopeTimeseries(
             pipelines = listOf(pipelineA, pipelineB),
@@ -188,8 +188,8 @@ internal class RumSessionScopeTimeseriesTest {
         val fakeJson = JsonObject().apply { addProperty("k", "v") }
         whenever(mockReaderA.read()) doReturn forge.getForgery<DataPoint<Double>>()
         whenever(mockReaderB.read()) doReturn forge.getForgery<DataPoint<Double>>()
-        whenever(mockSerializerA.serialize(any())) doThrow fakeError
-        whenever(mockSerializerB.serialize(any())) doReturn fakeJson
+        whenever(mockSerializerA.serialize(any(), any())) doThrow fakeError
+        whenever(mockSerializerB.serialize(any(), any())) doReturn fakeJson
         testedTimeseries.onSessionStart()
         val runnableA = captureScheduledRunnableForInterval(fakeIntervalAMs)
         val runnableB = captureScheduledRunnableForInterval(fakeIntervalBMs)
@@ -203,7 +203,7 @@ internal class RumSessionScopeTimeseriesTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            RumSessionScopeTimeseries.ERROR_FLUSH_FAILED,
+            "Timeseries serialization failed",
             fakeError
         )
         verify(mockDataWriter).write(any(), eq(fakeJson), eq(EventType.DEFAULT))
@@ -214,7 +214,7 @@ internal class RumSessionScopeTimeseriesTest {
         // Given
         val fakeJson = JsonObject().apply { addProperty("k", "v") }
         whenever(mockReaderA.read()) doReturn forge.getForgery<DataPoint<Double>>()
-        whenever(mockSerializerA.serialize(any())) doReturn fakeJson
+        whenever(mockSerializerA.serialize(any(), any())) doReturn fakeJson
         testedTimeseries.onSessionStart()
         val runnableA = captureScheduledRunnableForInterval(fakeIntervalAMs)
         runnableA.run()
@@ -223,7 +223,7 @@ internal class RumSessionScopeTimeseriesTest {
         testedTimeseries.onSessionStop()
 
         // Then
-        verify(mockSerializerA).serialize(any())
+        verify(mockSerializerA).serialize(any(), any())
         verify(mockDataWriter).write(any(), eq(fakeJson), eq(EventType.DEFAULT))
     }
 
@@ -234,7 +234,7 @@ internal class RumSessionScopeTimeseriesTest {
         val dataPoints = List(fakeBufferSize) { element }
         val fakeJson = JsonObject().apply { addProperty("a", "1") }
         whenever(mockReaderA.read()) doReturn element
-        whenever(mockSerializerA.serialize(dataPoints)) doReturn fakeJson
+        whenever(mockSerializerA.serialize(any(), eq(dataPoints))) doReturn fakeJson
 
         testedTimeseries.onSessionStart()
         val runnableA = captureScheduledRunnableForInterval(fakeIntervalAMs)
@@ -243,7 +243,7 @@ internal class RumSessionScopeTimeseriesTest {
         repeat(fakeBufferSize) { runnableA.run() }
 
         // Then
-        verify(mockSerializerA).serialize(any())
+        verify(mockSerializerA).serialize(any(), any())
         verify(mockDataWriter).write(any(), eq(fakeJson), eq(EventType.DEFAULT))
     }
 
@@ -273,19 +273,7 @@ internal class RumSessionScopeTimeseriesTest {
         runnableA.run()
 
         // Then
-        verify(mockSerializerA, never()).serialize(any())
-        verify(mockDataWriter, never()).write(any(), any(), any())
-    }
-
-    @Test
-    fun `M discard pre-existing data W onSessionStart() { buffer not empty }`(forge: Forge) {
-        // Given - start() drains all pipelines and ignores any serialized result
-        bufferA.add(forge.getForgery<DataPoint<Double>>())
-
-        // When
-        testedTimeseries.onSessionStart()
-
-        // Then - even though serializer may be invoked, no event reaches the writer
+        verify(mockSerializerA, never()).serialize(any(), any())
         verify(mockDataWriter, never()).write(any(), any(), any())
     }
 
@@ -293,7 +281,7 @@ internal class RumSessionScopeTimeseriesTest {
     fun `M skip writer W sample tick { serializer returns null }`(forge: Forge) {
         // Given - fill the buffer so Pipeline.drain() reaches the serializer; serializer returns null
         whenever(mockReaderA.read()) doReturn forge.getForgery<DataPoint<Double>>()
-        whenever(mockSerializerA.serialize(any())) doReturn null
+        whenever(mockSerializerA.serialize(any(), any())) doReturn null
         testedTimeseries.onSessionStart()
         val runnableA = captureScheduledRunnableForInterval(fakeIntervalAMs)
 
@@ -301,7 +289,7 @@ internal class RumSessionScopeTimeseriesTest {
         repeat(fakeBufferSize) { runnableA.run() }
 
         // Then
-        verify(mockSerializerA).serialize(any())
+        verify(mockSerializerA).serialize(any(), any())
         verify(mockDataWriter, never()).write(any(), any(), any())
     }
 
@@ -394,6 +382,92 @@ internal class RumSessionScopeTimeseriesTest {
             RumSessionScopeTimeseries.ERROR_SAMPLING_FAILED,
             fakeError
         )
+    }
+
+    @Test
+    fun `M log error and reschedule W sample tick { buffer drain throws }`(forge: Forge) {
+        // Given — drain() throws outside Pipeline's own try/catch, so it must be
+        // caught by RumSessionScopeTimeseries' sampling try/catch instead.
+        val fakeError = RuntimeException("drain failure")
+        val mockBuffer = mock<Buffer<Double>>()
+        whenever(mockBuffer.isFull()) doReturn true
+        whenever(mockBuffer.drain()) doThrow fakeError
+        whenever(mockReaderA.read()) doReturn forge.getForgery<DataPoint<Double>>()
+        val pipeline =
+            Pipeline(mockSdkCore, mockReaderA, mockBuffer, mockSerializerA, mockDataWriter, mockInternalLogger)
+        val timeseries = RumSessionScopeTimeseries(
+            pipelines = listOf(pipeline),
+            internalLogger = mockInternalLogger,
+            collectInBackground = false,
+            scheduledExecutorService = mockExecutor
+        )
+        timeseries.onViewTypeUpdate(RumViewType.FOREGROUND)
+        timeseries.onSessionStart()
+        val runnableA = captureScheduledRunnableForInterval(fakeIntervalAMs)
+
+        // When
+        runnableA.run()
+
+        // Then
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            RumSessionScopeTimeseries.ERROR_SAMPLING_FAILED,
+            fakeError
+        )
+        verify(mockExecutor, times(2))
+            .schedule(any<Runnable>(), eq(fakeIntervalAMs), eq(TimeUnit.MILLISECONDS))
+    }
+
+    @Test
+    fun `M log error and reschedule W sample tick { serializer throws }`(forge: Forge) {
+        // Given — serializer throws inside Pipeline's own try/catch: Pipeline logs it itself
+        // and the tick completes normally, so the sampling chain reschedules as usual.
+        val fakeError = RuntimeException("serializer failure")
+        whenever(mockReaderA.read()) doReturn forge.getForgery<DataPoint<Double>>()
+        whenever(mockSerializerA.serialize(any(), any())) doThrow fakeError
+        testedTimeseries.onSessionStart()
+        val runnableA = captureScheduledRunnableForInterval(fakeIntervalAMs)
+
+        // When
+        repeat(fakeBufferSize) { runnableA.run() }
+
+        // Then
+        // times(1) default on verifyLog also confirms this is the only ERROR log with that
+        // throwable — i.e. RumSessionScopeTimeseries' own sampling catch never fired here.
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            "Timeseries serialization failed",
+            fakeError
+        )
+        verify(mockDataWriter, never()).write(any(), any(), any())
+        verify(mockExecutor, times(fakeBufferSize + 1))
+            .schedule(any<Runnable>(), eq(fakeIntervalAMs), eq(TimeUnit.MILLISECONDS))
+    }
+
+    @Test
+    fun `M log error and reschedule W sample tick { write context resolution throws }`(forge: Forge) {
+        // Given — withWriteContext() itself throws (context/scope resolution failure), outside
+        // Pipeline's own try/catch, so it propagates up to the sampling try/catch.
+        val fakeError = RuntimeException("write context resolution failure")
+        whenever(mockReaderA.read()) doReturn forge.getForgery<DataPoint<Double>>()
+        whenever(mockRumFeatureScope.withWriteContext(any(), any())) doThrow fakeError
+        testedTimeseries.onSessionStart()
+        val runnableA = captureScheduledRunnableForInterval(fakeIntervalAMs)
+
+        // When
+        repeat(fakeBufferSize) { runnableA.run() }
+
+        // Then
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            RumSessionScopeTimeseries.ERROR_SAMPLING_FAILED,
+            fakeError
+        )
+        verify(mockExecutor, times(fakeBufferSize + 1))
+            .schedule(any<Runnable>(), eq(fakeIntervalAMs), eq(TimeUnit.MILLISECONDS))
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/csv/CsvTimeseries.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/csv/CsvTimeseries.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.timeseries.csv
 
+import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.domain.scope.RumViewType
@@ -21,8 +22,10 @@ import com.google.gson.JsonObject
  * but pulls samples from CSV-backed readers instead of `VitalReaderWrapper` and drives the
  * pipelines synchronously (no executor) so callers can assert on every emitted JSON.
  */
-internal class CsvTimeseries(private val pipelines: List<Triple<CSVReader, Buffer<Double>, JsonSerializer<Double>>>) :
-    Timeseries {
+internal class CsvTimeseries(
+    private val pipelines: List<Triple<CSVReader, Buffer<Double>, JsonSerializer<Double>>>,
+    private val datadogContext: DatadogContext
+) : Timeseries {
 
     private val emitted = mutableListOf<JsonObject>()
 
@@ -37,17 +40,20 @@ internal class CsvTimeseries(private val pipelines: List<Triple<CSVReader, Buffe
         for ((reader, buffer, serializer) in pipelines) {
             while (reader.hasNext()) {
                 buffer.add(reader.read())
-                if (buffer.isFull()) {
-                    buffer.drain().takeIf { it.isNotEmpty() }?.let(serializer::serialize)?.let(emitted::add)
-                }
+                if (buffer.isFull()) flush(buffer, serializer)
             }
-            buffer.drain().takeIf { it.isNotEmpty() }?.let(serializer::serialize)?.let(emitted::add)
+            flush(buffer, serializer)
         }
     }
 
+    private fun flush(buffer: Buffer<Double>, serializer: JsonSerializer<Double>) = buffer.drain()
+        .takeIf { it.isNotEmpty() }
+        ?.let { serializer.serialize(datadogContext, it) }
+        ?.let(emitted::add)
+
     override fun onSessionStop() = Unit
 
-    override fun onViewTypeUpdate(viewType: RumViewType) = Unit
+    override fun onViewTypeUpdate(newViewType: RumViewType) = Unit
 
     companion object {
 
@@ -56,6 +62,7 @@ internal class CsvTimeseries(private val pipelines: List<Triple<CSVReader, Buffe
          * a memory pipeline followed by a CPU pipeline, each backed by [CSVReader] and the
          * production [MemoryEventSerializer] / [CpuEventSerializer].
          */
+        @Suppress("LongParameterList")
         fun create(
             csvContent: String,
             sessionId: String,
@@ -64,39 +71,39 @@ internal class CsvTimeseries(private val pipelines: List<Triple<CSVReader, Buffe
             totalRamBytes: Long,
             bufferSize: Int,
             timeProvider: TimeProvider,
-            useDeltaCompression: Boolean = false
-        ): CsvTimeseries {
-            val memoryReader = CSVReader(csvContent, METRIC_MEMORY_USAGE, timeProvider)
-            val cpuReader = CSVReader(csvContent, METRIC_CPU_USAGE, timeProvider)
-
-            return CsvTimeseries(
-                pipelines = listOf(
-                    Triple(
-                        memoryReader,
-                        Buffer(bufferSize),
-                        MemoryEventSerializer(
-                            sessionId = sessionId,
-                            applicationId = applicationId,
-                            sessionType = sessionType,
-                            totalRamBytes = totalRamBytes,
-                            timeProvider = timeProvider,
-                            useDeltaCompression = useDeltaCompression
-                        )
-                    ),
-                    Triple(
-                        cpuReader,
-                        Buffer(bufferSize),
-                        CpuEventSerializer(
-                            sessionId = sessionId,
-                            applicationId = applicationId,
-                            sessionType = sessionType,
-                            timeProvider = timeProvider,
-                            useDeltaCompression = useDeltaCompression
-                        )
+            datadogContext: DatadogContext,
+            useDeltaCompression: Boolean = false,
+            additionalAttributes: Map<String, String> = emptyMap()
+        ) = CsvTimeseries(
+            datadogContext = datadogContext,
+            pipelines = listOf(
+                Triple(
+                    CSVReader(csvContent, METRIC_MEMORY_USAGE, timeProvider),
+                    Buffer(bufferSize),
+                    MemoryEventSerializer(
+                        sessionId = sessionId,
+                        applicationId = applicationId,
+                        sessionType = sessionType,
+                        totalRamBytes = totalRamBytes,
+                        timeProvider = timeProvider,
+                        additionalAttributes = additionalAttributes,
+                        useDeltaCompression = useDeltaCompression
+                    )
+                ),
+                Triple(
+                    CSVReader(csvContent, METRIC_CPU_USAGE, timeProvider),
+                    Buffer(bufferSize),
+                    CpuEventSerializer(
+                        sessionId = sessionId,
+                        applicationId = applicationId,
+                        sessionType = sessionType,
+                        timeProvider = timeProvider,
+                        additionalAttributes = additionalAttributes,
+                        useDeltaCompression = useDeltaCompression
                     )
                 )
             )
-        }
+        )
 
         const val METRIC_MEMORY_USAGE: String = "memory_usage"
         const val METRIC_CPU_USAGE: String = "cpu_usage"

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/csv/TimeseriesEndToEndTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/csv/TimeseriesEndToEndTest.kt
@@ -6,8 +6,10 @@
 
 package com.datadog.android.rum.internal.timeseries.csv
 
+import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.rum.RumSessionType
+import com.datadog.android.rum.internal.timeseries.serializer.TimeseriesAttributes
 import com.datadog.android.rum.utils.forge.Configurator
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
@@ -15,6 +17,7 @@ import com.google.gson.JsonNull
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.google.gson.JsonPrimitive
+import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -43,6 +46,9 @@ internal class TimeseriesEndToEndTest {
     @Mock
     lateinit var mockTimeProvider: TimeProvider
 
+    @Mock
+    lateinit var mockDatadogContext: DatadogContext
+
     private lateinit var csvContent: String
     private lateinit var emitted: List<JsonObject>
 
@@ -58,7 +64,8 @@ internal class TimeseriesEndToEndTest {
             sessionType = RumSessionType.USER,
             totalRamBytes = TOTAL_RAM_BYTES,
             bufferSize = BATCH_SIZE,
-            timeProvider = mockTimeProvider
+            timeProvider = mockTimeProvider,
+            datadogContext = mockDatadogContext
         )
         testedTimeseries.onSessionStart()
         testedTimeseries.onSessionStop()
@@ -107,7 +114,7 @@ internal class TimeseriesEndToEndTest {
     fun `M emit valid timeseries id W any batch`() {
         // Each emitted event must carry a non-blank UUID; randomness is not asserted.
         for (event in emitted) {
-            val id = event.getAsJsonObject("timeseries").get("id").asString
+            val id = event.getAsJsonObject(TimeseriesAttributes.KEY_TIMESERIES).get("id").asString
             assertThat(UUID.fromString(id)).isNotNull
         }
     }
@@ -115,16 +122,56 @@ internal class TimeseriesEndToEndTest {
     @Test
     fun `M produce monotonic start lt or eq to end W any batch`() {
         for (event in emitted) {
-            val ts = event.getAsJsonObject("timeseries")
+            val ts = event.getAsJsonObject(TimeseriesAttributes.KEY_TIMESERIES)
             assertThat(ts.get("start").asLong).isLessThanOrEqualTo(ts.get("end").asLong)
         }
     }
 
-    private fun metricNameOf(event: JsonObject): String = event.getAsJsonObject("timeseries").get("name").asString
+    @Test
+    fun `M add tags to every emitted event W additionalAttributes is not empty`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeAdditionalAttributes = forge.aMap { anAlphabeticalString() to anAlphabeticalString() }
+        val testedTimeseries = CsvTimeseries.create(
+            csvContent = csvContent,
+            sessionId = SESSION_ID,
+            applicationId = APPLICATION_ID,
+            sessionType = RumSessionType.USER,
+            totalRamBytes = TOTAL_RAM_BYTES,
+            bufferSize = BATCH_SIZE,
+            timeProvider = mockTimeProvider,
+            datadogContext = mockDatadogContext,
+            additionalAttributes = fakeAdditionalAttributes
+        )
+
+        // When
+        testedTimeseries.onSessionStart()
+        testedTimeseries.onSessionStop()
+
+        // Then
+        val events = testedTimeseries.captured
+        assertThat(events).isNotEmpty
+        for (event in events) {
+            val tags = event.getAsJsonObject(
+                TimeseriesAttributes.KEY_TIMESERIES
+            ).getAsJsonObject(TimeseriesAttributes.KEY_TAGS)
+            assertThat(tags).describedAs("tags on %s", event).isNotNull
+            for ((key, value) in fakeAdditionalAttributes) {
+                assertThat(tags.get(key)?.asString).isEqualTo(value)
+            }
+        }
+    }
+
+    private fun metricNameOf(event: JsonObject): String =
+        event.getAsJsonObject(TimeseriesAttributes.KEY_TIMESERIES)
+            .get(TimeseriesAttributes.KEY_NAME)
+            .asString
 
     private fun maskTimeseriesId(actual: JsonObject): JsonObject {
         val copy = actual.deepCopy()
-        copy.getAsJsonObject("timeseries").addProperty("id", MASKED_UUID)
+        copy.getAsJsonObject(TimeseriesAttributes.KEY_TIMESERIES)
+            .addProperty(KEY_ID, MASKED_UUID)
         return copy
     }
 
@@ -236,5 +283,7 @@ internal class TimeseriesEndToEndTest {
         private const val NAME_CPU: String = "cpu"
         private const val MASKED_UUID: String = "00000000-0000-0000-0000-000000000000"
         private const val FP_TOLERANCE: Double = 1e-9
+
+        private const val KEY_ID: String = "id"
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/serializer/CpuEventSerializerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/serializer/CpuEventSerializerTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.timeseries.serializer
 
+import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.assertj.TimeseriesCpuEventAssert.Companion.assertThat
@@ -15,6 +16,7 @@ import com.datadog.android.rum.model.TimeseriesCpuEvent
 import com.datadog.android.rum.utils.forge.Configurator
 import com.google.gson.JsonObject
 import fr.xgouchet.elmyr.annotation.DoubleForgery
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -53,6 +55,9 @@ internal class CpuEventSerializerTest {
     @IntForgery(min = 2, max = 9)
     var fakePrecision: Int = 0
 
+    @Forgery
+    lateinit var fakeDatadogContext: DatadogContext
+
     val fakeScale: Long get() = 10.0.pow(fakePrecision.toDouble()).toLong()
 
     val mockTimeProvider: TimeProvider = mock<TimeProvider> {
@@ -62,12 +67,14 @@ internal class CpuEventSerializerTest {
     private fun testedSerializer(
         useDeltaCompression: Boolean = false,
         sessionType: RumSessionType = RumSessionType.USER,
-        precision: Int = fakePrecision
+        precision: Int = fakePrecision,
+        additionalAttributes: Map<String, String> = emptyMap()
     ) = CpuEventSerializer(
         sessionId = fakeSessionId,
         applicationId = fakeApplicationId,
         sessionType = sessionType,
         timeProvider = mockTimeProvider,
+        additionalAttributes = additionalAttributes,
         useDeltaCompression = useDeltaCompression,
         precision = precision
     )
@@ -75,7 +82,7 @@ internal class CpuEventSerializerTest {
     @Test
     fun `M return null W serialize() { empty input }`() {
         // When
-        val result = testedSerializer().serialize(emptyList())
+        val result = testedSerializer().serialize(fakeDatadogContext, emptyList())
 
         // Then
         assertThat(result).isNull()
@@ -93,7 +100,7 @@ internal class CpuEventSerializerTest {
         )
 
         // When
-        val json = testedSerializer().serialize(samples).failIfNull()
+        val json = testedSerializer().serialize(fakeDatadogContext, samples).failIfNull()
 
         // Then
         assertThat(json)
@@ -105,6 +112,8 @@ internal class CpuEventSerializerTest {
             .hasApplicationId(fakeApplicationId)
             .hasSessionType(TimeseriesCpuEvent.Type.USER)
             .hasTimeseriesSchema(TimeseriesCpuEvent.Schema.OBJECT)
+            .hasService(fakeDatadogContext.service)
+            .hasVersion(fakeDatadogContext.version)
     }
 
     @Test
@@ -117,11 +126,53 @@ internal class CpuEventSerializerTest {
 
         // When
         val json = testedSerializer(sessionType = RumSessionType.SYNTHETICS)
-            .serialize(samples)
+            .serialize(fakeDatadogContext, samples)
             .failIfNull()
 
         // Then
         assertThat(json).hasSessionType(TimeseriesCpuEvent.Type.SYNTHETICS)
+    }
+
+    @Test
+    fun `M add tags W serialize() { additionalAttributes non-empty }`(
+        @DoubleForgery(min = 0.0, max = 100.0) fakeCpuValue: Double,
+        @LongForgery(min = 1L) fakeTs: Long,
+        @StringForgery fakeTagKey: String,
+        @StringForgery fakeTagValue: String
+    ) {
+        // Given
+        val samples = listOf(DataPoint(fakeTs, fakeCpuValue))
+
+        // When
+        val json = testedSerializer(additionalAttributes = mapOf(fakeTagKey to fakeTagValue))
+            .serialize(fakeDatadogContext, samples)
+            .failIfNull()
+
+        // Then
+        val tags = json
+            .getAsJsonObject(TimeseriesAttributes.KEY_TIMESERIES)
+            .getAsJsonObject(TimeseriesAttributes.KEY_TAGS)
+        assertThat(tags.get(fakeTagKey).asString).isEqualTo(fakeTagValue)
+    }
+
+    @Test
+    fun `M not add tags W serialize() { additionalAttributes empty }`(
+        @DoubleForgery(min = 0.0, max = 100.0) fakeCpuValue: Double,
+        @LongForgery(min = 1L) fakeTs: Long
+    ) {
+        // Given
+        val samples = listOf(DataPoint(fakeTs, fakeCpuValue))
+
+        // When
+        val json = testedSerializer(additionalAttributes = emptyMap())
+            .serialize(fakeDatadogContext, samples)
+            .failIfNull()
+
+        // Then
+        assertThat(
+            json.getAsJsonObject(TimeseriesAttributes.KEY_TIMESERIES)
+                .has(TimeseriesAttributes.KEY_TAGS)
+        ).isFalse()
     }
 
     @Test
@@ -143,7 +194,7 @@ internal class CpuEventSerializerTest {
 
         // When
         val json = testedSerializer(useDeltaCompression = true)
-            .serialize(samples)
+            .serialize(fakeDatadogContext, samples)
             .failIfNull()
 
         // Then
@@ -151,7 +202,7 @@ internal class CpuEventSerializerTest {
         assertThatDelta(json)
             .hasTimeseriesSchema(TimeseriesCpuEvent.Schema.DELTA_SCALAR)
             .hasDeltaPrecision(fakePrecision)
-            .hasDeltaResolution(RESOLUTION_NS)
+            .hasDeltaResolution(TimeseriesAttributes.NS)
             .hasDeltaTsValues(fakeTs1, fakeTimestampStep, fakeTimestampStep)
             .hasDeltaValueAt(0, scaled[0])
             .hasDeltaValueAt(1, scaled[1] - scaled[0])
@@ -165,7 +216,7 @@ internal class CpuEventSerializerTest {
     ) {
         // When
         val json = testedSerializer(useDeltaCompression = true)
-            .serialize(listOf(DataPoint(fakeTs, fakeCpu)))
+            .serialize(fakeDatadogContext, listOf(DataPoint(fakeTs, fakeCpu)))
             .failIfNull()
 
         // Then
@@ -186,7 +237,7 @@ internal class CpuEventSerializerTest {
         )
 
         // When
-        val json = testedSerializer().serialize(samples).failIfNull()
+        val json = testedSerializer().serialize(fakeDatadogContext, samples).failIfNull()
 
         // Then
         assertThat(json)
@@ -195,7 +246,6 @@ internal class CpuEventSerializerTest {
 
     private companion object {
         private const val CPU_OFFSET: Double = 0.0001
-        private const val RESOLUTION_NS: String = "ns"
         private const val NON_NULL_JSON_ERROR: String = "expected non-null json"
         private fun JsonObject?.failIfNull(): JsonObject {
             if (this == null) error(NON_NULL_JSON_ERROR) else return this

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/serializer/MemoryEventSerializerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/serializer/MemoryEventSerializerTest.kt
@@ -6,12 +6,14 @@
 
 package com.datadog.android.rum.internal.timeseries.serializer
 
+import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.timeseries.DataPoint
 import com.datadog.android.rum.model.TimeseriesMemoryEvent
 import com.datadog.android.rum.utils.forge.Configurator
 import fr.xgouchet.elmyr.annotation.DoubleForgery
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -60,6 +62,9 @@ internal class MemoryEventSerializerTest {
     @IntForgery(min = 2, max = 9)
     var fakePrecision: Int = 0
 
+    @Forgery
+    lateinit var fakeDatadogContext: DatadogContext
+
     val fakeScale: Long get() = 10.0.pow(fakePrecision.toDouble()).toLong()
 
     @BeforeEach
@@ -71,13 +76,15 @@ internal class MemoryEventSerializerTest {
         useDeltaCompression: Boolean = false,
         sessionType: RumSessionType = RumSessionType.USER,
         totalRamBytes: Long = fakeTotalRamBytes,
-        precision: Int = fakePrecision
+        precision: Int = fakePrecision,
+        additionalAttributes: Map<String, String> = emptyMap()
     ) = MemoryEventSerializer(
         sessionId = fakeSessionId,
         applicationId = fakeApplicationId,
         sessionType = sessionType,
         totalRamBytes = totalRamBytes,
         timeProvider = mockTimeProvider,
+        additionalAttributes = additionalAttributes,
         useDeltaCompression = useDeltaCompression,
         precision = precision
     )
@@ -85,7 +92,7 @@ internal class MemoryEventSerializerTest {
     @Test
     fun `M return null W serialize() { empty input }`() {
         // When
-        val result = testedSerializer().serialize(emptyList())
+        val result = testedSerializer().serialize(fakeDatadogContext, emptyList())
 
         // Then
         assertThat(result).isNull()
@@ -98,7 +105,7 @@ internal class MemoryEventSerializerTest {
     ) {
         // When
         val result = testedSerializer(totalRamBytes = 0L)
-            .serialize(listOf(DataPoint(fakeTs, fakeMemory)))
+            .serialize(fakeDatadogContext, listOf(DataPoint(fakeTs, fakeMemory)))
 
         // Then
         assertThat(result).isNull()
@@ -112,7 +119,7 @@ internal class MemoryEventSerializerTest {
     ) {
         // When
         val result = testedSerializer(totalRamBytes = fakeNegativeRam)
-            .serialize(listOf(DataPoint(fakeTs, fakeMemory)))
+            .serialize(fakeDatadogContext, listOf(DataPoint(fakeTs, fakeMemory)))
 
         // Then
         assertThat(result).isNull()
@@ -130,15 +137,17 @@ internal class MemoryEventSerializerTest {
         )
 
         // When
-        val result = testedSerializer().serialize(samples)
+        val result = testedSerializer().serialize(fakeDatadogContext, samples)
 
         // Then
         val json = checkNotNull(result)
-        val timeseries = json.getAsJsonObject(KEY_TIMESERIES)
-        assertThat(timeseries.get(KEY_SCHEMA).asString).isEqualTo(VALUE_SCHEMA_OBJECT)
+        val timeseries = json.getAsJsonObject(TimeseriesAttributes.KEY_TIMESERIES)
+        assertThat(timeseries.get(TimeseriesAttributes.KEY_SCHEMA).asString).isEqualTo(VALUE_SCHEMA_OBJECT)
         assertThat(timeseries.get(KEY_START).asLong).isEqualTo(fakeTs)
         assertThat(timeseries.get(KEY_END).asLong).isEqualTo(fakeTs + 1L)
         assertDoesNotThrow { UUID.fromString(timeseries.get(KEY_ID).asString) }
+        assertThat(json.get(KEY_SERVICE).asString).isEqualTo(fakeDatadogContext.service)
+        assertThat(json.get(KEY_VERSION).asString).isEqualTo(fakeDatadogContext.version)
 
         val parsed = TimeseriesMemoryEvent.fromJsonObject(json)
         assertThat(parsed.timeseries.data).hasSize(2)
@@ -155,11 +164,47 @@ internal class MemoryEventSerializerTest {
     ) {
         // When
         val result = testedSerializer(sessionType = RumSessionType.SYNTHETICS)
-            .serialize(listOf(DataPoint(fakeTs, fakeMemory), DataPoint(fakeTs + 1L, fakeMemory)))
+            .serialize(fakeDatadogContext, listOf(DataPoint(fakeTs, fakeMemory), DataPoint(fakeTs + 1L, fakeMemory)))
 
         // Then
         val json = checkNotNull(result)
         assertThat(json.getAsJsonObject(KEY_SESSION).get(KEY_TYPE).asString).isEqualTo(VALUE_TYPE_SYNTHETICS)
+    }
+
+    @Test
+    fun `M add tags W serialize() { additionalAttributes non-empty }`(
+        @DoubleForgery(min = 1.0) fakeMemory: Double,
+        @LongForgery(min = 1L) fakeTs: Long,
+        @StringForgery fakeTagKey: String,
+        @StringForgery fakeTagValue: String
+    ) {
+        // When
+        val result = testedSerializer(additionalAttributes = mapOf(fakeTagKey to fakeTagValue))
+            .serialize(fakeDatadogContext, listOf(DataPoint(fakeTs, fakeMemory)))
+
+        // Then
+        val json = checkNotNull(result)
+        val tags = json
+            .getAsJsonObject(TimeseriesAttributes.KEY_TIMESERIES)
+            .getAsJsonObject(TimeseriesAttributes.KEY_TAGS)
+        assertThat(tags.get(fakeTagKey).asString).isEqualTo(fakeTagValue)
+    }
+
+    @Test
+    fun `M not add tags W serialize() { additionalAttributes empty }`(
+        @DoubleForgery(min = 1.0) fakeMemory: Double,
+        @LongForgery(min = 1L) fakeTs: Long
+    ) {
+        // When
+        val result = testedSerializer(additionalAttributes = emptyMap())
+            .serialize(fakeDatadogContext, listOf(DataPoint(fakeTs, fakeMemory)))
+
+        // Then
+        val json = checkNotNull(result)
+        assertThat(
+            json.getAsJsonObject(TimeseriesAttributes.KEY_TIMESERIES)
+                .has(TimeseriesAttributes.KEY_TAGS)
+        ).isFalse()
     }
 
     @Test
@@ -181,23 +226,23 @@ internal class MemoryEventSerializerTest {
         )
 
         // When
-        val result = testedSerializer(useDeltaCompression = true).serialize(samples)
+        val result = testedSerializer(useDeltaCompression = true).serialize(fakeDatadogContext, samples)
 
         // Then
         val json = checkNotNull(result)
-        val timeseries = json.getAsJsonObject(KEY_TIMESERIES)
-        assertThat(timeseries.get(KEY_SCHEMA).asString).isEqualTo(VALUE_SCHEMA_DELTA_OBJECT)
-        val data = timeseries.get(KEY_DATA).asJsonObject
-        assertThat(data.get(KEY_PRECISION).asInt).isEqualTo(fakePrecision)
-        assertThat(data.get(KEY_RESOLUTION).asString).isEqualTo(VALUE_RESOLUTION_NS)
+        val timeseries = json.getAsJsonObject(TimeseriesAttributes.KEY_TIMESERIES)
+        assertThat(timeseries.get(TimeseriesAttributes.KEY_SCHEMA).asString).isEqualTo(VALUE_SCHEMA_DELTA_OBJECT)
+        val data = timeseries.get(TimeseriesAttributes.KEY_DATA).asJsonObject
+        assertThat(data.get(TimeseriesAttributes.KEY_PRECISION).asInt).isEqualTo(fakePrecision)
+        assertThat(data.get(TimeseriesAttributes.KEY_RESOLUTION).asString).isEqualTo(TimeseriesAttributes.NS)
 
-        val tsArray = data.get(KEY_TS).asJsonArray
+        val tsArray = data.get(TimeseriesAttributes.KEY_TS).asJsonArray
         assertThat(tsArray[0].asLong).isEqualTo(fakeTs1)
         assertThat(tsArray[1].asLong).isEqualTo(fakeTimestampStep)
         assertThat(tsArray[2].asLong).isEqualTo(fakeTimestampStep)
 
-        val maxArr = data.get(KEY_MEMORY_FOOTPRINT).asJsonArray
-        val pctArr = data.get(KEY_MEMORY_PERCENT).asJsonArray
+        val maxArr = data.get(TimeseriesAttributes.KEY_MEMORY_FOOTPRINT).asJsonArray
+        val pctArr = data.get(TimeseriesAttributes.KEY_MEMORY_PERCENT).asJsonArray
         val scaledMax = listOf(fakeMem1, fakeMem2, fakeMem3).map { (it * fakeScale).roundToLong() }
         val scaledPct = listOf(fakeMem1, fakeMem2, fakeMem3)
             .map { (it / fakeTotalRamBytes * PERCENT_FACTOR * fakeScale).roundToLong() }
@@ -218,13 +263,13 @@ internal class MemoryEventSerializerTest {
     ) {
         // When
         val result = testedSerializer(useDeltaCompression = true)
-            .serialize(listOf(DataPoint(fakeTs, fakeMemory)))
+            .serialize(fakeDatadogContext, listOf(DataPoint(fakeTs, fakeMemory)))
 
         // Then
         val json = checkNotNull(result)
-        val timeseries = json.getAsJsonObject(KEY_TIMESERIES)
-        assertThat(timeseries.get(KEY_SCHEMA).asString).isEqualTo(VALUE_SCHEMA_OBJECT)
-        assertThat(timeseries.get(KEY_DATA).isJsonArray).isTrue()
+        val timeseries = json.getAsJsonObject(TimeseriesAttributes.KEY_TIMESERIES)
+        assertThat(timeseries.get(TimeseriesAttributes.KEY_SCHEMA).asString).isEqualTo(VALUE_SCHEMA_OBJECT)
+        assertThat(timeseries.get(TimeseriesAttributes.KEY_DATA).isJsonArray).isTrue()
     }
 
     private companion object {
@@ -232,24 +277,17 @@ internal class MemoryEventSerializerTest {
         private const val MEMORY_OFFSET: Double = 0.0001
 
         // JSON keys
-        private const val KEY_TIMESERIES: String = "timeseries"
-        private const val KEY_SCHEMA: String = "schema"
-        private const val KEY_DATA: String = "data"
         private const val KEY_SESSION: String = "session"
         private const val KEY_TYPE: String = "type"
         private const val KEY_ID: String = "id"
         private const val KEY_START: String = "start"
         private const val KEY_END: String = "end"
-        private const val KEY_PRECISION: String = "precision"
-        private const val KEY_RESOLUTION: String = "resolution"
-        private const val KEY_TS: String = "ts"
-        private const val KEY_MEMORY_FOOTPRINT: String = "memory_footprint"
-        private const val KEY_MEMORY_PERCENT: String = "memory_percent"
+        private const val KEY_SERVICE: String = "service"
+        private const val KEY_VERSION: String = "version"
 
         // JSON values
         private const val VALUE_SCHEMA_OBJECT: String = "object"
         private const val VALUE_SCHEMA_DELTA_OBJECT: String = "delta-object"
         private const val VALUE_TYPE_SYNTHETICS: String = "synthetics"
-        private const val VALUE_RESOLUTION_NS: String = "ns"
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfigurationTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfigurationTest.kt
@@ -81,4 +81,53 @@ internal class TimeseriesConfigurationTest {
         // Then
         assertThat(config.collectInBackground).isTrue()
     }
+
+    @Test
+    fun `M default additionalAttributes to empty W built with no args`() {
+        // When
+        val config = TimeseriesConfiguration.Builder().build()
+
+        // Then
+        assertThat(config.additionalAttributes).isEmpty()
+    }
+
+    @Test
+    fun `M store attribute W addAttribute`() {
+        // When
+        val config = TimeseriesConfiguration.Builder()
+            .addAttribute("key1", "value1")
+            .addAttribute("key2", "value2")
+            .build()
+
+        // Then
+        assertThat(config.additionalAttributes).containsExactlyInAnyOrderEntriesOf(
+            mapOf("key1" to "value1", "key2" to "value2")
+        )
+    }
+
+    @Test
+    fun `M overwrite value W addAttribute called twice with same key`() {
+        // When
+        val config = TimeseriesConfiguration.Builder()
+            .addAttribute("key", "first")
+            .addAttribute("key", "second")
+            .build()
+
+        // Then
+        assertThat(config.additionalAttributes).containsExactlyEntriesOf(mapOf("key" to "second"))
+    }
+
+    @Test
+    fun `M keep built attributes unchanged W addAttribute after build`() {
+        // Given
+        val builder = TimeseriesConfiguration.Builder()
+            .addAttribute("key1", "value1")
+        val config = builder.build()
+
+        // When
+        builder.addAttribute("key2", "value2")
+
+        // Then
+        assertThat(config.additionalAttributes).containsExactlyEntriesOf(mapOf("key1" to "value1"))
+    }
 }


### PR DESCRIPTION
### What does this PR do?

This PR adjusts few issues of the `timeseries` feature, that was found during the dogfooding on mobile app:

* Collecting timeseries during `APPLICATION_LAUNCH` 
* Stopping collecting `timeseries` when session got expired
* Allowing to add custom tags for timeeries (this needed only for dogfooding and will be removed later)
* Specifying `version` and `service` from datadog context.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

