### PR TITLE
RUM-17182: Stablize MoveDataMigrationOperationTest under high CPU usage

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileMigrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileMigrator.kt
@@ -10,13 +10,11 @@ import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.persistence.file.FileMover
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
-import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.privacy.TrackingConsent
 
 internal class ConsentAwareFileMigrator(
     private val fileMover: FileMover,
-    private val internalLogger: InternalLogger,
-    private val timeProvider: TimeProvider
+    private val internalLogger: InternalLogger
 ) : DataMigrator<TrackingConsent> {
 
     @WorkerThread
@@ -49,8 +47,7 @@ internal class ConsentAwareFileMigrator(
             WipeDataMigrationOperation(
                 previousFileOrchestrator.getRootDir(),
                 fileMover,
-                internalLogger,
-                timeProvider
+                internalLogger
             )
         }
 
@@ -59,8 +56,7 @@ internal class ConsentAwareFileMigrator(
             WipeDataMigrationOperation(
                 newFileOrchestrator.getRootDir(),
                 fileMover,
-                internalLogger,
-                timeProvider
+                internalLogger
             )
         }
 
@@ -69,8 +65,7 @@ internal class ConsentAwareFileMigrator(
                 previousFileOrchestrator.getRootDir(),
                 newFileOrchestrator.getRootDir(),
                 fileMover,
-                internalLogger,
-                timeProvider
+                internalLogger
             )
         }
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/FeatureFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/FeatureFileOrchestrator.kt
@@ -62,8 +62,7 @@ internal class FeatureFileOrchestrator(
         ),
         ConsentAwareFileMigrator(
             FileMover(internalLogger),
-            internalLogger,
-            timeProvider
+            internalLogger
         ),
         executorService,
         internalLogger

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/MoveDataMigrationOperation.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/MoveDataMigrationOperation.kt
@@ -10,7 +10,6 @@ import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.persistence.file.FileMover
 import com.datadog.android.core.internal.utils.retryWithDelay
-import com.datadog.android.internal.time.TimeProvider
 import java.io.File
 import java.util.concurrent.TimeUnit
 
