### PR TITLE
RUM-16417: Apply remote configuration to RumConfiguration in Rum.enable()

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -494,7 +494,7 @@ data class com.datadog.android.core.`internal`.remote.model.RemoteConfiguration
     fun fromJson(kotlin.String): RemoteConfiguration
     fun fromJsonObject(com.google.gson.JsonObject): RemoteConfiguration
   data class Rum
-    constructor(kotlin.String, kotlin.String? = null, kotlin.String? = null, kotlin.Number? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Number? = null, VitalsUpdateFrequency? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null)
+    constructor(kotlin.String, kotlin.String? = null, kotlin.String? = null, kotlin.Number? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, LongTask? = null, VitalsUpdateFrequency? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Rum
@@ -512,11 +512,23 @@ data class com.datadog.android.core.`internal`.remote.model.RemoteConfiguration
       fun fromJson(kotlin.String): Profiling
       fun fromJsonObject(com.google.gson.JsonObject): Profiling
   data class Trace
-    constructor(kotlin.Number? = null, TraceContextInjection? = null, kotlin.collections.List<kotlin.String>? = null, kotlin.collections.List<TracingHeaderType>? = null)
+    constructor(kotlin.Number? = null, TraceContextInjection? = null, kotlin.collections.List<TracedHost>? = null, kotlin.collections.List<TracingHeaderType>? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Trace
       fun fromJsonObject(com.google.gson.JsonObject): Trace
+  data class LongTask
+    constructor(kotlin.Boolean? = null, kotlin.Number? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): LongTask
+      fun fromJsonObject(com.google.gson.JsonObject): LongTask
+  data class TracedHost
+    constructor(kotlin.String, kotlin.collections.List<TracingHeaderType>? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TracedHost
+      fun fromJsonObject(com.google.gson.JsonObject): TracedHost
   enum VitalsUpdateFrequency
     constructor(kotlin.String)
     - FREQUENT

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -934,6 +934,30 @@ public final class com/datadog/android/core/internal/remote/model/RemoteConfigur
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$ImagePrivacy;
 }
 
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$LongTask {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$LongTask$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Number;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Number;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Number;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Number;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$LongTask;
+	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$LongTask;Ljava/lang/Boolean;Ljava/lang/Number;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$LongTask;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$LongTask;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$LongTask;
+	public final fun getEnabled ()Ljava/lang/Boolean;
+	public final fun getThreshold ()Ljava/lang/Number;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$LongTask$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$LongTask;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$LongTask;
+}
+
 public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling {
 	public static final field Companion Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Profiling$Companion;
 	public fun <init> ()V
@@ -960,14 +984,13 @@ public final class com/datadog/android/core/internal/remote/model/RemoteConfigur
 
 public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum {
 	public static final field Companion Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$LongTask;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$LongTask;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Ljava/lang/Number;
-	public final fun component11 ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;
+	public final fun component10 ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;
+	public final fun component11 ()Ljava/lang/Boolean;
 	public final fun component12 ()Ljava/lang/Boolean;
 	public final fun component13 ()Ljava/lang/Boolean;
-	public final fun component14 ()Ljava/lang/Boolean;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/Number;
@@ -975,23 +998,22 @@ public final class com/datadog/android/core/internal/remote/model/RemoteConfigur
 	public final fun component6 ()Ljava/lang/Boolean;
 	public final fun component7 ()Ljava/lang/Boolean;
 	public final fun component8 ()Ljava/lang/Boolean;
-	public final fun component9 ()Ljava/lang/Boolean;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;
-	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Number;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;
+	public final fun component9 ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$LongTask;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$LongTask;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;
+	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Number;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$LongTask;Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Rum;
 	public final fun getApplicationId ()Ljava/lang/String;
 	public final fun getCrashReportsEnabled ()Ljava/lang/Boolean;
 	public final fun getEnv ()Ljava/lang/String;
-	public final fun getLongTaskThresholdMs ()Ljava/lang/Number;
+	public final fun getLongTask ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$LongTask;
 	public final fun getService ()Ljava/lang/String;
 	public final fun getTelemetrySampleRate ()Ljava/lang/Number;
 	public final fun getTrackAnonymousUser ()Ljava/lang/Boolean;
 	public final fun getTrackBackgroundEvents ()Ljava/lang/Boolean;
 	public final fun getTrackFrustrations ()Ljava/lang/Boolean;
 	public final fun getTrackNonFatalAnrs ()Ljava/lang/Boolean;
-	public final fun getTrackResources ()Ljava/lang/Boolean;
 	public final fun getTrackSlowFrames ()Ljava/lang/Boolean;
 	public final fun getTrackUserInteractions ()Ljava/lang/Boolean;
 	public final fun getVitalsUpdateFrequency ()Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$VitalsUpdateFrequency;
@@ -1104,6 +1126,29 @@ public final class com/datadog/android/core/internal/remote/model/RemoteConfigur
 
 public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$TraceContextInjection$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TraceContextInjection;
+}
+
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$TracedHost {
+	public static final field Companion Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracedHost$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracedHost;
+	public static synthetic fun copy$default (Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracedHost;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracedHost;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracedHost;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracedHost;
+	public final fun getHost ()Ljava/lang/String;
+	public final fun getPropagatorTypes ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$TracedHost$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracedHost;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracedHost;
 }
 
 public final class com/datadog/android/core/internal/remote/model/RemoteConfiguration$TracingHeaderType : java/lang/Enum {

--- a/dd-sdk-android-core/src/main/json/rc/mobile.json
+++ b/dd-sdk-android-core/src/main/json/rc/mobile.json
@@ -17,13 +17,23 @@
         "telemetrySampleRate": { "type": "number", "minimum": 0, "maximum": 100 },
         "trackAnonymousUser": { "type": "boolean" },
         "trackUserInteractions": { "type": "boolean" },
-        "trackResources": { "type": "boolean" },
         "trackBackgroundEvents": { "type": "boolean" },
         "trackFrustrations": { "type": "boolean" },
-        "longTaskThresholdMs": {
-          "type": "number",
-          "minimum": 100,
-          "description": "Minimum main-thread task duration to report as a long task"
+        "longTask": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Long task detection configuration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enables long task detection. Omit to fall back to SDK in-code default."
+            },
+            "threshold": {
+              "type": "number",
+              "minimum": 100,
+              "description": "Minimum main-thread task duration in ms. Only relevant when enabled is true."
+            }
+          }
         },
         "vitalsUpdateFrequency": {
           "type": "string",
@@ -34,6 +44,7 @@
     },
     "sessionReplay": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "sampleRate": { "type": "number", "minimum": 0, "maximum": 100 },
         "startRecordingImmediately": {
@@ -66,8 +77,19 @@
         "traceContextInjection": { "type": "string", "enum": ["all", "sampled"] },
         "tracedHosts": {
           "type": "array",
-          "description": "Hostnames for which distributed tracing headers are injected",
-          "items": { "type": "string" }
+          "description": "Per-host distributed tracing configuration",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["host"],
+            "properties": {
+              "host": { "type": "string" },
+              "propagatorTypes": {
+                "type": "array",
+                "items": { "type": "string", "enum": ["datadog", "b3", "b3multi", "tracecontext"] }
+              }
+            }
+          }
         },
         "tracingHeaderTypes": {
           "type": "array",

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -70,9 +70,6 @@ internal class Configurator :
 
         forge.addFactory(PersistenceStrategyBatchForgeryFactory())
 
-        // Remote Config
-        forge.addFactory(RemoteConfigurationForgeryFactory())
-
         forge.useJvmFactories()
 
         // telemetry

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemoteConfigurationForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemoteConfigurationForgeryFactory.kt
@@ -22,10 +22,14 @@ internal class RemoteConfigurationForgeryFactory : ForgeryFactory<RemoteConfigur
                     telemetrySampleRate = aNullable { anInt(min = 0, max = 100) },
                     trackAnonymousUser = aNullable { aBool() },
                     trackUserInteractions = aNullable { aBool() },
-                    trackResources = aNullable { aBool() },
                     trackBackgroundEvents = aNullable { aBool() },
                     trackFrustrations = aNullable { aBool() },
-                    longTaskThresholdMs = aNullable { anInt(min = 100) },
+                    longTask = aNullable {
+                        RemoteConfiguration.LongTask(
+                            enabled = aNullable { aBool() },
+                            threshold = aNullable { anInt(min = 100) }
+                        )
+                    },
                     vitalsUpdateFrequency = aNullable {
                         aValueFrom(RemoteConfiguration.VitalsUpdateFrequency::class.java)
                     },
@@ -61,7 +65,16 @@ internal class RemoteConfigurationForgeryFactory : ForgeryFactory<RemoteConfigur
                     traceContextInjection = aNullable {
                         aValueFrom(RemoteConfiguration.TraceContextInjection::class.java)
                     },
-                    tracedHosts = aNullable { aList { anAlphabeticalString() } },
+                    tracedHosts = aNullable {
+                        aList {
+                            RemoteConfiguration.TracedHost(
+                                host = anAlphabeticalString(),
+                                propagatorTypes = aNullable {
+                                    aList { aValueFrom(RemoteConfiguration.TracingHeaderType::class.java) }
+                                }
+                            )
+                        }
+                    },
                     tracingHeaderTypes = aNullable {
                         aList { aValueFrom(RemoteConfiguration.TracingHeaderType::class.java) }
                     }

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ForgeExt.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ForgeExt.kt
@@ -61,6 +61,7 @@ fun <T : Forge> T.useCoreFactories(): T {
     addFactory(RequestExecutionContextForgeryFactory())
     addFactory(RequestInfoForgeryFactory())
     addFactory(MutableRequestInfoForgeryFactory())
+    addFactory(RemoteConfigurationForgeryFactory())
 
     return this
 }

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/RemoteConfigurationForgeryFactory.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/RemoteConfigurationForgeryFactory.kt
@@ -4,14 +4,14 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.utils.forge
+package com.datadog.android.tests.elmyr
 
 import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 import java.util.UUID
 
-internal class RemoteConfigurationForgeryFactory : ForgeryFactory<RemoteConfiguration> {
+class RemoteConfigurationForgeryFactory : ForgeryFactory<RemoteConfiguration> {
     override fun getForgery(forge: Forge): RemoteConfiguration {
         return RemoteConfiguration(
             rum = forge.aNullable {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
@@ -20,6 +20,7 @@ import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.internal.sampling.SessionSamplingIdProvider
 import com.datadog.android.rum.internal.RumAnonymousIdentifierManager
 import com.datadog.android.rum.internal.RumFeature
+import com.datadog.android.rum.internal.applyRemoteConfiguration
 import com.datadog.android.rum.internal.domain.scope.RumVitalAppLaunchEventHelper
 import com.datadog.android.rum.internal.metric.SessionEndedMetricDispatcher
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
@@ -71,17 +72,19 @@ object Rum {
             return
         }
 
+        val effectiveConfiguration = rumConfiguration.applyRemoteConfiguration(sdkCore.remoteConfiguration)
+
         val rumFeature = RumFeature(
             sdkCore = sdkCore,
-            applicationId = rumConfiguration.applicationId,
-            configuration = rumConfiguration.featureConfiguration
+            applicationId = effectiveConfiguration.applicationId,
+            configuration = effectiveConfiguration.featureConfiguration
         )
 
         sdkCore.registerFeature(rumFeature)
 
         sdkCore.getFeature(rumFeature.name)?.dataStore?.let {
             RumAnonymousIdentifierManager(it, sdkCore).manageAnonymousId(
-                rumConfiguration.featureConfiguration.trackAnonymousUser
+                effectiveConfiguration.featureConfiguration.trackAnonymousUser
             )
         }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumConfigurationExt.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumConfigurationExt.kt
@@ -1,0 +1,77 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal
+
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
+import com.datadog.android.rum.RumConfiguration
+import com.datadog.android.rum.configuration.SlowFramesConfiguration
+import com.datadog.android.rum.configuration.VitalsUpdateFrequency
+import com.datadog.android.rum.internal.instrumentation.MainLooperLongTaskStrategy
+import com.datadog.android.rum.tracking.TrackingStrategy
+
+/**
+ * Applies a [RemoteConfiguration] to this [RumConfiguration], returning a new instance with the
+ * remote values overlaid on top of the developer-supplied configuration.
+ *
+ * Fields absent from the remote payload (null) are left unchanged. Only the `rum` section of the
+ * remote configuration is consumed here; other sections (sessionReplay, profiling, trace) are
+ * handled by their respective feature modules.
+ */
+internal fun RumConfiguration.applyRemoteConfiguration(rc: RemoteConfiguration?): RumConfiguration {
+    val rum = rc?.rum ?: return this
+    return copy(
+        featureConfiguration = featureConfiguration.copy(
+            telemetrySampleRate = rum.telemetrySampleRate?.toFloat()
+                ?: featureConfiguration.telemetrySampleRate,
+            trackAnonymousUser = rum.trackAnonymousUser
+                ?: featureConfiguration.trackAnonymousUser,
+            userActionTracking = rum.trackUserInteractions
+                ?: featureConfiguration.userActionTracking,
+            backgroundEventTracking = rum.trackBackgroundEvents
+                ?: featureConfiguration.backgroundEventTracking,
+            trackFrustrations = rum.trackFrustrations
+                ?: featureConfiguration.trackFrustrations,
+            trackNonFatalAnrs = rum.trackNonFatalAnrs
+                ?: featureConfiguration.trackNonFatalAnrs,
+            vitalsMonitorUpdateFrequency = rum.vitalsUpdateFrequency?.toSdkFrequency()
+                ?: featureConfiguration.vitalsMonitorUpdateFrequency,
+            slowFramesConfiguration = featureConfiguration.applySlowFrames(rum.trackSlowFrames),
+            longTaskTrackingStrategy = featureConfiguration.applyLongTask(rum.longTask)
+        )
+    )
+}
+
+private fun RumFeature.Configuration.applySlowFrames(
+    trackSlowFrames: Boolean?
+): SlowFramesConfiguration? = when (trackSlowFrames) {
+    true -> slowFramesConfiguration ?: SlowFramesConfiguration.DEFAULT
+    false -> null
+    null -> slowFramesConfiguration
+}
+
+private fun RumFeature.Configuration.applyLongTask(
+    longTask: RemoteConfiguration.LongTask?
+): TrackingStrategy? {
+    longTask ?: return longTaskTrackingStrategy
+    return when (longTask.enabled) {
+        false -> null
+        true -> MainLooperLongTaskStrategy(
+            longTask.threshold?.toLong()
+                ?: (longTaskTrackingStrategy as? MainLooperLongTaskStrategy)?.thresholdMs
+                ?: RumFeature.DEFAULT_LONG_TASK_THRESHOLD_MS
+        )
+        null -> longTaskTrackingStrategy
+    }
+}
+
+private fun RemoteConfiguration.VitalsUpdateFrequency.toSdkFrequency(): VitalsUpdateFrequency =
+    when (this) {
+        RemoteConfiguration.VitalsUpdateFrequency.FREQUENT -> VitalsUpdateFrequency.FREQUENT
+        RemoteConfiguration.VitalsUpdateFrequency.AVERAGE -> VitalsUpdateFrequency.AVERAGE
+        RemoteConfiguration.VitalsUpdateFrequency.RARE -> VitalsUpdateFrequency.RARE
+        RemoteConfiguration.VitalsUpdateFrequency.NEVER -> VitalsUpdateFrequency.NEVER
+    }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumConfigurationExtTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumConfigurationExtTest.kt
@@ -1,0 +1,684 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal
+
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
+import com.datadog.android.rum.RumConfiguration
+import com.datadog.android.rum.configuration.SlowFramesConfiguration
+import com.datadog.android.rum.configuration.VitalsUpdateFrequency
+import com.datadog.android.rum.internal.instrumentation.MainLooperLongTaskStrategy
+import com.datadog.android.rum.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.FloatForgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class RumConfigurationExtTest {
+
+    private lateinit var fakeApplicationId: String
+    private lateinit var testedRumConfiguration: RumConfiguration
+
+    @BeforeEach
+    fun setUp(forge: Forge) {
+        fakeApplicationId = forge.aStringMatching("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+        testedRumConfiguration = RumConfiguration.Builder(fakeApplicationId).build()
+    }
+
+    // region null RC
+
+    @Test
+    fun `M return config unchanged W applyRemoteConfiguration { null RC }`() {
+        // When
+        val result = testedRumConfiguration.applyRemoteConfiguration(null)
+
+        // Then
+        assertThat(result).isEqualTo(testedRumConfiguration)
+    }
+
+    @Test
+    fun `M return config unchanged W applyRemoteConfiguration { RC with null rum }`() {
+        // Given
+        val fakeRc = RemoteConfiguration(rum = null)
+
+        // When
+        val result = testedRumConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result).isEqualTo(testedRumConfiguration)
+    }
+
+    // endregion
+
+    // region telemetrySampleRate
+
+    @Test
+    fun `M override telemetrySampleRate W applyRemoteConfiguration { RC provides telemetrySampleRate }`(
+        @FloatForgery(min = 0f, max = 100f) fakeSampleRate: Float,
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                telemetrySampleRate = fakeSampleRate
+            )
+        )
+
+        // When
+        val result = testedRumConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.telemetrySampleRate).isEqualTo(fakeSampleRate)
+    }
+
+    @Test
+    fun `M keep existing telemetrySampleRate W applyRemoteConfiguration { RC omits telemetrySampleRate }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(applicationId = fakeAppId)
+        )
+        val expectedRate = testedRumConfiguration.featureConfiguration.telemetrySampleRate
+
+        // When
+        val result = testedRumConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.telemetrySampleRate).isEqualTo(expectedRate)
+    }
+
+    // endregion
+
+    // region trackAnonymousUser
+
+    @Test
+    fun `M override trackAnonymousUser W applyRemoteConfiguration { RC provides trackAnonymousUser=true }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val baseline = RumConfiguration.Builder(fakeApplicationId)
+            .trackAnonymousUser(false)
+            .build()
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                trackAnonymousUser = true
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.trackAnonymousUser).isTrue()
+    }
+
+    @Test
+    fun `M override trackAnonymousUser W applyRemoteConfiguration { RC provides trackAnonymousUser=false }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val baseline = RumConfiguration.Builder(fakeApplicationId)
+            .trackAnonymousUser(true)
+            .build()
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                trackAnonymousUser = false
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.trackAnonymousUser).isFalse()
+    }
+
+    @Test
+    fun `M keep existing trackAnonymousUser W applyRemoteConfiguration { RC omits trackAnonymousUser }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(applicationId = fakeAppId)
+        )
+        val expectedValue = testedRumConfiguration.featureConfiguration.trackAnonymousUser
+
+        // When
+        val result = testedRumConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.trackAnonymousUser).isEqualTo(expectedValue)
+    }
+
+    // endregion
+
+    // region trackUserInteractions
+
+    @Test
+    fun `M override userActionTracking W applyRemoteConfiguration { RC provides trackUserInteractions=false }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given - default builder has userActionTracking=true
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                trackUserInteractions = false
+            )
+        )
+
+        // When
+        val result = testedRumConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.userActionTracking).isFalse()
+    }
+
+    @Test
+    fun `M override userActionTracking W applyRemoteConfiguration { RC provides trackUserInteractions=true }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given - developer disabled user interaction tracking
+        val baseline = RumConfiguration.Builder(fakeApplicationId)
+            .disableUserInteractionTracking()
+            .build()
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                trackUserInteractions = true
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.userActionTracking).isTrue()
+    }
+
+    @Test
+    fun `M keep existing userActionTracking W applyRemoteConfiguration { RC omits trackUserInteractions }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(applicationId = fakeAppId)
+        )
+        val expectedValue = testedRumConfiguration.featureConfiguration.userActionTracking
+
+        // When
+        val result = testedRumConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.userActionTracking).isEqualTo(expectedValue)
+    }
+
+    // endregion
+
+    // region trackBackgroundEvents
+
+    @Test
+    fun `M override backgroundEventTracking W applyRemoteConfiguration { RC provides trackBackgroundEvents=true }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val baseline = RumConfiguration.Builder(fakeApplicationId)
+            .trackBackgroundEvents(false)
+            .build()
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                trackBackgroundEvents = true
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.backgroundEventTracking).isTrue()
+    }
+
+    @Test
+    fun `M override backgroundEventTracking W applyRemoteConfiguration { RC provides trackBackgroundEvents=false }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val baseline = RumConfiguration.Builder(fakeApplicationId)
+            .trackBackgroundEvents(true)
+            .build()
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                trackBackgroundEvents = false
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.backgroundEventTracking).isFalse()
+    }
+
+    // endregion
+
+    // region trackFrustrations
+
+    @Test
+    fun `M override trackFrustrations W applyRemoteConfiguration { RC provides trackFrustrations=false }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val baseline = RumConfiguration.Builder(fakeApplicationId)
+            .trackFrustrations(true)
+            .build()
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                trackFrustrations = false
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.trackFrustrations).isFalse()
+    }
+
+    @Test
+    fun `M override trackFrustrations W applyRemoteConfiguration { RC provides trackFrustrations=true }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val baseline = RumConfiguration.Builder(fakeApplicationId)
+            .trackFrustrations(false)
+            .build()
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                trackFrustrations = true
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.trackFrustrations).isTrue()
+    }
+
+    // endregion
+
+    // region trackNonFatalAnrs
+
+    @Test
+    fun `M override trackNonFatalAnrs W applyRemoteConfiguration { RC provides trackNonFatalAnrs=true }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val baseline = RumConfiguration.Builder(fakeApplicationId)
+            .trackNonFatalAnrs(false)
+            .build()
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                trackNonFatalAnrs = true
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.trackNonFatalAnrs).isTrue()
+    }
+
+    @Test
+    fun `M override trackNonFatalAnrs W applyRemoteConfiguration { RC provides trackNonFatalAnrs=false }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val baseline = RumConfiguration.Builder(fakeApplicationId)
+            .trackNonFatalAnrs(true)
+            .build()
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                trackNonFatalAnrs = false
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.trackNonFatalAnrs).isFalse()
+    }
+
+    // endregion
+
+    // region vitalsUpdateFrequency
+
+    @Test
+    fun `M override vitalsMonitorUpdateFrequency W applyRemoteConfiguration { RC vitalsUpdateFrequency FREQUENT }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                vitalsUpdateFrequency = RemoteConfiguration.VitalsUpdateFrequency.FREQUENT
+            )
+        )
+
+        // When
+        val result = testedRumConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.vitalsMonitorUpdateFrequency)
+            .isEqualTo(VitalsUpdateFrequency.FREQUENT)
+    }
+
+    @Test
+    fun `M override vitalsMonitorUpdateFrequency W applyRemoteConfiguration { RC vitalsUpdateFrequency AVERAGE }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                vitalsUpdateFrequency = RemoteConfiguration.VitalsUpdateFrequency.AVERAGE
+            )
+        )
+
+        // When
+        val result = testedRumConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.vitalsMonitorUpdateFrequency)
+            .isEqualTo(VitalsUpdateFrequency.AVERAGE)
+    }
+
+    @Test
+    fun `M override vitalsMonitorUpdateFrequency W applyRemoteConfiguration { RC provides vitalsUpdateFrequency RARE }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                vitalsUpdateFrequency = RemoteConfiguration.VitalsUpdateFrequency.RARE
+            )
+        )
+
+        // When
+        val result = testedRumConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.vitalsMonitorUpdateFrequency)
+            .isEqualTo(VitalsUpdateFrequency.RARE)
+    }
+
+    @Test
+    fun `M override vitalsMonitorUpdateFrequency W applyRemoteConfiguration { RC vitalsUpdateFrequency NEVER }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                vitalsUpdateFrequency = RemoteConfiguration.VitalsUpdateFrequency.NEVER
+            )
+        )
+
+        // When
+        val result = testedRumConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.vitalsMonitorUpdateFrequency)
+            .isEqualTo(VitalsUpdateFrequency.NEVER)
+    }
+
+    @Test
+    fun `M keep existing vitalsMonitorUpdateFrequency W applyRemoteConfiguration { RC omits vitalsUpdateFrequency }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(applicationId = fakeAppId)
+        )
+        val expectedValue = testedRumConfiguration.featureConfiguration.vitalsMonitorUpdateFrequency
+
+        // When
+        val result = testedRumConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.vitalsMonitorUpdateFrequency).isEqualTo(expectedValue)
+    }
+
+    // endregion
+
+    // region trackSlowFrames
+
+    @Test
+    fun `M set slowFramesConfiguration to DEFAULT W applyRemoteConfiguration { trackSlowFrames=true, null dev config }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given - developer explicitly disabled slow frames (null)
+        val baseline = RumConfiguration.Builder(fakeApplicationId)
+            .setSlowFramesConfiguration(null)
+            .build()
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                trackSlowFrames = true
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.slowFramesConfiguration)
+            .isEqualTo(SlowFramesConfiguration.DEFAULT)
+    }
+
+    @Test
+    fun `M preserve developer's slowFramesConfiguration W applyRemoteConfiguration { trackSlowFrames=true }`(
+        @StringForgery fakeAppId: String,
+        @LongForgery(min = 1L) fakeThresholdNs: Long
+    ) {
+        // Given - developer set a custom SlowFramesConfiguration
+        val fakeCustomConfig = SlowFramesConfiguration(maxSlowFrameThresholdNs = fakeThresholdNs)
+        val baseline = RumConfiguration.Builder(fakeApplicationId)
+            .setSlowFramesConfiguration(fakeCustomConfig)
+            .build()
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                trackSlowFrames = true
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then - developer's custom config is preserved
+        assertThat(result.featureConfiguration.slowFramesConfiguration)
+            .isEqualTo(fakeCustomConfig)
+    }
+
+    @Test
+    fun `M set slowFramesConfiguration to null W applyRemoteConfiguration { RC trackSlowFrames=false }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given - developer had it enabled
+        val baseline = RumConfiguration.Builder(fakeApplicationId)
+            .setSlowFramesConfiguration(SlowFramesConfiguration.DEFAULT)
+            .build()
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                trackSlowFrames = false
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.slowFramesConfiguration).isNull()
+    }
+
+    @Test
+    fun `M keep existing slowFramesConfiguration W applyRemoteConfiguration { RC omits trackSlowFrames }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(applicationId = fakeAppId)
+        )
+        val expectedValue = testedRumConfiguration.featureConfiguration.slowFramesConfiguration
+
+        // When
+        val result = testedRumConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.slowFramesConfiguration).isEqualTo(expectedValue)
+    }
+
+    // endregion
+
+    // region longTask
+
+    @Test
+    fun `M disable longTaskTrackingStrategy W applyRemoteConfiguration { RC longTask enabled=false }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                longTask = RemoteConfiguration.LongTask(enabled = false)
+            )
+        )
+
+        // When
+        val result = testedRumConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.longTaskTrackingStrategy).isNull()
+    }
+
+    @Test
+    fun `M enable longTaskTrackingStrategy with default threshold W applyRemoteConfiguration { longTask=true }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                longTask = RemoteConfiguration.LongTask(enabled = true, threshold = null)
+            )
+        )
+
+        // When
+        val result = testedRumConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        val strategy = result.featureConfiguration.longTaskTrackingStrategy
+        assertThat(strategy).isInstanceOf(MainLooperLongTaskStrategy::class.java)
+        assertThat((strategy as MainLooperLongTaskStrategy).thresholdMs)
+            .isEqualTo(RumFeature.DEFAULT_LONG_TASK_THRESHOLD_MS)
+    }
+
+    @Test
+    fun `M enable longTaskTrackingStrategy with RC threshold W applyRemoteConfiguration { longTask=true }`(
+        @StringForgery fakeAppId: String,
+        @LongForgery(min = 1L, max = 10000L) fakeThresholdMs: Long
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                longTask = RemoteConfiguration.LongTask(enabled = true, threshold = fakeThresholdMs)
+            )
+        )
+
+        // When
+        val result = testedRumConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        val strategy = result.featureConfiguration.longTaskTrackingStrategy
+        assertThat(strategy).isInstanceOf(MainLooperLongTaskStrategy::class.java)
+        assertThat((strategy as MainLooperLongTaskStrategy).thresholdMs).isEqualTo(fakeThresholdMs)
+    }
+
+    @Test
+    fun `M preserve developer's threshold W applyRemoteConfiguration { longTask=true, no RC threshold }`(
+        @StringForgery fakeAppId: String,
+        @LongForgery(min = 101L, max = 10000L) fakeCustomThresholdMs: Long
+    ) {
+        // Given - developer set a custom long task threshold
+        val baseline = RumConfiguration.Builder(fakeApplicationId)
+            .trackLongTasks(fakeCustomThresholdMs)
+            .build()
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(
+                applicationId = fakeAppId,
+                longTask = RemoteConfiguration.LongTask(enabled = true, threshold = null)
+            )
+        )
+
+        // When
+        val result = baseline.applyRemoteConfiguration(fakeRc)
+
+        // Then - developer's custom threshold is preserved
+        val strategy = result.featureConfiguration.longTaskTrackingStrategy
+        assertThat(strategy).isInstanceOf(MainLooperLongTaskStrategy::class.java)
+        assertThat((strategy as MainLooperLongTaskStrategy).thresholdMs).isEqualTo(fakeCustomThresholdMs)
+    }
+
+    @Test
+    fun `M keep existing longTaskTrackingStrategy W applyRemoteConfiguration { RC omits longTask }`(
+        @StringForgery fakeAppId: String
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            rum = RemoteConfiguration.Rum(applicationId = fakeAppId)
+        )
+        val expectedStrategy = testedRumConfiguration.featureConfiguration.longTaskTrackingStrategy
+
+        // When
+        val result = testedRumConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.featureConfiguration.longTaskTrackingStrategy).isEqualTo(expectedStrategy)
+    }
+
+    // endregion
+}


