### PR TITLE
RUM-17368: Mark client side stats APIs as ExperimentalTraceApi

### DIFF
--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/TraceConfiguration.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/TraceConfiguration.kt
@@ -68,6 +68,7 @@ data class TraceConfiguration internal constructor(
          *
          * @param enabled false by default
          */
+        @ExperimentalTraceApi
         fun setStatsComputationEnabled(enabled: Boolean): Builder {
             statsComputationEnabled = enabled
             return this
@@ -77,6 +78,7 @@ data class TraceConfiguration internal constructor(
          * Let the Tracing client-side stats feature target a custom server.
          * The provided url should be the full endpoint url, e.g.: https://example.com/stats/upload
          */
+        @ExperimentalTraceApi
         fun useCustomStatsEndpoint(endpoint: String): Builder {
             customStatsEndpointUrl = endpoint
             return this

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TraceConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TraceConfigurationBuilderTest.kt
@@ -34,6 +34,7 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
+@OptIn(ExperimentalTraceApi::class)
 internal class TraceConfigurationBuilderTest {
 
     private val testedBuilder: TraceConfiguration.Builder = TraceConfiguration.Builder()


### PR DESCRIPTION
### What does this PR do?
Marks the APIs to enable and configure client side stats APIs as `ExperimentalTraceApi` in prep for moving feature branch into `develop`. Feature will remain off by default

### Motivation
Prep for moving feature into `develop`

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

