### PR TITLE
Several Continuous Profiling minor bug fixes

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
@@ -57,10 +57,19 @@ internal class ProfilingDataWriter(
                             eventType = EventType.DEFAULT
                         )
                     }
+                    // TODO RUM-17263: when multiple SDK instances share the same resultFilePath,
+                    // the first writer to reach here deletes the file out from under the others,
+                    // so their reads fail and their profiles are dropped as perfetto_unreadable.
+                    // Deletion ownership needs to move to a single coordinator (read-once-and-fan-out
+                    // bytes, or reference-count across instances) before multi-instance is supported.
                     safeDelete(profilingResult.resultFilePath)
                 }
             }
         }
+    }
+
+    override fun discard(profilingResult: PerfettoResult) {
+        safeDelete(profilingResult.resultFilePath)
     }
 
     private fun buildRawBatchEvent(
@@ -74,7 +83,8 @@ internal class ProfilingDataWriter(
         val dropReason = when {
             longTaskEvents.isEmpty() && anrEvents.isEmpty() && vitalEvents.isEmpty() -> DROP_REASON_NO_RUM_EVENTS
             profilingResult.startReason != ProfilingStartReason.APPLICATION_LAUNCH &&
-                abs(driftMs) > MAX_CLOCK_DRIFT_MS -> DROP_REASON_CLOCK_DRIFT
+                    abs(driftMs) > MAX_CLOCK_DRIFT_MS -> DROP_REASON_CLOCK_DRIFT
+
             else -> null
         }
         if (dropReason != null) {
@@ -119,6 +129,7 @@ internal class ProfilingDataWriter(
                 )
                 null
             }
+
             firstRumContext == null -> {
                 logWriteResultMetric(
                     dropped = true,
@@ -131,6 +142,7 @@ internal class ProfilingDataWriter(
                 )
                 null
             }
+
             else -> {
                 val profileEvent = createProfileEvent(
                     context = context,

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
@@ -83,7 +83,7 @@ internal class ProfilingDataWriter(
         val dropReason = when {
             longTaskEvents.isEmpty() && anrEvents.isEmpty() && vitalEvents.isEmpty() -> DROP_REASON_NO_RUM_EVENTS
             profilingResult.startReason != ProfilingStartReason.APPLICATION_LAUNCH &&
-                    abs(driftMs) > MAX_CLOCK_DRIFT_MS -> DROP_REASON_CLOCK_DRIFT
+                abs(driftMs) > MAX_CLOCK_DRIFT_MS -> DROP_REASON_CLOCK_DRIFT
 
             else -> null
         }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -300,6 +300,7 @@ internal class ProfilingFeature(
                                 quotaResult.reason.rawValue
                             )
                         )
+                        dataWriter.discard(result)
                         pendingRumEvents.clear()
                     } else {
                         val (longTasks, anrEvents, vitalEvents) = pendingRumEvents.drain()

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingWriter.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingWriter.kt
@@ -19,4 +19,10 @@ internal interface ProfilingWriter {
         anrEvents: List<ProfilerEvent.RumAnrEvent>,
         vitalEvents: List<ProfilerEvent.RumVitalEvent>
     )
+
+    /**
+     * Deletes the profiling result file without uploading it. Used when a profile is dropped
+     * before it reaches the write path (e.g. quota denied), so the trace file is not leaked.
+     */
+    fun discard(profilingResult: PerfettoResult)
 }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -1111,6 +1111,34 @@ internal class ProfilingFeatureTest {
     }
 
     @Test
+    fun `M discard result and not write W app-launch profiling result received {quota denied}`(
+        @Forgery fakePerfettoResult: PerfettoResult
+    ) {
+        // Given
+        testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
+        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        val callbackCaptor = argumentCaptor<ProfilerCallback>()
+        testedFeature.onInitialize(mockContext)
+        testedFeature.dataWriter = mockDataWriter
+        verify(mockProfiler).registerProfilingCallback(
+            eq(mockContext),
+            eq(fakeInstanceName),
+            callbackCaptor.capture()
+        )
+        testedFeature.onReceive(fakeRumLongTaskEvent)
+        testedFeature.onReceive(fakeTTID)
+        testedFeature.propagateQuotaResult(QuotaResult.QUOTA_EXCEEDED)
+        val launchResult = fakePerfettoResult.copy(startReason = ProfilingStartReason.APPLICATION_LAUNCH)
+
+        // When
+        callbackCaptor.firstValue.onSuccess(launchResult)
+
+        // Then
+        verify(mockDataWriter).discard(launchResult)
+        verify(mockDataWriter, never()).write(any(), any(), any(), any())
+    }
+
+    @Test
     fun `M write launch event with ANR events W app-launch profiling result received`(
         @Forgery fakePerfettoResult: PerfettoResult
     ) {

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingDataWriterTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingDataWriterTest.kt
@@ -727,4 +727,43 @@ internal class ProfilingDataWriterTest {
             isNull()
         )
     }
+
+    @Test
+    fun `M delete result file W discard`(
+        @Forgery fakeResult: PerfettoResult,
+        forge: Forge
+    ) {
+        // Given
+        val file = File(tmp, "fake_profile.perfetto-stack-sample")
+        file.writeBytes(forge.aString().toByteArray())
+
+        // When
+        testedDataWriterTest.discard(fakeResult.copy(resultFilePath = file.absolutePath))
+
+        // Then
+        assertThat(file.exists()).isFalse()
+        verifyNoInteractions(mockEventBatchWriter)
+    }
+
+    @Test
+    fun `M log warn on delete failure W discard {file not found}`(
+        @Forgery fakeResult: PerfettoResult
+    ) {
+        // Given — file path exists in TempDir but file is never created
+        val nonExistentFile = File(tmp, "nonexistent.perfetto-stack-sample")
+
+        // When
+        testedDataWriterTest.discard(fakeResult.copy(resultFilePath = nonExistentFile.absolutePath))
+
+        // Then
+        verify(mockInternalLogger).log(
+            eq(InternalLogger.Level.WARN),
+            eq(InternalLogger.Target.MAINTAINER),
+            any<() -> String>(),
+            isNull(),
+            eq(false),
+            isNull()
+        )
+        verifyNoInteractions(mockEventBatchWriter)
+    }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -1808,7 +1808,11 @@ internal open class RumViewScope(
         val isRunning = datadogContext.isProfilerRunning()
         val quotaReason = datadogContext.resolveProfilingQuotaReason(sessionId)
         return when {
-            isRunning -> ViewEvent.Profiling(status = ViewEvent.ProfilingStatus.RUNNING)
+            isRunning -> ViewEvent.Profiling(
+                status = ViewEvent.ProfilingStatus.RUNNING,
+                clockDrift = datadogContext.time.serverTimeOffsetMs
+            )
+
             quotaReason != null -> ViewEvent.Profiling(
                 status = ViewEvent.ProfilingStatus.STOPPED,
                 quotaReason = quotaReason

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -282,7 +282,8 @@ internal open class RumViewScope(
                 operationKey = event.operationKey,
                 stepType = VitalOperationStepEvent.StepType.START,
                 failureReason = null,
-                eventAttributes = event.attributes
+                eventAttributes = event.attributes,
+                rumContext = capturedRumContext
             )
         }.onSuccess {
             sendProfilingRumOperationEvent(
@@ -314,7 +315,8 @@ internal open class RumViewScope(
                 operationKey = event.operationKey,
                 stepType = VitalOperationStepEvent.StepType.END,
                 failureReason = event.failureReason?.toSchemaFailureReason(),
-                eventAttributes = event.attributes
+                eventAttributes = event.attributes,
+                rumContext = capturedRumContext
             )
         }.onSuccess {
             sendProfilingRumOperationEvent(
@@ -359,9 +361,9 @@ internal open class RumViewScope(
         operationKey: String?,
         stepType: VitalOperationStepEvent.StepType,
         failureReason: VitalOperationStepEvent.FailureReason?,
-        eventAttributes: Map<String, Any?>
+        eventAttributes: Map<String, Any?>,
+        rumContext: RumContext
     ): VitalOperationStepEvent {
-        val rumContext = getRumContext()
         val syntheticsAttribute = if (
             rumContext.syntheticsTestId.isNullOrBlank() ||
             rumContext.syntheticsResultId.isNullOrBlank()
@@ -771,24 +773,7 @@ internal open class RumViewScope(
         // Fatal ANR comes from last session, in this case we don't attach it to Profiling Event.
         // TODO RUM-15344: address non-fatal ANR over Android API 30
         if (event.throwable is ANRException && !isFatal) {
-            val anrDurationMs = ANRDetectorRunnable.ANR_THRESHOLD_MS
-            val anrStartMs = event.eventTime.timestamp + serverTimeOffsetInMs - anrDurationMs
-            val anrDurationNs = TimeUnit.MILLISECONDS.toNanos(anrDurationMs)
-
             profilingStatus = resolveErrorProfilingStatus(datadogContext)
-            sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.sendEvent(
-                ProfilerEvent.RumAnrEvent(
-                    id = errorId,
-                    startMs = anrStartMs,
-                    durationNs = anrDurationNs,
-                    rumContext = ProfilingRumContext(
-                        applicationId = rumContext.applicationId,
-                        sessionId = rumContext.sessionId,
-                        viewId = rumContext.viewId,
-                        viewName = rumContext.viewName
-                    )
-                )
-            )
         }
         // end region
 
@@ -916,6 +901,22 @@ internal open class RumViewScope(
                     onSuccess {
                         it.eventSent(rumContext.viewId.orEmpty(), StorageEvent.Error())
                         if (event.throwable is ANRException) {
+                            val anrDurationMs = ANRDetectorRunnable.ANR_THRESHOLD_MS
+                            val anrStartMs = event.eventTime.timestamp + serverTimeOffsetInMs - anrDurationMs
+                            val anrDurationNs = TimeUnit.MILLISECONDS.toNanos(anrDurationMs)
+                            sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.sendEvent(
+                                ProfilerEvent.RumAnrEvent(
+                                    id = errorId,
+                                    startMs = anrStartMs,
+                                    durationNs = anrDurationNs,
+                                    rumContext = ProfilingRumContext(
+                                        applicationId = rumContext.applicationId,
+                                        sessionId = rumContext.sessionId,
+                                        viewId = rumContext.viewId,
+                                        viewName = rumContext.viewName
+                                    )
+                                )
+                            )
                             // Intentionally writing through `writeLastFatalAnrSent` even though this is a
                             // non-fatal ANR: both pipelines share the same persisted timestamp so that the
                             // fatal-ANR replay path (DatadogLateCrashReporter, via ApplicationExitInfo on
@@ -1545,20 +1546,6 @@ internal open class RumViewScope(
         )
 
         val longTaskId = UUID.randomUUID().toString()
-        sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.sendEvent(
-            ProfilerEvent.RumLongTaskEvent(
-                id = longTaskId,
-                startMs = timestamp - TimeUnit.NANOSECONDS.toMillis(event.durationNs),
-                durationNs = event.durationNs,
-                rumContext = ProfilingRumContext(
-                    applicationId = rumContext.applicationId,
-                    sessionId = rumContext.sessionId,
-                    viewId = rumContext.viewId,
-                    viewName = rumContext.viewName
-                )
-            )
-        )
-
         sdkCore.newRumEventWriteOperation(datadogContext, writeScope, writer) {
             val user = datadogContext.userInfo
             val syntheticsAttribute = if (
@@ -1656,7 +1643,22 @@ internal open class RumViewScope(
                 val storageEvent =
                     if (isFrozenFrame) StorageEvent.FrozenFrame else StorageEvent.LongTask
                 onError { it.eventDropped(rumContext.viewId.orEmpty(), storageEvent) }
-                onSuccess { it.eventSent(rumContext.viewId.orEmpty(), storageEvent) }
+                onSuccess {
+                    it.eventSent(rumContext.viewId.orEmpty(), storageEvent)
+                    sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.sendEvent(
+                        ProfilerEvent.RumLongTaskEvent(
+                            id = longTaskId,
+                            startMs = timestamp - TimeUnit.NANOSECONDS.toMillis(event.durationNs),
+                            durationNs = event.durationNs,
+                            rumContext = ProfilingRumContext(
+                                applicationId = rumContext.applicationId,
+                                sessionId = rumContext.sessionId,
+                                viewId = rumContext.viewId,
+                                viewName = rumContext.viewName
+                            )
+                        )
+                    )
+                }
             }
             .submit()
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -4257,6 +4257,38 @@ internal class RumViewScopeTest {
     }
 
     @Test
+    fun `M not send RumAnrEvent to profiling W handleEvent(AddError) {ANRException but write fails}`(
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @StringForgery stacktrace: String,
+        forge: Forge
+    ) {
+        // Given
+        val throwable = ANRException(Thread.currentThread())
+        testedScope.activeActionScope = mockActionScope
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        fakeEvent = RumRawEvent.AddError(
+            message,
+            source,
+            throwable,
+            stacktrace,
+            isFatal = false,
+            threads = emptyList(),
+            attributes = attributes,
+            eventTime = fakeEventTime
+        )
+        // The RUM error write does not succeed (e.g. dropped by the errorEventMapper or a storage failure).
+        whenever(mockWriter.write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))) doReturn false
+
+        // When
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then — the profile must not reference an ANR error id that RUM never ingested.
+        verify(mockWriter).write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))
+        verify(mockProfilingFeatureScope, never()).sendEvent(isA<ProfilerEvent.RumAnrEvent>())
+    }
+
+    @Test
     fun `M send event W handleEvent(AddError) on active view {throwable_message == blank}`(
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
@@ -6156,6 +6188,25 @@ internal class RumViewScopeTest {
                 )
             )
         }
+    }
+
+    @Test
+    fun `M not send RumLongTaskEvent to profiling W handleEvent(AddLongTask) {write fails}`(
+        @LongForgery(0L, 700_000_000L) durationNs: Long,
+        @StringForgery target: String
+    ) {
+        // Given
+        testedScope.activeActionScope = null
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target, eventTime = fakeEventTime)
+        // The RUM long task write does not succeed (e.g. dropped by the longTaskEventMapper or a storage failure).
+        whenever(mockWriter.write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))) doReturn false
+
+        // When
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then — the profile must not reference a long task id that RUM never ingested.
+        verify(mockWriter).write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))
+        verify(mockProfilingFeatureScope, never()).sendEvent(isA<ProfilerEvent.RumLongTaskEvent>())
     }
 
     @Test
@@ -10510,6 +10561,62 @@ internal class RumViewScopeTest {
                 viewName = fakeKey.name
             )
         )
+    }
+
+    @Test
+    fun `M not send RumVitalEvent OPERATION to profiling W handleEvent { StartOperation, write fails }`(
+        @StringForgery fakeName: String,
+        forge: Forge
+    ) {
+        // Given
+        val fakeOperationKey = forge.aNullable { anAlphabeticalString() }
+        val event = RumRawEvent.StartOperation(
+            fakeName,
+            operationKey = fakeOperationKey,
+            attributes = emptyMap(),
+            eventTime = fakeEventTime
+        )
+        // The RUM operation vital write does not succeed.
+        whenever(mockWriter.write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))) doReturn false
+
+        // When
+        testedScope.handleEvent(event, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then — the profile must not reference an operation vital id that RUM never ingested.
+        verify(mockProfilingFeatureScope, never()).sendEvent(isA<ProfilerEvent.RumVitalEvent>())
+    }
+
+    @Test
+    fun `M build vital and profiling event from same context W handleEvent { StartOperation }`(
+        @StringForgery fakeName: String,
+        forge: Forge
+    ) {
+        // Given
+        val fakeOperationKey = forge.aNullable { anAlphabeticalString() }
+        val event = RumRawEvent.StartOperation(
+            fakeName,
+            operationKey = fakeOperationKey,
+            attributes = emptyMap(),
+            eventTime = fakeEventTime
+        )
+
+        // When
+        testedScope.handleEvent(event, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then — the written vital and the profiling metadata must describe the same RUM context,
+        // so profile/RUM correlation cannot drift if the session/view is renewed mid-write.
+        val schemaEventCaptor = argumentCaptor<VitalOperationStepEvent>()
+        verify(mockWriter).write(eq(mockEventBatchWriter), schemaEventCaptor.capture(), eq(EventType.DEFAULT))
+        val writtenVital = schemaEventCaptor.firstValue
+
+        val profilerEventCaptor = argumentCaptor<ProfilerEvent.RumVitalEvent>()
+        verify(mockProfilingFeatureScope).sendEvent(profilerEventCaptor.capture())
+        val profilerEvent = profilerEventCaptor.firstValue
+
+        assertThat(profilerEvent.rumContext.applicationId).isEqualTo(writtenVital.application.id)
+        assertThat(profilerEvent.rumContext.sessionId).isEqualTo(writtenVital.session.id)
+        assertThat(profilerEvent.rumContext.viewId).isEqualTo(writtenVital.view.id)
+        assertThat(profilerEvent.rumContext.viewName).isEqualTo(writtenVital.view.name)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

- **RUM-17258**: Publish profiling metadata (ANR, long task, and operation-vital events) only *after* the corresponding RUM write is confirmed. Previously the profiler could reference a RUM event id that RUM ultimately dropped. The RUM  context is captured synchronously before the write and reused in `onSuccess`, so profile/RUM correlation cannot drift across a mid-write session renewal.
- **RUM-17262**: Discard (delete) the Perfetto trace file when a launch profile is denied by quota, instead of leaking it on disk.
- **RUM-17264**: Attach clock drift to the view profiling status while profiling  is `RUNNING`, matching the error/long-task/operation-vital resolvers.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

