### PR TITLE
RUM-17709: Apply remote configuration to Trace module at SDK instance ready

### DIFF
--- a/detekt_custom_safe_calls_third_party.yml
+++ b/detekt_custom_safe_calls_third_party.yml
@@ -724,7 +724,6 @@ datadog:
       - "kotlin.collections.Set.ifEmpty(kotlin.Function0)"
       - "kotlin.collections.Set.isEmpty()"
       - "kotlin.collections.Set.isNotEmpty()"
-      - "kotlin.collections.Set.takeIf(kotlin.Function1)"
       - "kotlin.collections.Set.joinToString(kotlin.CharSequence, kotlin.CharSequence, kotlin.CharSequence, kotlin.Int, kotlin.CharSequence, kotlin.Function1?)"
       - "kotlin.collections.Set.map(kotlin.Function1)"
       - "kotlin.collections.Set.none(kotlin.Function1)"

--- a/detekt_custom_safe_calls_third_party.yml
+++ b/detekt_custom_safe_calls_third_party.yml
@@ -724,6 +724,7 @@ datadog:
       - "kotlin.collections.Set.ifEmpty(kotlin.Function0)"
       - "kotlin.collections.Set.isEmpty()"
       - "kotlin.collections.Set.isNotEmpty()"
+      - "kotlin.collections.Set.takeIf(kotlin.Function1)"
       - "kotlin.collections.Set.joinToString(kotlin.CharSequence, kotlin.CharSequence, kotlin.CharSequence, kotlin.Int, kotlin.CharSequence, kotlin.Function1?)"
       - "kotlin.collections.Set.map(kotlin.Function1)"
       - "kotlin.collections.Set.none(kotlin.Function1)"

--- a/features/dd-sdk-android-trace/api/apiSurface
+++ b/features/dd-sdk-android-trace/api/apiSurface
@@ -80,6 +80,10 @@ class com.datadog.android.trace.internal.RumContextPropagator
   constructor(() -> com.datadog.android.api.feature.FeatureSdkCore?)
   companion object 
     fun com.datadog.android.trace.api.span.DatadogSpan.extractRumContext(RumContextPropagator, Boolean = false)
+fun applyRcSampleRate(com.datadog.android.core.sampling.Sampler<com.datadog.android.trace.api.span.DatadogSpan>, Float): com.datadog.android.core.sampling.Sampler<com.datadog.android.trace.api.span.DatadogSpan>
+fun com.datadog.android.core.internal.remote.model.RemoteConfiguration.Trace.toSdkInjection(): com.datadog.android.trace.TraceContextInjection?
+fun com.datadog.android.core.internal.remote.model.RemoteConfiguration.TracingHeaderType.toSdkHeaderType(): com.datadog.android.trace.TracingHeaderType
+fun com.datadog.android.core.internal.remote.model.RemoteConfiguration.Trace.buildRcHostResolver(): com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver?
 object com.datadog.android.trace.internal._TraceInternalProxy
   val spanIdConverter: DatadogSpanIdConverter
   var propagationHelper: DatadogPropagationHelper

--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -158,6 +158,13 @@ public final class com/datadog/android/trace/internal/RumContextPropagator$Compa
 	public static synthetic fun extractRumContext$default (Lcom/datadog/android/trace/internal/RumContextPropagator$Companion;Lcom/datadog/android/trace/api/span/DatadogSpan;Lcom/datadog/android/trace/internal/RumContextPropagator;ZILjava/lang/Object;)Lcom/datadog/android/trace/api/span/DatadogSpan;
 }
 
