### PR TITLE
RUM-16414: Expose remoteConfiguration on InternalSdkCore

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -237,6 +237,7 @@ interface com.datadog.android.core.InternalSdkCore : com.datadog.android.api.fea
   val lastFatalAnrSent: Long?
   val appStartTimeNs: Long
   val appUptimeNs: Long
+  val remoteConfiguration: com.datadog.android.core.internal.remote.model.RemoteConfiguration?
   fun writeLastViewEvent(ByteArray)
   fun deleteLastViewEvent()
   fun writeLastFatalAnrSent(Long)

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -670,6 +670,7 @@ public abstract interface class com/datadog/android/core/InternalSdkCore : com/d
 	public abstract fun getLastViewEvent ()Lcom/google/gson/JsonObject;
 	public abstract fun getNetworkInfo ()Lcom/datadog/android/api/context/NetworkInfo;
 	public abstract fun getPersistenceExecutorService ()Ljava/util/concurrent/ExecutorService;
+	public abstract fun getRemoteConfiguration ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration;
 	public abstract fun getRootStorageDir ()Ljava/io/File;
 	public abstract fun getTrackingConsent ()Lcom/datadog/android/privacy/TrackingConsent;
 	public abstract fun isDeveloperModeEnabled ()Z

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/InternalSdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/InternalSdkCore.kt
@@ -13,6 +13,7 @@ import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import com.datadog.android.lint.InternalApi
 import com.datadog.android.privacy.TrackingConsent
 import com.google.gson.JsonObject
