### PR TITLE
[HotFix] Fix R8 failures due to missing SourceLines annotation in 3.12.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,8 @@ variables:
   DD_ENV_TESTS: "ci"
   DD_CIVISIBILITY_ENABLED: "true"
   DD_INSIDE_CI: "true"
-  DD_COMMON_AGENT_CONFIG: "dd.env=ci,dd.trace.enabled=false,dd.jmx.fetch.enabled=false"
+  # Disable the DD Javac compiler plugin auto-config; it injects annotations into all compiled classes, breaking R8 for consumers.
+  DD_COMMON_AGENT_CONFIG: "dd.env=ci,dd.trace.enabled=false,dd.jmx.fetch.enabled=false,dd.civisibility.compiler.plugin.auto.configuration.enabled=false"
 
   KUBERNETES_MEMORY_REQUEST: "8Gi"
   KUBERNETES_MEMORY_LIMIT: "32Gi"

--- a/sample/benchmark/proguard-rules.pro
+++ b/sample/benchmark/proguard-rules.pro
@@ -27,9 +27,6 @@
 -dontwarn reactor.blockhound.integration.BlockHoundIntegration
 # These annotations are introduced by OpenTelemetry API and we need to make sure R8 will not complain about them
 -dontwarn  com.google.**
-# These annotations are injected by dd-java-agent at class-load time for source code profiling.
-# They are not present in the build classpath, so R8 must not treat them as errors.
--dontwarn datadog.compiler.annotations.**
 
 -keepattributes RuntimeVisibleAnnotations
 -keep class * extends androidx.navigation.Navigator

--- a/sample/kotlin/proguard-rules.pro
+++ b/sample/kotlin/proguard-rules.pro
@@ -32,6 +32,3 @@
 -dontwarn java.lang.management.RuntimeMXBean
 # These annotations are introduced by OpenTelemetry API and we need to make sure R8 will not complain about them
 -dontwarn  com.google.**
-# These annotations are injected by dd-java-agent at class-load time for source code profiling.
-# They are not present in the build classpath, so R8 must not treat them as errors.
--dontwarn datadog.compiler.annotations.**


### PR DESCRIPTION
Same as #3641, but targeting the release branch

### What does this PR do?
In CI, we monitor tests and our build via dd-trace-java. The issue is that for java compile tasks, they inject a javac plugin that adds in a SourceLines and SourcePath annotation. The issue is that this injected annotation is not in our runtime dependencies, so R8 will fail due to the missing annotation

Ramification for us is that our tests in the Test Optimization product may have their line numbers not as accurate due to the standard method line number table only tracks executable lines, so it won't include comments or method declaration in the UI. 

#### Verification
Ran locally with `org.gradle.jvmargs=-Xmx4096m -javaagent:/tmp/dd-tracer-repro/dd-java-agent.jar=dd.env=ci,dd.trace.enabled=false,dd.jmx.fetch.enabled=false,dd.trace.debug=true,dd.trace.startup.logs=true`
```
> Task :dd-sdk-android-internal:compileReleaseKotlin

> Task :dd-sdk-android-internal:compileReleaseJavaWithJavac
Dependency verification has been disabled.
Dependency verification has been disabled.
Dependency verification has been disabled.
DatadogCompilerPlugin initialized

> Task :dd-sdk-android-internal:apiBuild

--- 
mkdir -p /tmp/core-aar-check && unzip -p /tmp/dd-sdk-android-3120-repro/dd-sdk-android-core/build/outputs/aar/dd-sdk-android-core-release.aar classes.jar > /tmp/core-aar-check/classes.jar && javap -v -p -classpath /tmp/core-aar-check/classes.jar com.datadog.android.BuildConfig | grep -i "SourceLines\|SourcePath" -A2
  #48 = Utf8               Ldatadog/compiler/annotations/SourceLines;
  #49 = Utf8               start
  #50 = Integer            6
--
  #53 = Utf8               Ldatadog/compiler/annotations/SourcePath;
  #54 = Utf8               value
  #55 = Utf8               /private/tmp/dd-sdk-android-3120-repro/dd-sdk-android-core/build/generated/source/buildConfig/release/com/datadog/android/BuildConfig.java
--
    datadog.compiler.annotations.SourceLines(
      start=6
      end=18
--
    datadog.compiler.annotations.SourcePath(
      value="/private/tmp/dd-sdk-android-3120-repro/dd-sdk-android-core/build/generated/source/buildConfig/release/com/datadog/android/BuildConfig.java"
    )
```
----

With proposed fix locally: `org.gradle.jvmargs=-Xmx4096m -javaagent:/tmp/dd-tracer-repro/dd-java-agent.jar=dd.env=ci,dd.trace.enabled=false,dd.jmx.fetch.enabled=false,dd.civisibility.compiler.plugin.auto.configuration.enabled=false`

```
mkdir -p /tmp/core-aar-check2 && unzip -p /tmp/dd-sdk-android-3120-repro/dd-sdk-android-core/build/outputs/aar/dd-sdk-android-core-release.aar classes.jar > /tmp/core-aar-check2/classes.jar && (javap -v -p -classpath /tmp/core-aar-check2/classes.jar com.datadog.android.BuildConfig | grep -i "SourceLines\|SourcePath" || echo "not found")

not found
```

### Motivation
Fixes https://github.com/DataDog/dd-sdk-android/issues/3639

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

