### PR TITLE
RUM-17238: Add KTLint plugin to the Gradle build

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -69,7 +69,7 @@ import,com.google.code.gson,Apache-2.0,Copyright 2008 Google Inc
 import,com.google.guava,Apache-2.0,Copyright 2009 The Guava Authors
 import,com.hannesdorfmann,Apache-2.0,Copyright (c) 2015 Hannes Dorfmann.
 import,com.jakewharton.timber,Apache-2.0,Copyright 2013 Jake Wharton
-import,com.launchdarkly,Apache-2.0,Copyright 2016 Catamorphic, Co.
+import,com.launchdarkly,Apache-2.0,"Copyright 2016 Catamorphic, Co."
 import,com.lyft.kronos,Apache-2.0,Copyright (C) 2018 Lyft Inc.
 import,com.squareup.curtains,Apache-2.0,"Copyright 2021 Square, Inc"
 import,com.squareup.leakcanary,Apache-2.0,"Copyright 2015 Square, Inc"
@@ -243,4 +243,7 @@ build,org.slf4j,MIT,"Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland)"
 build,org.xerial,Apache-2.0,"Copyright (c) 2006, David Crawshaw."
 build,xerces,Apache-2.0,"Copyright 1999-2022 The Apache Software Foundation"
 build,xml-apis,"The Apache Software License, Version 2.0/The SAX License/The W3C License","Copyright © 2001-2009 The Apache Software Foundation."
-
+build,com.pinterest.ktlint,MIT,"Copyright 2019 Pinterest, Inc."
+build,com.github.ajalt.clikt,Apache-2.0,"Copyright clikt authors"
+build,io.github.oshai,Apache-2.0,"Copyright oshai authors"
+build,org.jlleitschuh.gradle,MIT,"Copyright (c) 2023 Jonathan Leitschuh"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -183,6 +183,7 @@ build,com.fasterxml.jackson.core,Apache-2.0,"Copyright (c) 2007- Tatu Saloranta"
 build,com.fasterxml.jackson.dataformat,Apache-2.,"Copyright (c) 2007- Tatu Saloranta"
 build,com.fasterxml.jackson.module,Apache-2.0,"Copyright (c) 2007- Tatu Saloranta"
 build,com.fasterxml.woodstox,Apache-2.0,"Copyright (c) 2007- Tatu Saloranta"
+build,com.github.ajalt.clikt,Apache-2.0,"Copyright clikt authors"
 build,com.github.tschuchortdev,MPL-2.0,"Copyright (C) 2023 Thilo Schuchort"
 build,com.google.android,Apache-2.0,Copyright (C) 2013 The Android Open Source Project
 build,com.google.api.grpc,Apache-2.0,Copyright 2020 Google LLC
@@ -197,6 +198,7 @@ build,com.google.jimfs,Apache-2.0,Copyright 2021 Google Inc.
 build,com.google.testing.platform,Apache-2.0,Copyright (C) 2021 The Android Open Source Project
 build,com.intellij,Apache-2.0,"Copyright 2000-2023 JetBrains s.r.o."
 build,com.pinterest,MIT,"Copyright 2019 Pinterest Inc, Copyright 2016-2019 Stanley Shyiko"
+build,com.pinterest.ktlint,MIT,"Copyright 2019 Pinterest, Inc."
 build,com.soywiz.korlibs.korte,MIT,Copyright (c) 2017-2019 Carlos Ballesteros Velasco and contributors
 build,com.sun.activation,"Eclipse Public License - v 2.0","Copyright (c) 2018, 2023 Oracle and/or its affiliates"
 build,com.sun.istack,"Eclipse Public License - v 2.0","Copyright (c) 2018, 2023 Oracle and/or its affiliates"
@@ -209,6 +211,7 @@ build,commons-logging,Apache-2.0,Copyright 2002-2024 The Apache Software Foundat
 build,io.github.aakira,Apache-2.0,"Copyright (C) 2019 A.Akira"
 build,io.github.classgraph,MIT,"Copyright (c) 2019 Luke Hutchison"
 build,io.github.microutils,Apache-2.0,Copyright (c) 2016-2018 Ohad Shai
