### PR TITLE
RUM-17657: Apply remote configuration to SessionReplayConfiguration in SessionReplay.enable()

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
@@ -12,8 +12,10 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.sessionreplay.internal.SessionReplayFeature
 import com.datadog.android.sessionreplay.internal.TouchPrivacyManager
+import com.datadog.android.sessionreplay.internal.applyRemoteConfiguration
 import java.lang.ref.WeakReference
 
 /**
@@ -26,6 +28,9 @@ object SessionReplay {
     internal const val IS_ALREADY_REGISTERED_WARNING =
         "Session Replay is already enabled and does not support multiple instances. " +
             "The existing instance will continue to be used."
+
+    internal const val UNEXPECTED_SDK_CORE_TYPE =
+        "SDK instance provided doesn't implement InternalSdkCore."
 
     /**
      * Enables a SessionReplay feature based on the configuration provided.
@@ -42,26 +47,37 @@ object SessionReplay {
         sessionReplayConfiguration: SessionReplayConfiguration,
         sdkCore: SdkCore = Datadog.getInstance()
     ) {
+        if (sdkCore !is InternalSdkCore) {
+            val logger = (sdkCore as? FeatureSdkCore)?.internalLogger ?: InternalLogger.UNBOUND
+            logger.log(
+                level = InternalLogger.Level.ERROR,
+                targets = listOf(InternalLogger.Target.USER),
+                messageBuilder = { UNEXPECTED_SDK_CORE_TYPE }
+            )
+            return
+        }
         val featureSdkCore = sdkCore as FeatureSdkCore
         sessionReplayConfiguration.systemRequirementsConfiguration
             .runIfRequirementsMet(featureSdkCore.internalLogger) {
-                val touchPrivacyManager = TouchPrivacyManager(sessionReplayConfiguration.touchPrivacy)
+                val effectiveConfiguration = sessionReplayConfiguration
+                    .applyRemoteConfiguration(sdkCore.remoteConfiguration)
+                val touchPrivacyManager = TouchPrivacyManager(effectiveConfiguration.touchPrivacy)
                 val sessionReplayFeature = SessionReplayFeature(
                     sdkCore = featureSdkCore,
-                    customEndpointUrl = sessionReplayConfiguration.customEndpointUrl,
-                    privacy = sessionReplayConfiguration.privacy,
-                    imagePrivacy = sessionReplayConfiguration.imagePrivacy,
-                    touchPrivacy = sessionReplayConfiguration.touchPrivacy,
+                    customEndpointUrl = effectiveConfiguration.customEndpointUrl,
+                    privacy = effectiveConfiguration.privacy,
+                    imagePrivacy = effectiveConfiguration.imagePrivacy,
+                    touchPrivacy = effectiveConfiguration.touchPrivacy,
                     touchPrivacyManager = touchPrivacyManager,
-                    textAndInputPrivacy = sessionReplayConfiguration.textAndInputPrivacy,
-                    customMappers = sessionReplayConfiguration.customMappers,
-                    customOptionSelectorDetectors = sessionReplayConfiguration.customOptionSelectorDetectors,
-                    customDrawableMappers = sessionReplayConfiguration.customDrawableMappers,
-                    sampleRate = sessionReplayConfiguration.sampleRate,
-                    startRecordingImmediately = sessionReplayConfiguration.startRecordingImmediately,
-                    dynamicOptimizationEnabled = sessionReplayConfiguration.dynamicOptimizationEnabled,
-                    internalCallback = sessionReplayConfiguration.internalCallback,
-                    heatmapsEnabled = sessionReplayConfiguration.heatmapsEnabled
+                    textAndInputPrivacy = effectiveConfiguration.textAndInputPrivacy,
+                    customMappers = effectiveConfiguration.customMappers,
+                    customOptionSelectorDetectors = effectiveConfiguration.customOptionSelectorDetectors,
+                    customDrawableMappers = effectiveConfiguration.customDrawableMappers,
+                    sampleRate = effectiveConfiguration.sampleRate,
+                    startRecordingImmediately = effectiveConfiguration.startRecordingImmediately,
+                    dynamicOptimizationEnabled = effectiveConfiguration.dynamicOptimizationEnabled,
+                    internalCallback = effectiveConfiguration.internalCallback,
+                    heatmapsEnabled = effectiveConfiguration.heatmapsEnabled
                 )
 
                 if (isAlreadyRegistered()) {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
@@ -56,14 +56,13 @@ object SessionReplay {
             )
             return
         }
-        val featureSdkCore = sdkCore as FeatureSdkCore
         sessionReplayConfiguration.systemRequirementsConfiguration
-            .runIfRequirementsMet(featureSdkCore.internalLogger) {
+            .runIfRequirementsMet(sdkCore.internalLogger) {
                 val effectiveConfiguration = sessionReplayConfiguration
                     .applyRemoteConfiguration(sdkCore.remoteConfiguration)
                 val touchPrivacyManager = TouchPrivacyManager(effectiveConfiguration.touchPrivacy)
                 val sessionReplayFeature = SessionReplayFeature(
-                    sdkCore = featureSdkCore,
+                    sdkCore = sdkCore,
                     customEndpointUrl = effectiveConfiguration.customEndpointUrl,
                     privacy = effectiveConfiguration.privacy,
                     imagePrivacy = effectiveConfiguration.imagePrivacy,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayConfigurationExt.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayConfigurationExt.kt
@@ -1,0 +1,57 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal
+
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
+import com.datadog.android.sessionreplay.ImagePrivacy
+import com.datadog.android.sessionreplay.SessionReplayConfiguration
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
+import com.datadog.android.sessionreplay.TouchPrivacy
+
+/**
+ * Applies a [RemoteConfiguration] to this [SessionReplayConfiguration], returning a new instance
+ * with the remote values overlaid on top of the developer-supplied configuration.
+ *
+ * Fields absent from the remote payload (null) are left unchanged. Only the `sessionReplay`
+ * section of the remote configuration is consumed here; other sections (rum, profiling, trace) are
+ * handled by their respective feature modules.
+ */
+internal fun SessionReplayConfiguration.applyRemoteConfiguration(
+    rc: RemoteConfiguration?
+): SessionReplayConfiguration {
+    val sr = rc?.sessionReplay ?: return this
+    return copy(
+        sampleRate = sr.sampleRate?.toFloat() ?: sampleRate,
+        startRecordingImmediately = sr.startRecordingImmediately ?: startRecordingImmediately,
+        textAndInputPrivacy = sr.textAndInputPrivacy?.toSdkPrivacy() ?: textAndInputPrivacy,
+        imagePrivacy = sr.imagePrivacy?.toSdkPrivacy() ?: imagePrivacy,
+        touchPrivacy = sr.touchPrivacy?.toSdkPrivacy() ?: touchPrivacy
+    )
+}
+
+private fun RemoteConfiguration.TextAndInputPrivacy.toSdkPrivacy(): TextAndInputPrivacy =
+    when (this) {
+        RemoteConfiguration.TextAndInputPrivacy.MASK_SENSITIVE_INPUTS ->
+            TextAndInputPrivacy.MASK_SENSITIVE_INPUTS
+        RemoteConfiguration.TextAndInputPrivacy.MASK_ALL_INPUTS ->
+            TextAndInputPrivacy.MASK_ALL_INPUTS
+        RemoteConfiguration.TextAndInputPrivacy.MASK_ALL ->
+            TextAndInputPrivacy.MASK_ALL
+    }
+
+private fun RemoteConfiguration.ImagePrivacy.toSdkPrivacy(): ImagePrivacy =
+    when (this) {
+        RemoteConfiguration.ImagePrivacy.MASK_NONE -> ImagePrivacy.MASK_NONE
+        RemoteConfiguration.ImagePrivacy.MASK_LARGE_ONLY -> ImagePrivacy.MASK_LARGE_ONLY
+        RemoteConfiguration.ImagePrivacy.MASK_ALL -> ImagePrivacy.MASK_ALL
+    }
+
+private fun RemoteConfiguration.TouchPrivacy.toSdkPrivacy(): TouchPrivacy =
+    when (this) {
+        RemoteConfiguration.TouchPrivacy.SHOW -> TouchPrivacy.SHOW
+        RemoteConfiguration.TouchPrivacy.HIDE -> TouchPrivacy.HIDE
+    }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayTest.kt
@@ -10,7 +10,10 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import com.datadog.android.sessionreplay.SessionReplay.IS_ALREADY_REGISTERED_WARNING
+import com.datadog.android.sessionreplay.SessionReplay.UNEXPECTED_SDK_CORE_TYPE
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.SessionReplayFeature
 import com.datadog.android.sessionreplay.internal.net.SegmentRequestFactory
