### PR TITLE
RUM-17726: Restore recomposition skipping for datadog semantics modifier

### DIFF
--- a/detekt_custom_safe_calls_android.yml
+++ b/detekt_custom_safe_calls_android.yml
@@ -286,6 +286,7 @@ datadog:
       - "androidx.compose.ui.geometry.Size(kotlin.Float, kotlin.Float)"
       - "androidx.compose.ui.geometry.Size.copy(kotlin.Float, kotlin.Float)"
       - "androidx.compose.ui.layout.LayoutCoordinates.boundsInWindow()"
+      - "androidx.compose.ui.semantics.SemanticsConfiguration.constructor()"
       - "androidx.compose.ui.semantics.SemanticsConfiguration.firstOrNull(kotlin.Function1)"
       - "androidx.compose.ui.Modifier.semantics(kotlin.Boolean, kotlin.Function1)"
       - "androidx.compose.ui.node.LayoutNode.getModifierInfo()"

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/DatadogModifier.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/DatadogModifier.kt
@@ -8,11 +8,15 @@
 package com.datadog.android.compose
 
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.SemanticsModifierNode
+import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsConfiguration
+import androidx.compose.ui.semantics.SemanticsModifier
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
-import androidx.compose.ui.semantics.semantics
 import com.datadog.android.compose.internal.InstrumentationType
 import com.datadog.android.compose.internal.sendTelemetry
 
@@ -27,8 +31,7 @@ import com.datadog.android.compose.internal.sendTelemetry
  *                attempt to resolve and capture the image content appropriately.
  */
 fun Modifier.datadog(name: String, isImage: Boolean = false): Modifier {
-    sendTelemetry(autoInstrumented = false, InstrumentationType.Semantics)
-    return this.datadogSemantics(name, isImage)
+    return this then DatadogSemanticsElement(name, isImage, autoInstrumented = false)
 }
 
 /**
@@ -36,12 +39,72 @@ fun Modifier.datadog(name: String, isImage: Boolean = false): Modifier {
  * with telemetry to indicate that the auto-instrumentation is used instead of manual instrumentation.
  */
 internal fun Modifier.instrumentedDatadog(name: String, isImage: Boolean): Modifier {
-    sendTelemetry(autoInstrumented = true, InstrumentationType.Semantics)
-    return this.datadogSemantics(name, isImage)
+    return this then DatadogSemanticsElement(name, isImage, autoInstrumented = true)
 }
 
