### PR TITLE
Fix isLaunchProfilingActive & isActive flag in Profiling

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
@@ -278,6 +278,7 @@ internal class ContinuousProfilingScheduler(
             unit = TimeUnit.MILLISECONDS,
             internalLogger = sdkCore.internalLogger,
             runnable = {
+                isActive = false
                 val cooldownMs = jitter(CONTINUOUS_COOLDOWN_DURATION_MS)
                 logToUser { LOG_ACTIVE_WINDOW_ENDED.format(Locale.US, cooldownMs) }
                 scheduleCooldown(cooldownMs)

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -238,6 +238,7 @@ internal class ProfilingFeature(
 
         if (continuousProfilingScheduler?.currentSessionSampled != true) {
             profiler.stop(sdkCore.name)
+            isLaunchProfilingActive = false
             tryWriteProfilingEvent()
             sdkCore.internalLogger.log(
                 InternalLogger.Level.INFO,

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -840,6 +840,36 @@ internal class ProfilingFeatureTest {
     }
 
     @Test
+    fun `M stop accumulating vital events W onReceive {launch stopped at TTID, quota still pending}`(
+        @Forgery fakeLaterVital: ProfilerEvent.RumVitalEvent
+    ) {
+        // Given — continuous disabled so launch profiling stops at TTID
+        testedFeature = ProfilingFeature(
+            mockSdkCore,
+            ProfilingConfiguration(
+                customEndpointUrl = null,
+                applicationLaunchSampleRate = 100f,
+                continuousSampleRate = 0f
+            ),
+            mockProfiler
+        )
+        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        testedFeature.onInitialize(mockContext)
+        // Launch trace is stopped at TTID; the quota decision and Perfetto result have NOT arrived,
+        // so the write is still pending.
+        testedFeature.onReceive(fakeTTID)
+        verify(mockProfiler).stop(fakeInstanceName)
+
+        // When — a vital arrives after the trace was stopped
+        testedFeature.onReceive(
+            fakeLaterVital.copy(type = ProfilerEvent.RumVitalEvent.Type.OPERATION)
+        )
+
+        // Then — it is not attached to the already-stopped launch profile
+        assertThat(testedFeature.pendingRumEvents.pendingVitalEvents).containsExactly(fakeTTID)
+    }
+
+    @Test
     fun `M accumulate vital event W onReceive {continuous active window open}`(
         @Forgery fakeContinuousVital: ProfilerEvent.RumVitalEvent
     ) {

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ContinuousProfilingSchedulerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ContinuousProfilingSchedulerTest.kt
@@ -325,6 +325,28 @@ internal class ContinuousProfilingSchedulerTest {
             .isBetween((cooldownBase * 0.8).toLong(), (cooldownBase * 1.2).toLong())
     }
 
+    @Test
+    fun `M clear active flag W active window end runnable fires`() {
+        // Given — open an active window
+        val runnableCaptor = argumentCaptor<Runnable>()
+        whenever(
+            mockSchedulerExecutor.schedule(runnableCaptor.capture(), any(), any<TimeUnit>())
+        ) doReturn mockFuture
+        testedScheduler.onRumSessionRenewed(sessionId = fakeSessionId, rumSessionSampleRate = 100f)
+        testedScheduler.start(launchProfilingActive = true)
+        testedScheduler.onAppLaunchProfilingComplete()
+        // Fire the cooldown runnable to reach scheduleNextCycle and start the active window
+        runnableCaptor.firstValue.run()
+        assertThat(testedScheduler.isActive).isTrue()
+
+        // When — the active window end runnable fires (before the Perfetto result callback lands)
+        runnableCaptor.secondValue.run()
+
+        // Then — buffering must stop immediately, without waiting for onActiveWindowEnded()
+        assertThat(testedScheduler.isActive).isFalse()
+        assertThat(testedScheduler.state).isEqualTo(ContinuousProfilingScheduler.State.COOLDOWN)
+    }
+
     // endregion
 
     // region onRumSessionRenewed


### PR DESCRIPTION
### What does this PR do?

* Set `isActive` to false when active window has ended in Continuous Profiler
* Set `isLaunchProfilingActive` to false when stop profiler from TTID event


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

