### PR TITLE
RUM-17104: Add telemetry for number of spans processed by client stats

### DIFF
--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/BatchStatsWriter.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/BatchStatsWriter.kt
@@ -18,7 +18,7 @@ internal class BatchStatsWriter(
 ) : StatsWriter {
     private val sequenceNumber = AtomicLong(0)
 
-    override fun write(statBuckets: List<ClientStatsBucket>) {
+    override fun write(statBuckets: List<ClientStatsBucket>, forced: Boolean) {
         sdkCore.getFeature(Feature.TRACING_CLIENT_STATS_FEATURE_NAME)
             ?.withWriteContext { datadogContext, writeScope ->
                 val payload = ClientStatsPayload(
@@ -34,12 +34,56 @@ internal class BatchStatsWriter(
 
                 writeScope { batchWriter ->
                     val rawBatchEvent = RawBatchEvent(data = payload.toMsgPackPayload())
-                    batchWriter.write(
+                    val written = batchWriter.write(
                         event = rawBatchEvent,
                         batchMetadata = null,
                         eventType = EventType.DEFAULT
                     )
+                    if (written) {
+                        sendFlushMetric(statBuckets, forced)
+                    }
                 }
             }
+    }
+
+    private fun sendFlushMetric(buckets: List<ClientStatsBucket>, forced: Boolean) {
+        var groupsCount = 0
+        var spansCount = 0L
+        var errorsCount = 0L
+        for (bucket in buckets) {
+            groupsCount += bucket.stats.size
+            for (group in bucket.stats) {
+                spansCount += group.hits
+                errorsCount += group.errors
+            }
+        }
+
+        sdkCore.internalLogger.logMetric(
+            messageBuilder = { METRIC_MESSAGE },
+            additionalProperties = mapOf(
+                KEY_METRIC_TYPE to VALUE_METRIC_TYPE,
+                KEY_BUCKETS_COUNT to buckets.size,
+                KEY_GROUPS_COUNT to groupsCount,
+                KEY_SPANS_COUNT to spansCount,
+                KEY_ERRORS_COUNT to errorsCount,
+                KEY_FORCED to forced
+            ),
+            samplingRate = SAMPLING_RATE
+        )
+    }
+
+    internal companion object {
+        internal const val METRIC_MESSAGE = "[Mobile Metric] Trace Client Stats"
+
+        internal const val KEY_METRIC_TYPE = "metric_type"
+        internal const val VALUE_METRIC_TYPE = "trace client stats"
+
+        internal const val KEY_BUCKETS_COUNT = "buckets_count"
+        internal const val KEY_GROUPS_COUNT = "groups_count"
+        internal const val KEY_SPANS_COUNT = "spans_count"
+        internal const val KEY_ERRORS_COUNT = "errors_count"
+        internal const val KEY_FORCED = "forced"
+
+        private const val SAMPLING_RATE: Float = 15.0f
     }
 }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentrator.kt
@@ -190,7 +190,7 @@ internal class StatsConcentrator(
     private fun flushBuckets(flushAll: Boolean) {
         val buckets = drainBuckets(flushAll)
         if (buckets.isNotEmpty()) {
-            statsWriter.write(buckets)
+            statsWriter.write(buckets, forced = flushAll)
         }
     }
 

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsWriter.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsWriter.kt
@@ -7,5 +7,11 @@
 package com.datadog.android.trace.internal.domain.metrics
 
 internal fun interface StatsWriter {
-    fun write(statBuckets: List<ClientStatsBucket>)
+    /**
+     * Writes the given stat buckets to storage.
+     *
+     * @param statBuckets the buckets to write.
+     * @param forced whether this flush was forced (SDK teardown) rather than periodic.
+     */
+    fun write(statBuckets: List<ClientStatsBucket>, forced: Boolean)
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/BatchStatsWriterTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/BatchStatsWriterTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.trace.internal.domain.metrics
 
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.EventWriteScope
 import com.datadog.android.api.feature.Feature
@@ -16,6 +17,7 @@ import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.trace.assertj.MsgPackAssert
 import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
@@ -31,6 +33,8 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
@@ -38,6 +42,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 
@@ -63,6 +68,9 @@ internal class BatchStatsWriterTest {
     @Mock
     lateinit var mockEventBatchWriter: EventBatchWriter
 
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
@@ -75,9 +83,13 @@ internal class BatchStatsWriterTest {
     @StringForgery
     lateinit var fakeRuntimeID: String
 
+    @BoolForgery
+    var fakeForced: Boolean = false
+
     @BeforeEach
     fun `set up`() {
         whenever(mockSdkCore.getFeature(Feature.TRACING_CLIENT_STATS_FEATURE_NAME)) doReturn mockFeatureScope
+        whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockFeatureScope.withWriteContext(eq(emptySet()), any())) doAnswer {
             val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(1)
             callback.invoke(fakeDatadogContext, mockEventWriteScope)
@@ -86,6 +98,7 @@ internal class BatchStatsWriterTest {
             val callback = it.getArgument<(EventBatchWriter) -> Unit>(0)
             callback.invoke(mockEventBatchWriter)
         }
+        whenever(mockEventBatchWriter.write(any(), anyOrNull(), any())) doReturn true
 
         testedWriter = BatchStatsWriter(mockSdkCore, fakeRuntimeID)
     }
@@ -98,7 +111,7 @@ internal class BatchStatsWriterTest {
         val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
 
         // When
-        testedWriter.write(fakeBuckets)
+        testedWriter.write(fakeBuckets, fakeForced)
 
         // Then
         verify(mockEventBatchWriter).write(any(), eq(null), eq(EventType.DEFAULT))
@@ -110,7 +123,7 @@ internal class BatchStatsWriterTest {
         val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
 
         // When
-        testedWriter.write(fakeBuckets)
+        testedWriter.write(fakeBuckets, fakeForced)
 
         // Then
         val captor = argumentCaptor<RawBatchEvent>()
@@ -124,7 +137,7 @@ internal class BatchStatsWriterTest {
         val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
 
         // When
-        testedWriter.write(fakeBuckets)
+        testedWriter.write(fakeBuckets, fakeForced)
 
         // Then
         val captor = argumentCaptor<RawBatchEvent>()
@@ -138,7 +151,7 @@ internal class BatchStatsWriterTest {
         val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
 
         // When
-        testedWriter.write(fakeBuckets)
+        testedWriter.write(fakeBuckets, fakeForced)
 
         // Then
         val captor = argumentCaptor<RawBatchEvent>()
@@ -152,7 +165,7 @@ internal class BatchStatsWriterTest {
         val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
 
         // When
-        testedWriter.write(fakeBuckets)
+        testedWriter.write(fakeBuckets, fakeForced)
 
         // Then
         val captor = argumentCaptor<RawBatchEvent>()
@@ -166,7 +179,7 @@ internal class BatchStatsWriterTest {
         val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
 
         // When
-        testedWriter.write(fakeBuckets)
+        testedWriter.write(fakeBuckets, fakeForced)
 
         // Then
         val captor = argumentCaptor<RawBatchEvent>()
@@ -182,7 +195,7 @@ internal class BatchStatsWriterTest {
         val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
 
         // When
-        repeat(callCount) { testedWriter.write(fakeBuckets) }
+        repeat(callCount) { testedWriter.write(fakeBuckets, fakeForced) }
 
         // Then
         val captor = argumentCaptor<RawBatchEvent>()
@@ -198,7 +211,7 @@ internal class BatchStatsWriterTest {
         val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
 
         // When
-        testedWriter.write(fakeBuckets)
+        testedWriter.write(fakeBuckets, fakeForced)
 
         // Then
         val captor = argumentCaptor<RawBatchEvent>()
@@ -213,11 +226,135 @@ internal class BatchStatsWriterTest {
         val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
 
         // When
-        testedWriter.write(fakeBuckets)
+        testedWriter.write(fakeBuckets, fakeForced)
 
         // Then
         verify(mockEventBatchWriter, never()).write(any(), any(), any())
     }
 
     // endregion
+
+    // region flush telemetry
+
+    @Test
+    fun `M send flush metric after writing to storage W write()`() {
+        // Given
+        val fakeGroup = fakeGroup(hits = 3L, errors = 1L)
+        val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, listOf(fakeGroup)))
+
+        // When
+        testedWriter.write(fakeBuckets, fakeForced)
+
+        // Then
+        val captor = argumentCaptor<Map<String, Any?>>()
+        verify(mockInternalLogger).logMetric(
+            messageBuilder = argThat { invoke() == BatchStatsWriter.METRIC_MESSAGE },
+            additionalProperties = captor.capture(),
+            samplingRate = eq(15.0f),
+            creationSampleRate = eq(null)
+        )
+        assertThat(captor.firstValue[BatchStatsWriter.KEY_METRIC_TYPE]).isEqualTo(BatchStatsWriter.VALUE_METRIC_TYPE)
+        assertThat(captor.firstValue[BatchStatsWriter.KEY_BUCKETS_COUNT]).isEqualTo(1)
+        assertThat(captor.firstValue[BatchStatsWriter.KEY_GROUPS_COUNT]).isEqualTo(1)
+        assertThat(captor.firstValue[BatchStatsWriter.KEY_SPANS_COUNT]).isEqualTo(3L)
+        assertThat(captor.firstValue[BatchStatsWriter.KEY_ERRORS_COUNT]).isEqualTo(1L)
+        assertThat(captor.firstValue[BatchStatsWriter.KEY_FORCED]).isEqualTo(fakeForced)
+    }
+
+    @Test
+    fun `M sum groups, hits and errors across buckets W write()`() {
+        // Given
+        val group1 = fakeGroup(hits = 3L, errors = 1L)
+        val group2 = fakeGroup(hits = 5L, errors = 2L)
+        val group3 = fakeGroup(hits = 2L, errors = 0L)
+        val fakeBuckets = listOf(
+            ClientStatsBucket(fakeBucketStart, fakeBucketDuration, listOf(group1, group2)),
+            ClientStatsBucket(fakeBucketStart, fakeBucketDuration, listOf(group3))
+        )
+
+        // When
+        testedWriter.write(fakeBuckets, fakeForced)
+
+        // Then
+        val captor = argumentCaptor<Map<String, Any?>>()
+        verify(mockInternalLogger).logMetric(
+            messageBuilder = argThat { invoke() == BatchStatsWriter.METRIC_MESSAGE },
+            additionalProperties = captor.capture(),
+            samplingRate = eq(15.0f),
+            creationSampleRate = eq(null)
+        )
+        assertThat(captor.firstValue[BatchStatsWriter.KEY_METRIC_TYPE]).isEqualTo(BatchStatsWriter.VALUE_METRIC_TYPE)
+        assertThat(captor.firstValue[BatchStatsWriter.KEY_BUCKETS_COUNT]).isEqualTo(2)
+        assertThat(captor.firstValue[BatchStatsWriter.KEY_GROUPS_COUNT]).isEqualTo(3)
+        assertThat(captor.firstValue[BatchStatsWriter.KEY_SPANS_COUNT]).isEqualTo(10L)
+        assertThat(captor.firstValue[BatchStatsWriter.KEY_ERRORS_COUNT]).isEqualTo(3L)
+    }
+
+    @Test
+    fun `M forward forced flag W write()`(
+        @BoolForgery fakeMetricForced: Boolean
+    ) {
+        // Given
+        val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
+
+        // When
+        testedWriter.write(fakeBuckets, fakeMetricForced)
+
+        // Then
+        val captor = argumentCaptor<Map<String, Any?>>()
+        verify(mockInternalLogger).logMetric(
+            messageBuilder = argThat { invoke() == BatchStatsWriter.METRIC_MESSAGE },
+            additionalProperties = captor.capture(),
+            samplingRate = eq(15.0f),
+            creationSampleRate = eq(null)
+        )
+        assertThat(captor.firstValue[BatchStatsWriter.KEY_FORCED]).isEqualTo(fakeMetricForced)
+    }
+
+    @Test
+    fun `M not send flush metric W write() { feature not registered }`() {
+        // Given
+        whenever(mockSdkCore.getFeature(Feature.TRACING_CLIENT_STATS_FEATURE_NAME)) doReturn null
+        val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
+
+        // When
+        testedWriter.write(fakeBuckets, fakeForced)
+
+        // Then
+        verifyNoInteractions(mockInternalLogger)
+    }
+
+    @Test
+    fun `M not send flush metric W write() { batch write fails }`() {
+        // Given
+        whenever(mockEventBatchWriter.write(any(), anyOrNull(), any())) doReturn false
+        val fakeBuckets = listOf(ClientStatsBucket(fakeBucketStart, fakeBucketDuration, emptyList()))
+
+        // When
+        testedWriter.write(fakeBuckets, fakeForced)
+
+        // Then
+        verifyNoInteractions(mockInternalLogger)
+    }
+
+    // endregion
+
+    private fun fakeGroup(hits: Long, errors: Long) = ClientGroupedStats(
+        service = "service",
+        name = "name",
+        resource = "resource",
+        httpStatusCode = 200,
+        type = "type",
+        spanKind = "kind",
+        isTraceRoot = Trilean.TRUE,
+        hits = hits,
+        errors = errors,
+        duration = 0L,
+        topLevelHits = 0L,
+        okSummary = ByteArray(0),
+        errorSummary = ByteArray(0),
+        isSynthetic = false,
+        peerTags = emptyList(),
+        serviceSource = ""
+    )
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentratorTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/metrics/StatsConcentratorTest.kt
@@ -659,6 +659,34 @@ internal class StatsConcentratorTest {
         assertThat(buckets[0].stats[0].hits).isEqualTo(1L)
     }
 
+    @Test
+    fun `M mark write as not forced W scheduleFlush() { flushAll = false }`(forge: Forge) {
+        // Given
+        val (span) = forge.makeEligibleSpan()
+        stubNow(farFuture())
+        testedConcentrator.record(listOf(span))
+
+        // When
+        testedConcentrator.scheduleFlush(flushAll = false)
+
+        // Then
+        verify(mockStatsWriter).write(any(), eq(false))
+    }
+
+    @Test
+    fun `M mark write as forced W scheduleFlush() { flushAll = true }`(forge: Forge) {
+        // Given
+        val (span) = forge.makeEligibleSpan()
+        stubNow(farFuture())
+        testedConcentrator.record(listOf(span))
+
+        // When
+        testedConcentrator.scheduleFlush(flushAll = true)
+
+        // Then
+        verify(mockStatsWriter).write(any(), eq(true))
+    }
+
     // endregion
 
     // region stop
@@ -674,7 +702,7 @@ internal class StatsConcentratorTest {
         testedConcentrator.stop()
 
         // Then
-        verify(mockStatsWriter).write(any())
+        verify(mockStatsWriter).write(any(), any())
     }
 
     @Test
@@ -1038,7 +1066,7 @@ internal class StatsConcentratorTest {
 
     private fun captureBuckets(): List<ClientStatsBucket> {
         val captor = argumentCaptor<List<ClientStatsBucket>>()
-        verify(mockStatsWriter).write(captor.capture())
+        verify(mockStatsWriter).write(captor.capture(), any())
         return captor.firstValue
     }
 


### PR DESCRIPTION
### What does this PR do?
iOS Counter Part: https://github.com/DataDog/dd-sdk-ios/pull/3035

Outputs metrics related to how many spans we processed when we flush data for writing
