### PR TITLE
RUM-17387: Add foreground refresh for RemoteConfigService

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -31,6 +31,7 @@ import com.datadog.android.core.internal.lifecycle.ProcessLifecycleCallback
 import com.datadog.android.core.internal.logger.SdkInternalLogger
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.remote.NoOpRemoteConfigFetcher
+import com.datadog.android.core.internal.remote.RemoteConfigLifecycleCallback
 import com.datadog.android.core.internal.remote.RemoteConfigNetworkFetcher
 import com.datadog.android.core.internal.remote.RemoteConfigService
 import com.datadog.android.core.internal.remote.RemoteConfigServiceImpl
@@ -86,6 +87,8 @@ internal class DatadogCore(
     internal lateinit var coreFeature: CoreFeature
 
     internal var remoteConfigService: RemoteConfigService? = null
+
+    internal var rcLifecycleMonitor: ProcessLifecycleMonitor? = null
 
     private lateinit var shutdownHook: Thread
 
@@ -525,6 +528,15 @@ internal class DatadogCore(
             internalLogger = internalLogger
         )
         remoteConfigService?.syncWithRemote()
+
+        val service = remoteConfigService ?: return
+        if (appContext is Application && coreFeature.isMainProcess) {
+            rcLifecycleMonitor = ProcessLifecycleMonitor(
+                RemoteConfigLifecycleCallback(service)
+            ).apply {
+                appContext.registerActivityLifecycleCallbacks(this)
+            }
+        }
     }
 
     private fun initializeCrashReportFeature() {
@@ -744,10 +756,17 @@ internal class DatadogCore(
         if (appContext is Application && lifecycleMonitor != null) {
             appContext.unregisterActivityLifecycleCallbacks(lifecycleMonitor)
         }
+        processLifecycleMonitor = null
 
-        contextProvider = NoOpContextProvider()
+        val rcMonitor = rcLifecycleMonitor
+        if (appContext is Application && rcMonitor != null) {
+            appContext.unregisterActivityLifecycleCallbacks(rcMonitor)
+        }
+        rcLifecycleMonitor = null
         remoteConfigService?.stop()
         remoteConfigService = null
+
+        contextProvider = NoOpContextProvider()
         coreFeature.stop()
         isDeveloperModeEnabled = false
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigLifecycleCallback.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/remote/RemoteConfigLifecycleCallback.kt
@@ -1,0 +1,43 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.remote
+
+import com.datadog.android.internal.lifecycle.ProcessLifecycleMonitor
+
+/**
+ * Triggers a remote configuration refresh every time the app comes to the foreground.
+ * OkHttp's ETag cache ensures the CDN fetch is a cheap 304 Not Modified when the config
+ * has not changed since the last sync.
+ */
+internal class RemoteConfigLifecycleCallback(
+    private val remoteConfigService: RemoteConfigService
+) : ProcessLifecycleMonitor.Callback {
+
+    // Both onStarted() and onStopped() are invoked on the main thread by ProcessLifecycleMonitor
+    // (via Application.ActivityLifecycleCallbacks), so wasBackgrounded is only ever read and
+    // written on the main thread. No AtomicBoolean or @Volatile needed.
+    private var wasBackgrounded = false
+
+    override fun onStarted() {
+        if (wasBackgrounded) {
+            // syncWithRemote() is non-blocking — it dispatches to an executor and returns immediately.
+            remoteConfigService.syncWithRemote()
+        }
+    }
+
+    override fun onResumed() {
+        // NO-OP
+    }
+
+    override fun onStopped() {
+        wasBackgrounded = true
+    }
+
+    override fun onPaused() {
+        // NO-OP
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
@@ -21,9 +21,11 @@ import com.datadog.android.core.internal.DatadogCore
 import com.datadog.android.core.internal.SdkFeature
 import com.datadog.android.core.internal.remote.NoOpRemoteConfigFetcher
 import com.datadog.android.core.internal.remote.RemoteConfigFetcher
+import com.datadog.android.core.internal.remote.RemoteConfigLifecycleCallback
 import com.datadog.android.core.internal.remote.RemoteConfigService
 import com.datadog.android.core.thread.FlushableExecutorService
 import com.datadog.android.error.internal.CrashReportsFeature
+import com.datadog.android.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.security.Encryption
@@ -57,6 +59,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -739,6 +742,43 @@ internal class DatadogCoreInitializationTest {
     }
 
     @Test
+    fun `M unregister RC lifecycle monitor W stop() { remoteConfigurationId set }`(
+        @StringForgery fakeRemoteConfigurationId: String
+    ) {
+        // Given — crashReportsEnabled=false ensures a stable unregister count:
+        // processLifecycleMonitor (1) + rcLifecycleMonitor (1) = 2 total.
+        testedCore = DatadogCore(
+            appContext.mockInstance,
+            fakeInstanceId,
+            fakeInstanceName,
+            executorServiceFactory = mockExecutorServiceFactory,
+            remoteConfigServiceFactory = mockRemoteConfigServiceFactory
+        ).apply {
+            initialize(
+                fakeConfiguration.copy(
+                    crashReportsEnabled = false,
+                    coreConfig = fakeConfiguration.coreConfig.copy(
+                        remoteConfigurationId = fakeRemoteConfigurationId
+                    )
+                )
+            )
+        }
+
+        // When
+        testedCore.stop()
+
+        // Then — exactly 2 unregister calls: processLifecycleMonitor + rcLifecycleMonitor.
+        // Exactly one wraps a RemoteConfigLifecycleCallback.
+        argumentCaptor<Application.ActivityLifecycleCallbacks> {
+            verify(appContext.mockInstance, times(2))
+                .unregisterActivityLifecycleCallbacks(capture())
+            val rcMonitors = allValues.filterIsInstance<ProcessLifecycleMonitor>()
+                .filter { it.callback is RemoteConfigLifecycleCallback }
+            assertThat(rcMonitors).hasSize(1)
+        }
+    }
+
+    @Test
     fun `M use NoOpRemoteConfigFetcher W setupRemoteConfiguration() { secondary process }`(
         @StringForgery fakeRemoteConfigurationId: String
     ) {
@@ -769,6 +809,34 @@ internal class DatadogCoreInitializationTest {
 
         // Then — secondary process path uses NoOpRemoteConfigFetcher (no network, no OkHttp cache)
         assertThat(capturedFetcher).isInstanceOf(NoOpRemoteConfigFetcher::class.java)
+    }
+
+    @Test
+    fun `M not register RC lifecycle monitor W setupRemoteConfiguration() { secondary process }`(
+        @StringForgery fakeRemoteConfigurationId: String
+    ) {
+        // Given
+        testedCore = DatadogCore(
+            appContext.mockInstance,
+            fakeInstanceId,
+            fakeInstanceName,
+            executorServiceFactory = mockExecutorServiceFactory,
+            remoteConfigServiceFactory = mockRemoteConfigServiceFactory
+        ).apply {
+            initialize(fakeConfiguration)
+            coreFeature.isMainProcess = false
+            setupRemoteConfiguration(
+                fakeConfiguration.copy(
+                    coreConfig = fakeConfiguration.coreConfig.copy(
+                        remoteConfigurationId = fakeRemoteConfigurationId
+                    )
+                )
+            )
+        }
+
+        // Then — secondary processes should not register a RC lifecycle monitor.
+        // Checked directly on the field to avoid captor ambiguity with calls from initialize().
+        assertThat(testedCore.rcLifecycleMonitor).isNull()
     }
 
     // endregion

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigLifecycleCallbackTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/remote/RemoteConfigLifecycleCallbackTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.remote
+
+import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class RemoteConfigLifecycleCallbackTest {
+
+    @Mock
+    lateinit var mockRemoteConfigService: RemoteConfigService
+
+    private lateinit var testedCallback: RemoteConfigLifecycleCallback
+
+    @BeforeEach
+    fun `set up`() {
+        testedCallback = RemoteConfigLifecycleCallback(mockRemoteConfigService)
+    }
+
+    @Test
+    fun `M call syncWithRemote W onStarted() { previously backgrounded }`() {
+        // Given
+        testedCallback.onStopped()
+
+        // When
+        testedCallback.onStarted()
+
+        // Then
+        verify(mockRemoteConfigService).syncWithRemote()
+    }
+
+    @Test
+    fun `M not call syncWithRemote W onStarted() { not previously backgrounded }`() {
+        // When — cold start, onStopped never called
+        testedCallback.onStarted()
+
+        // Then
+        verifyNoInteractions(mockRemoteConfigService)
+    }
+
+    @Test
+    fun `M do nothing W onResumed()`() {
+        // When
+        testedCallback.onResumed()
+
+        // Then
+        verifyNoInteractions(mockRemoteConfigService)
+    }
+
+    @Test
+    fun `M do nothing W onStopped()`() {
+        // When
+        testedCallback.onStopped()
+
+        // Then
+        verifyNoInteractions(mockRemoteConfigService)
+    }
+
+    @Test
+    fun `M do nothing W onPaused()`() {
+        // When
+        testedCallback.onPaused()
+
+        // Then
+        verifyNoInteractions(mockRemoteConfigService)
+    }
+
+    @Test
+    fun `M call syncWithRemote on each foreground W multiple background-foreground cycles`() {
+        // When — simulate two full background/foreground cycles
+        testedCallback.onStopped()
+        testedCallback.onStarted()
+
+        testedCallback.onStopped()
+        testedCallback.onStarted()
+
+        // Then — syncWithRemote called exactly once per foreground return
+        verify(mockRemoteConfigService, times(2)).syncWithRemote()
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Adds a foreground refresh mechanism to the Remote Configuration service. Every time the app returns to the foreground, `RemoteConfigService.syncWithRemote()` is called so the SDK picks up configuration changes without waiting for the next cold launch.

Key design decisions:
- A dedicated `RemoteConfigLifecycleCallback` implements `ProcessLifecycleMonitor.Callback`, following the same pattern as `ProfilingLifecycleCallback` and `BatchMetricsDispatcher`
- A `wasBackgrounded` flag prevents a duplicate fetch on cold start — `onStarted()` is skipped until `onStopped()` has fired at least once
- The lifecycle monitor is only registered in the main process — secondary processes use `NoOpRemoteConfigFetcher` intentionally and should not trigger foreground syncs

### Motivation

Part of the Mobile Remote Configuration feature (RUM-17387). Implements the foreground refresh strategy described in the RFC caching section, matching iOS behaviour (PR #2992).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)