### PR TITLE
RUM-17171: Add OkHttp HTTP cache to RemoteConfigNetworkFetcher for ETag-based conditional requests

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -30,6 +30,7 @@ import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.core.internal.lifecycle.ProcessLifecycleCallback
 import com.datadog.android.core.internal.logger.SdkInternalLogger
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.remote.NoOpRemoteConfigFetcher
 import com.datadog.android.core.internal.remote.RemoteConfigNetworkFetcher
 import com.datadog.android.core.internal.remote.RemoteConfigService
 import com.datadog.android.core.internal.remote.RemoteConfigServiceImpl
@@ -493,21 +494,32 @@ internal class DatadogCore(
         sendCoreConfigurationTelemetryEvent(configuration)
     }
 
-    private fun setupRemoteConfiguration(configuration: Configuration) {
+    internal fun setupRemoteConfiguration(configuration: Configuration) {
         val id = configuration.coreConfig.remoteConfigurationId ?: return
+        val fetcher = if (coreFeature.isMainProcess) {
+            RemoteConfigNetworkFetcher(
+                callFactoryProvider = { httpCache ->
+                    coreFeature.createOkHttpCallFactory {
+                        cache(httpCache)
+                        val proxy = configuration.coreConfig.proxy
+                        if (proxy != null) {
+                            proxy(proxy)
+                            proxyAuthenticator(configuration.coreConfig.proxyAuth)
+                        }
+                    }
+                },
+                internalLogger = internalLogger,
+                storageDir = coreFeature.storageDir
+            )
+        } else {
+            // Secondary process: read from the JSON file written by the main process,
+            // but never fetch from the network or create an OkHttp cache.
+            NoOpRemoteConfigFetcher()
+        }
         remoteConfigService = remoteConfigServiceFactory.create(
             remoteConfigurationId = id,
             remoteConfigurationEndpoint = configuration.coreConfig.site.remoteConfigurationEndpoint,
-            callFactoryProvider = { httpCache ->
-                coreFeature.createOkHttpCallFactory {
-                    cache(httpCache)
-                    val proxy = configuration.coreConfig.proxy
-                    if (proxy != null) {
-                        proxy(proxy)
-                        proxyAuthenticator(configuration.coreConfig.proxyAuth)
-                    }
-                }
-            },
+            fetcher = fetcher,
             storageDir = coreFeature.storageDir,
             executor = coreFeature.uploadExecutorService,
             internalLogger = internalLogger
@@ -781,15 +793,11 @@ internal class DatadogCore(
         internal val CONFIGURATION_TELEMETRY_DELAY_MS = TimeUnit.SECONDS.toMillis(5)
 
         internal val DEFAULT_REMOTE_CONFIG_SERVICE_FACTORY =
-            RemoteConfigService.Factory { id, endpoint, callFactoryProvider, storageDir, executor, logger ->
+            RemoteConfigService.Factory { id, endpoint, fetcher, storageDir, executor, logger ->
                 RemoteConfigServiceImpl(
                     remoteConfigurationId = id,
                     remoteConfigurationEndpoint = endpoint,
-                    fetcher = RemoteConfigNetworkFetcher(
-                        callFactoryProvider = callFactoryProvider,
-                        internalLogger = logger,
-                        storageDir = storageDir
-                    ),
+                    fetcher = fetcher,
                     storageDir = storageDir,
                     executor = executor,
                     internalLogger = logger

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -498,11 +498,14 @@ internal class DatadogCore(
         remoteConfigService = remoteConfigServiceFactory.create(
             remoteConfigurationId = id,
             remoteConfigurationEndpoint = configuration.coreConfig.site.remoteConfigurationEndpoint,
-            callFactory = coreFeature.createOkHttpCallFactory {
-                val proxy = configuration.coreConfig.proxy
-                if (proxy != null) {
-                    proxy(proxy)
-                    proxyAuthenticator(configuration.coreConfig.proxyAuth)
+            callFactoryProvider = { httpCache ->
+                coreFeature.createOkHttpCallFactory {
+                    cache(httpCache)
+                    val proxy = configuration.coreConfig.proxy
+                    if (proxy != null) {
+                        proxy(proxy)
+                        proxyAuthenticator(configuration.coreConfig.proxyAuth)
+                    }
                 }
             },
             storageDir = coreFeature.storageDir,
@@ -730,6 +733,7 @@ internal class DatadogCore(
         }
 
         contextProvider = NoOpContextProvider()
+        remoteConfigService?.stop()
         remoteConfigService = null
         coreFeature.stop()
         isDeveloperModeEnabled = false
@@ -777,11 +781,15 @@ internal class DatadogCore(
         internal val CONFIGURATION_TELEMETRY_DELAY_MS = TimeUnit.SECONDS.toMillis(5)
 
         internal val DEFAULT_REMOTE_CONFIG_SERVICE_FACTORY =
-            RemoteConfigService.Factory { id, endpoint, callFactory, storageDir, executor, logger ->
+            RemoteConfigService.Factory { id, endpoint, callFactoryProvider, storageDir, executor, logger ->
                 RemoteConfigServiceImpl(
                     remoteConfigurationId = id,
                     remoteConfigurationEndpoint = endpoint,
-                    fetcher = RemoteConfigNetworkFetcher(callFactory, logger),
+                    fetcher = RemoteConfigNetworkFetcher(
+                        callFactoryProvider = callFactoryProvider,
+                        internalLogger = logger,
+                        storageDir = storageDir
+                    ),
                     storageDir = storageDir,
                     executor = executor,
                     internalLogger = logger

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcher.kt
@@ -8,10 +8,12 @@ package com.datadog.android.core.internal.remote
 
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
+import okhttp3.Cache
 import okhttp3.Call
 import okhttp3.HttpUrl
 import okhttp3.Request
 import okhttp3.Response
+import java.io.File
 import java.io.IOException
 
 /**
@@ -26,12 +28,25 @@ internal interface RemoteConfigFetcher {
      */
     @WorkerThread
     fun fetch(url: HttpUrl): String?
+
+    /**
+     * Releases any resources held by this fetcher (e.g. HTTP cache).
+     */
+    fun stop()
 }
 
 internal class RemoteConfigNetworkFetcher(
-    private val callFactory: Call.Factory,
-    private val internalLogger: InternalLogger
+    callFactoryProvider: (Cache) -> Call.Factory,
+    private val internalLogger: InternalLogger,
+    storageDir: File
 ) : RemoteConfigFetcher {
+
+    private val httpCache = Cache(
+        directory = File(storageDir, HTTP_CACHE_DIR_NAME),
+        maxSize = HTTP_CACHE_MAX_SIZE
+    )
+
+    private val callFactory: Call.Factory = callFactoryProvider(httpCache)
 
     @WorkerThread
     @Suppress("TooGenericExceptionCaught")
@@ -64,6 +79,19 @@ internal class RemoteConfigNetworkFetcher(
                 additionalProperties = mapOf(ATTR_URL to url.toString())
             )
             null
+        }
+    }
+
+    override fun stop() {
+        try {
+            httpCache.close()
+        } catch (e: IOException) {
+            internalLogger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.MAINTAINER,
+                { ERROR_CLOSE_CACHE },
+                e
+            )
         }
     }
 
@@ -102,7 +130,13 @@ internal class RemoteConfigNetworkFetcher(
         internal const val ERROR_NETWORK = "Remote config fetch failed due to a network error"
         internal const val ERROR_HTTP = "Remote config fetch failed with an HTTP error"
         internal const val ERROR_EMPTY_BODY = "Remote config response body is empty"
+        internal const val ERROR_CLOSE_CACHE = "Failed to close remote config HTTP cache"
         internal const val ATTR_RESPONSE_CODE = "response_code"
         internal const val ATTR_URL = "url"
+        internal const val HTTP_CACHE_DIR_NAME = "rc-http-cache"
+
+        // One RC entry is ~1.4 KB (437-byte body + headers + journal). 50 KB gives ~35x headroom
+        // to accommodate future schema growth without revisiting this value.
+        internal const val HTTP_CACHE_MAX_SIZE = 50L * 1024
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcher.kt
@@ -33,6 +33,13 @@ internal interface RemoteConfigFetcher {
      * Releases any resources held by this fetcher (e.g. HTTP cache).
      */
     fun stop()
+
+    /**
+     * Evicts all entries from the HTTP cache, forcing a full network re-fetch on the next call.
+     * Should be called when a fetched response cannot be parsed, to prevent the bad response
+     * from being served from cache on subsequent launches.
+     */
+    fun evictCache()
 }
 
 internal class RemoteConfigNetworkFetcher(
@@ -95,6 +102,19 @@ internal class RemoteConfigNetworkFetcher(
         }
     }
 
+    override fun evictCache() {
+        try {
+            httpCache.evictAll()
+        } catch (e: IOException) {
+            internalLogger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.MAINTAINER,
+                { ERROR_EVICT_CACHE },
+                e
+            )
+        }
+    }
+
     private fun handleResponse(response: Response, url: HttpUrl): String? {
         return if (response.isSuccessful) {
             @Suppress("UnsafeThirdPartyFunctionCall") // safe: wrapped in outer try-catch
@@ -131,6 +151,7 @@ internal class RemoteConfigNetworkFetcher(
         internal const val ERROR_HTTP = "Remote config fetch failed with an HTTP error"
         internal const val ERROR_EMPTY_BODY = "Remote config response body is empty"
         internal const val ERROR_CLOSE_CACHE = "Failed to close remote config HTTP cache"
+        internal const val ERROR_EVICT_CACHE = "Failed to evict remote config HTTP cache"
         internal const val ATTR_RESPONSE_CODE = "response_code"
         internal const val ATTR_URL = "url"
         internal const val HTTP_CACHE_DIR_NAME = "rc-http-cache"

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcher.kt
@@ -8,6 +8,7 @@ package com.datadog.android.core.internal.remote
 
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
+import com.datadog.tools.annotation.NoOpImplementation
 import okhttp3.Cache
 import okhttp3.Call
 import okhttp3.HttpUrl
@@ -19,6 +20,7 @@ import java.io.IOException
 /**
  * Fetches the remote configuration document from the Datadog CDN.
  */
+@NoOpImplementation
 internal interface RemoteConfigFetcher {
     /**
      * Fetches the remote configuration document from the given URL.
@@ -45,13 +47,13 @@ internal interface RemoteConfigFetcher {
 internal class RemoteConfigNetworkFetcher(
     callFactoryProvider: (Cache) -> Call.Factory,
     private val internalLogger: InternalLogger,
-    storageDir: File
-) : RemoteConfigFetcher {
-
-    private val httpCache = Cache(
+    storageDir: File,
+    // only for unit tests
+    private val httpCache: Cache = Cache(
         directory = File(storageDir, HTTP_CACHE_DIR_NAME),
         maxSize = HTTP_CACHE_MAX_SIZE
     )
+) : RemoteConfigFetcher {
 
     private val callFactory: Call.Factory = callFactoryProvider(httpCache)
 
@@ -103,6 +105,7 @@ internal class RemoteConfigNetworkFetcher(
     }
 
     override fun evictCache() {
+        if (httpCache.isClosed) return
         try {
             httpCache.evictAll()
         } catch (e: IOException) {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcher.kt
@@ -34,7 +34,7 @@ internal interface RemoteConfigFetcher {
     /**
      * Releases any resources held by this fetcher (e.g. HTTP cache).
      */
-    fun stop()
+    fun release()
 
     /**
      * Evicts all entries from the HTTP cache, forcing a full network re-fetch on the next call.
@@ -91,7 +91,7 @@ internal class RemoteConfigNetworkFetcher(
         }
     }
 
-    override fun stop() {
+    override fun release() {
         try {
             httpCache.close()
         } catch (e: IOException) {
@@ -105,7 +105,7 @@ internal class RemoteConfigNetworkFetcher(
     }
 
     override fun evictCache() {
-        if (httpCache.isClosed) return
+        // DiskLruCache.evictAll() is internally synchronized — safe to call even after close()
         try {
             httpCache.evictAll()
         } catch (e: IOException) {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcher.kt
@@ -129,6 +129,9 @@ internal class RemoteConfigNetworkFetcher(
                     { ERROR_EMPTY_BODY },
                     additionalProperties = mapOf(ATTR_URL to url.toString())
                 )
+                // Evict the cached empty response so the next syncWithRemote()
+                // re-fetches from the network rather than serving the empty body again.
+                evictCache()
                 null
             } else {
                 body

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
@@ -16,6 +16,7 @@ import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.internal.utils.allowThreadDiskReads
 import com.google.gson.JsonParseException
+import okhttp3.Cache
 import okhttp3.Call
 import okhttp3.HttpUrl
 import java.io.File
@@ -28,12 +29,13 @@ import java.util.concurrent.Executor
 internal interface RemoteConfigService {
     fun syncWithRemote()
     fun getCurrentConfig(): RemoteConfiguration?
+    fun stop()
 
     fun interface Factory {
         fun create(
             remoteConfigurationId: String,
             remoteConfigurationEndpoint: HttpUrl,
-            callFactory: Call.Factory,
+            callFactoryProvider: (Cache) -> Call.Factory,
             storageDir: File,
             executor: Executor,
             internalLogger: InternalLogger
@@ -74,6 +76,10 @@ internal class RemoteConfigServiceImpl(
     }
 
     override fun getCurrentConfig(): RemoteConfiguration? = cachedConfig
+
+    override fun stop() {
+        fetcher.stop()
+    }
 
     override fun syncWithRemote() {
         executor.executeSafe(SYNC_OPERATION_NAME, internalLogger) {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
@@ -16,8 +16,6 @@ import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.internal.utils.allowThreadDiskReads
 import com.google.gson.JsonParseException
-import okhttp3.Cache
-import okhttp3.Call
 import okhttp3.HttpUrl
 import java.io.File
 import java.util.concurrent.Executor
@@ -35,7 +33,7 @@ internal interface RemoteConfigService {
         fun create(
             remoteConfigurationId: String,
             remoteConfigurationEndpoint: HttpUrl,
-            callFactoryProvider: (Cache) -> Call.Factory,
+            fetcher: RemoteConfigFetcher,
             storageDir: File,
             executor: Executor,
             internalLogger: InternalLogger

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
@@ -90,7 +90,13 @@ internal class RemoteConfigServiceImpl(
     @WorkerThread
     private fun fetchAndCache() {
         val rawConfig = fetcher.fetch(configUrl) ?: return
-        val config = parseConfig(rawConfig) ?: return
+        val config = parseConfig(rawConfig)
+        if (config == null) {
+            // Evict the bad response from the HTTP cache so the next syncWithRemote()
+            // re-fetches from the network rather than serving the unparseable body again.
+            fetcher.evictCache()
+            return
+        }
 
         configFile.parentFile?.mkdirsSafe(internalLogger)
         val written = fileReaderWriter.writeData(

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigService.kt
@@ -76,7 +76,7 @@ internal class RemoteConfigServiceImpl(
     override fun getCurrentConfig(): RemoteConfiguration? = cachedConfig
 
     override fun stop() {
-        fetcher.stop()
+        fetcher.release()
     }
 
     override fun syncWithRemote() {

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
@@ -19,6 +19,8 @@ import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.DatadogContextProvider
 import com.datadog.android.core.internal.DatadogCore
 import com.datadog.android.core.internal.SdkFeature
+import com.datadog.android.core.internal.remote.NoOpRemoteConfigFetcher
+import com.datadog.android.core.internal.remote.RemoteConfigFetcher
 import com.datadog.android.core.internal.remote.RemoteConfigService
 import com.datadog.android.core.thread.FlushableExecutorService
 import com.datadog.android.error.internal.CrashReportsFeature
@@ -728,6 +730,39 @@ internal class DatadogCoreInitializationTest {
 
         // Then
         verify(mockRemoteConfigService).stop()
+    }
+
+    @Test
+    fun `M use NoOpRemoteConfigFetcher W setupRemoteConfiguration() { secondary process }`(
+        @StringForgery fakeRemoteConfigurationId: String
+    ) {
+        // Given — initialize normally (main process), then set isMainProcess=false
+        // and call setupRemoteConfiguration() directly to exercise the secondary process path
+        var capturedFetcher: RemoteConfigFetcher? = null
+        testedCore = DatadogCore(
+            appContext.mockInstance,
+            fakeInstanceId,
+            fakeInstanceName,
+            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService },
+            remoteConfigServiceFactory = { _, _, fetcher, _, _, _ ->
+                capturedFetcher = fetcher
+                mockRemoteConfigService
+            }
+        ).apply {
+            initialize(fakeConfiguration)
+            // Simulate secondary process then re-run setupRemoteConfiguration directly
+            coreFeature.isMainProcess = false
+            setupRemoteConfiguration(
+                fakeConfiguration.copy(
+                    coreConfig = fakeConfiguration.coreConfig.copy(
+                        remoteConfigurationId = fakeRemoteConfigurationId
+                    )
+                )
+            )
+        }
+
+        // Then — secondary process path uses NoOpRemoteConfigFetcher (no network, no OkHttp cache)
+        assertThat(capturedFetcher).isInstanceOf(NoOpRemoteConfigFetcher::class.java)
     }
 
     // endregion

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
@@ -84,6 +84,9 @@ internal class DatadogCoreInitializationTest {
     @Mock
     lateinit var mockRemoteConfigService: RemoteConfigService
 
+    private lateinit var mockExecutorServiceFactory: FlushableExecutorService.Factory
+    private lateinit var mockRemoteConfigServiceFactory: RemoteConfigService.Factory
+
     @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL)
     lateinit var fakeInstanceId: String
 
@@ -100,6 +103,9 @@ internal class DatadogCoreInitializationTest {
         whenever(mockPersistenceExecutorService.execute(any())) doAnswer {
             it.getArgument<Runnable>(0).run()
         }
+
+        mockExecutorServiceFactory = FlushableExecutorService.Factory { _, _, _, _ -> mockPersistenceExecutorService }
+        mockRemoteConfigServiceFactory = RemoteConfigService.Factory { _, _, _, _, _, _ -> mockRemoteConfigService }
     }
 
     @AfterEach
@@ -118,7 +124,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(fakeConfiguration.copy(crashReportsEnabled = crashReportsEnabled))
         }
@@ -194,7 +200,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(fakeConfiguration)
         }
@@ -217,7 +223,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -245,7 +251,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -274,7 +280,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -302,7 +308,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -361,7 +367,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(configuration)
         }
@@ -409,7 +415,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(fakeConfiguration.copy(additionalConfig = mapOf(Datadog.DD_SOURCE_TAG to source)))
         }
@@ -427,7 +433,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(
                 fakeConfiguration.copy(additionalConfig = mapOf(Datadog.DD_SOURCE_TAG to source))
@@ -447,7 +453,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(
                 fakeConfiguration.copy(additionalConfig = mapOf(Datadog.DD_SOURCE_TAG to source))
@@ -467,7 +473,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(fakeConfiguration.copy(additionalConfig = customAttributes.nonNullData))
         }
@@ -485,7 +491,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -507,7 +513,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -529,7 +535,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -551,7 +557,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(fakeConfiguration.copy(additionalConfig = customAttributes.nonNullData))
         }
@@ -569,7 +575,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -591,7 +597,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -616,7 +622,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -641,7 +647,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = mockExecutorServiceFactory
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -663,8 +669,8 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService },
-            remoteConfigServiceFactory = { _, _, _, _, _, _ -> mockRemoteConfigService }
+            executorServiceFactory = mockExecutorServiceFactory,
+            remoteConfigServiceFactory = mockRemoteConfigServiceFactory
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -687,8 +693,8 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService },
-            remoteConfigServiceFactory = { _, _, _, _, _, _ -> mockRemoteConfigService }
+            executorServiceFactory = mockExecutorServiceFactory,
+            remoteConfigServiceFactory = mockRemoteConfigServiceFactory
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -713,8 +719,8 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService },
-            remoteConfigServiceFactory = { _, _, _, _, _, _ -> mockRemoteConfigService }
+            executorServiceFactory = mockExecutorServiceFactory,
+            remoteConfigServiceFactory = mockRemoteConfigServiceFactory
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -743,7 +749,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService },
+            executorServiceFactory = mockExecutorServiceFactory,
             remoteConfigServiceFactory = { _, _, fetcher, _, _, _ ->
                 capturedFetcher = fetcher
                 mockRemoteConfigService

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
@@ -702,6 +702,34 @@ internal class DatadogCoreInitializationTest {
         verify(mockRemoteConfigService, never()).syncWithRemote()
     }
 
+    @Test
+    fun `M stop RemoteConfigService W stop() { remoteConfigurationId set }`(
+        @StringForgery fakeRemoteConfigurationId: String
+    ) {
+        // Given
+        testedCore = DatadogCore(
+            appContext.mockInstance,
+            fakeInstanceId,
+            fakeInstanceName,
+            executorServiceFactory = { _, _, _, _ -> mockPersistenceExecutorService },
+            remoteConfigServiceFactory = { _, _, _, _, _, _ -> mockRemoteConfigService }
+        ).apply {
+            initialize(
+                fakeConfiguration.copy(
+                    coreConfig = fakeConfiguration.coreConfig.copy(
+                        remoteConfigurationId = fakeRemoteConfigurationId
+                    )
+                )
+            )
+        }
+
+        // When
+        testedCore.stop()
+
+        // Then
+        verify(mockRemoteConfigService).stop()
+    }
+
     // endregion
 
     companion object {

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcherTest.kt
@@ -257,4 +257,14 @@ internal class RemoteConfigFetcherTest {
     }
 
     // endregion
+
+    // region evictCache()
+
+    @Test
+    fun `M not throw W evictCache()`() {
+        // When / Then — cache is a real object on fakeStorageDir; evictAll() should succeed
+        testedFetcher.evictCache()
+    }
+
+    // endregion
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcherTest.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.api.io.TempDir
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -32,6 +33,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.isA
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.io.File
 import java.io.IOException
 
 @Extensions(
@@ -51,6 +53,9 @@ internal class RemoteConfigFetcherTest {
     @Mock
     lateinit var mockCall: Call
 
+    @TempDir
+    lateinit var fakeStorageDir: File
+
     private lateinit var testedFetcher: RemoteConfigNetworkFetcher
 
     private val fakeUrl = "https://sdk-configuration.browser-intake-datadoghq.com/v1/fake-id.json"
@@ -58,8 +63,9 @@ internal class RemoteConfigFetcherTest {
     @BeforeEach
     fun `set up`() {
         testedFetcher = RemoteConfigNetworkFetcher(
-            callFactory = mockCallFactory,
-            internalLogger = mockInternalLogger
+            callFactoryProvider = { _ -> mockCallFactory },
+            internalLogger = mockInternalLogger,
+            storageDir = fakeStorageDir
         )
     }
 
@@ -231,6 +237,23 @@ internal class RemoteConfigFetcherTest {
             throwableClass = RuntimeException::class.java,
             additionalProperties = mapOf(RemoteConfigNetworkFetcher.ATTR_URL to fakeUrl.toHttpUrl().toString())
         )
+    }
+
+    // endregion
+
+    // region stop()
+
+    @Test
+    fun `M not throw W stop()`() {
+        // When / Then — cache is a real object on fakeStorageDir; close() should succeed
+        testedFetcher.stop()
+    }
+
+    @Test
+    fun `M be idempotent W stop() { called multiple times }`() {
+        // When / Then — second close on an already-closed cache should not throw from our code
+        testedFetcher.stop()
+        testedFetcher.stop()
     }
 
     // endregion

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcherTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import okhttp3.Cache
 import okhttp3.Call
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
@@ -31,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.isA
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.io.File
@@ -53,6 +55,9 @@ internal class RemoteConfigFetcherTest {
     @Mock
     lateinit var mockCall: Call
 
+    @Mock
+    lateinit var mockHttpCache: Cache
+
     @TempDir
     lateinit var fakeStorageDir: File
 
@@ -65,7 +70,8 @@ internal class RemoteConfigFetcherTest {
         testedFetcher = RemoteConfigNetworkFetcher(
             callFactoryProvider = { _ -> mockCallFactory },
             internalLogger = mockInternalLogger,
-            storageDir = fakeStorageDir
+            storageDir = fakeStorageDir,
+            httpCache = mockHttpCache
         )
     }
 
@@ -244,16 +250,29 @@ internal class RemoteConfigFetcherTest {
     // region stop()
 
     @Test
-    fun `M not throw W stop()`() {
-        // When / Then — cache is a real object on fakeStorageDir; close() should succeed
+    fun `M close httpCache W stop()`() {
+        // When
         testedFetcher.stop()
+
+        // Then
+        verify(mockHttpCache).close()
     }
 
     @Test
-    fun `M be idempotent W stop() { called multiple times }`() {
-        // When / Then — second close on an already-closed cache should not throw from our code
+    fun `M log warning W stop() { cache close throws IOException }`() {
+        // Given
+        whenever(mockHttpCache.close()).doThrow(IOException("disk error"))
+
+        // When
         testedFetcher.stop()
-        testedFetcher.stop()
+
+        // Then
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.WARN,
+            target = InternalLogger.Target.MAINTAINER,
+            message = RemoteConfigNetworkFetcher.ERROR_CLOSE_CACHE,
+            throwableClass = IOException::class.java
+        )
     }
 
     // endregion
@@ -261,9 +280,29 @@ internal class RemoteConfigFetcherTest {
     // region evictCache()
 
     @Test
-    fun `M not throw W evictCache()`() {
-        // When / Then — cache is a real object on fakeStorageDir; evictAll() should succeed
+    fun `M evict httpCache W evictCache()`() {
+        // When
         testedFetcher.evictCache()
+
+        // Then
+        verify(mockHttpCache).evictAll()
+    }
+
+    @Test
+    fun `M log warning W evictCache() { evictAll throws IOException }`() {
+        // Given
+        whenever(mockHttpCache.evictAll()).doThrow(IOException("disk error"))
+
+        // When
+        testedFetcher.evictCache()
+
+        // Then
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.WARN,
+            target = InternalLogger.Target.MAINTAINER,
+            message = RemoteConfigNetworkFetcher.ERROR_EVICT_CACHE,
+            throwableClass = IOException::class.java
+        )
     }
 
     // endregion

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcherTest.kt
@@ -125,6 +125,7 @@ internal class RemoteConfigFetcherTest {
             message = RemoteConfigNetworkFetcher.ERROR_EMPTY_BODY,
             additionalProperties = mapOf(RemoteConfigNetworkFetcher.ATTR_URL to fakeUrl.toHttpUrl().toString())
         )
+        verify(mockHttpCache).evictAll()
     }
 
     // endregion

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigFetcherTest.kt
@@ -251,21 +251,21 @@ internal class RemoteConfigFetcherTest {
     // region stop()
 
     @Test
-    fun `M close httpCache W stop()`() {
+    fun `M close httpCache W release()`() {
         // When
-        testedFetcher.stop()
+        testedFetcher.release()
 
         // Then
         verify(mockHttpCache).close()
     }
 
     @Test
-    fun `M log warning W stop() { cache close throws IOException }`() {
+    fun `M log warning W release() { cache close throws IOException }`() {
         // Given
         whenever(mockHttpCache.close()).doThrow(IOException("disk error"))
 
         // When
-        testedFetcher.stop()
+        testedFetcher.release()
 
         // Then
         mockInternalLogger.verifyLog(

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigServiceTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigServiceTest.kt
@@ -362,4 +362,20 @@ internal class RemoteConfigServiceTest {
     }
 
     // endregion
+
+    // region stop()
+
+    @Test
+    fun `M stop fetcher W stop()`() {
+        // Given
+        testedService = buildService()
+
+        // When
+        testedService.stop()
+
+        // Then
+        verify(mockFetcher).stop()
+    }
+
+    // endregion
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigServiceTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigServiceTest.kt
@@ -275,6 +275,7 @@ internal class RemoteConfigServiceTest {
         // Then
         assertThat(testedService.getCurrentConfig()).isNull()
         verify(mockFileReaderWriter, never()).writeData(any(), any(), any())
+        verify(mockFetcher).evictCache()
         mockInternalLogger.verifyLog(
             level = InternalLogger.Level.ERROR,
             targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
@@ -332,6 +333,7 @@ internal class RemoteConfigServiceTest {
         // Then
         assertThat(testedService.getCurrentConfig()).isNull()
         verify(mockFileReaderWriter, never()).writeData(any(), any(), any())
+        verify(mockFetcher).evictCache()
         mockInternalLogger.verifyLog(
             level = InternalLogger.Level.ERROR,
             targets = listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigServiceTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigServiceTest.kt
@@ -368,7 +368,7 @@ internal class RemoteConfigServiceTest {
     // region stop()
 
     @Test
-    fun `M stop fetcher W stop()`() {
+    fun `M release fetcher resources W stop()`() {
         // Given
         testedService = buildService()
 
@@ -376,7 +376,7 @@ internal class RemoteConfigServiceTest {
         testedService.stop()
 
         // Then
-        verify(mockFetcher).stop()
+        verify(mockFetcher).release()
     }
 
     // endregion

--- a/detekt_custom_safe_calls_third_party.yml
+++ b/detekt_custom_safe_calls_third_party.yml
@@ -976,6 +976,7 @@ datadog:
       - "com.lyft.kronos.KronosClock.shutdown()"
       # endregion
       # region OkHttp
+      - "okhttp3.Cache.constructor(java.io.File, kotlin.Long)"
       - "okhttp3.Call.Factory.newCall(okhttp3.Request)"
       - "okhttp3.Call.hashCode()"
       - "okhttp3.Call.request()"
@@ -1014,6 +1015,7 @@ datadog:
       - "okhttp3.MultipartBody.parts()"
       - "okhttp3.OkHttpClient.Builder()"
       - "okhttp3.OkHttpClient.Builder.build()"
+      - "okhttp3.OkHttpClient.Builder.cache(okhttp3.Cache?)"
       - "okhttp3.OkHttpClient.Builder.callTimeout(kotlin.Long, java.util.concurrent.TimeUnit)"
       - "okhttp3.OkHttpClient.Builder.connectionSpecs(kotlin.collections.List)"
       - "okhttp3.OkHttpClient.Builder.constructor()"

--- a/detekt_custom_unsafe_calls.yml
+++ b/detekt_custom_unsafe_calls.yml
@@ -228,6 +228,7 @@ datadog:
       # endregion
       # region OkHttp
       - "okhttp3.Cache.close():java.io.IOException"
+      - "okhttp3.Cache.evictAll():java.io.IOException"
       - "okhttp3.Call.execute():java.io.IOException"
       - "okhttp3.Dns.lookup(kotlin.String):java.net.UnknownHostException"
       - "okhttp3.Headers.Builder.add(kotlin.String, kotlin.String):java.lang.IllegalArgumentException"

--- a/detekt_custom_unsafe_calls.yml
+++ b/detekt_custom_unsafe_calls.yml
@@ -227,6 +227,7 @@ datadog:
       - "kotlinx.coroutines.withContext(kotlin.coroutines.CoroutineContext, kotlin.coroutines.SuspendFunction1):kotlinx.coroutines.CancellationException"
       # endregion
       # region OkHttp
+      - "okhttp3.Cache.close():java.io.IOException"
       - "okhttp3.Call.execute():java.io.IOException"
       - "okhttp3.Dns.lookup(kotlin.String):java.net.UnknownHostException"
       - "okhttp3.Headers.Builder.add(kotlin.String, kotlin.String):java.lang.IllegalArgumentException"


### PR DESCRIPTION
### What does this PR do?

Attaches an `okhttp3.Cache` exclusively to the RC OkHttp client so that ETag-based conditional requests and `max-age` freshness are handled automatically by OkHttp.

- The cache is owned by `RemoteConfigNetworkFetcher` and closed in `stop()`, which is delegated from `RemoteConfigService.stop()` and called from `DatadogCore.stop()`
- When a fetched response fails schema validation (unknown enum, malformed JSON), `evictCache()` is called immediately to purge the bad response from the OkHttp disk cache, preventing it from being served again within the `max-age` window
- Secondary processes (e.g. `:push`) receive a `NoOpRemoteConfigFetcher` that never creates an `okhttp3.Cache` instance, preventing concurrent `DiskLruCache` access across processes (see OkHttp [#8083](https://github.com/square/okhttp/issues/8083) and [#8957](https://github.com/square/okhttp/issues/8957)). This is consistent with the SDK's existing design where secondary processes are passive — they rely on the main process for all network operations
- Cache directory: `storageDir/rc-http-cache`, max size: 50 KB
- `okhttp3.Cache.constructor`, `okhttp3.OkHttpClient.Builder.cache()` added to `detekt_custom_safe_calls_third_party.yml`; `okhttp3.Cache.close()` and `okhttp3.Cache.evictAll()` added to `detekt_custom_unsafe_calls.yml`

Verified end-to-end on device:
- Launch 1: `fromCache=false networkCode=200` — fresh CDN response, ETag stored
- Launch 2: `fromCache=true networkCode=null` — served from disk, zero network call
- Revalidation: `fromCache=false networkCode=304 If-None-Match="06a8a5ab..."` — CDN confirmed unchanged

### Motivation

Follow-up to RUM-16389. The CDN returns `ETag` and `Cache-Control: max-age=3600` — without a cache, every `syncWithRemote()` call makes an unconditional GET, re-downloading content that hasn't changed.

### Additional Notes

The `max-age=3600` header is served by the CDN (CloudFront + S3). OkHttp's `Cache` implementation is RFC 7234-compliant and handles ETag storage, `If-None-Match` injection, and transparent 304 responses automatically.

**TTL rate-limiting is satisfied by the CDN's `Cache-Control` header.** OkHttp's `Cache` enforces the `max-age=3600` window — within that 1-hour period, `syncWithRemote()` serves from disk with zero network activity regardless of how many times it's called. No additional client-side TTL tracking is needed.

**Multi-process safety:** Secondary processes use `NoOpRemoteConfigFetcher` which reads from the JSON file written by the main process — the same disk-sharing mechanism already used for event batch files. This is consistent with the SDK warning: *"nothing will be uploaded from this process"* — secondary processes are intentionally passive on all network operations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)