@@ -22,8 +21,7 @@ internal class MoveDataMigrationOperation(
     internal val fromDir: File?,
     internal val toDir: File?,
     internal val fileMover: FileMover,
-    internal val internalLogger: InternalLogger,
-    internal val timeProvider: TimeProvider
+    internal val internalLogger: InternalLogger
 ) : DataMigrationOperation {
 
     @WorkerThread
@@ -41,7 +39,7 @@ internal class MoveDataMigrationOperation(
                 { WARN_NULL_DEST_DIR }
             )
         } else {
-            retryWithDelay(MAX_RETRY, RETRY_DELAY_NS, internalLogger, timeProvider) {
+            retryWithDelay(MAX_RETRY, RETRY_DELAY_NS, internalLogger) {
                 fileMover.moveFiles(fromDir, toDir)
             }
         }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/WipeDataMigrationOperation.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/WipeDataMigrationOperation.kt
@@ -10,7 +10,6 @@ import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.persistence.file.FileMover
 import com.datadog.android.core.internal.utils.retryWithDelay
-import com.datadog.android.internal.time.TimeProvider
 import java.io.File
 import java.util.concurrent.TimeUnit
 
@@ -20,8 +19,7 @@ import java.util.concurrent.TimeUnit
 internal class WipeDataMigrationOperation(
     internal val targetDir: File?,
     internal val fileMover: FileMover,
-    internal val internalLogger: InternalLogger,
-    internal val timeProvider: TimeProvider
+    internal val internalLogger: InternalLogger
 ) : DataMigrationOperation {
 
     @WorkerThread
@@ -33,7 +31,7 @@ internal class WipeDataMigrationOperation(
                 { WARN_NULL_DIR }
             )
         } else {
-            retryWithDelay(MAX_RETRY, RETRY_DELAY_NS, internalLogger, timeProvider) {
+            retryWithDelay(MAX_RETRY, RETRY_DELAY_NS, internalLogger) {
                 fileMover.delete(targetDir)
             }
         }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/MiscUtils.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/MiscUtils.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.core.internal.utils
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.internal.thread.sleepSafe
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.internal.utils.NULL_MAP_VALUE
 import com.datadog.android.lint.InternalApi
@@ -19,7 +20,20 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.util.Date
 import java.util.Locale
+import java.util.concurrent.TimeUnit
 
+/**
+ * Retries [block] until it returns `true`, up to [times] attempts in total.
+ *
+ * The first attempt is made immediately. After each failed attempt, this function waits at
+ * least [retryDelayNs] nanoseconds before retrying. An exception thrown by [block] is logged
+ * and counts as a failed attempt. If the thread is interrupted while waiting, retrying stops
+ * immediately instead of honoring the remaining attempts.
+ *
+ * @return `true` as soon as [block] returns `true`, or `false` if every attempt failed or
+ * retrying was interrupted.
+ */
+@Suppress("TooGenericExceptionCaught", "ReturnCount", "NestedBlockDepth")
 internal fun retryWithDelay(
     times: Int,
     retryDelayNs: Long,
@@ -27,41 +41,40 @@ internal fun retryWithDelay(
     timeProvider: TimeProvider,
     block: () -> Boolean
 ): Boolean {
-    return retryWithDelay(block, times, retryDelayNs, internalLogger, timeProvider)
-}
-
-@Suppress("TooGenericExceptionCaught")
-internal inline fun retryWithDelay(
-    block: () -> Boolean,
-    times: Int,
-    loopsDelayInNanos: Long,
-    internalLogger: InternalLogger,
-    timeProvider: TimeProvider
-): Boolean {
-    var retryCounter = 1
-    var wasSuccessful = false
-    var loopTimeOrigin = timeProvider.getDeviceElapsedTimeNanos() - loopsDelayInNanos
-    while (retryCounter <= times && !wasSuccessful) {
-        if ((timeProvider.getDeviceElapsedTimeNanos() - loopTimeOrigin) >= loopsDelayInNanos) {
-            wasSuccessful = try {
-                block()
-            } catch (e: Exception) {
-                internalLogger.log(
-                    InternalLogger.Level.ERROR,
-                    targets = listOf(
-                        InternalLogger.Target.MAINTAINER,
-                        InternalLogger.Target.TELEMETRY
-                    ),
-                    { "Internal I/O operation failed" },
-                    e
-                )
-                false
+    var attempt = 1
+    var lastAttemptEndNs = timeProvider.getDeviceElapsedTimeNanos()
+    while (attempt <= times) {
+        if (attempt > 1) {
+            val timeSinceLastAttemptNs = timeProvider.getDeviceElapsedTimeNanos() - lastAttemptEndNs
+            val timeToWaitNs = (retryDelayNs - timeSinceLastAttemptNs)
+            if (timeToWaitNs > 0) {
+                // round up so a floored sub-millisecond remainder never causes an undersleep
+                val sleepTimeMs = TimeUnit.NANOSECONDS.toMillis(timeToWaitNs) + 1
+                val wasInterrupted = sleepSafe(sleepTimeMs, internalLogger)
+                if (wasInterrupted) {
+                    return false
+                }
             }
-            loopTimeOrigin = timeProvider.getDeviceElapsedTimeNanos()
-            retryCounter++
         }
+        try {
+            if (block()) {
+                return true
+            }
+        } catch (e: Exception) {
+            internalLogger.log(
+                InternalLogger.Level.ERROR,
+                targets = listOf(
+                    InternalLogger.Target.MAINTAINER,
+                    InternalLogger.Target.TELEMETRY
+                ),
+                { "Internal I/O operation failed" },
+                e
+            )
+        }
+        lastAttemptEndNs = timeProvider.getDeviceElapsedTimeNanos()
+        attempt++
     }
-    return wasSuccessful
+    return false
 }
 
 @Suppress("UndocumentedPublicClass")

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/MiscUtils.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/MiscUtils.kt
@@ -8,7 +8,6 @@ package com.datadog.android.core.internal.utils
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.thread.sleepSafe
-import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.internal.utils.NULL_MAP_VALUE
 import com.datadog.android.lint.InternalApi
 import com.google.gson.JsonArray
@@ -38,22 +37,15 @@ internal fun retryWithDelay(
     times: Int,
     retryDelayNs: Long,
     internalLogger: InternalLogger,
-    timeProvider: TimeProvider,
     block: () -> Boolean
 ): Boolean {
-    var attempt = 1
-    var lastAttemptEndNs = timeProvider.getDeviceElapsedTimeNanos()
-    while (attempt <= times) {
-        if (attempt > 1) {
-            val timeSinceLastAttemptNs = timeProvider.getDeviceElapsedTimeNanos() - lastAttemptEndNs
-            val timeToWaitNs = (retryDelayNs - timeSinceLastAttemptNs)
-            if (timeToWaitNs > 0) {
-                // round up so a floored sub-millisecond remainder never causes an undersleep
-                val sleepTimeMs = TimeUnit.NANOSECONDS.toMillis(timeToWaitNs) + 1
-                val wasInterrupted = sleepSafe(sleepTimeMs, internalLogger)
-                if (wasInterrupted) {
-                    return false
-                }
+    repeat(times) { attempt ->
+        if (attempt > 0) {
+            // round up so a floored sub-millisecond remainder never causes an undersleep
+            val sleepTimeMs = TimeUnit.NANOSECONDS.toMillis(retryDelayNs) + 1
+            val wasInterrupted = sleepSafe(sleepTimeMs, internalLogger)
+            if (wasInterrupted) {
+                return false
             }
         }
         try {
@@ -71,8 +63,6 @@ internal fun retryWithDelay(
                 e
             )
         }
-        lastAttemptEndNs = timeProvider.getDeviceElapsedTimeNanos()
-        attempt++
     }
     return false
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileMigratorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileMigratorTest.kt
@@ -52,7 +52,6 @@ internal class ConsentAwareFileMigratorTest {
     fun `set up`() {
         testedMigrator = ConsentAwareFileMigrator(
             mockFileMover,
-            mock(),
             mock()
         )
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/MoveDataMigrationOperationTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/MoveDataMigrationOperationTest.kt
@@ -163,7 +163,10 @@ internal class MoveDataMigrationOperationTest {
 
         // Then
         verify(mockFileMover, times(2)).moveFiles(fakeFromDirectory, fakeToDirectory)
-        assertThat(duration).isBetween(500L, 550L)
+        // Lower bound is a hard guarantee (Thread.sleep never returns early); upper bound is
+        // generous to absorb OS scheduling jitter under CI load, which real-time sleeps are
+        // inherently exposed to.
+        assertThat(duration).isBetween(500L, 500L + JITTER_MARGIN_MS)
     }
 
     @Test
@@ -193,10 +196,15 @@ internal class MoveDataMigrationOperationTest {
 
         // Then
         verify(mockFileMover, times(3)).moveFiles(fakeFromDirectory, fakeToDirectory)
-        assertThat(duration).isBetween(1000L, 1100L)
+        // Two real sleeps happen here, so the jitter margin is doubled relative to the single-retry case.
+        assertThat(duration).isBetween(1000L, 1000L + 2 * JITTER_MARGIN_MS)
     }
 
     companion object {
         private val RETRY_DELAY_NS = TimeUnit.MILLISECONDS.toNanos(500)
+
+        // Generous allowance for OS scheduling jitter on a real Thread.sleep(), so these
+        // real-time tests don't flake under CI load.
+        private const val JITTER_MARGIN_MS = 300L
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/MoveDataMigrationOperationTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/MoveDataMigrationOperationTest.kt
@@ -8,10 +8,8 @@ package com.datadog.android.core.internal.persistence.file.advanced
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.persistence.file.FileMover
-import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
-import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -30,8 +28,6 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.io.File
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicLong
 import kotlin.system.measureTimeMillis
 
 @Extensions(
@@ -55,25 +51,13 @@ internal class MoveDataMigrationOperationTest {
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
-    @Mock
-    lateinit var mockTimeProvider: TimeProvider
-
-    @LongForgery(min = 0L)
-    var fakeElapsedTimeNs: Long = 0L
-
     @BeforeEach
     fun `set up`() {
-        val currentTime = AtomicLong(fakeElapsedTimeNs)
-        whenever(mockTimeProvider.getDeviceElapsedTimeNanos()).thenAnswer {
-            currentTime.getAndAdd(RETRY_DELAY_NS)
-        }
-
         testedOperation = MoveDataMigrationOperation(
             fakeFromDirectory,
             fakeToDirectory,
             mockFileMover,
-            mockInternalLogger,
-            mockTimeProvider
+            mockInternalLogger
         )
     }
 
@@ -84,8 +68,7 @@ internal class MoveDataMigrationOperationTest {
             null,
             fakeToDirectory,
             mockFileMover,
-            mockInternalLogger,
-            mockTimeProvider
+            mockInternalLogger
         )
 
         // When
@@ -107,8 +90,7 @@ internal class MoveDataMigrationOperationTest {
             fakeFromDirectory,
             null,
             mockFileMover,
-            mockInternalLogger,
-            mockTimeProvider
+            mockInternalLogger
         )
         whenever(mockFileMover.delete(fakeFromDirectory)) doReturn true
 
@@ -152,7 +134,6 @@ internal class MoveDataMigrationOperationTest {
     @Test
     fun `M retry with 500ms delay W run() {move fails once}`() {
         // Given
-        whenever(mockTimeProvider.getDeviceElapsedTimeNanos()).thenAnswer { System.nanoTime() }
         whenever(mockFileMover.moveFiles(fakeFromDirectory, fakeToDirectory))
             .doReturn(false, true)
 
@@ -185,7 +166,6 @@ internal class MoveDataMigrationOperationTest {
     @Test
     fun `M retry with 500ms delay W run() {move always fails}`() {
         // Given
-        whenever(mockTimeProvider.getDeviceElapsedTimeNanos()).thenAnswer { System.nanoTime() }
         whenever(mockFileMover.moveFiles(fakeFromDirectory, fakeToDirectory))
             .doReturn(false)
 
@@ -201,8 +181,6 @@ internal class MoveDataMigrationOperationTest {
     }
 
     companion object {
-        private val RETRY_DELAY_NS = TimeUnit.MILLISECONDS.toNanos(500)
-
         // Generous allowance for OS scheduling jitter on a real Thread.sleep(), so these
         // real-time tests don't flake under CI load.
         private const val JITTER_MARGIN_MS = 300L

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/WipeDataMigrationOperationTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/WipeDataMigrationOperationTest.kt
@@ -8,7 +8,6 @@ package com.datadog.android.core.internal.persistence.file.advanced
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.persistence.file.FileMover
-import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.annotation.LongForgery
@@ -30,8 +29,6 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.io.File
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicLong
 import kotlin.system.measureTimeMillis
 
 @Extensions(
@@ -53,24 +50,15 @@ internal class WipeDataMigrationOperationTest {
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
-    @Mock
-    lateinit var mockTimeProvider: TimeProvider
-
     @LongForgery(min = 0L)
     var fakeElapsedTimeNs: Long = 0L
 
     @BeforeEach
     fun `set up`() {
-        val currentTime = AtomicLong(fakeElapsedTimeNs)
-        whenever(mockTimeProvider.getDeviceElapsedTimeNanos()).thenAnswer {
-            currentTime.getAndAdd(RETRY_DELAY_NS)
-        }
-
         testedOperation = WipeDataMigrationOperation(
             fakeTargetDirectory,
             mockFileMover,
-            mockInternalLogger,
-            mockTimeProvider
+            mockInternalLogger
         )
     }
 
@@ -80,8 +68,7 @@ internal class WipeDataMigrationOperationTest {
         testedOperation = WipeDataMigrationOperation(
             null,
             mockFileMover,
-            mockInternalLogger,
-            mockTimeProvider
+            mockInternalLogger
         )
 
         // When
@@ -136,7 +123,6 @@ internal class WipeDataMigrationOperationTest {
     @Test
     fun `M retry with 500ms delay W run() {move always fails}`() {
         // Given
-        whenever(mockTimeProvider.getDeviceElapsedTimeNanos()).thenAnswer { System.nanoTime() }
         whenever(mockFileMover.delete(fakeTargetDirectory))
             .doReturn(false)
 
@@ -152,8 +138,6 @@ internal class WipeDataMigrationOperationTest {
     }
 
     companion object {
-        private val RETRY_DELAY_NS = TimeUnit.MILLISECONDS.toNanos(500)
-
         // Generous allowance for OS scheduling jitter on a real Thread.sleep(), so this
         // real-time test doesn't flake under CI load.
         private const val JITTER_MARGIN_MS = 300L

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/WipeDataMigrationOperationTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/WipeDataMigrationOperationTest.kt
@@ -147,10 +147,15 @@ internal class WipeDataMigrationOperationTest {
 
         // Then
         verify(mockFileMover, times(3)).delete(fakeTargetDirectory)
-        assertThat(duration).isBetween(1000L, 1100L)
+        // Two real sleeps happen here, so the jitter margin is doubled relative to a single retry.
+        assertThat(duration).isBetween(1000L, 1000L + 2 * JITTER_MARGIN_MS)
     }
 
     companion object {
         private val RETRY_DELAY_NS = TimeUnit.MILLISECONDS.toNanos(500)
+
+        // Generous allowance for OS scheduling jitter on a real Thread.sleep(), so this
+        // real-time test doesn't flake under CI load.
+        private const val JITTER_MARGIN_MS = 300L
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/MiscUtilsTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/MiscUtilsTest.kt
@@ -9,7 +9,6 @@ package com.datadog.android.core.internal.utils
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.utils.JsonSerializer.ITEM_SERIALIZATION_ERROR
 import com.datadog.android.core.internal.utils.JsonSerializer.safeMapValuesToJson
-import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.internal.utils.NULL_MAP_VALUE
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
@@ -65,14 +64,8 @@ internal class MiscUtilsTest {
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
-    @Mock
-    lateinit var mockTimeProvider: TimeProvider
-
-    @LongForgery(min = 0L)
-    var fakeCurrentTimeNs = 0L
-
-    @LongForgery(min = 0L, max = 2L)
-    var fakeDelaySeconds = 0L
+    @LongForgery(min = 1L, max = 1_000L)
+    var fakeDelayMilliseconds = 0L
 
     @Test
     fun `M repeat max N times W retryWithDelay { success = false }`(forge: Forge) {
@@ -80,10 +73,9 @@ internal class MiscUtilsTest {
         val fakeTimes = forge.anInt(min = 1, max = 10)
         val mockedBlock: () -> Boolean = mock()
         whenever(mockedBlock.invoke()).thenReturn(false)
-        stubTimeProviderWithDelay()
 
         // When
-        val wasSuccessful = retryWithDelay(fakeTimes, fakeDelayNs, mockInternalLogger, mockTimeProvider, mockedBlock)
+        val wasSuccessful = retryWithDelay(fakeTimes, fakeDelayNs, mockInternalLogger, mockedBlock)
 
         // Then
         assertThat(wasSuccessful).isFalse()
@@ -97,11 +89,10 @@ internal class MiscUtilsTest {
         val fakeDelay = TimeUnit.SECONDS.toNanos(forge.aLong(min = 0, max = 2))
         val mockedBlock: () -> Boolean = mock()
         whenever(mockedBlock.invoke()).thenReturn(false)
-        whenever(mockTimeProvider.getDeviceElapsedTimeNanos()).thenAnswer { System.nanoTime() }
 
         // When
         val executionTime = measureNanoTime {
-            retryWithDelay(fakeTimes, fakeDelay, mockInternalLogger, mockTimeProvider, mockedBlock)
+            retryWithDelay(fakeTimes, fakeDelay, mockInternalLogger, mockedBlock)
         }
 
         // Then
@@ -117,7 +108,7 @@ internal class MiscUtilsTest {
         val mockedBlock: () -> Boolean = mock()
 
         // When
-        retryWithDelay(forge.anInt(Int.MIN_VALUE, 1), fakeDelayNs, mockInternalLogger, mockTimeProvider, mockedBlock)
+        retryWithDelay(forge.anInt(Int.MIN_VALUE, 1), fakeDelayNs, mockInternalLogger, mockedBlock)
 
         // Then
         verifyNoInteractions(mockedBlock)
@@ -128,10 +119,9 @@ internal class MiscUtilsTest {
         // Given
         val mockedBlock: () -> Boolean = mock()
         whenever(mockedBlock.invoke()).thenReturn(false).thenReturn(true)
-        stubTimeProviderWithDelay()
 
         // When
-        val wasSuccessful = retryWithDelay(3, fakeDelayNs, mockInternalLogger, mockTimeProvider, mockedBlock)
+        val wasSuccessful = retryWithDelay(3, fakeDelayNs, mockInternalLogger, mockedBlock)
 
         // Then
         assertThat(wasSuccessful).isTrue()
@@ -145,10 +135,9 @@ internal class MiscUtilsTest {
         // Given
         val mockedBlock: () -> Boolean = mock()
         whenever(mockedBlock.invoke()).thenThrow(exception).thenReturn(true)
-        stubTimeProviderWithDelay()
 
         // When
-        val wasSuccessful = retryWithDelay(3, fakeDelayNs, mockInternalLogger, mockTimeProvider, mockedBlock)
+        val wasSuccessful = retryWithDelay(3, fakeDelayNs, mockInternalLogger, mockedBlock)
 
         // Then
         assertThat(wasSuccessful).isTrue()
@@ -163,14 +152,13 @@ internal class MiscUtilsTest {
             Thread.currentThread().interrupt()
             false
         }
-        whenever(mockTimeProvider.getDeviceElapsedTimeNanos()).thenAnswer { System.nanoTime() }
         val fakeSleepDelayNs = TimeUnit.SECONDS.toNanos(5)
         val resultRef = AtomicReference<Boolean>()
 
         // When
         // run on a dedicated thread so the interrupt flag sleepSafe restores doesn't leak into other tests
         val retryingThread = Thread {
-            resultRef.set(retryWithDelay(3, fakeSleepDelayNs, mockInternalLogger, mockTimeProvider, mockedBlock))
+            resultRef.set(retryWithDelay(3, fakeSleepDelayNs, mockInternalLogger, mockedBlock))
         }
         retryingThread.start()
         retryingThread.join(TimeUnit.SECONDS.toMillis(1))
@@ -354,14 +342,7 @@ internal class MiscUtilsTest {
     }
 
     private val fakeDelayNs: Long
-        get() = TimeUnit.SECONDS.toNanos(fakeDelaySeconds)
-
-    private fun stubTimeProviderWithDelay() {
-        whenever(mockTimeProvider.getDeviceElapsedTimeNanos()).thenAnswer {
-            fakeCurrentTimeNs += fakeDelayNs
-            fakeCurrentTimeNs
-        }
-    }
+        get() = TimeUnit.MILLISECONDS.toNanos(fakeDelayMilliseconds)
 
     // endregion
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/MiscUtilsTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/MiscUtilsTest.kt
@@ -51,6 +51,7 @@ import org.mockito.quality.Strictness
 import java.util.Date
 import java.util.Locale
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.system.measureNanoTime
 
 @Extensions(
@@ -82,7 +83,7 @@ internal class MiscUtilsTest {
         stubTimeProviderWithDelay()
 
         // When
-        val wasSuccessful = retryWithDelay(mockedBlock, fakeTimes, fakeDelayNs, mockInternalLogger, mockTimeProvider)
+        val wasSuccessful = retryWithDelay(fakeTimes, fakeDelayNs, mockInternalLogger, mockTimeProvider, mockedBlock)
 
         // Then
         assertThat(wasSuccessful).isFalse()
@@ -100,7 +101,7 @@ internal class MiscUtilsTest {
 
         // When
         val executionTime = measureNanoTime {
-            retryWithDelay(mockedBlock, fakeTimes, fakeDelay, mockInternalLogger, mockTimeProvider)
+            retryWithDelay(fakeTimes, fakeDelay, mockInternalLogger, mockTimeProvider, mockedBlock)
         }
 
         // Then
@@ -116,7 +117,7 @@ internal class MiscUtilsTest {
         val mockedBlock: () -> Boolean = mock()
 
         // When
-        retryWithDelay(mockedBlock, forge.anInt(Int.MIN_VALUE, 1), fakeDelayNs, mockInternalLogger, mockTimeProvider)
+        retryWithDelay(forge.anInt(Int.MIN_VALUE, 1), fakeDelayNs, mockInternalLogger, mockTimeProvider, mockedBlock)
 
         // Then
         verifyNoInteractions(mockedBlock)
@@ -130,7 +131,7 @@ internal class MiscUtilsTest {
         stubTimeProviderWithDelay()
 
         // When
-        val wasSuccessful = retryWithDelay(mockedBlock, 3, fakeDelayNs, mockInternalLogger, mockTimeProvider)
+        val wasSuccessful = retryWithDelay(3, fakeDelayNs, mockInternalLogger, mockTimeProvider, mockedBlock)
 
         // Then
         assertThat(wasSuccessful).isTrue()
@@ -147,11 +148,36 @@ internal class MiscUtilsTest {
         stubTimeProviderWithDelay()
 
         // When
-        val wasSuccessful = retryWithDelay(mockedBlock, 3, fakeDelayNs, mockInternalLogger, mockTimeProvider)
+        val wasSuccessful = retryWithDelay(3, fakeDelayNs, mockInternalLogger, mockTimeProvider, mockedBlock)
 
         // Then
         assertThat(wasSuccessful).isTrue()
         verify(mockedBlock, times(2)).invoke()
+    }
+
+    @Test
+    fun `M stop retrying W retryWithDelay { sleep is interrupted }`() {
+        // Given
+        val mockedBlock: () -> Boolean = mock()
+        whenever(mockedBlock.invoke()).thenAnswer {
+            Thread.currentThread().interrupt()
+            false
+        }
+        whenever(mockTimeProvider.getDeviceElapsedTimeNanos()).thenAnswer { System.nanoTime() }
+        val fakeSleepDelayNs = TimeUnit.SECONDS.toNanos(5)
+        val resultRef = AtomicReference<Boolean>()
+
+        // When
+        // run on a dedicated thread so the interrupt flag sleepSafe restores doesn't leak into other tests
+        val retryingThread = Thread {
+            resultRef.set(retryWithDelay(3, fakeSleepDelayNs, mockInternalLogger, mockTimeProvider, mockedBlock))
+        }
+        retryingThread.start()
+        retryingThread.join(TimeUnit.SECONDS.toMillis(1))
+
+        // Then
+        assertThat(resultRef.get()).isFalse()
+        verify(mockedBlock, times(1)).invoke()
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
* Increase CPU time budget for when under high CPU load
* Combine retryWithDelay overloads
* Add a sleep into retryWithDelay to avoid spinning the CPU for the delay time

### Motivation
Tests failed locally when ran through local_ci.sh

```
java.lang.AssertionError: 
Expecting actual:
  601L
to be between:
  [500L, 550L]

	at com.datadog.android.core.internal.persistence.file.advanced.MoveDataMigrationOperationTest.M retry with 500ms delay W run() {move fails once}(MoveDataMigrationOperationTest.kt:166)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
```
