### PR TITLE
RUM-17698: Apply remote configuration to ProfilingConfiguration in Profiling.enable()

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/Profiling.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/Profiling.kt
@@ -10,14 +10,17 @@ import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.datadog.android.Datadog
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.profiling.internal.NoOpProfiler
 import com.datadog.android.profiling.internal.Profiler
 import com.datadog.android.profiling.internal.ProfilingFeature
 import com.datadog.android.profiling.internal.ProfilingStartReason
 import com.datadog.android.profiling.internal.ProfilingStorage
+import com.datadog.android.profiling.internal.applyRemoteConfiguration
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
 import com.datadog.android.profiling.internal.time.MutableTimeProvider
 import java.util.concurrent.Executors
@@ -47,14 +50,23 @@ object Profiling {
         configuration: ProfilingConfiguration = ProfilingConfiguration.DEFAULT,
         sdkCore: SdkCore = Datadog.getInstance()
     ) {
-        val featureSdkCore = sdkCore as FeatureSdkCore
+        if (sdkCore !is InternalSdkCore) {
+            val logger = (sdkCore as? FeatureSdkCore)?.internalLogger ?: InternalLogger.UNBOUND
+            logger.log(
+                InternalLogger.Level.ERROR,
+                InternalLogger.Target.USER,
+                { UNEXPECTED_SDK_CORE_TYPE }
+            )
+            return
+        }
         initializeProfiler()
+        val effectiveConfiguration = configuration.applyRemoteConfiguration(sdkCore.remoteConfiguration)
         val profilingFeature = ProfilingFeature(
-            sdkCore = featureSdkCore,
-            configuration = configuration,
+            sdkCore = sdkCore,
+            configuration = effectiveConfiguration,
             profiler = profiler
         )
-        featureSdkCore.registerFeature(profilingFeature)
+        sdkCore.registerFeature(profilingFeature)
     }
 
     /**
@@ -113,4 +125,7 @@ object Profiling {
             )
         }
     }
+
+    internal const val UNEXPECTED_SDK_CORE_TYPE =
+        "SDK instance provided doesn't implement InternalSdkCore."
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingConfigurationExt.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingConfigurationExt.kt
@@ -1,0 +1,32 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling.internal
+
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
+import com.datadog.android.profiling.ExperimentalProfilingApi
+import com.datadog.android.profiling.ProfilingConfiguration
+
+/**
+ * Applies a [RemoteConfiguration] to this [ProfilingConfiguration], returning a new instance
+ * with the remote values overlaid on top of the developer-supplied configuration.
+ *
+ * Fields absent from the remote payload (null) are left unchanged. Only the `profiling`
+ * section of the remote configuration is consumed here; other sections (rum, sessionReplay, trace)
+ * are handled by their respective feature modules.
+ */
+@ExperimentalProfilingApi
+internal fun ProfilingConfiguration.applyRemoteConfiguration(
+    rc: RemoteConfiguration?
+): ProfilingConfiguration {
+    val profiling = rc?.profiling ?: return this
+    return copy(
+        applicationLaunchSampleRate = profiling.applicationLaunchSampleRate?.toFloat()
+            ?: applicationLaunchSampleRate,
+        continuousSampleRate = profiling.continuousSampleRate?.toFloat()
+            ?: continuousSampleRate
+    )
+}

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
@@ -9,8 +9,11 @@ package com.datadog.android.profiling
 import android.content.Context
 import android.os.ProfilingManager
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import com.datadog.android.internal.data.SharedPreferencesStorage
+import com.datadog.android.profiling.Profiling.UNEXPECTED_SDK_CORE_TYPE
 import com.datadog.android.profiling.forge.Configurator
 import com.datadog.android.profiling.internal.NoOpProfiler
 import com.datadog.android.profiling.internal.Profiler
@@ -19,6 +22,7 @@ import com.datadog.android.profiling.internal.ProfilingStartReason
 import com.datadog.android.profiling.internal.ProfilingStorage
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
 import com.datadog.android.profiling.utils.config.MainLooperTestConfiguration
+import com.datadog.android.utils.verifyLog
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
@@ -82,6 +86,7 @@ class ProfilingTest {
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockSdkCore.name) doReturn fakeInstanceName
         whenever(mockSdkCore.createSingleThreadExecutorService(any())) doReturn mockProfilingExecutor
