### PR TITLE
RUM-17238: Use Gradle plugin to run detekt

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -234,6 +234,7 @@ build,org.eclipse.jetty.toolchain,"Eclipse Public License - v 2.0","Copyright Ec
 build,org.freemarker,Apache-2.0,"Copyright 2015-2018 The Apache Software Foundation"
 build,org.fusesource.jansi,Apache-2.0,"Copyright Jansi authors"
 build,org.glassfish.jaxb,"Eclipse Distribution License - v 1.0","Copyright (c) 2018 Oracle and/or its affiliates"
+build,org.jcommander,Apache-2.0,"Copyright (C) 2010 the original author or authors"
 build,org.jetbrains.dokka,Apache-2.0,"Copyright 2014-2019 JetBrains s.r.o. and Dokka project contributors."
 build,org.jetbrains.intellij.deps,LGPL-2.1-only,"Copyright (c) 2001-2002, Eric D. Friedman, Jason Baldridge, Copyright (c) 1999 CERN - European Organization for Nuclear Research"
 build,org.jvnet.staxex,"Eclipse Distribution License - v 1.0","Copyright (c) 1997-2015 Oracle and/or its affiliates"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     // but since buildSrc leaks to the buildscript, we still have to load plugin artifacts
     // and then it will be classpath conflict. Maybe convention plugins will fix that.
     implementation(libs.kotlinGradlePlugin)
+    implementation(libs.detektGradlePlugin)
     implementation(libs.androidToolsGradlePlugin)
     implementation(libs.versionsGradlePlugin)
     implementation(libs.dokkaGradlePlugin)

--- a/buildSrc/src/main/kotlin/detekt-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/detekt-conventions.gradle.kts
@@ -1,0 +1,47 @@
+import io.gitlab.arturbosch.detekt.Detekt
+
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+plugins {
+    id("io.gitlab.arturbosch.detekt")
+}
+
+dependencies {
+    detektPlugins(project(":tools:detekt"))
+}
+
+detekt {
+    config.setFrom(
+        rootProject.file("detekt.yml"),
+        rootProject.file("detekt_custom_safe_calls_android.yml"),
+        rootProject.file("detekt_custom_safe_calls_third_party.yml"),
+        rootProject.file("detekt_custom_unsafe_calls.yml")
+    )
+    ignoredVariants = listOf("release")
+}
+
+tasks.withType<Detekt>().configureEach {
+    jvmTarget = "17"
+    reports {
+        sarif.required = false
+        html.required = false
+        xml.required = false
+        txt.required = false
+        md.required = false
+    }
+}
+
+// Disable the default task named "detekt" since it does not run type resolution
+// Use it purely as a nicely named umbrella task
+tasks.detekt {
+    isEnabled = false
+
+    dependsOn(
+        tasks.named("detektMain"),
+        tasks.named("detektTest")
+    )
+}

