### PR TITLE
RUM-16389: Fetch and store remote configuration file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,8 @@ The sample app reads credentials from gitignored JSON files in `config/`. Missin
   "logsEndpoint": "",
   "tracesEndpoint": "",
   "rumEndpoint": "",
-  "sessionReplayEndpoint": ""
+  "sessionReplayEndpoint": "",
+  "remoteConfigurationId": ""
 }
 ```
 

--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -484,13 +484,13 @@ enum com.datadog.android.trace.TracingHeaderType
   - B3
   - B3MULTI
   - TRACECONTEXT
-data class com.datadog.android.core.`internal`.remote.model.Android
+data class com.datadog.android.core.`internal`.remote.model.RemoteConfiguration
   constructor(Rum? = null, SessionReplay? = null, Profiling? = null, Trace? = null)
   val platform: kotlin.String
   fun toJson(): com.google.gson.JsonElement
   companion object 
-    fun fromJson(kotlin.String): Android
-    fun fromJsonObject(com.google.gson.JsonObject): Android
+    fun fromJson(kotlin.String): RemoteConfiguration
+    fun fromJsonObject(com.google.gson.JsonObject): RemoteConfiguration
   data class Rum
     constructor(kotlin.String, kotlin.String? = null, kotlin.String? = null, kotlin.Number? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Number? = null, VitalsUpdateFrequency? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null)
     fun toJson(): com.google.gson.JsonElement

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -887,62 +887,62 @@ public final class com/datadog/android/core/internal/persistence/file/FileExtKt 
 	public static synthetic fun readTextSafe$default (Ljava/io/File;Ljava/nio/charset/Charset;Lcom/datadog/android/api/InternalLogger;ILjava/lang/Object;)Ljava/lang/String;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android {
-	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$Companion;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Companion;
 	public fun <init> ()V
-	public fun <init> (Lcom/datadog/android/core/internal/remote/model/Android$Rum;Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;Lcom/datadog/android/core/internal/remote/model/Android$Profiling;Lcom/datadog/android/core/internal/remote/model/Android$Trace;)V
-	public synthetic fun <init> (Lcom/datadog/android/core/internal/remote/model/Android$Rum;Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;Lcom/datadog/android/core/internal/remote/model/Android$Profiling;Lcom/datadog/android/core/internal/remote/model/Android$Trace;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/datadog/android/core/internal/remote/model/Android$Rum;
-	public final fun component2 ()Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;
-	public final fun component3 ()Lcom/datadog/android/core/internal/remote/model/Android$Profiling;
-	public final fun component4 ()Lcom/datadog/android/core/internal/remote/model/Android$Trace;
-	public final fun copy (Lcom/datadog/android/core/internal/remote/model/Android$Rum;Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;Lcom/datadog/android/core/internal/remote/model/Android$Profiling;Lcom/datadog/android/core/internal/remote/model/Android$Trace;)Lcom/datadog/android/core/internal/remote/model/Android;
-	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/Android;Lcom/datadog/android/core/internal/remote/model/Android$Rum;Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;Lcom/datadog/android/core/internal/remote/model/Android$Profiling;Lcom/datadog/android/core/internal/remote/model/Android$Trace;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/Android;
+	public fun <init> (Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$SessionReplay;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace;)V
+	public synthetic fun <init> (Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$SessionReplay;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;
+	public final fun component2 ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$SessionReplay;
+	public final fun component3 ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling;
+	public final fun component4 ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace;
+	public final fun copy (Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$SessionReplay;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$SessionReplay;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration;
 	public final fun getPlatform ()Ljava/lang/String;
-	public final fun getProfiling ()Lcom/datadog/android/core/internal/remote/model/Android$Profiling;
-	public final fun getRum ()Lcom/datadog/android/core/internal/remote/model/Android$Rum;
-	public final fun getSessionReplay ()Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;
-	public final fun getTrace ()Lcom/datadog/android/core/internal/remote/model/Android$Trace;
+	public final fun getProfiling ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling;
+	public final fun getRum ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;
+	public final fun getSessionReplay ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$SessionReplay;
+	public final fun getTrace ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$ImagePrivacy : java/lang/Enum {
-	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy$Companion;
-	public static final field MASK_ALL Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
-	public static final field MASK_LARGE_ONLY Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
-	public static final field MASK_NONE Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$ImagePrivacy : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$ImagePrivacy$Companion;
+	public static final field MASK_ALL Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$ImagePrivacy;
+	public static final field MASK_LARGE_ONLY Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$ImagePrivacy;
+	public static final field MASK_NONE Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$ImagePrivacy;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$ImagePrivacy;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
-	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
-	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$ImagePrivacy;
+	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$ImagePrivacy;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$ImagePrivacy$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$ImagePrivacy$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$ImagePrivacy;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$Profiling {
-	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$Profiling$Companion;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;)V
 	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Number;
 	public final fun component2 ()Ljava/lang/Number;
-	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/core/internal/remote/model/Android$Profiling;
-	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/Android$Profiling;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/Android$Profiling;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Number;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling;
+	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling;Ljava/lang/Number;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$Profiling;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android$Profiling;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling;
 	public final fun getApplicationLaunchSampleRate ()Ljava/lang/Number;
 	public final fun getContinuousSampleRate ()Ljava/lang/Number;
 	public fun hashCode ()I
@@ -950,18 +950,18 @@ public final class com/datadog/android/core/internal/remote/model/Android$Profil
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$Profiling$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$Profiling;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android$Profiling;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$Rum {
-	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$Rum$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ljava/lang/Number;
-	public final fun component11 ()Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
+	public final fun component11 ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;
 	public final fun component12 ()Ljava/lang/Boolean;
 	public final fun component13 ()Ljava/lang/Boolean;
 	public final fun component14 ()Ljava/lang/Boolean;
@@ -973,11 +973,11 @@ public final class com/datadog/android/core/internal/remote/model/Android$Rum {
 	public final fun component7 ()Ljava/lang/Boolean;
 	public final fun component8 ()Ljava/lang/Boolean;
 	public final fun component9 ()Ljava/lang/Boolean;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lcom/datadog/android/core/internal/remote/model/Android$Rum;
-	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/Android$Rum;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/Android$Rum;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;
+	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$Rum;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android$Rum;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;
 	public final fun getApplicationId ()Ljava/lang/String;
 	public final fun getCrashReportsEnabled ()Ljava/lang/Boolean;
 	public final fun getEnv ()Ljava/lang/String;
@@ -991,92 +991,92 @@ public final class com/datadog/android/core/internal/remote/model/Android$Rum {
 	public final fun getTrackResources ()Ljava/lang/Boolean;
 	public final fun getTrackSlowFrames ()Ljava/lang/Boolean;
 	public final fun getTrackUserInteractions ()Ljava/lang/Boolean;
-	public final fun getVitalsUpdateFrequency ()Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
+	public final fun getVitalsUpdateFrequency ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$Rum$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$Rum;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android$Rum;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$SessionReplay {
-	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay$Companion;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$SessionReplay {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$SessionReplay$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Number;Ljava/lang/Boolean;Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;)V
-	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Boolean;Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Boolean;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TextAndInputPrivacy;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TouchPrivacy;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$ImagePrivacy;)V
+	public synthetic fun <init> (Ljava/lang/Number;Ljava/lang/Boolean;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TextAndInputPrivacy;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TouchPrivacy;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$ImagePrivacy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Number;
 	public final fun component2 ()Ljava/lang/Boolean;
-	public final fun component3 ()Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
-	public final fun component4 ()Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;
-	public final fun component5 ()Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
-	public final fun copy (Ljava/lang/Number;Ljava/lang/Boolean;Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;)Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;
-	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;Ljava/lang/Number;Ljava/lang/Boolean;Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;
+	public final fun component3 ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TextAndInputPrivacy;
+	public final fun component4 ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TouchPrivacy;
+	public final fun component5 ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$ImagePrivacy;
+	public final fun copy (Ljava/lang/Number;Ljava/lang/Boolean;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TextAndInputPrivacy;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TouchPrivacy;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$ImagePrivacy;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$SessionReplay;
+	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$SessionReplay;Ljava/lang/Number;Ljava/lang/Boolean;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TextAndInputPrivacy;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TouchPrivacy;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$ImagePrivacy;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$SessionReplay;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;
-	public final fun getImagePrivacy ()Lcom/datadog/android/core/internal/remote/model/Android$ImagePrivacy;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$SessionReplay;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$SessionReplay;
+	public final fun getImagePrivacy ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$ImagePrivacy;
 	public final fun getSampleRate ()Ljava/lang/Number;
 	public final fun getStartRecordingImmediately ()Ljava/lang/Boolean;
-	public final fun getTextAndInputPrivacy ()Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
-	public final fun getTouchPrivacy ()Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;
+	public final fun getTextAndInputPrivacy ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TextAndInputPrivacy;
+	public final fun getTouchPrivacy ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TouchPrivacy;
 	public fun hashCode ()I
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$SessionReplay$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android$SessionReplay;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$SessionReplay$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$SessionReplay;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$SessionReplay;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy : java/lang/Enum {
-	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy$Companion;
-	public static final field MASK_ALL Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
-	public static final field MASK_ALL_INPUTS Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
-	public static final field MASK_SENSITIVE_INPUTS Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$TextAndInputPrivacy : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TextAndInputPrivacy$Companion;
+	public static final field MASK_ALL Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TextAndInputPrivacy;
+	public static final field MASK_ALL_INPUTS Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TextAndInputPrivacy;
+	public static final field MASK_SENSITIVE_INPUTS Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TextAndInputPrivacy;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TextAndInputPrivacy;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
-	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
-	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TextAndInputPrivacy;
+	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TextAndInputPrivacy;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TextAndInputPrivacy;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$TextAndInputPrivacy$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TextAndInputPrivacy;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$TouchPrivacy : java/lang/Enum {
-	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy$Companion;
-	public static final field HIDE Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;
-	public static final field SHOW Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$TouchPrivacy : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TouchPrivacy$Companion;
+	public static final field HIDE Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TouchPrivacy;
+	public static final field SHOW Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TouchPrivacy;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TouchPrivacy;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
-	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;
-	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TouchPrivacy;
+	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TouchPrivacy;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$TouchPrivacy$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TouchPrivacy;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$TouchPrivacy$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TouchPrivacy;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$Trace {
-	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$Trace$Companion;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;Ljava/util/List;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TraceContextInjection;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TraceContextInjection;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Number;
-	public final fun component2 ()Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;
+	public final fun component2 ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TraceContextInjection;
 	public final fun component3 ()Ljava/util/List;
 	public final fun component4 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;Ljava/util/List;Ljava/util/List;)Lcom/datadog/android/core/internal/remote/model/Android$Trace;
-	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/Android$Trace;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/Android$Trace;
+	public final fun copy (Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TraceContextInjection;Ljava/util/List;Ljava/util/List;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace;
+	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TraceContextInjection;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$Trace;
-	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android$Trace;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace;
 	public final fun getSampleRate ()Ljava/lang/Number;
-	public final fun getTraceContextInjection ()Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;
+	public final fun getTraceContextInjection ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TraceContextInjection;
 	public final fun getTracedHosts ()Ljava/util/List;
 	public final fun getTracingHeaderTypes ()Ljava/util/List;
 	public fun hashCode ()I
@@ -1084,55 +1084,55 @@ public final class com/datadog/android/core/internal/remote/model/Android$Trace 
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$Trace$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$Trace;
-	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/Android$Trace;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$TraceContextInjection : java/lang/Enum {
-	public static final field ALL Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;
-	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection$Companion;
-	public static final field SAMPLED Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$TraceContextInjection : java/lang/Enum {
+	public static final field ALL Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TraceContextInjection;
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TraceContextInjection$Companion;
+	public static final field SAMPLED Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TraceContextInjection;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TraceContextInjection;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
-	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;
-	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TraceContextInjection;
+	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TraceContextInjection;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$TraceContextInjection$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TraceContextInjection;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$TraceContextInjection$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TraceContextInjection;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$TracingHeaderType : java/lang/Enum {
-	public static final field B3 Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType;
-	public static final field B3MULTI Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType;
-	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType$Companion;
-	public static final field DATADOG Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType;
-	public static final field TRACECONTEXT Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType;
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$TracingHeaderType : java/lang/Enum {
+	public static final field B3 Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracingHeaderType;
+	public static final field B3MULTI Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracingHeaderType;
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracingHeaderType$Companion;
+	public static final field DATADOG Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracingHeaderType;
+	public static final field TRACECONTEXT Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracingHeaderType;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracingHeaderType;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
-	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType;
-	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracingHeaderType;
+	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracingHeaderType;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$TracingHeaderType$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$TracingHeaderType;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$TracingHeaderType$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracingHeaderType;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency : java/lang/Enum {
-	public static final field AVERAGE Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
-	public static final field Companion Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency$Companion;
-	public static final field FREQUENT Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
-	public static final field NEVER Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
-	public static final field RARE Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
-	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency : java/lang/Enum {
+	public static final field AVERAGE Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency$Companion;
+	public static final field FREQUENT Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;
+	public static final field NEVER Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;
+	public static final field RARE Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
-	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
-	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;
+	public static fun values ()[Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;
 }
 
-public final class com/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency$Companion {
-	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/Android$VitalsUpdateFrequency;
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;
 }
 
 public final class com/datadog/android/core/internal/utils/ByteArrayExtKt {

--- a/dd-sdk-android-core/build.gradle.kts
+++ b/dd-sdk-android-core/build.gradle.kts
@@ -48,6 +48,7 @@ createJsonModelsGenerationTask("generateRemoteConfigModelsFromJson") {
     inputDirPath = "src/main/json/rc"
     targetPackageName = "com.datadog.android.core.internal.remote.model"
     ignoredFiles = listOf("mobile.json")
+    inputNameMapping = mapOf("android.json" to "RemoteConfiguration")
 }
 
 /**

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/DatadogSite.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/DatadogSite.kt
@@ -6,6 +6,8 @@
 
 package com.datadog.android
 
+import okhttp3.HttpUrl.Companion.toHttpUrl
+
 /**
  * Defines the Datadog sites you can send tracked data to.
  *
@@ -77,4 +79,9 @@ enum class DatadogSite private constructor(internal val siteName: String, privat
 
     /** The intake endpoint url. */
     val intakeEndpoint: String = "https://$intakeHostName"
+
+    /** The remote configuration CDN endpoint url. */
+    @Suppress("UnsafeThirdPartyFunctionCall") // host is a compile-time constant, cannot be malformed
+    internal val remoteConfigurationEndpoint: okhttp3.HttpUrl =
+        "https://sdk-configuration.$intakeHostName".toHttpUrl()
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/DatadogSite.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/DatadogSite.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android
 
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 
 /**
@@ -82,6 +83,6 @@ enum class DatadogSite private constructor(internal val siteName: String, privat
 
     /** The remote configuration CDN endpoint url. */
     @Suppress("UnsafeThirdPartyFunctionCall") // host is a compile-time constant, cannot be malformed
-    internal val remoteConfigurationEndpoint: okhttp3.HttpUrl =
+    internal val remoteConfigurationEndpoint: HttpUrl =
         "https://sdk-configuration.$intakeHostName".toHttpUrl()
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -30,6 +30,9 @@ import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.core.internal.lifecycle.ProcessLifecycleCallback
 import com.datadog.android.core.internal.logger.SdkInternalLogger
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.remote.RemoteConfigNetworkFetcher
+import com.datadog.android.core.internal.remote.RemoteConfigService
+import com.datadog.android.core.internal.remote.RemoteConfigServiceImpl
 import com.datadog.android.core.internal.time.DefaultAppStartTimeProvider
 import com.datadog.android.core.internal.time.composeTimeInfo
 import com.datadog.android.core.internal.utils.executeSafe
@@ -65,6 +68,7 @@ import java.util.concurrent.locks.Lock
  * @param internalLoggerProvider Provider for [InternalLogger] instance.
  * @param executorServiceFactory Custom factory for executors, used only in unit-tests
  * @param buildSdkVersionProvider Build.VERSION.SDK_INT provider used for the test
+ * @param remoteConfigServiceFactory Custom factory for remote config service, used only in unit-tests
  */
 @Suppress("TooManyFunctions")
 internal class DatadogCore(
@@ -74,10 +78,13 @@ internal class DatadogCore(
     internalLoggerProvider: (FeatureSdkCore) -> InternalLogger = { SdkInternalLogger(it) },
     // only for unit tests
     private val executorServiceFactory: FlushableExecutorService.Factory? = null,
-    private val buildSdkVersionProvider: BuildSdkVersionProvider = BuildSdkVersionProvider.DEFAULT
+    private val buildSdkVersionProvider: BuildSdkVersionProvider = BuildSdkVersionProvider.DEFAULT,
+    private val remoteConfigServiceFactory: RemoteConfigService.Factory? = null
 ) : InternalSdkCore {
 
     internal lateinit var coreFeature: CoreFeature
+
+    internal var remoteConfigService: RemoteConfigService? = null
 
     private lateinit var shutdownHook: Thread
 
@@ -478,10 +485,26 @@ internal class DatadogCore(
             initializeCrashReportFeature()
         }
 
+        setupRemoteConfiguration(mutableConfig)
+
         setupLifecycleMonitorCallback(appContext)
 
         setupShutdownHook()
         sendCoreConfigurationTelemetryEvent(configuration)
+    }
+
+    private fun setupRemoteConfiguration(configuration: Configuration) {
+        val id = configuration.coreConfig.remoteConfigurationId ?: return
+        val factory = remoteConfigServiceFactory ?: DEFAULT_REMOTE_CONFIG_SERVICE_FACTORY
+        remoteConfigService = factory.create(
+            remoteConfigurationId = id,
+            remoteConfigurationEndpoint = configuration.coreConfig.site.remoteConfigurationEndpoint,
+            callFactory = coreFeature.createOkHttpCallFactory { },
+            storageDir = coreFeature.storageDir,
+            executor = coreFeature.uploadExecutorService,
+            internalLogger = internalLogger
+        )
+        remoteConfigService?.syncWithRemote()
     }
 
     private fun initializeCrashReportFeature() {
@@ -702,6 +725,7 @@ internal class DatadogCore(
         }
 
         contextProvider = NoOpContextProvider()
+        remoteConfigService = null
         coreFeature.stop()
         isDeveloperModeEnabled = false
 
@@ -746,5 +770,17 @@ internal class DatadogCore(
             "SDK core already has \"%s\" listener registered."
 
         internal val CONFIGURATION_TELEMETRY_DELAY_MS = TimeUnit.SECONDS.toMillis(5)
+
+        internal val DEFAULT_REMOTE_CONFIG_SERVICE_FACTORY =
+            RemoteConfigService.Factory { id, endpoint, callFactory, storageDir, executor, logger ->
+                RemoteConfigServiceImpl(
+                    remoteConfigurationId = id,
+                    remoteConfigurationEndpoint = endpoint,
+                    fetcher = RemoteConfigNetworkFetcher(callFactory, logger),
+                    storageDir = storageDir,
+                    executor = executor,
+                    internalLogger = logger
+                )
+            }
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -68,7 +68,7 @@ import java.util.concurrent.locks.Lock
  * @param internalLoggerProvider Provider for [InternalLogger] instance.
  * @param executorServiceFactory Custom factory for executors, used only in unit-tests
  * @param buildSdkVersionProvider Build.VERSION.SDK_INT provider used for the test
- * @param remoteConfigServiceFactory Custom factory for remote config service, used only in unit-tests
+ * @param remoteConfigServiceFactory Factory for creating the remote config service, defaults to the real implementation
  */
 @Suppress("TooManyFunctions")
 internal class DatadogCore(
@@ -79,7 +79,7 @@ internal class DatadogCore(
     // only for unit tests
     private val executorServiceFactory: FlushableExecutorService.Factory? = null,
     private val buildSdkVersionProvider: BuildSdkVersionProvider = BuildSdkVersionProvider.DEFAULT,
-    private val remoteConfigServiceFactory: RemoteConfigService.Factory? = null
+    private val remoteConfigServiceFactory: RemoteConfigService.Factory = DEFAULT_REMOTE_CONFIG_SERVICE_FACTORY
 ) : InternalSdkCore {
 
     internal lateinit var coreFeature: CoreFeature
@@ -495,11 +495,16 @@ internal class DatadogCore(
 
     private fun setupRemoteConfiguration(configuration: Configuration) {
         val id = configuration.coreConfig.remoteConfigurationId ?: return
-        val factory = remoteConfigServiceFactory ?: DEFAULT_REMOTE_CONFIG_SERVICE_FACTORY
-        remoteConfigService = factory.create(
+        remoteConfigService = remoteConfigServiceFactory.create(
             remoteConfigurationId = id,
             remoteConfigurationEndpoint = configuration.coreConfig.site.remoteConfigurationEndpoint,
-            callFactory = coreFeature.createOkHttpCallFactory { },
+            callFactory = coreFeature.createOkHttpCallFactory {
+                val proxy = configuration.coreConfig.proxy
+                if (proxy != null) {
+                    proxy(proxy)
+                    proxyAuthenticator(configuration.coreConfig.proxyAuth)
+                }
+            },
             storageDir = coreFeature.storageDir,
             executor = coreFeature.uploadExecutorService,
             internalLogger = internalLogger

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcher.kt
@@ -76,7 +76,6 @@ internal class RemoteConfigNetworkFetcher(
                     InternalLogger.Level.ERROR,
                     listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
                     { ERROR_EMPTY_BODY },
-                    onlyOnce = true,
                     additionalProperties = mapOf(ATTR_URL to url.toString())
                 )
                 null
@@ -88,7 +87,6 @@ internal class RemoteConfigNetworkFetcher(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
                 { ERROR_HTTP },
-                onlyOnce = true,
                 additionalProperties = mapOf(
                     ATTR_RESPONSE_CODE to response.code,
                     ATTR_URL to url.toString()

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcher.kt
@@ -11,8 +11,8 @@ import com.datadog.android.api.InternalLogger
 import okhttp3.Call
 import okhttp3.HttpUrl
 import okhttp3.Request
+import okhttp3.Response
 import java.io.IOException
-import java.util.Locale
 
 /**
  * Fetches the remote configuration document from the Datadog CDN.
@@ -50,22 +50,24 @@ internal class RemoteConfigNetworkFetcher(
             internalLogger.log(
                 InternalLogger.Level.WARN,
                 InternalLogger.Target.MAINTAINER,
-                { ERROR_NETWORK.format(Locale.US, url) },
-                e
+                { ERROR_NETWORK },
+                e,
+                additionalProperties = mapOf(ATTR_URL to url.toString())
             )
             null
         } catch (e: Throwable) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                { ERROR_NETWORK.format(Locale.US, url) },
-                e
+                { ERROR_NETWORK },
+                e,
+                additionalProperties = mapOf(ATTR_URL to url.toString())
             )
             null
         }
     }
 
-    private fun handleResponse(response: okhttp3.Response, url: HttpUrl): String? {
+    private fun handleResponse(response: Response, url: HttpUrl): String? {
         return if (response.isSuccessful) {
             @Suppress("UnsafeThirdPartyFunctionCall") // safe: wrapped in outer try-catch
             val body = response.body?.use { it.string() }
@@ -73,8 +75,9 @@ internal class RemoteConfigNetworkFetcher(
                 internalLogger.log(
                     InternalLogger.Level.ERROR,
                     listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                    { ERROR_EMPTY_BODY.format(Locale.US, url) },
-                    onlyOnce = true
+                    { ERROR_EMPTY_BODY },
+                    onlyOnce = true,
+                    additionalProperties = mapOf(ATTR_URL to url.toString())
                 )
                 null
             } else {
@@ -84,9 +87,12 @@ internal class RemoteConfigNetworkFetcher(
             internalLogger.log(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                { ERROR_HTTP.format(Locale.US, url, response.code) },
+                { ERROR_HTTP },
                 onlyOnce = true,
-                additionalProperties = mapOf(ATTR_RESPONSE_CODE to response.code)
+                additionalProperties = mapOf(
+                    ATTR_RESPONSE_CODE to response.code,
+                    ATTR_URL to url.toString()
+                )
             )
             @Suppress("UnsafeThirdPartyFunctionCall") // safe: wrapped in outer try-catch
             response.body?.close()
@@ -95,9 +101,10 @@ internal class RemoteConfigNetworkFetcher(
     }
 
     internal companion object {
-        internal const val ERROR_NETWORK = "Remote config fetch failed for url: %s"
-        internal const val ERROR_HTTP = "Remote config fetch failed for url: %s with status code: %d"
-        internal const val ERROR_EMPTY_BODY = "Remote config response body is empty for url: %s"
+        internal const val ERROR_NETWORK = "Remote config fetch failed due to a network error"
+        internal const val ERROR_HTTP = "Remote config fetch failed with an HTTP error"
+        internal const val ERROR_EMPTY_BODY = "Remote config response body is empty"
         internal const val ATTR_RESPONSE_CODE = "response_code"
+        internal const val ATTR_URL = "url"
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcher.kt
@@ -1,0 +1,103 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.remote
+
+import androidx.annotation.WorkerThread
+import com.datadog.android.api.InternalLogger
+import okhttp3.Call
+import okhttp3.HttpUrl
+import okhttp3.Request
+import java.io.IOException
+import java.util.Locale
+
+/**
+ * Fetches the remote configuration document from the Datadog CDN.
+ */
+internal interface RemoteConfigFetcher {
+    /**
+     * Fetches the remote configuration document from the given URL.
+     *
+     * @param url the CDN URL to fetch from.
+     * @return the raw JSON response body, or null if the fetch failed.
+     */
+    @WorkerThread
+    fun fetch(url: HttpUrl): String?
+}
+
+internal class RemoteConfigNetworkFetcher(
+    private val callFactory: Call.Factory,
+    private val internalLogger: InternalLogger
+) : RemoteConfigFetcher {
+
+    @WorkerThread
+    @Suppress("TooGenericExceptionCaught")
+    override fun fetch(url: HttpUrl): String? {
+        @Suppress("UnsafeThirdPartyFunctionCall") // safe: url is a valid HttpUrl, get() has no preconditions
+        val request = Request.Builder()
+            .url(url)
+            .get()
+            .build()
+        return try {
+            @Suppress("UnsafeThirdPartyFunctionCall") // safe: wrapped in outer try-catch
+            val response = callFactory.newCall(request).execute()
+            handleResponse(response, url)
+        } catch (e: IOException) {
+            // Device is likely offline — log to maintainer only, no telemetry noise.
+            internalLogger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.MAINTAINER,
+                { ERROR_NETWORK.format(Locale.US, url) },
+                e
+            )
+            null
+        } catch (e: Throwable) {
+            internalLogger.log(
+                InternalLogger.Level.ERROR,
+                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                { ERROR_NETWORK.format(Locale.US, url) },
+                e
+            )
+            null
+        }
+    }
+
+    private fun handleResponse(response: okhttp3.Response, url: HttpUrl): String? {
+        return if (response.isSuccessful) {
+            @Suppress("UnsafeThirdPartyFunctionCall") // safe: wrapped in outer try-catch
+            val body = response.body?.use { it.string() }
+            if (body.isNullOrEmpty()) {
+                internalLogger.log(
+                    InternalLogger.Level.ERROR,
+                    listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                    { ERROR_EMPTY_BODY.format(Locale.US, url) },
+                    onlyOnce = true
+                )
+                null
+            } else {
+                body
+            }
+        } else {
+            internalLogger.log(
+                InternalLogger.Level.ERROR,
+                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                { ERROR_HTTP.format(Locale.US, url, response.code) },
+                onlyOnce = true,
+                additionalProperties = mapOf(ATTR_RESPONSE_CODE to response.code)
+            )
+            @Suppress("UnsafeThirdPartyFunctionCall") // safe: wrapped in outer try-catch
+            response.body?.close()
+            null
+        }
+    }
+
+    internal companion object {
+        internal const val ERROR_NETWORK = "Remote config fetch failed for url: %s"
+        internal const val ERROR_HTTP = "Remote config fetch failed for url: %s with status code: %d"
+        internal const val ERROR_EMPTY_BODY = "Remote config response body is empty for url: %s"
+        internal const val ATTR_RESPONSE_CODE = "response_code"
+    }
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
@@ -84,18 +84,7 @@ internal class RemoteConfigServiceImpl(
     @WorkerThread
     private fun fetchAndCache() {
         val rawConfig = fetcher.fetch(configUrl) ?: return
-
-        val config = try {
-            RemoteConfiguration.fromJson(rawConfig)
-        } catch (e: JsonParseException) {
-            internalLogger.log(
-                InternalLogger.Level.ERROR,
-                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-                { ERROR_PARSE },
-                e
-            )
-            return
-        }
+        val config = parseConfig(rawConfig) ?: return
 
         configFile.parentFile?.mkdirsSafe(internalLogger)
         val written = fileReaderWriter.writeData(
@@ -109,6 +98,31 @@ internal class RemoteConfigServiceImpl(
     }
 
     @WorkerThread
+    private fun parseConfig(rawConfig: String): RemoteConfiguration? {
+        return try {
+            RemoteConfiguration.fromJson(rawConfig)
+        } catch (e: JsonParseException) {
+            internalLogger.log(
+                InternalLogger.Level.ERROR,
+                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                { ERROR_PARSE },
+                e
+            )
+            null
+        } catch (e: NoSuchElementException) {
+            // Generated enum readers use values().first { } which throws NoSuchElementException
+            // for unknown enum values — treat the same as a parse failure.
+            internalLogger.log(
+                InternalLogger.Level.ERROR,
+                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                { ERROR_PARSE },
+                e
+            )
+            null
+        }
+    }
+
+    @WorkerThread
     @Suppress("ReturnCount")
     private fun readConfigFromDisk(): RemoteConfiguration? {
         if (!configFile.existsSafe(internalLogger)) return null
@@ -117,6 +131,18 @@ internal class RemoteConfigServiceImpl(
         return try {
             RemoteConfiguration.fromJson(String(bytes, Charsets.UTF_8))
         } catch (e: JsonParseException) {
+            internalLogger.log(
+                InternalLogger.Level.ERROR,
+                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                { ERROR_PARSE },
+                e
+            )
+            // Delete the corrupt file so the next successful fetch can write a clean one.
+            configFile.deleteSafe(internalLogger)
+            null
+        } catch (e: NoSuchElementException) {
+            // Generated enum readers use values().first { } which throws NoSuchElementException
+            // for unknown enum values — treat the same as a parse failure.
             internalLogger.log(
                 InternalLogger.Level.ERROR,
                 listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
@@ -15,6 +15,7 @@ import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.internal.utils.allowThreadDiskReads
 import com.google.gson.JsonParseException
+import okhttp3.Call
 import okhttp3.HttpUrl
 import java.io.File
 import java.util.concurrent.Executor
@@ -26,6 +27,17 @@ import java.util.concurrent.Executor
 internal interface RemoteConfigService {
     fun syncWithRemote()
     fun getCurrentConfig(): RemoteConfiguration?
+
+    fun interface Factory {
+        fun create(
+            remoteConfigurationId: String,
+            remoteConfigurationEndpoint: HttpUrl,
+            callFactory: Call.Factory,
+            storageDir: File,
+            executor: Executor,
+            internalLogger: InternalLogger
+        ): RemoteConfigService
+    }
 }
 
 internal class RemoteConfigServiceImpl(

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
@@ -11,7 +11,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.deleteSafe
 import com.datadog.android.core.internal.persistence.file.existsSafe
-import com.datadog.android.core.internal.remote.model.Android
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.internal.utils.allowThreadDiskReads
 import com.google.gson.JsonParseException
@@ -25,7 +25,7 @@ import java.util.concurrent.Executor
  */
 internal interface RemoteConfigService {
     fun syncWithRemote()
-    fun getCurrentConfig(): Android?
+    fun getCurrentConfig(): RemoteConfiguration?
 }
 
 internal class RemoteConfigServiceImpl(
@@ -50,7 +50,7 @@ internal class RemoteConfigServiceImpl(
         .build()
 
     @Volatile
-    private var cachedConfig: Android? = null
+    private var cachedConfig: RemoteConfiguration? = null
 
     init {
         // Synchronous read on the caller's thread (main thread during SDK init).
@@ -60,7 +60,7 @@ internal class RemoteConfigServiceImpl(
         cachedConfig = allowThreadDiskReads { readConfigFromDisk() }
     }
 
-    override fun getCurrentConfig(): Android? = cachedConfig
+    override fun getCurrentConfig(): RemoteConfiguration? = cachedConfig
 
     override fun syncWithRemote() {
         executor.executeSafe(SYNC_OPERATION_NAME, internalLogger) {
@@ -73,7 +73,7 @@ internal class RemoteConfigServiceImpl(
         val rawConfig = fetcher.fetch(configUrl) ?: return
 
         val config = try {
-            Android.fromJson(rawConfig)
+            RemoteConfiguration.fromJson(rawConfig)
         } catch (e: JsonParseException) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
@@ -96,12 +96,12 @@ internal class RemoteConfigServiceImpl(
 
     @WorkerThread
     @Suppress("ReturnCount")
-    private fun readConfigFromDisk(): Android? {
+    private fun readConfigFromDisk(): RemoteConfiguration? {
         if (!configFile.existsSafe(internalLogger)) return null
         val bytes = fileReaderWriter.readData(configFile)
         if (bytes.isEmpty()) return null
         return try {
-            Android.fromJson(String(bytes, Charsets.UTF_8))
+            RemoteConfiguration.fromJson(String(bytes, Charsets.UTF_8))
         } catch (e: JsonParseException) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
@@ -1,0 +1,123 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.remote
+
+import androidx.annotation.WorkerThread
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.internal.persistence.file.FileReaderWriter
+import com.datadog.android.core.internal.persistence.file.deleteSafe
+import com.datadog.android.core.internal.persistence.file.existsSafe
+import com.datadog.android.core.internal.remote.model.Android
+import com.datadog.android.core.internal.utils.executeSafe
+import com.datadog.android.internal.utils.allowThreadDiskReads
+import com.google.gson.JsonParseException
+import okhttp3.HttpUrl
+import java.io.File
+import java.util.concurrent.Executor
+
+/**
+ * Manages the remote configuration lifecycle: fetches from the CDN, persists to disk,
+ * and exposes the latest configuration for feature consumption.
+ */
+internal interface RemoteConfigService {
+    fun syncWithRemote()
+    fun getCurrentConfig(): Android?
+}
+
+internal class RemoteConfigServiceImpl(
+    remoteConfigurationId: String,
+    remoteConfigurationEndpoint: HttpUrl,
+    private val fetcher: RemoteConfigFetcher,
+    storageDir: File,
+    private val executor: Executor,
+    private val internalLogger: InternalLogger,
+    private val fileReaderWriter: FileReaderWriter = FileReaderWriter.create(internalLogger, null)
+) : RemoteConfigService {
+
+    private val configFile = File(storageDir, "$remoteConfigurationId.json")
+
+    // addPathSegment throws IllegalArgumentException for invalid URL chars (e.g. '?', '#').
+    // remoteConfigurationId is a UUID-format opaque ID from the Datadog UI, which only
+    // contains hex chars and hyphens — all valid URL path segment characters.
+    @Suppress("UnsafeThirdPartyFunctionCall")
+    private val configUrl: HttpUrl = remoteConfigurationEndpoint.newBuilder()
+        .addPathSegment(API_VERSION)
+        .addPathSegment("$remoteConfigurationId.json")
+        .build()
+
+    @Volatile
+    private var cachedConfig: Android? = null
+
+    init {
+        // Synchronous read on the caller's thread (main thread during SDK init).
+        // Acceptable because the file is small and only present after a previous
+        // successful fetch — absent on first launch.
+        @Suppress("ThreadSafety") // allowThreadDiskReads is the SDK mechanism for safe main-thread disk reads
+        cachedConfig = allowThreadDiskReads { readConfigFromDisk() }
+    }
+
+    override fun getCurrentConfig(): Android? = cachedConfig
+
+    override fun syncWithRemote() {
+        executor.executeSafe(SYNC_OPERATION_NAME, internalLogger) {
+            fetchAndCache()
+        }
+    }
+
+    @WorkerThread
+    private fun fetchAndCache() {
+        val rawConfig = fetcher.fetch(configUrl) ?: return
+
+        val config = try {
+            Android.fromJson(rawConfig)
+        } catch (e: JsonParseException) {
+            internalLogger.log(
+                InternalLogger.Level.ERROR,
+                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                { ERROR_PARSE },
+                e
+            )
+            return
+        }
+
+        val written = fileReaderWriter.writeData(
+            file = configFile,
+            data = rawConfig.toByteArray(Charsets.UTF_8),
+            append = false
+        )
+        if (written) {
+            cachedConfig = config
+        }
+    }
+
+    @WorkerThread
+    @Suppress("ReturnCount")
+    private fun readConfigFromDisk(): Android? {
+        if (!configFile.existsSafe(internalLogger)) return null
+        val bytes = fileReaderWriter.readData(configFile)
+        if (bytes.isEmpty()) return null
+        return try {
+            Android.fromJson(String(bytes, Charsets.UTF_8))
+        } catch (e: JsonParseException) {
+            internalLogger.log(
+                InternalLogger.Level.ERROR,
+                listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                { ERROR_PARSE },
+                e
+            )
+            // Delete the corrupt file so the next successful fetch can write a clean one.
+            configFile.deleteSafe(internalLogger)
+            null
+        }
+    }
+
+    internal companion object {
+        internal const val API_VERSION = "v1"
+        internal const val SYNC_OPERATION_NAME = "remote config sync"
+        internal const val ERROR_PARSE = "Failed to parse remote configuration"
+    }
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
@@ -11,6 +11,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.deleteSafe
 import com.datadog.android.core.internal.persistence.file.existsSafe
+import com.datadog.android.core.internal.persistence.file.mkdirsSafe
 import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.internal.utils.allowThreadDiskReads
@@ -96,6 +97,7 @@ internal class RemoteConfigServiceImpl(
             return
         }
 
+        configFile.parentFile?.mkdirsSafe(internalLogger)
         val written = fileReaderWriter.writeData(
             file = configFile,
             data = rawConfig.toByteArray(Charsets.UTF_8),

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
@@ -19,6 +19,7 @@ import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.DatadogContextProvider
 import com.datadog.android.core.internal.DatadogCore
 import com.datadog.android.core.internal.SdkFeature
+import com.datadog.android.core.internal.remote.RemoteConfigService
 import com.datadog.android.core.thread.FlushableExecutorService
 import com.datadog.android.error.internal.CrashReportsFeature
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
@@ -53,6 +54,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -76,6 +78,9 @@ internal class DatadogCoreInitializationTest {
 
     @Mock
     lateinit var mockPersistenceExecutorService: FlushableExecutorService
+
+    @Mock
+    lateinit var mockRemoteConfigService: RemoteConfigService
 
     @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL)
     lateinit var fakeInstanceId: String
@@ -645,6 +650,56 @@ internal class DatadogCoreInitializationTest {
 
         // Then
         assertThat(testedCore.coreFeature.packageVersionProvider.version).isEqualTo(appVersion)
+    }
+
+    @Test
+    fun `M create and sync RemoteConfigService W initialize() { remoteConfigurationId set }`(
+        @StringForgery fakeRemoteConfigurationId: String
+    ) {
+        // When
+        testedCore = DatadogCore(
+            appContext.mockInstance,
+            fakeInstanceId,
+            fakeInstanceName,
+            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService },
+            remoteConfigServiceFactory = { _, _, _, _, _, _ -> mockRemoteConfigService }
+        ).apply {
+            initialize(
+                fakeConfiguration.copy(
+                    coreConfig = fakeConfiguration.coreConfig.copy(
+                        remoteConfigurationId = fakeRemoteConfigurationId
+                    )
+                )
+            )
+        }
+
+        // Then
+        assertThat(testedCore.remoteConfigService).isSameAs(mockRemoteConfigService)
+        verify(mockRemoteConfigService).syncWithRemote()
+    }
+
+    @Test
+    fun `M not create RemoteConfigService W initialize() { remoteConfigurationId null }`() {
+        // When
+        testedCore = DatadogCore(
+            appContext.mockInstance,
+            fakeInstanceId,
+            fakeInstanceName,
+            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService },
+            remoteConfigServiceFactory = { _, _, _, _, _, _ -> mockRemoteConfigService }
+        ).apply {
+            initialize(
+                fakeConfiguration.copy(
+                    coreConfig = fakeConfiguration.coreConfig.copy(
+                        remoteConfigurationId = null
+                    )
+                )
+            )
+        }
+
+        // Then
+        assertThat(testedCore.remoteConfigService).isNull()
+        verify(mockRemoteConfigService, never()).syncWithRemote()
     }
 
     // endregion

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcherTest.kt
@@ -1,0 +1,231 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.remote
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.verifyLog
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import okhttp3.Call
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.isA
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import java.io.IOException
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class RemoteConfigFetcherTest {
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @Mock
+    lateinit var mockCallFactory: Call.Factory
+
+    @Mock
+    lateinit var mockCall: Call
+
+    private lateinit var testedFetcher: RemoteConfigNetworkFetcher
+
+    private val fakeUrl = "https://sdk-configuration.browser-intake-datadoghq.com/v1/fake-id.json"
+
+    @BeforeEach
+    fun `set up`() {
+        testedFetcher = RemoteConfigNetworkFetcher(
+            callFactory = mockCallFactory,
+            internalLogger = mockInternalLogger
+        )
+    }
+
+    // region fetch() - Success
+
+    @Test
+    fun `M return response body W fetch() { successful 2xx response }`(
+        @StringForgery fakeBody: String
+    ) {
+        // Given
+        val fakeRequest = Request.Builder().url(fakeUrl).build()
+        val fakeResponse = Response.Builder()
+            .request(fakeRequest)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body(fakeBody.toResponseBody("application/json".toMediaType()))
+            .build()
+        whenever(mockCallFactory.newCall(isA())).doReturn(mockCall)
+        whenever(mockCall.execute()).doReturn(fakeResponse)
+
+        // When
+        val result = testedFetcher.fetch(fakeUrl.toHttpUrl())
+
+        // Then
+        assertThat(result).isEqualTo(fakeBody)
+    }
+
+    @Test
+    fun `M return null and log W fetch() { 2xx response with empty body }`() {
+        // Given
+        val fakeRequest = Request.Builder().url(fakeUrl).build()
+        val fakeResponse = Response.Builder()
+            .request(fakeRequest)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body("".toResponseBody("application/json".toMediaType()))
+            .build()
+        whenever(mockCallFactory.newCall(isA())).doReturn(mockCall)
+        whenever(mockCall.execute()).doReturn(fakeResponse)
+
+        // When
+        val result = testedFetcher.fetch(fakeUrl.toHttpUrl())
+
+        // Then
+        assertThat(result).isNull()
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            message = RemoteConfigNetworkFetcher.ERROR_EMPTY_BODY.format(fakeUrl.toHttpUrl()),
+            onlyOnce = true
+        )
+    }
+
+    // endregion
+
+    // region fetch() - HTTP errors
+
+    @Test
+    fun `M return null and log W fetch() { 4xx response }`(
+        @StringForgery fakeBody: String
+    ) {
+        // Given
+        val fakeRequest = Request.Builder().url(fakeUrl).build()
+        val fakeResponse = Response.Builder()
+            .request(fakeRequest)
+            .protocol(Protocol.HTTP_1_1)
+            .code(404)
+            .message("Not Found")
+            .body(fakeBody.toResponseBody("application/json".toMediaType()))
+            .build()
+        whenever(mockCallFactory.newCall(isA())).doReturn(mockCall)
+        whenever(mockCall.execute()).doReturn(fakeResponse)
+
+        // When
+        val result = testedFetcher.fetch(fakeUrl.toHttpUrl())
+
+        // Then
+        assertThat(result).isNull()
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            message = RemoteConfigNetworkFetcher.ERROR_HTTP.format(fakeUrl.toHttpUrl(), 404),
+            onlyOnce = true,
+            additionalProperties = mapOf(RemoteConfigNetworkFetcher.ATTR_RESPONSE_CODE to 404)
+        )
+    }
+
+    @Test
+    fun `M return null and log W fetch() { 5xx response }`(
+        @StringForgery fakeBody: String
+    ) {
+        // Given
+        val fakeRequest = Request.Builder().url(fakeUrl).build()
+        val fakeResponse = Response.Builder()
+            .request(fakeRequest)
+            .protocol(Protocol.HTTP_1_1)
+            .code(500)
+            .message("Internal Server Error")
+            .body(fakeBody.toResponseBody("application/json".toMediaType()))
+            .build()
+        whenever(mockCallFactory.newCall(isA())).doReturn(mockCall)
+        whenever(mockCall.execute()).doReturn(fakeResponse)
+
+        // When
+        val result = testedFetcher.fetch(fakeUrl.toHttpUrl())
+
+        // Then
+        assertThat(result).isNull()
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            message = RemoteConfigNetworkFetcher.ERROR_HTTP.format(fakeUrl.toHttpUrl(), 500),
+            onlyOnce = true,
+            additionalProperties = mapOf(RemoteConfigNetworkFetcher.ATTR_RESPONSE_CODE to 500)
+        )
+    }
+
+    // endregion
+
+    // region fetch() - Network errors
+
+    @Test
+    fun `M return null and log to maintainer only W fetch() { IOException }`(
+        @StringForgery fakeMessage: String
+    ) {
+        // Given
+        val exception = IOException(fakeMessage)
+        whenever(mockCallFactory.newCall(isA())).doReturn(mockCall)
+        whenever(mockCall.execute()).doThrow(exception)
+
+        // When
+        val result = testedFetcher.fetch(fakeUrl.toHttpUrl())
+
+        // Then
+        assertThat(result).isNull()
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.WARN,
+            target = InternalLogger.Target.MAINTAINER,
+            message = RemoteConfigNetworkFetcher.ERROR_NETWORK.format(fakeUrl.toHttpUrl()),
+            throwableClass = IOException::class.java
+        )
+    }
+
+    @Test
+    fun `M return null and log to maintainer and telemetry W fetch() { unexpected exception }`(
+        @StringForgery fakeMessage: String
+    ) {
+        // Given
+        val exception = RuntimeException(fakeMessage)
+        whenever(mockCallFactory.newCall(isA())).doReturn(mockCall)
+        whenever(mockCall.execute()).doThrow(exception)
+
+        // When
+        val result = testedFetcher.fetch(fakeUrl.toHttpUrl())
+
+        // Then
+        assertThat(result).isNull()
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            message = RemoteConfigNetworkFetcher.ERROR_NETWORK.format(fakeUrl.toHttpUrl()),
+            throwableClass = RuntimeException::class.java
+        )
+    }
+
+    // endregion
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcherTest.kt
@@ -111,7 +111,6 @@ internal class RemoteConfigFetcherTest {
             level = InternalLogger.Level.ERROR,
             targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
             message = RemoteConfigNetworkFetcher.ERROR_EMPTY_BODY,
-            onlyOnce = true,
             additionalProperties = mapOf(RemoteConfigNetworkFetcher.ATTR_URL to fakeUrl.toHttpUrl().toString())
         )
     }
@@ -145,7 +144,6 @@ internal class RemoteConfigFetcherTest {
             level = InternalLogger.Level.ERROR,
             targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
             message = RemoteConfigNetworkFetcher.ERROR_HTTP,
-            onlyOnce = true,
             additionalProperties = mapOf(
                 RemoteConfigNetworkFetcher.ATTR_RESPONSE_CODE to 404,
                 RemoteConfigNetworkFetcher.ATTR_URL to fakeUrl.toHttpUrl().toString()
@@ -178,7 +176,6 @@ internal class RemoteConfigFetcherTest {
             level = InternalLogger.Level.ERROR,
             targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
             message = RemoteConfigNetworkFetcher.ERROR_HTTP,
-            onlyOnce = true,
             additionalProperties = mapOf(
                 RemoteConfigNetworkFetcher.ATTR_RESPONSE_CODE to 500,
                 RemoteConfigNetworkFetcher.ATTR_URL to fakeUrl.toHttpUrl().toString()

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcherTest.kt
@@ -110,8 +110,9 @@ internal class RemoteConfigFetcherTest {
         mockInternalLogger.verifyLog(
             level = InternalLogger.Level.ERROR,
             targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            message = RemoteConfigNetworkFetcher.ERROR_EMPTY_BODY.format(fakeUrl.toHttpUrl()),
-            onlyOnce = true
+            message = RemoteConfigNetworkFetcher.ERROR_EMPTY_BODY,
+            onlyOnce = true,
+            additionalProperties = mapOf(RemoteConfigNetworkFetcher.ATTR_URL to fakeUrl.toHttpUrl().toString())
         )
     }
 
@@ -143,9 +144,12 @@ internal class RemoteConfigFetcherTest {
         mockInternalLogger.verifyLog(
             level = InternalLogger.Level.ERROR,
             targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            message = RemoteConfigNetworkFetcher.ERROR_HTTP.format(fakeUrl.toHttpUrl(), 404),
+            message = RemoteConfigNetworkFetcher.ERROR_HTTP,
             onlyOnce = true,
-            additionalProperties = mapOf(RemoteConfigNetworkFetcher.ATTR_RESPONSE_CODE to 404)
+            additionalProperties = mapOf(
+                RemoteConfigNetworkFetcher.ATTR_RESPONSE_CODE to 404,
+                RemoteConfigNetworkFetcher.ATTR_URL to fakeUrl.toHttpUrl().toString()
+            )
         )
     }
 
@@ -173,9 +177,12 @@ internal class RemoteConfigFetcherTest {
         mockInternalLogger.verifyLog(
             level = InternalLogger.Level.ERROR,
             targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            message = RemoteConfigNetworkFetcher.ERROR_HTTP.format(fakeUrl.toHttpUrl(), 500),
+            message = RemoteConfigNetworkFetcher.ERROR_HTTP,
             onlyOnce = true,
-            additionalProperties = mapOf(RemoteConfigNetworkFetcher.ATTR_RESPONSE_CODE to 500)
+            additionalProperties = mapOf(
+                RemoteConfigNetworkFetcher.ATTR_RESPONSE_CODE to 500,
+                RemoteConfigNetworkFetcher.ATTR_URL to fakeUrl.toHttpUrl().toString()
+            )
         )
     }
 
@@ -200,8 +207,9 @@ internal class RemoteConfigFetcherTest {
         mockInternalLogger.verifyLog(
             level = InternalLogger.Level.WARN,
             target = InternalLogger.Target.MAINTAINER,
-            message = RemoteConfigNetworkFetcher.ERROR_NETWORK.format(fakeUrl.toHttpUrl()),
-            throwableClass = IOException::class.java
+            message = RemoteConfigNetworkFetcher.ERROR_NETWORK,
+            throwableClass = IOException::class.java,
+            additionalProperties = mapOf(RemoteConfigNetworkFetcher.ATTR_URL to fakeUrl.toHttpUrl().toString())
         )
     }
 
@@ -222,8 +230,9 @@ internal class RemoteConfigFetcherTest {
         mockInternalLogger.verifyLog(
             level = InternalLogger.Level.ERROR,
             targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
-            message = RemoteConfigNetworkFetcher.ERROR_NETWORK.format(fakeUrl.toHttpUrl()),
-            throwableClass = RuntimeException::class.java
+            message = RemoteConfigNetworkFetcher.ERROR_NETWORK,
+            throwableClass = RuntimeException::class.java,
+            additionalProperties = mapOf(RemoteConfigNetworkFetcher.ATTR_URL to fakeUrl.toHttpUrl().toString())
         )
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigServiceTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigServiceTest.kt
@@ -1,0 +1,275 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.remote
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.internal.persistence.file.FileReaderWriter
+import com.datadog.android.core.internal.remote.model.Android
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.verifyLog
+import com.google.gson.JsonParseException
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.api.io.TempDir
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import java.io.File
+import java.util.concurrent.ExecutorService
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class RemoteConfigServiceTest {
+
+    @Mock
+    lateinit var mockFetcher: RemoteConfigFetcher
+
+    @Mock
+    lateinit var mockExecutor: ExecutorService
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @Mock
+    lateinit var mockFileReaderWriter: FileReaderWriter
+
+    @TempDir
+    lateinit var fakeStorageDir: File
+
+    private lateinit var testedService: RemoteConfigServiceImpl
+
+    private val fakeRemoteConfigurationId = "test-rc-id"
+    private val fakeEndpoint: HttpUrl = "https://sdk-configuration.browser-intake-datadoghq.com".toHttpUrl()
+
+    @BeforeEach
+    fun `set up`() {
+        // Run executor tasks synchronously
+        whenever(mockExecutor.execute(any())).thenAnswer { invocation ->
+            val runnable = invocation.getArgument<Runnable>(0)
+            runnable.run()
+        }
+
+        // No cache on disk by default
+        whenever(mockFileReaderWriter.readData(any())).doReturn(ByteArray(0))
+        whenever(mockFileReaderWriter.writeData(any(), any(), any())).doReturn(true)
+    }
+
+    private fun buildService(): RemoteConfigServiceImpl {
+        return RemoteConfigServiceImpl(
+            remoteConfigurationId = fakeRemoteConfigurationId,
+            remoteConfigurationEndpoint = fakeEndpoint,
+            fetcher = mockFetcher,
+            storageDir = fakeStorageDir,
+            executor = mockExecutor,
+            internalLogger = mockInternalLogger,
+            fileReaderWriter = mockFileReaderWriter
+        )
+    }
+
+    // region getCurrentConfig() — cold-start
+
+    @Test
+    fun `M return null W getCurrentConfig() { no cache on disk }`() {
+        // Given
+        testedService = buildService()
+
+        // When
+        val result = testedService.getCurrentConfig()
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `M return cached config W getCurrentConfig() { valid cache on disk }`(forge: Forge) {
+        // Given — write a real file so existsSafe() passes
+        val fakeAndroid = forgeValidAndroid(forge)
+        val fakeJson = fakeAndroid.toJson().toString()
+        val cacheFile = File(fakeStorageDir, "$fakeRemoteConfigurationId.json")
+        cacheFile.writeText(fakeJson)
+        testedService = RemoteConfigServiceImpl(
+            remoteConfigurationId = fakeRemoteConfigurationId,
+            remoteConfigurationEndpoint = fakeEndpoint,
+            fetcher = mockFetcher,
+            storageDir = fakeStorageDir,
+            executor = mockExecutor,
+            internalLogger = mockInternalLogger
+            // use real FileReaderWriter to read the real file
+        )
+
+        // When
+        val result = testedService.getCurrentConfig()
+
+        // Then
+        assertThat(result).isEqualTo(fakeAndroid)
+    }
+
+    @Test
+    fun `M return null and delete corrupt file W getCurrentConfig() { invalid JSON on disk }`() {
+        // Given — write a real file with invalid JSON
+        val cacheFile = File(fakeStorageDir, "$fakeRemoteConfigurationId.json")
+        cacheFile.writeText("not-valid-json{{{")
+        testedService = RemoteConfigServiceImpl(
+            remoteConfigurationId = fakeRemoteConfigurationId,
+            remoteConfigurationEndpoint = fakeEndpoint,
+            fetcher = mockFetcher,
+            storageDir = fakeStorageDir,
+            executor = mockExecutor,
+            internalLogger = mockInternalLogger
+        )
+
+        // When
+        val result = testedService.getCurrentConfig()
+
+        // Then
+        assertThat(result).isNull()
+        assertThat(cacheFile).doesNotExist()
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            message = RemoteConfigServiceImpl.ERROR_PARSE,
+            throwableClass = JsonParseException::class.java
+        )
+    }
+
+    // endregion
+
+    // region syncWithRemote() — success
+
+    @Test
+    fun `M update cachedConfig and write to disk W syncWithRemote() { successful fetch }`(
+        forge: Forge
+    ) {
+        // Given
+        testedService = buildService()
+        val fakeAndroid = forgeValidAndroid(forge)
+        val fakeJson = fakeAndroid.toJson().toString()
+        whenever(mockFetcher.fetch(any())).doReturn(fakeJson)
+
+        // When
+        testedService.syncWithRemote()
+
+        // Then
+        assertThat(testedService.getCurrentConfig()).isEqualTo(fakeAndroid)
+        verify(mockFileReaderWriter).writeData(
+            file = any(),
+            data = eq(fakeJson.toByteArray(Charsets.UTF_8)),
+            append = eq(false)
+        )
+    }
+
+    @Test
+    fun `M build correct URL W syncWithRemote()`(forge: Forge) {
+        // Given
+        testedService = buildService()
+        val expectedUrl = fakeEndpoint.newBuilder()
+            .addPathSegment("v1")
+            .addPathSegment("$fakeRemoteConfigurationId.json")
+            .build()
+        whenever(mockFetcher.fetch(expectedUrl)).doReturn(forgeValidAndroid(forge).toJson().toString())
+
+        // When
+        testedService.syncWithRemote()
+
+        // Then
+        verify(mockFetcher).fetch(expectedUrl)
+    }
+
+    // endregion
+
+    // region syncWithRemote() — fetch failure
+
+    @Test
+    fun `M not update cache W syncWithRemote() { fetch returns null }`() {
+        // Given
+        testedService = buildService()
+        whenever(mockFetcher.fetch(any())).doReturn(null)
+
+        // When
+        testedService.syncWithRemote()
+
+        // Then
+        assertThat(testedService.getCurrentConfig()).isNull()
+        verify(mockFileReaderWriter, never()).writeData(any(), any(), any())
+    }
+
+    // endregion
+
+    // region syncWithRemote() — parse failure
+
+    @Test
+    fun `M not update cache or disk W syncWithRemote() { invalid JSON response }`() {
+        // Given
+        testedService = buildService()
+        whenever(mockFetcher.fetch(any())).doReturn("not-valid-json{{{")
+
+        // When
+        testedService.syncWithRemote()
+
+        // Then
+        assertThat(testedService.getCurrentConfig()).isNull()
+        verify(mockFileReaderWriter, never()).writeData(any(), any(), any())
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            message = RemoteConfigServiceImpl.ERROR_PARSE,
+            throwableClass = JsonParseException::class.java
+        )
+    }
+
+    // endregion
+
+    // region syncWithRemote() — disk write failure
+
+    @Test
+    fun `M not update cachedConfig W syncWithRemote() { disk write fails }`(forge: Forge) {
+        // Given
+        testedService = buildService()
+        val fakeJson = forgeValidAndroid(forge).toJson().toString()
+        whenever(mockFetcher.fetch(any())).doReturn(fakeJson)
+        whenever(mockFileReaderWriter.writeData(any(), any(), any())).doReturn(false)
+
+        // When
+        testedService.syncWithRemote()
+
+        // Then
+        assertThat(testedService.getCurrentConfig()).isNull()
+    }
+
+    // endregion
+
+    // region helpers
+
+    private fun forgeValidAndroid(forge: Forge): Android {
+        return Android(
+            rum = Android.Rum(
+                applicationId = forge.getForgery<java.util.UUID>().toString()
+            )
+        )
+    }
+
+    // endregion
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigServiceTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigServiceTest.kt
@@ -204,6 +204,34 @@ internal class RemoteConfigServiceTest {
         verify(mockFetcher).fetch(expectedUrl)
     }
 
+    @Test
+    fun `M create storageDir and write config W syncWithRemote() { storageDir does not exist yet }`(
+        @Forgery fakeRemoteConfiguration: RemoteConfiguration
+    ) {
+        // Given — use a non-existent subdirectory as storageDir
+        val nonExistentStorageDir = File(fakeStorageDir, "not-yet-created")
+        assertThat(nonExistentStorageDir).doesNotExist()
+        val fakeJson = fakeRemoteConfiguration.toJson().toString()
+        whenever(mockFetcher.fetch(any())).doReturn(fakeJson)
+        testedService = RemoteConfigServiceImpl(
+            remoteConfigurationId = fakeRemoteConfigurationId,
+            remoteConfigurationEndpoint = fakeEndpoint,
+            fetcher = mockFetcher,
+            storageDir = nonExistentStorageDir,
+            executor = mockExecutor,
+            internalLogger = mockInternalLogger
+            // use real FileReaderWriter so the actual disk write path is exercised
+        )
+
+        // When
+        testedService.syncWithRemote()
+
+        // Then
+        val cacheFile = File(nonExistentStorageDir, "$fakeRemoteConfigurationId.json")
+        assertThat(cacheFile).exists()
+        assertThat(testedService.getCurrentConfig()?.toJson()?.toString()).isEqualTo(fakeJson)
+    }
+
     // endregion
 
     // region syncWithRemote() — fetch failure

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigServiceTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigServiceTest.kt
@@ -255,6 +255,72 @@ internal class RemoteConfigServiceTest {
     // region syncWithRemote() — parse failure
 
     @Test
+    fun `M not update cache or disk W syncWithRemote() { response with unknown enum value }`() {
+        // Given — valid JSON but with an unknown vitalsUpdateFrequency enum value
+        testedService = buildService()
+        val fakeJson = """
+            {
+              "platform": "android",
+              "rum": {
+                "applicationId": "38030dde-f9f9-4e52-9443-b9804a030080",
+                "vitalsUpdateFrequency": "supersonic"
+              }
+            }
+        """.trimIndent()
+        whenever(mockFetcher.fetch(any())).doReturn(fakeJson)
+
+        // When
+        testedService.syncWithRemote()
+
+        // Then
+        assertThat(testedService.getCurrentConfig()).isNull()
+        verify(mockFileReaderWriter, never()).writeData(any(), any(), any())
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            message = RemoteConfigServiceImpl.ERROR_PARSE,
+            throwableClass = NoSuchElementException::class.java
+        )
+    }
+
+    @Test
+    fun `M return null W getCurrentConfig() { cached file has unknown enum value }`() {
+        // Given — write a real file with an unknown enum value
+        val cacheFile = File(fakeStorageDir, "$fakeRemoteConfigurationId.json")
+        cacheFile.writeText(
+            """
+            {
+              "platform": "android",
+              "rum": {
+                "applicationId": "38030dde-f9f9-4e52-9443-b9804a030080",
+                "vitalsUpdateFrequency": "supersonic"
+              }
+            }
+            """.trimIndent()
+        )
+        testedService = RemoteConfigServiceImpl(
+            remoteConfigurationId = fakeRemoteConfigurationId,
+            remoteConfigurationEndpoint = fakeEndpoint,
+            fetcher = mockFetcher,
+            storageDir = fakeStorageDir,
+            executor = mockExecutor,
+            internalLogger = mockInternalLogger
+        )
+
+        // When
+        val result = testedService.getCurrentConfig()
+
+        // Then
+        assertThat(result).isNull()
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            message = RemoteConfigServiceImpl.ERROR_PARSE,
+            throwableClass = NoSuchElementException::class.java
+        )
+    }
+
+    @Test
     fun `M not update cache or disk W syncWithRemote() { invalid JSON response }`() {
         // Given
         testedService = buildService()

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigServiceTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigServiceTest.kt
@@ -12,7 +12,7 @@ import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import com.google.gson.JsonParseException
-import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import okhttp3.HttpUrl
@@ -104,9 +104,10 @@ internal class RemoteConfigServiceTest {
     }
 
     @Test
-    fun `M return cached config W getCurrentConfig() { valid cache on disk }`(forge: Forge) {
+    fun `M return cached config W getCurrentConfig() { valid cache on disk }`(
+        @Forgery fakeRemoteConfiguration: RemoteConfiguration
+    ) {
         // Given — write a real file so existsSafe() passes
-        val fakeRemoteConfiguration = forgeValidRemoteConfiguration(forge)
         val fakeJson = fakeRemoteConfiguration.toJson().toString()
         val cacheFile = File(fakeStorageDir, "$fakeRemoteConfigurationId.json")
         cacheFile.writeText(fakeJson)
@@ -123,8 +124,10 @@ internal class RemoteConfigServiceTest {
         // When
         val result = testedService.getCurrentConfig()
 
-        // Then
-        assertThat(result).isEqualTo(fakeRemoteConfiguration)
+        // Then — compare JSON output: the generated model uses Number fields that deserialize
+        // as LazilyParsedNumber (no equals() override), so object equality is unreliable.
+        // Comparing serialized JSON verifies the full roundtrip without false negatives.
+        assertThat(result?.toJson()?.toString()).isEqualTo(fakeJson)
     }
 
     @Test
@@ -161,19 +164,20 @@ internal class RemoteConfigServiceTest {
 
     @Test
     fun `M update cachedConfig and write to disk W syncWithRemote() { successful fetch }`(
-        forge: Forge
+        @Forgery fakeRemoteConfiguration: RemoteConfiguration
     ) {
         // Given
         testedService = buildService()
-        val fakeRemoteConfiguration = forgeValidRemoteConfiguration(forge)
         val fakeJson = fakeRemoteConfiguration.toJson().toString()
         whenever(mockFetcher.fetch(any())).doReturn(fakeJson)
 
         // When
         testedService.syncWithRemote()
 
-        // Then
-        assertThat(testedService.getCurrentConfig()).isEqualTo(fakeRemoteConfiguration)
+        // Then — compare JSON output: the generated model uses Number fields that deserialize
+        // as LazilyParsedNumber (no equals() override), so object equality is unreliable.
+        // Comparing serialized JSON verifies the full roundtrip without false negatives.
+        assertThat(testedService.getCurrentConfig()?.toJson()?.toString()).isEqualTo(fakeJson)
         verify(mockFileReaderWriter).writeData(
             file = any(),
             data = eq(fakeJson.toByteArray(Charsets.UTF_8)),
@@ -182,14 +186,16 @@ internal class RemoteConfigServiceTest {
     }
 
     @Test
-    fun `M build correct URL W syncWithRemote()`(forge: Forge) {
+    fun `M build correct URL W syncWithRemote()`(
+        @Forgery fakeRemoteConfiguration: RemoteConfiguration
+    ) {
         // Given
         testedService = buildService()
         val expectedUrl = fakeEndpoint.newBuilder()
             .addPathSegment("v1")
             .addPathSegment("$fakeRemoteConfigurationId.json")
             .build()
-        whenever(mockFetcher.fetch(expectedUrl)).doReturn(forgeValidRemoteConfiguration(forge).toJson().toString())
+        whenever(mockFetcher.fetch(expectedUrl)).doReturn(fakeRemoteConfiguration.toJson().toString())
 
         // When
         testedService.syncWithRemote()
@@ -245,10 +251,12 @@ internal class RemoteConfigServiceTest {
     // region syncWithRemote() — disk write failure
 
     @Test
-    fun `M not update cachedConfig W syncWithRemote() { disk write fails }`(forge: Forge) {
+    fun `M not update cachedConfig W syncWithRemote() { disk write fails }`(
+        @Forgery fakeRemoteConfiguration: RemoteConfiguration
+    ) {
         // Given
         testedService = buildService()
-        val fakeJson = forgeValidRemoteConfiguration(forge).toJson().toString()
+        val fakeJson = fakeRemoteConfiguration.toJson().toString()
         whenever(mockFetcher.fetch(any())).doReturn(fakeJson)
         whenever(mockFileReaderWriter.writeData(any(), any(), any())).doReturn(false)
 
@@ -257,18 +265,6 @@ internal class RemoteConfigServiceTest {
 
         // Then
         assertThat(testedService.getCurrentConfig()).isNull()
-    }
-
-    // endregion
-
-    // region helpers
-
-    private fun forgeValidRemoteConfiguration(forge: Forge): RemoteConfiguration {
-        return RemoteConfiguration(
-            rum = RemoteConfiguration.Rum(
-                applicationId = forge.getForgery<java.util.UUID>().toString()
-            )
-        )
     }
 
     // endregion

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigServiceTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigServiceTest.kt
@@ -8,7 +8,7 @@ package com.datadog.android.core.internal.remote
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
-import com.datadog.android.core.internal.remote.model.Android
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import com.google.gson.JsonParseException
@@ -106,8 +106,8 @@ internal class RemoteConfigServiceTest {
     @Test
     fun `M return cached config W getCurrentConfig() { valid cache on disk }`(forge: Forge) {
         // Given — write a real file so existsSafe() passes
-        val fakeAndroid = forgeValidAndroid(forge)
-        val fakeJson = fakeAndroid.toJson().toString()
+        val fakeRemoteConfiguration = forgeValidRemoteConfiguration(forge)
+        val fakeJson = fakeRemoteConfiguration.toJson().toString()
         val cacheFile = File(fakeStorageDir, "$fakeRemoteConfigurationId.json")
         cacheFile.writeText(fakeJson)
         testedService = RemoteConfigServiceImpl(
@@ -124,7 +124,7 @@ internal class RemoteConfigServiceTest {
         val result = testedService.getCurrentConfig()
 
         // Then
-        assertThat(result).isEqualTo(fakeAndroid)
+        assertThat(result).isEqualTo(fakeRemoteConfiguration)
     }
 
     @Test
@@ -165,15 +165,15 @@ internal class RemoteConfigServiceTest {
     ) {
         // Given
         testedService = buildService()
-        val fakeAndroid = forgeValidAndroid(forge)
-        val fakeJson = fakeAndroid.toJson().toString()
+        val fakeRemoteConfiguration = forgeValidRemoteConfiguration(forge)
+        val fakeJson = fakeRemoteConfiguration.toJson().toString()
         whenever(mockFetcher.fetch(any())).doReturn(fakeJson)
 
         // When
         testedService.syncWithRemote()
 
         // Then
-        assertThat(testedService.getCurrentConfig()).isEqualTo(fakeAndroid)
+        assertThat(testedService.getCurrentConfig()).isEqualTo(fakeRemoteConfiguration)
         verify(mockFileReaderWriter).writeData(
             file = any(),
             data = eq(fakeJson.toByteArray(Charsets.UTF_8)),
@@ -189,7 +189,7 @@ internal class RemoteConfigServiceTest {
             .addPathSegment("v1")
             .addPathSegment("$fakeRemoteConfigurationId.json")
             .build()
-        whenever(mockFetcher.fetch(expectedUrl)).doReturn(forgeValidAndroid(forge).toJson().toString())
+        whenever(mockFetcher.fetch(expectedUrl)).doReturn(forgeValidRemoteConfiguration(forge).toJson().toString())
 
         // When
         testedService.syncWithRemote()
@@ -248,7 +248,7 @@ internal class RemoteConfigServiceTest {
     fun `M not update cachedConfig W syncWithRemote() { disk write fails }`(forge: Forge) {
         // Given
         testedService = buildService()
-        val fakeJson = forgeValidAndroid(forge).toJson().toString()
+        val fakeJson = forgeValidRemoteConfiguration(forge).toJson().toString()
         whenever(mockFetcher.fetch(any())).doReturn(fakeJson)
         whenever(mockFileReaderWriter.writeData(any(), any(), any())).doReturn(false)
 
@@ -263,9 +263,9 @@ internal class RemoteConfigServiceTest {
 
     // region helpers
 
-    private fun forgeValidAndroid(forge: Forge): Android {
-        return Android(
-            rum = Android.Rum(
+    private fun forgeValidRemoteConfiguration(forge: Forge): RemoteConfiguration {
+        return RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
                 applicationId = forge.getForgery<java.util.UUID>().toString()
             )
         )

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCoreForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCoreForgeryFactory.kt
@@ -61,7 +61,10 @@ internal class ConfigurationCoreForgeryFactory :
                 forge.aValueFrom(BackPressureMitigation::class.java)
             ),
             uploadSchedulerStrategy = forge.aNullable { mock() },
-            remoteConfigurationId = forge.aNullable { anAlphabeticalString() }
+            // Intentionally null: a forged non-null ID would cause DatadogCore to schedule
+            // a real CDN fetch on the upload executor, turning unrelated unit tests into
+            // network tests. Tests that exercise RC behaviour set the ID explicitly.
+            remoteConfigurationId = null
         )
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -71,6 +71,9 @@ internal class Configurator :
 
         forge.addFactory(PersistenceStrategyBatchForgeryFactory())
 
+        // Remote Config
+        forge.addFactory(RemoteConfigurationForgeryFactory())
+
         forge.useJvmFactories()
 
         // telemetry

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemoteConfigurationForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemoteConfigurationForgeryFactory.kt
@@ -9,13 +9,14 @@ package com.datadog.android.utils.forge
 import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
+import java.util.UUID
 
 internal class RemoteConfigurationForgeryFactory : ForgeryFactory<RemoteConfiguration> {
     override fun getForgery(forge: Forge): RemoteConfiguration {
         return RemoteConfiguration(
             rum = forge.aNullable {
                 RemoteConfiguration.Rum(
-                    applicationId = getForgery<java.util.UUID>().toString(),
+                    applicationId = getForgery<UUID>().toString(),
                     service = aNullable { anAlphabeticalString() },
                     env = aNullable { anAlphabeticalString() },
                     telemetrySampleRate = aNullable { anInt(min = 0, max = 100) },

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemoteConfigurationForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemoteConfigurationForgeryFactory.kt
@@ -1,0 +1,71 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class RemoteConfigurationForgeryFactory : ForgeryFactory<RemoteConfiguration> {
+    override fun getForgery(forge: Forge): RemoteConfiguration {
+        return RemoteConfiguration(
+            rum = forge.aNullable {
+                RemoteConfiguration.Rum(
+                    applicationId = getForgery<java.util.UUID>().toString(),
+                    service = aNullable { anAlphabeticalString() },
+                    env = aNullable { anAlphabeticalString() },
+                    telemetrySampleRate = aNullable { anInt(min = 0, max = 100) },
+                    trackAnonymousUser = aNullable { aBool() },
+                    trackUserInteractions = aNullable { aBool() },
+                    trackResources = aNullable { aBool() },
+                    trackBackgroundEvents = aNullable { aBool() },
+                    trackFrustrations = aNullable { aBool() },
+                    longTaskThresholdMs = aNullable { anInt(min = 100) },
+                    vitalsUpdateFrequency = aNullable {
+                        aValueFrom(RemoteConfiguration.VitalsUpdateFrequency::class.java)
+                    },
+                    trackSlowFrames = aNullable { aBool() },
+                    crashReportsEnabled = aNullable { aBool() },
+                    trackNonFatalAnrs = aNullable { aBool() }
+                )
+            },
+            sessionReplay = forge.aNullable {
+                RemoteConfiguration.SessionReplay(
+                    sampleRate = aNullable { anInt(min = 0, max = 100) },
+                    startRecordingImmediately = aNullable { aBool() },
+                    textAndInputPrivacy = aNullable {
+                        aValueFrom(RemoteConfiguration.TextAndInputPrivacy::class.java)
+                    },
+                    touchPrivacy = aNullable {
+                        aValueFrom(RemoteConfiguration.TouchPrivacy::class.java)
+                    },
+                    imagePrivacy = aNullable {
+                        aValueFrom(RemoteConfiguration.ImagePrivacy::class.java)
+                    }
+                )
+            },
+            profiling = forge.aNullable {
+                RemoteConfiguration.Profiling(
+                    continuousSampleRate = aNullable { anInt(min = 0, max = 100) },
+                    applicationLaunchSampleRate = aNullable { anInt(min = 0, max = 100) }
+                )
+            },
+            trace = forge.aNullable {
+                RemoteConfiguration.Trace(
+                    sampleRate = aNullable { anInt(min = 0, max = 100) },
+                    traceContextInjection = aNullable {
+                        aValueFrom(RemoteConfiguration.TraceContextInjection::class.java)
+                    },
+                    tracedHosts = aNullable { aList { anAlphabeticalString() } },
+                    tracingHeaderTypes = aNullable {
+                        aList { aValueFrom(RemoteConfiguration.TracingHeaderType::class.java) }
+                    }
+                )
+            }
+        )
+    }
+}

--- a/sample/README.md
+++ b/sample/README.md
@@ -27,6 +27,16 @@ To allow the download of logs (to test the `Data List` screen), add the followin
 }
 ```
 