+        whenever(mockSdkCore.remoteConfiguration) doReturn null
         whenever(mockContext.getSystemService(ProfilingManager::class.java)) doReturn mockProfilingManager
         ProfilingStorage.sharedPreferencesStorage = mockSharedPreferencesStorage
     }
@@ -204,6 +209,60 @@ class ProfilingTest {
         // Then
         verify(mockProfiler).stop(fakeInstanceName)
     }
+
+    // region Remote Configuration
+
+    @Test
+    fun `M log error and not register W enable { sdkCore is not InternalSdkCore }`(
+        @Forgery fakeConfiguration: ProfilingConfiguration
+    ) {
+        // Given
+        val mockNonInternalCore = mock<FeatureSdkCore>()
+        val mockLogger = mock<InternalLogger>()
+        whenever(mockNonInternalCore.internalLogger) doReturn mockLogger
+
+        // When
+        Profiling.enable(fakeConfiguration, mockNonInternalCore)
+
+        // Then
+        mockLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            target = InternalLogger.Target.USER,
+            message = UNEXPECTED_SDK_CORE_TYPE
+        )
+        assertThat(Profiling.profiler).isInstanceOf(NoOpProfiler::class.java)
+    }
+
+    @Test
+    fun `M register feature W enable { RC provides profiling values }`(
+        @Forgery fakeConfiguration: ProfilingConfiguration,
+        @Forgery fakeRemoteConfiguration: RemoteConfiguration
+    ) {
+        // Given
+        whenever(mockSdkCore.remoteConfiguration) doReturn fakeRemoteConfiguration
+
+        // When
+        Profiling.enable(fakeConfiguration, mockSdkCore)
+
+        // Then
+        verify(mockSdkCore).registerFeature(any<ProfilingFeature>())
+    }
+
+    @Test
+    fun `M register feature with in-code configuration W enable { null remote configuration }`(
+        @Forgery fakeConfiguration: ProfilingConfiguration
+    ) {
+        // Given
+        whenever(mockSdkCore.remoteConfiguration) doReturn null
+
+        // When
+        Profiling.enable(fakeConfiguration, mockSdkCore)
+
+        // Then
+        verify(mockSdkCore).registerFeature(any<ProfilingFeature>())
+    }
+
+    // endregion
 
     private fun resetProfilerField() {
         Profiling.profiler = NoOpProfiler()

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingConfigurationExtTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingConfigurationExtTest.kt
@@ -1,0 +1,178 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling.internal
+
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
+import com.datadog.android.profiling.ExperimentalProfilingApi
+import com.datadog.android.profiling.ProfilingConfiguration
+import com.datadog.android.profiling.forge.Configurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.FloatForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@OptIn(ExperimentalProfilingApi::class)
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class ProfilingConfigurationExtTest {
+
+    private lateinit var testedConfiguration: ProfilingConfiguration
+
+    @BeforeEach
+    fun setUp(forge: Forge) {
+        testedConfiguration = forge.getForgery()
+    }
+
+    // region null RC
+
+    @Test
+    fun `M return config unchanged W applyRemoteConfiguration { null RC }`() {
+        // When
+        val result = testedConfiguration.applyRemoteConfiguration(null)
+
+        // Then
+        assertThat(result).isEqualTo(testedConfiguration)
+    }
+
+    @Test
+    fun `M return config unchanged W applyRemoteConfiguration { RC with null profiling }`() {
+        // Given
+        val fakeRc = RemoteConfiguration(profiling = null)
+
+        // When
+        val result = testedConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result).isEqualTo(testedConfiguration)
+    }
+
+    @Test
+    fun `M return config unchanged W applyRemoteConfiguration { RC with empty profiling namespace }`() {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            profiling = RemoteConfiguration.Profiling(
+                applicationLaunchSampleRate = null,
+                continuousSampleRate = null
+            )
+        )
+
+        // When
+        val result = testedConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result).isEqualTo(testedConfiguration)
+    }
+
+    // endregion
+
+    // region applicationLaunchSampleRate
+
+    @Test
+    fun `M override applicationLaunchSampleRate W applyRemoteConfiguration { RC provides value }`(
+        @FloatForgery(min = 0f, max = 100f) fakeSampleRate: Float
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            profiling = RemoteConfiguration.Profiling(applicationLaunchSampleRate = fakeSampleRate)
+        )
+
+        // When
+        val result = testedConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.applicationLaunchSampleRate).isEqualTo(fakeSampleRate)
+    }
+
+    @Test
+    fun `M keep existing applicationLaunchSampleRate W applyRemoteConfiguration { RC omits it }`() {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            profiling = RemoteConfiguration.Profiling(applicationLaunchSampleRate = null)
+        )
+        val expectedValue = testedConfiguration.applicationLaunchSampleRate
+
+        // When
+        val result = testedConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.applicationLaunchSampleRate).isEqualTo(expectedValue)
+    }
+
+    // endregion
+
+    // region continuousSampleRate
+
+    @Test
+    fun `M override continuousSampleRate W applyRemoteConfiguration { RC provides value }`(
+        @FloatForgery(min = 0f, max = 100f) fakeSampleRate: Float
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            profiling = RemoteConfiguration.Profiling(continuousSampleRate = fakeSampleRate)
+        )
+
+        // When
+        val result = testedConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.continuousSampleRate).isEqualTo(fakeSampleRate)
+    }
+
+    @Test
+    fun `M keep existing continuousSampleRate W applyRemoteConfiguration { RC omits it }`() {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            profiling = RemoteConfiguration.Profiling(continuousSampleRate = null)
+        )
+        val expectedValue = testedConfiguration.continuousSampleRate
+
+        // When
+        val result = testedConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.continuousSampleRate).isEqualTo(expectedValue)
+    }
+
+    // endregion
+
+    // region both fields
+
+    @Test
+    fun `M override both fields W applyRemoteConfiguration { RC provides both values }`(
+        @FloatForgery(min = 0f, max = 100f) fakeAppLaunchRate: Float,
+        @FloatForgery(min = 0f, max = 100f) fakeContinuousRate: Float
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            profiling = RemoteConfiguration.Profiling(
+                applicationLaunchSampleRate = fakeAppLaunchRate,
+                continuousSampleRate = fakeContinuousRate
+            )
+        )
+
+        // When
+        val result = testedConfiguration.applyRemoteConfiguration(fakeRc)
+
+        // Then
+        assertThat(result.applicationLaunchSampleRate).isEqualTo(fakeAppLaunchRate)
+        assertThat(result.continuousSampleRate).isEqualTo(fakeContinuousRate)
+    }
+
+    // endregion
+}