--- a/dd-sdk-android-core/build.gradle.kts
+++ b/dd-sdk-android-core/build.gradle.kts
@@ -41,6 +41,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 /**

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -697,8 +697,9 @@ internal class DatadogCore(
             features.remove(it)?.stop()
         }
 
-        if (appContext is Application && processLifecycleMonitor != null) {
-            appContext.unregisterActivityLifecycleCallbacks(processLifecycleMonitor)
+        val lifecycleMonitor = processLifecycleMonitor
+        if (appContext is Application && lifecycleMonitor != null) {
+            appContext.unregisterActivityLifecycleCallbacks(lifecycleMonitor)
         }
 
         contextProvider = NoOpContextProvider()

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
@@ -83,7 +83,7 @@ internal class BatchMetricsDispatcher(
 
     // region Internal
 
-    @SuppressWarnings("ReturnCount")
+    @Suppress("ReturnCount")
     private fun resolveBatchDeletedMetricAttributes(
         file: File,
         deletionReason: RemovalReason,
@@ -115,7 +115,7 @@ internal class BatchMetricsDispatcher(
         )
     }
 
-    @SuppressWarnings("ReturnCount")
+    @Suppress("ReturnCount")
     private fun resolveBatchClosedMetricAttributes(
         file: File,
         batchMetadata: BatchClosedMetadata

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/ndk/internal/DatadogNdkCrashHandler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/ndk/internal/DatadogNdkCrashHandler.kt
@@ -153,7 +153,7 @@ internal class DatadogNdkCrashHandler(
         }
     }
 
-    @SuppressWarnings("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught")
     private fun clearCrashLog() {
         if (ndkCrashDataDirectory.existsSafe(internalLogger)) {
             try {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/ndk/internal/DatadogNdkCrashHandler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/ndk/internal/DatadogNdkCrashHandler.kt
@@ -86,10 +86,11 @@ internal class DatadogNdkCrashHandler(
 
     @WorkerThread
     private fun checkAndHandleNdkCrashReport(sdkCore: FeatureSdkCore) {
-        if (lastNdkCrashLog != null) {
+        val ndkCrashLog = lastNdkCrashLog
+        if (ndkCrashLog != null) {
             handleNdkCrashLog(
                 sdkCore,
-                lastNdkCrashLog,
+                ndkCrashLog,
                 lastRumViewEvent
             )
             clearAllReferences()

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
@@ -950,7 +950,7 @@ internal class DatadogCoreTest {
                 countDownLatch.countDown()
                 it.putAll(fakeNewContext)
             }
-        }.apply { start() }
+        }.start()
         testedCore.setContextUpdateReceiver(mockContextUpdateListener)
 
         // Then

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
@@ -535,8 +535,8 @@ internal class DatadogCoreTest {
 
         // When
         testedCore.updateFeatureContext(feature, fakeUseContextThread) {
-            testedCore.updateFeatureContext(feature, fakeUseContextThread) {
-                it.putAll(fakeContextA)
+            testedCore.updateFeatureContext(feature, fakeUseContextThread) { innerContext ->
+                innerContext.putAll(fakeContextA)
             }
             it.putAll(fakeContextB)
         }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploaderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploaderTest.kt
@@ -521,7 +521,7 @@ internal class DataOkHttpUploaderTest {
         var statusCode: Int
         do {
             statusCode = forge.anInt(200, 600)
-        } while (statusCode in arrayOf(202, 400, 401, 403, 408, 413, 429, 500, 502, 503, 504, 507))
+        } while (statusCode in intArrayOf(202, 400, 401, 403, 408, 413, 429, 500, 502, 503, 504, 507))
         whenever(mockCall.execute()) doReturn mockResponse(statusCode, message)
 
         // When

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/logger/SdkInternalLoggerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/logger/SdkInternalLoggerTest.kt
@@ -716,7 +716,7 @@ internal class SdkInternalLoggerTest {
         }
 
         // Then
-        val count = mockingDetails(mockRumFeatureScope).invocations.filter { it.method.name == "sendEvent" }.size
+        val count = mockingDetails(mockRumFeatureScope).invocations.count { it.method.name == "sendEvent" }
         assertThat(count).isCloseTo(expectedCallCount, offset(marginOfError))
     }
 
@@ -792,7 +792,7 @@ internal class SdkInternalLoggerTest {
         }
 
         // Then
-        val count = mockingDetails(mockRumFeatureScope).invocations.filter { it.method.name == "sendEvent" }.size
+        val count = mockingDetails(mockRumFeatureScope).invocations.count { it.method.name == "sendEvent" }
         assertThat(count).isCloseTo(expectedCallCount, offset(marginOfError))
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/DefaultFirstPartyHostHeaderTypeResolverTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/DefaultFirstPartyHostHeaderTypeResolverTest.kt
@@ -380,13 +380,7 @@ internal class DefaultFirstPartyHostHeaderTypeResolverTest {
     @Test
     fun `M return all header types W getAllHeaderTypes() {first party hosts}`() {
         // Given
-        var allUsedHeaderTraces = mutableSetOf<TracingHeaderType>()
-
-        // When
-        for ((_, tracingHeaders) in fakeHosts) {
-            allUsedHeaderTraces =
-                allUsedHeaderTraces.plus(tracingHeaders) as MutableSet<TracingHeaderType>
-        }
+        val allUsedHeaderTraces = fakeHosts.values.flatten().toSet()
 
         // Then
         assertThat(testedDetector.getAllHeaderTypes()).isEqualTo(allUsedHeaderTraces)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileReaderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileReaderTest.kt
@@ -84,6 +84,8 @@ internal class DataStoreFileReaderTest {
     private lateinit var fakeDataBytes: ByteArray
     private lateinit var versionBlock: TLVBlock
     private lateinit var dataBlock: TLVBlock
+
+    @Suppress("DoubleMutabilityForCollection") // must stay mutable: tests add/remove/clear blocks in place
     private lateinit var blocksReturned: ArrayList<TLVBlock>
 
     @BeforeEach
@@ -236,7 +238,8 @@ internal class DataStoreFileReaderTest {
     @Test
     fun `M log unexpectedBlocksOrder error W read() { unexpected block order }`() {
         // Given
-        blocksReturned = arrayListOf(dataBlock, versionBlock)
+        blocksReturned.clear()
+        blocksReturned.addAll(listOf(dataBlock, versionBlock))
         whenever(mockTLVBlockFileReader.read(mockDataStoreFile)).thenReturn(blocksReturned)
         val mockCallback = mock<DataStoreReadCallback<ByteArray>>()
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/WorkerParametersForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/WorkerParametersForgeryFactory.kt
@@ -22,9 +22,7 @@ class WorkerParametersForgeryFactory : ForgeryFactory<WorkerParameters> {
     // region ForgeryFactory
 
     override fun getForgery(forge: Forge): WorkerParameters {
-        val sameThreadExecutor = object : Executor {
-            override fun execute(command: Runnable) = command.run()
-        }
+        val sameThreadExecutor = Executor { command -> command.run() }
         return WorkerParameters(
             forge.getForgery(),
             Data.EMPTY,

--- a/dd-sdk-android-internal/build.gradle.kts
+++ b/dd-sdk-android-internal/build.gradle.kts
@@ -37,6 +37,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/heatmaps/HeatmapIdentifierStoreTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/heatmaps/HeatmapIdentifierStoreTest.kt
@@ -251,7 +251,7 @@ internal class HeatmapIdentifierStoreTest {
                     repeat(READS_PER_READER) {
                         // ConcurrentLinkedQueue.add() doesn't throw for non-null elements
                         @Suppress("UnsafeThirdPartyFunctionCall")
-                        testedStore.getHeatmapIdentifier(viewId, fakeScreenName)?.let { seenValues.add(it) }
+                        testedStore.getHeatmapIdentifier(viewId, fakeScreenName)?.let { identifier -> seenValues.add(identifier) }
                     }
                 } catch (t: Throwable) {
                     firstError.compareAndSet(null, t)

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/heatmaps/HeatmapIdentifierStoreTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/heatmaps/HeatmapIdentifierStoreTest.kt
@@ -251,7 +251,9 @@ internal class HeatmapIdentifierStoreTest {
                     repeat(READS_PER_READER) {
                         // ConcurrentLinkedQueue.add() doesn't throw for non-null elements
                         @Suppress("UnsafeThirdPartyFunctionCall")
-                        testedStore.getHeatmapIdentifier(viewId, fakeScreenName)?.let { identifier -> seenValues.add(identifier) }
+                        testedStore.getHeatmapIdentifier(viewId, fakeScreenName)?.let { identifier ->
+                            seenValues.add(identifier)
+                        }
                     }
                 } catch (t: Throwable) {
                     firstError.compareAndSet(null, t)

--- a/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/network/HttpSpecTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/android/internal/network/HttpSpecTest.kt
@@ -77,9 +77,11 @@ internal class HttpSpecTest {
         private inline fun <reified C : Any> Any.getDeclaredConstants(): List<Pair<String, C>> {
             val constantType = C::class.javaPrimitiveType ?: C::class.java
             return this::class.java.declaredFields
+                .asSequence()
                 .filter { Modifier.isStatic(it.modifiers) && Modifier.isPublic(it.modifiers) }
                 .filter { it.type == constantType }
                 .map { it.name to it.get(null) as C }
+                .toList()
         }
     }
 }

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,0 +1,877 @@
+build:
+  maxIssues: 0
+  excludeCorrectable: false
+
+config:
+  validation: true
+  warningsAsErrors: true
+  checkExhaustiveness: false
+  # when writing own rules with new properties, exclude the property path e.g.: 'my_rule_set,.*>.*>[my_property]'
+  excludes: ''
+
+processors:
+  active: true
+
+console-reports:
+  active: true
+  exclude:
+    - 'ComplexityReport'
+    - 'FileBasedFindingsReport'
+    - 'BuildFailureReport'
+    - 'LiteFindingsReport'
+
+output-reports:
+  active: false
+
+comments:
+  active: true
+  AbsentOrWrongFileLicense:
+    active: false
+    licenseTemplateFile: 'license.template'
+    licenseTemplateIsRegex: false
+  CommentOverPrivateFunction:
+    active: false
+  CommentOverPrivateProperty:
+    active: false
+  DeprecatedBlockTag:
+    active: true
+  EndOfSentenceFormat:
+    active: true
+    excludes:
+      - '**/test/**'
+      - '**/build/generated/**'
+      - '**/dd-sdk-android/tools/**'
+      - '**/dd-sdk-android/sample/**'
+      - '**/dd-sdk-android/reliability/**'
+      - '**/dd-sdk-android/instrumented/**'
+    endOfSentenceFormat: '([.?!][ \t\n\r\f<])|([.?!:]$)'
+  KDocReferencesNonPublicProperty:
+    active: true
+    excludes:
+      - '**/dd-sdk-android/tools/**'
+      - '**/dd-sdk-android/sample/**'
+      - '**/dd-sdk-android/reliability/**'
+      - '**/dd-sdk-android/instrumented/**'
+  OutdatedDocumentation:
+    active: true
+    matchTypeParameters: true
+    matchDeclarationsOrder: true
+    allowParamOnConstructorProperties: true
+    excludes:
+      - '**/test/**'
+      - '**/androidTest/**'
+      - '**/build/generated/**'
+  UndocumentedPublicClass:
+    active: true
+    ignoreDefaultCompanionObject: true
+    excludes:
+      - '**/test/**'
+      - '**/androidTest/**'
+      - '**/build/generated/**'
+      - '**/dd-sdk-android/tools/**'
+      - '**/dd-sdk-android/sample/**'
+      - '**/dd-sdk-android/reliability/**'
+      - '**/dd-sdk-android/instrumented/**'
+    searchInNestedClass: true
+    searchInInnerClass: true
+    searchInInnerObject: true
+    searchInInnerInterface: true
+    searchInProtectedClass: true
+  UndocumentedPublicFunction:
+    active: true
+    excludes:
+      - '**/test/**'
+      - '**/androidTest/**'
+      - '**/build/generated/**'
+      - '**/dd-sdk-android/tools/**'
+      - '**/dd-sdk-android/sample/**'
+      - '**/dd-sdk-android/reliability/**'
+      - '**/dd-sdk-android/instrumented/**'
+    searchProtectedFunction: true
+  UndocumentedPublicProperty:
+    active: true
+    excludes:
+      - '**/test/**'
+      - '**/androidTest/**'
+      - '**/build/generated/**'
+      - '**/dd-sdk-android/tools/**'
+      - '**/dd-sdk-android/sample/**'
+      - '**/dd-sdk-android/reliability/**'
+      - '**/dd-sdk-android/instrumented/**'
+    searchProtectedProperty: true
+
+complexity:
+  active: true
+  excludes: ['**/build/**']
+  CognitiveComplexMethod:
+    active: false
+    threshold: 15
+  ComplexCondition:
+    active: true
+    threshold: 4
+  ComplexInterface:
+    active: false
+    threshold: 10
+    includeStaticDeclarations: false
+    includePrivateDeclarations: false
+    ignoreOverloaded: false
+  CyclomaticComplexMethod:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    threshold: 15
+    ignoreSingleWhenExpression: true
+    ignoreSimpleWhenEntries: true
+    ignoreNestingFunctions: false
+    nestingFunctions:
+      - 'also'
+      - 'apply'
+      - 'forEach'
+      - 'isNotNull'
+      - 'ifNull'
+      - 'let'
+      - 'run'
+      - 'use'
+      - 'with'
+  LabeledExpression:
+    active: false
+    ignoredLabels: []
+  LargeClass:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    threshold: 600
+  LongMethod:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    threshold: 60
+  LongParameterList:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    functionThreshold: 12
+    constructorThreshold: 12
+    ignoreDefaultParameters: true
+    ignoreDataClasses: true
+    ignoreAnnotatedParameter: []
+    ignoreAnnotated: [ 'Composable' ]
+  MethodOverloading:
+    active: true
+    threshold: 6
+  NamedArguments:
+    active: false
+    threshold: 6
+    ignoreArgumentsMatchingNames: true
+  NestedBlockDepth:
+    active: true
+    threshold: 4
+  NestedScopeFunctions:
+    active: false
+    threshold: 1
+    functions:
+      - 'kotlin.apply'
+      - 'kotlin.run'
+      - 'kotlin.with'
+      - 'kotlin.let'
+      - 'kotlin.also'
+  ReplaceSafeCallChainWithRun:
+    active: false
+  StringLiteralDuplication:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    threshold: 3
+    ignoreAnnotation: true
+    excludeStringsWithLessThan5Characters: true
+    ignoreStringsRegex: '$^'
+  TooManyFunctions:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    thresholdInFiles: 11
+    thresholdInClasses: 11
+    thresholdInInterfaces: 11
+    thresholdInObjects: 11
+    thresholdInEnums: 11
+    ignoreDeprecated: true
+    ignorePrivate: false
+    ignoreOverridden: true
+
+coroutines:
+  active: true
+  excludes: ['**/build/**']
+  GlobalCoroutineUsage:
+    active: false
+  InjectDispatcher:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    dispatcherNames:
+      - 'IO'
+      - 'Default'
+      - 'Unconfined'
+  RedundantSuspendModifier:
+    active: true
+  SleepInsteadOfDelay:
+    active: true
+  SuspendFunSwallowedCancellation:
+    active: true
+  SuspendFunWithCoroutineScopeReceiver:
+    active: false
+  SuspendFunWithFlowReturnType:
+    active: true
+
+empty-blocks:
+  active: true
+  excludes: ['**/build/**']
+  EmptyCatchBlock:
+    active: true
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  EmptyClassBlock:
+    active: true
+  EmptyDefaultConstructor:
+    active: true
+  EmptyDoWhileBlock:
+    active: true
+  EmptyElseBlock:
+    active: true
+  EmptyFinallyBlock:
+    active: true
+  EmptyForBlock:
+    active: true
+  EmptyFunctionBlock:
+    active: true
+    ignoreOverridden: true
+  EmptyIfBlock:
+    active: true
+  EmptyInitBlock:
+    active: true
+  EmptyKtFile:
+    active: true
+  EmptySecondaryConstructor:
+    active: true
+  EmptyTryBlock:
+    active: true
+  EmptyWhenBlock:
+    active: true
+  EmptyWhileBlock:
+    active: true
+
+exceptions:
+  active: true
+  excludes: ['**/build/**']
+  ExceptionRaisedInUnexpectedLocation:
+    active: true
+    methodNames:
+      - 'equals'
+      - 'finalize'
+      - 'hashCode'
+      - 'toString'
+  InstanceOfCheckForException:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+  NotImplementedDeclaration:
+    active: false
+  ObjectExtendsThrowable:
+    active: true
+  PrintStackTrace:
+    active: true
+  RethrowCaughtException:
+    active: true
+  ReturnFromFinally:
+    active: true
+    ignoreLabeled: false
+  SwallowedException:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    ignoredExceptionTypes:
+      - 'InterruptedException'
+      - 'MalformedURLException'
+      - 'NumberFormatException'
+      - 'ParseException'
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  ThrowingExceptionFromFinally:
+    active: true
+  ThrowingExceptionInMain:
+    active: false
+  ThrowingExceptionsWithoutMessageOrCause:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    exceptions:
+      - 'ArrayIndexOutOfBoundsException'
+      - 'Exception'
+      - 'IllegalArgumentException'
+      - 'IllegalMonitorStateException'
+      - 'IllegalStateException'
+      - 'IndexOutOfBoundsException'
+      - 'NullPointerException'
+      - 'RuntimeException'
+      - 'Throwable'
+  ThrowingNewInstanceOfSameException:
+    active: true
+  TooGenericExceptionCaught:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    exceptionNames:
+      - 'ArrayIndexOutOfBoundsException'
+      - 'Error'
+      - 'Exception'
+      - 'IllegalMonitorStateException'
+      - 'IndexOutOfBoundsException'
+      - 'NullPointerException'
+      - 'RuntimeException'
+      - 'Throwable'
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
+  TooGenericExceptionThrown:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    exceptionNames:
+      - 'Error'
+      - 'Exception'
+      - 'RuntimeException'
+      - 'Throwable'
+
+naming:
+  active: true
+  excludes: ['**/build/**']
+  BooleanPropertyNaming:
+    active: false
+    allowedPattern: '^(is|has|are)'
+  ClassNaming:
+    active: true
+    excludes: [ "**/test/**", "**/*Test/**", '**/testFixtures/**']
+    classPattern: '[A-Z][a-zA-Z0-9]*'
+  ConstructorParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    privateParameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+  EnumNaming:
+    active: true
+    excludes: [ "**/test/**", "**/*Test/**", '**/testFixtures/**']
+    enumEntryPattern: '[A-Z][_a-zA-Z0-9]*'
+  ForbiddenClassName:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    forbiddenName: []
+  FunctionMaxLength:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    maximumFunctionNameLength: 100
+  FunctionMinLength:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    minimumFunctionNameLength: 2
+  FunctionNaming:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    functionPattern: '[a-zA-Z][a-zA-Z0-9]*'
+    excludeClassPattern: '$^'
+    ignoreAnnotated: [ 'Composable' ]
+  FunctionParameterNaming:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+  InvalidPackageDeclaration:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    rootPackage: ''
+    requireRootInDeclaration: false
+  LambdaParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*|_'
+  MatchingDeclarationName:
+    active: true
+    mustBeFirst: true
+  MemberNameEqualsClassName:
+    active: true
+    ignoreOverridden: true
+  NoNameShadowing:
+    active: true
+  NonBooleanPropertyPrefixedWithIs:
+    active: false
+  ObjectPropertyNaming:
+    active: true
+    constantPattern: '[A-Za-z][_A-Za-z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
+  PackageNaming:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    packagePattern: '^(com\.datadog|io\.shopist)(\.[a-z][A-Za-z0-9]*)+'
+  TopLevelPropertyNaming:
+    active: true
+    constantPattern: '[A-Z][_A-Z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
+  VariableMaxLength:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    maximumVariableNameLength: 64
+  VariableMinLength:
+    active: true
+    minimumVariableNameLength: 1
+  VariableNaming:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    variablePattern: '[a-z][A-Za-z0-9]*'
+    privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+
+performance:
+  active: true
+  excludes: ['**/build/**']
+  ArrayPrimitive:
+    active: true
+  CouldBeSequence:
+    active: true
+    threshold: 3
+  ForEachOnRange:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+  SpreadOperator:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+  UnnecessaryPartOfBinaryExpression:
+    active: true
+  UnnecessaryTemporaryInstantiation:
+    active: true
+
+potential-bugs:
+  active: true
+  excludes: ['**/build/**']
+  AvoidReferentialEquality:
+    active: true
+    forbiddenTypePatterns:
+      - 'kotlin.String'
+  CastNullableToNonNullableType:
+    active: false
+  CastToNullableType:
+    active: true
+  Deprecation:
+    active: true
+  DontDowncastCollectionTypes:
+    active: true
+  DoubleMutabilityForCollection:
+    active: true
+    mutableTypes:
+      - 'kotlin.collections.MutableList'
+      - 'kotlin.collections.MutableMap'
+      - 'kotlin.collections.MutableSet'
+      - 'java.util.ArrayList'
+      - 'java.util.LinkedHashSet'
+      - 'java.util.HashSet'
+      - 'java.util.LinkedHashMap'
+      - 'java.util.HashMap'
+  ElseCaseInsteadOfExhaustiveWhen:
+    active: false
+    ignoredSubjectTypes: []
+  EqualsAlwaysReturnsTrueOrFalse:
+    active: true
+  EqualsWithHashCodeExist:
+    active: true
+  ExitOutsideMain:
+    active: true
+  ExplicitGarbageCollectionCall:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+  HasPlatformType:
+    active: true
+  IgnoredReturnValue:
+    active: true
+    restrictToConfig: true
+    returnValueAnnotations:
+      - 'CheckResult'
+      - '*.CheckResult'
+      - 'CheckReturnValue'
+      - '*.CheckReturnValue'
+    ignoreReturnValueAnnotations:
+      - 'CanIgnoreReturnValue'
+      - '*.CanIgnoreReturnValue'
+    returnValueTypes:
+      - 'kotlin.sequences.Sequence'
+      - 'kotlinx.coroutines.flow.*Flow'
+      - 'java.util.stream.*Stream'
+    ignoreFunctionCall: []
+  ImplicitDefaultLocale:
+    active: true
+  ImplicitUnitReturnType:
+    active: false
+    allowExplicitReturnType: true
+  InvalidRange:
+    active: true
+  IteratorHasNextCallsNextMethod:
+    active: true
+  IteratorNotThrowingNoSuchElementException:
+    active: true
+  LateinitUsage:
+    active: false
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    ignoreOnClassesPattern: ''
+  MapGetWithNotNullAssertionOperator:
+    active: true
+  MissingPackageDeclaration:
+    active: true
+    excludes: ['**/*.kts']
+  NullCheckOnMutableProperty:
+    active: true
+  NullableToStringCall:
+    active: false
+  PropertyUsedBeforeDeclaration:
+    active: false
+  UnconditionalJumpStatementInLoop:
+    active: true
+  UnnecessaryNotNullCheck:
+    active: false
+  UnnecessaryNotNullOperator:
+    active: true
+  UnnecessarySafeCall:
+    active: true
+  UnreachableCatchBlock:
+    active: true
+  UnreachableCode:
+    active: true
+  UnsafeCallOnNullableType:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+  UnsafeCast:
+    active: true
+  UnusedUnaryOperator:
+    active: true
+  UselessPostfixExpression:
+    active: true
+  WrongEqualsTypeParameter:
+    active: true
+
+style:
+  active: true
+  excludes: ['**/build/**']
+  AlsoCouldBeApply:
+    active: false
+  BracesOnIfStatements:
+    active: false
+    singleLine: 'never'
+    multiLine: 'always'
+  BracesOnWhenStatements:
+    active: false
+    singleLine: 'necessary'
+    multiLine: 'consistent'
+  CanBeNonNullable:
+    active: false
+  CascadingCallWrapping:
+    active: false
+    includeElvis: true
+  ClassOrdering:
+    active: false
+  CollapsibleIfStatements:
+    active: false
+  DataClassContainsFunctions:
+    active: false
+    conversionFunctionPrefix:
+      - 'to'
+      - 'as'
+    allowOperators: true
+  DataClassShouldBeImmutable:
+    active: false
+  DestructuringDeclarationWithTooManyEntries:
+    active: true
+    maxDestructuringEntries: 3
+  DoubleNegativeLambda:
+    active: true
+    negativeFunctions:
+      - reason: 'Use `takeIf` instead.'
+        value: 'takeUnless'
+      - reason: 'Use `all` instead.'
+        value: 'none'
+    negativeFunctionNameParts:
+      - 'not'
+      - 'non'
+  EqualsNullCall:
+    active: true
+  EqualsOnSignatureLine:
+    active: false
+  ExplicitCollectionElementAccessMethod:
+    active: false
+  ExplicitItLambdaParameter:
+    active: true
+  ExpressionBodySyntax:
+    active: false
+    includeLineWrapping: false
+  ForbiddenAnnotation:
+    active: true
+    annotations:
+      - reason: 'it is a java annotation. Use `Suppress` instead.'
+        value: 'java.lang.SuppressWarnings'
+      - reason: 'it is a java annotation. Use `kotlin.Deprecated` instead.'
+        value: 'java.lang.Deprecated'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.MustBeDocumented` instead.'
+        value: 'java.lang.annotation.Documented'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.Target` instead.'
+        value: 'java.lang.annotation.Target'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.Retention` instead.'
+        value: 'java.lang.annotation.Retention'
+      - reason: 'it is a java annotation. Use `kotlin.annotation.Repeatable` instead.'
+        value: 'java.lang.annotation.Repeatable'
+      - reason: 'Kotlin does not support @Inherited annotation, see https://youtrack.jetbrains.com/issue/KT-22265'
+        value: 'java.lang.annotation.Inherited'
+  ForbiddenComment:
+    active: false
+    comments:
+      - reason: 'Forbidden FIXME todo marker in comment, please fix the problem.'
+        value: 'FIXME:'
+      - reason: 'Forbidden STOPSHIP todo marker in comment, please address the problem before shipping the code.'
+        value: 'STOPSHIP:'
+      - reason: 'Forbidden TODO todo marker in comment, please do the changes.'
+        value: 'TODO:'
+    allowedPatterns: ''
+  ForbiddenImport:
+    active: false
+    imports: []
+    forbiddenPatterns: ''
+  ForbiddenMethodCall:
+    active: false
+    methods:
+      - reason: 'print does not allow you to configure the output stream. Use a logger instead.'
+        value: 'kotlin.io.print'
+      - reason: 'println does not allow you to configure the output stream. Use a logger instead.'
+        value: 'kotlin.io.println'
+  ForbiddenSuppress:
+    active: false
+    rules: []
+  ForbiddenVoid:
+    active: true
+    ignoreOverridden: false
+    ignoreUsageInGenerics: false
+  FunctionOnlyReturningConstant:
+    active: true
+    ignoreOverridableFunction: true
+    ignoreActualFunction: true
+    excludedFunctions: []
+  LoopWithTooManyJumpStatements:
+    active: true
+    maxJumpCount: 1
+  MagicNumber:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**', '**/tools/**']
+    ignoreNumbers:
+      - '-1'
+      - '0'
+      - '1'
+      - '2'
+    ignoreHashCodeFunction: true
+    ignorePropertyDeclaration: false
+    ignoreLocalVariableDeclaration: false
+    ignoreConstantDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
+    ignoreAnnotation: false
+    ignoreNamedArgument: true
+    ignoreEnums: false
+    ignoreRanges: false
+    ignoreExtensionFunctions: true
+  MandatoryBracesLoops:
+    active: false
+  MaxChainedCallsOnSameLine:
+    active: false
+    maxChainedCalls: 5
+  MaxLineLength:
+    active: true
+    maxLineLength: 120
+    excludePackageStatements: true
+    excludeImportStatements: true
+    excludeCommentStatements: true
+    excludeRawStrings: true
+  MayBeConst:
+    active: true
+  ModifierOrder:
+    active: true
+  MultilineLambdaItParameter:
+    active: false
+  MultilineRawStringIndentation:
+    active: false
+    indentSize: 4
+    trimmingMethods:
+      - 'trimIndent'
+      - 'trimMargin'
+  NestedClassesVisibility:
+    active: true
+  NewLineAtEndOfFile:
+    active: true
+  NoTabs:
+    active: false
+  NullableBooleanCheck:
+    active: false
+  ObjectLiteralToLambda:
+    active: true
+  OptionalAbstractKeyword:
+    active: true
+  OptionalUnit:
+    active: false
+  PreferToOverPairSyntax:
+    active: false
+  ProtectedMemberInFinalClass:
+    active: true
+  RedundantExplicitType:
+    active: false
+  RedundantHigherOrderMapUsage:
+    active: true
+  RedundantVisibilityModifierRule:
+    active: false
+  ReturnCount:
+    active: true
+    max: 2
+    excludedFunctions:
+      - 'equals'
+    excludeLabeled: false
+    excludeReturnFromLambda: true
+    excludeGuardClauses: false
+  SafeCast:
+    active: true
+  SerialVersionUIDInSerializableClass:
+    active: true
+  SpacingBetweenPackageAndImports:
+    active: false
+  StringShouldBeRawString:
+    active: false
+    maxEscapedCharacterCount: 2
+    ignoredCharacters: []
+  ThrowsCount:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**', '**/tools/**']
+    max: 2
+    excludeGuardClauses: false
+  TrailingWhitespace:
+    active: false
+  TrimMultilineRawString:
+    active: false
+    trimmingMethods:
+      - 'trimIndent'
+      - 'trimMargin'
+  UnderscoresInNumericLiterals:
+    active: false
+    acceptableLength: 4
+    allowNonStandardGrouping: false
+  UnnecessaryAbstractClass:
+    active: false
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**', '**/tools/**']
+  UnnecessaryAnnotationUseSiteTarget:
+    active: false
+  UnnecessaryApply:
+    active: true
+  UnnecessaryBackticks:
+    active: false
+  UnnecessaryBracesAroundTrailingLambda:
+    active: false
+  UnnecessaryFilter:
+    active: true
+  UnnecessaryInheritance:
+    active: true
+  UnnecessaryInnerClass:
+    active: false
+  UnnecessaryLet:
+    active: false
+  UnnecessaryParentheses:
+    active: false
+    allowForUnclearPrecedence: false
+  UntilInsteadOfRangeTo:
+    active: false
+  UnusedImports:
+    active: true
+  UnusedParameter:
+    active: true
+    allowedNames: 'ignored|expected'
+  UnusedPrivateClass:
+    active: true
+  UnusedPrivateMember:
+    active: true
+    allowedNames: ''
+    ignoreAnnotated:
+      - 'Preview*'
+  UnusedPrivateProperty:
+    active: true
+    allowedNames: '_|ignored|expected|serialVersionUID'
+  UseAnyOrNoneInsteadOfFind:
+    active: true
+  UseArrayLiteralsInAnnotations:
+    active: true
+  UseCheckNotNull:
+    active: true
+  UseCheckOrError:
+    active: true
+  UseDataClass:
+    active: false
+    allowVars: false
+  UseEmptyCounterpart:
+    active: false
+  UseIfEmptyOrIfBlank:
+    active: false
+  UseIfInsteadOfWhen:
+    active: false
+    ignoreWhenContainingVariableDeclaration: false
+  UseIsNullOrEmpty:
+    active: true
+  UseLet:
+    active: false
+  UseOrEmpty:
+    active: false
+  UseRequire:
+    active: true
+  UseRequireNotNull:
+    active: true
+  UseSumOfInsteadOfFlatMapSize:
+    active: false
+  UselessCallOnNotNull:
+    active: true
+  UtilityClassWithPublicConstructor:
+    active: true
+  VarCouldBeVal:
+    active: true
+    excludes: ['**/test/**', '**/*Test/**', '**/testFixtures/**']
+    ignoreLateinitVar: false
+  WildcardImport:
+    active: true
+    excludeImports: []
+
+datadog:
+  active: true
+  excludes:
+    - '**/build/**'
+    - '**/test/**'
+    - '**/testDebug/**'
+    - '**/testRelease/**'
+    - '**/androidTest/**'
+    - '**/testFixtures/**'
+    - '**/buildSrc/**'
+    - '**/*.kts'
+    - '**/instrumented/**'
+    - '**/reliability/**'
+    - '**/sample/**'
+    - '**/tools/**'
+  PackageNameVisibility:
+    active: true
+    withBreakingChanges: true
+    ignoredAnnotations:
+      - "com.datadog.android.lint.InternalApi"
+  PreferTimeProvider:
+    active: true
+    allowedFiles:
+      - '.*TimeProvider.*'
+      - '.*Time\.kt'
+      - '.*DdRumContentProvider.*'
+  ThreadSafety:
+    active: true
+    workerThreadSwitchingCalls:
+      - "com.datadog.android.core.internal.utils.submitSafe"
+      - "com.datadog.android.core.internal.utils.executeSafe"
+      - "com.datadog.android.core.internal.utils.scheduleSafe"
+      - "com.datadog.android.api.feature.FeatureScope.withWriteContext"
+      - "com.datadog.android.api.feature.EventWriteScope.invoke"
+    mainThreadSwitchingCalls:
+      - "android.widget.LinearLayout.post"
+  TodoWithoutTask:
+    active: true
+    deprecatedPrefixes:
+      - "RUMM"
+      - "REPLAY"
+  UnsafeThirdPartyFunctionCall:
+    active: true
+    internalPackagePrefix: 'com.datadog'
+    treatUnknownFunctionAsThrowing: true
+    treatUnknownConstructorAsThrowing: true
+
+datadog-test-pyramid:
+  active: false

--- a/features/dd-sdk-android-flags-openfeature/build.gradle.kts
+++ b/features/dd-sdk-android-flags-openfeature/build.gradle.kts
@@ -36,6 +36,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProviderTest.kt
+++ b/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProviderTest.kt
@@ -4,6 +4,9 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
+// doNothing() (used inside lenient().apply { ... } below) confuses detekt's UnusedImports usage tracking
+@file:Suppress("UnusedImports")
+
 package com.datadog.android.flags.openfeature
 
 import com.datadog.android.api.InternalLogger

--- a/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProviderTest.kt
+++ b/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProviderTest.kt
@@ -71,6 +71,7 @@ internal class DatadogFlagsProviderTest {
     private var capturedStateListener: FlagsStateListener? = null
 
     @BeforeEach
+    @Suppress("UnnecessaryApply") // lenient()'s pending-stub marker must consume the same mock invocation it wraps
     fun setUp() {
         whenever(mockSdkCore.internalLogger).thenReturn(mockInternalLogger)
 

--- a/features/dd-sdk-android-flags/build.gradle.kts
+++ b/features/dd-sdk-android-flags/build.gradle.kts
@@ -38,6 +38,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 createJsonModelsGenerationTask("generateFlagsModelsFromJson") {

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/aggregation/EvaluationAggregator.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/aggregation/EvaluationAggregator.kt
@@ -18,7 +18,7 @@ import kotlin.concurrent.withLock
  * ensuring exclusive access during [drain].
  */
 internal class EvaluationAggregator(private val maxAggregations: Int) {
-    private var aggregationMap = mutableMapOf<EvaluationAggregationKey, EvaluationAggregationStats>()
+    private val aggregationMap = mutableMapOf<EvaluationAggregationKey, EvaluationAggregationStats>()
 
     private val mapLock = ReentrantLock()
 
@@ -88,14 +88,13 @@ internal class EvaluationAggregator(private val maxAggregations: Int) {
     }
 
     /**
-     * Swaps the aggregation map with a fresh one and returns the old map.
-     * Must be called while holding the write lock.
+     * Snapshots the aggregation map and clears it. Must be called while holding the write lock.
      *
-     * @return the old map, or null if empty
+     * @return the snapshotted map, or null if empty
      */
     private fun drainAggregationStats(): Map<EvaluationAggregationKey, EvaluationAggregationStats> = mapLock.withLock {
-        val toDrain = aggregationMap
-        aggregationMap = mutableMapOf()
+        val toDrain = aggregationMap.toMap()
+        aggregationMap.clear()
         toDrain
     }
 }

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/NoOpFlagsClientTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/NoOpFlagsClientTest.kt
@@ -20,7 +20,6 @@ import org.json.JSONObject
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.ArgumentMatchers.argThat
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/aggregation/EvaluationAggregatorTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/aggregation/EvaluationAggregatorTest.kt
@@ -324,7 +324,7 @@ internal class EvaluationAggregatorTest {
             startLatch.await()
             repeat(drainCount) {
                 Thread.sleep(1)
-                allDrained.addAll(testedAggregator.drain().map { it.count })
+                allDrained.addAll(testedAggregator.drain().map { record -> record.count })
             }
             finishLatch.countDown()
         }

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/net/PrecomputeMapperTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/net/PrecomputeMapperTest.kt
@@ -279,14 +279,17 @@ internal class PrecomputeMapperTest {
         assertThat(result).hasSize(3)
         assertThat(result).containsKeys(flagKey1, flagKey2, flagKey3)
 
-        assertThat(result[flagKey1]!!.variationType).isEqualTo(VariationType.STRING.value)
-        assertThat(result[flagKey1]!!.variationValue).isEqualTo("value1")
+        val flag1 = result.getValue(flagKey1)
+        assertThat(flag1.variationType).isEqualTo(VariationType.STRING.value)
+        assertThat(flag1.variationValue).isEqualTo("value1")
 
-        assertThat(result[flagKey2]!!.variationType).isEqualTo(VariationType.BOOLEAN.value)
-        assertThat(result[flagKey2]!!.variationValue).isEqualTo("true")
+        val flag2 = result.getValue(flagKey2)
+        assertThat(flag2.variationType).isEqualTo(VariationType.BOOLEAN.value)
+        assertThat(flag2.variationValue).isEqualTo("true")
 
-        assertThat(result[flagKey3]!!.variationType).isEqualTo(VariationType.INTEGER.value)
-        assertThat(result[flagKey3]!!.variationValue).isEqualTo("42")
+        val flag3 = result.getValue(flagKey3)
+        assertThat(flag3.variationType).isEqualTo(VariationType.INTEGER.value)
+        assertThat(flag3.variationValue).isEqualTo("42")
 
         verifyNoInteractions(mockInternalLogger)
     }

--- a/features/dd-sdk-android-logs/build.gradle.kts
+++ b/features/dd-sdk-android-logs/build.gradle.kts
@@ -40,6 +40,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/features/dd-sdk-android-ndk/build.gradle.kts
+++ b/features/dd-sdk-android-ndk/build.gradle.kts
@@ -37,6 +37,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/features/dd-sdk-android-ndk/src/main/kotlin/com/datadog/android/ndk/internal/NdkCrashReportsFeature.kt
+++ b/features/dd-sdk-android-ndk/src/main/kotlin/com/datadog/android/ndk/internal/NdkCrashReportsFeature.kt
@@ -114,7 +114,7 @@ internal class NdkCrashReportsFeature(
             nativeLibraryLoaded = true
         } catch (e: SecurityException) {
             exception = e
-        } catch (@SuppressWarnings("TooGenericExceptionCaught") e: NullPointerException) {
+        } catch (@Suppress("TooGenericExceptionCaught") e: NullPointerException) {
             exception = e
         } catch (e: UnsatisfiedLinkError) {
             exception = e

--- a/features/dd-sdk-android-profiling/build.gradle.kts
+++ b/features/dd-sdk-android-profiling/build.gradle.kts
@@ -41,6 +41,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingRequestFactory.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingRequestFactory.kt
@@ -66,9 +66,7 @@ internal class ProfilingRequestFactory(
 
     @Suppress("UnsafeThirdPartyFunctionCall", "ThrowingInternalException") // Caught in the caller
     private fun buildRequestBody(batchData: List<RawBatchEvent>): RequestBody {
-        if (batchData.isEmpty()) {
-            throw IllegalStateException(EMPTY_BATCH_DATA_ERROR_MESSAGE)
-        }
+        check(batchData.isNotEmpty()) { EMPTY_BATCH_DATA_ERROR_MESSAGE }
         if (batchData.size > 1) {
             internalLogger.log(
                 InternalLogger.Level.WARN,

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingRequestFactory.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingRequestFactory.kt
@@ -64,7 +64,7 @@ internal class ProfilingRequestFactory(
         return customEndpointUrl ?: (context.site.intakeEndpoint + "/api/v2/profile")
     }
 
-    @Suppress("UnsafeThirdPartyFunctionCall", "ThrowingInternalException") // Caught in the caller
+    @Suppress("UnsafeThirdPartyFunctionCall", "CheckInternal") // Caught in the caller
     private fun buildRequestBody(batchData: List<RawBatchEvent>): RequestBody {
         check(batchData.isNotEmpty()) { EMPTY_BATCH_DATA_ERROR_MESSAGE }
         if (batchData.size > 1) {

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingStorage.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingStorage.kt
@@ -18,9 +18,7 @@ internal object ProfilingStorage {
     internal var sharedPreferencesStorage: SharedPreferencesStorage? = null
 
     internal fun setSampleRate(appContext: Context, sampleRate: Float) {
-        getStorage(appContext).apply {
-            putFloat(KEY_PROFILING_SAMPLE_RATE, sampleRate)
-        }
+        getStorage(appContext).putFloat(KEY_PROFILING_SAMPLE_RATE, sampleRate)
     }
 
     internal fun getSampleRate(appContext: Context): Float {

--- a/features/dd-sdk-android-rum-debug-widget/build.gradle.kts
+++ b/features/dd-sdk-android-rum-debug-widget/build.gradle.kts
@@ -36,6 +36,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/features/dd-sdk-android-rum-debug-widget/src/main/kotlin/com/datadog/android/insights/internal/widgets/ChartView.kt
+++ b/features/dd-sdk-android-rum-debug-widget/src/main/kotlin/com/datadog/android/insights/internal/widgets/ChartView.kt
@@ -61,7 +61,7 @@ internal class ChartView @JvmOverloads constructor(
             invalidate()
         }
 
-    private var data = EvictingQueue<Double>(MAX_DATA_POINTS)
+    private val data = EvictingQueue<Double>(MAX_DATA_POINTS)
     private var dataAveraged = listOf<Double>()
     private val textMargin = px(TEXT_MARGIN_DP)
     private var yMin = Double.MAX_VALUE

--- a/features/dd-sdk-android-rum/build.gradle.kts
+++ b/features/dd-sdk-android-rum/build.gradle.kts
@@ -42,6 +42,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -196,7 +196,7 @@ interface RumMonitor {
      * @see [startResource]
      * @see [stopResource]
      */
-    @SuppressWarnings("LongParameterList")
+    @Suppress("LongParameterList")
     fun stopResourceWithError(
         key: String,
         statusCode: Int?,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
@@ -187,14 +187,14 @@ internal class DatadogLateCrashReporter(
         threadDumps: List<ThreadDump>?,
         viewEvent: ViewEvent
     ): ErrorEvent {
-        val connectivity = viewEvent.connectivity?.let {
+        val connectivity = viewEvent.connectivity?.let { viewConnectivity ->
             val connectivityStatus =
-                ErrorEvent.ConnectivityStatus.valueOf(it.status.name)
+                ErrorEvent.ConnectivityStatus.valueOf(viewConnectivity.status.name)
             val connectivityInterfaces =
-                it.interfaces?.map { ErrorEvent.Interface.valueOf(it.name) }
+                viewConnectivity.interfaces?.map { ErrorEvent.Interface.valueOf(it.name) }
             val cellular = ErrorEvent.Cellular(
-                it.cellular?.technology,
-                it.cellular?.carrierName
+                viewConnectivity.cellular?.technology,
+                viewConnectivity.cellular?.carrierName
             )
             ErrorEvent.Connectivity(connectivityStatus, connectivityInterfaces, cellular = cellular)
         }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/accessibility/DefaultAccessibilityReader.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/accessibility/DefaultAccessibilityReader.kt
@@ -62,7 +62,7 @@ internal class DefaultAccessibilityReader(
         }
     }
 
-    private val touchListener = TouchExplorationStateChangeListener {
+    private val touchListener = TouchExplorationStateChangeListener { _ ->
         val newScreenReaderEnabled = isScreenReaderEnabled(accessibilityManager)
         updateState { it.copy(isScreenReaderEnabled = newScreenReaderEnabled) }
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializer.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializer.kt
@@ -53,7 +53,7 @@ internal class RumEventDeserializer(private val internalLogger: InternalLogger) 
 
     // region Internal
 
-    @SuppressWarnings("ThrowingInternalException")
+    @Suppress("ThrowingInternalException")
     @Throws(JsonParseException::class)
     private fun parseEvent(eventType: String?, model: JsonObject): Any {
         return when (eventType) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
@@ -226,7 +226,7 @@ internal class RumApplicationScope(
         }
 
         // Confidence telemetry, only end up with one active session
-        if (childScopes.filter { it.isActive() }.size > 1) {
+        if (childScopes.count { it.isActive() } > 1) {
             sdkCore.internalLogger.log(
                 InternalLogger.Level.ERROR,
                 InternalLogger.Target.TELEMETRY,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -418,7 +418,7 @@ internal class RumResourceScope(
         }
     }
 
-    @SuppressWarnings("LongMethod")
+    @Suppress("LongMethod")
     private fun sendError(
         message: String,
         source: RumErrorSource,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -103,7 +103,7 @@ internal class RumSessionScope(
     )
 
     internal val activeView: RumViewScope?
-        get() = if (isActive() && childScope != null) {
+        get() = if (isActive()) {
             childScope?.activeView
         } else {
             null

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/ViewEndedMetricDispatcher.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/ViewEndedMetricDispatcher.kt
@@ -66,8 +66,9 @@ internal class ViewEndedMetricDispatcher(
         tnsState: ViewInitializationMetricsState
     ): Map<String, Any> = buildMap {
         putNonNull(KEY_DURATION, duration)
-        if (loadingTime != null) {
-            put(KEY_LOADING_TIME, buildMap { put(KEY_VALUE, loadingTime) })
+        val currentLoadingTime = loadingTime
+        if (currentLoadingTime != null) {
+            put(KEY_LOADING_TIME, buildMap { put(KEY_VALUE, currentLoadingTime) })
         }
         put(KEY_VIEW_TYPE, toAttributeValue(viewType))
         put(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor.kt
@@ -20,7 +20,7 @@ import com.datadog.android.rum.resource.ResourceId
 /**
  * FOR INTERNAL USAGE ONLY.
  */
-@SuppressWarnings("UndocumentedPublicFunction")
+@Suppress("UndocumentedPublicFunction")
 @InternalApi
 interface AdvancedNetworkRumMonitor : RumMonitor {
 
@@ -124,7 +124,7 @@ interface AdvancedNetworkRumMonitor : RumMonitor {
      * @see [stopResource]
      */
     @InternalApi
-    @SuppressWarnings("LongParameterList")
+    @Suppress("LongParameterList")
     fun stopResourceWithError(
         key: ResourceId,
         statusCode: Int?,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -23,7 +23,7 @@ import com.datadog.tools.annotation.NoOpImplementation
 /**
  * FOR INTERNAL USAGE ONLY.
  */
-@SuppressWarnings("ComplexInterface", "TooManyFunctions")
+@Suppress("ComplexInterface", "TooManyFunctions")
 @NoOpImplementation
 internal interface AdvancedRumMonitor : RumMonitor, AdvancedNetworkRumMonitor {
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/utils/SdkCoreExt.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/utils/SdkCoreExt.kt
@@ -47,7 +47,7 @@ internal class WriteOperation(
     }
 
     fun submit() {
-        writeScope {
+        writeScope { eventBatchWriter ->
             if (rumDataWriter is NoOpDataWriter) {
                 sdkCore.internalLogger.log(
                     level = InternalLogger.Level.INFO,
@@ -58,7 +58,7 @@ internal class WriteOperation(
             } else {
                 try {
                     val event = eventSource()
-                    val isSuccess = rumDataWriter.write(it, event, eventType)
+                    val isSuccess = rumDataWriter.write(eventBatchWriter, event, eventType)
                     if (isSuccess) {
                         advancedRumMonitor?.let {
                             onSuccess(it)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/FrameStatesAggregator.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/FrameStatesAggregator.kt
@@ -167,7 +167,7 @@ internal class FrameStatesAggregator(
     // region Internal
     private fun trackActivity(window: Window, activity: Activity) {
         val list = activeActivities[window] ?: mutableListOf()
-        if (list.find { it.get() == activity } != null) {
+        if (list.any { it.get() == activity }) {
             return
         }
         list.add(WeakReference(activity))

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
@@ -46,7 +46,7 @@ class NavigationViewTrackingStrategy(
 
     private var startedActivity: Activity? = null
 
-    private var lifecycleCallbackRefs =
+    private val lifecycleCallbackRefs =
         WeakHashMap<Activity, NavControllerFragmentLifecycleCallbacks>()
 
     private val predicate: ComponentPredicate<Fragment> = object : ComponentPredicate<Fragment> {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
@@ -135,11 +135,11 @@ internal class RumTest {
         whenever(mockSdkCore.registerFeature(any())) doAnswer {
             val feature = it.getArgument<RumFeature>(0)
 
-            val mockApplication = mock<Application> {
-                whenever(it.packageName) doReturn fakePackageName
-                whenever(it.resources) doReturn mock()
-                whenever(it.contentResolver) doReturn mock()
-                whenever(it.resources.configuration) doReturn mock()
+            val mockApplication = mock<Application> { application ->
+                whenever(application.packageName) doReturn fakePackageName
+                whenever(application.resources) doReturn mock()
+                whenever(application.contentResolver) doReturn mock()
+                whenever(application.resources.configuration) doReturn mock()
             }
             whenever(mockApplication.applicationContext) doReturn mockApplication
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnableTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnableTest.kt
@@ -100,7 +100,7 @@ internal class ANRDetectorRunnableTest {
             assertThat(allThreads.all { !it.crashed }).isTrue()
 
             val anrThread = allThreads.firstOrNull { it.name == Thread.currentThread().name }
-            check(anrThread != null)
+            checkNotNull(anrThread)
             assertThat(anrThread.stack).isEqualTo(anrExceptionCaptor.lastValue.loggableStackTrace())
             assertThat(allThreads.filter { it.name == anrThread.name }).hasSize(1)
             assertThat(allThreads.filterNot { it.name == anrThread.name }).isNotEmpty

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializerTest.kt
@@ -57,14 +57,14 @@ internal class RumEventDeserializerTest {
                     anyOrNull(),
                     anyOrNull()
                 )
-            ).thenAnswer {
-                it.getArgument(0)
+            ).thenAnswer { invocation ->
+                invocation.getArgument(0)
             }
-            whenever(it.validateTags(any())).thenAnswer {
-                it.getArgument(0)
+            whenever(it.validateTags(any())).thenAnswer { invocation ->
+                invocation.getArgument(0)
             }
-            whenever(it.validateTimings(any())).thenAnswer {
-                it.getArgument(0)
+            whenever(it.validateTimings(any())).thenAnswer { invocation ->
+                invocation.getArgument(0)
             }
         }
     )

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -9134,10 +9134,7 @@ internal class RumViewScopeTest {
 
         argumentCaptor<ViewEvent> {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
-            assertThat(lastValue)
-                .apply {
-                    hasSessionActive(false)
-                }
+            assertThat(lastValue).hasSessionActive(false)
         }
     }
 
@@ -9507,10 +9504,7 @@ internal class RumViewScopeTest {
         // Then
         argumentCaptor<ViewEvent> {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
-            assertThat(firstValue)
-                .apply {
-                    hasDuration(1)
-                }
+            assertThat(firstValue).hasDuration(1)
         }
         if (rawEventData.event !is RumRawEvent.StartView) {
             mockInternalLogger.verifyLog(
@@ -9538,10 +9532,7 @@ internal class RumViewScopeTest {
         // Then
         argumentCaptor<ViewEvent> {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
-            assertThat(firstValue)
-                .apply {
-                    hasDuration(1)
-                }
+            assertThat(firstValue).hasDuration(1)
         }
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
@@ -9577,10 +9568,7 @@ internal class RumViewScopeTest {
         // Then
         argumentCaptor<ViewEvent> {
             verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
-            assertThat(lastValue)
-                .apply {
-                    hasDuration(durationNs)
-                }
+            assertThat(lastValue).hasDuration(durationNs)
         }
     }
 
@@ -10786,7 +10774,7 @@ internal class RumViewScopeTest {
         @JvmStatic
         fun brokenTimeRawEventData(): List<RumRawEventData> {
             val forge = Forge()
-            Configurator().apply { configure(forge) }
+            Configurator().configure(forge)
             val fakeKey = forge.getForgery<RumScopeKey>()
             val fakeName = forge.anAlphabeticalString()
             val eventTime = Time(0, 0)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
@@ -556,10 +556,10 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
             RumAttributes.ACTION_TARGET_RESOURCE_ID to expectedResourceName
         )
         val providers = Array<ViewAttributesProvider>(forge.anInt(min = 0, max = 10)) {
-            mock {
-                whenever(it.extractAttributes(eq(validTarget), any())).thenAnswer {
+            mock { provider ->
+                whenever(provider.extractAttributes(eq(validTarget), any())).thenAnswer { invocation ->
                     @Suppress("UNCHECKED_CAST")
-                    val map = it.arguments[1] as MutableMap<String, Any?>
+                    val map = invocation.arguments[1] as MutableMap<String, Any?>
                     map[forge.aString()] = forge.aString()
                     expectedAttributes = map
                     null
@@ -626,10 +626,10 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         )
 
         val providers = Array<ViewAttributesProvider>(forge.anInt(min = 0, max = 10)) {
-            mock {
-                whenever(it.extractAttributes(eq(validTarget), any())).thenAnswer {
+            mock { provider ->
+                whenever(provider.extractAttributes(eq(validTarget), any())).thenAnswer { invocation ->
                     @Suppress("UNCHECKED_CAST")
-                    val map = it.arguments[1] as MutableMap<String, Any?>
+                    val map = invocation.arguments[1] as MutableMap<String, Any?>
                     map[forge.aString()] = forge.aString()
                     expectedAttributes = map
                     null

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
@@ -551,7 +551,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         }
         val expectedResourceName = forge.anAlphabeticalString()
         mockResourcesForTarget(validTarget, expectedResourceName)
-        var expectedAttributes: MutableMap<String, Any?> = mutableMapOf(
+        var expectedAttributes: Map<String, Any?> = mapOf(
             RumAttributes.ACTION_TARGET_CLASS_NAME to validTarget.javaClass.canonicalName,
             RumAttributes.ACTION_TARGET_RESOURCE_ID to expectedResourceName
         )
@@ -620,7 +620,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         }
         val expectedResourceName = forge.anAlphabeticalString()
         mockResourcesForTarget(validTarget, expectedResourceName)
-        var expectedAttributes: MutableMap<String, Any?> = mutableMapOf(
+        var expectedAttributes: Map<String, Any?> = mapOf(
             RumAttributes.ACTION_TARGET_CLASS_NAME to validTarget.javaClass.simpleName,
             RumAttributes.ACTION_TARGET_RESOURCE_ID to expectedResourceName
         )

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/RumSessionEndedMetricTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/RumSessionEndedMetricTest.kt
@@ -519,9 +519,7 @@ class RumSessionEndedMetricTest {
         val sessionEndedMetric = stubSessionEndedMetric()
 
         // When
-        viewEvent.copy(session = viewEvent.session.copy(id = fakeSessionId)).apply {
-            sessionEndedMetric.onViewTracked(this)
-        }
+        sessionEndedMetric.onViewTracked(viewEvent.copy(session = viewEvent.session.copy(id = fakeSessionId)))
 
         // Then
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcherTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcherTest.kt
@@ -98,9 +98,10 @@ internal class SessionEndedMetricDispatcherTest {
             fakeNtpOffsetAtStart,
             backgroundEventTracking
         )
-        viewEvent.copy(session = viewEvent.session.copy(id = fakeSessionId2)).apply {
-            dispatcher.onViewTracked(fakeSessionId1, this)
-        }
+        dispatcher.onViewTracked(
+            fakeSessionId1,
+            viewEvent.copy(session = viewEvent.session.copy(id = fakeSessionId2))
+        )
 
         dispatcher.endMetric(fakeSessionId1, fakeNtpOffsetAtEnd)
         dispatcher.endMetric(fakeSessionId2, fakeNtpOffsetAtEnd)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -2662,11 +2662,9 @@ internal class DatadogRumMonitorTest {
         val mockRootScope = mock<RumApplicationScope>().apply {
             whenever(getRumContext()) doReturn forge.getForgery<RumContext>()
             whenever(handleEvent(any(), any(), any(), any())) doAnswer {
-                if (isMethodOccupied) {
-                    throw IllegalStateException(
-                        "Only one thread should" +
-                            " be allowed to enter rootScope at the time."
-                    )
+                check(!isMethodOccupied) {
+                    "Only one thread should" +
+                        " be allowed to enter rootScope at the time."
                 }
                 isMethodOccupied = true
                 Thread.sleep(100)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumFirstDrawTimeReporterHandleImplTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/startup/RumFirstDrawTimeReporterHandleImplTest.kt
@@ -35,9 +35,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
-import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import kotlin.time.Duration

--- a/features/dd-sdk-android-session-replay-compose/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-compose/build.gradle.kts
@@ -37,6 +37,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SwitchSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SwitchSemanticsNodeMapper.kt
@@ -64,7 +64,7 @@ internal class SwitchSemanticsNodeMapper(
                 isDarkBackground = isDarkBackground
             )
 
-            listOfNotNull(trackWireframe, thumbWireframe)
+            listOf(trackWireframe, thumbWireframe)
         }
 
         return SemanticsWireframe(

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
@@ -211,14 +211,14 @@ internal fun Field.getSafe(target: Any?): Any? {
 internal fun getClassSafe(className: String, isCritical: Boolean = true): Class<*>? {
     return try {
         Class.forName(className)
-    } catch (e: LinkageError) {
-        if (isCritical) {
-            logReflectionException(className, LOG_TYPE_CLASS, LOG_REASON_LINKAGE_ERROR, e)
-        }
-        null
     } catch (e: ExceptionInInitializerError) {
         if (isCritical) {
             logReflectionException(className, LOG_TYPE_CLASS, LOG_REASON_INITIALIZATION_ERROR, e)
+        }
+        null
+    } catch (e: LinkageError) {
+        if (isCritical) {
+            logReflectionException(className, LOG_TYPE_CLASS, LOG_REASON_LINKAGE_ERROR, e)
         }
         null
     } catch (e: ClassNotFoundException) {

--- a/features/dd-sdk-android-session-replay-material/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-material/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/features/dd-sdk-android-session-replay/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay/build.gradle.kts
@@ -41,6 +41,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
@@ -64,7 +64,7 @@ data class SessionReplayConfiguration internal constructor(
         }
 
         private var customEndpointUrl: String? = null
-        private var privacy = SessionReplayPrivacy.MASK
+        private val privacy = SessionReplayPrivacy.MASK
 
         // indicates whether fine grained masking levels have been explicitly set
         private var fineGrainedMaskingSet = false
@@ -73,7 +73,7 @@ data class SessionReplayConfiguration internal constructor(
         private var startRecordingImmediately = true
         private var touchPrivacy = TouchPrivacy.HIDE
         private var textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL
-        private var extensionSupportSet: MutableSet<ExtensionSupport> = mutableSetOf()
+        private val extensionSupportSet: MutableSet<ExtensionSupport> = mutableSetOf()
         private var dynamicOptimizationEnabled = true
         private var systemRequirementsConfiguration = SystemRequirementsConfiguration.NONE
         private var internalCallback: SessionReplayInternalCallback = NoOpSessionReplayInternalCallback()

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandler.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandler.kt
@@ -129,7 +129,7 @@ internal class RecordedDataQueueHandler(
         while (recordedDataQueue.isNotEmpty()) {
             // peeking is safe here because we are in a synchronized block
             // and we check for isEmpty first
-            @SuppressWarnings("UnsafeThirdPartyFunctionCall")
+            @Suppress("UnsafeThirdPartyFunctionCall")
             val nextItem = recordedDataQueue.peek()
 
             if (nextItem != null) {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/net/ResourceRequestBodyFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/net/ResourceRequestBodyFactory.kt
@@ -33,7 +33,7 @@ internal class ResourceRequestBodyFactory(
         val applicationId = getApplicationId(deserializedResources) ?: return null
 
         // type is valid, so cannot throw IllegalArgumentException
-        @SuppressWarnings("UnsafeThirdPartyFunctionCall")
+        @Suppress("UnsafeThirdPartyFunctionCall")
         val builder = MultipartBody.Builder()
             .setType(MultipartBody.FORM)
 
@@ -78,7 +78,7 @@ internal class ResourceRequestBodyFactory(
         }
 
         // list is not empty, so cannot throw NoSuchElementException
-        @SuppressWarnings("UnsafeThirdPartyFunctionCall")
+        @Suppress("UnsafeThirdPartyFunctionCall")
         val applicationId = resources.last().applicationId
 
         return applicationId

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowInspector.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowInspector.kt
@@ -35,7 +35,7 @@ internal object WindowInspector {
         return@lazy GLOBAL_WM_CLASS?.getDeclaredField("mViews")
     }
 
-    @SuppressWarnings("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught")
     fun getGlobalWindowViews(
         internalLogger: InternalLogger,
         buildSdkVersionProvider: BuildSdkVersionProvider = BuildSdkVersionProvider.DEFAULT

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListener.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListener.kt
@@ -50,6 +50,7 @@ internal class WindowsOnDrawListener(
     }
 
     // Note: we declare the anonymous object explicitly to annotate the run method as @UiThread
+    @Suppress("ObjectLiteralToLambda")
     private val snapshotRunnable: Runnable = object : Runnable {
 
         @UiThread

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/EditTextMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/EditTextMapper.kt
@@ -83,7 +83,7 @@ class EditTextMapper(
 
     companion object {
 
-        internal val SENSITIVE_TEXT_VARIATIONS = arrayOf(
+        internal val SENSITIVE_TEXT_VARIATIONS = intArrayOf(
             InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS,
             InputType.TYPE_TEXT_VARIATION_POSTAL_ADDRESS,
             InputType.TYPE_TEXT_VARIATION_PASSWORD,
@@ -92,7 +92,7 @@ class EditTextMapper(
             InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD
         )
 
-        internal val SENSITIVE_NUMBER_VARIATIONS = arrayOf(
+        internal val SENSITIVE_NUMBER_VARIATIONS = intArrayOf(
             InputType.TYPE_NUMBER_VARIATION_PASSWORD
         )
     }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/net/BatchesToSegmentsMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/net/BatchesToSegmentsMapperTest.kt
@@ -249,6 +249,7 @@ internal class BatchesToSegmentsMapperTest {
                 )
             }
         val fakeBatchData = fakeEnrichedRecords
+            .asSequence()
             .map { JsonParser.parseString(it.toJson()).asJsonObject }
             .map {
                 val records = it.get(EnrichedRecord.RECORDS_KEY)
@@ -260,6 +261,7 @@ internal class BatchesToSegmentsMapperTest {
                 it
             }
             .map { it.toString().toByteArray() }
+            .toList()
 
         // When
         assertThat(testedMapper.map(datadogContext, fakeBatchData)).isEmpty()
@@ -287,6 +289,7 @@ internal class BatchesToSegmentsMapperTest {
             }
         var removedRecords = 0
         val fakeBatchData = fakeEnrichedRecords
+            .asSequence()
             .map { JsonParser.parseString(it.toJson()).asJsonObject }
             .mapIndexed { index, jsonObject ->
                 if (index == 0) {
@@ -303,6 +306,7 @@ internal class BatchesToSegmentsMapperTest {
                 }
             }
             .map { it.toString().toByteArray() }
+            .toList()
 
         // When
         val mappedSegments = testedMapper.map(datadogContext, fakeBatchData)
@@ -335,12 +339,14 @@ internal class BatchesToSegmentsMapperTest {
                 )
             }
         val fakeBatchData = fakeEnrichedRecords
+            .asSequence()
             .map { JsonParser.parseString(it.toJson()).asJsonObject }
             .map {
                 it.remove(EnrichedRecord.APPLICATION_ID_KEY)
                 it
             }
             .map { it.toString().toByteArray() }
+            .toList()
         // When
         assertThat(testedMapper.map(datadogContext, fakeBatchData)).isEmpty()
         mockInternalLogger.verifyLog(
@@ -374,6 +380,7 @@ internal class BatchesToSegmentsMapperTest {
             }
         var removedRecords = 0
         val fakeBatchData = fakeEnrichedRecords
+            .asSequence()
             .map { JsonParser.parseString(it.toJson()).asJsonObject }
             .mapIndexed { index, jsonObject ->
                 if (index == 0) {
@@ -387,6 +394,7 @@ internal class BatchesToSegmentsMapperTest {
                 }
             }
             .map { it.toString().toByteArray() }
+            .toList()
 
         // When
         val mappedSegments = testedMapper.map(datadogContext, fakeBatchData)
@@ -420,12 +428,14 @@ internal class BatchesToSegmentsMapperTest {
                 )
             }
         val fakeBatchData = fakeEnrichedRecords
+            .asSequence()
             .map { JsonParser.parseString(it.toJson()).asJsonObject }
             .map {
                 it.remove(EnrichedRecord.SESSION_ID_KEY)
                 it
             }
             .map { it.toString().toByteArray() }
+            .toList()
 
         // When
         assertThat(testedMapper.map(datadogContext, fakeBatchData)).isEmpty()
@@ -460,6 +470,7 @@ internal class BatchesToSegmentsMapperTest {
             }
         var removedRecords = 0
         val fakeBatchData = fakeEnrichedRecords
+            .asSequence()
             .map { JsonParser.parseString(it.toJson()).asJsonObject }
             .mapIndexed { index, jsonObject ->
                 if (index == 0) {
@@ -473,6 +484,7 @@ internal class BatchesToSegmentsMapperTest {
                 }
             }
             .map { it.toString().toByteArray() }
+            .toList()
 
         // When
         val mappedSegments = testedMapper.map(datadogContext, fakeBatchData)
@@ -507,12 +519,14 @@ internal class BatchesToSegmentsMapperTest {
                 )
             }
         val fakeBatchData = fakeEnrichedRecords
+            .asSequence()
             .map { JsonParser.parseString(it.toJson()).asJsonObject }
             .map {
                 it.remove(EnrichedRecord.VIEW_ID_KEY)
                 it
             }
             .map { it.toString().toByteArray() }
+            .toList()
 
         // Then
         assertThat(testedMapper.map(datadogContext, fakeBatchData)).isEmpty()
@@ -547,6 +561,7 @@ internal class BatchesToSegmentsMapperTest {
             }
         var removedRecords = 0
         val fakeBatchData = fakeEnrichedRecords
+            .asSequence()
             .map { JsonParser.parseString(it.toJson()).asJsonObject }
             .mapIndexed { index, jsonObject ->
                 if (index == 0) {
@@ -560,6 +575,7 @@ internal class BatchesToSegmentsMapperTest {
                 }
             }
             .map { it.toString().toByteArray() }
+            .toList()
 
         // When
         val mappedSegments = testedMapper.map(datadogContext, fakeBatchData)
@@ -595,6 +611,7 @@ internal class BatchesToSegmentsMapperTest {
             }
         var removedRecords = 0
         val fakeBatchData = fakeEnrichedRecords
+            .asSequence()
             .map { JsonParser.parseString(it.toJson()).asJsonObject }
             .mapIndexed { index, jsonObject ->
                 if (index == 0) {
@@ -614,6 +631,7 @@ internal class BatchesToSegmentsMapperTest {
                 }
             }
             .map { it.toString().toByteArray() }
+            .toList()
 
         // When
         val mappedSegments = testedMapper.map(datadogContext, fakeBatchData)
@@ -649,6 +667,7 @@ internal class BatchesToSegmentsMapperTest {
             }
         var removedRecords = 0
         val fakeBatchData = fakeEnrichedRecords
+            .asSequence()
             .map { JsonParser.parseString(it.toJson()).asJsonObject }
             .mapIndexed { index, jsonObject ->
                 if (index == 0) {
@@ -662,6 +681,7 @@ internal class BatchesToSegmentsMapperTest {
                 }
             }
             .map { it.toString().toByteArray() }
+            .toList()
 
         // When
         val mappedSegments = testedMapper.map(datadogContext, fakeBatchData)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/net/BatchesToSegmentsMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/net/BatchesToSegmentsMapperTest.kt
@@ -251,14 +251,13 @@ internal class BatchesToSegmentsMapperTest {
         val fakeBatchData = fakeEnrichedRecords
             .asSequence()
             .map { JsonParser.parseString(it.toJson()).asJsonObject }
-            .map {
+            .onEach {
                 val records = it.get(EnrichedRecord.RECORDS_KEY)
                     .asJsonArray
                 records.forEach { record ->
                     record.asJsonObject.remove(BatchesToSegmentsMapper.TIMESTAMP_KEY)
                 }
                 it.add(EnrichedRecord.RECORDS_KEY, records)
-                it
             }
             .map { it.toString().toByteArray() }
             .toList()
@@ -341,9 +340,8 @@ internal class BatchesToSegmentsMapperTest {
         val fakeBatchData = fakeEnrichedRecords
             .asSequence()
             .map { JsonParser.parseString(it.toJson()).asJsonObject }
-            .map {
+            .onEach {
                 it.remove(EnrichedRecord.APPLICATION_ID_KEY)
-                it
             }
             .map { it.toString().toByteArray() }
             .toList()
@@ -430,9 +428,8 @@ internal class BatchesToSegmentsMapperTest {
         val fakeBatchData = fakeEnrichedRecords
             .asSequence()
             .map { JsonParser.parseString(it.toJson()).asJsonObject }
-            .map {
+            .onEach {
                 it.remove(EnrichedRecord.SESSION_ID_KEY)
-                it
             }
             .map { it.toString().toByteArray() }
             .toList()
@@ -521,9 +518,8 @@ internal class BatchesToSegmentsMapperTest {
         val fakeBatchData = fakeEnrichedRecords
             .asSequence()
             .map { JsonParser.parseString(it.toJson()).asJsonObject }
-            .map {
+            .onEach {
                 it.remove(EnrichedRecord.VIEW_ID_KEY)
-                it
             }
             .map { it.toString().toByteArray() }
             .toList()

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/MutationResolverTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/MutationResolverTest.kt
@@ -770,15 +770,6 @@ internal class MutationResolverTest {
 
     // region Internal
 
-    private fun Forge.forgeDifferent(wireframeClip: MobileSegment.WireframeClip?): MobileSegment.WireframeClip {
-        while (true) {
-            val differentClip: MobileSegment.WireframeClip = getForgery()
-            if (differentClip != wireframeClip) {
-                return differentClip
-            }
-        }
-    }
-
     private fun MobileSegment.Wireframe.id(): Long {
         return when (this) {
             is MobileSegment.Wireframe.ShapeWireframe -> this.id

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/WireframeUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/WireframeUtilsTest.kt
@@ -591,9 +591,8 @@ internal class WireframeUtilsTest {
         forge: Forge
     ) {
         // Given
-        forge.getForgery<WireframeBounds>().copy(width = 0).apply {
-            whenever(mockBoundsUtils.resolveBounds(fakeWireframe)).thenReturn(this)
-        }
+        whenever(mockBoundsUtils.resolveBounds(fakeWireframe))
+            .thenReturn(forge.getForgery<WireframeBounds>().copy(width = 0))
 
         // Then
         assertThat(testedWireframeUtils.checkWireframeIsValid(fakeWireframe)).isFalse
@@ -605,9 +604,8 @@ internal class WireframeUtilsTest {
         forge: Forge
     ) {
         // Given
-        forge.getForgery<WireframeBounds>().copy(height = 0).apply {
-            whenever(mockBoundsUtils.resolveBounds(fakeWireframe)).thenReturn(this)
-        }
+        whenever(mockBoundsUtils.resolveBounds(fakeWireframe))
+            .thenReturn(forge.getForgery<WireframeBounds>().copy(height = 0))
 
         // Then
         assertThat(testedWireframeUtils.checkWireframeIsValid(fakeWireframe)).isFalse
@@ -620,12 +618,12 @@ internal class WireframeUtilsTest {
         // Given
         val fakeWireframe = forge.getForgery<MobileSegment.Wireframe.ShapeWireframe>()
             .copy(shapeStyle = null, border = null)
-        forge.getForgery<WireframeBounds>().copy(
-            width = forge.aPositiveLong(true),
-            height = forge.aPositiveLong(true)
-        ).apply {
-            whenever(mockBoundsUtils.resolveBounds(fakeWireframe)).thenReturn(this)
-        }
+        whenever(mockBoundsUtils.resolveBounds(fakeWireframe)).thenReturn(
+            forge.getForgery<WireframeBounds>().copy(
+                width = forge.aPositiveLong(true),
+                height = forge.aPositiveLong(true)
+            )
+        )
 
         // Then
         assertThat(testedWireframeUtils.checkWireframeIsValid(fakeWireframe)).isFalse
@@ -638,12 +636,12 @@ internal class WireframeUtilsTest {
         // Given
         val fakeWireframe = forge.getForgery<MobileSegment.Wireframe.ShapeWireframe>()
             .copy(shapeStyle = forge.getForgery(), border = null)
-        forge.getForgery<WireframeBounds>().copy(
-            width = forge.aPositiveLong(true),
-            height = forge.aPositiveLong(true)
-        ).apply {
-            whenever(mockBoundsUtils.resolveBounds(fakeWireframe)).thenReturn(this)
-        }
+        whenever(mockBoundsUtils.resolveBounds(fakeWireframe)).thenReturn(
+            forge.getForgery<WireframeBounds>().copy(
+                width = forge.aPositiveLong(true),
+                height = forge.aPositiveLong(true)
+            )
+        )
 
         // Then
         assertThat(testedWireframeUtils.checkWireframeIsValid(fakeWireframe)).isTrue
@@ -656,12 +654,12 @@ internal class WireframeUtilsTest {
         // Given
         val fakeWireframe = forge.getForgery<MobileSegment.Wireframe.ShapeWireframe>()
             .copy(shapeStyle = null, border = forge.getForgery())
-        forge.getForgery<WireframeBounds>().copy(
-            width = forge.aPositiveLong(true),
-            height = forge.aPositiveLong(true)
-        ).apply {
-            whenever(mockBoundsUtils.resolveBounds(fakeWireframe)).thenReturn(this)
-        }
+        whenever(mockBoundsUtils.resolveBounds(fakeWireframe)).thenReturn(
+            forge.getForgery<WireframeBounds>().copy(
+                width = forge.aPositiveLong(true),
+                height = forge.aPositiveLong(true)
+            )
+        )
 
         // Then
         assertThat(testedWireframeUtils.checkWireframeIsValid(fakeWireframe)).isTrue
@@ -674,12 +672,12 @@ internal class WireframeUtilsTest {
         // Given
         val fakeWireframe = forge.getForgery<MobileSegment.Wireframe.TextWireframe>()
             .copy(shapeStyle = null, border = null)
-        forge.getForgery<WireframeBounds>().copy(
-            width = forge.aPositiveLong(true),
-            height = forge.aPositiveLong(true)
-        ).apply {
-            whenever(mockBoundsUtils.resolveBounds(fakeWireframe)).thenReturn(this)
-        }
+        whenever(mockBoundsUtils.resolveBounds(fakeWireframe)).thenReturn(
+            forge.getForgery<WireframeBounds>().copy(
+                width = forge.aPositiveLong(true),
+                height = forge.aPositiveLong(true)
+            )
+        )
 
         // Then
         assertThat(testedWireframeUtils.checkWireframeIsValid(fakeWireframe)).isTrue

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/DebouncerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/DebouncerTest.kt
@@ -195,7 +195,7 @@ internal class DebouncerTest {
             .postDelayed(any(), eq(Debouncer.DEBOUNCE_TIME_IN_MS))
         verify(mockHandler, times(fakeDelayedRunnables.size + 1))
             .removeCallbacksAndMessages(null)
-        assertThat(fakeDelayedRunnables.filter { it.wasExecuted }.size).isEqualTo(0)
+        assertThat(fakeDelayedRunnables.count { it.wasExecuted }).isEqualTo(0)
         assertThat(fakeExecutedRunnable.wasExecuted).isTrue
     }
 
@@ -241,8 +241,8 @@ internal class DebouncerTest {
         val numOfCancelInvocations = fakeDelayedRunnablesPack1.size +
             fakeDelayedRunnablesPack2.size + 1
         verify(mockHandler, times(numOfCancelInvocations)).removeCallbacksAndMessages(null)
-        assertThat(fakeDelayedRunnablesPack1.filter { it.wasExecuted }.size).isEqualTo(0)
-        assertThat(fakeDelayedRunnablesPack2.filter { it.wasExecuted }.size).isEqualTo(0)
+        assertThat(fakeDelayedRunnablesPack1.count { it.wasExecuted }).isEqualTo(0)
+        assertThat(fakeDelayedRunnablesPack2.count { it.wasExecuted }).isEqualTo(0)
         assertThat(fakeExecutedRunnable.wasExecuted).isTrue
     }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ForgeExt.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ForgeExt.kt
@@ -40,9 +40,9 @@ internal inline fun <reified T : View> Forge.aMockView(): T {
     return mock {
         val absX = anInt(min = 0)
         val absY = anInt(min = 0)
-        whenever(it.getLocationOnScreen(any())).thenAnswer {
+        whenever(it.getLocationOnScreen(any())).thenAnswer { invocation ->
             val location = (
-                it.arguments[0]
+                invocation.arguments[0]
                     as IntArray
                 )
             location[0] = absX

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversalTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversalTest.kt
@@ -112,12 +112,12 @@ internal class TreeViewTraversalTest {
         val fakeTypeToMapperMap: Map<Class<out View>, WireframeMapper<View>> = fakeTypes
             .associateWith { mock() }
         val fakeTypeMapperWrappers = fakeTypes.map {
-            val mapper = fakeTypeToMapperMap[it]!!
+            val mapper = fakeTypeToMapperMap.getValue(it)
             MapperTypeWrapper(it, mapper)
         }
         val mockView = forge.anElementFrom(mockViews)
         whenever(
-            fakeTypeToMapperMap[mockView::class.java]!!.map(
+            fakeTypeToMapperMap.getValue(mockView::class.java).map(
                 eq(mockView),
                 eq(fakeMappingContext),
                 any(),
@@ -231,12 +231,12 @@ internal class TreeViewTraversalTest {
         val fakeTypeToMapperMap: Map<Class<out ViewGroup>, TraverseAllChildrenMapper<ViewGroup>> = fakeTypes
             .associateWith { mock() }
         val fakeTypeMapperWrappers = fakeTypes.map {
-            val mapper = fakeTypeToMapperMap[it]!!
+            val mapper = fakeTypeToMapperMap.getValue(it)
             MapperTypeWrapper(it, mapper)
         }
         val mockView = forge.anElementFrom(mockViews)
         whenever(
-            fakeTypeToMapperMap[mockView::class.java]!!.map(
+            fakeTypeToMapperMap.getValue(mockView::class.java).map(
                 eq(mockView),
                 eq(fakeMappingContext),
                 any(),

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/MotionEventUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/MotionEventUtilsTest.kt
@@ -38,8 +38,8 @@ internal class MotionEventUtilsTest {
     @Mock
     lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
 
-    var pointerXExpectedValues = mutableListOf<Float>()
-    var pointerYExpectedValues = mutableListOf<Float>()
+    val pointerXExpectedValues = mutableListOf<Float>()
+    val pointerYExpectedValues = mutableListOf<Float>()
 
     @BeforeEach
     fun `set up`(forge: Forge) {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/ImageViewUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/ImageViewUtilsTest.kt
@@ -218,8 +218,8 @@ internal class ImageViewUtilsTest {
         val fakeLeftPadding = forge.aPositiveInt()
         val fakeRightPadding = forge.aPositiveInt()
         val mockView: View = mock {
-            whenever(it.getLocationOnScreen(any())).thenAnswer {
-                val coords = it.arguments[0] as IntArray
+            whenever(it.getLocationOnScreen(any())).thenAnswer { invocation ->
+                val coords = invocation.arguments[0] as IntArray
                 coords[0] = fakeGlobalX
                 coords[1] = fakeGlobalY
                 null
@@ -259,8 +259,8 @@ internal class ImageViewUtilsTest {
         whenever(mockDrawable.intrinsicHeight).thenReturn(fakeDrawableHeight)
 
         val mockImageView: ImageView = mock {
-            whenever(it.getLocationOnScreen(any())).thenAnswer {
-                val coords = it.arguments[0] as IntArray
+            whenever(it.getLocationOnScreen(any())).thenAnswer { invocation ->
+                val coords = invocation.arguments[0] as IntArray
                 coords[0] = fakeGlobalX
                 coords[1] = fakeGlobalY
                 null
@@ -307,8 +307,8 @@ internal class ImageViewUtilsTest {
         whenever(mockDrawable.intrinsicHeight).thenReturn(fakeDrawableHeight)
 
         val mockImageView: ImageView = mock {
-            whenever(it.getLocationOnScreen(any())).thenAnswer {
-                val coords = it.arguments[0] as IntArray
+            whenever(it.getLocationOnScreen(any())).thenAnswer { invocation ->
+                val coords = invocation.arguments[0] as IntArray
                 coords[0] = fakeGlobalX
                 coords[1] = fakeGlobalY
                 null
@@ -355,8 +355,8 @@ internal class ImageViewUtilsTest {
         whenever(mockDrawable.intrinsicHeight).thenReturn(fakeDrawableHeight)
 
         val mockImageView: ImageView = mock {
-            whenever(it.getLocationOnScreen(any())).thenAnswer {
-                val coords = it.arguments[0] as IntArray
+            whenever(it.getLocationOnScreen(any())).thenAnswer { invocation ->
+                val coords = invocation.arguments[0] as IntArray
                 coords[0] = fakeGlobalX
                 coords[1] = fakeGlobalY
                 null
@@ -403,8 +403,8 @@ internal class ImageViewUtilsTest {
         whenever(mockDrawable.intrinsicHeight).thenReturn(fakeDrawableHeight)
 
         val mockImageView: ImageView = mock {
-            whenever(it.getLocationOnScreen(any())).thenAnswer {
-                val coords = it.arguments[0] as IntArray
+            whenever(it.getLocationOnScreen(any())).thenAnswer { invocation ->
+                val coords = invocation.arguments[0] as IntArray
                 coords[0] = fakeGlobalX
                 coords[1] = fakeGlobalY
                 null
@@ -458,8 +458,8 @@ internal class ImageViewUtilsTest {
         whenever(mockDrawable.intrinsicHeight).thenReturn(fakeDrawableHeight)
 
         val mockImageView: ImageView = mock {
-            whenever(it.getLocationOnScreen(any())).thenAnswer {
-                val coords = it.arguments[0] as IntArray
+            whenever(it.getLocationOnScreen(any())).thenAnswer { invocation ->
+                val coords = invocation.arguments[0] as IntArray
                 coords[0] = fakeGlobalX
                 coords[1] = fakeGlobalY
                 null
@@ -506,8 +506,8 @@ internal class ImageViewUtilsTest {
         whenever(mockDrawable.intrinsicHeight).thenReturn(fakeDrawableHeight)
 
         val mockImageView: ImageView = mock {
-            whenever(it.getLocationOnScreen(any())).thenAnswer {
-                val coords = it.arguments[0] as IntArray
+            whenever(it.getLocationOnScreen(any())).thenAnswer { invocation ->
+                val coords = invocation.arguments[0] as IntArray
                 coords[0] = fakeGlobalX
                 coords[1] = fakeGlobalY
                 null
@@ -558,8 +558,8 @@ internal class ImageViewUtilsTest {
         whenever(mockDrawable.intrinsicHeight).thenReturn(fakeDrawableHeight)
 
         val mockImageView: ImageView = mock {
-            whenever(it.getLocationOnScreen(any())).thenAnswer {
-                val coords = it.arguments[0] as IntArray
+            whenever(it.getLocationOnScreen(any())).thenAnswer { invocation ->
+                val coords = invocation.arguments[0] as IntArray
                 coords[0] = fakeGlobalX
                 coords[1] = fakeGlobalY
                 null
@@ -608,8 +608,8 @@ internal class ImageViewUtilsTest {
         whenever(mockDrawable.intrinsicHeight).thenReturn(fakeDrawableHeight)
 
         val mockImageView: ImageView = mock {
-            whenever(it.getLocationOnScreen(any())).thenAnswer {
-                val coords = it.arguments[0] as IntArray
+            whenever(it.getLocationOnScreen(any())).thenAnswer { invocation ->
+                val coords = invocation.arguments[0] as IntArray
                 coords[0] = fakeGlobalX
                 coords[1] = fakeGlobalY
                 null
@@ -654,8 +654,8 @@ internal class ImageViewUtilsTest {
         whenever(mockDrawable.intrinsicHeight).thenReturn(fakeDrawableHeight)
 
         val mockImageView: ImageView = mock {
-            whenever(it.getLocationOnScreen(any())).thenAnswer {
-                val coords = it.arguments[0] as IntArray
+            whenever(it.getLocationOnScreen(any())).thenAnswer { invocation ->
+                val coords = invocation.arguments[0] as IntArray
                 coords[0] = fakeGlobalX
                 coords[1] = fakeGlobalY
                 null
@@ -699,8 +699,8 @@ internal class ImageViewUtilsTest {
         whenever(mockDrawable.intrinsicHeight).thenReturn(fakeDrawableHeight)
 
         val mockImageView: ImageView = mock {
-            whenever(it.getLocationOnScreen(any())).thenAnswer {
-                val coords = it.arguments[0] as IntArray
+            whenever(it.getLocationOnScreen(any())).thenAnswer { invocation ->
+                val coords = invocation.arguments[0] as IntArray
                 coords[0] = fakeGlobalX
                 coords[1] = fakeGlobalY
                 null
@@ -744,8 +744,8 @@ internal class ImageViewUtilsTest {
         whenever(mockDrawable.intrinsicHeight).thenReturn(fakeDrawableHeight)
 
         val mockImageView: ImageView = mock {
-            whenever(it.getLocationOnScreen(any())).thenAnswer {
-                val coords = it.arguments[0] as IntArray
+            whenever(it.getLocationOnScreen(any())).thenAnswer { invocation ->
+                val coords = invocation.arguments[0] as IntArray
                 coords[0] = fakeGlobalX
                 coords[1] = fakeGlobalY
                 null

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/InvocationUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/InvocationUtilsTest.kt
@@ -28,7 +28,6 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
-import java.lang.Exception
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -86,8 +85,8 @@ internal class InvocationUtilsTest {
     ) {
         // Given
         val mockFunc = mock<() -> Boolean>()
-        val mockException: Exception = mock()
-        doThrow(mockException).`when`(mockFunc)
+        val mockException: RuntimeException = mock()
+        whenever(mockFunc()) doThrow mockException
 
         val captor = argumentCaptor<() -> String>()
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/MiscUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/MiscUtilsTest.kt
@@ -125,8 +125,8 @@ internal class MiscUtilsTest {
         val expectedScreenWidth = fakeScreenWidth.toLong().densityNormalized(fakeDensity)
         val expectedScreenHeight = fakeScreenHeight.toLong().densityNormalized(fakeDensity)
         val mockDisplay: Display = mock {
-            whenever(it.getSize(any())).thenAnswer {
-                val point = it.arguments[0] as Point
+            whenever(it.getSize(any())).thenAnswer { invocation ->
+                val point = invocation.arguments[0] as Point
                 point.x = fakeScreenWidth
                 point.y = fakeScreenHeight
                 null

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/EditTextMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/EditTextMapperTest.kt
@@ -273,7 +273,7 @@ internal abstract class EditTextMapperTest :
 
     companion object {
 
-        private val safeTextVariations = arrayOf(
+        private val safeTextVariations = intArrayOf(
             InputType.TYPE_TEXT_VARIATION_NORMAL,
             InputType.TYPE_TEXT_VARIATION_URI,
             InputType.TYPE_TEXT_VARIATION_EMAIL_SUBJECT,
@@ -285,17 +285,17 @@ internal abstract class EditTextMapperTest :
             InputType.TYPE_TEXT_VARIATION_PHONETIC
         )
 
-        private val safeNumberVariations = arrayOf(
+        private val safeNumberVariations = intArrayOf(
             InputType.TYPE_NUMBER_VARIATION_NORMAL
         )
 
-        private val safeDateTimeVariations = arrayOf(
+        private val safeDateTimeVariations = intArrayOf(
             InputType.TYPE_DATETIME_VARIATION_NORMAL,
             InputType.TYPE_DATETIME_VARIATION_DATE,
             InputType.TYPE_DATETIME_VARIATION_TIME
         )
 
-        private val sensitiveTextVariations = arrayOf(
+        private val sensitiveTextVariations = intArrayOf(
             InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS,
             InputType.TYPE_TEXT_VARIATION_POSTAL_ADDRESS,
             InputType.TYPE_TEXT_VARIATION_PASSWORD,
@@ -304,7 +304,7 @@ internal abstract class EditTextMapperTest :
             InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD
         )
 
-        private val sensitiveNumberVariations = arrayOf(
+        private val sensitiveNumberVariations = intArrayOf(
             InputType.TYPE_NUMBER_VARIATION_PASSWORD
         )
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/DefaultViewBoundsResolverTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/DefaultViewBoundsResolverTest.kt
@@ -39,8 +39,8 @@ internal class DefaultViewBoundsResolverTest {
         val fakeWidth = forge.aPositiveInt()
         val fakeHeight = forge.aPositiveInt()
         val mockView: View = mock {
-            whenever(it.getLocationOnScreen(any())).thenAnswer {
-                val coords = it.arguments[0] as IntArray
+            whenever(it.getLocationOnScreen(any())).thenAnswer { invocation ->
+                val coords = invocation.arguments[0] as IntArray
                 coords[0] = fakeGlobalX
                 coords[1] = fakeGlobalY
                 null

--- a/features/dd-sdk-android-trace-api/build.gradle.kts
+++ b/features/dd-sdk-android-trace-api/build.gradle.kts
@@ -37,6 +37,7 @@ plugins {
     id("apiSurface")
     id("transitiveDependencies")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/features/dd-sdk-android-trace-api/src/main/kotlin/com/datadog/android/trace/api/span/DatadogSpan.kt
+++ b/features/dd-sdk-android-trace-api/src/main/kotlin/com/datadog/android/trace/api/span/DatadogSpan.kt
@@ -13,7 +13,7 @@ import com.datadog.tools.annotation.NoOpImplementation
  * This includes span metadata, error handling, timing, and tag/metric management.
  */
 @NoOpImplementation
-@SuppressWarnings("TooManyFunctions")
+@Suppress("TooManyFunctions")
 interface DatadogSpan {
     /**
      * Indicates whether the current span is marked as an error.

--- a/features/dd-sdk-android-trace-api/src/main/kotlin/com/datadog/android/trace/api/span/DatadogSpanBuilder.kt
+++ b/features/dd-sdk-android-trace-api/src/main/kotlin/com/datadog/android/trace/api/span/DatadogSpanBuilder.kt
@@ -13,7 +13,7 @@ import com.datadog.tools.annotation.NoOpImplementation
  * before initializing it.
  */
 @NoOpImplementation
-@SuppressWarnings("TooManyFunctions")
+@Suppress("TooManyFunctions")
 interface DatadogSpanBuilder {
 
     /**

--- a/features/dd-sdk-android-trace-api/src/main/kotlin/com/datadog/android/trace/api/tracer/DatadogTracerBuilder.kt
+++ b/features/dd-sdk-android-trace-api/src/main/kotlin/com/datadog/android/trace/api/tracer/DatadogTracerBuilder.kt
@@ -14,7 +14,7 @@ import com.datadog.tools.annotation.NoOpImplementation
  * Builder interface for creating and configuring a [DatadogTracer] instance.
  */
 @NoOpImplementation(publicNoOpImplementation = true)
-@SuppressWarnings("TooManyFunctions")
+@Suppress("TooManyFunctions")
 interface DatadogTracerBuilder {
     /**
      * Constructs and returns an instance of [DatadogTracer] based on the current builder configuration.

--- a/features/dd-sdk-android-trace-internal/build.gradle.kts
+++ b/features/dd-sdk-android-trace-internal/build.gradle.kts
@@ -38,6 +38,7 @@ plugins {
     id("apiSurface")
     id("transitiveDependencies")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/features/dd-sdk-android-trace-internal/src/main/kotlin/com/datadog/android/trace/internal/domain/event/BigIntegerUtils.kt
+++ b/features/dd-sdk-android-trace-internal/src/main/kotlin/com/datadog/android/trace/internal/domain/event/BigIntegerUtils.kt
@@ -11,7 +11,7 @@ import java.math.BigInteger
 
 // TODO RUM-9902 Make internal internal after opentracing code removal. Required for DdSpanToSpanEventMapperTest
 @InternalApi
-@SuppressWarnings("UndocumentedPublicClass")
+@Suppress("UndocumentedPublicClass")
 object BigIntegerUtils {
 
     private const val LONG_BITS_SIZE = 64

--- a/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/PendingTraceTestBase.kt
+++ b/features/dd-sdk-android-trace-internal/src/test/kotlin/com/datadog/trace/core/PendingTraceTestBase.kt
@@ -21,7 +21,7 @@ import kotlin.concurrent.thread
 internal abstract class PendingTraceTestBase : DDCoreSpecification() {
 
     protected val writer = ListWriter()
-    protected val tracer = tracerBuilder().writer(writer).build()
+    protected val tracer: CoreTracer = tracerBuilder().writer(writer).build()
 
     protected lateinit var rootSpan: DDSpan
     protected lateinit var trace: PendingTrace

--- a/features/dd-sdk-android-trace-otel/build.gradle.kts
+++ b/features/dd-sdk-android-trace-otel/build.gradle.kts
@@ -37,6 +37,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/features/dd-sdk-android-trace-otel/src/test/kotlin/com/datadog/android/trace/opentelemetry/OtelTracerBuilderProviderTest.kt
+++ b/features/dd-sdk-android-trace-otel/src/test/kotlin/com/datadog/android/trace/opentelemetry/OtelTracerBuilderProviderTest.kt
@@ -101,7 +101,7 @@ internal class OtelTracerBuilderProviderTest {
     @Mock
     lateinit var mockTraceWriter: DatadogSpanWriter
 
-    lateinit var fakeRumContext: MutableMap<String, String>
+    lateinit var fakeRumContext: Map<String, String>
 
     @StringForgery(type = StringForgeryType.HEXADECIMAL)
     lateinit var fakeApplicationId: String
@@ -121,7 +121,7 @@ internal class OtelTracerBuilderProviderTest {
         whenever(
             mockSdkCore.getFeature(Feature.TRACING_FEATURE_NAME)
         ) doReturn mockTracingFeatureScope
-        fakeRumContext = mutableMapOf(
+        fakeRumContext = mapOf(
             OtelTracerProvider.RUM_APPLICATION_ID_KEY to fakeApplicationId,
             OtelTracerProvider.RUM_SESSION_ID_KEY to fakeSessionId,
             OtelTracerProvider.RUM_VIEW_ID_KEY to fakeViewId,

--- a/features/dd-sdk-android-trace/build.gradle.kts
+++ b/features/dd-sdk-android-trace/build.gradle.kts
@@ -40,6 +40,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/DatadogTracing.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/DatadogTracing.kt
@@ -21,7 +21,7 @@ import com.datadog.trace.core.CoreTracer
 /**
  * Object responsible for providing tracing capabilities in the Datadog SDK.
  */
-@SuppressWarnings("UndocumentedPublicFunction")
+@Suppress("UndocumentedPublicFunction")
 object DatadogTracing {
     /**
      * Creates and returns a new instance of [DatadogTracerBuilder]. This method initializes and configures the

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/SpanExt.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/SpanExt.kt
@@ -18,7 +18,7 @@ import com.datadog.android.trace.api.span.DatadogSpan
  * @param block the lambda function traced by this newly created [DatadogSpan]
  *
  */
-@SuppressWarnings("TooGenericExceptionCaught")
+@Suppress("TooGenericExceptionCaught")
 inline fun <T : Any?> withinSpan(
     operationName: String,
     parentSpan: DatadogSpan? = null,

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/SpanSamplingIdProviderTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/SpanSamplingIdProviderTest.kt
@@ -63,7 +63,7 @@ internal class SpanSamplingIdProviderTest {
     ) {
         // Given
         val expectedId = part4.toULong()
-        val sessionId = arrayOf(part0, part1, part2, part3, part4).joinToString("-") { it.toHexString() }
+        val sessionId = longArrayOf(part0, part1, part2, part3, part4).joinToString("-") { it.toHexString() }
         val fakeTagsWithSessionId = fakeTags + mapOf(LogAttributes.RUM_SESSION_ID to sessionId)
         whenever(mockSpanContext.tags) doReturn fakeTagsWithSessionId
 

--- a/features/dd-sdk-android-webview/build.gradle.kts
+++ b/features/dd-sdk-android-webview/build.gradle.kts
@@ -37,6 +37,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumer.kt
@@ -115,8 +115,8 @@ internal class WebViewLogEventConsumer(
             LogAttributes.SERVICE to datadogContext.service
         )
         val eventDdTags = try {
-            event.get(DDTAGS_KEY_NAME)?.asString?.let {
-                it.split(DDTAGS_SEPARATOR)
+            event.get(DDTAGS_KEY_NAME)?.asString?.let { ddTags ->
+                ddTags.split(DDTAGS_SEPARATOR)
                     .mapNotNull { tag ->
                         @Suppress("UnsafeThirdPartyFunctionCall") // safe indexOf invocation
                         val splitIndex = tag.indexOf(":")

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventMapper.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventMapper.kt
@@ -25,7 +25,7 @@ internal class WebViewReplayEventMapper(
         IllegalStateException::class,
         NumberFormatException::class
     )
-    @Suppress("ThrowingInternalException")
+    @Suppress("ThrowingInternalException", "UnsafeThirdPartyFunctionCall") // Caught in the caller
     fun mapEvent(
         event: JsonObject,
         rumContext: RumContext,
@@ -33,7 +33,7 @@ internal class WebViewReplayEventMapper(
     ): JsonObject {
         val viewDataObject = event.get(VIEW_OBJECT_KEY)?.asJsonObject
         val viewId = viewDataObject?.get(VIEW_ID_KEY)?.asString
-            ?: throw IllegalStateException(BROWSER_EVENT_MISSING_VIEW_DATA_ERROR_MESSAGE)
+            ?: error(BROWSER_EVENT_MISSING_VIEW_DATA_ERROR_MESSAGE)
         event.get(EVENT_KEY)?.asJsonObject?.let { record ->
             val timeOffset = offsetProvider.getOffset(viewId, datadogContext)
             record.get(TIMESTAMP_KEY)?.let { timestamp ->
@@ -43,7 +43,7 @@ internal class WebViewReplayEventMapper(
             }
             record.addProperty(SLOT_ID_KEY, webViewId)
             return bundleIntoEnrichedRecord(record, viewId, rumContext)
-        } ?: throw IllegalStateException(BROWSER_EVENT_MISSING_RECORD_ERROR_MESSAGE)
+        } ?: error(BROWSER_EVENT_MISSING_RECORD_ERROR_MESSAGE)
     }
 
     private fun bundleIntoEnrichedRecord(

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventMapper.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventMapper.kt
@@ -25,7 +25,7 @@ internal class WebViewReplayEventMapper(
         IllegalStateException::class,
         NumberFormatException::class
     )
-    @Suppress("ThrowingInternalException", "UnsafeThirdPartyFunctionCall") // Caught in the caller
+    @Suppress("UnsafeThirdPartyFunctionCall") // Caught in the caller
     fun mapEvent(
         event: JsonObject,
         rumContext: RumContext,

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventMapper.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventMapper.kt
@@ -25,7 +25,7 @@ internal class WebViewReplayEventMapper(
         IllegalStateException::class,
         NumberFormatException::class
     )
-    @SuppressWarnings("ThrowingInternalException")
+    @Suppress("ThrowingInternalException")
     fun mapEvent(
         event: JsonObject,
         rumContext: RumContext,

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,5 @@ org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 
 # Allows Kotlin with target JVM compat 17 to be built on JDK 21
 kotlin.jvm.target.validation.mode = IGNORE
+
 # Leave the next line blank for CI

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -116,6 +116,7 @@ apolloRuntime = { module = "com.apollographql.apollo:apollo-runtime", version.re
 kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 versionsGradlePlugin = { module = "com.github.ben-manes:gradle-versions-plugin", version.ref = "versionsGradlePlugin" }
 dokkaGradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
+detektGradlePlugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 unmockGradlePlugin = { module = "com.github.bjoernq:unmockplugin", version.ref = "unmock" }
 
 # Annotation processors

--- a/integrations/dd-sdk-android-apollo/build.gradle.kts
+++ b/integrations/dd-sdk-android-apollo/build.gradle.kts
@@ -32,6 +32,7 @@ plugins {
     id("apiSurface")
     id("transitiveDependencies")
     id("verificationXml")
+    id("detekt-conventions")
 }
 
 android {

--- a/integrations/dd-sdk-android-apollo/src/test/java/com/datadog/android/apollo/DatadogApolloInterceptorTest.kt
+++ b/integrations/dd-sdk-android-apollo/src/test/java/com/datadog/android/apollo/DatadogApolloInterceptorTest.kt
@@ -37,7 +37,7 @@ import org.mockito.quality.Strictness
     ExtendWith(ForgeExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
-@Suppress("UnusedFlow")
+@Suppress("UnusedFlow", "IgnoredReturnValue")
 internal class DatadogApolloInterceptorTest {
 
     @Mock

--- a/integrations/dd-sdk-android-coil/build.gradle.kts
+++ b/integrations/dd-sdk-android-coil/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/integrations/dd-sdk-android-coil3/build.gradle.kts
+++ b/integrations/dd-sdk-android-coil3/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/integrations/dd-sdk-android-compose/build.gradle.kts
+++ b/integrations/dd-sdk-android-compose/build.gradle.kts
@@ -37,6 +37,7 @@ plugins {
     id("apiSurface")
     id("transitiveDependencies")
     id("verificationXml")
+    id("detekt-conventions")
 }
 
 android {

--- a/integrations/dd-sdk-android-cronet/build.gradle.kts
+++ b/integrations/dd-sdk-android-cronet/build.gradle.kts
@@ -36,6 +36,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/integrations/dd-sdk-android-cronet/src/test/kotlin/com/datadog/android/cronet/internal/CronetRequestInfoTest.kt
+++ b/integrations/dd-sdk-android-cronet/src/test/kotlin/com/datadog/android/cronet/internal/CronetRequestInfoTest.kt
@@ -39,7 +39,7 @@ internal class CronetRequestInfoTest {
     @StringForgery(regex = URL_FORGERY_PATTERN)
     lateinit var fakeUrl: String
     lateinit var fakeMethod: String
-    lateinit var fakeHeaders: MutableMap<String, List<String>>
+    lateinit var fakeHeaders: Map<String, List<String>>
 
     @Mock
     lateinit var mockExecutor: Executor
@@ -56,7 +56,7 @@ internal class CronetRequestInfoTest {
     @BeforeEach
     fun `set up`(forge: Forge) {
         fakeMethod = forge.anElementFrom(HttpSpec.Method.values())
-        fakeHeaders = forge.exhaustiveAttributes().mapValues { listOf(it.value.toString()) }.toMutableMap()
+        fakeHeaders = forge.exhaustiveAttributes().mapValues { listOf(it.value.toString()) }
     }
 
     @Test

--- a/integrations/dd-sdk-android-cronet/src/test/kotlin/com/datadog/android/utils/forge/ProxyForgeFactory.kt
+++ b/integrations/dd-sdk-android-cronet/src/test/kotlin/com/datadog/android/utils/forge/ProxyForgeFactory.kt
@@ -19,8 +19,8 @@ internal class ProxyForgeFactory : ForgeryFactory<Proxy> {
         forge.aString(),
         forge.anInt(min = 1, max = 65535),
         mock<Executor> {
-            on { execute(any()) } doAnswer {
-                it.getArgument<() -> Unit>(0).invoke()
+            on { execute(any()) } doAnswer { invocation ->
+                invocation.getArgument<() -> Unit>(0).invoke()
             }
         },
         object : Proxy.Callback() {

--- a/integrations/dd-sdk-android-fresco/build.gradle.kts
+++ b/integrations/dd-sdk-android-fresco/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/integrations/dd-sdk-android-glide/build.gradle.kts
+++ b/integrations/dd-sdk-android-glide/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/integrations/dd-sdk-android-okhttp-otel/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp-otel/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/integrations/dd-sdk-android-okhttp/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp/build.gradle.kts
@@ -39,6 +39,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
@@ -1595,8 +1595,9 @@ internal open class TracingInterceptorNotSendingSpanTest {
     ) {
         fakeResponse = forge.anOkHttpResponse(fakeRequest, statusCode) {
             body(fakeResponseBody.toResponseBody(fakeMediaType))
-            if (fakeMediaType != null) {
-                header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
+            val mediaType = fakeMediaType
+            if (mediaType != null) {
+                header(TracingInterceptor.HEADER_CT, mediaType.type)
             }
             configure()
         }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/utils/assertj/HeadersAssert.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/utils/assertj/HeadersAssert.kt
@@ -63,9 +63,9 @@ internal class HeadersAssert(actual: Headers) :
 
             val rawActualTags = vendor.substringAfter("dd=")
                 .split(";")
-                .map { it.split(":").let { it[0] to it[1] } }
+                .map { it.split(":").let { parts -> parts[0] to parts[1] } }
                 .groupBy { it.first }
-                .mapValues { it.value.map { it.second } }
+                .mapValues { it.value.map { pair -> pair.second } }
 
             rawActualTags.forEach {
                 assertThat(it.value)

--- a/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
@@ -34,6 +34,7 @@ plugins {
     id("apiSurface")
     id("transitiveDependencies")
     id("verificationXml")
+    id("detekt-conventions")
 }
 
 android {

--- a/integrations/dd-sdk-android-rum-coroutines/src/main/kotlin/com/datadog/android/rum/coroutines/FlowExt.kt
+++ b/integrations/dd-sdk-android-rum-coroutines/src/main/kotlin/com/datadog/android/rum/coroutines/FlowExt.kt
@@ -11,7 +11,6 @@ import com.datadog.android.api.SdkCore
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumErrorSource
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 
 internal const val ERROR_FLOW: String = "Coroutine Flow error"

--- a/integrations/dd-sdk-android-rum-coroutines/src/test/kotlin/com/datadog/android/rum/coroutines/FlowExtTest.kt
+++ b/integrations/dd-sdk-android-rum-coroutines/src/test/kotlin/com/datadog/android/rum/coroutines/FlowExtTest.kt
@@ -13,7 +13,6 @@ import com.datadog.android.rum.RumMonitor
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext

--- a/integrations/dd-sdk-android-rx/build.gradle.kts
+++ b/integrations/dd-sdk-android-rx/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/integrations/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/DatadogRxExtTest.kt
+++ b/integrations/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/DatadogRxExtTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.rx
 
-import android.annotation.SuppressLint
 import com.datadog.android.api.SdkCore
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumErrorSource
@@ -127,13 +126,13 @@ class DatadogRxExtTest {
         )
     }
 
-    @SuppressLint("CheckResult")
     @Test
     fun `M send an error event W exception in the stream {Completable}`() {
         // WHEN
-        CompletableError.error(fakeException).sendErrorToDatadog(mockSdkCore).test()
+        val testObserver = CompletableError.error(fakeException).sendErrorToDatadog(mockSdkCore).test()
 
         // THEN
+        testObserver.assertError(fakeException)
         verify(mockRumMonitor).addError(
             DatadogRumErrorConsumer.REQUEST_ERROR_MESSAGE,
             RumErrorSource.SOURCE,

--- a/integrations/dd-sdk-android-sqldelight/build.gradle.kts
+++ b/integrations/dd-sdk-android-sqldelight/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/integrations/dd-sdk-android-timber/build.gradle.kts
+++ b/integrations/dd-sdk-android-timber/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
@@ -34,6 +34,7 @@ plugins {
     id("apiSurface")
     id("transitiveDependencies")
     id("verificationXml")
+    id("detekt-conventions")
 }
 
 android {

--- a/integrations/dd-sdk-android-trace-coroutines/src/main/kotlin/com/datadog/android/trace/internal/coroutines/InternalCoroutineExt.kt
+++ b/integrations/dd-sdk-android-trace-coroutines/src/main/kotlin/com/datadog/android/trace/internal/coroutines/InternalCoroutineExt.kt
@@ -16,6 +16,7 @@ import kotlin.coroutines.CoroutineContext
 
 private const val TAG_DISPATCHER: String = "coroutine.dispatcher"
 
+@Suppress("InjectDispatcher") // context is a comparison sentinel here, not an instantiated dispatcher
 internal suspend fun <T : Any?> CoroutineScope.withinCoroutineSpan(
     operationName: String,
     parentSpan: DatadogSpan? = null,

--- a/integrations/dd-sdk-android-tv/build.gradle.kts
+++ b/integrations/dd-sdk-android-tv/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")
+    id("detekt-conventions")
 }
 
 android {

--- a/integrations/dd-sdk-android-tv/src/main/kotlin/com/datadog/android/tv/LeanbackViewAttributesProvider.kt
+++ b/integrations/dd-sdk-android-tv/src/main/kotlin/com/datadog/android/tv/LeanbackViewAttributesProvider.kt
@@ -50,12 +50,12 @@ class LeanbackViewAttributesProvider :
         child: View,
         attributes: MutableMap<String, Any?>
     ) {
-        parent.findAction(child)?.let {
-            attributes[ACTION_TARGET_ACTION_ID] = it.id
-            it.label1?.let {
+        parent.findAction(child)?.let { action ->
+            attributes[ACTION_TARGET_ACTION_ID] = action.id
+            action.label1?.let {
                 attributes[ACTION_TARGET_LABEL1] = it
             }
-            it.label2?.let {
+            action.label2?.let {
                 attributes[ACTION_TARGET_LABEL2] = it
             }
         }

--- a/integrations/dd-sdk-android-tv/src/test/kotlin/com/datadog/android/tv/LeanbackViewAttributesProviderTest.kt
+++ b/integrations/dd-sdk-android-tv/src/test/kotlin/com/datadog/android/tv/LeanbackViewAttributesProviderTest.kt
@@ -58,6 +58,7 @@ internal class LeanbackViewAttributesProviderTest : ObjectTest<LeanbackViewAttri
     @Mock
     lateinit var mockViewHolder: ItemBridgeAdapter.ViewHolder
 
+    @Suppress("DoubleMutabilityForCollection") // must stay MutableMap: extractAttributes() mutates it in place
     lateinit var fakeAttributes: MutableMap<String, Any?>
 
     @BeforeEach

--- a/local_ci.sh
+++ b/local_ci.sh
@@ -49,90 +49,6 @@ done
 # exit on errors
 set -e
 
-# Syncs detekt-common.yml and detekt-public-api.yml from dd-source into config/ at the
-# revision pinned by ci/pipelines/default-pipeline.yml. The dd-source repo is restored
-# to its prior state afterwards so switching branches there can't affect our checks.
-sync_detekt_configs() {
-  local config_dir="config"
-  local pipeline_file="ci/pipelines/default-pipeline.yml"
-  local stamp_file="$config_dir/detekt_dd-source_config.stamp"
-  local detekt_common_config="$config_dir/detekt-common.yml"
-  local detekt_public_api_config="$config_dir/detekt-public-api.yml"
-
-  mkdir -p "$config_dir"
-
-  local version
-  version=$(grep -oE 'gitlab-templates\.ddbuild\.io/mobile/v[0-9]+-[0-9a-f]+/static-analysis\.yml' "$pipeline_file" \
-    | head -1 \
-    | sed -E 's|.*/mobile/(v[0-9]+-[0-9a-f]+)/.*|\1|')
-
-  if [ -z "$version" ]; then
-    echo "  Could not extract dd-source detekt template version from $pipeline_file"
-    exit 1
-  fi
-
-  # Template tag format: vXXXX-${CI_COMMIT_SHA:0:8}
-  local sha="${version##*-}"
-
-  local current=""
-  if [ -f "$stamp_file" ]; then
-    current=$(cat "$stamp_file")
-  fi
-
-  if [ "$current" = "$version" ] && [ -f "$detekt_common_config" ] && [ -f "$detekt_public_api_config" ]; then
-    echo "  Detekt configs already at $version"
-    return 0
-  fi
-
-  echo "  Detekt configs out of date (have '${current:-none}', want '$version'); syncing from dd-source"
-
-  if [ -z "$DD_SOURCE" ]; then
-    echo "  DD_SOURCE not set. Please set it to your local dd-source checkout."
-    echo "  E.g.: export DD_SOURCE=/Volumes/Dev/ci/dd-source"
-    exit 1
-  fi
-  if [ ! -d "$DD_SOURCE/.git" ]; then
-    echo "  DD_SOURCE ($DD_SOURCE) is not a git repository"
-    exit 1
-  fi
-
-  local sdk_dir
-  sdk_dir=$(pwd)
-
-  (
-    cd "$DD_SOURCE"
-
-    orig_ref=$(git symbolic-ref --short -q HEAD || git rev-parse HEAD)
-    stashed=0
-
-    restore_dd_source() {
-      git checkout --quiet "$orig_ref" 2>/dev/null || true
-      if [ "$stashed" = "1" ]; then
-        git stash pop --quiet 2>/dev/null \
-          || echo "  Warning: could not restore stash in $DD_SOURCE; check 'git stash list'"
-      fi
-    }
-    trap restore_dd_source EXIT
-
-    if ! git diff --quiet || ! git diff --cached --quiet || [ -n "$(git ls-files --others --exclude-standard)" ]; then
-      git stash push -u -m "dd-sdk-android-detekt-sync" > /dev/null
-      stashed=1
-    fi
-
-    git fetch --quiet origin main
-    if ! git checkout --quiet "$sha" 2>/dev/null; then
-      echo "  Could not check out $sha in $DD_SOURCE — make sure dd-source main is up to date"
-      exit 1
-    fi
-
-    cp "domains/mobile/config/android/gitlab/detekt/detekt-common.yml" "$sdk_dir/$detekt_common_config"
-    cp "domains/mobile/config/android/gitlab/detekt/detekt-public-api.yml" "$sdk_dir/$detekt_public_api_config"
-  )
-
-  echo "$version" > "$stamp_file"
-  echo "  Detekt configs synced to $version"
-}
-
 if [[ $SETUP == 1 ]]; then
   echo "-- SETUP"
 
@@ -186,14 +102,7 @@ if [[ $ANALYSIS == 1 ]]; then
   fi
 
   echo "---- Detekt"
-  echo "------ Sync Detekt configs from dd-source"
-  sync_detekt_configs
-
-  echo "------ Detekt common rules"
-  detekt --parallel --config "config/detekt-common.yml"
-
-  echo "------ Detekt public API rules"
-  detekt --parallel --config "config/detekt-public-api.yml"
+  ./gradlew detekt --continue
 
   if [[ $COMPILE == 1 ]]; then
     # Assemble is required to get generated classes type resolution
@@ -201,10 +110,6 @@ if [[ $ANALYSIS == 1 ]]; then
     ./gradlew assembleLibrariesDebug :tools:detekt:jar
     ./gradlew printSdkDebugRuntimeClasspath --no-parallel
     classpath=$(cat sdk_classpath)
-
-    # TODO RUM-628 Switch to Java 17 bytecode
-    echo "------ Detekt custom rules"
-    detekt --parallel --config detekt_custom_general.yml,detekt_custom_safe_calls_android.yml,detekt_custom_safe_calls_third_party.yml,detekt_custom_unsafe_calls.yml --plugins tools/detekt/build/libs/detekt.jar -cp "$classpath" --jvm-target 11 -ex "**/*.kts"
 
     echo "------ Detekt test pyramid rules"
     rm -f apiSurface.log apiUsage.log


### PR DESCRIPTION
### What does this PR do?

This PR **ONLY** affects local_ci.sh
All rule violations are grouped by commit, if you feel there is a rule that is not worth it, we can drop the commit and disable the rule

---

Consolidates detekt's rule on/off config, previously split across `detekt-common.yml`, `detekt-public-api.yml`, `detekt_custom_general.yml`, into a single source (`detekt.yml`) run entirely through the Gradle `io.gitlab.arturbosch.detekt` plugin. Then fixes, or deliberately suppresses with a recorded reason, every violation the unified config surfaces. The safe/unsafe-call data-list files (`detekt_custom_safe_calls_*.yml`, `detekt_custom_unsafe_calls.yml`) are unaffected — they hold allow/deny-list data, not rule toggles, and stay loaded alongside `detekt.yml`.

**Why this surfaced so many "new" violations:** the shared analysis pipeline doesn't run with type resolution. Several rules need type information to fire correctly (`HasPlatformType`, `CastNullableToNonNullableType`, `IgnoredReturnValue`, `UnsafeCallOnNullableType`, etc.), so despite being "active" in config they produced few or no findings. Meanwhile the Datadog custom rulesets ran through a separate `customDetektRules` task did run with type resolution, but ran with different configuration.

The consolidated setup runs everything through `detektMain` / `detektTest`, which does get real type resolution via its compile classpath. 

## Legend

- ✅ = active (rule/ruleset enabled) in that file
- ⬜ = inactive (rule/ruleset disabled) in that file
- `—` = not defined in that file

---

## `comments`

Sourced verbatim from `detekt-public-api.yml`. `detekt_custom_general.yml` also enables it but with a different `AbsentOrWrongFileLicense` value — final file follows public-api.

| Rule | `detekt-common.yml` | `detekt-public-api.yml` | `detekt_custom_general.yml` | `detekt.yml` (final) | Source / Note |
|---|---|---|---|---|---|
| **comments** (ruleset) | ⬜ | ✅ | ✅ | ✅ | public-api / custom_general both enable it |
| `AbsentOrWrongFileLicense` | — | ⬜ | ✅ | ⬜ | Matches public-api, **not** custom_general |
| `CommentOverPrivateFunction` | — | ⬜ | — | ⬜ | Matches public-api |
| `CommentOverPrivateProperty` | — | ⬜ | — | ⬜ | Matches public-api |
| `DeprecatedBlockTag` | — | ✅ | — | ✅ | Matches public-api |
| `EndOfSentenceFormat` | — | ✅ | — | ✅ | Matches public-api (same excludes + format) |
| `KDocReferencesNonPublicProperty` | — | ✅ | — | ✅ | Matches public-api |
| `OutdatedDocumentation` | — | ✅ | — | ✅ | Matches public-api |
| `UndocumentedPublicClass` | — | ✅ | — | ✅ | Matches public-api |
| `UndocumentedPublicFunction` | — | ✅ | — | ✅ | Matches public-api |
| `UndocumentedPublicProperty` | — | ✅ | — | ✅ | Matches public-api |

## `complexity`

Sourced from `detekt-common.yml`, except one overridden rule.

| Rule | `detekt-common.yml` | `detekt-public-api.yml` | `detekt_custom_general.yml` | `detekt.yml` (final) | Source / Note                                                                                                                                                                                                                          |
|---|---|---|---|---|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| **complexity** (ruleset) | ✅ | ⬜ | ⬜ | ✅ | common                                                                                                                                                                                                                                 |
| `CognitiveComplexMethod` | ⬜ | — | — | ⬜ | common                                                                                                                                                                                                                                 |
| `ComplexCondition` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                 |
| `ComplexInterface` | ⬜ | — | — | ⬜ | common                                                                                                                                                                                                                                 |
| `CyclomaticComplexMethod` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                 |
| `LabeledExpression` | ⬜ | — | — | ⬜ | common                                                                                                                                                                                                                                 |
| `LargeClass` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                 |
| `LongMethod` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                 |
| `LongParameterList` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                 |
| `MethodOverloading` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                 |
| `NamedArguments` | ✅ | — | — | ⬜ | ⚠️ **Overridden** — differs from all sources (common has it on); disabled deliberately — usually off by default upstream, kept off here as a style choice                                                                              |
| `NestedBlockDepth` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                 |
| `NestedScopeFunctions` | ⬜ | — | — | ⬜ | common                                                                                                                                                                                                                                 |
| `ReplaceSafeCallChainWithRun` | ✅ | — | — | ⬜ | ⚠️ **Overridden** — differs from all sources (common has it on); disabled deliberately — normally off by default upstream, and it's arguable if it improves readability/reduces cyclomatic complexity by removing redundant null checks |
| `StringLiteralDuplication` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                 |
| `TooManyFunctions` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                 |

## `coroutines`

Sourced verbatim from `detekt-common.yml`. No overrides.

| Rule | `detekt-common.yml` | `detekt-public-api.yml` | `detekt_custom_general.yml` | `detekt.yml` (final) | Source / Note |
|---|---|---|---|---|---|
| **coroutines** (ruleset) | ✅ | ⬜ | ⬜ | ✅ | common |
| `GlobalCoroutineUsage` | ⬜ | — | — | ⬜ | common |
| `InjectDispatcher` | ✅ | — | — | ✅ | common |
| `RedundantSuspendModifier` | ✅ | — | — | ✅ | common |
| `SleepInsteadOfDelay` | ✅ | — | — | ✅ | common |
| `SuspendFunSwallowedCancellation` | ✅ | — | — | ✅ | common |
| `SuspendFunWithCoroutineScopeReceiver` | ⬜ | — | — | ⬜ | common |
| `SuspendFunWithFlowReturnType` | ✅ | — | — | ✅ | common |

## `empty-blocks`

Sourced verbatim from `detekt-common.yml`. No overrides.

| Rule | `detekt-common.yml` | `detekt-public-api.yml` | `detekt_custom_general.yml` | `detekt.yml` (final) | Source / Note |
|---|---|---|---|---|---|
| **empty-blocks** (ruleset) | ✅ | ⬜ | ⬜ | ✅ | common |
| `EmptyCatchBlock` | ✅ | — | — | ✅ | common |
| `EmptyClassBlock` | ✅ | — | — | ✅ | common |
| `EmptyDefaultConstructor` | ✅ | — | — | ✅ | common |
| `EmptyDoWhileBlock` | ✅ | — | — | ✅ | common |
| `EmptyElseBlock` | ✅ | — | — | ✅ | common |
| `EmptyFinallyBlock` | ✅ | — | — | ✅ | common |
| `EmptyForBlock` | ✅ | — | — | ✅ | common |
| `EmptyFunctionBlock` | ✅ | — | — | ✅ | common |
| `EmptyIfBlock` | ✅ | — | — | ✅ | common |
| `EmptyInitBlock` | ✅ | — | — | ✅ | common |
| `EmptyKtFile` | ✅ | — | — | ✅ | common |
| `EmptySecondaryConstructor` | ✅ | — | — | ✅ | common |
| `EmptyTryBlock` | ✅ | — | — | ✅ | common |
| `EmptyWhenBlock` | ✅ | — | — | ✅ | common |
| `EmptyWhileBlock` | ✅ | — | — | ✅ | common |

## `exceptions`

Sourced verbatim from `detekt-common.yml`. No overrides.

| Rule | `detekt-common.yml` | `detekt-public-api.yml` | `detekt_custom_general.yml` | `detekt.yml` (final) | Source / Note |
|---|---|---|---|---|---|
| **exceptions** (ruleset) | ✅ | ⬜ | ⬜ | ✅ | common |
| `ExceptionRaisedInUnexpectedLocation` | ✅ | — | — | ✅ | common |
| `InstanceOfCheckForException` | ✅ | — | — | ✅ | common |
| `NotImplementedDeclaration` | ⬜ | — | — | ⬜ | common |
| `ObjectExtendsThrowable` | ✅ | — | — | ✅ | common |
| `PrintStackTrace` | ✅ | — | — | ✅ | common |
| `RethrowCaughtException` | ✅ | — | — | ✅ | common |
| `ReturnFromFinally` | ✅ | — | — | ✅ | common |
| `SwallowedException` | ✅ | — | — | ✅ | common |
| `ThrowingExceptionFromFinally` | ✅ | — | — | ✅ | common |
| `ThrowingExceptionInMain` | ⬜ | — | — | ⬜ | common |
| `ThrowingExceptionsWithoutMessageOrCause` | ✅ | — | — | ✅ | common |
| `ThrowingNewInstanceOfSameException` | ✅ | — | — | ✅ | common |
| `TooGenericExceptionCaught` | ✅ | — | — | ✅ | common |
| `TooGenericExceptionThrown` | ✅ | — | — | ✅ | common |

## `naming`

Sourced from `detekt-common.yml`, except one overridden rule.

| Rule | `detekt-common.yml` | `detekt-public-api.yml` | `detekt_custom_general.yml` | `detekt.yml` (final) | Source / Note                                                                                                  |
|---|---|---|---|---|----------------------------------------------------------------------------------------------------------------|
| **naming** (ruleset) | ✅ | ⬜ | ⬜ | ✅ | common                                                                                                         |
| `BooleanPropertyNaming` | ✅ | — | — | ⬜ | ⚠️ **Overridden** — differs from all sources (common has it on); reason: off by default, purely a style choice |
| `ClassNaming` | ✅ | — | — | ✅ | common                                                                                                         |
| `ConstructorParameterNaming` | ✅ | — | — | ✅ | common                                                                                                         |
| `EnumNaming` | ✅ | — | — | ✅ | common                                                                                                         |
| `ForbiddenClassName` | ✅ | — | — | ✅ | common                                                                                                         |
| `FunctionMaxLength` | ✅ | — | — | ✅ | common                                                                                                         |
| `FunctionMinLength` | ✅ | — | — | ✅ | common                                                                                                         |
| `FunctionNaming` | ✅ | — | — | ✅ | common                                                                                                         |
| `FunctionParameterNaming` | ✅ | — | — | ✅ | common                                                                                                         |
| `InvalidPackageDeclaration` | ✅ | — | — | ✅ | common                                                                                                         |
| `LambdaParameterNaming` | ✅ | — | — | ✅ | common                                                                                                         |
| `MatchingDeclarationName` | ✅ | — | — | ✅ | common                                                                                                         |
| `MemberNameEqualsClassName` | ✅ | — | — | ✅ | common                                                                                                         |
| `NoNameShadowing` | ✅ | — | — | ✅ | common                                                                                                         |
| `NonBooleanPropertyPrefixedWithIs` | ✅ | — | — | ⬜ | **Overridden** — differs from all sources (common has it on); reason: off by default, purely a style choice |                                                                                                         |
| `ObjectPropertyNaming` | ✅ | — | — | ✅ | common                                                                                                         |
| `PackageNaming` | ✅ | — | — | ✅ | common                                                                                                         |
| `TopLevelPropertyNaming` | ✅ | — | — | ✅ | common                                                                                                         |
| `VariableMaxLength` | ✅ | — | — | ✅ | common                                                                                                         |
| `VariableMinLength` | ✅ | — | — | ✅ | common                                                                                                         |
| `VariableNaming` | ✅ | — | — | ✅ | common                                                                                                         |

## `performance`

Sourced verbatim from `detekt-common.yml`. No overrides; not present in the other two files.

| Rule | `detekt-common.yml` | `detekt-public-api.yml` | `detekt_custom_general.yml` | `detekt.yml` (final) | Source / Note |
|---|---|---|---|---|---|
| **performance** (ruleset) | ✅ | — | — | ✅ | common |
| `ArrayPrimitive` | ✅ | — | — | ✅ | common |
| `CouldBeSequence` | ✅ | — | — | ✅ | common |
| `ForEachOnRange` | ✅ | — | — | ✅ | common |
| `SpreadOperator` | ✅ | — | — | ✅ | common |
| `UnnecessaryPartOfBinaryExpression` | ✅ | — | — | ✅ | common |
| `UnnecessaryTemporaryInstantiation` | ✅ | — | — | ✅ | common |

## `potential-bugs`

Sourced from `detekt-common.yml`, except one overridden rule.

| Rule | `detekt-common.yml` | `detekt-public-api.yml` | `detekt_custom_general.yml` | `detekt.yml` (final) | Source / Note                                                                                                                                                                                                                                                                                                                                |
|---|---|---|---|---|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| **potential-bugs** (ruleset) | ✅ | ⬜ | ⬜ | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `AvoidReferentialEquality` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `CastNullableToNonNullableType` | ✅ | — | — | ⬜ | ⚠️ **Overridden** — differs from all sources (common has it on); disabled deliberately — normally off by default upstream, and fires often on filter/map chains where the value type has already been verified (e.g. `.filterKeys { it is String }.mapKeys { it.key as String }`), which the rule can't reason about                         |
| `CastToNullableType` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `Deprecation` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `DontDowncastCollectionTypes` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `DoubleMutabilityForCollection` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `ElseCaseInsteadOfExhaustiveWhen` | ✅ | — | — | ⬜ | ⚠️ **Overridden** — differs from all sources (common has it on); disabled deliberately — off by default upstream; can find real bugs, but several violations (e.g. `RumRawEvent` sealed-class `when`s with 42 subtypes, Android `BlendMode` enum) would require large/awkward exhaustive `when` blocks whose ROI needs a separate discussion |
| `EqualsAlwaysReturnsTrueOrFalse` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `EqualsWithHashCodeExist` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `ExitOutsideMain` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `ExplicitGarbageCollectionCall` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `HasPlatformType` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `IgnoredReturnValue` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `ImplicitDefaultLocale` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `ImplicitUnitReturnType` | ⬜ | — | — | ⬜ | common                                                                                                                                                                                                                                                                                                                                       |
| `InvalidRange` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `IteratorHasNextCallsNextMethod` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `IteratorNotThrowingNoSuchElementException` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `LateinitUsage` | ⬜ | — | — | ⬜ | common                                                                                                                                                                                                                                                                                                                                       |
| `MapGetWithNotNullAssertionOperator` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `MissingPackageDeclaration` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `NullCheckOnMutableProperty` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `NullableToStringCall` | ⬜ | — | — | ⬜ | common                                                                                                                                                                                                                                                                                                                                       |
| `PropertyUsedBeforeDeclaration` | ✅ | — | — | ⬜ | ⚠️ **Overridden** — differs from all sources (common has it on); reason: off by default, its a style choice                                                                                                                                                                                                                                  |
| `UnconditionalJumpStatementInLoop` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `UnnecessaryNotNullCheck` | ⬜ | — | — | ⬜ | common                                                                                                                                                                                                                                                                                                                                       |
| `UnnecessaryNotNullOperator` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `UnnecessarySafeCall` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `UnreachableCatchBlock` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `UnreachableCode` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `UnsafeCallOnNullableType` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `UnsafeCast` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `UnusedUnaryOperator` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `UselessPostfixExpression` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |
| `WrongEqualsTypeParameter` | ✅ | — | — | ✅ | common                                                                                                                                                                                                                                                                                                                                       |

## `style`

Sourced from `detekt-common.yml`; every rule matches exactly except `UseOrEmpty`.

| Rule | `detekt-common.yml` | `detekt-public-api.yml` | `detekt_custom_general.yml` | `detekt.yml` (final) | Source / Note |
|---|---|---|---|---|---|
| **style** (ruleset) | ✅ | ⬜ | ⬜ | ✅ | common |
| `AlsoCouldBeApply` | ⬜ | — | — | ⬜ | common |
| `BracesOnIfStatements` | ⬜ | — | — | ⬜ | common |
| `BracesOnWhenStatements` | ⬜ | — | — | ⬜ | common |
| `CanBeNonNullable` | ⬜ | — | — | ⬜ | common |
| `CascadingCallWrapping` | ⬜ | — | — | ⬜ | common |
| `ClassOrdering` | ⬜ | — | — | ⬜ | common |
| `CollapsibleIfStatements` | ⬜ | — | — | ⬜ | common |
| `DataClassContainsFunctions` | ⬜ | — | — | ⬜ | common |
| `DataClassShouldBeImmutable` | ⬜ | — | — | ⬜ | common |
| `DestructuringDeclarationWithTooManyEntries` | ✅ | — | — | ✅ | common |
| `DoubleNegativeLambda` | ✅ | — | — | ✅ | common |
| `EqualsNullCall` | ✅ | — | — | ✅ | common |
| `EqualsOnSignatureLine` | ⬜ | — | — | ⬜ | common |
| `ExplicitCollectionElementAccessMethod` | ⬜ | — | — | ⬜ | common |
| `ExplicitItLambdaParameter` | ✅ | — | — | ✅ | common |
| `ExpressionBodySyntax` | ⬜ | — | — | ⬜ | common |
| `ForbiddenAnnotation` | ✅ | — | — | ✅ | common |
| `ForbiddenComment` | ⬜ | — | — | ⬜ | common |
| `ForbiddenImport` | ⬜ | — | — | ⬜ | common |
| `ForbiddenMethodCall` | ⬜ | — | — | ⬜ | common |
| `ForbiddenSuppress` | ⬜ | — | — | ⬜ | common |
| `ForbiddenVoid` | ✅ | — | — | ✅ | common |
| `FunctionOnlyReturningConstant` | ✅ | — | — | ✅ | common |
| `LoopWithTooManyJumpStatements` | ✅ | — | — | ✅ | common |
| `MagicNumber` | ✅ | — | — | ✅ | common |
| `MandatoryBracesLoops` | ⬜ | — | — | ⬜ | common |
| `MaxChainedCallsOnSameLine` | ⬜ | — | — | ⬜ | common |
| `MaxLineLength` | ✅ | — | — | ✅ | common |
| `MayBeConst` | ✅ | — | — | ✅ | common |
| `ModifierOrder` | ✅ | — | — | ✅ | common |
| `MultilineLambdaItParameter` | ⬜ | — | — | ⬜ | common |
| `MultilineRawStringIndentation` | ⬜ | — | — | ⬜ | common |
| `NestedClassesVisibility` | ✅ | — | — | ✅ | common |
| `NewLineAtEndOfFile` | ✅ | — | — | ✅ | common |
| `NoTabs` | ⬜ | — | — | ⬜ | common |
| `NullableBooleanCheck` | ⬜ | — | — | ⬜ | common |
| `ObjectLiteralToLambda` | ✅ | — | — | ✅ | common |
| `OptionalAbstractKeyword` | ✅ | — | — | ✅ | common |
| `OptionalUnit` | ⬜ | — | — | ⬜ | common |
| `PreferToOverPairSyntax` | ⬜ | — | — | ⬜ | common |
| `ProtectedMemberInFinalClass` | ✅ | — | — | ✅ | common |
| `RedundantExplicitType` | ⬜ | — | — | ⬜ | common |
| `RedundantHigherOrderMapUsage` | ✅ | — | — | ✅ | common |
| `RedundantVisibilityModifierRule` | ⬜ | — | — | ⬜ | common |
| `ReturnCount` | ✅ | — | — | ✅ | common |
| `SafeCast` | ✅ | — | — | ✅ | common |
| `SerialVersionUIDInSerializableClass` | ✅ | — | — | ✅ | common |
| `SpacingBetweenPackageAndImports` | ⬜ | — | — | ⬜ | common |
| `StringShouldBeRawString` | ⬜ | — | — | ⬜ | common |
| `ThrowsCount` | ✅ | — | — | ✅ | common |
| `TrailingWhitespace` | ⬜ | — | — | ⬜ | common |
| `TrimMultilineRawString` | ⬜ | — | — | ⬜ | common |
| `UnderscoresInNumericLiterals` | ⬜ | — | — | ⬜ | common |
| `UnnecessaryAbstractClass` | ✅ | — | — | ⬜ | ⚠️ Overridden — see summary |
| `UnnecessaryAnnotationUseSiteTarget` | ⬜ | — | — | ⬜ | common |
| `UnnecessaryApply` | ✅ | — | — | ✅ | common |
| `UnnecessaryBackticks` | ⬜ | — | — | ⬜ | common |
| `UnnecessaryBracesAroundTrailingLambda` | ⬜ | — | — | ⬜ | common |
| `UnnecessaryFilter` | ✅ | — | — | ✅ | common |
| `UnnecessaryInheritance` | ✅ | — | — | ✅ | common |
| `UnnecessaryInnerClass` | ⬜ | — | — | ⬜ | common |
| `UnnecessaryLet` | ⬜ | — | — | ⬜ | common |
| `UnnecessaryParentheses` | ⬜ | — | — | ⬜ | common |
| `UntilInsteadOfRangeTo` | ⬜ | — | — | ⬜ | common |
| `UnusedImports` | ✅ | — | — | ✅ | common |
| `UnusedParameter` | ✅ | — | — | ✅ | common |
| `UnusedPrivateClass` | ✅ | — | — | ✅ | common |
| `UnusedPrivateMember` | ✅ | — | — | ✅ | common |
| `UnusedPrivateProperty` | ✅ | — | — | ✅ | common |
| `UseAnyOrNoneInsteadOfFind` | ✅ | — | — | ✅ | common |
| `UseArrayLiteralsInAnnotations` | ✅ | — | — | ✅ | common |
| `UseCheckNotNull` | ✅ | — | — | ✅ | common |
| `UseCheckOrError` | ✅ | — | — | ✅ | common |
| `UseDataClass` | ⬜ | — | — | ⬜ | common |
| `UseEmptyCounterpart` | ⬜ | — | — | ⬜ | common |
| `UseIfEmptyOrIfBlank` | ⬜ | — | — | ⬜ | common |
| `UseIfInsteadOfWhen` | ⬜ | — | — | ⬜ | common |
| `UseIsNullOrEmpty` | ✅ | — | — | ✅ | common |
| `UseLet` | ⬜ | — | — | ⬜ | common |
| `UseOrEmpty` | ✅ | — | — | ⬜ | ⚠️ **Overridden** — differs from all sources (common has it on); disabled deliberately — normally enabled, but the codebase currently has a large number of violations |
| `UseRequire` | ✅ | — | — | ✅ | common |
| `UseRequireNotNull` | ✅ | — | — | ✅ | common |
| `UseSumOfInsteadOfFlatMapSize` | ⬜ | — | — | ⬜ | common |
| `UselessCallOnNotNull` | ✅ | — | — | ✅ | common |
| `UtilityClassWithPublicConstructor` | ✅ | — | — | ✅ | common |
| `VarCouldBeVal` | ✅ | — | — | ✅ | common |
| `WildcardImport` | ✅ | — | — | ✅ | common |

## `datadog`

Sourced verbatim from `detekt_custom_general.yml` — the only file that defines this rule set. No overrides.

| Rule | `detekt-common.yml` | `detekt-public-api.yml` | `detekt_custom_general.yml` | `detekt.yml` (final) | Source / Note |
|---|---|---|---|---|---|
| **datadog** (ruleset) | — | — | ✅ | ✅ | custom_general |
| `PackageNameVisibility` | — | — | ✅ | ✅ | custom_general |
| `PreferTimeProvider` | — | — | ✅ | ✅ | custom_general |
| `ThreadSafety` | — | — | ✅ | ✅ | custom_general |
| `TodoWithoutTask` | — | — | ✅ | ✅ | custom_general |
| `UnsafeThirdPartyFunctionCall` | — | — | ✅ | ✅ | custom_general |

## Non-rule config diffs (`build`, `config`, `processors`, `console-reports`, `output-reports`)

These don't toggle lint rules, but are worth noting:

- **`build` / `config`**: cosmetic only — comment ordering and equivalent settings (`maxIssues: 0`, `warningsAsErrors: true`, etc.) across all files.
- **`processors`**: all four files enable it; only the ordering of commented-out processor names differs.
- **`console-reports`**: all four files enable it. The final `detekt.yml` additionally excludes `ComplexityReport`, `FileBasedFindingsReport`, `BuildFailureReport`, and `LiteFindingsReport` — a deliberate addition to reduce console noise, not sourced from any file.
- **`output-reports`**: all three sources enable this, but the final file sets `active: false`, matching `detekt-conventions.gradle.kts` setting `sarif/html/xml/txt/md.required = false` at the Gradle task level — report generation is controlled there instead.