+### Remote Configuration
+
+To enable Remote Configuration, add the following attribute. You can find the ID in the Datadog UI during application onboarding.
+
+```json
+{
+    "remoteConfigurationId": "YOUR REMOTE CONFIGURATION ID"
+}
+```
+
 ### Staging
 
 If you need to target a site that is not part of the `DatadogSite` enum, configure custom endpoints using the following attributes:


### PR DESCRIPTION
### What does this PR do?

Implements the fetch-and-store layer for Android SDK Remote Configuration.

On SDK initialization, if a `remoteConfigurationId` has been configured via `Configuration.Builder.setRemoteConfigurationId()`, the SDK:

1. Reads any previously cached config from disk synchronously on the calling thread (available immediately to features on the same launch)
2. Fetches the latest config from the Datadog RC CDN asynchronously (`https://sdk-configuration.<site>/v1/<id>.json`)
3. Parses and validates the response against the Android RC JSON schema
4. Persists the result to disk for the next launch

### Motivation

Part of the Mobile Remote Configuration feature (RUM-16389). This PR covers the fetch-and-store layer. Exposing the config to features (RUM, Session Replay, etc.) is a follow-up ticket.

### Additional Notes

Foreground refresh (periodic `syncWithRemote`) is a follow-up ticket.

The `RemoteConfigService.Factory` + `DEFAULT_REMOTE_CONFIG_SERVICE_FACTORY` pattern follows the existing `executorServiceFactory` convention in `DatadogCore` for testability.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)