### PR DESCRIPTION
### What does this PR do?

Introduces `RumConfigurationExt.applyRemoteConfiguration()`, an internal extension function that overlays the remote configuration's `rum` section onto the developer-supplied `RumConfiguration` before `RumFeature` is constructed. Wires it into `Rum.enable()` so that remote values take effect on every SDK initialization.

Also updates the shared mobile RC schema (`mobile.json`) to the latest RFC shape: `longTask` is now a nested object with `enabled` + `threshold`, `tracedHosts` is now an array of `{host, propagatorTypes?}` objects, `trackResources` is removed (iOS-only), and `additionalProperties: false` is added to `sessionReplay`. Moves `RemoteConfigurationForgeryFactory` to `dd-sdk-android-core` testFixtures so all modules can share it via `useCoreFactories()`.

### Motivation

[RUM-16417](https://datadoghq.atlassian.net/browse/RUM-16417) — the RC fetch and storage were implemented in earlier PRs; this PR completes the loop by reading the stored config at `Rum.enable()` time and applying it to the feature configuration before RUM starts.

### Additional Notes

**RC fields mapped from remote payload to `RumFeature.Configuration`:**

| RC field | Android field |
|---|---|
| `rum.telemetrySampleRate` | `telemetrySampleRate` |
| `rum.trackAnonymousUser` | `trackAnonymousUser` |
| `rum.trackUserInteractions` | `userActionTracking` |
| `rum.trackBackgroundEvents` | `backgroundEventTracking` |
| `rum.trackFrustrations` | `trackFrustrations` |
| `rum.trackNonFatalAnrs` | `trackNonFatalAnrs` (Android-only) |
| `rum.vitalsUpdateFrequency` | `vitalsMonitorUpdateFrequency` |
| `rum.trackSlowFrames` | `slowFramesConfiguration` (`true` preserves developer's custom config or falls back to `DEFAULT`; `false` disables) |
| `rum.longTask.enabled + .threshold` | `longTaskTrackingStrategy` |

**Not mapped (deferred):**
- `rum.crashReportsEnabled` — Android-only field; maps to `Configuration.crashReportsEnabled` (core-level, set before `Datadog.initialize()`).
- `profiling.*` (`continuousSampleRate`, `applicationLaunchSampleRate`) — consumed by the profiling module, not RUM. Mirrors iOS behaviour (`DatadogProfiling` applies this, not `DatadogRUM`).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the implementing team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

[RUM-16417]: https://datadoghq.atlassian.net/browse/RUM-16417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