### PR DESCRIPTION
### What does this PR do?

Introduces `ProfilingConfigurationExt.applyRemoteConfiguration()`, an internal extension function that overlays the remote configuration's `profiling` section onto the developer-supplied `ProfilingConfiguration` before `ProfilingFeature` is constructed. Wires it into `Profiling.enable()` so that remote values take effect on every SDK initialization.

Also adds an `InternalSdkCore` guard to `Profiling.enable()` — consistent with the equivalent guard in `Rum.enable()` and `SessionReplay.enable()` — to access `remoteConfiguration` from Core.

### Motivation

[RUM-17698](https://datadoghq.atlassian.net/browse/RUM-17698) — the RC fetch, storage, and `remoteConfiguration` exposure were implemented in earlier PRs; this PR applies the stored Profiling config at `Profiling.enable()` time. Mirrors the iOS implementation in RUM-17198.

### Additional Notes

**RC fields mapped from remote payload to `ProfilingConfiguration`:**

| RC field | `ProfilingConfiguration` field | Notes |
|---|---|---|
| `profiling.applicationLaunchSampleRate` | `applicationLaunchSampleRate: Float` | `Number?.toFloat()` |
| `profiling.continuousSampleRate` | `continuousSampleRate: Float` | `Number?.toFloat()` — Android applies this; iOS does not (no in-code equivalent yet on iOS) |

Fields absent from the remote payload are left unchanged. If `RemoteConfiguration` is `null` or the `profiling` namespace is absent, Profiling starts with in-code values only — behaviour is identical to today.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the implementing team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

[RUM-17698]: https://datadoghq.atlassian.net/browse/RUM-17698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