@@ -45,7 +48,7 @@ import org.mockito.quality.Strictness
 internal class SessionReplayTest {
 
     @Mock
-    lateinit var mockSdkCore: FeatureSdkCore
+    lateinit var mockSdkCore: InternalSdkCore
 
     @Mock
     lateinit var mockSystemRequirementsConfiguration: SystemRequirementsConfiguration
@@ -53,6 +56,7 @@ internal class SessionReplayTest {
     @BeforeEach
     fun `set up`() {
         whenever(mockSdkCore.internalLogger) doReturn mock()
+        whenever(mockSdkCore.remoteConfiguration) doReturn null
         SessionReplay.currentRegisteredCore = null
     }
 
@@ -127,14 +131,16 @@ internal class SessionReplayTest {
     @Test
     fun `M warn and send telemetry W enable { session replay feature already registered with another core }`(
         @Forgery fakeSessionReplayConfiguration: SessionReplayConfiguration,
-        @Mock mockCore1: FeatureSdkCore,
-        @Mock mockCore2: FeatureSdkCore,
+        @Mock mockCore1: InternalSdkCore,
+        @Mock mockCore2: InternalSdkCore,
         @Mock mockInternalLogger: InternalLogger
     ) {
         // Given
         whenever(mockCore1.isCoreActive()).thenReturn(true)
         whenever(mockCore1.internalLogger).thenReturn(mockInternalLogger)
+        whenever(mockCore1.remoteConfiguration) doReturn null
         whenever(mockCore2.internalLogger).thenReturn(mockInternalLogger)
+        whenever(mockCore2.remoteConfiguration) doReturn null
         val fakeSessionReplayConfigurationWithMockRequirement = fakeSessionReplayConfiguration.copy(
             systemRequirementsConfiguration = mockSystemRequirementsConfiguration
         )
@@ -172,13 +178,15 @@ internal class SessionReplayTest {
     @Test
     fun `M allow changing cores W enable { Session Replay already enabled but old core inactive }`(
         @Forgery fakeSessionReplayConfiguration: SessionReplayConfiguration,
-        @Mock mockCore1: FeatureSdkCore,
-        @Mock mockCore2: FeatureSdkCore,
+        @Mock mockCore1: InternalSdkCore,
+        @Mock mockCore2: InternalSdkCore,
         @Mock mockInternalLogger: InternalLogger
     ) {
         // Given
         whenever(mockCore1.internalLogger).thenReturn(mockInternalLogger)
+        whenever(mockCore1.remoteConfiguration) doReturn null
         whenever(mockCore2.internalLogger).thenReturn(mockInternalLogger)
+        whenever(mockCore2.remoteConfiguration) doReturn null
         val fakeSessionReplayConfigurationWithMockRequirement = fakeSessionReplayConfiguration.copy(
             systemRequirementsConfiguration = mockSystemRequirementsConfiguration
         )
@@ -204,4 +212,120 @@ internal class SessionReplayTest {
         // Then
         assertThat(SessionReplay.currentRegisteredCore?.get()).isEqualTo(mockCore2)
     }
+
+    // region Remote Configuration
+
+    @Test
+    fun `M log error and return W enable { sdkCore is not InternalSdkCore }`(
+        @Forgery fakeSessionReplayConfiguration: SessionReplayConfiguration,
+        @Mock mockNonInternalCore: FeatureSdkCore,
+        @Mock mockInternalLogger: InternalLogger
+    ) {
+        // Given
+        whenever(mockNonInternalCore.internalLogger) doReturn mockInternalLogger
+
+        // When
+        SessionReplay.enable(fakeSessionReplayConfiguration, mockNonInternalCore)
+
+        // Then
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.USER),
+            message = UNEXPECTED_SDK_CORE_TYPE
+        )
+        assertThat(SessionReplay.currentRegisteredCore).isNull()
+    }
+
+    @Test
+    fun `M register feature with merged configuration W enable { RC provides sessionReplay values }`(
+        @Forgery fakeSessionReplayConfiguration: SessionReplayConfiguration,
+        @Forgery fakeRemoteConfiguration: RemoteConfiguration
+    ) {
+        // Given
+        val fakeConfigWithMockRequirements = fakeSessionReplayConfiguration.copy(
+            systemRequirementsConfiguration = mockSystemRequirementsConfiguration
+        )
+        whenever(mockSdkCore.remoteConfiguration) doReturn fakeRemoteConfiguration
+        whenever(
+            mockSystemRequirementsConfiguration.runIfRequirementsMet(any(), any())
+        ) doAnswer {
+            it.getArgument<() -> Unit>(1).invoke()
+        }
+
+        // When
+        SessionReplay.enable(fakeConfigWithMockRequirements, mockSdkCore)
+
+        // Then — SessionReplayFeature is registered with the effective (potentially merged) config
+        argumentCaptor<SessionReplayFeature> {
+            verify(mockSdkCore).registerFeature(capture())
+            val remoteSessionReplay = fakeRemoteConfiguration.sessionReplay
+            // Privacy fields from RC override in-code values when present
+            assertThat(lastValue.imagePrivacy).isEqualTo(
+                remoteSessionReplay?.imagePrivacy?.toSdkImagePrivacy()
+                    ?: fakeConfigWithMockRequirements.imagePrivacy
+            )
+            assertThat(lastValue.textAndInputPrivacy).isEqualTo(
+                remoteSessionReplay?.textAndInputPrivacy?.toSdkTextAndInputPrivacy()
+                    ?: fakeConfigWithMockRequirements.textAndInputPrivacy
+            )
+            assertThat(lastValue.touchPrivacy).isEqualTo(
+                remoteSessionReplay?.touchPrivacy?.toSdkTouchPrivacy()
+                    ?: fakeConfigWithMockRequirements.touchPrivacy
+            )
+        }
+    }
+
+    @Test
+    fun `M register feature with in-code configuration W enable { null remote configuration }`(
+        @Forgery fakeSessionReplayConfiguration: SessionReplayConfiguration
+    ) {
+        // Given
+        val fakeConfigWithMockRequirements = fakeSessionReplayConfiguration.copy(
+            systemRequirementsConfiguration = mockSystemRequirementsConfiguration
+        )
+        whenever(mockSdkCore.remoteConfiguration) doReturn null
+        whenever(
+            mockSystemRequirementsConfiguration.runIfRequirementsMet(any(), any())
+        ) doAnswer {
+            it.getArgument<() -> Unit>(1).invoke()
+        }
+
+        // When
+        SessionReplay.enable(fakeConfigWithMockRequirements, mockSdkCore)
+
+        // Then — SessionReplayFeature is registered with in-code values unchanged
+        argumentCaptor<SessionReplayFeature> {
+            verify(mockSdkCore).registerFeature(capture())
+            assertThat(lastValue.imagePrivacy).isEqualTo(fakeConfigWithMockRequirements.imagePrivacy)
+            assertThat(lastValue.textAndInputPrivacy)
+                .isEqualTo(fakeConfigWithMockRequirements.textAndInputPrivacy)
+            assertThat(lastValue.touchPrivacy).isEqualTo(fakeConfigWithMockRequirements.touchPrivacy)
+        }
+    }
+
+    // endregion
+
+    // region Helpers
+
+    private fun RemoteConfiguration.ImagePrivacy.toSdkImagePrivacy(): ImagePrivacy = when (this) {
+        RemoteConfiguration.ImagePrivacy.MASK_NONE -> ImagePrivacy.MASK_NONE
+        RemoteConfiguration.ImagePrivacy.MASK_LARGE_ONLY -> ImagePrivacy.MASK_LARGE_ONLY
+        RemoteConfiguration.ImagePrivacy.MASK_ALL -> ImagePrivacy.MASK_ALL
+    }
+
+    private fun RemoteConfiguration.TextAndInputPrivacy.toSdkTextAndInputPrivacy(): TextAndInputPrivacy =
+        when (this) {
+            RemoteConfiguration.TextAndInputPrivacy.MASK_SENSITIVE_INPUTS ->
+                TextAndInputPrivacy.MASK_SENSITIVE_INPUTS
+            RemoteConfiguration.TextAndInputPrivacy.MASK_ALL_INPUTS ->
+                TextAndInputPrivacy.MASK_ALL_INPUTS
+            RemoteConfiguration.TextAndInputPrivacy.MASK_ALL -> TextAndInputPrivacy.MASK_ALL
+        }
+
+    private fun RemoteConfiguration.TouchPrivacy.toSdkTouchPrivacy(): TouchPrivacy = when (this) {
+        RemoteConfiguration.TouchPrivacy.SHOW -> TouchPrivacy.SHOW
+        RemoteConfiguration.TouchPrivacy.HIDE -> TouchPrivacy.HIDE
+    }
+
+    // endregion
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayConfigurationExtTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayConfigurationExtTest.kt
@@ -1,0 +1,346 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal
+
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
+import com.datadog.android.sessionreplay.ImagePrivacy
+import com.datadog.android.sessionreplay.SessionReplayConfiguration
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
+import com.datadog.android.sessionreplay.TouchPrivacy
+import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.FloatForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class SessionReplayConfigurationExtTest {
+
+    private lateinit var testedConfiguration: SessionReplayConfiguration
+
+    @BeforeEach
+    fun setUp(forge: Forge) {
+        testedConfiguration = forge.getForgery()
+    }
+
+    // region null RC
+
+    @Test
+    fun `M return config unchanged W applyRemoteConfiguration { null RC }`() {
+        // When
+        val result = testedConfiguration.applyRemoteConfiguration(null)
+
+        // Then
+        assertThat(result).isEqualTo(testedConfiguration)
+    }
+
+    @Test
+    fun `M return config unchanged W applyRemoteConfiguration { RC with null sessionReplay }`() {
+        // Given
+        val fakeRc = RemoteConfiguration(sessionReplay = null)
+
+        // When
+        val result = testedConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result).isEqualTo(testedConfiguration)
+    }
+
+    // endregion
+
+    // region sampleRate
+
+    @Test
+    fun `M override sampleRate W applyRemoteConfiguration { RC provides sampleRate }`(
+        @FloatForgery(min = 0f, max = 100f) fakeSampleRate: Float
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            sessionReplay = RemoteConfiguration.SessionReplay(sampleRate = fakeSampleRate)
+        )
+
+        // When
+        val result = testedConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.sampleRate).isEqualTo(fakeSampleRate)
+    }
+
+    @Test
+    fun `M keep existing sampleRate W applyRemoteConfiguration { RC omits sampleRate }`() {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            sessionReplay = RemoteConfiguration.SessionReplay(sampleRate = null)
+        )
+        val expectedSampleRate = testedConfiguration.sampleRate
+
+        // When
+        val result = testedConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.sampleRate).isEqualTo(expectedSampleRate)
+    }
+
+    // endregion
+
+    // region startRecordingImmediately
+
+    @Test
+    fun `M override startRecordingImmediately W applyRemoteConfiguration { RC provides true }`() {
+        // Given
+        val baseline = testedConfiguration.copy(startRecordingImmediately = false)
+        val fakeRc = RemoteConfiguration(
+            sessionReplay = RemoteConfiguration.SessionReplay(startRecordingImmediately = true)
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.startRecordingImmediately).isTrue()
+    }
+
+    @Test
+    fun `M override startRecordingImmediately W applyRemoteConfiguration { RC provides false }`() {
+        // Given
+        val baseline = testedConfiguration.copy(startRecordingImmediately = true)
+        val fakeRc = RemoteConfiguration(
+            sessionReplay = RemoteConfiguration.SessionReplay(startRecordingImmediately = false)
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.startRecordingImmediately).isFalse()
+    }
+
+    @Test
+    fun `M keep existing startRecordingImmediately W applyRemoteConfiguration { RC omits it }`() {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            sessionReplay = RemoteConfiguration.SessionReplay(startRecordingImmediately = null)
+        )
+        val expectedValue = testedConfiguration.startRecordingImmediately
+
+        // When
+        val result = testedConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.startRecordingImmediately).isEqualTo(expectedValue)
+    }
+
+    // endregion
+
+    // region textAndInputPrivacy
+
+    @Test
+    fun `M override textAndInputPrivacy W applyRemoteConfiguration { RC MASK_SENSITIVE_INPUTS }`() {
+        // Given
+        val baseline = testedConfiguration.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL)
+        val fakeRc = RemoteConfiguration(
+            sessionReplay = RemoteConfiguration.SessionReplay(
+                textAndInputPrivacy = RemoteConfiguration.TextAndInputPrivacy.MASK_SENSITIVE_INPUTS
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.textAndInputPrivacy).isEqualTo(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
+    }
+
+    @Test
+    fun `M override textAndInputPrivacy W applyRemoteConfiguration { RC MASK_ALL_INPUTS }`() {
+        // Given
+        val baseline = testedConfiguration.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL)
+        val fakeRc = RemoteConfiguration(
+            sessionReplay = RemoteConfiguration.SessionReplay(
+                textAndInputPrivacy = RemoteConfiguration.TextAndInputPrivacy.MASK_ALL_INPUTS
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.textAndInputPrivacy).isEqualTo(TextAndInputPrivacy.MASK_ALL_INPUTS)
+    }
+
+    @Test
+    fun `M override textAndInputPrivacy W applyRemoteConfiguration { RC MASK_ALL }`() {
+        // Given
+        val baseline = testedConfiguration.copy(
+            textAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS
+        )
+        val fakeRc = RemoteConfiguration(
+            sessionReplay = RemoteConfiguration.SessionReplay(
+                textAndInputPrivacy = RemoteConfiguration.TextAndInputPrivacy.MASK_ALL
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.textAndInputPrivacy).isEqualTo(TextAndInputPrivacy.MASK_ALL)
+    }
+
+    @Test
+    fun `M keep existing textAndInputPrivacy W applyRemoteConfiguration { RC omits it }`() {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            sessionReplay = RemoteConfiguration.SessionReplay(textAndInputPrivacy = null)
+        )
+        val expectedValue = testedConfiguration.textAndInputPrivacy
+
+        // When
+        val result = testedConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.textAndInputPrivacy).isEqualTo(expectedValue)
+    }
+
+    // endregion
+
+    // region imagePrivacy
+
+    @Test
+    fun `M override imagePrivacy W applyRemoteConfiguration { RC MASK_NONE }`() {
+        // Given
+        val baseline = testedConfiguration.copy(imagePrivacy = ImagePrivacy.MASK_ALL)
+        val fakeRc = RemoteConfiguration(
+            sessionReplay = RemoteConfiguration.SessionReplay(
+                imagePrivacy = RemoteConfiguration.ImagePrivacy.MASK_NONE
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.imagePrivacy).isEqualTo(ImagePrivacy.MASK_NONE)
+    }
+
+    @Test
+    fun `M override imagePrivacy W applyRemoteConfiguration { RC MASK_LARGE_ONLY }`() {
+        // Given
+        val baseline = testedConfiguration.copy(imagePrivacy = ImagePrivacy.MASK_ALL)
+        val fakeRc = RemoteConfiguration(
+            sessionReplay = RemoteConfiguration.SessionReplay(
+                imagePrivacy = RemoteConfiguration.ImagePrivacy.MASK_LARGE_ONLY
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.imagePrivacy).isEqualTo(ImagePrivacy.MASK_LARGE_ONLY)
+    }
+
+    @Test
+    fun `M override imagePrivacy W applyRemoteConfiguration { RC MASK_ALL }`() {
+        // Given
+        val baseline = testedConfiguration.copy(imagePrivacy = ImagePrivacy.MASK_NONE)
+        val fakeRc = RemoteConfiguration(
+            sessionReplay = RemoteConfiguration.SessionReplay(
+                imagePrivacy = RemoteConfiguration.ImagePrivacy.MASK_ALL
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.imagePrivacy).isEqualTo(ImagePrivacy.MASK_ALL)
+    }
+
+    @Test
+    fun `M keep existing imagePrivacy W applyRemoteConfiguration { RC omits it }`() {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            sessionReplay = RemoteConfiguration.SessionReplay(imagePrivacy = null)
+        )
+        val expectedValue = testedConfiguration.imagePrivacy
+
+        // When
+        val result = testedConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.imagePrivacy).isEqualTo(expectedValue)
+    }
+
+    // endregion
+
+    // region touchPrivacy
+
+    @Test
+    fun `M override touchPrivacy W applyRemoteConfiguration { RC SHOW }`() {
+        // Given
+        val baseline = testedConfiguration.copy(touchPrivacy = TouchPrivacy.HIDE)
+        val fakeRc = RemoteConfiguration(
+            sessionReplay = RemoteConfiguration.SessionReplay(
+                touchPrivacy = RemoteConfiguration.TouchPrivacy.SHOW
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.touchPrivacy).isEqualTo(TouchPrivacy.SHOW)
+    }
+
+    @Test
+    fun `M override touchPrivacy W applyRemoteConfiguration { RC HIDE }`() {
+        // Given
+        val baseline = testedConfiguration.copy(touchPrivacy = TouchPrivacy.SHOW)
+        val fakeRc = RemoteConfiguration(
+            sessionReplay = RemoteConfiguration.SessionReplay(
+                touchPrivacy = RemoteConfiguration.TouchPrivacy.HIDE
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.touchPrivacy).isEqualTo(TouchPrivacy.HIDE)
+    }
+
+    @Test
+    fun `M keep existing touchPrivacy W applyRemoteConfiguration { RC omits it }`() {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            sessionReplay = RemoteConfiguration.SessionReplay(touchPrivacy = null)
+        )
+        val expectedValue = testedConfiguration.touchPrivacy
+
+        // When
+        val result = testedConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.touchPrivacy).isEqualTo(expectedValue)
+    }
+
+    // endregion
+}