@@ -86,6 +87,16 @@ interface InternalSdkCore : FeatureSdkCore {
      */
     @InternalApi
     val appUptimeNs: Long
+
+    /**
+     * The last successfully fetched and cached remote configuration, or `null` if none is
+     * available (first launch, `remoteConfigurationId` not configured, or deserialization failure).
+     *
+     * Features read this synchronously once at enable time to apply remote values on top of their
+     * developer-supplied configuration. Remote values take precedence over in-code values.
+     */
+    @InternalApi
+    val remoteConfiguration: RemoteConfiguration?
 
     /**
      * Writes current RUM view event to the dedicated file for the needs of NDK crash reporting.

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -35,6 +35,7 @@ import com.datadog.android.core.internal.remote.RemoteConfigLifecycleCallback
 import com.datadog.android.core.internal.remote.RemoteConfigNetworkFetcher
 import com.datadog.android.core.internal.remote.RemoteConfigService
 import com.datadog.android.core.internal.remote.RemoteConfigServiceImpl
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import com.datadog.android.core.internal.time.DefaultAppStartTimeProvider
 import com.datadog.android.core.internal.time.composeTimeInfo
 import com.datadog.android.core.internal.utils.executeSafe
@@ -442,6 +443,9 @@ internal class DatadogCore(
             )
             .getSafe("getDatadogContext", internalLogger)
     }
+
+    override val remoteConfiguration: RemoteConfiguration?
+        get() = remoteConfigService?.getCurrentConfig()
 
     // endregion
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/NoOpInternalSdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/NoOpInternalSdkCore.kt
@@ -19,6 +19,7 @@ import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.logger.SdkInternalLogger
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.privacy.TrackingConsent
@@ -85,6 +86,8 @@ internal object NoOpInternalSdkCore : InternalSdkCore {
         get() = 0
     override val appUptimeNs: Long
         get() = 0
+    override val remoteConfiguration: RemoteConfiguration?
+        get() = null
 
     // endregion
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
@@ -23,6 +23,7 @@ import com.datadog.android.core.internal.remote.NoOpRemoteConfigFetcher
 import com.datadog.android.core.internal.remote.RemoteConfigFetcher
 import com.datadog.android.core.internal.remote.RemoteConfigLifecycleCallback
 import com.datadog.android.core.internal.remote.RemoteConfigService
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import com.datadog.android.core.thread.FlushableExecutorService
 import com.datadog.android.error.internal.CrashReportsFeature
 import com.datadog.android.internal.lifecycle.ProcessLifecycleMonitor
@@ -57,6 +58,7 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -837,6 +839,58 @@ internal class DatadogCoreInitializationTest {
         // Then — secondary processes should not register a RC lifecycle monitor.
         // Checked directly on the field to avoid captor ambiguity with calls from initialize().
         assertThat(testedCore.rcLifecycleMonitor).isNull()
+    }
+
+    @Test
+    fun `M return remoteConfiguration W remoteConfiguration { remoteConfigurationId set }`(
+        @StringForgery fakeRemoteConfigurationId: String,
+        @Forgery fakeRemoteConfiguration: RemoteConfiguration
+    ) {
+        // Given
+        whenever(mockRemoteConfigService.getCurrentConfig()).doReturn(fakeRemoteConfiguration)
+        testedCore = DatadogCore(
+            appContext.mockInstance,
+            fakeInstanceId,
+            fakeInstanceName,
+            executorServiceFactory = mockExecutorServiceFactory,
+            remoteConfigServiceFactory = mockRemoteConfigServiceFactory
+        ).apply {
+            initialize(
+                fakeConfiguration.copy(
+                    coreConfig = fakeConfiguration.coreConfig.copy(
+                        remoteConfigurationId = fakeRemoteConfigurationId
+                    )
+                )
+            )
+        }
+
+        // When / Then
+        assertThat(testedCore.remoteConfiguration).isSameAs(fakeRemoteConfiguration)
+    }
+
+    @Test
+    fun `M return null W remoteConfiguration { remoteConfigurationId null }`() {
+        // Given
+        testedCore = DatadogCore(
+            appContext.mockInstance,
+            fakeInstanceId,
+            fakeInstanceName,
+            executorServiceFactory = mockExecutorServiceFactory,
+            remoteConfigServiceFactory = mockRemoteConfigServiceFactory
+        ).apply {
+            initialize(
+                fakeConfiguration.copy(
+                    coreConfig = fakeConfiguration.coreConfig.copy(
+                        remoteConfigurationId = null
+                    )
+                )
+            )
+        }
+
+        // When / Then
+        // remoteConfigService is null when remoteConfigurationId is null (setupRemoteConfiguration
+        // returns early), so remoteConfiguration delegates to null?.getCurrentConfig() = null.
+        assertThat(testedCore.remoteConfiguration).isNull()
     }
 
     // endregion

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/NoOpInternalSdkCoreTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/NoOpInternalSdkCoreTest.kt
@@ -62,6 +62,15 @@ internal class NoOpInternalSdkCoreTest {
     }
 
     @Test
+    fun `M return null W remoteConfiguration`() {
+        // When
+        val result = NoOpInternalSdkCore.remoteConfiguration
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
     fun `M return null W getFeature()`(@StringForgery fakeFeatureName: String) {
         // When
         val result = NoOpInternalSdkCore.getFeature(fakeFeatureName)


### PR DESCRIPTION
### What does this PR do?

Exposes a `remoteConfiguration: RemoteConfiguration?` property on `InternalSdkCore` so feature modules can read the cached remote configuration synchronously at enable time.

The property delegates to `remoteConfigService?.getCurrentConfig()`, which returns whatever was read from disk at SDK initialization. Returns `null` when `remoteConfigurationId` was not configured, on first launch, or when deserialization failed — in all cases features fall back to their in-code configuration unchanged.

### Motivation

Part of the Mobile Remote Configuration feature (RUM-16414). This is the prerequisite for RUM-16417 (apply RC to RUM at enablement) and subsequent feature consumption tickets for Session Replay, Profiling, and Trace.

### Additional Notes

This PR only exposes the endpoint — feature consumption (reading the value and applying it) is tracked separately per feature (RUM-16417 etc.).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)