### PR TITLE
Explicitly enable Gradle Tooling API actions parallelism

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@
 org.gradle.jvmargs=-Xmx6144m
 org.gradle.caching=true
 org.gradle.parallel=true
+org.gradle.tooling.parallel=true
 android.useAndroidX=true
 android.experimental.enableTestFixturesKotlinSupport=true
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
### What does this PR do?

Android Studio Quail 2 complains about `org.gradle.tooling.parallel` ([docs](https://docs.gradle.org/current/userguide/performance.html#sec:configure_tooling_api_actions_parallelism)) not being enabled.

Setting it up in addition to `org.gradle.parallel` enabled earlier in https://github.com/DataDog/dd-sdk-android/pull/3583.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