+build,io.github.oshai,Apache-2.0,"Copyright oshai authors"
 build,io.gitlab.arturbosch.detekt,Apache-2.0,Copyright 2016-2019 the original author or authors
 build,io.grpc,Apache-2.0,Copyright 2014 The gRPC Authors
 build,io.netty,Apache-2.0,Copyright 2014 The Netty Project
@@ -237,13 +240,10 @@ build,org.glassfish.jaxb,"Eclipse Distribution License - v 1.0","Copyright (c) 2
 build,org.jcommander,Apache-2.0,"Copyright (C) 2010 the original author or authors"
 build,org.jetbrains.dokka,Apache-2.0,"Copyright 2014-2019 JetBrains s.r.o. and Dokka project contributors."
 build,org.jetbrains.intellij.deps,LGPL-2.1-only,"Copyright (c) 2001-2002, Eric D. Friedman, Jason Baldridge, Copyright (c) 1999 CERN - European Organization for Nuclear Research"
+build,org.jlleitschuh.gradle,MIT,"Copyright (c) 2023 Jonathan Leitschuh"
 build,org.jvnet.staxex,"Eclipse Distribution License - v 1.0","Copyright (c) 1997-2015 Oracle and/or its affiliates"
 build,org.ow2.asm,BSD-3-Clause,"Copyright (c) 2000-2011 INRIA, France Telecom"
 build,org.slf4j,MIT,"Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland)"
 build,org.xerial,Apache-2.0,"Copyright (c) 2006, David Crawshaw."
 build,xerces,Apache-2.0,"Copyright 1999-2022 The Apache Software Foundation"
 build,xml-apis,"The Apache Software License, Version 2.0/The SAX License/The W3C License","Copyright © 2001-2009 The Apache Software Foundation."