-private fun Modifier.datadogSemantics(name: String, isImage: Boolean): Modifier {
-    return this.semantics {
+private class DatadogSemanticsElement(
+    private val name: String,
+    private val isImage: Boolean,
+    private val autoInstrumented: Boolean
+) : ModifierNodeElement<DatadogSemanticsNode>(), SemanticsModifier {
+
+    override val semanticsConfiguration: SemanticsConfiguration
+        get() = SemanticsConfiguration().apply {
+            datadog = name
+            if (isImage) {
+                this[SemanticsProperties.Role] = Role.Image
+            }
+        }
+
+    override fun create(): DatadogSemanticsNode =
+        DatadogSemanticsNode(name, isImage, autoInstrumented)
+
+    override fun update(node: DatadogSemanticsNode) {
+        node.update(name, isImage)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DatadogSemanticsElement) return false
+        return name == other.name &&
+            isImage == other.isImage &&
+            autoInstrumented == other.autoInstrumented
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = HASH_MULTIPLIER * result + isImage.hashCode()
+        result = HASH_MULTIPLIER * result + autoInstrumented.hashCode()
+        return result
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "datadog"
+        properties["name"] = this@DatadogSemanticsElement.name
+        properties["isImage"] = isImage
+    }
+
+    private companion object {
+        private const val HASH_MULTIPLIER = 31
+    }
+}
+
+private class DatadogSemanticsNode(
+    private var name: String,
+    private var isImage: Boolean,
+    private val autoInstrumented: Boolean
+) : Modifier.Node(), SemanticsModifierNode {
+
+    override fun onAttach() {
+        sendTelemetry(autoInstrumented = autoInstrumented, InstrumentationType.Semantics)
+    }
+
+    fun update(name: String, isImage: Boolean) {
+        this.name = name
+        this.isImage = isImage
+    }
+
+    override fun SemanticsPropertyReceiver.applySemantics() {
         this.datadog = name
         if (isImage) {
             this[SemanticsProperties.Role] = Role.Image

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/DatadogModifierTest.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/DatadogModifierTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.compose
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsModifier
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Regression tests for #3661.
+ *
+ * The Datadog semantics modifier must compare equal for equal inputs. Under Compose strong
+ * skipping, `Modifier` is a stable parameter compared with `equals()`; if the injected modifier
+ * were not value-equal across recompositions, any composable receiving it would stop skipping.
+ */
+@ExtendWith(ForgeExtension::class)
+internal class DatadogModifierTest {
+
+    @Test
+    fun `M compare equal W instrumentedDatadog() { same inputs }`(
+        @StringForgery fakeName: String
+    ) {
+        // When
+        val first = Modifier.instrumentedDatadog(fakeName, isImage = true)
+        val second = Modifier.instrumentedDatadog(fakeName, isImage = true)
+
+        // Then
+        assertThat(first).isEqualTo(second)
+        assertThat(first.hashCode()).isEqualTo(second.hashCode())
+    }
+
+    @Test
+    fun `M compare equal W datadog() { same inputs }`(
+        @StringForgery fakeName: String
+    ) {
+        // When
+        val first = Modifier.datadog(fakeName, isImage = false)
+        val second = Modifier.datadog(fakeName, isImage = false)
+
+        // Then
+        assertThat(first).isEqualTo(second)
+        assertThat(first.hashCode()).isEqualTo(second.hashCode())
+    }
+
+    @Test
+    fun `M not compare equal W instrumentedDatadog() { different name }`(
+        @StringForgery fakeName: String,
+        @StringForgery otherName: String
+    ) {
+        // When
+        val first = Modifier.instrumentedDatadog(fakeName, isImage = false)
+        val second = Modifier.instrumentedDatadog(otherName, isImage = false)
+
+        // Then
+        assertThat(first).isNotEqualTo(second)
+    }
+
+    @Test
+    fun `M not compare equal W instrumentedDatadog() { different isImage }`(
+        @StringForgery fakeName: String
+    ) {
+        // When
+        val first = Modifier.instrumentedDatadog(fakeName, isImage = false)
+        val second = Modifier.instrumentedDatadog(fakeName, isImage = true)
+
+        // Then
+        assertThat(first).isNotEqualTo(second)
+    }
+
+    @Test
+    fun `M not compare equal W datadog() vs instrumentedDatadog() { same inputs }`(
+        @StringForgery fakeName: String
+    ) {
+        // When
+        val manual = Modifier.datadog(fakeName, isImage = false)
+        val auto = Modifier.instrumentedDatadog(fakeName, isImage = false)
+
+        // Then
+        // The two carry different auto-instrumentation provenance, so they must not collapse.
+        assertThat(manual).isNotEqualTo(auto)
+    }
+
+    // region Regression tests for #3662
+
+    // LayoutNode#getModifierInfo() reports the Modifier.Element itself (not the Modifier.Node it
+    // creates), so tooling that inspects it for `is SemanticsModifier` — e.g. the Compose action
+    // tracker in LayoutNodeUtils — relies on the element exposing SemanticsModifier directly.
+    @Test
+    fun `M expose SemanticsModifier W datadog() { for action tracking compatibility }`(
+        @StringForgery fakeName: String
+    ) {
+        // When
+        val modifier = Modifier.datadog(fakeName, isImage = true)
+
+        // Then
+        check(modifier is SemanticsModifier)
+        val config = modifier.semanticsConfiguration
+        assertThat(config.getOrNull(DatadogSemanticsPropertyKey)).isEqualTo(fakeName)
+        assertThat(config.getOrNull(SemanticsProperties.Role)).isEqualTo(Role.Image)
+    }
+
+    @Test
+    fun `M expose SemanticsModifier W instrumentedDatadog() { for action tracking compatibility }`(
+        @StringForgery fakeName: String
+    ) {
+        // When
+        val modifier = Modifier.instrumentedDatadog(fakeName, isImage = false)
+
+        // Then
+        check(modifier is SemanticsModifier)
+        val config = modifier.semanticsConfiguration
+        assertThat(config.getOrNull(DatadogSemanticsPropertyKey)).isEqualTo(fakeName)
+        assertThat(config.getOrNull(SemanticsProperties.Role)).isNull()
+    }
+
+    // endregion
+}


### PR DESCRIPTION
### What does this PR do?

Fixes a regression where enabling Compose auto-instrumentation (`composeInstrumentation = AUTO`) stopped composables from skipping recomposition, even when their parameters were unchanged.

`Modifier.datadog()` / `instrumentedDatadog()` built their semantics with the lambda-based `Modifier.semantics { }`, whose element equality is keyed on a capturing lambda — a new, never-equal instance on every recomposition. Under Compose strong skipping, `Modifier` is a stable parameter compared with `equals()`, so `CombinedModifier` never compared equal and instrumented children never skipped.

This replaces the lambda construction with a `ModifierNodeElement` / `SemanticsModifierNode` keyed on `(name, isImage, autoInstrumented)`. Equal inputs now produce a value-equal element, restoring skipping to match the un-instrumented case. Telemetry moves into the node's `onAttach` so it no longer runs on every recomposition (it was already `onlyOnce`-deduped).

### Motivation

Reported in #3661: a ~150-row live-updating list re-executed every visible row on each update (~900 executions/min with AUTO vs. ~4/min disabled). The applied semantics are unchanged, so Session Replay is unaffected, and the public `datadog()` signature is unchanged, so the fix ships in the runtime artifact regardless of the Gradle plugin version in use.

### Additional Notes

- Adds `DatadogModifierTest` asserting the modifier compares equal (and hashes equal) for equal inputs, and not equal otherwise.
- Verified `checkApiSurfaceChanges` passes (public API unchanged).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

Fixes #3661
