### PR TITLE
RUM-16362: Fix interop wireframe positioning in Compose windows

### DIFF
--- a/detekt_custom_safe_calls_android.yml
+++ b/detekt_custom_safe_calls_android.yml
@@ -233,6 +233,7 @@ datadog:
       - "android.graphics.Rect.constructor()"
       - "android.graphics.Rect.constructor(kotlin.Int, kotlin.Int, kotlin.Int, kotlin.Int)"
       - "android.graphics.Rect.height()"
+      - "android.graphics.Rect.offset(kotlin.Int, kotlin.Int)"
       - "android.graphics.Rect.width()"
       - "android.graphics.RectF.constructor()"
       - "android.graphics.RectF.width()"

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/data/UiContext.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/data/UiContext.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.compose.internal.data
 import androidx.compose.ui.unit.Density
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
+import com.datadog.android.sessionreplay.compose.internal.utils.ComposeWindowOffset
 import com.datadog.android.sessionreplay.utils.ImageWireframeHelper
 
 internal data class UiContext(
@@ -17,7 +18,11 @@ internal data class UiContext(
     val textAndInputPrivacy: TextAndInputPrivacy,
     val imagePrivacy: ImagePrivacy,
     val isInUserInputLayout: Boolean = false,
-    val imageWireframeHelper: ImageWireframeHelper
+    val imageWireframeHelper: ImageWireframeHelper,
+    // The Compose root's distance from the screen origin. Baked into every wireframe's bounds by
+    // SemanticsUtils.resolveInnerBounds/resolveBackgroundInfo so positions stay screen-absolute
+    // even when Compose is embedded in a scrolled/offset host view. See RUM-16362.
+    val windowOffset: ComposeWindowOffset = ComposeWindowOffset.NONE
 ) {
     val composeDensity: Density
         get() = Density(density)

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapper.kt
@@ -36,14 +36,15 @@ internal abstract class AbstractSemanticsNodeMapper(
         return (semanticsNode.id.toLong() shl SEMANTICS_ID_BIT_SHIFT) + currentIndex
     }
 
-    protected fun resolveBounds(semanticsNode: SemanticsNode): GlobalBounds {
-        return semanticsUtils.resolveInnerBounds(semanticsNode)
+    protected fun resolveBounds(semanticsNode: SemanticsNode, parentContext: UiContext): GlobalBounds {
+        return semanticsUtils.resolveInnerBounds(semanticsNode, parentContext.windowOffset)
     }
 
     protected fun resolveModifierWireframes(
-        semanticsNode: SemanticsNode
+        semanticsNode: SemanticsNode,
+        parentContext: UiContext
     ): List<MobileSegment.Wireframe> {
-        return semanticsUtils.resolveBackgroundInfo(semanticsNode)
+        return semanticsUtils.resolveBackgroundInfo(semanticsNode, parentContext.windowOffset)
             .mapIndexed { index, backgroundInfo ->
                 convertBackgroundInfoToWireframes(
                     semanticsNode = semanticsNode,

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AndroidComposeViewMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AndroidComposeViewMapper.kt
@@ -42,9 +42,7 @@ internal class AndroidComposeViewMapper(
     ): List<MobileSegment.Wireframe> {
         val rootSemanticsNode = view.semanticsOwner.unmergedRootSemanticsNode
         // Use the node's own density so it matches SemanticsUtils.resolveInnerBounds.
-        val systemDensity =
-            mappingContext.systemInformation.screenDensity.let { if (it == 0.0f) 1.0f else it }
-        val density = rootSemanticsNode.layoutInfo.density.density.let { if (it == 0.0f) systemDensity else it }
+        val density = rootSemanticsNode.layoutInfo.density.density
         // positionInRoot is relative to the view, not the screen — offset to match other SR mappers.
         val windowOffset = view.resolveComposeWindowOffset(density)
         return rootSemanticsNodeMapper.createComposeWireframes(

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AndroidComposeViewMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AndroidComposeViewMapper.kt
@@ -11,6 +11,7 @@ package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 import androidx.annotation.UiThread
 import androidx.compose.ui.platform.AndroidComposeView
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.compose.internal.utils.resolveComposeWindowOffset
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
 import com.datadog.android.sessionreplay.recorder.mapper.BaseWireframeMapper
@@ -39,14 +40,20 @@ internal class AndroidComposeViewMapper(
         asyncJobStatusCallback: AsyncJobStatusCallback,
         internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
-        val density =
+        val rootSemanticsNode = view.semanticsOwner.unmergedRootSemanticsNode
+        // Use the node's own density so it matches SemanticsUtils.resolveInnerBounds.
+        val systemDensity =
             mappingContext.systemInformation.screenDensity.let { if (it == 0.0f) 1.0f else it }
+        val density = rootSemanticsNode.layoutInfo.density.density.let { if (it == 0.0f) systemDensity else it }
+        // positionInRoot is relative to the view, not the screen — offset to match other SR mappers.
+        val windowOffset = view.resolveComposeWindowOffset(density)
         return rootSemanticsNodeMapper.createComposeWireframes(
-            view.semanticsOwner.unmergedRootSemanticsNode,
+            rootSemanticsNode,
             density,
             mappingContext,
             asyncJobStatusCallback,
-            internalLogger
+            internalLogger,
+            windowOffset = windowOffset
         )
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapper.kt
@@ -26,7 +26,7 @@ internal class ButtonSemanticsNodeMapper(
         internalLogger: InternalLogger
     ): SemanticsWireframe {
         return SemanticsWireframe(
-            wireframes = resolveModifierWireframes(semanticsNode),
+            wireframes = resolveModifierWireframes(semanticsNode, parentContext),
             uiContext = parentContext
         )
     }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/CheckboxSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/CheckboxSemanticsNodeMapper.kt
@@ -38,7 +38,7 @@ internal class CheckboxSemanticsNodeMapper(
         asyncJobStatusCallback: AsyncJobStatusCallback,
         internalLogger: InternalLogger
     ): SemanticsWireframe {
-        val globalBounds = resolveBounds(semanticsNode)
+        val globalBounds = resolveBounds(semanticsNode, parentContext)
 
         val checkableWireframes = if (isCheckboxMasked(parentContext)) {
             listOf(

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeHiddenMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeHiddenMapper.kt
@@ -26,7 +26,7 @@ internal class ComposeHiddenMapper(
         internalLogger: InternalLogger
     ): SemanticsWireframe? {
         val id = resolveId(semanticsNode)
-        val viewGlobalBounds = resolveBounds(semanticsNode)
+        val viewGlobalBounds = resolveBounds(semanticsNode, parentContext)
         return SemanticsWireframe(
             wireframes = MobileSegment.Wireframe.PlaceholderWireframe(
                 id = id,

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapper.kt
@@ -10,6 +10,7 @@ import androidx.annotation.UiThread
 import androidx.compose.ui.platform.ComposeView
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
+import com.datadog.android.sessionreplay.compose.internal.utils.resolveComposeWindowOffset
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
 import com.datadog.android.sessionreplay.recorder.mapper.BaseWireframeMapper
@@ -39,16 +40,20 @@ internal class ComposeViewMapper(
         asyncJobStatusCallback: AsyncJobStatusCallback,
         internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
-        val density =
+        val rootSemanticsNode = semanticsUtils.findRootSemanticsNode(view) ?: return emptyList()
+        // Use the node's own density so it matches SemanticsUtils.resolveInnerBounds.
+        val systemDensity =
             mappingContext.systemInformation.screenDensity.let { if (it == 0.0f) 1.0f else it }
-        return semanticsUtils.findRootSemanticsNode(view)?.let { node ->
-            rootSemanticsNodeMapper.createComposeWireframes(
-                node,
-                density,
-                mappingContext,
-                asyncJobStatusCallback,
-                internalLogger
-            )
-        } ?: emptyList()
+        val density = rootSemanticsNode.layoutInfo.density.density.let { if (it == 0.0f) systemDensity else it }
+        // positionInRoot is relative to the view, not the screen — offset to match other SR mappers.
+        val windowOffset = view.resolveComposeWindowOffset(density)
+        return rootSemanticsNodeMapper.createComposeWireframes(
+            rootSemanticsNode,
+            density,
+            mappingContext,
+            asyncJobStatusCallback,
+            internalLogger,
+            windowOffset = windowOffset
+        )
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapper.kt
@@ -42,9 +42,7 @@ internal class ComposeViewMapper(
     ): List<MobileSegment.Wireframe> {
         val rootSemanticsNode = semanticsUtils.findRootSemanticsNode(view) ?: return emptyList()
         // Use the node's own density so it matches SemanticsUtils.resolveInnerBounds.
-        val systemDensity =
-            mappingContext.systemInformation.screenDensity.let { if (it == 0.0f) 1.0f else it }
-        val density = rootSemanticsNode.layoutInfo.density.density.let { if (it == 0.0f) systemDensity else it }
+        val density = rootSemanticsNode.layoutInfo.density.density
         // positionInRoot is relative to the view, not the screen — offset to match other SR mappers.
         val windowOffset = view.resolveComposeWindowOffset(density)
         return rootSemanticsNodeMapper.createComposeWireframes(

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ContainerSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ContainerSemanticsNodeMapper.kt
@@ -24,7 +24,7 @@ internal class ContainerSemanticsNodeMapper(
         asyncJobStatusCallback: AsyncJobStatusCallback,
         internalLogger: InternalLogger
     ): SemanticsWireframe {
-        val wireframes = resolveModifierWireframes(semanticsNode)
+        val wireframes = resolveModifierWireframes(semanticsNode, parentContext)
         val backgroundColor = semanticsUtils.resolveBackgroundColor(semanticsNode)?.let {
             convertColor(it)
         }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ImageSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ImageSemanticsNodeMapper.kt
@@ -30,9 +30,9 @@ internal class ImageSemanticsNodeMapper(
         asyncJobStatusCallback: AsyncJobStatusCallback,
         internalLogger: InternalLogger
     ): SemanticsWireframe {
-        val containerBounds = resolveBounds(semanticsNode)
+        val containerBounds = resolveBounds(semanticsNode, parentContext)
         val bitmapInfo = semanticsUtils.resolveSemanticsPainter(semanticsNode, internalLogger)
-        val containerFrames = resolveModifierWireframes(semanticsNode).toMutableList()
+        val containerFrames = resolveModifierWireframes(semanticsNode, parentContext).toMutableList()
         val imagePrivacy =
             semanticsUtils.getImagePrivacyOverride(semanticsNode) ?: parentContext.imagePrivacy
         val imageWireframe = if (bitmapInfo != null) {

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RadioButtonSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RadioButtonSemanticsNodeMapper.kt
@@ -53,6 +53,7 @@ internal class RadioButtonSemanticsNodeMapper(
 
         resolveBoxWireframe(
             semanticsNode = semanticsNode,
+            parentContext = parentContext,
             color = radioButtonColor,
             wireframeIndex = 0
         )
@@ -61,6 +62,7 @@ internal class RadioButtonSemanticsNodeMapper(
         if (!isMasked(parentContext)) {
             resolveDotWireframe(
                 semanticsNode = semanticsNode,
+                parentContext = parentContext,
                 color = radioButtonColor,
                 wireframeIndex = 1
             )
@@ -75,10 +77,11 @@ internal class RadioButtonSemanticsNodeMapper(
 
     private fun resolveBoxWireframe(
         semanticsNode: SemanticsNode,
+        parentContext: UiContext,
         wireframeIndex: Int,
         color: String
     ): MobileSegment.Wireframe {
-        val globalBounds = resolveBounds(semanticsNode)
+        val globalBounds = resolveBounds(semanticsNode, parentContext)
 
         return MobileSegment.Wireframe.ShapeWireframe(
             id = resolveId(semanticsNode, wireframeIndex),
@@ -98,11 +101,12 @@ internal class RadioButtonSemanticsNodeMapper(
 
     private fun resolveDotWireframe(
         semanticsNode: SemanticsNode,
+        parentContext: UiContext,
         wireframeIndex: Int,
         color: String
     ): MobileSegment.Wireframe? {
         val selected = semanticsNode.config.getOrNull(SemanticsProperties.Selected) ?: false
-        val globalBounds = resolveBounds(semanticsNode)
+        val globalBounds = resolveBounds(semanticsNode, parentContext)
         return if (selected) {
             MobileSegment.Wireframe.ShapeWireframe(
                 id = resolveId(semanticsNode, wireframeIndex),

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapper.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
+import android.view.View
 import androidx.annotation.UiThread
 import androidx.compose.ui.graphics.toAndroidRectF
 import androidx.compose.ui.semantics.Role
@@ -16,6 +17,7 @@ import androidx.compose.ui.semantics.getOrNull
 import androidx.core.graphics.toRect
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
+import com.datadog.android.sessionreplay.compose.internal.utils.ComposeWindowOffset
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.compose.internal.utils.withinComposeBenchmarkSpan
 import com.datadog.android.sessionreplay.internal.TouchPrivacyManager
@@ -64,7 +66,8 @@ internal class RootSemanticsNodeMapper(
         density: Float,
         mappingContext: MappingContext,
         asyncJobStatusCallback: AsyncJobStatusCallback,
-        internalLogger: InternalLogger
+        internalLogger: InternalLogger,
+        windowOffset: ComposeWindowOffset = ComposeWindowOffset.NONE
     ): List<MobileSegment.Wireframe> {
         val wireframes = mutableListOf<MobileSegment.Wireframe>()
         withinComposeBenchmarkSpan(ROOT_NODE_SPAN_NAME, true) {
@@ -72,12 +75,19 @@ internal class RootSemanticsNodeMapper(
                 semanticsNode = semanticsNode,
                 wireframes = wireframes,
                 touchPrivacyManager = mappingContext.touchPrivacyManager,
+                // windowOffset is baked into every wireframe's bounds via UiContext (see
+                // SemanticsUtils.resolveInnerBounds/resolveBackgroundInfo) so positions are correct
+                // from the moment each wireframe is created — including ones later mutated in place
+                // by async resource resolution (e.g. ImageWireframe.resourceId). Translating
+                // already-built wireframes after the fact would silently detach those async
+                // updates. See RUM-16362.
                 parentUiContext = UiContext(
                     parentContentColor = null,
                     density = density,
                     imagePrivacy = mappingContext.imagePrivacy,
                     textAndInputPrivacy = mappingContext.textAndInputPrivacy,
-                    imageWireframeHelper = mappingContext.imageWireframeHelper
+                    imageWireframeHelper = mappingContext.imageWireframeHelper,
+                    windowOffset = windowOffset
                 ),
                 asyncJobStatusCallback = asyncJobStatusCallback,
                 mappingContext = mappingContext,
@@ -106,48 +116,31 @@ internal class RootSemanticsNodeMapper(
 
         // If Hidden node is detected, add placeholder wireframe and return
         if (semanticsUtils.isNodeHidden(semanticsNode)) {
-            composeHiddenMapper.map(
-                semanticsNode,
-                parentUiContext,
-                asyncJobStatusCallback,
-                internalLogger
-            )?.let {
-                wireframes.addAll(it.wireframes)
-            }
+            addHiddenWireframe(semanticsNode, parentUiContext, asyncJobStatusCallback, internalLogger, wireframes)
             return
         }
 
         val interopView = semanticsUtils.getInteropView(semanticsNode)
-
         if (interopView != null) {
-            val interopViewWireframes =
-                mappingContext.interopViewCallback.map(interopView, mappingContext)
-            wireframes.addAll(interopViewWireframes)
+            addInteropWireframes(interopView, mappingContext, wireframes)
             return
         }
 
         val mapper = getSemanticsNodeMapper(semanticsNode)
-        updateTouchOverrideAreas(
-            touchPrivacyManager = touchPrivacyManager,
-            semanticsNode = semanticsNode
-        )
+        updateTouchOverrideAreas(touchPrivacyManager, semanticsNode, parentUiContext.windowOffset)
         withinComposeBenchmarkSpan(
             mapper::class.java.simpleName,
             isContainer = mapper is ContainerSemanticsNodeMapper
         ) {
-            val semanticsWireframe = mapper.map(
-                semanticsNode = semanticsNode,
-                parentContext = parentUiContext,
-                asyncJobStatusCallback = asyncJobStatusCallback,
-                internalLogger = internalLogger
+            val currentUiContext = addMapperWireframes(
+                mapper,
+                semanticsNode,
+                parentUiContext,
+                asyncJobStatusCallback,
+                internalLogger,
+                wireframes
             )
-            var currentUiContext = parentUiContext
-            semanticsWireframe?.let {
-                wireframes.addAll(it.wireframes)
-                currentUiContext = it.uiContext ?: currentUiContext
-            }
-            val children = semanticsNode.children
-            children.forEach {
+            semanticsNode.children.forEach {
                 createComposerWireframes(
                     semanticsNode = it,
                     touchPrivacyManager = touchPrivacyManager,
@@ -159,6 +152,54 @@ internal class RootSemanticsNodeMapper(
                 )
             }
         }
+    }
+
+    @UiThread
+    private fun addHiddenWireframe(
+        semanticsNode: SemanticsNode,
+        parentUiContext: UiContext,
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger,
+        wireframes: MutableList<MobileSegment.Wireframe>
+    ) {
+        composeHiddenMapper.map(
+            semanticsNode,
+            parentUiContext,
+            asyncJobStatusCallback,
+            internalLogger
+        )?.let {
+            wireframes.addAll(it.wireframes)
+        }
+    }
+
+    @UiThread
+    private fun addInteropWireframes(
+        interopView: View,
+        mappingContext: MappingContext,
+        wireframes: MutableList<MobileSegment.Wireframe>
+    ) {
+        // Already screen-absolute (getLocationOnScreen internally) — no offset needed.
+        wireframes.addAll(mappingContext.interopViewCallback.map(interopView, mappingContext))
+    }
+
+    /** Maps [semanticsNode] with [mapper], adds its wireframes to [wireframes], and returns the UiContext for its children. */
+    @UiThread
+    private fun addMapperWireframes(
+        mapper: SemanticsNodeMapper,
+        semanticsNode: SemanticsNode,
+        parentUiContext: UiContext,
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger,
+        wireframes: MutableList<MobileSegment.Wireframe>
+    ): UiContext {
+        val semanticsWireframe = mapper.map(
+            semanticsNode = semanticsNode,
+            parentContext = parentUiContext,
+            asyncJobStatusCallback = asyncJobStatusCallback,
+            internalLogger = internalLogger
+        ) ?: return parentUiContext
+        wireframes.addAll(semanticsWireframe.wireframes)
+        return semanticsWireframe.uiContext ?: parentUiContext
     }
 
     private fun getSemanticsNodeMapper(
@@ -188,11 +229,15 @@ internal class RootSemanticsNodeMapper(
 
     @UiThread
     private fun updateTouchOverrideAreas(
+        touchPrivacyManager: TouchPrivacyManager,
         semanticsNode: SemanticsNode,
-        touchPrivacyManager: TouchPrivacyManager
+        windowOffset: ComposeWindowOffset
     ) {
         semanticsUtils.getTouchPrivacyOverride(semanticsNode)?.let { touchPrivacy ->
-            val viewArea = semanticsNode.boundsInRoot.toAndroidRectF().toRect()
+            // boundsInRoot is root-relative; offset it like wireframes so touch redaction stays aligned.
+            val viewArea = semanticsNode.boundsInRoot.toAndroidRectF().toRect().apply {
+                offset(windowOffset.xPx, windowOffset.yPx)
+            }
             touchPrivacyManager.addTouchOverrideArea(viewArea, touchPrivacy)
         }
     }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapper.kt
@@ -75,12 +75,10 @@ internal class RootSemanticsNodeMapper(
                 semanticsNode = semanticsNode,
                 wireframes = wireframes,
                 touchPrivacyManager = mappingContext.touchPrivacyManager,
-                // windowOffset is baked into every wireframe's bounds via UiContext (see
-                // SemanticsUtils.resolveInnerBounds/resolveBackgroundInfo) so positions are correct
-                // from the moment each wireframe is created — including ones later mutated in place
-                // by async resource resolution (e.g. ImageWireframe.resourceId). Translating
-                // already-built wireframes after the fact would silently detach those async
-                // updates. See RUM-16362.
+                // Positions must be correct from creation (see UiContext.windowOffset), since
+                // wireframes can be mutated in place later by async resource resolution (e.g.
+                // ImageWireframe.resourceId); translating them after the fact would silently
+                // detach those updates. See RUM-16362.
                 parentUiContext = UiContext(
                     parentContentColor = null,
                     density = density,
@@ -132,14 +130,14 @@ internal class RootSemanticsNodeMapper(
             mapper::class.java.simpleName,
             isContainer = mapper is ContainerSemanticsNodeMapper
         ) {
-            val currentUiContext = addMapperWireframes(
-                mapper,
-                semanticsNode,
-                parentUiContext,
-                asyncJobStatusCallback,
-                internalLogger,
-                wireframes
+            val semanticsWireframe = mapper.map(
+                semanticsNode = semanticsNode,
+                parentContext = parentUiContext,
+                asyncJobStatusCallback = asyncJobStatusCallback,
+                internalLogger = internalLogger
             )
+            val currentUiContext = semanticsWireframe?.uiContext ?: parentUiContext
+            semanticsWireframe?.let { wireframes.addAll(it.wireframes) }
             semanticsNode.children.forEach {
                 createComposerWireframes(
                     semanticsNode = it,
@@ -180,26 +178,6 @@ internal class RootSemanticsNodeMapper(
     ) {
         // Already screen-absolute (getLocationOnScreen internally) — no offset needed.
         wireframes.addAll(mappingContext.interopViewCallback.map(interopView, mappingContext))
-    }
-
-    /** Maps [semanticsNode] with [mapper], adds its wireframes to [wireframes], and returns the UiContext for its children. */
-    @UiThread
-    private fun addMapperWireframes(
-        mapper: SemanticsNodeMapper,
-        semanticsNode: SemanticsNode,
-        parentUiContext: UiContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback,
-        internalLogger: InternalLogger,
-        wireframes: MutableList<MobileSegment.Wireframe>
-    ): UiContext {
-        val semanticsWireframe = mapper.map(
-            semanticsNode = semanticsNode,
-            parentContext = parentUiContext,
-            asyncJobStatusCallback = asyncJobStatusCallback,
-            internalLogger = internalLogger
-        ) ?: return parentUiContext
-        wireframes.addAll(semanticsWireframe.wireframes)
-        return semanticsWireframe.uiContext ?: parentUiContext
     }
 
     private fun getSemanticsNodeMapper(

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SliderSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SliderSemanticsNodeMapper.kt
@@ -42,7 +42,7 @@ internal class SliderSemanticsNodeMapper(
         semanticsNode: SemanticsNode,
         index: Int
     ): MobileSegment.Wireframe? {
-        val globalBounds = resolveBounds(semanticsNode)
+        val globalBounds = resolveBounds(semanticsNode, parentContext)
         val progressBarRangeInfo = semanticsUtils.getProgressBarRangeInfo(semanticsNode)
 
         val progress = progressBarRangeInfo?.let {
@@ -76,7 +76,7 @@ internal class SliderSemanticsNodeMapper(
         semanticsNode: SemanticsNode,
         index: Int
     ): MobileSegment.Wireframe {
-        val globalBounds = resolveBounds(semanticsNode)
+        val globalBounds = resolveBounds(semanticsNode, parentContext)
         val trackHeight = DEFAULT_TRACK_HEIGHT.value * parentContext.density
         val yOffset = (globalBounds.height - trackHeight).toLong() / 2
         return MobileSegment.Wireframe.ShapeWireframe(

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SwitchSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SwitchSemanticsNodeMapper.kt
@@ -35,7 +35,7 @@ internal class SwitchSemanticsNodeMapper(
         internalLogger: InternalLogger
     ): SemanticsWireframe {
         val isSwitchOn = isSwitchOn(semanticsNode)
-        val globalBounds = resolveBounds(semanticsNode)
+        val globalBounds = resolveBounds(semanticsNode, parentContext)
         val isDarkBackground =
             parentContext.parentContentColor?.let { colorUtils.isDarkColor(it, internalLogger) } ?: false
         val switchWireframes = if (isSwitchMasked(parentContext)) {

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TabSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TabSemanticsNodeMapper.kt
@@ -26,7 +26,7 @@ internal class TabSemanticsNodeMapper(
         asyncJobStatusCallback: AsyncJobStatusCallback,
         internalLogger: InternalLogger
     ): SemanticsWireframe {
-        val globalBounds = resolveBounds(semanticsNode)
+        val globalBounds = resolveBounds(semanticsNode, parentContext)
         val shapeStyle =
             MobileSegment.ShapeStyle(backgroundColor = parentContext.parentContentColor)
         val wireframe = MobileSegment.Wireframe.ShapeWireframe(

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapper.kt
@@ -51,7 +51,7 @@ internal class TextFieldSemanticsNodeMapper(
         val color = semanticsUtils.resolveBackgroundColor(semanticsNode)?.let {
             convertColor(it)
         }
-        val globalBounds = semanticsUtils.resolveInnerBounds(semanticsNode)
+        val globalBounds = semanticsUtils.resolveInnerBounds(semanticsNode, parentContext.windowOffset)
         val shape = semanticsUtils.resolveBackgroundShape(semanticsNode)
         val cornerRadius = shape?.let {
             semanticsUtils.resolveCornerRadius(it, globalBounds, parentContext.composeDensity)
@@ -78,7 +78,7 @@ internal class TextFieldSemanticsNodeMapper(
         index: Int,
         internalLogger: InternalLogger
     ): MobileSegment.Wireframe? {
-        val globalBounds = semanticsUtils.resolveInnerBounds(semanticsNode)
+        val globalBounds = semanticsUtils.resolveInnerBounds(semanticsNode, parentContext.windowOffset)
         val editText = resolveEditText(semanticsNode.config)?.let {
             transformCapturedText(it, textAndInputPrivacy, true)
         }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapper.kt
@@ -32,7 +32,7 @@ internal open class TextSemanticsNodeMapper(
         val textAndInputPrivacy = semanticsUtils.getTextAndInputPrivacyOverride(semanticsNode)
             ?: parentContext.textAndInputPrivacy
         val textWireframe = resolveTextWireFrame(parentContext, semanticsNode, textAndInputPrivacy, internalLogger)
-        val backgroundWireframes = resolveModifierWireframes(semanticsNode)
+        val backgroundWireframes = resolveModifierWireframes(semanticsNode, parentContext)
         wireframes.addAll(backgroundWireframes)
         textWireframe?.let {
             wireframes.add(it)
@@ -53,7 +53,7 @@ internal open class TextSemanticsNodeMapper(
         val capturedText = textLayoutInfo?.text?.let {
             transformCapturedText(it, textAndInputPrivacy)
         }
-        val bounds = resolveBounds(semanticsNode)
+        val bounds = resolveBounds(semanticsNode, parentContext)
         return capturedText?.let { text ->
             MobileSegment.Wireframe.TextWireframe(
                 id = semanticsNode.id.toLong(),

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/BackgroundResolver.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/BackgroundResolver.kt
@@ -19,14 +19,17 @@ import com.datadog.android.sessionreplay.utils.GlobalBounds
 
 internal class BackgroundResolver(
     private val reflectionUtils: ReflectionUtils,
-    private val innerBoundsOf: (SemanticsNode) -> GlobalBounds,
+    private val innerBoundsOf: (SemanticsNode, ComposeWindowOffset) -> GlobalBounds,
     private val internalLogger: InternalLogger = InternalLogger.UNBOUND
 ) {
-    internal fun resolveBackgroundInfo(semanticsNode: SemanticsNode): List<BackgroundInfo> {
+    internal fun resolveBackgroundInfo(
+        semanticsNode: SemanticsNode,
+        windowOffset: ComposeWindowOffset = ComposeWindowOffset.NONE
+    ): List<BackgroundInfo> {
         val backgroundInfoList = mutableListOf<BackgroundInfo>()
         // CurrentBackgroundInfo is to store bounds, color and shape information in sequence of modifiers.
         var currentBackgroundInfo = BackgroundInfo()
-        var currentBounds: GlobalBounds = resolveOuterBounds(semanticsNode)
+        var currentBounds: GlobalBounds = resolveOuterBounds(semanticsNode, windowOffset)
         // If the currentBounds is already invalid, return with the existing wireframes
         if (currentBounds.width <= 0 || currentBounds.height <= 0) {
             return backgroundInfoList
@@ -84,8 +87,8 @@ internal class BackgroundResolver(
         }
     }
 
-    private fun resolveOuterBounds(semanticsNode: SemanticsNode): GlobalBounds {
-        var currentBounds = innerBoundsOf(semanticsNode)
+    private fun resolveOuterBounds(semanticsNode: SemanticsNode, windowOffset: ComposeWindowOffset): GlobalBounds {
+        var currentBounds = innerBoundsOf(semanticsNode, windowOffset)
         semanticsNode.layoutInfo.getModifierInfo().filter {
             reflectionUtils.isPaddingElement(it.modifier)
         }.forEach {

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/ComposeWindowOffset.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/ComposeWindowOffset.kt
@@ -1,0 +1,37 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.utils
+
+import android.view.View
+
+/**
+ * A view's distance from the screen origin, in raw pixels and density-independent pixels.
+ *
+ * `positionInRoot`/`boundsInRoot` on a [androidx.compose.ui.semantics.SemanticsNode] are relative
+ * to the [androidx.compose.ui.platform.AndroidComposeView], not the screen. When Compose is
+ * embedded in a non-full-screen host (e.g. a `ComposeView` inside an XML `ScrollView`), this
+ * offset must be added to every wireframe position resolved from the semantics tree so it lines
+ * up with the rest of the (screen-absolute) Session Replay wireframes.
+ */
+internal data class ComposeWindowOffset(val xPx: Int, val yPx: Int, val xDp: Long, val yDp: Long) {
+    internal companion object {
+        internal val NONE = ComposeWindowOffset(xPx = 0, yPx = 0, xDp = 0L, yDp = 0L)
+    }
+}
+
+/** Screen offset for [this] view, in both raw px (touch areas) and dp (wireframes). */
+internal fun View.resolveComposeWindowOffset(density: Float): ComposeWindowOffset {
+    val screenPos = IntArray(2)
+    @Suppress("UnsafeThirdPartyFunctionCall") // array is always size 2 as required
+    getLocationOnScreen(screenPos)
+    return ComposeWindowOffset(
+        xPx = screenPos[0],
+        yPx = screenPos[1],
+        xDp = (screenPos[0] / density).toLong(),
+        yDp = (screenPos[1] / density).toLong()
+    )
+}

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
@@ -58,8 +58,11 @@ internal class SemanticsUtils(
         return null
     }
 
-    internal fun resolveBackgroundInfo(semanticsNode: SemanticsNode): List<BackgroundInfo> =
-        backgroundResolver.resolveBackgroundInfo(semanticsNode)
+    internal fun resolveBackgroundInfo(
+        semanticsNode: SemanticsNode,
+        windowOffset: ComposeWindowOffset = ComposeWindowOffset.NONE
+    ): List<BackgroundInfo> =
+        backgroundResolver.resolveBackgroundInfo(semanticsNode, windowOffset)
 
     internal fun resolveBackgroundColor(semanticsNode: SemanticsNode): Long? =
         backgroundResolver.resolveBackgroundColor(semanticsNode)
@@ -101,7 +104,10 @@ internal class SemanticsUtils(
     internal fun resolveCornerRadius(shape: Shape, currentBounds: GlobalBounds, density: Density): Float =
         backgroundResolver.resolveCornerRadius(shape, currentBounds, density)
 
-    internal fun resolveInnerBounds(semanticsNode: SemanticsNode): GlobalBounds {
+    internal fun resolveInnerBounds(
+        semanticsNode: SemanticsNode,
+        windowOffset: ComposeWindowOffset = ComposeWindowOffset.NONE
+    ): GlobalBounds {
         val offset = semanticsNode.positionInRoot
         // Resolve the measured size.
         // Some semantics node doesn't have InnerLayerCoordinator, so use boundsInRoot as a fallback.
@@ -109,8 +115,10 @@ internal class SemanticsUtils(
         val density = semanticsNode.layoutInfo.density.density
         val width = (size.width / density).toLong()
         val height = (size.height / density).toLong()
-        val x = (offset.x / density).toLong()
-        val y = (offset.y / density).toLong()
+        // positionInRoot is relative to the AndroidComposeView, not the screen — add the host
+        // view's screen offset so bounds line up with the rest of the (screen-absolute) wireframes.
+        val x = (offset.x / density).toLong() + windowOffset.xDp
+        val y = (offset.y / density).toLong() + windowOffset.yDp
         return GlobalBounds(x, y, width, height)
     }
 

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapperTest.kt
@@ -105,13 +105,14 @@ internal open class AbstractSemanticsNodeMapperTest {
     }
 
     @Test
-    fun `M return correct bound W resolveBounds`() {
+    fun `M return correct bound W resolveBounds`(@Forgery fakeUiContext: UiContext) {
         // Given
         val semanticsNode = mock<SemanticsNode>()
-        whenever(mockSemanticsUtils.resolveInnerBounds(semanticsNode)) doReturn fakeGlobalBounds
+        whenever(mockSemanticsUtils.resolveInnerBounds(semanticsNode, fakeUiContext.windowOffset)) doReturn
+            fakeGlobalBounds
 
         // When
-        val result = testedMapper.stubResolveBounds(semanticsNode)
+        val result = testedMapper.stubResolveBounds(semanticsNode, fakeUiContext)
 
         // Then
         assertThat(result).isEqualTo(fakeGlobalBounds)
@@ -298,8 +299,8 @@ internal class StubAbstractSemanticsNodeMapper(
         return super.resolveId(semanticsNode, index)
     }
 
-    fun stubResolveBounds(semanticsNode: SemanticsNode): GlobalBounds {
-        return super.resolveBounds(semanticsNode)
+    fun stubResolveBounds(semanticsNode: SemanticsNode, parentContext: UiContext): GlobalBounds {
+        return super.resolveBounds(semanticsNode, parentContext)
     }
 
     fun stubResolveTextAlign(textLayoutInfo: TextLayoutInfo): MobileSegment.TextPosition {

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AndroidComposeViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AndroidComposeViewMapperTest.kt
@@ -8,6 +8,7 @@
 
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
+import androidx.compose.ui.layout.LayoutInfo
 import androidx.compose.ui.platform.AndroidComposeView
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsConfiguration
@@ -15,7 +16,9 @@ import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.unit.Density
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.compose.internal.utils.ComposeWindowOffset
 import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
 import com.datadog.android.sessionreplay.recorder.MappingContext
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -23,6 +26,7 @@ import com.datadog.android.sessionreplay.utils.ColorStringFormatter
 import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
 import com.datadog.android.sessionreplay.utils.ViewBoundsResolver
 import com.datadog.android.sessionreplay.utils.ViewIdentifierResolver
+import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -34,6 +38,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -79,6 +84,9 @@ class AndroidComposeViewMapperTest {
     @Mock
     private lateinit var mockSemanticsConfiguration: SemanticsConfiguration
 
+    @Mock
+    private lateinit var mockLayoutInfo: LayoutInfo
+
     @Forgery
     private lateinit var fakeMappingContext: MappingContext
 
@@ -93,13 +101,20 @@ class AndroidComposeViewMapperTest {
             mockDrawableToColorMapper,
             mockRootSemanticsNodeMapper
         )
+        // Node density 0f falls back to system density, matching the tests below that assert
+        // against fakeMappingContext.systemInformation.screenDensity.
+        whenever(mockLayoutInfo.density) doReturn Density(0f)
+        whenever(mockRootSemanticsNodeMapper.createComposeWireframes(any(), any(), any(), any(), any(), any()))
+            .thenReturn(emptyList())
+        whenever(mockAndroidComposeView.semanticsOwner).thenReturn(mockSemanticsOwner)
+        val defaultRootSemanticsNode = mockSemanticsNode(null)
+        whenever(mockSemanticsOwner.unmergedRootSemanticsNode).thenReturn(defaultRootSemanticsNode)
     }
 
     @Test
     fun `M invoke rootSemanticsNodeMapper createComposeWireframes W map`() {
         // Given
         val mockSemanticsNode = mockSemanticsNode(null)
-        whenever(mockAndroidComposeView.semanticsOwner).thenReturn(mockSemanticsOwner)
         whenever(mockSemanticsOwner.unmergedRootSemanticsNode).thenReturn(mockSemanticsNode)
 
         // When
@@ -116,7 +131,89 @@ class AndroidComposeViewMapperTest {
             eq(fakeMappingContext.systemInformation.screenDensity),
             eq(fakeMappingContext),
             eq(mockAsyncJobStatusCallback),
+            any(),
             any()
+        )
+    }
+
+    @Test
+    fun `M pass window offset to createComposeWireframes W map {view has non-zero screen position}`(forge: Forge) {
+        // Given
+        // windowOffset is now forwarded to RootSemanticsNodeMapper and baked into each wireframe's
+        // bounds at creation time (see SemanticsUtils.resolveInnerBounds), instead of being applied
+        // as a post-hoc translation here. Post-hoc translation would silently detach async-populated
+        // fields like ImageWireframe.resourceId from the wireframe actually returned. See RUM-16362.
+        val fakeScreenX = forge.anInt(min = 1, max = 1000)
+        val fakeScreenY = forge.anInt(min = 1, max = 1000)
+        val density = fakeMappingContext.systemInformation.screenDensity.let { if (it == 0.0f) 1.0f else it }
+        doAnswer { invocation ->
+            val array = invocation.arguments[0] as IntArray
+            array[0] = fakeScreenX
+            array[1] = fakeScreenY
+            null
+        }.whenever(mockAndroidComposeView).getLocationOnScreen(any())
+
+        // When
+        testedAndroidComposeViewMapper.map(
+            mockAndroidComposeView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
+
+        // Then
+        val expectedWindowOffset = ComposeWindowOffset(
+            xPx = fakeScreenX,
+            yPx = fakeScreenY,
+            xDp = (fakeScreenX / density).toLong(),
+            yDp = (fakeScreenY / density).toLong()
+        )
+        verify(mockRootSemanticsNodeMapper).createComposeWireframes(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(expectedWindowOffset)
+        )
+    }
+
+    @Test
+    fun `M use root semantics node density for window offset W map {node overrides density}`(forge: Forge) {
+        // Given
+        val fakeScreenX = forge.anInt(min = 1, max = 1000)
+        val fakeScreenY = forge.anInt(min = 1, max = 1000)
+        val fakeNodeDensity = forge.aFloat(min = 0.5f, max = 4f)
+        whenever(mockLayoutInfo.density) doReturn Density(fakeNodeDensity)
+        doAnswer { invocation ->
+            val array = invocation.arguments[0] as IntArray
+            array[0] = fakeScreenX
+            array[1] = fakeScreenY
+            null
+        }.whenever(mockAndroidComposeView).getLocationOnScreen(any())
+
+        // When
+        testedAndroidComposeViewMapper.map(
+            mockAndroidComposeView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
+
+        // Then — offset and the density passed down both use the root node's own density
+        val expectedWindowOffset = ComposeWindowOffset(
+            xPx = fakeScreenX,
+            yPx = fakeScreenY,
+            xDp = (fakeScreenX / fakeNodeDensity).toLong(),
+            yDp = (fakeScreenY / fakeNodeDensity).toLong()
+        )
+        verify(mockRootSemanticsNodeMapper).createComposeWireframes(
+            any(),
+            eq(fakeNodeDensity),
+            any(),
+            any(),
+            any(),
+            eq(expectedWindowOffset)
         )
     }
 
@@ -124,6 +221,7 @@ class AndroidComposeViewMapperTest {
         return mock {
             whenever(mockSemanticsConfiguration.getOrNull(SemanticsProperties.Role)) doReturn role
             whenever(it.config) doReturn mockSemanticsConfiguration
+            whenever(it.layoutInfo) doReturn mockLayoutInfo
         }
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AndroidComposeViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AndroidComposeViewMapperTest.kt
@@ -90,10 +90,12 @@ class AndroidComposeViewMapperTest {
     @Forgery
     private lateinit var fakeMappingContext: MappingContext
 
+    private var fakeDefaultNodeDensity: Float = 0f
+
     private lateinit var testedAndroidComposeViewMapper: AndroidComposeViewMapper
 
     @BeforeEach
-    fun `set up`() {
+    fun `set up`(forge: Forge) {
         testedAndroidComposeViewMapper = AndroidComposeViewMapper(
             mockViewIdentifierResolver,
             mockColorStringFormatter,
@@ -101,9 +103,8 @@ class AndroidComposeViewMapperTest {
             mockDrawableToColorMapper,
             mockRootSemanticsNodeMapper
         )
-        // Node density 0f falls back to system density, matching the tests below that assert
-        // against fakeMappingContext.systemInformation.screenDensity.
-        whenever(mockLayoutInfo.density) doReturn Density(0f)
+        fakeDefaultNodeDensity = forge.aFloat(min = 0.5f, max = 4f)
+        whenever(mockLayoutInfo.density) doReturn Density(fakeDefaultNodeDensity)
         whenever(mockRootSemanticsNodeMapper.createComposeWireframes(any(), any(), any(), any(), any(), any()))
             .thenReturn(emptyList())
         whenever(mockAndroidComposeView.semanticsOwner).thenReturn(mockSemanticsOwner)
@@ -128,7 +129,7 @@ class AndroidComposeViewMapperTest {
         // Then
         verify(mockRootSemanticsNodeMapper).createComposeWireframes(
             eq(mockSemanticsNode),
-            eq(fakeMappingContext.systemInformation.screenDensity),
+            eq(fakeDefaultNodeDensity),
             eq(fakeMappingContext),
             eq(mockAsyncJobStatusCallback),
             any(),
@@ -145,7 +146,7 @@ class AndroidComposeViewMapperTest {
         // fields like ImageWireframe.resourceId from the wireframe actually returned. See RUM-16362.
         val fakeScreenX = forge.anInt(min = 1, max = 1000)
         val fakeScreenY = forge.anInt(min = 1, max = 1000)
-        val density = fakeMappingContext.systemInformation.screenDensity.let { if (it == 0.0f) 1.0f else it }
+        val density = fakeDefaultNodeDensity
         doAnswer { invocation ->
             val array = invocation.arguments[0] as IntArray
             array[0] = fakeScreenX

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapperTest.kt
@@ -89,13 +89,13 @@ internal class ButtonSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest()
             color = fakeBackgroundColor,
             cornerRadius = fakeCornerRadius
         )
-        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode)) doReturn rectToBounds(
-            fakeBounds,
-            fakeDensity
-        )
-        whenever(mockSemanticsUtils.resolveBackgroundInfo(mockSemanticsNode)) doReturn listOf(
-            fakeBackgroundInfo
-        )
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode, fakeUiContext.windowOffset)) doReturn
+            rectToBounds(
+                fakeBounds,
+                fakeDensity
+            )
+        whenever(mockSemanticsUtils.resolveBackgroundInfo(mockSemanticsNode, fakeUiContext.windowOffset)) doReturn
+            listOf(fakeBackgroundInfo)
 
         // When
         val actual = testedButtonSemanticsNodeMapper.map(

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/CheckboxSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/CheckboxSemanticsNodeMapperTest.kt
@@ -21,6 +21,7 @@ import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.Chec
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.CheckboxSemanticsNodeMapper.Companion.CHECKBOX_SIZE_DP
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.CheckboxSemanticsNodeMapper.Companion.STROKE_WIDTH_DP
 import com.datadog.android.sessionreplay.compose.internal.utils.ColorUtils
+import com.datadog.android.sessionreplay.compose.internal.utils.ComposeWindowOffset
 import com.datadog.android.sessionreplay.compose.internal.utils.PathUtils
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils.Companion.DEFAULT_COLOR_BLACK
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils.Companion.DEFAULT_COLOR_WHITE
@@ -29,6 +30,7 @@ import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
 import com.datadog.android.sessionreplay.utils.ImageWireframeHelper
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -90,6 +92,9 @@ internal class CheckboxSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest
     @StringForgery(regex = "#[0-9A-F]{8}")
     lateinit var fakeCheckmarkColorHexString: String
 
+    @Forgery
+    lateinit var fakeWindowOffset: ComposeWindowOffset
+
     @Mock
     private lateinit var mockUiContext: UiContext
 
@@ -118,10 +123,13 @@ internal class CheckboxSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest
         whenever(mockUiContext.textAndInputPrivacy)
             .thenReturn(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
 
-        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode)) doReturn rectToBounds(
-            fakeBounds,
-            fakeDensity
-        )
+        whenever(mockUiContext.windowOffset) doReturn fakeWindowOffset
+
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode, fakeWindowOffset)) doReturn
+            rectToBounds(
+                fakeBounds,
+                fakeDensity
+            )
 
         mockSemanticsNodeWithBound {
             whenever(mockSemanticsNode.layoutInfo).doReturn(mockLayoutInfo)
@@ -371,7 +379,8 @@ internal class CheckboxSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest
     @Test
     fun `M call image wireframe creation W map { checked, reflection resolution success }`() {
         // Given
-        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode)) doReturn fakeGlobalBounds
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode, fakeWindowOffset)) doReturn
+            fakeGlobalBounds
 
         whenever(mockConfig.getOrNull(SemanticsProperties.ToggleableState))
             .thenReturn(ToggleableState.On)
@@ -447,7 +456,8 @@ internal class CheckboxSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest
     @Test
     fun `M return image wireframe W map { checked, reflection resolution success }`() {
         // Given
-        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode)) doReturn fakeGlobalBounds
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode, fakeWindowOffset)) doReturn
+            fakeGlobalBounds
 
         whenever(mockConfig.getOrNull(SemanticsProperties.ToggleableState))
             .thenReturn(ToggleableState.On)

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeHiddenNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeHiddenNodeMapperTest.kt
@@ -69,10 +69,11 @@ internal class ComposeHiddenNodeMapperTest : AbstractSemanticsNodeMapperTest() {
     fun `M return the correct wireframe W map`() {
         // Given
         val mockSemanticsNode = mockSemanticsNode()
-        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode)) doReturn rectToBounds(
-            fakeBounds,
-            fakeDensity
-        )
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode, fakeUiContext.windowOffset)) doReturn
+            rectToBounds(
+                fakeBounds,
+                fakeDensity
+            )
 
         // When
         val actual = testedComposeHiddenNodeMapper.map(

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapperTest.kt
@@ -90,10 +90,12 @@ class ComposeViewMapperTest {
     @Forgery
     private lateinit var fakeMappingContext: MappingContext
 
+    private var fakeDefaultNodeDensity: Float = 0f
+
     private lateinit var testedComposeViewMapper: ComposeViewMapper
 
     @BeforeEach
-    fun `set up`() {
+    fun `set up`(forge: Forge) {
         testedComposeViewMapper = ComposeViewMapper(
             mockViewIdentifierResolver,
             mockColorStringFormatter,
@@ -102,9 +104,8 @@ class ComposeViewMapperTest {
             mockSemanticsUtils,
             mockRootSemanticsNodeMapper
         )
-        // Node density 0f falls back to system density, matching the tests below that assert
-        // against fakeMappingContext.systemInformation.screenDensity.
-        whenever(mockLayoutInfo.density) doReturn Density(0f)
+        fakeDefaultNodeDensity = forge.aFloat(min = 0.5f, max = 4f)
+        whenever(mockLayoutInfo.density) doReturn Density(fakeDefaultNodeDensity)
         whenever(mockRootSemanticsNodeMapper.createComposeWireframes(any(), any(), any(), any(), any(), any()))
             .thenReturn(emptyList())
         val defaultRootSemanticsNode = mockSemanticsNode(null)
@@ -128,7 +129,7 @@ class ComposeViewMapperTest {
         // Then
         verify(mockRootSemanticsNodeMapper).createComposeWireframes(
             eq(mockSemanticsNode),
-            eq(fakeMappingContext.systemInformation.screenDensity),
+            eq(fakeDefaultNodeDensity),
             eq(fakeMappingContext),
             eq(mockAsyncJobStatusCallback),
             any(),
@@ -163,7 +164,7 @@ class ComposeViewMapperTest {
         // fields like ImageWireframe.resourceId from the wireframe actually returned. See RUM-16362.
         val fakeScreenX = forge.anInt(min = 1, max = 1000)
         val fakeScreenY = forge.anInt(min = 1, max = 1000)
-        val density = fakeMappingContext.systemInformation.screenDensity.let { if (it == 0.0f) 1.0f else it }
+        val density = fakeDefaultNodeDensity
         doAnswer { invocation ->
             val array = invocation.arguments[0] as IntArray
             array[0] = fakeScreenX

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ComposeViewMapperTest.kt
@@ -6,13 +6,16 @@
 
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
+import androidx.compose.ui.layout.LayoutInfo
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.unit.Density
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.compose.internal.utils.ComposeWindowOffset
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -21,9 +24,11 @@ import com.datadog.android.sessionreplay.utils.ColorStringFormatter
 import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
 import com.datadog.android.sessionreplay.utils.ViewBoundsResolver
 import com.datadog.android.sessionreplay.utils.ViewIdentifierResolver
+import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -32,9 +37,11 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -77,6 +84,9 @@ class ComposeViewMapperTest {
     @Mock
     private lateinit var mockSemanticsConfiguration: SemanticsConfiguration
 
+    @Mock
+    private lateinit var mockLayoutInfo: LayoutInfo
+
     @Forgery
     private lateinit var fakeMappingContext: MappingContext
 
@@ -92,6 +102,13 @@ class ComposeViewMapperTest {
             mockSemanticsUtils,
             mockRootSemanticsNodeMapper
         )
+        // Node density 0f falls back to system density, matching the tests below that assert
+        // against fakeMappingContext.systemInformation.screenDensity.
+        whenever(mockLayoutInfo.density) doReturn Density(0f)
+        whenever(mockRootSemanticsNodeMapper.createComposeWireframes(any(), any(), any(), any(), any(), any()))
+            .thenReturn(emptyList())
+        val defaultRootSemanticsNode = mockSemanticsNode(null)
+        whenever(mockSemanticsUtils.findRootSemanticsNode(mockView)).thenReturn(defaultRootSemanticsNode)
     }
 
     @Test
@@ -114,7 +131,107 @@ class ComposeViewMapperTest {
             eq(fakeMappingContext.systemInformation.screenDensity),
             eq(fakeMappingContext),
             eq(mockAsyncJobStatusCallback),
+            any(),
             any()
+        )
+    }
+
+    @Test
+    fun `M return empty list W map {no root semantics node}`() {
+        // Given
+        whenever(mockSemanticsUtils.findRootSemanticsNode(mockView)).thenReturn(null)
+
+        // When
+        val result = testedComposeViewMapper.map(
+            mockView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
+
+        // Then
+        assertThat(result).isEmpty()
+        verify(mockView, never()).getLocationOnScreen(any())
+    }
+
+    @Test
+    fun `M pass window offset to createComposeWireframes W map {view has non-zero screen position}`(forge: Forge) {
+        // Given
+        // windowOffset is now forwarded to RootSemanticsNodeMapper and baked into each wireframe's
+        // bounds at creation time (see SemanticsUtils.resolveInnerBounds), instead of being applied
+        // as a post-hoc translation here. Post-hoc translation would silently detach async-populated
+        // fields like ImageWireframe.resourceId from the wireframe actually returned. See RUM-16362.
+        val fakeScreenX = forge.anInt(min = 1, max = 1000)
+        val fakeScreenY = forge.anInt(min = 1, max = 1000)
+        val density = fakeMappingContext.systemInformation.screenDensity.let { if (it == 0.0f) 1.0f else it }
+        doAnswer { invocation ->
+            val array = invocation.arguments[0] as IntArray
+            array[0] = fakeScreenX
+            array[1] = fakeScreenY
+            null
+        }.whenever(mockView).getLocationOnScreen(any())
+
+        // When
+        testedComposeViewMapper.map(
+            mockView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
+
+        // Then
+        val expectedWindowOffset = ComposeWindowOffset(
+            xPx = fakeScreenX,
+            yPx = fakeScreenY,
+            xDp = (fakeScreenX / density).toLong(),
+            yDp = (fakeScreenY / density).toLong()
+        )
+        verify(mockRootSemanticsNodeMapper).createComposeWireframes(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            eq(expectedWindowOffset)
+        )
+    }
+
+    @Test
+    fun `M use root semantics node density for window offset W map {node overrides density}`(forge: Forge) {
+        // Given
+        val fakeScreenX = forge.anInt(min = 1, max = 1000)
+        val fakeScreenY = forge.anInt(min = 1, max = 1000)
+        val fakeNodeDensity = forge.aFloat(min = 0.5f, max = 4f)
+        whenever(mockLayoutInfo.density) doReturn Density(fakeNodeDensity)
+        doAnswer { invocation ->
+            val array = invocation.arguments[0] as IntArray
+            array[0] = fakeScreenX
+            array[1] = fakeScreenY
+            null
+        }.whenever(mockView).getLocationOnScreen(any())
+
+        // When
+        testedComposeViewMapper.map(
+            mockView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
+
+        // Then — offset and the density passed down both use the root node's own density
+        val expectedWindowOffset = ComposeWindowOffset(
+            xPx = fakeScreenX,
+            yPx = fakeScreenY,
+            xDp = (fakeScreenX / fakeNodeDensity).toLong(),
+            yDp = (fakeScreenY / fakeNodeDensity).toLong()
+        )
+        verify(mockRootSemanticsNodeMapper).createComposeWireframes(
+            any(),
+            eq(fakeNodeDensity),
+            any(),
+            any(),
+            any(),
+            eq(expectedWindowOffset)
         )
     }
 
@@ -122,6 +239,7 @@ class ComposeViewMapperTest {
         return mock {
             whenever(mockSemanticsConfiguration.getOrNull(SemanticsProperties.Role)) doReturn role
             whenever(it.config) doReturn mockSemanticsConfiguration
+            whenever(it.layoutInfo) doReturn mockLayoutInfo
         }
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ContainerSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ContainerSemanticsNodeMapperTest.kt
@@ -82,9 +82,8 @@ internal class ContainerSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTes
             color = fakeBackgroundColor,
             cornerRadius = fakeCornerRadius
         )
-        whenever(mockSemanticsUtils.resolveBackgroundInfo(mockSemanticsNode)) doReturn listOf(
-            fakeBackgroundInfo
-        )
+        whenever(mockSemanticsUtils.resolveBackgroundInfo(mockSemanticsNode, fakeUiContext.windowOffset)) doReturn
+            listOf(fakeBackgroundInfo)
         whenever(mockSemanticsUtils.resolveBackgroundColor(mockSemanticsNode)) doReturn fakeBackgroundColor
 
         // When

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ImageSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ImageSemanticsNodeMapperTest.kt
@@ -490,10 +490,10 @@ internal class ImageSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest() 
         )
         whenever(mockBitmap.width) doReturn 100
         whenever(mockBitmap.height) doReturn 100
-        whenever(mockSemanticsUtils.resolveInnerBounds(any())) doReturn containerBounds
+        whenever(mockSemanticsUtils.resolveInnerBounds(any(), any())) doReturn containerBounds
         whenever(mockSemanticsUtils.resolveSemanticsPainter(any(), any())) doReturn bitmapInfo
         whenever(mockSemanticsUtils.getImagePrivacyOverride(any())) doReturn null
-        whenever(mockSemanticsUtils.resolveBackgroundInfo(any())) doReturn emptyList()
+        whenever(mockSemanticsUtils.resolveBackgroundInfo(any(), any())) doReturn emptyList()
         whenever(
             mockImageWireframeHelper.createImageWireframeByBitmap(
                 id = any(),
@@ -538,9 +538,11 @@ internal class ImageSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest() 
         // Given
         val mockSemanticsNode = mockSemanticsNodeWithBound()
         val containerBounds = rectToBounds(fakeBounds, fakeDensity)
-        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode)) doReturn containerBounds
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode, fakeUiContext.windowOffset)) doReturn
+            containerBounds
         whenever(mockSemanticsUtils.resolveSemanticsPainter(eq(mockSemanticsNode), any())) doReturn null
-        whenever(mockSemanticsUtils.resolveBackgroundInfo(mockSemanticsNode)) doReturn emptyList()
+        whenever(mockSemanticsUtils.resolveBackgroundInfo(mockSemanticsNode, fakeUiContext.windowOffset)) doReturn
+            emptyList()
 
         // When
         val result = testedMapper.map(
@@ -567,10 +569,10 @@ internal class ImageSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest() 
         )
         whenever(mockBitmap.width) doReturn 100
         whenever(mockBitmap.height) doReturn 100
-        whenever(mockSemanticsUtils.resolveInnerBounds(any())) doReturn containerBounds
+        whenever(mockSemanticsUtils.resolveInnerBounds(any(), any())) doReturn containerBounds
         whenever(mockSemanticsUtils.resolveSemanticsPainter(any(), any())) doReturn bitmapInfo
         whenever(mockSemanticsUtils.getImagePrivacyOverride(any())) doReturn ImagePrivacy.MASK_ALL
-        whenever(mockSemanticsUtils.resolveBackgroundInfo(any())) doReturn emptyList()
+        whenever(mockSemanticsUtils.resolveBackgroundInfo(any(), any())) doReturn emptyList()
         whenever(
             mockImageWireframeHelper.createImageWireframeByBitmap(
                 id = any(),

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RadioButtonSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RadioButtonSemanticsNodeMapperTest.kt
@@ -14,10 +14,12 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.RadioButtonSemanticsNodeMapper.Companion.DEFAULT_COLOR_GRAY
+import com.datadog.android.sessionreplay.compose.internal.utils.ComposeWindowOffset
 import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -60,6 +62,9 @@ internal class RadioButtonSemanticsNodeMapperTest : AbstractSemanticsNodeMapperT
     @StringForgery(regex = "#[0-9A-F]{8}")
     lateinit var fakeBackgroundColorHexString: String
 
+    @Forgery
+    lateinit var fakeWindowOffset: ComposeWindowOffset
+
     @Mock
     lateinit var mockUiContext: UiContext
 
@@ -69,14 +74,16 @@ internal class RadioButtonSemanticsNodeMapperTest : AbstractSemanticsNodeMapperT
         mockSemanticsNode = mockSemanticsNode()
 
         whenever(mockUiContext.textAndInputPrivacy) doReturn TextAndInputPrivacy.MASK_SENSITIVE_INPUTS
+        whenever(mockUiContext.windowOffset) doReturn fakeWindowOffset
         mockColorStringFormatter(fakeBackgroundColor, fakeBackgroundColorHexString)
         whenever(mockSemanticsUtils.resolveRadioButtonColor(mockSemanticsNode))
             .doReturn(fakeBackgroundColor)
 
-        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode)) doReturn rectToBounds(
-            fakeBounds,
-            fakeDensity
-        )
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode, fakeWindowOffset)) doReturn
+            rectToBounds(
+                fakeBounds,
+                fakeDensity
+            )
 
         testedRadioButtonSemanticsNodeMapper = RadioButtonSemanticsNodeMapper(
             colorStringFormatter = mockColorStringFormatter,

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/RootSemanticsNodeMapperTest.kt
@@ -7,15 +7,23 @@
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
 import android.view.View
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.toAndroidRectF
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.core.graphics.toRect
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.TouchPrivacy
+import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWireframe
+import com.datadog.android.sessionreplay.compose.internal.data.UiContext
+import com.datadog.android.sessionreplay.compose.internal.utils.ComposeWindowOffset
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
+import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
@@ -23,6 +31,7 @@ import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -31,6 +40,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -89,9 +99,6 @@ class RootSemanticsNodeMapperTest {
     @Mock
     private lateinit var mockSliderSemanticsNodeMapper: SliderSemanticsNodeMapper
 
-    @Mock
-    private lateinit var mockSemanticsConfiguration: SemanticsConfiguration
-
     @Forgery
     private lateinit var fakeMappingContext: MappingContext
 
@@ -143,6 +150,41 @@ class RootSemanticsNodeMapperTest {
             asyncJobStatusCallback = eq(mockAsyncJobStatusCallback),
             internalLogger = eq(mockInternalLogger)
         )
+    }
+
+    @Test
+    fun `M thread window offset into UiContext W createComposeWireframes`(forge: Forge) {
+        // Given — windowOffset must reach child mappers via UiContext so bounds are baked in at
+        // wireframe-creation time (not translated after the fact, which would detach async-mutated
+        // fields like ImageWireframe.resourceId from the wireframe instance actually returned).
+        // See RUM-16362.
+        val mockSemanticsNode = mockSemanticsNode(null)
+        val fakeWindowOffset = ComposeWindowOffset(
+            xPx = forge.anInt(min = 1, max = 500),
+            yPx = forge.anInt(min = 1, max = 500),
+            xDp = forge.aLong(min = 1, max = 500),
+            yDp = forge.aLong(min = 1, max = 500)
+        )
+
+        // When
+        testedRootSemanticsNodeMapper.createComposeWireframes(
+            mockSemanticsNode,
+            fakeMappingContext.systemInformation.screenDensity,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger,
+            windowOffset = fakeWindowOffset
+        )
+
+        // Then
+        val contextCaptor = argumentCaptor<UiContext>()
+        verify(mockContainerSemanticsNodeMapper).map(
+            semanticsNode = eq(mockSemanticsNode),
+            parentContext = contextCaptor.capture(),
+            asyncJobStatusCallback = eq(mockAsyncJobStatusCallback),
+            internalLogger = eq(mockInternalLogger)
+        )
+        assertThat(contextCaptor.firstValue.windowOffset).isEqualTo(fakeWindowOffset)
     }
 
     @Test
@@ -358,13 +400,23 @@ class RootSemanticsNodeMapperTest {
     }
 
     @Test
-    fun `M call interop callback W semantics node has interop view`() {
+    fun `M call interop callback W semantics node has interop view`(forge: Forge) {
+        // Given
         val mockSemanticsNode = mockSemanticsNode(null)
         val mockView = mock<View>()
+        val fakeInteropWireframe = MobileSegment.Wireframe.ShapeWireframe(
+            id = forge.aLong(),
+            x = forge.aLong(min = 0, max = 500),
+            y = forge.aLong(min = 0, max = 500),
+            width = forge.aLong(min = 1, max = 500),
+            height = forge.aLong(min = 1, max = 500)
+        )
         whenever(mockSemanticsUtils.getInteropView(mockSemanticsNode)) doReturn mockView
+        whenever(fakeMappingContext.interopViewCallback.map(mockView, fakeMappingContext))
+            .thenReturn(listOf(fakeInteropWireframe))
 
         // When
-        testedRootSemanticsNodeMapper.createComposeWireframes(
+        val result = testedRootSemanticsNodeMapper.createComposeWireframes(
             mockSemanticsNode,
             fakeMappingContext.systemInformation.screenDensity,
             fakeMappingContext,
@@ -377,12 +429,96 @@ class RootSemanticsNodeMapperTest {
             eq(mockView),
             eq(fakeMappingContext)
         )
+        assertThat(result).containsExactly(fakeInteropWireframe)
+    }
+
+    @Test
+    fun `M preserve document order W createComposeWireframes {compose and interop siblings mixed}`(forge: Forge) {
+        // Given — a Button child then an interop child; interop must not be pushed to the end.
+        val parentNode = mockSemanticsNode(null)
+        val composeChild = mockSemanticsNode(Role.Button)
+        val interopChild = mockSemanticsNode(null)
+        whenever(parentNode.children) doReturn listOf(composeChild, interopChild)
+
+        val fakeComposeWireframe = MobileSegment.Wireframe.ShapeWireframe(
+            id = forge.aLong(),
+            x = forge.aLong(min = 0, max = 500),
+            y = forge.aLong(min = 0, max = 500),
+            width = forge.aLong(min = 1, max = 500),
+            height = forge.aLong(min = 1, max = 500)
+        )
+        val fakeInteropWireframe = MobileSegment.Wireframe.ShapeWireframe(
+            id = forge.aLong(),
+            x = forge.aLong(min = 0, max = 500),
+            y = forge.aLong(min = 0, max = 500),
+            width = forge.aLong(min = 1, max = 500),
+            height = forge.aLong(min = 1, max = 500)
+        )
+        val mockView = mock<View>()
+        whenever(mockButtonSemanticsNodeMapper.map(eq(composeChild), any(), any(), any()))
+            .thenReturn(SemanticsWireframe(listOf(fakeComposeWireframe), null))
+        whenever(mockSemanticsUtils.getInteropView(interopChild)) doReturn mockView
+        whenever(fakeMappingContext.interopViewCallback.map(mockView, fakeMappingContext))
+            .thenReturn(listOf(fakeInteropWireframe))
+
+        // When
+        val result = testedRootSemanticsNodeMapper.createComposeWireframes(
+            parentNode,
+            fakeMappingContext.systemInformation.screenDensity,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
+
+        // Then — wireframes appear in traversal order: compose child before interop child
+        assertThat(result).containsExactly(fakeComposeWireframe, fakeInteropWireframe)
+    }
+
+    @Test
+    fun `M offset touch override area by window offset W createComposeWireframes {touch privacy override}`(
+        forge: Forge
+    ) {
+        // Given
+        val mockSemanticsNode = mockSemanticsNode(null)
+        val fakeTouchPrivacy = forge.aValueFrom(TouchPrivacy::class.java)
+        val fakeLeft = forge.aFloat(min = 0f, max = 100f)
+        val fakeTop = forge.aFloat(min = 0f, max = 100f)
+        val fakeBoundsInRoot = Rect(fakeLeft, fakeTop, fakeLeft + 50f, fakeTop + 50f)
+        val fakeOffsetXPx = forge.anInt(min = 1, max = 500)
+        val fakeOffsetYPx = forge.anInt(min = 1, max = 500)
+        whenever(mockSemanticsUtils.getTouchPrivacyOverride(mockSemanticsNode)) doReturn fakeTouchPrivacy
+        whenever(mockSemanticsNode.boundsInRoot) doReturn fakeBoundsInRoot
+
+        // When
+        testedRootSemanticsNodeMapper.createComposeWireframes(
+            mockSemanticsNode,
+            fakeMappingContext.systemInformation.screenDensity,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger,
+            windowOffset = ComposeWindowOffset(xPx = fakeOffsetXPx, yPx = fakeOffsetYPx, xDp = 0L, yDp = 0L)
+        )
+
+        // Then — captured rather than compared via eq() to avoid Rect's toString() misbehaving
+        // inside Mockito's mismatch reporting under the Android unit-test stub jar.
+        val areaCaptor = argumentCaptor<android.graphics.Rect>()
+        verify(fakeMappingContext.touchPrivacyManager).addTouchOverrideArea(areaCaptor.capture(), eq(fakeTouchPrivacy))
+        val expectedArea = fakeBoundsInRoot.toAndroidRectF().toRect().apply {
+            offset(fakeOffsetXPx, fakeOffsetYPx)
+        }
+        assertThat(areaCaptor.firstValue.left).isEqualTo(expectedArea.left)
+        assertThat(areaCaptor.firstValue.top).isEqualTo(expectedArea.top)
+        assertThat(areaCaptor.firstValue.right).isEqualTo(expectedArea.right)
+        assertThat(areaCaptor.firstValue.bottom).isEqualTo(expectedArea.bottom)
     }
 
     private fun mockSemanticsNode(role: Role?): SemanticsNode {
+        // Each node gets its own config mock — sharing one across differently-roled siblings
+        // would make the last stub win for all of them.
+        val config = mock<SemanticsConfiguration>()
+        whenever(config.getOrNull(SemanticsProperties.Role)) doReturn role
         return mock {
-            whenever(mockSemanticsConfiguration.getOrNull(SemanticsProperties.Role)) doReturn role
-            whenever(it.config) doReturn mockSemanticsConfiguration
+            whenever(it.config) doReturn config
         }
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SliderSemanticsNodeMapperNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SliderSemanticsNodeMapperNodeMapperTest.kt
@@ -23,6 +23,7 @@ import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
@@ -63,13 +64,15 @@ internal class SliderSemanticsNodeMapperNodeMapperTest : AbstractSemanticsNodeMa
     @FloatForgery
     var fakeCornerRadius: Float = 0f
 
-    @FloatForgery
+    // fakeEndInclusive must be strictly greater than fakeStart — the mapper only emits a thumb
+    // wireframe when the range is non-empty (rangeAbs > 0). Set explicitly in `set up` instead of
+    // via independent @FloatForgery fields, which could otherwise forge an empty/inverted range
+    // and silently drop the thumb wireframe the test always expects.
     var fakeStart: Float = 0f
 
     @FloatForgery
     var fakeCurrent: Float = 0f
 
-    @FloatForgery
     var fakeEndInclusive: Float = 0f
 
     @Forgery
@@ -78,6 +81,8 @@ internal class SliderSemanticsNodeMapperNodeMapperTest : AbstractSemanticsNodeMa
     @BeforeEach
     override fun `set up`(forge: Forge) {
         super.`set up`(forge)
+        fakeStart = forge.aFloat(min = -1_000f, max = 1_000f)
+        fakeEndInclusive = forge.aFloat(min = fakeStart + 1f, max = fakeStart + 1_000f)
         testedSliderSemanticsNodeMapper = SliderSemanticsNodeMapper(
             colorStringFormatter = mockColorStringFormatter,
             semanticsUtils = mockSemanticsUtils
@@ -90,6 +95,7 @@ internal class SliderSemanticsNodeMapperNodeMapperTest : AbstractSemanticsNodeMa
         }
     }
 
+    @Test
     fun `M return the correct wireframe W map`() {
         // Given
         val mockSemanticsNode = mockSemanticsNode()
@@ -99,10 +105,10 @@ internal class SliderSemanticsNodeMapperNodeMapperTest : AbstractSemanticsNodeMa
             color = fakeBackgroundColor,
             cornerRadius = fakeCornerRadius
         )
-        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode)) doReturn fakeGlobalBounds
-        whenever(mockSemanticsUtils.resolveBackgroundInfo(mockSemanticsNode)) doReturn listOf(
-            fakeBackgroundInfo
-        )
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode, fakeUiContext.windowOffset)) doReturn
+            fakeGlobalBounds
+        whenever(mockSemanticsUtils.resolveBackgroundInfo(mockSemanticsNode, fakeUiContext.windowOffset)) doReturn
+            listOf(fakeBackgroundInfo)
         whenever(mockSemanticsUtils.getProgressBarRangeInfo(mockSemanticsNode)) doReturn
             mockProgressBarRangeInfo
         whenever(mockProgressBarRangeInfo.range) doReturn mockRange

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SwitchSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SwitchSemanticsNodeMapperTest.kt
@@ -18,6 +18,7 @@ import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.Swit
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.SwitchSemanticsNodeMapper.Companion.CORNER_RADIUS_DP
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.SwitchSemanticsNodeMapper.Companion.THUMB_DIAMETER_DP
 import com.datadog.android.sessionreplay.compose.internal.mappers.semantics.SwitchSemanticsNodeMapper.Companion.TRACK_WIDTH_DP
+import com.datadog.android.sessionreplay.compose.internal.utils.ComposeWindowOffset
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils.Companion.DEFAULT_COLOR_BLACK
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils.Companion.DEFAULT_COLOR_WHITE
@@ -54,6 +55,9 @@ internal class SwitchSemanticsNodeMapperTest {
     @Forgery
     lateinit var fakeGlobalBounds: GlobalBounds
 
+    @Forgery
+    lateinit var fakeWindowOffset: ComposeWindowOffset
+
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
@@ -78,7 +82,9 @@ internal class SwitchSemanticsNodeMapperTest {
     @BeforeEach
     fun `set up`() {
         whenever(mockSemanticsNode.id) doReturn fakeSemanticsId
-        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode)) doReturn fakeGlobalBounds
+        whenever(mockParentContext.windowOffset) doReturn fakeWindowOffset
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode, fakeWindowOffset)) doReturn
+            fakeGlobalBounds
         whenever(mockSemanticsNode.config).thenReturn(mockConfig)
         whenever(mockParentContext.textAndInputPrivacy).thenReturn(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
 

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TabSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TabSemanticsNodeMapperTest.kt
@@ -73,10 +73,11 @@ internal class TabSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest() {
     fun `M return the correct wireframe W map`() {
         // Given
         val mockSemanticsNode = mockSemanticsNode()
-        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode)) doReturn rectToBounds(
-            fakeBounds,
-            fakeDensity
-        )
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode, fakeUiContext.windowOffset)) doReturn
+            rectToBounds(
+                fakeBounds,
+                fakeDensity
+            )
 
         // When
         val actual = testedTabSemanticsNodeMapper.map(

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextFieldSemanticsNodeMapperTest.kt
@@ -108,7 +108,8 @@ internal class TextFieldSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTes
             fakeEditText
         )
         whenever(mockSemanticsUtils.resolveTextLayoutInfo(eq(mockSemanticsNode), any())) doReturn fakeTextLayoutInfo
-        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode)) doReturn innerBounds
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode, fakeUiContext.windowOffset))
+            .doReturn(innerBounds)
         whenever(mockSemanticsUtils.resolveBackgroundColor(mockSemanticsNode)) doReturn fakeBackgroundColor
         whenever(mockSemanticsUtils.resolveBackgroundShape(mockSemanticsNode)) doReturn mockShape
         whenever(
@@ -191,7 +192,8 @@ internal class TextFieldSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTes
             fakeEditText
         )
         whenever(mockSemanticsUtils.resolveTextLayoutInfo(eq(mockSemanticsNode), any())) doReturn fakeTextLayoutInfo
-        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode)) doReturn innerBounds
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode, fakeUiContext.windowOffset))
+            .doReturn(innerBounds)
         whenever(mockSemanticsUtils.resolveBackgroundColor(mockSemanticsNode)) doReturn fakeBackgroundColor
         whenever(mockSemanticsUtils.resolveBackgroundShape(mockSemanticsNode)) doReturn mockShape
         whenever(

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapperTest.kt
@@ -102,7 +102,7 @@ internal class TextSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest() {
         val mockNode = mockSemanticsNodeWithBound {}
 
         whenever(mockSemanticsUtils.resolveTextLayoutInfo(eq(mockNode), any())) doReturn fakeTextLayoutInfo
-        whenever(mockSemanticsUtils.resolveInnerBounds(mockNode)) doReturn rectToBounds(
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockNode, fakeUiContext.windowOffset)) doReturn rectToBounds(
             fakeBounds,
             fakeDensity
         )
@@ -140,7 +140,7 @@ internal class TextSemanticsNodeMapperTest : AbstractSemanticsNodeMapperTest() {
         val mockNode = mockSemanticsNodeWithBound {}
         whenever(mockSemanticsUtils.getTextAndInputPrivacyOverride(mockNode)) doReturn TextAndInputPrivacy.MASK_ALL
         whenever(mockSemanticsUtils.resolveTextLayoutInfo(eq(mockNode), any())) doReturn fakeTextLayoutInfo
-        whenever(mockSemanticsUtils.resolveInnerBounds(mockNode)) doReturn rectToBounds(
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockNode, fakeUiContext.windowOffset)) doReturn rectToBounds(
             fakeBounds,
             fakeDensity
         )

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtilsTest.kt
@@ -362,6 +362,30 @@ internal class SemanticsUtilsTest {
     }
 
     @Test
+    fun `M add window offset to inner bounds W resolveInnerBounds { non-zero windowOffset }`(
+        @Forgery fakeWindowOffset: ComposeWindowOffset
+    ) {
+        // Given — RUM-16362: the host view's screen offset must be baked into bounds at the point
+        // they're resolved, so it stays attached to the same wireframe instance that async
+        // resource resolution later mutates (e.g. ImageWireframe.resourceId).
+        val placeable = mock<Placeable>()
+        whenever(mockReflectionUtils.getPlaceable(mockSemanticsNode)) doReturn placeable
+        whenever(mockSemanticsNode.positionInRoot) doReturn fakeOffset
+
+        // When
+        val result = testedSemanticsUtils.resolveInnerBounds(mockSemanticsNode, fakeWindowOffset)
+        val expected = GlobalBounds(
+            x = (fakeOffset.x / fakeDensity).toLong() + fakeWindowOffset.xDp,
+            y = (fakeOffset.y / fakeDensity).toLong() + fakeWindowOffset.yDp,
+            width = (placeable.width / fakeDensity).toLong(),
+            height = (placeable.width / fakeDensity).toLong()
+        )
+
+        // Then
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
     fun `M return corner radius W resolveCornerRadius`(
         @Forgery fakeBounds: GlobalBounds,
         @IntForgery fakeCornerSizeValue: Int
@@ -689,6 +713,37 @@ internal class SemanticsUtilsTest {
         )
 
         // Then
+        assertThat(result).containsExactly(expected)
+    }
+
+    @Test
+    fun `M add window offset to backgroundInfo bounds W resolveBackgroundInfo { non-zero windowOffset }`(
+        forge: Forge,
+        @LongForgery(min = 17L) fakeColorValue: Long,
+        @Forgery fakeWindowOffset: ComposeWindowOffset
+    ) {
+        // Given — RUM-16362: BackgroundResolver's bounds (used for background/padding shape
+        // wireframes) go through a separate code path from resolveInnerBounds, and must get the
+        // same window offset applied.
+        val (fakeRect, fakeBounds) = forgeBackgroundBounds(forge)
+        val backgroundModifierInfo = backgroundModifierStub(color = fakeColorValue, brush = null)
+        whenever(mockLayoutInfo.getModifierInfo()) doReturn listOf(backgroundModifierInfo)
+        whenever(mockSemanticsNode.boundsInRoot) doReturn fakeRect
+        whenever(mockSemanticsNode.positionInRoot) doReturn Offset(fakeRect.left, fakeRect.top)
+
+        // When
+        val result = testedSemanticsUtils.resolveBackgroundInfo(mockSemanticsNode, fakeWindowOffset)
+
+        // Then
+        val expected = BackgroundInfo(
+            color = fakeColorValue,
+            globalBounds = GlobalBounds(
+                x = fakeBounds.x + fakeWindowOffset.xDp,
+                y = fakeBounds.y + fakeWindowOffset.yDp,
+                width = fakeBounds.width,
+                height = fakeBounds.height
+            )
+        )
         assertThat(result).containsExactly(expected)
     }
 

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/ComposeWindowOffsetForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/ComposeWindowOffsetForgeryFactory.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.test.elmyr
+
+import com.datadog.android.sessionreplay.compose.internal.utils.ComposeWindowOffset
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class ComposeWindowOffsetForgeryFactory : ForgeryFactory<ComposeWindowOffset> {
+    override fun getForgery(forge: Forge): ComposeWindowOffset {
+        return ComposeWindowOffset(
+            xPx = forge.anInt(min = 0, max = 65536),
+            yPx = forge.anInt(min = 0, max = 65536),
+            xDp = forge.aLong(min = 0L, max = 65536L),
+            yDp = forge.aLong(min = 0L, max = 65536L)
+        )
+    }
+}

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/SessionReplayComposeForgeConfigurator.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/SessionReplayComposeForgeConfigurator.kt
@@ -28,6 +28,7 @@ class SessionReplayComposeForgeConfigurator : BaseConfigurator() {
         forge.addFactory(WireframeForgeryFactory())
 
         // Compose Specifics
+        forge.addFactory(ComposeWindowOffsetForgeryFactory())
         forge.addFactory(UIContextForgeryFactory())
         forge.addFactory(ComposeWireframeForgeryFactory())
         forge.addFactory(TextLayoutInfoForgeryFactory())

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/UIContextForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/UIContextForgeryFactory.kt
@@ -21,7 +21,8 @@ internal class UIContextForgeryFactory : ForgeryFactory<UiContext> {
             imagePrivacy = forge.aValueFrom(ImagePrivacy::class.java),
             textAndInputPrivacy = forge.aValueFrom(TextAndInputPrivacy::class.java),
             isInUserInputLayout = forge.aBool(),
-            imageWireframeHelper = mock()
+            imageWireframeHelper = mock(),
+            windowOffset = forge.getForgery()
         )
     }
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/WebViewSample.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/WebViewSample.kt
@@ -12,12 +12,19 @@ import android.webkit.WebViewClient
 import android.widget.ImageView
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
 import com.datadog.android.rum.ExperimentalRumApi
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.sample.R
@@ -32,9 +39,8 @@ private val webViewTrackingHosts = listOf(
 @Composable
 internal fun InteropViewSample() {
     Column {
-        Text(
-            text = "ImageView"
-        )
+        AndroidViewInDialogSample()
+        Text(text = "ImageView")
         AndroidView(
             modifier = Modifier.height(120.dp),
             factory = { context ->
@@ -69,6 +75,30 @@ internal fun InteropViewSample() {
                 webView.loadUrl("https://datadoghq.dev/browser-sdk-test-playground/webview-support/#click_event")
             }
         )
+    }
+}
+
+@Composable
+private fun AndroidViewInDialogSample() {
+    var showDialog by remember { mutableStateOf(false) }
+    Button(onClick = { showDialog = true }) {
+        Text("Open dialog with AndroidView")
+    }
+    if (showDialog) {
+        Dialog(onDismissRequest = { showDialog = false }) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text("AndroidView inside a Compose Dialog")
+                AndroidView(
+                    modifier = Modifier.height(120.dp),
+                    factory = { context ->
+                        ImageView(context).apply {
+                            setImageResource(R.drawable.ic_dd_icon_red)
+                        }
+                    },
+                    update = {}
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes Session Replay rendering embedded Compose content at the top of its scroll container instead of its actual scrolled position. When a ComposeView is nested inside an XML ScrollView/NestedScrollView (a common pattern during incremental Compose migration), SemanticsNode.positionInRoot is relative to the AndroidComposeView, not the screen — so wireframe coordinates never accounted for where the ComposeView itself sits on screen. This went unnoticed for full-screen Compose because the root AndroidComposeView sits at roughly (0, statusBarHeight), making positionInRoot coincidentally line up with screen coordinates. ComposeViewMapper and AndroidComposeViewMapper now resolve the host view's on-screen position via getLocationOnScreen() and translate the resulting wireframes by that offset, so scrolled/embedded Compose content is captured at its true position. Since getLocationOnScreen() reflects the current scroll offset at capture time, this fixes all scroll positions without special-casing ScrollView.

One visible side effect: on typical full-screen (non-edge-to-edge) activities, this now correctly shifts Compose content down by the status bar height, which exposes a plain background-colored strip where the status bar sits. The strip was previously invisible because content incorrectly extended up into it under the old bug. This is a pre-existing SR limitation becoming visible in a new place, not a regression from this fix, and is out of scope here.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Interop wireframes (Android Views embedded via AndroidView inside Compose) are already screen-absolute, so they're tracked separately (ComposeWireframeEntry.Compose vs .Interop) and excluded from the new offset to avoid double-counting. Touch-privacy override areas are offset the same way to stay aligned with the corrected wireframe positions.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