-build,com.pinterest.ktlint,MIT,"Copyright 2019 Pinterest, Inc."
-build,com.github.ajalt.clikt,Apache-2.0,"Copyright clikt authors"
-build,io.github.oshai,Apache-2.0,"Copyright oshai authors"
-build,org.jlleitschuh.gradle,MIT,"Copyright (c) 2023 Jonathan Leitschuh"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ import java.util.Properties
 
 plugins {
     `maven-publish`
+    id("ktlint")
     id("test-pyramid-aggregation")
     alias(libs.plugins.nexusPublishGradlePlugin)
     alias(libs.plugins.dependencyLicenseGradlePlugin)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -56,6 +56,8 @@ dependencies {
     // Verification Metadata XML
     implementation(libs.kotlinXmlBuilder)
 
+    implementation(libs.ktlintGradlePlugin)
+
     // Tests
     testImplementation(libs.jUnit4)
     testImplementation(libs.mockitoKotlin)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     `kotlin-dsl`
     alias(libs.plugins.versionsGradlePlugin)
+    alias(libs.plugins.ktlintGradlePlugin)
 }
 
 buildscript {
@@ -93,6 +94,13 @@ gradlePlugin {
 
 java.targetCompatibility = JavaVersion.VERSION_17
 java.sourceCompatibility = JavaVersion.VERSION_17
+
+ktlint {
+    version = provider { libs.versions.ktlint.get() }
+    filter {
+        exclude { it.file.path.contains("/build/generated") }
+    }
+}
 
 tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -98,7 +98,7 @@ java.sourceCompatibility = JavaVersion.VERSION_17
 ktlint {
     version = provider { libs.versions.ktlint.get() }
     filter {
-        exclude { it.file.path.contains("/build/generated") }
+        exclude { it.file.invariantSeparatorsPath.contains("/build/generated") }
     }
 }
 

--- a/buildSrc/src/main/kotlin/ktlint.gradle.kts
+++ b/buildSrc/src/main/kotlin/ktlint.gradle.kts
@@ -15,6 +15,6 @@ val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 ktlint {
     version = provider { libs.findVersion("ktlint").get().requiredVersion }
     filter {
-        exclude { it.file.path.contains("/build/generated/") }
+        exclude { it.file.invariantSeparatorsPath.contains("/build/generated/") }
     }
 }

--- a/buildSrc/src/main/kotlin/ktlint.gradle.kts
+++ b/buildSrc/src/main/kotlin/ktlint.gradle.kts
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+import org.gradle.api.artifacts.VersionCatalogsExtension
+
+plugins {
+    id("org.jlleitschuh.gradle.ktlint")
+}
+
+val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+ktlint {
+    version = provider { libs.findVersion("ktlint").get().requiredVersion }
+    filter {
+        exclude { it.file.path.contains("/build/generated/") }
+    }
+}

--- a/dd-sdk-android-core/build.gradle.kts
+++ b/dd-sdk-android-core/build.gradle.kts
@@ -18,6 +18,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/dd-sdk-android-internal/build.gradle.kts
+++ b/dd-sdk-android-internal/build.gradle.kts
@@ -15,6 +15,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     id("com.android.library")
     kotlin("android")
     id("com.google.devtools.ksp")

--- a/features/dd-sdk-android-flags-openfeature/build.gradle.kts
+++ b/features/dd-sdk-android-flags-openfeature/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/features/dd-sdk-android-flags/build.gradle.kts
+++ b/features/dd-sdk-android-flags/build.gradle.kts
@@ -15,6 +15,7 @@ import com.datadog.gradle.utils.createJsonModelsGenerationTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/features/dd-sdk-android-logs/build.gradle.kts
+++ b/features/dd-sdk-android-logs/build.gradle.kts
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.nio.file.Paths
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/features/dd-sdk-android-ndk/build.gradle.kts
+++ b/features/dd-sdk-android-ndk/build.gradle.kts
@@ -16,6 +16,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/features/dd-sdk-android-profiling/build.gradle.kts
+++ b/features/dd-sdk-android-profiling/build.gradle.kts
@@ -18,6 +18,7 @@ import com.datadog.gradle.utils.createRumSchemaCloneTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/features/dd-sdk-android-rum-debug-widget/build.gradle.kts
+++ b/features/dd-sdk-android-rum-debug-widget/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/features/dd-sdk-android-rum/build.gradle.kts
+++ b/features/dd-sdk-android-rum/build.gradle.kts
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.nio.file.Paths
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/features/dd-sdk-android-session-replay-compose/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-compose/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/features/dd-sdk-android-session-replay-material/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-material/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/features/dd-sdk-android-session-replay/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay/build.gradle.kts
@@ -18,6 +18,7 @@ import com.datadog.gradle.utils.createRumSchemaCloneTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/features/dd-sdk-android-trace-api/build.gradle.kts
+++ b/features/dd-sdk-android-trace-api/build.gradle.kts
@@ -16,6 +16,7 @@ import com.datadog.gradle.config.taskConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/features/dd-sdk-android-trace-internal/build.gradle.kts
+++ b/features/dd-sdk-android-trace-internal/build.gradle.kts
@@ -16,6 +16,7 @@ import com.datadog.gradle.plugin.gitclone.GitCloneDependenciesTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/features/dd-sdk-android-trace-otel/build.gradle.kts
+++ b/features/dd-sdk-android-trace-otel/build.gradle.kts
@@ -15,6 +15,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/features/dd-sdk-android-trace/build.gradle.kts
+++ b/features/dd-sdk-android-trace/build.gradle.kts
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.nio.file.Paths
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/features/dd-sdk-android-webview/build.gradle.kts
+++ b/features/dd-sdk-android-webview/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,6 +63,8 @@ kspTesting = "1.5.0"
 # Tools
 detekt = "1.23.8"
 dokka = "2.2.0"
+ktlint = "1.5.0"
+ktlintGradlePlugin = "14.2.0"
 unmock = "0.9.0"
 robolectric = "4.4_r1-robolectric-r2"
 androidLint = "31.0.2"
@@ -215,6 +217,7 @@ systemStubsJupiter = { module = "uk.org.webcompere:system-stubs-jupiter", versio
 # Tools
 detektApi = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detekt" }
 detektTest = { module = "io.gitlab.arturbosch.detekt:detekt-test", version.ref = "detekt" }
+ktlintGradlePlugin = { module = "org.jlleitschuh.gradle.ktlint:org.jlleitschuh.gradle.ktlint.gradle.plugin", version.ref = "ktlintGradlePlugin" }
 okHttpMock = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okHttp" }
 robolectric = { module = "org.robolectric:android-all", version.ref = "robolectric" }
 androidLintApi = { module = "com.android.tools.lint:lint-api", version.ref = "androidLint" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -393,3 +393,4 @@ sqlDelightGradlePlugin = { id = "com.squareup.sqldelight", version.ref = "sqlDel
 binaryCompatibilityGradlePlugin = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibility" }
 kotlinxSerializationPlugin = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 koverPlugin = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+ktlintGradlePlugin = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGradlePlugin" }

--- a/instrumented/integration/build.gradle.kts
+++ b/instrumented/integration/build.gradle.kts
@@ -10,6 +10,7 @@ import com.datadog.gradle.config.java17
 import com.datadog.gradle.config.kotlinConfig
 
 plugins {
+    id("ktlint")
     id("com.android.application")
     kotlin("android")
 }

--- a/integrations/dd-sdk-android-apollo/build.gradle.kts
+++ b/integrations/dd-sdk-android-apollo/build.gradle.kts
@@ -11,6 +11,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/integrations/dd-sdk-android-coil/build.gradle.kts
+++ b/integrations/dd-sdk-android-coil/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/integrations/dd-sdk-android-coil3/build.gradle.kts
+++ b/integrations/dd-sdk-android-coil3/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/integrations/dd-sdk-android-compose/build.gradle.kts
+++ b/integrations/dd-sdk-android-compose/build.gradle.kts
@@ -15,6 +15,7 @@ import com.datadog.gradle.config.taskConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/integrations/dd-sdk-android-cronet/build.gradle.kts
+++ b/integrations/dd-sdk-android-cronet/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/integrations/dd-sdk-android-fresco/build.gradle.kts
+++ b/integrations/dd-sdk-android-fresco/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/integrations/dd-sdk-android-glide/build.gradle.kts
+++ b/integrations/dd-sdk-android-glide/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/integrations/dd-sdk-android-okhttp-otel/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp-otel/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/integrations/dd-sdk-android-okhttp/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp/build.gradle.kts
@@ -16,6 +16,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/integrations/dd-sdk-android-rx/build.gradle.kts
+++ b/integrations/dd-sdk-android-rx/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/integrations/dd-sdk-android-sqldelight/build.gradle.kts
+++ b/integrations/dd-sdk-android-sqldelight/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/integrations/dd-sdk-android-timber/build.gradle.kts
+++ b/integrations/dd-sdk-android-timber/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/integrations/dd-sdk-android-tv/build.gradle.kts
+++ b/integrations/dd-sdk-android-tv/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/reliability/core-it/build.gradle.kts
+++ b/reliability/core-it/build.gradle.kts
@@ -12,6 +12,7 @@ import com.datadog.gradle.config.kotlinConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.application")
     kotlin("android")

--- a/reliability/single-fit/logs/build.gradle.kts
+++ b/reliability/single-fit/logs/build.gradle.kts
@@ -11,6 +11,7 @@ import com.datadog.gradle.config.kotlinConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/reliability/single-fit/okhttp/build.gradle.kts
+++ b/reliability/single-fit/okhttp/build.gradle.kts
@@ -11,6 +11,7 @@ import com.datadog.gradle.config.kotlinConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/reliability/single-fit/profiling/build.gradle.kts
+++ b/reliability/single-fit/profiling/build.gradle.kts
@@ -11,6 +11,7 @@ import com.datadog.gradle.config.kotlinConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/reliability/single-fit/rum/build.gradle.kts
+++ b/reliability/single-fit/rum/build.gradle.kts
@@ -11,6 +11,7 @@ import com.datadog.gradle.config.kotlinConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/reliability/single-fit/trace/build.gradle.kts
+++ b/reliability/single-fit/trace/build.gradle.kts
@@ -11,6 +11,7 @@ import com.datadog.gradle.config.kotlinConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/reliability/stub-core/build.gradle.kts
+++ b/reliability/stub-core/build.gradle.kts
@@ -10,6 +10,7 @@ import com.datadog.gradle.config.kotlinConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/reliability/stub-feature/build.gradle.kts
+++ b/reliability/stub-feature/build.gradle.kts
@@ -10,6 +10,7 @@ import com.datadog.gradle.config.kotlinConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     // Build
     id("com.android.library")
     kotlin("android")

--- a/sample/automotive/build.gradle.kts
+++ b/sample/automotive/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.taskConfig
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
+    id("ktlint")
     id("com.android.application")
     kotlin("android")
     id("com.github.ben-manes.versions")

--- a/sample/benchmark/build.gradle.kts
+++ b/sample/benchmark/build.gradle.kts
@@ -13,6 +13,7 @@ import com.datadog.gradle.config.kotlinConfig
 import com.datadog.gradle.plugin.InstrumentationMode
 
 plugins {
+    id("ktlint")
     id("com.android.application")
     kotlin("android")
     alias(libs.plugins.composeCompilerPlugin)

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -17,6 +17,7 @@ import com.datadog.gradle.config.taskConfig
 import com.datadog.gradle.plugin.InstrumentationMode
 
 plugins {
+    id("ktlint")
     id("com.android.application")
     kotlin("android")
     alias(libs.plugins.composeCompilerPlugin)

--- a/sample/tv/build.gradle.kts
+++ b/sample/tv/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.kotlinConfig
 import com.datadog.gradle.config.taskConfig
 
 plugins {
+    id("ktlint")
     id("com.android.application")
     kotlin("android")
     id("com.github.ben-manes.versions")

--- a/sample/vendor-lib/build.gradle.kts
+++ b/sample/vendor-lib/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.taskConfig
 import java.io.File
 
 plugins {
+    id("ktlint")
     id("com.android.library")
     kotlin("android")
     id("com.github.ben-manes.versions")

--- a/sample/wear/build.gradle.kts
+++ b/sample/wear/build.gradle.kts
@@ -10,6 +10,7 @@ import com.datadog.gradle.config.configureFlavorForSampleApp
 import com.datadog.gradle.config.java17
 
 plugins {
+    id("ktlint")
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
 }

--- a/tools/benchmark/build.gradle.kts
+++ b/tools/benchmark/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.publishingConfig
 import com.datadog.gradle.utils.createJsonModelsGenerationTask
 
 plugins {
+    id("ktlint")
     id("com.android.library")
     kotlin("android")
     id("com.github.ben-manes.versions")

--- a/tools/detekt/build.gradle.kts
+++ b/tools/detekt/build.gradle.kts
@@ -9,6 +9,7 @@ import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
 
 plugins {
+    id("ktlint")
     id("org.jetbrains.kotlin.jvm")
     id("com.github.ben-manes.versions")
 }

--- a/tools/javabackport/build.gradle.kts
+++ b/tools/javabackport/build.gradle.kts
@@ -7,6 +7,7 @@
 import com.datadog.gradle.config.kotlinConfig
 
 plugins {
+    id("ktlint")
     id("org.jetbrains.kotlin.jvm")
 }
 

--- a/tools/lint/build.gradle.kts
+++ b/tools/lint/build.gradle.kts
@@ -10,6 +10,7 @@ import com.datadog.gradle.config.kotlinConfig
 import com.datadog.gradle.config.taskConfig
 
 plugins {
+    id("ktlint")
     id("org.jetbrains.kotlin.jvm")
     id("com.github.ben-manes.versions")
     id("com.android.lint")

--- a/tools/noopfactory/build.gradle.kts
+++ b/tools/noopfactory/build.gradle.kts
@@ -10,6 +10,7 @@ import com.datadog.gradle.config.kotlinConfig
 import com.datadog.gradle.config.taskConfig
 
 plugins {
+    id("ktlint")
     id("org.jetbrains.kotlin.jvm")
     id("com.github.ben-manes.versions")
 }

--- a/tools/unit/build.gradle.kts
+++ b/tools/unit/build.gradle.kts
@@ -12,6 +12,7 @@ import com.datadog.gradle.config.kotlinConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
+    id("ktlint")
     id("com.android.library")
     kotlin("android")
     id("com.github.ben-manes.versions")


### PR DESCRIPTION
### What does this PR do?
Moves ktlint into Gradle which will replace the `analysis:ktlint` job
I left local_ci.sh as is since its faster than bootstrapping the Gradle build and runs only on the git diff

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

