### PR TITLE
Add a separate additive semantics tag for Compose element paths

### DIFF
--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/DatadogModifier.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/DatadogModifier.kt
@@ -34,23 +34,42 @@ fun Modifier.datadog(name: String, isImage: Boolean = false): Modifier {
 /**
  * This is the internal function reserved to Datadog Kotlin Compiler Plugin for auto instrumentation,
  * with telemetry to indicate that the auto-instrumentation is used instead of manual instrumentation.
+ *
+ * @param name The name of the component, identical in meaning and value to what manual
+ *             instrumentation would set. Unaffected by [elementPath].
+ * @param isImage Set to `true` if the component represents an image.
+ * @param elementPath A path unique to this call site at compile time (e.g. "MyScreen/Button#1"),
+ *                     intended for future stable element identification (e.g. heatmaps). This is
+ *                     additive: it is stored under a separate key and never replaces or alters
+ *                     [name] or the existing `_dd_semantics` tag read by RUM action tracking today.
+ *                     Defaults to `null` (no value stored) when omitted
  */
-internal fun Modifier.instrumentedDatadog(name: String, isImage: Boolean): Modifier {
+internal fun Modifier.instrumentedDatadog(name: String, isImage: Boolean, elementPath: String? = null): Modifier {
     sendTelemetry(autoInstrumented = true, InstrumentationType.Semantics)
-    return this.datadogSemantics(name, isImage)
+    return this.datadogSemantics(name, isImage, elementPath)
 }
 
-private fun Modifier.datadogSemantics(name: String, isImage: Boolean): Modifier {
+private fun Modifier.datadogSemantics(name: String, isImage: Boolean, elementPath: String? = null): Modifier {
     return this.semantics {
         this.datadog = name
         if (isImage) {
             this[SemanticsProperties.Role] = Role.Image
+        }
+        if (elementPath != null) {
+            this[DatadogElementPathPropertyKey] = elementPath
         }
     }
 }
 
 internal val DatadogSemanticsPropertyKey: SemanticsPropertyKey<String> = SemanticsPropertyKey(
     name = "_dd_semantics",
+    mergePolicy = { parentValue, _ ->
+        parentValue
+    }
+)
+
+internal val DatadogElementPathPropertyKey: SemanticsPropertyKey<String> = SemanticsPropertyKey(
+    name = "_dd_element_path",
     mergePolicy = { parentValue, _ ->
         parentValue
     }

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/DatadogModifierTest.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/DatadogModifierTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.compose
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsConfiguration
+import androidx.compose.ui.semantics.SemanticsModifier
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.getOrNull
+import com.datadog.tools.unit.forge.BaseConfigurator
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+
+@Extensions(ExtendWith(ForgeExtension::class))
+@ForgeConfiguration(value = BaseConfigurator::class)
+class DatadogModifierTest {
+
+    @Test
+    fun `M not set element path W instrumentedDatadog() {elementPath omitted}`(
+        @StringForgery name: String
+    ) {
+        // When
+        val modifier = Modifier.instrumentedDatadog(name = name, isImage = false)
+
+        // Then
+        assertThat(modifier.findValue(DatadogSemanticsPropertyKey)).isEqualTo(name)
+        assertThat(modifier.findValue(DatadogElementPathPropertyKey)).isNull()
+    }
+
+    @Test
+    fun `M set element path independently W instrumentedDatadog() {elementPath provided}`(
+        @StringForgery name: String,
+        @StringForgery elementPath: String
+    ) {
+        // When
+        val modifier = Modifier.instrumentedDatadog(name = name, isImage = false, elementPath = elementPath)
+
+        // Then
+        assertThat(modifier.findValue(DatadogSemanticsPropertyKey)).isEqualTo(name)
+        assertThat(modifier.findValue(DatadogElementPathPropertyKey)).isEqualTo(elementPath)
+    }
+
+    @Test
+    fun `M not set element path W datadog() {manual instrumentation}`(
+        @StringForgery name: String
+    ) {
+        // When
+        val modifier = Modifier.datadog(name = name, isImage = false)
+
+        // Then
+        assertThat(modifier.findValue(DatadogSemanticsPropertyKey)).isEqualTo(name)
+        assertThat(modifier.findValue(DatadogElementPathPropertyKey)).isNull()
+    }
+
+    private fun <T> Modifier.findValue(key: SemanticsPropertyKey<T>): T? {
+        val configs = foldIn(mutableListOf<SemanticsConfiguration>()) { acc, element ->
+            if (element is SemanticsModifier) {
+                acc.add(element.semanticsConfiguration)
+            }
+            acc
+        }
+        return configs.firstNotNullOfOrNull { it.getOrNull(key) }
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Adds the tag _dd_element_path that will contain the full path of every element that we can later use for heatmaps support.

### Motivation
Preparatory step for populating a permanentId through the gradle plugin.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