### PR DESCRIPTION
### What does this PR do?

Introduces `SessionReplayConfigurationExt.applyRemoteConfiguration()`, an internal extension function that overlays the remote configuration's `sessionReplay` section onto the developer-supplied `SessionReplayConfiguration` before `SessionReplayFeature` is constructed. Wires it into `SessionReplay.enable()` so that remote values take effect on every SDK initialization.

Also adds an `InternalSdkCore` guard to `SessionReplay.enable()` — consistent with the equivalent guard in `Rum.enable()` — to access `remoteConfiguration` from Core.

### Motivation

[RUM-17657](https://datadoghq.atlassian.net/browse/RUM-17657) — the RC fetch, storage, and `remoteConfiguration` exposure were implemented in earlier PRs; this PR applies the stored Session Replay config at `SessionReplay.enable()` time. Mirrors the iOS implementation in [dd-sdk-ios#3046](https://github.com/DataDog/dd-sdk-ios/pull/3046).

### Additional Notes

**RC fields mapped from remote payload to `SessionReplayConfiguration`:**

| RC field | `SessionReplayConfiguration` field | Notes |
|---|---|---|
| `sessionReplay.sampleRate` | `sampleRate: Float` | Shared |
| `sessionReplay.startRecordingImmediately` | `startRecordingImmediately: Boolean` | Shared |
| `sessionReplay.textAndInputPrivacy` | `textAndInputPrivacy: TextAndInputPrivacy` | Shared |
| `sessionReplay.touchPrivacy` | `touchPrivacy: TouchPrivacy` | Shared |
| `sessionReplay.imagePrivacy` | `imagePrivacy: ImagePrivacy` | Platform-specific (Android: `MASK_LARGE_ONLY`; iOS: `MASK_NON_BUNDLED_ONLY`) |

Fields absent from the remote payload are left unchanged. If `RemoteConfiguration` is `null` or the `sessionReplay` namespace is absent, Session Replay starts with in-code values only — behaviour is identical to today.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the implementing team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

[RUM-17657]: https://datadoghq.atlassian.net/browse/RUM-17657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