### PR TITLE
RUM-16305: Update several hardcoded data limits

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -200,7 +200,6 @@ interface com.datadog.android.api.net.RequestFactory
 interface com.datadog.android.api.storage.DataWriter<T>
   fun write(EventBatchWriter, T, EventType): Boolean
 interface com.datadog.android.api.storage.EventBatchWriter
-  fun currentMetadata(): ByteArray?
   fun write(RawBatchEvent, ByteArray?, EventType): Boolean
 enum com.datadog.android.api.storage.EventType
   - DEFAULT

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -577,7 +577,6 @@ public abstract interface class com/datadog/android/api/storage/DataWriter {
 }
 
 public abstract interface class com/datadog/android/api/storage/EventBatchWriter {
-	public abstract fun currentMetadata ()[B
 	public abstract fun write (Lcom/datadog/android/api/storage/RawBatchEvent;[BLcom/datadog/android/api/storage/EventType;)Z
 }
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/EventBatchWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/EventBatchWriter.kt
@@ -9,15 +9,9 @@ package com.datadog.android.api.storage
 import androidx.annotation.WorkerThread
 
 /**
- * Writer allowing [FeatureScope] to write events in the storage exposing current batch metadata.
+ * Writer allowing [FeatureScope] to write events in the storage.
  */
 interface EventBatchWriter {
-
-    /**
-     * @return the metadata of the current writeable batch
-     */
-    @WorkerThread
-    fun currentMetadata(): ByteArray?
 
     /**
      * Writes the content of the event to the current available batch.

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/FeatureStorageConfiguration.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/FeatureStorageConfiguration.kt
@@ -24,17 +24,17 @@ data class FeatureStorageConfiguration(
 
         /**
          * Default storage configuration with the following parameters:
-         * max item size = 512 KB,
-         * max items per batch = 500,
-         * max batch size = 4 MB,
+         * max item size = 1 MB,
+         * max items per batch = 1000,
+         * max batch size = 5 MB,
          * old batch threshold = 18 hours.
          */
         val DEFAULT: FeatureStorageConfiguration = FeatureStorageConfiguration(
-            // 512 KB
-            maxItemSize = 512L * 1024,
-            maxItemsPerBatch = 500,
-            // 4 MB
-            maxBatchSize = 4L * 1024 * 1024,
+            // 1 MB
+            maxItemSize = 1024L * 1024,
+            maxItemsPerBatch = 1000,
+            // 5 MB
+            maxBatchSize = 5L * 1024 * 1024,
             // 18 hours
             oldBatchThreshold = 18L * 60L * 60L * 1000L
         )

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -40,7 +40,6 @@ import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.net.info.NoOpNetworkInfoProvider
 import com.datadog.android.core.internal.persistence.JsonObjectDeserializer
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
-import com.datadog.android.core.internal.persistence.file.FileWriter
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileReaderWriter
 import com.datadog.android.core.internal.persistence.file.deleteSafe
 import com.datadog.android.core.internal.persistence.file.existsSafe
@@ -231,7 +230,7 @@ internal class CoreFeature(
 
     @get:WorkerThread
     private val lastViewEventFile: File by lazy { File(storageDir, LAST_RUM_VIEW_EVENT_FILE_NAME) }
-    private val lastViewEventFileWriter: FileWriter<RawBatchEvent> by lazy {
+    private val lastViewEventFileWriter: BatchFileReaderWriter by lazy {
         BatchFileReaderWriter.create(
             internalLogger = internalLogger,
             encryption = localDataEncryption
@@ -387,7 +386,8 @@ internal class CoreFeature(
 
     @WorkerThread
     internal fun writeLastViewEvent(data: ByteArray) {
-        lastViewEventFileWriter.writeData(lastViewEventFile, RawBatchEvent(data), false)
+        val serialized = lastViewEventFileWriter.serializeToBytes(RawBatchEvent(data = data)) ?: return
+        lastViewEventFileWriter.writeBinaryData(lastViewEventFile, serialized, false)
     }
 
     @WorkerThread

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AbstractStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AbstractStorage.kt
@@ -68,11 +68,6 @@ internal class AbstractStorage(
         val strategy = resolvePersistenceStrategy(datadogContext)
         val writer = object : EventBatchWriter {
             @WorkerThread
-            override fun currentMetadata(): ByteArray? {
-                return strategy.currentMetadata()
-            }
-
-            @WorkerThread
             override fun write(event: RawBatchEvent, batchMetadata: ByteArray?, eventType: EventType): Boolean {
                 return strategy.write(event, batchMetadata, eventType)
             }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriter.kt
@@ -28,6 +28,7 @@ internal class FileEventBatchWriter(
 ) : EventBatchWriter {
 
     @WorkerThread
+    @Suppress("ReturnCount")
     override fun write(
         event: RawBatchEvent,
         batchMetadata: ByteArray?,

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriter.kt
@@ -14,43 +14,18 @@ import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
-import com.datadog.android.core.internal.persistence.file.FileWriter
-import com.datadog.android.core.internal.persistence.file.existsSafe
+import com.datadog.android.core.internal.persistence.file.batch.BatchFileReaderWriter
 import java.io.File
 import java.util.Locale
 
 internal class FileEventBatchWriter(
     private val fileOrchestrator: FileOrchestrator,
-    private val eventsWriter: FileWriter<RawBatchEvent>,
+    private val eventsWriter: BatchFileReaderWriter,
     private val metadataReaderWriter: FileReaderWriter,
     private val filePersistenceConfig: FilePersistenceConfig,
     private val batchWriteEventListener: BatchWriteEventListener,
     private val internalLogger: InternalLogger
 ) : EventBatchWriter {
-
-    @get:WorkerThread
-    private val batchFile: File? by lazy {
-        @Suppress("ThreadSafety") // called in the worker context
-        fileOrchestrator.getWritableFile()
-    }
-
-    @get:WorkerThread
-    private val metadataFile: File?
-        get() = batchFile?.let {
-            @Suppress("ThreadSafety") // called in the worker context
-            fileOrchestrator.getMetadataFile(it)
-        }
-
-    @WorkerThread
-    override fun currentMetadata(): ByteArray? {
-        return with(metadataFile) {
-            if (this == null || !existsSafe(internalLogger)) {
-                null
-            } else {
-                metadataReaderWriter.readData(this)
-            }
-        }
-    }
 
     @WorkerThread
     override fun write(
@@ -58,7 +33,19 @@ internal class FileEventBatchWriter(
         batchMetadata: ByteArray?,
         eventType: EventType
     ): Boolean {
-        val (batchFile, metadataFile) = batchFile to metadataFile
+        // prevent useless operation for empty event
+        if (event.data.isEmpty()) {
+            return true
+        }
+        if (!checkEventSize(event.data.size)) {
+            return false
+        }
+
+        // Serialize once (TLV-wrapped, encrypted if configured) so the exact on-disk size is known
+        // before asking the orchestrator for a file with enough room to hold it.
+        val serializedEvent = eventsWriter.serializeToBytes(event) ?: return false
+
+        val batchFile = fileOrchestrator.getWritableFile(serializedEvent.size.toLong())
         if (batchFile == null) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
@@ -68,12 +55,9 @@ internal class FileEventBatchWriter(
             return false
         }
 
-        // prevent useless operation for empty event
-        return if (event.data.isEmpty()) {
-            true
-        } else if (!checkEventSize(event.data.size)) {
-            false
-        } else if (eventsWriter.writeData(batchFile, event, true)) {
+        val metadataFile = fileOrchestrator.getMetadataFile(batchFile)
+
+        return if (eventsWriter.writeBinaryData(batchFile, serializedEvent, true)) {
             batchWriteEventListener.onWriteEvent(event.data.size.toLong())
             if (batchMetadata?.isNotEmpty() == true && metadataFile != null) {
                 writeBatchMetadata(metadataFile, batchMetadata)

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/NoOpEventBatchWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/NoOpEventBatchWriter.kt
@@ -12,10 +12,6 @@ import com.datadog.android.api.storage.RawBatchEvent
 
 internal class NoOpEventBatchWriter : EventBatchWriter {
 
-    override fun currentMetadata(): ByteArray? {
-        return null
-    }
-
     override fun write(
         event: RawBatchEvent,
         batchMetadata: ByteArray?,

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileOrchestrator.kt
@@ -21,11 +21,14 @@ import java.io.File
 internal interface FileOrchestrator {
 
     /**
+     * @param eventSize the size (in bytes) of the event about to be written, used to decide
+     * whether an existing batch file has enough room to accommodate it without exceeding the
+     * maximum batch size.
      * @return a File with enough space to write data, or null if no space is available
      * or the disk can't be written to.
      */
     @WorkerThread
-    fun getWritableFile(): File?
+    fun getWritableFile(eventSize: Long): File?
 
     /**
      * @param excludeFiles a set of files to exclude from the readable files

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FilePersistenceConfig.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FilePersistenceConfig.kt
@@ -19,11 +19,11 @@ internal data class FilePersistenceConfig(
     val cleanupFrequencyThreshold: Long = CLEANUP_FREQUENCY_THRESHOLD_MS
 ) {
     companion object {
-        internal const val MAX_BATCH_SIZE: Long = 4L * 1024 * 1024 // 4 MB
-        internal const val MAX_ITEMS_PER_BATCH: Int = 500
-        internal const val MAX_ITEM_SIZE: Long = 512L * 1024 // 512 KB
+        internal const val MAX_BATCH_SIZE: Long = 5L * 1024 * 1024 // 5 MB
+        internal const val MAX_ITEMS_PER_BATCH: Int = 1000
+        internal const val MAX_ITEM_SIZE: Long = 1024L * 1024 // 1 MB
         internal const val OLD_FILE_THRESHOLD: Long = 18L * 60L * 60L * 1000L // 18 hours
-        internal const val MAX_DISK_SPACE: Long = 128 * MAX_BATCH_SIZE // 512 MB
+        internal const val MAX_DISK_SPACE: Long = 128 * MAX_BATCH_SIZE // 640 MB
         internal const val MAX_DELAY_BETWEEN_MESSAGES_MS = 5000L
         internal const val CLEANUP_FREQUENCY_THRESHOLD_MS = 5000L // 5s
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FilePersistenceConfig.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FilePersistenceConfig.kt
@@ -23,7 +23,7 @@ internal data class FilePersistenceConfig(
         internal const val MAX_ITEMS_PER_BATCH: Int = 1000
         internal const val MAX_ITEM_SIZE: Long = 1024L * 1024 // 1 MB
         internal const val OLD_FILE_THRESHOLD: Long = 18L * 60L * 60L * 1000L // 18 hours
-        internal const val MAX_DISK_SPACE: Long = 128 * MAX_BATCH_SIZE // 640 MB
+        internal const val MAX_DISK_SPACE: Long = 512L * 1024 * 1024 // 512 MB
         internal const val MAX_DELAY_BETWEEN_MESSAGES_MS = 5000L
         internal const val CLEANUP_FREQUENCY_THRESHOLD_MS = 5000L // 5s
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
@@ -39,8 +39,8 @@ internal open class ConsentAwareFileOrchestrator(
     // region FileOrchestrator
 
     @WorkerThread
-    override fun getWritableFile(): File? {
-        return delegateOrchestrator.getWritableFile()
+    override fun getWritableFile(eventSize: Long): File? {
+        return delegateOrchestrator.getWritableFile(eventSize)
     }
 
     @WorkerThread

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
@@ -237,7 +237,7 @@ internal class BatchFileOrchestrator(
         }
 
         val isRecentEnough = isFileRecent(lastFile, recentWriteDelayMs)
-        val hasRoomForMore = lastFile.lengthSafe(internalLogger) < config.maxBatchSize
+        val hasRoomForMore = lastFile.lengthSafe(internalLogger) < config.maxBatchSize - config.maxItemSize
         val hasSlotForMore = (lastKnownFileItemCount < config.maxItemsPerBatch)
 
         return if (isRecentEnough && hasRoomForMore && hasSlotForMore) {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
@@ -57,7 +57,7 @@ internal class BatchFileOrchestrator(
     // region FileOrchestrator
 
     @WorkerThread
-    override fun getWritableFile(): File? {
+    override fun getWritableFile(eventSize: Long): File? {
         if (!isRootDirValid()) {
             return null
         }
@@ -69,7 +69,7 @@ internal class BatchFileOrchestrator(
             lastCleanupTimestamp = timeProvider.getDeviceTimestampMillis()
         }
 
-        return getReusableWritableFile() ?: createNewFile()
+        return getReusableWritableFile(eventSize) ?: createNewFile()
     }
 
     @WorkerThread
@@ -221,7 +221,7 @@ internal class BatchFileOrchestrator(
     }
 
     @Suppress("ReturnCount")
-    private fun getReusableWritableFile(): File? {
+    private fun getReusableWritableFile(eventSize: Long): File? {
         val files = listBatchFiles()
         val lastFile = files.latestBatchFile ?: return null
 
@@ -237,7 +237,7 @@ internal class BatchFileOrchestrator(
         }
 
         val isRecentEnough = isFileRecent(lastFile, recentWriteDelayMs)
-        val hasRoomForMore = lastFile.lengthSafe(internalLogger) < config.maxBatchSize - config.maxItemSize
+        val hasRoomForMore = lastFile.lengthSafe(internalLogger) + eventSize <= config.maxBatchSize
         val hasSlotForMore = (lastKnownFileItemCount < config.maxItemsPerBatch)
 
         return if (isRecentEnough && hasRoomForMore && hasSlotForMore) {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileReaderWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileReaderWriter.kt
@@ -6,12 +6,34 @@
 
 package com.datadog.android.core.internal.persistence.file.batch
 
+import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.storage.RawBatchEvent
-import com.datadog.android.core.internal.persistence.file.FileWriter
 import com.datadog.android.security.Encryption
+import java.io.File
 
-internal interface BatchFileReaderWriter : FileWriter<RawBatchEvent>, BatchFileReader {
+internal interface BatchFileReaderWriter : BatchFileReader {
+
+    /**
+     * Serializes an event into the exact binary payload that would be written to disk (TLV-wrapped,
+     * and encrypted if encryption is configured). The size of the returned array is the exact number
+     * of bytes [writeBinaryData] would append for this event.
+     * @param data the event to serialize
+     * @return the on-disk binary representation of the event, or null if the event could not be
+     * serialized (e.g. encryption produced an empty result for non-empty data). Callers must skip
+     * the write when null is returned.
+     */
+    fun serializeToBytes(data: RawBatchEvent): ByteArray?
+
+    /**
+     * Writes a pre-serialized payload (as returned by [serializeToBytes]) to a file.
+     * @param file the file to write to
+     * @param bytes the pre-serialized payload to write
+     * @param append whether to append data at the end of the file or overwrite
+     * @return whether the write operation was successful
+     */
+    @WorkerThread
+    fun writeBinaryData(file: File, bytes: ByteArray, append: Boolean): Boolean
 
     companion object {
         /**

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/EncryptedBatchReaderWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/EncryptedBatchReaderWriter.kt
@@ -18,31 +18,28 @@ internal class EncryptedBatchReaderWriter(
     private val internalLogger: InternalLogger
 ) : BatchFileReaderWriter by delegate {
 
-    @WorkerThread
-    override fun writeData(
-        file: File,
-        data: RawBatchEvent,
-        append: Boolean
-    ): Boolean {
-        val encryptedRawBatchEvent = RawBatchEvent(
-            data = encryption.encrypt(data.data),
-            metadata = encryption.encrypt(data.metadata)
-        )
+    override fun serializeToBytes(data: RawBatchEvent): ByteArray? {
+        val encryptedData = encryption.encrypt(data.data)
 
-        if (data.data.isNotEmpty() && encryptedRawBatchEvent.data.isEmpty()) {
+        if (data.data.isNotEmpty() && encryptedData.isEmpty()) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
                 InternalLogger.Target.USER,
                 { BAD_ENCRYPTION_RESULT_MESSAGE }
             )
-            return false
+            return null
         }
 
-        return delegate.writeData(
-            file,
-            encryptedRawBatchEvent,
-            append
+        val encryptedRawBatchEvent = RawBatchEvent(
+            data = encryptedData,
+            metadata = encryption.encrypt(data.metadata)
         )
+        return delegate.serializeToBytes(encryptedRawBatchEvent)
+    }
+
+    @WorkerThread
+    override fun writeBinaryData(file: File, bytes: ByteArray, append: Boolean): Boolean {
+        return delegate.writeBinaryData(file, bytes, append)
     }
 
     @WorkerThread

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriter.kt
@@ -26,16 +26,31 @@ internal class PlainBatchFileReaderWriter(
     private val internalLogger: InternalLogger
 ) : BatchFileReaderWriter {
 
-    // region FileWriter
+    // region BatchFileReaderWriter
+
+    @Suppress("UnsafeThirdPartyFunctionCall")
+    override fun serializeToBytes(data: RawBatchEvent): ByteArray {
+        val meta = data.metadata
+        val metaBlockSize = TYPE_SIZE_BYTES + LENGTH_SIZE_BYTES + meta.size
+        val dataBlockSize = TYPE_SIZE_BYTES + LENGTH_SIZE_BYTES + data.data.size
+
+        // ByteBuffer by default has BigEndian ordering, which matches to how Java
+        // reads data, so no need to define it explicitly
+        return ByteBuffer
+            .allocate(metaBlockSize + dataBlockSize)
+            .putAsTlv(BlockType.META, meta)
+            .putAsTlv(BlockType.EVENT, data.data)
+            .array()
+    }
 
     @WorkerThread
-    override fun writeData(
+    override fun writeBinaryData(
         file: File,
-        data: RawBatchEvent,
+        bytes: ByteArray,
         append: Boolean
     ): Boolean {
         return try {
-            lockFileAndWriteData(file, append, data)
+            lockFileAndWriteData(file, append, bytes)
             true
         } catch (e: IOException) {
             internalLogger.log(
@@ -94,7 +109,7 @@ internal class PlainBatchFileReaderWriter(
     private fun lockFileAndWriteData(
         file: File,
         append: Boolean,
-        data: RawBatchEvent
+        bytes: ByteArray
     ) {
         RandomAccessFile(file, "rw").use { raf ->
             val channel = raf.channel
@@ -106,17 +121,7 @@ internal class PlainBatchFileReaderWriter(
                 channel.truncate(rollbackLength)
                 channel.position(rollbackLength)
 
-                val meta = data.metadata
-                val metaBlockSize = TYPE_SIZE_BYTES + LENGTH_SIZE_BYTES + meta.size
-                val dataBlockSize = TYPE_SIZE_BYTES + LENGTH_SIZE_BYTES + data.data.size
-
-                // ByteBuffer by default has BigEndian ordering, which matches to how Java
-                // reads data, so no need to define it explicitly
-                val buffer = ByteBuffer
-                    .allocate(metaBlockSize + dataBlockSize)
-                    .putAsTlv(BlockType.META, meta)
-                    .putAsTlv(BlockType.EVENT, data.data)
-                buffer.flip()
+                val buffer = ByteBuffer.wrap(bytes)
 
                 try {
                     while (buffer.hasRemaining()) {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleFileOrchestrator.kt
@@ -20,7 +20,7 @@ internal class SingleFileOrchestrator(
     // region FileOrchestrator
 
     @WorkerThread
-    override fun getWritableFile(): File? {
+    override fun getWritableFile(eventSize: Long): File? {
         file.parentFile?.mkdirsSafe(internalLogger)
         return file
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleItemDataWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleItemDataWriter.kt
@@ -54,7 +54,7 @@ internal open class SingleItemDataWriter<T : Any>(
     @WorkerThread
     private fun writeData(byteArray: ByteArray): Boolean {
         if (!checkEventSize(byteArray.size)) return false
-        val file = fileOrchestrator.getWritableFile() ?: return false
+        val file = fileOrchestrator.getWritableFile(byteArray.size.toLong()) ?: return false
         return fileWriter.writeData(file, byteArray, false)
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -1284,13 +1284,13 @@ internal class CoreFeatureTest {
         val legacyNdkViewEventFile = DatadogNdkCrashHandler.getLastViewEventFile(tempDir)
         legacyNdkViewEventFile.parentFile?.mkdirs()
 
-        BatchFileReaderWriter
-            .create(internalLogger = mock(), encryption = null)
-            .writeData(
-                legacyNdkViewEventFile,
-                RawBatchEvent(fakeViewEvent.toString().toByteArray()),
-                append = false
-            )
+        val fixtureWriter = BatchFileReaderWriter.create(internalLogger = mock(), encryption = null)
+        val fixtureEvent = RawBatchEvent(fakeViewEvent.toString().toByteArray())
+        fixtureWriter.writeBinaryData(
+            legacyNdkViewEventFile,
+            checkNotNull(fixtureWriter.serializeToBytes(fixtureEvent)),
+            append = false
+        )
 
         // When
         val lastViewEvent = testedFeature.lastViewEvent

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AbstractStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AbstractStorageTest.kt
@@ -164,59 +164,6 @@ internal class AbstractStorageTest {
     }
 
     @Test
-    fun `M provide writer W getEventWriteScope()+currentMetadata() {consent=granted, batchMetadata=null}`() {
-        // Given
-        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
-        whenever(mockGrantedPersistenceStrategy.currentMetadata()) doReturn null
-        val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
-        var resultMetadata: ByteArray? = null
-        whenever(mockWriteCallback.invoke(any())) doAnswer {
-            resultMetadata = it.getArgument<EventBatchWriter>(0).currentMetadata()
-        }
-
-        // When
-        testedStorage.getEventWriteScope(fakeDatadogContext)
-            .invoke(mockWriteCallback)
-
-        // Then
-        assertThat(resultMetadata).isNull()
-        verify(mockGrantedPersistenceStrategy).currentMetadata()
-        verifyNoMoreInteractions(
-            mockGrantedPersistenceStrategy,
-            mockPendingPersistenceStrategy,
-            mockInternalLogger
-        )
-    }
-
-    @Test
-    fun `M provide writer W getEventWriteScope()+currentMetadata() {consent=granted, batchMetadata!=null}`(
-        @StringForgery fakeBatchMetadata: String
-    ) {
-        // Given
-        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
-        val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
-        val batchMetadata = fakeBatchMetadata.toByteArray()
-        whenever(mockGrantedPersistenceStrategy.currentMetadata()) doReturn batchMetadata
-        var resultMetadata: ByteArray? = null
-        whenever(mockWriteCallback.invoke(any())) doAnswer {
-            resultMetadata = it.getArgument<EventBatchWriter>(0).currentMetadata()
-        }
-
-        // When
-        testedStorage.getEventWriteScope(fakeDatadogContext)
-            .invoke(mockWriteCallback)
-
-        // Then
-        assertThat(resultMetadata).isEqualTo(batchMetadata)
-        verify(mockGrantedPersistenceStrategy).currentMetadata()
-        verifyNoMoreInteractions(
-            mockGrantedPersistenceStrategy,
-            mockPendingPersistenceStrategy,
-            mockInternalLogger
-        )
-    }
-
-    @Test
     fun `M provide writer W getEventWriteScope()+write() {consent=pending, batchMetadata=null}`(
         @BoolForgery fakeResult: Boolean,
         @Forgery fakeBatchEvent: RawBatchEvent
@@ -275,59 +222,6 @@ internal class AbstractStorageTest {
     }
 
     @Test
-    fun `M provide writer W getEventWriteScope()+currentMetadata() {consent=pending, batchMetadata=null}`() {
-        // Given
-        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
-        val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
-        var resultMetadata: ByteArray? = null
-        whenever(mockWriteCallback.invoke(any())) doAnswer {
-            resultMetadata = it.getArgument<EventBatchWriter>(0).currentMetadata()
-        }
-        whenever(mockPendingPersistenceStrategy.currentMetadata()) doReturn null
-
-        // When
-        testedStorage.getEventWriteScope(fakeDatadogContext)
-            .invoke(mockWriteCallback)
-
-        // Then
-        assertThat(resultMetadata).isNull()
-        verify(mockPendingPersistenceStrategy).currentMetadata()
-        verifyNoMoreInteractions(
-            mockGrantedPersistenceStrategy,
-            mockPendingPersistenceStrategy,
-            mockInternalLogger
-        )
-    }
-
-    @Test
-    fun `M provide writer W getEventWriteScope()+currentMetadata() {consent=pending, batchMetadata!=null}`(
-        @StringForgery fakeBatchMetadata: String
-    ) {
-        // Given
-        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
-        val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
-        val batchMetadata = fakeBatchMetadata.toByteArray()
-        var resultMetadata: ByteArray? = null
-        whenever(mockWriteCallback.invoke(any())) doAnswer {
-            resultMetadata = it.getArgument<EventBatchWriter>(0).currentMetadata()
-        }
-        whenever(mockPendingPersistenceStrategy.currentMetadata()) doReturn batchMetadata
-
-        // When
-        testedStorage.getEventWriteScope(fakeDatadogContext)
-            .invoke(mockWriteCallback)
-
-        // Then
-        assertThat(resultMetadata).isEqualTo(batchMetadata)
-        verify(mockPendingPersistenceStrategy).currentMetadata()
-        verifyNoMoreInteractions(
-            mockGrantedPersistenceStrategy,
-            mockPendingPersistenceStrategy,
-            mockInternalLogger
-        )
-    }
-
-    @Test
     fun `M provide no-op writer W getEventWriteScope()+write() {consent=not_granted}`(
         @Forgery fakeBatchEvent: RawBatchEvent,
         @StringForgery fakeBatchMetadata: String
@@ -348,29 +242,6 @@ internal class AbstractStorageTest {
         // Then
         assertThat(result).isFalse()
         verifyNoInteractions(
-            mockGrantedPersistenceStrategy,
-            mockPendingPersistenceStrategy,
-            mockInternalLogger
-        )
-    }
-
-    @Test
-    fun `M provide no-op writer W getEventWriteScope()+currentMetadata() {consent=not_granted}`() {
-        // Given
-        fakeDatadogContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.NOT_GRANTED)
-        val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
-        var resultMetadata: ByteArray? = null
-        whenever(mockWriteCallback.invoke(any())) doAnswer {
-            resultMetadata = it.getArgument<EventBatchWriter>(0).currentMetadata()
-        }
-
-        // When
-        testedStorage.getEventWriteScope(fakeDatadogContext)
-            .invoke(mockWriteCallback)
-
-        // Then
-        assertThat(resultMetadata).isNull()
-        verifyNoMoreInteractions(
             mockGrantedPersistenceStrategy,
             mockPendingPersistenceStrategy,
             mockInternalLogger

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AsyncEventWriteScopeTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AsyncEventWriteScopeTest.kt
@@ -99,7 +99,7 @@ class AsyncEventWriteScopeTest {
         // if write operations are parallel, there is a chance that there will be a conflict
         // updating the meta (applying different updates to the same original state).
         val callback: (EventBatchWriter) -> Unit = {
-            val value = it.currentMetadata()?.first() ?: 0
+            val value = accumulator
             it.write(
                 event = RawBatchEvent(data = event),
                 batchMetadata = byteArrayOf((value + 1).toByte()),
@@ -107,7 +107,6 @@ class AsyncEventWriteScopeTest {
             )
         }
 
-        whenever(mockEventBatchWriter.currentMetadata()) doAnswer { byteArrayOf(accumulator) }
         whenever(
             mockEventBatchWriter.write(any(), any(), any())
         ) doAnswer {

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriterTest.kt
@@ -16,7 +16,7 @@ import com.datadog.android.core.internal.persistence.FileEventBatchWriter.Compan
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
-import com.datadog.android.core.internal.persistence.file.FileWriter
+import com.datadog.android.core.internal.persistence.file.batch.BatchFileReaderWriter
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.Forge
@@ -29,12 +29,13 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
-import org.junit.jupiter.api.io.TempDir
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
@@ -54,7 +55,7 @@ internal class FileEventBatchWriterTest {
     private lateinit var testedWriter: EventBatchWriter
 
     @Mock
-    lateinit var mockBatchWriter: FileWriter<RawBatchEvent>
+    lateinit var mockBatchWriter: BatchFileReaderWriter
 
     @Mock
     lateinit var mockMetaReaderWriter: FileReaderWriter
@@ -91,8 +92,9 @@ internal class FileEventBatchWriterTest {
             batchWriteEventListener = mockBatchWriteEventListener
         )
         whenever(mockFilePersistenceConfig.maxItemSize) doReturn Long.MAX_VALUE
-        whenever(mockFileOrchestrator.getWritableFile()) doReturn fakeBatchFile
+        whenever(mockFileOrchestrator.getWritableFile(any())) doReturn fakeBatchFile
         whenever(mockFileOrchestrator.getMetadataFile(fakeBatchFile)) doReturn fakeBatchMetadataFile
+        whenever(mockBatchWriter.serializeToBytes(any())) doAnswer { it.getArgument<RawBatchEvent>(0).data }
     }
 
     // region write
@@ -106,7 +108,7 @@ internal class FileEventBatchWriterTest {
         val serializedMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         whenever(mockMetaReaderWriter.readData(fakeBatchMetadataFile)) doReturn serializedMetadata
         whenever(
-            mockBatchWriter.writeData(fakeBatchFile, batchEvent, true)
+            mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true)
         ) doReturn true
 
         // When
@@ -115,9 +117,10 @@ internal class FileEventBatchWriterTest {
         // Then
         assertThat(result).isTrue()
 
-        verify(mockBatchWriter).writeData(
+        verify(mockBatchWriter).serializeToBytes(batchEvent)
+        verify(mockBatchWriter).writeBinaryData(
             fakeBatchFile,
-            batchEvent,
+            batchEvent.data,
             append = true
         )
         verify(mockMetaReaderWriter).writeData(
@@ -159,7 +162,7 @@ internal class FileEventBatchWriterTest {
     ) {
         // Given
         val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
-        whenever(mockFileOrchestrator.getWritableFile()) doReturn null
+        whenever(mockFileOrchestrator.getWritableFile(any())) doReturn null
 
         // When
         val result = testedWriter.write(batchEvent, serializedBatchMetadata, fakeEventType)
@@ -172,6 +175,24 @@ internal class FileEventBatchWriterTest {
             listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
             NO_BATCH_FILE_AVAILABLE
         )
+    }
+
+    @Test
+    fun `M return false W write() {serialization returns null}`(
+        @Forgery batchEvent: RawBatchEvent,
+        @StringForgery batchMetadata: String
+    ) {
+        // Given
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
+        whenever(mockBatchWriter.serializeToBytes(batchEvent)) doReturn null
+
+        // When
+        val result = testedWriter.write(batchEvent, serializedBatchMetadata, fakeEventType)
+
+        // Then
+        assertThat(result).isFalse
+        verify(mockFileOrchestrator, never()).getWritableFile(any())
+        verifyNoInteractions(mockMetaReaderWriter)
     }
 
     @Test
@@ -204,12 +225,11 @@ internal class FileEventBatchWriterTest {
     @Test
     fun `M return false W write() {write operation failed}`(
         @Forgery batchEvent: RawBatchEvent,
-        @StringForgery batchMetadata: String,
-        @Forgery batchFile: File
+        @StringForgery batchMetadata: String
     ) {
         // Given
         val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
-        whenever(mockBatchWriter.writeData(batchFile, batchEvent, true)) doReturn false
+        whenever(mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true)) doReturn false
 
         // When
         val result = testedWriter.write(batchEvent, serializedBatchMetadata, fakeEventType)
@@ -228,7 +248,7 @@ internal class FileEventBatchWriterTest {
 
         val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
 
-        whenever(mockBatchWriter.writeData(fakeBatchFile, batchEvent, true)) doReturn true
+        whenever(mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true)) doReturn true
 
         // When
         val result = testedWriter.write(batchEvent, serializedBatchMetadata, fakeEventType)
@@ -245,7 +265,7 @@ internal class FileEventBatchWriterTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockBatchWriter.writeData(fakeBatchFile, batchEvent, true)) doReturn true
+        whenever(mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true)) doReturn true
 
         // When
         val result = testedWriter.write(batchEvent, forge.aNullable { ByteArray(0) }, fakeEventType)
@@ -253,9 +273,10 @@ internal class FileEventBatchWriterTest {
         // Then
         assertThat(result).isTrue
 
-        verify(mockBatchWriter).writeData(
+        verify(mockBatchWriter).serializeToBytes(batchEvent)
+        verify(mockBatchWriter).writeBinaryData(
             fakeBatchFile,
-            batchEvent,
+            batchEvent.data,
             true
         )
         verifyNoMoreInteractions(mockBatchWriter)
@@ -289,7 +310,7 @@ internal class FileEventBatchWriterTest {
         // Given
         val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         whenever(
-            mockBatchWriter.writeData(fakeBatchFile, batchEvent, true)
+            mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true)
         ) doReturn false
 
         // When
@@ -309,7 +330,7 @@ internal class FileEventBatchWriterTest {
         // Given
         val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         whenever(
-            mockBatchWriter.writeData(fakeBatchFile, batchEvent, true)
+            mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true)
         ) doReturn true
         whenever(
             mockMetaReaderWriter.writeData(fakeBatchMetadataFile, serializedBatchMetadata, false)
@@ -333,61 +354,6 @@ internal class FileEventBatchWriterTest {
 
     // endregion
 
-    // region currentMetadata
-
-    @Test
-    fun `M not read metadata W currentMetadata() {no available file}`() {
-        // Given
-        whenever(mockFileOrchestrator.getMetadataFile(fakeBatchFile)) doReturn null
-
-        // When
-        val meta = testedWriter.currentMetadata()
-
-        // Then
-        assertThat(meta).isNull()
-        verifyNoInteractions(mockMetaReaderWriter)
-    }
-
-    @Test
-    fun `M not read metadata W currentMetadata() { file doesn't exist }`() {
-        // Given
-        val fakeNonExistentMetaFile = mock<File>().apply {
-            whenever(exists()) doReturn false
-        }
-
-        whenever(mockFileOrchestrator.getMetadataFile(fakeBatchFile)) doReturn fakeNonExistentMetaFile
-
-        // When
-        val meta = testedWriter.currentMetadata()
-
-        // Then
-        assertThat(meta).isNull()
-        verifyNoInteractions(mockMetaReaderWriter)
-    }
-
-    @Test
-    fun `M read metadata W currentMetadata()`(
-        @StringForgery fakeMetadata: String,
-        @TempDir fakeMetadataDir: File,
-        forge: Forge
-    ) {
-        // Given
-        val fakeMetaFile = File(fakeMetadataDir, forge.anAlphabeticalString())
-        fakeMetaFile.createNewFile()
-
-        whenever(mockFileOrchestrator.getMetadataFile(fakeBatchFile)) doReturn fakeMetaFile
-        whenever(mockMetaReaderWriter.readData(fakeMetaFile)) doReturn
-            fakeMetadata.toByteArray()
-
-        // When
-        val meta = testedWriter.currentMetadata()
-
-        // Then
-        assertThat(meta).isEqualTo(fakeMetadata.toByteArray())
-    }
-
-    // endregion
-
     // region benchmark
 
     @Test
@@ -398,7 +364,7 @@ internal class FileEventBatchWriterTest {
         // Given
         val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         whenever(
-            mockBatchWriter.writeData(fakeBatchFile, batchEvent, true)
+            mockBatchWriter.writeBinaryData(fakeBatchFile, batchEvent.data, true)
         ) doReturn true
         whenever(
             mockMetaReaderWriter.writeData(fakeBatchMetadataFile, serializedBatchMetadata, false)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/NoOpEventBatchWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/NoOpEventBatchWriterTest.kt
@@ -41,11 +41,6 @@ internal class NoOpEventBatchWriterTest {
     }
 
     @Test
-    fun `M return no metadata W currentMetadata()`() {
-        assertThat(testedWriter.currentMetadata()).isNull()
-    }
-
-    @Test
     fun `M notify about successful write W write()`(
         @Forgery fakeData: RawBatchEvent,
         @StringForgery fakeMetadata: String,

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestratorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestratorTest.kt
@@ -14,6 +14,7 @@ import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -148,13 +149,14 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `M return pending writable file W getWritableFile() {consent=PENDING}`(
-        @Forgery file: File
+        @Forgery file: File,
+        @LongForgery(min = 0L) fakeEventSize: Long
     ) {
         // Given
-        whenever(mockPendingOrchestrator.getWritableFile()) doReturn file
+        whenever(mockPendingOrchestrator.getWritableFile(fakeEventSize)) doReturn file
 
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(fakeEventSize)
 
         // Then
         assertThat(result).isSameAs(file)
@@ -163,17 +165,18 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `M return pending writable file W getWritableFile() {consent=GRANTED then PENDING}`(
-        @Forgery file: File
+        @Forgery file: File,
+        @LongForgery(min = 0L) fakeEventSize: Long
     ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.GRANTED)
         runPendingRunnable()
-        whenever(mockPendingOrchestrator.getWritableFile()) doReturn file
+        whenever(mockPendingOrchestrator.getWritableFile(fakeEventSize)) doReturn file
 
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.GRANTED, TrackingConsent.PENDING)
         runPendingRunnable()
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(fakeEventSize)
 
         // Then
         assertThat(result).isSameAs(file)
@@ -182,17 +185,18 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `M return pending writable file W getWritableFile() {consent=NOT_GRANTED then PENDING}`(
-        @Forgery file: File
+        @Forgery file: File,
+        @LongForgery(min = 0L) fakeEventSize: Long
     ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.NOT_GRANTED)
         runPendingRunnable()
-        whenever(mockPendingOrchestrator.getWritableFile()) doReturn file
+        whenever(mockPendingOrchestrator.getWritableFile(fakeEventSize)) doReturn file
 
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.NOT_GRANTED, TrackingConsent.PENDING)
         runPendingRunnable()
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(fakeEventSize)
 
         // Then
         assertThat(result).isSameAs(file)
@@ -201,15 +205,16 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `M return granted writable file W getWritableFile() {consent=GRANTED}`(
-        @Forgery file: File
+        @Forgery file: File,
+        @LongForgery(min = 0L) fakeEventSize: Long
     ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.GRANTED)
         runPendingRunnable()
-        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
+        whenever(mockGrantedOrchestrator.getWritableFile(fakeEventSize)) doReturn file
 
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(fakeEventSize)
 
         // Then
         assertThat(result).isSameAs(file)
@@ -218,17 +223,18 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `M return granted writable file W getWritableFile() {consent=NOT_GRANTED then GRANTED}`(
-        @Forgery file: File
+        @Forgery file: File,
+        @LongForgery(min = 0L) fakeEventSize: Long
     ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.NOT_GRANTED)
         runPendingRunnable()
-        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
+        whenever(mockGrantedOrchestrator.getWritableFile(fakeEventSize)) doReturn file
 
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.NOT_GRANTED, TrackingConsent.GRANTED)
         runPendingRunnable()
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(fakeEventSize)
 
         // Then
         assertThat(result).isSameAs(file)
@@ -237,17 +243,18 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `M return granted writable file W getWritableFile() {consent=PENDING then GRANTED}`(
-        @Forgery file: File
+        @Forgery file: File,
+        @LongForgery(min = 0L) fakeEventSize: Long
     ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.PENDING)
         runPendingRunnable()
-        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
+        whenever(mockGrantedOrchestrator.getWritableFile(fakeEventSize)) doReturn file
 
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.PENDING, TrackingConsent.GRANTED)
         runPendingRunnable()
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(fakeEventSize)
 
         // Then
         assertThat(result).isSameAs(file)
@@ -255,13 +262,15 @@ internal class ConsentAwareFileOrchestratorTest {
     }
 
     @Test
-    fun `M return null file W getWritableFile() {consent=NOT_GRANTED}`() {
+    fun `M return null file W getWritableFile() {consent=NOT_GRANTED}`(
+        @LongForgery(min = 0L) fakeEventSize: Long
+    ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.NOT_GRANTED)
         runPendingRunnable()
 
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(fakeEventSize)
 
         // Then
         assertThat(result).isNull()
@@ -269,7 +278,9 @@ internal class ConsentAwareFileOrchestratorTest {
     }
 
     @Test
-    fun `M return null file W getWritableFile() {consent=GRANTED then NOT_GRANTED}`() {
+    fun `M return null file W getWritableFile() {consent=GRANTED then NOT_GRANTED}`(
+        @LongForgery(min = 0L) fakeEventSize: Long
+    ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.GRANTED)
         runPendingRunnable()
@@ -277,7 +288,7 @@ internal class ConsentAwareFileOrchestratorTest {
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.GRANTED, TrackingConsent.NOT_GRANTED)
         runPendingRunnable()
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(fakeEventSize)
 
         // Then
         assertThat(result).isNull()
@@ -285,7 +296,9 @@ internal class ConsentAwareFileOrchestratorTest {
     }
 
     @Test
-    fun `M return null file W getWritableFile() {consent=PENDING then NOT_GRANTED}`() {
+    fun `M return null file W getWritableFile() {consent=PENDING then NOT_GRANTED}`(
+        @LongForgery(min = 0L) fakeEventSize: Long
+    ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.PENDING)
         runPendingRunnable()
@@ -293,7 +306,7 @@ internal class ConsentAwareFileOrchestratorTest {
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.PENDING, TrackingConsent.NOT_GRANTED)
         runPendingRunnable()
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(fakeEventSize)
 
         // Then
         assertThat(result).isNull()

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/SingleFileOrchestratorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/SingleFileOrchestratorTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.core.internal.persistence.file.advanced
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.persistence.file.single.SingleFileOrchestrator
 import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -57,18 +58,22 @@ internal class SingleFileOrchestratorTest {
     // region getWritableFile
 
     @Test
-    fun `M create parent dir W getWritableFile()`() {
+    fun `M create parent dir W getWritableFile()`(
+        @LongForgery(min = 0L) fakeEventSize: Long
+    ) {
         // When
-        testedOrchestrator.getWritableFile()
+        testedOrchestrator.getWritableFile(fakeEventSize)
 
         // Then
         assertThat(fakeFile.parentFile).exists()
     }
 
     @Test
-    fun `M return file W getWritableFile()`() {
+    fun `M return file W getWritableFile()`(
+        @LongForgery(min = 0L) fakeEventSize: Long
+    ) {
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(fakeEventSize)
 
         // Then
         assertThat(result).isSameAs(fakeFile)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestratorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestratorTest.kt
@@ -107,7 +107,7 @@ internal class BatchFileOrchestratorTest {
         assumeTrue(fakeRootDir.listFiles().isNullOrEmpty())
 
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(1L)
 
         // Then
         checkNotNull(result)
@@ -118,11 +118,11 @@ internal class BatchFileOrchestratorTest {
     fun `M send batch_closed metric W getWritableFile()`() {
         // Given
         val fileCreationTimestamp = stubTimeProvider.deviceTimestampMs
-        val oldFile = testedOrchestrator.getWritableFile()
+        val oldFile = testedOrchestrator.getWritableFile(1L)
         stubTimeProvider.deviceTimestampMs += RECENT_DELAY_MS + 1
 
         // When
-        testedOrchestrator.getWritableFile()
+        testedOrchestrator.getWritableFile(1L)
 
         // Then
         val fileArgumentCaptor = argumentCaptor<File>()
@@ -156,7 +156,7 @@ internal class BatchFileOrchestratorTest {
         )
 
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(1L)
 
         // Then
         assertThat(result).isNull()
@@ -184,7 +184,7 @@ internal class BatchFileOrchestratorTest {
         )
 
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(1L)
 
         // Then
         assertThat(result).isNull()
@@ -213,7 +213,7 @@ internal class BatchFileOrchestratorTest {
         )
 
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(1L)
 
         // Then
         assertThat(result).isNull()
@@ -231,7 +231,7 @@ internal class BatchFileOrchestratorTest {
         fakeRootDir.deleteRecursively()
 
         // When
-        testedOrchestrator.getWritableFile()
+        testedOrchestrator.getWritableFile(1L)
 
         // Then
         assertThat(fakeRootDir).exists().isDirectory()
@@ -255,7 +255,7 @@ internal class BatchFileOrchestratorTest {
         youngFile.createNewFile()
 
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(1L)
 
         // Then
         checkNotNull(result)
@@ -291,12 +291,12 @@ internal class BatchFileOrchestratorTest {
         youngFile.createNewFile()
 
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(1L)
         // let's add very old file after the previous cleanup call. If threshold is respected,
         // cleanup shouldn't be performed during the next getWritableFile call
         val evenOlderFile = File(fakeRootDir, (oldTimestamp - 1).toString())
         evenOlderFile.createNewFile()
-        testedOrchestrator.getWritableFile()
+        testedOrchestrator.getWritableFile(1L)
 
         // Then
         checkNotNull(result)
@@ -329,11 +329,11 @@ internal class BatchFileOrchestratorTest {
         oldFileMeta.createNewFile()
 
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(1L)
         stubTimeProvider.deviceTimestampMs += CLEANUP_FREQUENCY_THRESHOLD_MS + 1
         val evenOlderFile = File(fakeRootDir, (oldTimestamp - 1).toString())
         evenOlderFile.createNewFile()
-        testedOrchestrator.getWritableFile()
+        testedOrchestrator.getWritableFile(1L)
 
         // Then
         checkNotNull(result)
@@ -372,7 +372,7 @@ internal class BatchFileOrchestratorTest {
         val currentTime = stubTimeProvider.deviceTimestampMs
 
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(1L)
 
         // Then
         checkNotNull(result)
@@ -389,13 +389,13 @@ internal class BatchFileOrchestratorTest {
     ) {
         // Given
         assumeTrue(fakeRootDir.listFiles().isNullOrEmpty())
-        val previousFile = testedOrchestrator.getWritableFile()
+        val previousFile = testedOrchestrator.getWritableFile(1L)
         checkNotNull(previousFile)
         previousFile.writeText(previousData)
         stubTimeProvider.deviceTimestampMs += 1
 
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(1L)
 
         // Then
         checkNotNull(result)
@@ -411,7 +411,7 @@ internal class BatchFileOrchestratorTest {
         // Given
         assumeTrue(fakeRootDir.listFiles().isNullOrEmpty())
         val fileCreateTimestamp = stubTimeProvider.deviceTimestampMs
-        val previousFile = testedOrchestrator.getWritableFile()
+        val previousFile = testedOrchestrator.getWritableFile(1L)
 
         checkNotNull(previousFile)
         previousFile.writeText(previousData)
@@ -419,7 +419,7 @@ internal class BatchFileOrchestratorTest {
         val newFileTimestamp = stubTimeProvider.deviceTimestampMs
 
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(1L)
 
         // Then
         checkNotNull(result)
@@ -449,7 +449,7 @@ internal class BatchFileOrchestratorTest {
         val newFileTimestamp = stubTimeProvider.deviceTimestampMs
 
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(1L)
 
         // Then
         checkNotNull(result)
@@ -466,7 +466,7 @@ internal class BatchFileOrchestratorTest {
         // Given
         assumeTrue(fakeRootDir.listFiles().isNullOrEmpty())
         val fileCreateTimestamp = stubTimeProvider.deviceTimestampMs
-        val previousFile = testedOrchestrator.getWritableFile()
+        val previousFile = testedOrchestrator.getWritableFile(1L)
         checkNotNull(previousFile)
         previousFile.createNewFile()
         previousFile.delete()
@@ -474,7 +474,7 @@ internal class BatchFileOrchestratorTest {
         val newFileTimestamp = stubTimeProvider.deviceTimestampMs
 
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(1L)
 
         // Then
         checkNotNull(result)
@@ -498,14 +498,14 @@ internal class BatchFileOrchestratorTest {
         // Given
         assumeTrue(fakeRootDir.listFiles().isNullOrEmpty())
         val fileCreateTimestamp = stubTimeProvider.deviceTimestampMs
-        val previousFile = testedOrchestrator.getWritableFile()
+        val previousFile = testedOrchestrator.getWritableFile(1L)
         checkNotNull(previousFile)
         previousFile.writeText(previousData)
         stubTimeProvider.deviceTimestampMs += 1
         val newFileTimestamp = stubTimeProvider.deviceTimestampMs
 
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(1L)
 
         // Then
         checkNotNull(result)
@@ -523,20 +523,21 @@ internal class BatchFileOrchestratorTest {
     }
 
     @Test
-    fun `M return new File W getWritableFile() {previous file leaves no room for a max-size item}`(
-        @StringForgery(size = MAX_BATCH_SIZE - MAX_ITEM_SIZE) previousData: String
+    fun `M return new File W getWritableFile() {previous file has no room for the event}`(
+        // one byte too much to fit a max-size event without exceeding maxBatchSize
+        @StringForgery(size = MAX_BATCH_SIZE - MAX_ITEM_SIZE + 1) previousData: String
     ) {
         // Given
         assumeTrue(fakeRootDir.listFiles().isNullOrEmpty())
         val fileCreateTimestamp = stubTimeProvider.deviceTimestampMs
-        val previousFile = testedOrchestrator.getWritableFile()
+        val previousFile = testedOrchestrator.getWritableFile(1L)
         checkNotNull(previousFile)
         previousFile.writeText(previousData)
         stubTimeProvider.deviceTimestampMs += 1
         val newFileTimestamp = stubTimeProvider.deviceTimestampMs
 
         // When
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(MAX_ITEM_SIZE.toLong())
 
         // Then
         checkNotNull(result)
@@ -551,6 +552,28 @@ internal class BatchFileOrchestratorTest {
             assertThat(firstValue.eventsCount).isEqualTo(1L)
         }
         verifyNoMoreInteractions(mockMetricsDispatcher)
+    }
+
+    @Test
+    fun `M return existing File W getWritableFile() {previous file has exact room for the event}`(
+        // leaves room for exactly one max-size event before reaching maxBatchSize
+        @StringForgery(size = MAX_BATCH_SIZE - MAX_ITEM_SIZE) previousData: String
+    ) {
+        // Given
+        assumeTrue(fakeRootDir.listFiles().isNullOrEmpty())
+        val previousFile = testedOrchestrator.getWritableFile(1L)
+        checkNotNull(previousFile)
+        previousFile.writeText(previousData)
+        stubTimeProvider.deviceTimestampMs += 1
+
+        // When
+        val result = testedOrchestrator.getWritableFile(MAX_ITEM_SIZE.toLong())
+
+        // Then
+        checkNotNull(result)
+        assertThat(result).isEqualTo(previousFile)
+        assertThat(previousFile.readText()).isEqualTo(previousData)
+        verifyNoInteractions(mockMetricsDispatcher)
     }
 
     @Test
@@ -560,7 +583,7 @@ internal class BatchFileOrchestratorTest {
         // Given
         assumeTrue(fakeRootDir.listFiles().isNullOrEmpty())
         val fileCreateTimestamp = stubTimeProvider.deviceTimestampMs
-        var previousFile = testedOrchestrator.getWritableFile()
+        var previousFile = testedOrchestrator.getWritableFile(1L)
 
         repeat(4) {
             checkNotNull(previousFile)
@@ -572,7 +595,7 @@ internal class BatchFileOrchestratorTest {
             previousFile?.writeText(previousData[0])
 
             for (i in 1 until MAX_ITEM_PER_BATCH) {
-                val file = testedOrchestrator.getWritableFile()
+                val file = testedOrchestrator.getWritableFile(1L)
                 assumeTrue(file == previousFile)
                 file?.appendText(previousData[i])
             }
@@ -581,7 +604,7 @@ internal class BatchFileOrchestratorTest {
             // When
             stubTimeProvider.deviceTimestampMs += 1
             val newFileTimestamp = stubTimeProvider.deviceTimestampMs
-            val nextFile = testedOrchestrator.getWritableFile()
+            val nextFile = testedOrchestrator.getWritableFile(1L)
 
             // Then
             checkNotNull(nextFile)
@@ -611,7 +634,7 @@ internal class BatchFileOrchestratorTest {
         assumeTrue(fakeRootDir.listFiles().isNullOrEmpty())
         val filesCount = MAX_DISK_SPACE / MAX_BATCH_SIZE
         val files = (0..filesCount).map {
-            val file = testedOrchestrator.getWritableFile()
+            val file = testedOrchestrator.getWritableFile(1L)
             checkNotNull(file)
             file.writeText(previousData)
             stubTimeProvider.deviceTimestampMs += 1
@@ -621,7 +644,7 @@ internal class BatchFileOrchestratorTest {
         // When
         stubTimeProvider.deviceTimestampMs += CLEANUP_FREQUENCY_THRESHOLD_MS + 1
         val newFileTimestamp = stubTimeProvider.deviceTimestampMs
-        val result = testedOrchestrator.getWritableFile()
+        val result = testedOrchestrator.getWritableFile(1L)
 
         // Then
         checkNotNull(result)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestratorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestratorTest.kt
@@ -523,6 +523,37 @@ internal class BatchFileOrchestratorTest {
     }
 
     @Test
+    fun `M return new File W getWritableFile() {previous file leaves no room for a max-size item}`(
+        @StringForgery(size = MAX_BATCH_SIZE - MAX_ITEM_SIZE) previousData: String
+    ) {
+        // Given
+        assumeTrue(fakeRootDir.listFiles().isNullOrEmpty())
+        val fileCreateTimestamp = stubTimeProvider.deviceTimestampMs
+        val previousFile = testedOrchestrator.getWritableFile()
+        checkNotNull(previousFile)
+        previousFile.writeText(previousData)
+        stubTimeProvider.deviceTimestampMs += 1
+        val newFileTimestamp = stubTimeProvider.deviceTimestampMs
+
+        // When
+        val result = testedOrchestrator.getWritableFile()
+
+        // Then
+        checkNotNull(result)
+        assertThat(result)
+            .doesNotExist()
+            .hasParent(fakeRootDir)
+        assertThat(result.name.toLong()).isEqualTo(newFileTimestamp)
+        assertThat(previousFile.readText()).isEqualTo(previousData)
+        argumentCaptor<BatchClosedMetadata> {
+            verify(mockMetricsDispatcher).sendBatchClosedMetric(eq(previousFile), capture())
+            assertThat(firstValue.lastTimeWasUsedInMs).isEqualTo(fileCreateTimestamp)
+            assertThat(firstValue.eventsCount).isEqualTo(1L)
+        }
+        verifyNoMoreInteractions(mockMetricsDispatcher)
+    }
+
+    @Test
     fun `M return new File W getWritableFile() {previous file has too many items}`(
         forge: Forge
     ) {

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/EncryptedBatchReaderWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/EncryptedBatchReaderWriterTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -27,6 +28,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
@@ -59,7 +61,7 @@ internal class EncryptedBatchReaderWriterTest {
 
     @BeforeEach
     fun setUp() {
-        whenever(mockBatchFileReaderWriter.writeData(any(), any(), any())) doReturn true
+        whenever(mockBatchFileReaderWriter.writeBinaryData(any(), any(), any())) doReturn true
 
         whenever(mockEncryption.encrypt(any())) doAnswer {
             val bytes = it.getArgument<ByteArray>(0)
@@ -78,58 +80,71 @@ internal class EncryptedBatchReaderWriterTest {
             )
     }
 
-    // region BatchFileReaderWriter#writeData tests
+    // region BatchFileReaderWriter#serializeToBytes tests
 
     @Test
-    fun `M encrypt data and return true W writeData()`(
+    fun `M encrypt data and delegate W serializeToBytes()`(
         @Forgery batchEvent: RawBatchEvent,
-        @BoolForgery append: Boolean
+        @StringForgery fakeSerialized: String
     ) {
-        // When
-        val result = testedReaderWriter.writeData(
-            mockFile,
-            batchEvent,
-            append = append
-        )
+        // Given
+        val serializedBytes = fakeSerialized.toByteArray()
         val encryptedData = encrypt(batchEvent.data)
         val encryptedMetadata = encrypt(batchEvent.metadata)
+        whenever(mockBatchFileReaderWriter.serializeToBytes(any())) doReturn serializedBytes
+
+        // When
+        val result = testedReaderWriter.serializeToBytes(batchEvent)
 
         // Then
-        assertThat(result).isTrue()
-        verify(mockBatchFileReaderWriter)
-            .writeData(
-                mockFile,
-                RawBatchEvent(data = encryptedData, metadata = encryptedMetadata),
-                append
-            )
-
-        verifyNoInteractions(mockInternalLogger)
+        assertThat(result).isEqualTo(serializedBytes)
+        verify(mockBatchFileReaderWriter).serializeToBytes(
+            RawBatchEvent(data = encryptedData, metadata = encryptedMetadata)
+        )
     }
 
     @Test
-    fun `M log internal error and return false W writeData() { bad encryption result }`(
-        @Forgery batchEvent: RawBatchEvent,
-        @BoolForgery append: Boolean
+    fun `M log error and return null W serializeToBytes() { bad encryption result }`(
+        @Forgery batchEvent: RawBatchEvent
     ) {
         // Given
-        whenever(mockEncryption.encrypt(batchEvent.data)) doReturn ByteArray(0)
+        // non-empty event data whose encryption yields an empty result
+        val nonEmptyEvent = batchEvent.copy(data = ByteArray(4) { 1 })
+        whenever(mockEncryption.encrypt(nonEmptyEvent.data)) doReturn ByteArray(0)
 
         // When
-        val result = testedReaderWriter.writeData(
-            mockFile,
-            batchEvent,
-            append = append
-        )
+        val result = testedReaderWriter.serializeToBytes(nonEmptyEvent)
 
         // Then
-        assertThat(result).isFalse()
+        assertThat(result).isNull()
         mockInternalLogger.verifyLog(
             InternalLogger.Level.ERROR,
             InternalLogger.Target.USER,
             EncryptedBatchReaderWriter.BAD_ENCRYPTION_RESULT_MESSAGE
         )
         verifyNoMoreInteractions(mockInternalLogger)
-        verifyNoInteractions(mockBatchFileReaderWriter)
+        verify(mockBatchFileReaderWriter, never()).serializeToBytes(any())
+    }
+
+    // endregion
+
+    // region BatchFileReaderWriter#writeBinaryData tests
+
+    @Test
+    fun `M delegate without re-encrypting W writeBinaryData()`(
+        @StringForgery fakeContent: String,
+        @BoolForgery append: Boolean
+    ) {
+        // Given
+        val bytes = fakeContent.toByteArray()
+        whenever(mockBatchFileReaderWriter.writeBinaryData(mockFile, bytes, append)) doReturn true
+
+        // When
+        val result = testedReaderWriter.writeBinaryData(mockFile, bytes, append)
+
+        // Then
+        assertThat(result).isTrue()
+        verify(mockBatchFileReaderWriter).writeBinaryData(mockFile, bytes, append)
     }
 
     // endregion
@@ -154,34 +169,45 @@ internal class EncryptedBatchReaderWriterTest {
 
     // endregion
 
-    // region writeData + readData
+    // region serializeToBytes + writeBinaryData + readData
 
     @Test
-    fun `M return valid data W writeData() + readData()`(
+    fun `M return valid data W serializeToBytes() + writeBinaryData() + readData()`(
         @Forgery events: List<RawBatchEvent>
     ) {
         // Given
+        // serializeToBytes returns encryptedEvent.data as placeholder bytes; we map that ByteArray
+        // reference to the full encrypted event so writeBinaryData can store it, and readData
+        // returns the stored encrypted events for EncryptedBatchReaderWriter to decrypt.
+        val encryptedEventByBytes = mutableMapOf<ByteArray, RawBatchEvent>()
         val storage = mutableListOf<RawBatchEvent>()
 
         whenever(
-            mockBatchFileReaderWriter.writeData(
-                eq(mockFile),
-                any(),
-                eq(true)
-            )
+            mockBatchFileReaderWriter.serializeToBytes(any())
         ) doAnswer {
-            storage.add(it.getArgument(1))
+            val encryptedEvent = it.getArgument<RawBatchEvent>(0)
+            val bytes = encryptedEvent.data
+            encryptedEventByBytes[bytes] = encryptedEvent
+            bytes
+        }
+
+        whenever(
+            mockBatchFileReaderWriter.writeBinaryData(eq(mockFile), any(), eq(true))
+        ) doAnswer {
+            val bytes = it.getArgument<ByteArray>(1)
+            encryptedEventByBytes[bytes]?.also { event -> storage.add(event) }
             true
         }
 
         whenever(
             mockBatchFileReaderWriter.readData(mockFile)
-        ) doAnswer { storage }
+        ) doAnswer { storage.toList() }
 
         // When
         var writeResult = true
         events.forEach {
-            writeResult = writeResult && testedReaderWriter.writeData(mockFile, it, true)
+            val bytes = checkNotNull(testedReaderWriter.serializeToBytes(it))
+            writeResult = writeResult && testedReaderWriter.writeBinaryData(mockFile, bytes, true)
         }
         val readResult = testedReaderWriter.readData(mockFile)
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriterTest.kt
@@ -77,10 +77,10 @@ internal class PlainBatchFileReaderWriterTest {
         testedReaderWriter = PlainBatchFileReaderWriter(mockInternalLogger)
     }
 
-    // region writeData
+    // region writeBinaryData
 
     @Test
-    fun `M write data in empty file W writeData() {append=false}`(
+    fun `M write bytes in empty file W writeBinaryData() {append=false}`(
         @StringForgery fileName: String,
         @Forgery event: RawBatchEvent
     ) {
@@ -89,9 +89,9 @@ internal class PlainBatchFileReaderWriterTest {
         file.createNewFile()
 
         // When
-        val result = testedReaderWriter.writeData(
+        val result = testedReaderWriter.writeBinaryData(
             file,
-            event,
+            encode(event),
             append = false
         )
 
@@ -101,28 +101,7 @@ internal class PlainBatchFileReaderWriterTest {
     }
 
     @Test
-    fun `M write data in empty file  W writeData() {append=true}`(
-        @StringForgery fileName: String,
-        @Forgery event: RawBatchEvent
-    ) {
-        // Given
-        val file = File(fakeRootDirectory, fileName)
-        file.createNewFile()
-
-        // When
-        val result = testedReaderWriter.writeData(
-            file,
-            event,
-            append = false
-        )
-
-        // Then
-        assertThat(result).isTrue()
-        assertThat(file).exists().hasBinaryContent(encode(event))
-    }
-
-    @Test
-    fun `M overwrite data in non empty file W writeData() {append=false}`(
+    fun `M overwrite bytes in non empty file W writeBinaryData() {append=false}`(
         @StringForgery fileName: String,
         @StringForgery previousContent: String,
         @Forgery event: RawBatchEvent
@@ -132,9 +111,9 @@ internal class PlainBatchFileReaderWriterTest {
         file.writeText(previousContent)
 
         // When
-        val result = testedReaderWriter.writeData(
+        val result = testedReaderWriter.writeBinaryData(
             file,
-            event,
+            encode(event),
             append = false
         )
 
@@ -144,7 +123,7 @@ internal class PlainBatchFileReaderWriterTest {
     }
 
     @Test
-    fun `M append data in non empty file W writeData() {append=true}`(
+    fun `M append bytes in non empty file W writeBinaryData() {append=true}`(
         @StringForgery fileName: String,
         @Forgery previousEvent: RawBatchEvent,
         @Forgery event: RawBatchEvent
@@ -154,9 +133,9 @@ internal class PlainBatchFileReaderWriterTest {
         file.writeBytes(encode(previousEvent))
 
         // When
-        val result = testedReaderWriter.writeData(
+        val result = testedReaderWriter.writeBinaryData(
             file,
-            event,
+            encode(event),
             append = true
         )
 
@@ -169,7 +148,7 @@ internal class PlainBatchFileReaderWriterTest {
     }
 
     @Test
-    fun `M return false and warn W writeData() {parent dir does not exist}`(
+    fun `M return false and warn W writeBinaryData() {parent dir does not exist}`(
         @StringForgery fileName: String,
         @Forgery event: RawBatchEvent,
         @BoolForgery append: Boolean
@@ -179,9 +158,9 @@ internal class PlainBatchFileReaderWriterTest {
         val file = File(fakeSrcDir, fileName)
 
         // When
-        val result = testedReaderWriter.writeData(
+        val result = testedReaderWriter.writeBinaryData(
             file,
-            event,
+            encode(event),
             append = append
         )
 
@@ -197,7 +176,7 @@ internal class PlainBatchFileReaderWriterTest {
     }
 
     @Test
-    fun `M return false and warn W writeData() {file is not file}`(
+    fun `M return false and warn W writeBinaryData() {file is not file}`(
         @StringForgery fileName: String,
         @Forgery event: RawBatchEvent,
         @BoolForgery append: Boolean
@@ -207,9 +186,9 @@ internal class PlainBatchFileReaderWriterTest {
         file.mkdirs()
 
         // When
-        val result = testedReaderWriter.writeData(
+        val result = testedReaderWriter.writeBinaryData(
             file,
-            event,
+            encode(event),
             append = append
         )
 
@@ -224,7 +203,7 @@ internal class PlainBatchFileReaderWriterTest {
     }
 
     @Test
-    fun `M roll back partial write W writeData() {channel write throws IOException}`(
+    fun `M roll back partial write W writeBinaryData() {channel write throws IOException}`(
         @StringForgery fileName: String,
         @Forgery event: RawBatchEvent,
         @BoolForgery append: Boolean,
@@ -244,9 +223,9 @@ internal class PlainBatchFileReaderWriterTest {
             whenever(mock.channel) doReturn mockChannel
         }.use {
             // When
-            val result = testedReaderWriter.writeData(
+            val result = testedReaderWriter.writeBinaryData(
                 file,
-                event,
+                encode(event),
                 append = append
             )
 
@@ -261,6 +240,21 @@ internal class PlainBatchFileReaderWriterTest {
                 IOException::class.java
             )
         }
+    }
+
+    // endregion
+
+    // region serializeToBytes
+
+    @Test
+    fun `M return TLV encoded bytes W serializeToBytes()`(
+        @Forgery event: RawBatchEvent
+    ) {
+        // When
+        val result = testedReaderWriter.serializeToBytes(event)
+
+        // Then
+        assertThat(result).isEqualTo(encode(event))
     }
 
     // endregion
@@ -449,10 +443,10 @@ internal class PlainBatchFileReaderWriterTest {
 
     // endregion
 
-    // region writeData + readData
+    // region writeBinaryData + readData
 
     @Test
-    fun `M return file content W writeData + readData() { append = false }`(
+    fun `M return file content W writeBinaryData + readData() { append = false }`(
         @StringForgery fileName: String,
         @Forgery event: RawBatchEvent
     ) {
@@ -460,7 +454,11 @@ internal class PlainBatchFileReaderWriterTest {
         val file = File(fakeRootDirectory, fileName)
 
         // When
-        val writeResult = testedReaderWriter.writeData(file, event, false)
+        val writeResult = testedReaderWriter.writeBinaryData(
+            file,
+            testedReaderWriter.serializeToBytes(event),
+            false
+        )
         val readResult = testedReaderWriter.readData(file)
 
         // Then
@@ -469,7 +467,7 @@ internal class PlainBatchFileReaderWriterTest {
     }
 
     @Test
-    fun `M return file content W writeData + readData() { append = true }`(
+    fun `M return file content W writeBinaryData + readData() { append = true }`(
         @StringForgery fileName: String,
         @Forgery events: List<RawBatchEvent>
     ) {
@@ -479,9 +477,9 @@ internal class PlainBatchFileReaderWriterTest {
         // When
         var writeResult = true
         events.forEach {
-            writeResult = writeResult && testedReaderWriter.writeData(
+            writeResult = writeResult && testedReaderWriter.writeBinaryData(
                 file,
-                it,
+                testedReaderWriter.serializeToBytes(it),
                 true
             )
         }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleItemDataWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleItemDataWriterTest.kt
@@ -94,7 +94,7 @@ internal class SingleItemDataWriterTest {
     ) {
         // Given
         val serialized = data.reversed().toByteArray(Charsets.UTF_8)
-        whenever(mockOrchestrator.getWritableFile()) doReturn file
+        whenever(mockOrchestrator.getWritableFile(any())) doReturn file
 
         // When
         testedWriter.write(data)
@@ -115,7 +115,7 @@ internal class SingleItemDataWriterTest {
     ) {
         // Given
         val lastSerialized = data.last().reversed().toByteArray(Charsets.UTF_8)
-        whenever(mockOrchestrator.getWritableFile()) doReturn file
+        whenever(mockOrchestrator.getWritableFile(any())) doReturn file
 
         // When
         testedWriter.write(data)

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/ResourcesFeature.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/ResourcesFeature.kt
@@ -58,7 +58,7 @@ internal class ResourcesFeature(
         /**
          * Session Replay Resources storage configuration with the following parameters:
          * max item size = 10 MB,
-         * max items per batch = 500,
+         * max items per batch = 1000,
          * max batch size = 10 MB, SR intake batch limit is 10MB
          * old batch threshold = 18 hours.
          */

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -402,7 +402,7 @@ internal class SessionReplayFeature(
         /**
          * Session Replay storage configuration with the following parameters:
          * max item size = 10 MB,
-         * max items per batch = 500,
+         * max items per batch = 1000,
          * max batch size = 10 MB, SR intake batch limit is 10MB
          * old batch threshold = 5 hours.
          */

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayFeature.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayFeature.kt
@@ -59,7 +59,7 @@ internal class WebViewReplayFeature(
         /**
          * Storage configuration with the following parameters:
          * max item size = 10 MB,
-         * max items per batch = 500,
+         * max items per batch = 1000,
          * max batch size = 10 MB, SR intake batch limit is 10MB
          * old batch threshold = 18 hours.
          */


### PR DESCRIPTION
## What does this PR do?

Aligns several hardcoded client-side data limits with the documented backend limits. Mirrors the equivalent iOS change in [dd-sdk-ios#2832](https://github.com/DataDog/dd-sdk-ios/pull/2832).

### Changes

| Change | Doc |
| --- | --- |
| **Max batch / payload size `4 MB → 5 MB`.** | [Logs API — Send logs](https://docs.datadoghq.com/api/latest/logs/send-logs/) |
| **Max items per batch `500 → 1000`.** | [Logs API — Send logs](https://docs.datadoghq.com/api/latest/logs/send-logs/) |
| **Max item / single-event size `512 KB → 1 MB`.** | [Logs API — Send logs](https://docs.datadoghq.com/api/latest/logs/send-logs/) |


### Motivation