+public final class com/datadog/android/trace/internal/TraceRemoteConfigExtKt {
+	public static final fun applyRcSampleRate (Lcom/datadog/android/core/sampling/Sampler;F)Lcom/datadog/android/core/sampling/Sampler;
+	public static final fun buildRcHostResolver (Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace;)Lcom/datadog/android/core/internal/net/DefaultFirstPartyHostHeaderTypeResolver;
+	public static final fun toSdkHeaderType (Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$TracingHeaderType;)Lcom/datadog/android/trace/TracingHeaderType;
+	public static final fun toSdkInjection (Lcom/datadog/android/core/internal/remote/model/RemoteConfiguration$Trace;)Lcom/datadog/android/trace/TraceContextInjection;
+}
+
 public final class com/datadog/android/trace/internal/_TraceInternalProxy {
 	public static final field INSTANCE Lcom/datadog/android/trace/internal/_TraceInternalProxy;
 	public static final field spanIdConverter Lcom/datadog/android/trace/internal/DatadogSpanIdConverter;

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ApmNetworkInstrumentation.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/ApmNetworkInstrumentation.kt
@@ -37,6 +37,7 @@ import com.datadog.android.trace.internal.net.finishRumAware
 import com.datadog.android.trace.internal.net.sample
 import java.net.HttpURLConnection
 import java.util.Locale
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * For internal usage only.
@@ -58,7 +59,7 @@ import java.util.Locale
  * @param networkingLibraryName the name identifying the network instrumentation (e.g., "OkHttp", "Cronet").
  * @param networkTracingScope Tracing scope for the instrumentation. See [ApmNetworkTracingScope] enum for more details.
  */
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 @InternalApi
 class ApmNetworkInstrumentation internal constructor(
     internal val canSendSpan: Boolean,
@@ -66,13 +67,15 @@ class ApmNetworkInstrumentation internal constructor(
     val traceOrigin: String?,
     internal val tracerProvider: TracerProvider,
     internal val redacted404ResourceName: Boolean,
-    internal val traceSampler: Sampler<DatadogSpan>,
-    internal val injectionType: TraceContextInjection,
+    @Volatile internal var traceSampler: Sampler<DatadogSpan>,
+    @Volatile internal var injectionType: TraceContextInjection,
     internal val tracedRequestListener: NetworkTracedRequestListener,
-    internal val localFirstPartyHostHeaderTypeResolver: DefaultFirstPartyHostHeaderTypeResolver,
+    @Volatile internal var localFirstPartyHostHeaderTypeResolver: DefaultFirstPartyHostHeaderTypeResolver,
     private val networkingLibraryName: String,
     val networkTracingScope: ApmNetworkTracingScope = ApmNetworkTracingScope.ALL
 ) {
+    private val rcApplied = AtomicBoolean(false)
+
     private val rumContextPropagator = RumContextPropagator { internalSdkCore }
     private val internalSdkCore: InternalSdkCore?
         get() = sdkCoreReference.get() as? InternalSdkCore
@@ -83,7 +86,17 @@ class ApmNetworkInstrumentation internal constructor(
 
     /** Reference to the SDK core instance. */
     val sdkCoreReference: SdkReference = SdkReference(sdkInstanceName) {
-        val sdkCore = it as InternalSdkCore
+        onSdkInstanceReady(it as InternalSdkCore)
+    }
+
+    internal fun onSdkInstanceReady(sdkCore: InternalSdkCore) {
+        if (rcApplied.compareAndSet(false, true)) {
+            sdkCore.remoteConfiguration?.trace?.let { trace ->
+                trace.sampleRate?.toFloat()?.let { traceSampler = applyRcSampleRate(traceSampler, it) }
+                trace.toSdkInjection()?.let { injectionType = it }
+                trace.buildRcHostResolver()?.let { localFirstPartyHostHeaderTypeResolver = it }
+            }
+        }
         if (localFirstPartyHostHeaderTypeResolver.isEmpty() && sdkCore.firstPartyHostResolver.isEmpty()) {
             sdkCore.internalLogger.logToUser(InternalLogger.Level.WARN, onlyOnce = true) {
                 WARNING_TRACING_NO_HOSTS.format(Locale.US, networkingLibraryName)

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/TraceRemoteConfigExt.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/TraceRemoteConfigExt.kt
@@ -1,0 +1,90 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.internal
+
+import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
+import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.lint.InternalApi
+import com.datadog.android.trace.DeterministicTraceSampler
+import com.datadog.android.trace.TraceContextInjection
+import com.datadog.android.trace.TracingHeaderType
+import com.datadog.android.trace.api.span.DatadogSpan
+import com.datadog.android.trace.internal.net.SessionRebasedSampler
+
+/**
+ * Applies the RC `sampleRate` to the given [current] sampler, preserving a
+ * [SessionRebasedSampler] wrapper if one is present (used by [DatadogInterceptor] to maintain
+ * `traceSampleRate × sessionSampleRate / 100` cross-product rebasing).
+ */
+@InternalApi
+fun applyRcSampleRate(current: Sampler<DatadogSpan>, rcRate: Float): Sampler<DatadogSpan> {
+    val newBase = DeterministicTraceSampler(rcRate)
+    return if (current is SessionRebasedSampler) SessionRebasedSampler(newBase) else newBase
+}
+
+/**
+ * Maps a remote [RemoteConfiguration.Trace.traceContextInjection] value to the SDK
+ * [TraceContextInjection] enum, or returns `null` when the remote field is absent.
+ */
+@InternalApi
+fun RemoteConfiguration.Trace.toSdkInjection(): TraceContextInjection? =
+    when (traceContextInjection) {
+        RemoteConfiguration.TraceContextInjection.ALL -> TraceContextInjection.ALL
+        RemoteConfiguration.TraceContextInjection.SAMPLED -> TraceContextInjection.SAMPLED
+        null -> null
+    }
+
+/**
+ * Maps a remote [RemoteConfiguration.TracingHeaderType] to the SDK [TracingHeaderType].
+ */
+@InternalApi
+fun RemoteConfiguration.TracingHeaderType.toSdkHeaderType(): TracingHeaderType =
+    when (this) {
+        RemoteConfiguration.TracingHeaderType.DATADOG -> TracingHeaderType.DATADOG
+        RemoteConfiguration.TracingHeaderType.B3 -> TracingHeaderType.B3
+        RemoteConfiguration.TracingHeaderType.B3MULTI -> TracingHeaderType.B3MULTI
+        RemoteConfiguration.TracingHeaderType.TRACECONTEXT -> TracingHeaderType.TRACECONTEXT
+    }
+
+/**
+ * Builds a new [DefaultFirstPartyHostHeaderTypeResolver] from the RC `tracedHosts`, mirroring
+ * iOS PR #3047 semantics:
+ * - `null` (absent) → returns `null` (caller keeps existing resolver unchanged)
+ * - explicit empty list → returns an empty resolver (no first-party requests will be traced)
+ * - non-empty list → returns a resolver with RC hosts replacing the developer's hosts
+ *
+ * For each host the header types are resolved in order:
+ * 1. Per-host `propagatorTypes` from the RC payload
+ * 2. Global `tracingHeaderTypes` from the RC payload
+ * 3. SDK default `{DATADOG, TRACECONTEXT}`
+ */
+@Suppress("ReturnCount")
+@InternalApi
+fun RemoteConfiguration.Trace.buildRcHostResolver(): DefaultFirstPartyHostHeaderTypeResolver? {
+    val rcHosts = tracedHosts ?: return null
+    if (rcHosts.isEmpty()) {
+        return DefaultFirstPartyHostHeaderTypeResolver(emptyMap())
+    }
+    // null (absent) → SDK default; [] (explicit empty) → no global fallback types
+    val globalTypes = tracingHeaderTypes
+        ?.map { it.toSdkHeaderType() }
+        ?.toSet()
+        ?: setOf(TracingHeaderType.DATADOG, TracingHeaderType.TRACECONTEXT)
+
+    val newHosts = rcHosts.associate { tracedHost ->
+        // null (absent) → fall back to globalTypes; [] (explicit empty) → no headers for this host
+        val types = tracedHost.propagatorTypes
+            ?.map { it.toSdkHeaderType() }
+            ?.toSet()
+            ?: globalTypes
+        tracedHost.host to types
+    }
+    // RC hosts come from the server and are already validated — pass directly to the resolver
+    // which will lowercase them in its constructor.
+    return DefaultFirstPartyHostHeaderTypeResolver(newHosts)
+}

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/TraceRemoteConfigExtTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/TraceRemoteConfigExtTest.kt
@@ -1,0 +1,240 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.internal
+
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
+import com.datadog.android.trace.TraceContextInjection
+import com.datadog.android.trace.TracingHeaderType
+import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class TraceRemoteConfigExtTest {
+
+    // region toSdkInjection
+
+    @Test
+    fun `M return ALL W toSdkInjection { remote ALL }`() {
+        // Given
+        val trace = RemoteConfiguration.Trace(
+            traceContextInjection = RemoteConfiguration.TraceContextInjection.ALL
+        )
+
+        // When / Then
+        assertThat(trace.toSdkInjection()).isEqualTo(TraceContextInjection.ALL)
+    }
+
+    @Test
+    fun `M return SAMPLED W toSdkInjection { remote SAMPLED }`() {
+        // Given
+        val trace = RemoteConfiguration.Trace(
+            traceContextInjection = RemoteConfiguration.TraceContextInjection.SAMPLED
+        )
+
+        // When / Then
+        assertThat(trace.toSdkInjection()).isEqualTo(TraceContextInjection.SAMPLED)
+    }
+
+    @Test
+    fun `M return null W toSdkInjection { absent }`() {
+        // Given
+        val trace = RemoteConfiguration.Trace(traceContextInjection = null)
+
+        // When / Then
+        assertThat(trace.toSdkInjection()).isNull()
+    }
+
+    // endregion
+
+    // region toSdkHeaderType
+
+    @Test
+    fun `M map all RemoteConfiguration TracingHeaderType values W toSdkHeaderType`() {
+        assertThat(RemoteConfiguration.TracingHeaderType.DATADOG.toSdkHeaderType())
+            .isEqualTo(TracingHeaderType.DATADOG)
+        assertThat(RemoteConfiguration.TracingHeaderType.B3.toSdkHeaderType())
+            .isEqualTo(TracingHeaderType.B3)
+        assertThat(RemoteConfiguration.TracingHeaderType.B3MULTI.toSdkHeaderType())
+            .isEqualTo(TracingHeaderType.B3MULTI)
+        assertThat(RemoteConfiguration.TracingHeaderType.TRACECONTEXT.toSdkHeaderType())
+            .isEqualTo(TracingHeaderType.TRACECONTEXT)
+    }
+
+    // endregion
+
+    // region buildRcHostResolver
+
+    @Test
+    fun `M return null W buildRcHostResolver { tracedHosts absent }`() {
+        // Given
+        val trace = RemoteConfiguration.Trace(tracedHosts = null)
+
+        // When / Then
+        assertThat(trace.buildRcHostResolver()).isNull()
+    }
+
+    @Test
+    fun `M return empty resolver W buildRcHostResolver { tracedHosts explicit empty list }`() {
+        // Given
+        val trace = RemoteConfiguration.Trace(tracedHosts = emptyList())
+
+        // When
+        val resolver = trace.buildRcHostResolver()
+
+        // Then
+        assertThat(resolver).isNotNull
+        assertThat(resolver!!.isEmpty()).isTrue()
+    }
+
+    @Test
+    fun `M return resolver with RC hosts W buildRcHostResolver { non-empty tracedHosts }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeRcHost = forge.aStringMatching("[a-z]+\\.[a-z]{2,3}")
+        val trace = RemoteConfiguration.Trace(
+            tracedHosts = listOf(
+                RemoteConfiguration.TracedHost(
+                    host = fakeRcHost,
+                    propagatorTypes = listOf(RemoteConfiguration.TracingHeaderType.B3)
+                )
+            )
+        )
+
+        // When
+        val resolver = trace.buildRcHostResolver()
+
+        // Then
+        assertThat(resolver).isNotNull
+        assertThat(resolver!!.headerTypesForUrl("https://$fakeRcHost/path"))
+            .containsExactly(TracingHeaderType.B3)
+    }
+
+    @Test
+    fun `M use per-host propagatorTypes W buildRcHostResolver { host has propagatorTypes }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeHost = forge.aStringMatching("[a-z]+\\.[a-z]{2,3}")
+        val trace = RemoteConfiguration.Trace(
+            tracedHosts = listOf(
+                RemoteConfiguration.TracedHost(
+                    host = fakeHost,
+                    propagatorTypes = listOf(
+                        RemoteConfiguration.TracingHeaderType.B3MULTI,
+                        RemoteConfiguration.TracingHeaderType.TRACECONTEXT
+                    )
+                )
+            )
+        )
+
+        // When
+        val resolver = trace.buildRcHostResolver()
+
+        // Then
+        assertThat(resolver!!.headerTypesForUrl("https://$fakeHost/path"))
+            .containsExactlyInAnyOrder(TracingHeaderType.B3MULTI, TracingHeaderType.TRACECONTEXT)
+    }
+
+    @Test
+    fun `M use global tracingHeaderTypes W buildRcHostResolver { host has no propagatorTypes }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeHost = forge.aStringMatching("[a-z]+\\.[a-z]{2,3}")
+        val trace = RemoteConfiguration.Trace(
+            tracedHosts = listOf(
+                RemoteConfiguration.TracedHost(host = fakeHost, propagatorTypes = null)
+            ),
+            tracingHeaderTypes = listOf(RemoteConfiguration.TracingHeaderType.B3)
+        )
+
+        // When
+        val resolver = trace.buildRcHostResolver()
+
+        // Then
+        assertThat(resolver!!.headerTypesForUrl("https://$fakeHost/path"))
+            .containsExactly(TracingHeaderType.B3)
+    }
+
+    @Test
+    fun `M use SDK default header types W buildRcHostResolver { no propagatorTypes, no global types }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeHost = forge.aStringMatching("[a-z]+\\.[a-z]{2,3}")
+        val trace = RemoteConfiguration.Trace(
+            tracedHosts = listOf(
+                RemoteConfiguration.TracedHost(host = fakeHost, propagatorTypes = null)
+            ),
+            tracingHeaderTypes = null
+        )
+
+        // When
+        val resolver = trace.buildRcHostResolver()
+
+        // Then
+        assertThat(resolver!!.headerTypesForUrl("https://$fakeHost/path"))
+            .containsExactlyInAnyOrder(TracingHeaderType.DATADOG, TracingHeaderType.TRACECONTEXT)
+    }
+
+    @Test
+    fun `M use empty header types W buildRcHostResolver { host has explicit empty propagatorTypes }`(
+        forge: Forge
+    ) {
+        // Given — explicit empty propagatorTypes means "trace host with no headers"
+        val fakeHost = forge.aStringMatching("[a-z]+\\.[a-z]{2,3}")
+        val trace = RemoteConfiguration.Trace(
+            tracedHosts = listOf(
+                RemoteConfiguration.TracedHost(host = fakeHost, propagatorTypes = emptyList())
+            ),
+            tracingHeaderTypes = listOf(RemoteConfiguration.TracingHeaderType.B3)
+        )
+
+        // When
+        val resolver = trace.buildRcHostResolver()
+
+        // Then — empty set, not the global fallback
+        assertThat(resolver!!.headerTypesForUrl("https://$fakeHost/path")).isEmpty()
+    }
+
+    @Test
+    fun `M use empty global types W buildRcHostResolver { explicit empty tracingHeaderTypes }`(
+        forge: Forge
+    ) {
+        // Given — explicit empty tracingHeaderTypes means no global fallback
+        val fakeHost = forge.aStringMatching("[a-z]+\\.[a-z]{2,3}")
+        val trace = RemoteConfiguration.Trace(
+            tracedHosts = listOf(
+                RemoteConfiguration.TracedHost(host = fakeHost, propagatorTypes = null)
+            ),
+            tracingHeaderTypes = emptyList()
+        )
+
+        // When
+        val resolver = trace.buildRcHostResolver()
+
+        // Then — empty global types → empty set for host (no SDK default applied)
+        assertThat(resolver!!.headerTypesForUrl("https://$fakeHost/path")).isEmpty()
+    }
+
+    // endregion
+}

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/net/ApmNetworkInstrumentationTest.kt
@@ -17,9 +17,11 @@ import com.datadog.android.api.instrumentation.network.HttpResponseInfo
 import com.datadog.android.api.instrumentation.network.MutableHttpRequestInfo
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.trace.ApmNetworkInstrumentationConfiguration
 import com.datadog.android.trace.ApmNetworkTracingScope
+import com.datadog.android.trace.DeterministicTraceSampler
 import com.datadog.android.trace.NetworkTracedRequestListener
 import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
@@ -148,6 +150,7 @@ internal class ApmNetworkInstrumentationTest {
             on { getFeature(Feature.TRACING_FEATURE_NAME) } doReturn mockTracingFeature
             on { getFeature(Feature.RUM_FEATURE_NAME) } doReturn mockRumFeature
             on { firstPartyHostResolver } doReturn mock()
+            on { remoteConfiguration } doReturn null
         }
         datadogRegistryRegisterMethod.invoke(datadogRegistryField.get(null), null, mockSdkCore)
 
@@ -1162,6 +1165,166 @@ internal class ApmNetworkInstrumentationTest {
         span = mockSpan,
         sampleRate = fakeSampleRate
     )
+
+    // region Remote Configuration
+
+    @Test
+    fun `M override traceSampler W onSdkInstanceReady { RC provides sampleRate }`(
+        @FloatForgery(min = 0f, max = 100f) fakeRcSampleRate: Float
+    ) {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            trace = RemoteConfiguration.Trace(sampleRate = fakeRcSampleRate)
+        )
+        whenever(mockSdkCore.remoteConfiguration) doReturn fakeRc
+        val instrumentation = createInstrumentation()
+
+        // When
+        instrumentation.onSdkInstanceReady(mockSdkCore)
+
+        // Then
+        assertThat(instrumentation.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(instrumentation.traceSampler.getSampleRate()).isEqualTo(fakeRcSampleRate)
+    }
+
+    @Test
+    fun `M preserve SessionRebasedSampler W onSdkInstanceReady { RC provides sampleRate, headerPropagationOnly }`(
+        @FloatForgery(min = 0f, max = 100f) fakeRcSampleRate: Float
+    ) {
+        // Given — headerPropagationOnly wraps sampler in SessionRebasedSampler at construction
+        val fakeRc = RemoteConfiguration(
+            trace = RemoteConfiguration.Trace(sampleRate = fakeRcSampleRate)
+        )
+        whenever(mockSdkCore.remoteConfiguration) doReturn fakeRc
+        val instrumentation = _TraceInternalProxy.createApmNetworkInstrumentation(
+            "test",
+            ApmNetworkInstrumentationConfiguration(emptyList<String>())
+                .setHeaderPropagationOnly()
+        )
+
+        // When
+        instrumentation.onSdkInstanceReady(mockSdkCore)
+
+        // Then — wrapper preserved, inner rate updated
+        assertThat(instrumentation.traceSampler).isInstanceOf(SessionRebasedSampler::class.java)
+        assertThat(instrumentation.traceSampler.getSampleRate()).isEqualTo(fakeRcSampleRate)
+    }
+
+    @Test
+    fun `M override injectionType W onSdkInstanceReady { RC provides ALL traceContextInjection }`() {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            trace = RemoteConfiguration.Trace(
+                traceContextInjection = RemoteConfiguration.TraceContextInjection.ALL
+            )
+        )
+        whenever(mockSdkCore.remoteConfiguration) doReturn fakeRc
+        val instrumentation = createInstrumentation()
+
+        // When
+        instrumentation.onSdkInstanceReady(mockSdkCore)
+
+        // Then
+        assertThat(instrumentation.injectionType).isEqualTo(TraceContextInjection.ALL)
+    }
+
+    @Test
+    fun `M replace localFirstPartyHostHeaderTypeResolver W onSdkInstanceReady { RC provides tracedHosts }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeRcHost = forge.aStringMatching("[a-z]+\\.[a-z]{2,3}")
+        val fakeRc = RemoteConfiguration(
+            trace = RemoteConfiguration.Trace(
+                tracedHosts = listOf(
+                    RemoteConfiguration.TracedHost(
+                        host = fakeRcHost,
+                        propagatorTypes = listOf(RemoteConfiguration.TracingHeaderType.DATADOG)
+                    )
+                )
+            )
+        )
+        whenever(mockSdkCore.remoteConfiguration) doReturn fakeRc
+        val instrumentation = createInstrumentation()
+
+        // When
+        instrumentation.onSdkInstanceReady(mockSdkCore)
+
+        // Then — RC host is resolvable
+        assertThat(
+            instrumentation.localFirstPartyHostHeaderTypeResolver
+                .headerTypesForUrl("https://$fakeRcHost/path")
+        ).containsExactly(TracingHeaderType.DATADOG)
+    }
+
+    @Test
+    fun `M not apply RC on second onSdkInstanceReady W { called multiple times }`(
+        @FloatForgery(min = 0f, max = 100f) fakeRcSampleRate: Float,
+        @FloatForgery(min = 0f, max = 100f) fakeSecondRcSampleRate: Float
+    ) {
+        // Given — first RC applied
+        val fakeRc = RemoteConfiguration(
+            trace = RemoteConfiguration.Trace(sampleRate = fakeRcSampleRate)
+        )
+        whenever(mockSdkCore.remoteConfiguration) doReturn fakeRc
+        val instrumentation = createInstrumentation()
+        instrumentation.onSdkInstanceReady(mockSdkCore)
+
+        // When — second call with different RC
+        val fakeSecondRc = RemoteConfiguration(
+            trace = RemoteConfiguration.Trace(sampleRate = fakeSecondRcSampleRate)
+        )
+        whenever(mockSdkCore.remoteConfiguration) doReturn fakeSecondRc
+        instrumentation.onSdkInstanceReady(mockSdkCore)
+
+        // Then — rate from first call preserved
+        assertThat(instrumentation.traceSampler.getSampleRate()).isEqualTo(fakeRcSampleRate)
+    }
+
+    @Test
+    fun `M keep in-code values W onSdkInstanceReady { null RC }`() {
+        // Given
+        whenever(mockSdkCore.remoteConfiguration) doReturn null
+        val instrumentation = createInstrumentation()
+        val originalSampler = instrumentation.traceSampler
+        val originalInjection = instrumentation.injectionType
+
+        // When
+        instrumentation.onSdkInstanceReady(mockSdkCore)
+
+        // Then
+        assertThat(instrumentation.traceSampler).isSameAs(originalSampler)
+        assertThat(instrumentation.injectionType).isEqualTo(originalInjection)
+    }
+
+    @Test
+    fun `M keep in-code values W onSdkInstanceReady { RC trace namespace present but all fields null }`() {
+        // Given
+        val fakeRc = RemoteConfiguration(
+            trace = RemoteConfiguration.Trace(
+                sampleRate = null,
+                traceContextInjection = null,
+                tracedHosts = null,
+                tracingHeaderTypes = null
+            )
+        )
+        whenever(mockSdkCore.remoteConfiguration) doReturn fakeRc
+        val instrumentation = createInstrumentation()
+        val originalSampler = instrumentation.traceSampler
+        val originalInjection = instrumentation.injectionType
+
+        // When
+        instrumentation.onSdkInstanceReady(mockSdkCore)
+
+        // Then — all fields preserved
+        assertThat(instrumentation.traceSampler).isSameAs(originalSampler)
+        assertThat(instrumentation.injectionType).isEqualTo(originalInjection)
+        // rcApplied=true so second call is also no-op
+        instrumentation.onSdkInstanceReady(mockSdkCore)
+        assertThat(instrumentation.traceSampler).isSameAs(originalSampler)
+    }
+
+    // endregion
 
     private fun createInstrumentation(
         canSendSpan: Boolean = true,

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -26,6 +26,7 @@ import com.datadog.android.lint.InternalApi
 import com.datadog.android.okhttp.internal.trace.toTelemetryTracingHeaderType
 import com.datadog.android.trace.DatadogTracing
 import com.datadog.android.trace.DeterministicTraceSampler
+import com.datadog.android.trace.internal.applyRcSampleRate
 import com.datadog.android.trace.GlobalDatadogTracer
 import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
@@ -38,15 +39,18 @@ import com.datadog.android.trace.internal.ParentContextSource
 import com.datadog.android.trace.internal.RumContextPropagator
 import com.datadog.android.trace.internal.RumContextPropagator.Companion.extractRumContext
 import com.datadog.android.trace.internal._TraceInternalProxy
+import com.datadog.android.trace.internal.buildRcHostResolver
 import com.datadog.android.trace.internal.net.TraceContext
 import com.datadog.android.trace.internal.net.effectiveSampleRate
 import com.datadog.android.trace.internal.net.isDropped
 import com.datadog.android.trace.internal.net.isDroppedPriority
+import com.datadog.android.trace.internal.toSdkInjection
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import java.net.HttpURLConnection
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import com.datadog.android.okhttp.TraceContext as DeprecatedTraceContext
 
@@ -86,12 +90,14 @@ internal constructor(
     internal val tracedHosts: Map<String, Set<TracingHeaderType>>,
     internal val tracedRequestListener: TracedRequestListener,
     internal val traceOrigin: String?,
-    internal val traceSampler: Sampler<DatadogSpan>,
-    internal val traceContextInjection: TraceContextInjection,
+    @Volatile internal var traceSampler: Sampler<DatadogSpan>,
+    @Volatile internal var traceContextInjection: TraceContextInjection,
     internal val redacted404ResourceName: Boolean,
     internal val localTracerFactory: (SdkCore, Set<TracingHeaderType>) -> DatadogTracer,
     private val globalTracerProvider: () -> DatadogTracer?
 ) : Interceptor {
+
+    private val rcApplied = AtomicBoolean(false)
 
     private val localTracerReference: AtomicReference<DatadogTracer> = AtomicReference()
     private val sanitizedHosts = HostsSanitizer().sanitizeHosts(
@@ -99,7 +105,7 @@ internal constructor(
         NETWORK_REQUESTS_TRACKING_FEATURE_NAME
     )
 
-    private val localFirstPartyHostHeaderTypeResolver = DefaultFirstPartyHostHeaderTypeResolver(
+    @Volatile internal var localFirstPartyHostHeaderTypeResolver = DefaultFirstPartyHostHeaderTypeResolver(
         tracedHosts.filterKeys { sanitizedHosts.contains(it) }
     )
 
@@ -212,6 +218,13 @@ internal constructor(
     // region Internal
 
     internal open fun onSdkInstanceReady(sdkCore: InternalSdkCore) {
+        if (rcApplied.compareAndSet(false, true)) {
+            sdkCore.remoteConfiguration?.trace?.let { trace ->
+                trace.sampleRate?.toFloat()?.let { traceSampler = applyRcSampleRate(traceSampler, it) }
+                trace.toSdkInjection()?.let { traceContextInjection = it }
+                trace.buildRcHostResolver()?.let { localFirstPartyHostHeaderTypeResolver = it }
+            }
+        }
         updateTracingFeatureContext(sdkCore)
         if (localFirstPartyHostHeaderTypeResolver.isEmpty() &&
             sdkCore.firstPartyHostResolver.isEmpty()
@@ -230,7 +243,7 @@ internal constructor(
         sdkCore.updateFeatureContext(Feature.TRACING_FEATURE_NAME, useContextThread = false) {
             it[OKHTTP_INTERCEPTOR_SAMPLE_RATE] = traceSampler.getSampleRate()
             it[OKHTTP_INTERCEPTOR_HEADER_TYPES] = TracingHeaderTypesSet(
-                tracedHosts.values.flatten()
+                localFirstPartyHostHeaderTypeResolver.getAllHeaderTypes()
                     .map(TracingHeaderType::toTelemetryTracingHeaderType)
                     .toSet()
             )

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -26,7 +26,6 @@ import com.datadog.android.lint.InternalApi
 import com.datadog.android.okhttp.internal.trace.toTelemetryTracingHeaderType
 import com.datadog.android.trace.DatadogTracing
 import com.datadog.android.trace.DeterministicTraceSampler
-import com.datadog.android.trace.internal.applyRcSampleRate
 import com.datadog.android.trace.GlobalDatadogTracer
 import com.datadog.android.trace.TraceContextInjection
 import com.datadog.android.trace.TracingHeaderType
@@ -39,6 +38,7 @@ import com.datadog.android.trace.internal.ParentContextSource
 import com.datadog.android.trace.internal.RumContextPropagator
 import com.datadog.android.trace.internal.RumContextPropagator.Companion.extractRumContext
 import com.datadog.android.trace.internal._TraceInternalProxy
+import com.datadog.android.trace.internal.applyRcSampleRate
 import com.datadog.android.trace.internal.buildRcHostResolver
 import com.datadog.android.trace.internal.net.TraceContext
 import com.datadog.android.trace.internal.net.effectiveSampleRate

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
@@ -10,6 +10,7 @@ import com.datadog.android.api.SdkCore
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.internal.network.HttpSpec
 import com.datadog.android.internal.telemetry.TracingHeaderTypesSet
@@ -190,6 +191,7 @@ internal open class TracingInterceptorTest {
         whenever(rumMonitor.mockSdkCore.getFeature(Feature.TRACING_FEATURE_NAME)) doReturn mock()
         whenever(rumMonitor.mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(rumMonitor.mockSdkCore.firstPartyHostResolver) doReturn mockResolver
+        whenever(rumMonitor.mockSdkCore.remoteConfiguration) doReturn null
         testedInterceptor = instantiateTestedInterceptor(
             fakeLocalHosts,
             globalTracerProvider = { mockTracer },
@@ -1780,6 +1782,154 @@ internal open class TracingInterceptorTest {
         configure(builder)
 
         return builder.build()
+    }
+
+    // endregion
+
+    // region Remote Configuration
+
+    @Test
+    fun `M override traceSampler W onSdkInstanceReady { RC provides sampleRate }`(
+        @FloatForgery(min = 0f, max = 100f) fakeRcSampleRate: Float
+    ) {
+        // Given — set RC before constructing the interceptor so onSdkInstanceReady fires with it
+        val fakeRc = RemoteConfiguration(
+            trace = RemoteConfiguration.Trace(sampleRate = fakeRcSampleRate)
+        )
+        whenever(rumMonitor.mockSdkCore.remoteConfiguration) doReturn fakeRc
+        testedInterceptor = instantiateTestedInterceptor(
+            fakeLocalHosts,
+            globalTracerProvider = { mockTracer },
+            localTracerFactory = { _, _ -> mockLocalTracer }
+        )
+
+        // Then
+        assertThat(testedInterceptor.traceSampler).isInstanceOf(DeterministicTraceSampler::class.java)
+        assertThat(testedInterceptor.traceSampler.getSampleRate()).isEqualTo(fakeRcSampleRate)
+    }
+
+    @Test
+    fun `M override traceContextInjection W onSdkInstanceReady { RC provides ALL injection }`() {
+        // Given — set RC before constructing the interceptor so onSdkInstanceReady fires with it
+        val fakeRc = RemoteConfiguration(
+            trace = RemoteConfiguration.Trace(
+                traceContextInjection = RemoteConfiguration.TraceContextInjection.ALL
+            )
+        )
+        whenever(rumMonitor.mockSdkCore.remoteConfiguration) doReturn fakeRc
+        testedInterceptor = instantiateTestedInterceptor(
+            fakeLocalHosts,
+            globalTracerProvider = { mockTracer },
+            localTracerFactory = { _, _ -> mockLocalTracer }
+        )
+
+        // Then
+        assertThat(testedInterceptor.traceContextInjection).isEqualTo(TraceContextInjection.ALL)
+    }
+
+    @Test
+    fun `M not apply RC on second onSdkInstanceReady W onSdkInstanceReady { called multiple times }`(
+        @FloatForgery(min = 0f, max = 100f) fakeRcSampleRate: Float,
+        @FloatForgery(min = 0f, max = 100f) fakeSecondRcSampleRate: Float
+    ) {
+        // Given — first RC set at construction time
+        val fakeRc = RemoteConfiguration(
+            trace = RemoteConfiguration.Trace(sampleRate = fakeRcSampleRate)
+        )
+        whenever(rumMonitor.mockSdkCore.remoteConfiguration) doReturn fakeRc
+        testedInterceptor = instantiateTestedInterceptor(
+            fakeLocalHosts,
+            globalTracerProvider = { mockTracer },
+            localTracerFactory = { _, _ -> mockLocalTracer }
+        )
+
+        // When — second onSdkInstanceReady with different RC
+        val fakeSecondRc = RemoteConfiguration(
+            trace = RemoteConfiguration.Trace(sampleRate = fakeSecondRcSampleRate)
+        )
+        whenever(rumMonitor.mockSdkCore.remoteConfiguration) doReturn fakeSecondRc
+        testedInterceptor.onSdkInstanceReady(rumMonitor.mockSdkCore)
+
+        // Then — rate from first call is preserved, second RC ignored
+        assertThat(testedInterceptor.traceSampler.getSampleRate()).isEqualTo(fakeRcSampleRate)
+    }
+
+    @Test
+    fun `M keep in-code values W onSdkInstanceReady { null RC }`() {
+        // Given — null RC at construction, so in-code values are preserved
+        whenever(rumMonitor.mockSdkCore.remoteConfiguration) doReturn null
+        testedInterceptor = instantiateTestedInterceptor(
+            fakeLocalHosts,
+            globalTracerProvider = { mockTracer },
+            localTracerFactory = { _, _ -> mockLocalTracer }
+        )
+        val originalSampler = testedInterceptor.traceSampler
+        val originalInjection = testedInterceptor.traceContextInjection
+
+        // When — second call also with null RC
+        testedInterceptor.onSdkInstanceReady(rumMonitor.mockSdkCore)
+
+        // Then
+        assertThat(testedInterceptor.traceSampler).isSameAs(originalSampler)
+        assertThat(testedInterceptor.traceContextInjection).isEqualTo(originalInjection)
+    }
+
+    @Test
+    fun `M replace localFirstPartyHostHeaderTypeResolver W onSdkInstanceReady { RC provides tracedHosts }`(
+        forge: Forge
+    ) {
+        // Given — RC provides a host not in the developer's in-code list
+        val fakeRcHost = forge.aStringMatching("[a-z]+\\.[a-z]{2,3}")
+        val fakeRc = RemoteConfiguration(
+            trace = RemoteConfiguration.Trace(
+                tracedHosts = listOf(
+                    RemoteConfiguration.TracedHost(
+                        host = fakeRcHost,
+                        propagatorTypes = listOf(RemoteConfiguration.TracingHeaderType.DATADOG)
+                    )
+                )
+            )
+        )
+        whenever(rumMonitor.mockSdkCore.remoteConfiguration) doReturn fakeRc
+        testedInterceptor = instantiateTestedInterceptor(
+            fakeLocalHosts,
+            globalTracerProvider = { mockTracer },
+            localTracerFactory = { _, _ -> mockLocalTracer }
+        )
+
+        // Then — RC host is resolvable, developer hosts are replaced
+        assertThat(
+            testedInterceptor.localFirstPartyHostHeaderTypeResolver
+                .headerTypesForUrl("https://$fakeRcHost/path")
+        ).containsExactly(TracingHeaderType.DATADOG)
+    }
+
+    @Test
+    fun `M keep in-code values W onSdkInstanceReady { RC trace namespace present but all fields null }`() {
+        // Given — RC has a trace namespace but every field inside it is null
+        val fakeRc = RemoteConfiguration(
+            trace = RemoteConfiguration.Trace(
+                sampleRate = null,
+                traceContextInjection = null,
+                tracedHosts = null,
+                tracingHeaderTypes = null
+            )
+        )
+        whenever(rumMonitor.mockSdkCore.remoteConfiguration) doReturn fakeRc
+        testedInterceptor = instantiateTestedInterceptor(
+            fakeLocalHosts,
+            globalTracerProvider = { mockTracer },
+            localTracerFactory = { _, _ -> mockLocalTracer }
+        )
+        val originalSampler = testedInterceptor.traceSampler
+        val originalInjection = testedInterceptor.traceContextInjection
+
+        // Then — all fields preserved, rcApplied is true so further calls are no-ops too
+        assertThat(testedInterceptor.traceSampler).isSameAs(originalSampler)
+        assertThat(testedInterceptor.traceContextInjection).isEqualTo(originalInjection)
+        testedInterceptor.onSdkInstanceReady(rumMonitor.mockSdkCore)
+        assertThat(testedInterceptor.traceSampler).isSameAs(originalSampler)
+        assertThat(testedInterceptor.traceContextInjection).isEqualTo(originalInjection)
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

Applies the RC `trace` namespace to both Android tracing paths when the SDK instance becomes available:

- **Commit 1** — introduces `TraceRemoteConfigExt.kt` (shared helpers: `applyRcSampleRate()`, `toSdkInjection()`, `buildRcHostResolver()`) and wires RC into `TracingInterceptor.onSdkInstanceReady()`
- **Commit 2** — wires RC into `ApmNetworkInstrumentation.onSdkInstanceReady()` (the modern OkHttp/Cronet path)

RC is applied **once** per interceptor lifetime, guarded by `AtomicBoolean.compareAndSet`, on both the legacy (`TracingInterceptor`/`DatadogInterceptor`) and modern (`ApmNetworkInstrumentation`) paths.

### Motivation

[RUM-17709](https://datadoghq.atlassian.net/browse/RUM-17709) — applies the RC `trace` namespace on Android. Mirrors the iOS implementation in [dd-sdk-ios#3047](https://github.com/DataDog/dd-sdk-ios/pull/3047).

### Additional Notes

**RC fields mapped from `RemoteConfiguration.Trace`:**

| RC field | Effect on both paths |
|---|---|
| `trace.sampleRate` | Replaces `traceSampler` with `DeterministicTraceSampler(rcRate)`; preserves `SessionRebasedSampler` wrapper when present (used by `DatadogInterceptor` for RUM × APM cross-product rebasing) |
| `trace.traceContextInjection` | Updates `traceContextInjection` / `injectionType` |
| `trace.tracedHosts` + `trace.tracingHeaderTypes` | Replaces `localFirstPartyHostHeaderTypeResolver` via `buildRcHostResolver()`. Semantics mirror iOS PR #3047: null → no-op; `[]` → clear hosts; non-empty → replace |

**`propagatorTypes` / `tracingHeaderTypes` semantics (matching iOS):**
- `null` (absent) → fall back to global types / SDK default
- `[]` (explicit empty list) → no headers for that host / no global fallback — **not** treated as absent

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

[RUM-17709]: https://datadoghq.atlassian.net/browse/RUM-17709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