### PR TITLE
chore(codeowners): fix stale FFE team handle for flags module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,5 +9,5 @@
 
 ## Feature Flags
 
-/features/dd-sdk-android-flags-openfeature/ @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flags-sdks
-/features/dd-sdk-android-flags-openfeature/README.md @DataDog/documentation @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flags-sdks
+/features/dd-sdk-android-flags-openfeature/ @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk
+/features/dd-sdk-android-flags-openfeature/README.md @DataDog/documentation @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk


### PR DESCRIPTION
### What does this PR do?

Replaces `@DataDog/feature-flags-sdks` with `@DataDog/feature-flagging-and-experimentation-sdk` as the FFE code owner for `/features/dd-sdk-android-flags-openfeature/` (and its `README.md`).

### Motivation

Consistency across the RUM SDKs. `@DataDog/feature-flags-sdks` is a stale/narrow team handle that predates the current FFE team; every other SDK's CODEOWNERS already points at `@DataDog/feature-flagging-and-experimentation-sdk`:

- dd-sdk-ios: https://github.com/DataDog/dd-sdk-ios/blob/develop/.github/CODEOWNERS
- dd-sdk-flutter: https://github.com/DataDog/dd-sdk-flutter/blob/develop/.github/CODEOWNERS
- dd-sdk-reactnative (companion PR, not yet merged): https://github.com/DataDog/dd-sdk-reactnative/pull/1333

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)