### PR TITLE
RUM-17738: Add remoteConfigurationId to DatadogContext and RUM ViewEvent

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -73,7 +73,7 @@ interface com.datadog.android.api.SdkCore
 data class com.datadog.android.api.context.AccountInfo
   constructor(String, String? = null, Map<String, Any?> = emptyMap())
 data class com.datadog.android.api.context.DatadogContext
-  constructor(com.datadog.android.DatadogSite, String, String, String, String, Int, String, String, String, TimeInfo, ProcessInfo, NetworkInfo, DeviceInfo, UserInfo, AccountInfo?, com.datadog.android.privacy.TrackingConsent, String?, Map<String, Map<String, Any?>>)
+  constructor(com.datadog.android.DatadogSite, String, String, String, String, Int, String, String, String, TimeInfo, ProcessInfo, NetworkInfo, DeviceInfo, UserInfo, AccountInfo?, com.datadog.android.privacy.TrackingConsent, String?, String?, Map<String, Map<String, Any?>>)
 data class com.datadog.android.api.context.DeviceInfo
   constructor(String, String, String, DeviceType, String, String, String, String, String, Int?, LocaleInfo, Int, Int?, Boolean?)
 enum com.datadog.android.api.context.DeviceType

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -172,7 +172,7 @@ public final class com/datadog/android/api/context/AccountInfo {
 }
 
 public final class com/datadog/android/api/context/DatadogContext {
-	public fun <init> (Lcom/datadog/android/DatadogSite;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/api/context/TimeInfo;Lcom/datadog/android/api/context/ProcessInfo;Lcom/datadog/android/api/context/NetworkInfo;Lcom/datadog/android/api/context/DeviceInfo;Lcom/datadog/android/api/context/UserInfo;Lcom/datadog/android/api/context/AccountInfo;Lcom/datadog/android/privacy/TrackingConsent;Ljava/lang/String;Ljava/util/Map;)V
+	public fun <init> (Lcom/datadog/android/DatadogSite;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/api/context/TimeInfo;Lcom/datadog/android/api/context/ProcessInfo;Lcom/datadog/android/api/context/NetworkInfo;Lcom/datadog/android/api/context/DeviceInfo;Lcom/datadog/android/api/context/UserInfo;Lcom/datadog/android/api/context/AccountInfo;Lcom/datadog/android/privacy/TrackingConsent;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public final fun component1 ()Lcom/datadog/android/DatadogSite;
 	public final fun component10 ()Lcom/datadog/android/api/context/TimeInfo;
 	public final fun component11 ()Lcom/datadog/android/api/context/ProcessInfo;
@@ -182,7 +182,8 @@ public final class com/datadog/android/api/context/DatadogContext {
 	public final fun component15 ()Lcom/datadog/android/api/context/AccountInfo;
 	public final fun component16 ()Lcom/datadog/android/privacy/TrackingConsent;
 	public final fun component17 ()Ljava/lang/String;
-	public final fun component18 ()Ljava/util/Map;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/util/Map;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
@@ -191,8 +192,8 @@ public final class com/datadog/android/api/context/DatadogContext {
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Lcom/datadog/android/DatadogSite;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/api/context/TimeInfo;Lcom/datadog/android/api/context/ProcessInfo;Lcom/datadog/android/api/context/NetworkInfo;Lcom/datadog/android/api/context/DeviceInfo;Lcom/datadog/android/api/context/UserInfo;Lcom/datadog/android/api/context/AccountInfo;Lcom/datadog/android/privacy/TrackingConsent;Ljava/lang/String;Ljava/util/Map;)Lcom/datadog/android/api/context/DatadogContext;
-	public static synthetic fun copy$default (Lcom/datadog/android/api/context/DatadogContext;Lcom/datadog/android/DatadogSite;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/api/context/TimeInfo;Lcom/datadog/android/api/context/ProcessInfo;Lcom/datadog/android/api/context/NetworkInfo;Lcom/datadog/android/api/context/DeviceInfo;Lcom/datadog/android/api/context/UserInfo;Lcom/datadog/android/api/context/AccountInfo;Lcom/datadog/android/privacy/TrackingConsent;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/datadog/android/api/context/DatadogContext;
+	public final fun copy (Lcom/datadog/android/DatadogSite;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/api/context/TimeInfo;Lcom/datadog/android/api/context/ProcessInfo;Lcom/datadog/android/api/context/NetworkInfo;Lcom/datadog/android/api/context/DeviceInfo;Lcom/datadog/android/api/context/UserInfo;Lcom/datadog/android/api/context/AccountInfo;Lcom/datadog/android/privacy/TrackingConsent;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/datadog/android/api/context/DatadogContext;
+	public static synthetic fun copy$default (Lcom/datadog/android/api/context/DatadogContext;Lcom/datadog/android/DatadogSite;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/datadog/android/api/context/TimeInfo;Lcom/datadog/android/api/context/ProcessInfo;Lcom/datadog/android/api/context/NetworkInfo;Lcom/datadog/android/api/context/DeviceInfo;Lcom/datadog/android/api/context/UserInfo;Lcom/datadog/android/api/context/AccountInfo;Lcom/datadog/android/privacy/TrackingConsent;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/datadog/android/api/context/DatadogContext;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccountInfo ()Lcom/datadog/android/api/context/AccountInfo;
 	public final fun getAppBuildId ()Ljava/lang/String;
@@ -202,6 +203,7 @@ public final class com/datadog/android/api/context/DatadogContext {
 	public final fun getFeaturesContext ()Ljava/util/Map;
 	public final fun getNetworkInfo ()Lcom/datadog/android/api/context/NetworkInfo;
 	public final fun getProcessInfo ()Lcom/datadog/android/api/context/ProcessInfo;
+	public final fun getRemoteConfigurationId ()Ljava/lang/String;
 	public final fun getSdkVersion ()Ljava/lang/String;
 	public final fun getService ()Ljava/lang/String;
 	public final fun getSite ()Lcom/datadog/android/DatadogSite;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/context/DatadogContext.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/context/DatadogContext.kt
@@ -33,6 +33,7 @@ import com.datadog.android.privacy.TrackingConsent
  * @property accountInfo information about the current account
  * @property trackingConsent information about the current tracking consent
  * @property appBuildId unique build ID of the running application. Will be missing if Datadog Gradle Plugin is not applied or obfuscation is not enabled for the running build.
+ * @property remoteConfigurationId the opaque identifier of the remote configuration applied to the SDK, if any. Matches the value provided via [com.datadog.android.core.configuration.Configuration.Builder.setRemoteConfigurationId].
  * @property featuresContext agnostic dictionary with information from all features registered to
  * the parent SDK instance
  */
@@ -54,5 +55,6 @@ data class DatadogContext(
     val accountInfo: AccountInfo?,
     val trackingConsent: TrackingConsent,
     val appBuildId: String?,
+    val remoteConfigurationId: String?,
     val featuresContext: Map<String, Map<String, Any?>>
 )

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -198,6 +198,9 @@ internal class CoreFeature(
 
     @Volatile
     internal var appBuildId: String? = null
+
+    @Volatile
+    internal var remoteConfigurationId: String? = null
     internal var customUploadSchedulerStrategy: UploadSchedulerStrategy? = null
 
     internal lateinit var uploadExecutorService: ScheduledThreadPoolExecutor
@@ -583,6 +586,7 @@ internal class CoreFeature(
         site = configuration.site
         backpressureStrategy = configuration.backpressureStrategy
         customUploadSchedulerStrategy = configuration.uploadSchedulerStrategy
+        remoteConfigurationId = configuration.remoteConfigurationId
     }
 
     private fun setupInfoProviders(

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogContextProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogContextProvider.kt
@@ -63,6 +63,7 @@ internal class DatadogContextProvider(
             accountInfo = coreFeature.accountInfoProvider.getAccountInfo(),
             trackingConsent = coreFeature.trackingConsentProvider.getConsent(),
             appBuildId = coreFeature.appBuildId,
+            remoteConfigurationId = coreFeature.remoteConfigurationId,
             featuresContext = mutableMapOf<String, Map<String, Any?>>().apply {
                 withFeatureContexts.forEach {
                     val featureContext = featureContextProvider.getFeatureContext(it)

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/NoOpContextProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/NoOpContextProvider.kt
@@ -64,6 +64,7 @@ internal class NoOpContextProvider : ContextProvider {
         accountInfo = null,
         trackingConsent = TrackingConsent.NOT_GRANTED,
         appBuildId = null,
+        remoteConfigurationId = null,
         featuresContext = emptyMap()
     )
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -518,6 +518,29 @@ internal class CoreFeatureTest {
     }
 
     @Test
+    fun `M initializes remoteConfigurationId W initialize()`(
+        @StringForgery fakeRemoteConfigurationId: String
+    ) {
+        // Given
+        fakeConfig = fakeConfig.copy(
+            coreConfig = fakeConfig.coreConfig.copy(
+                remoteConfigurationId = fakeRemoteConfigurationId
+            )
+        )
+
+        // When
+        testedFeature.initialize(
+            appContext.mockInstance,
+            fakeSdkInstanceId,
+            fakeConfig,
+            fakeConsent
+        )
+
+        // Then
+        assertThat(testedFeature.remoteConfigurationId).isEqualTo(fakeRemoteConfigurationId)
+    }
+
+    @Test
     fun `M initializes build ID W initialize() { asset manager is closed }`() {
         // Given
         whenever(

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/DatadogContextProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/DatadogContextProviderTest.kt
@@ -189,6 +189,7 @@ internal class DatadogContextProviderTest {
         }
 
         assertThat(context.appBuildId).isEqualTo(coreFeature.mockInstance.appBuildId)
+        assertThat(context.remoteConfigurationId).isEqualTo(coreFeature.mockInstance.remoteConfigurationId)
         assertThat(context.trackingConsent).isEqualTo(fakeTrackingConsent)
 
         assertThat(context.featuresContext).isEqualTo(fakeFeaturesContext)

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/DatadogContextForgeryFactory.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/DatadogContextForgeryFactory.kt
@@ -35,6 +35,7 @@ class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
             accountInfo = forge.getForgery(),
             trackingConsent = forge.aValueFrom(TrackingConsent::class.java),
             appBuildId = forge.aNullable { getForgery<UUID>().toString() },
+            remoteConfigurationId = forge.aNullable { getForgery<UUID>().toString() },
             // building nested maps with default size slows down tests quite a lot, so will use
             // an explicit small size
             featuresContext = forge.aMap(size = 2) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -1449,7 +1449,8 @@ internal open class RumViewScope(
                     configuration = ViewEvent.Configuration(
                         sessionSampleRate = sampleRate,
                         sessionReplaySampleRate = resolveSessionReplaySampleRate(datadogContext),
-                        traceSampleRate = resolveTraceSampleRate(datadogContext)
+                        traceSampleRate = resolveTraceSampleRate(datadogContext),
+                        remoteConfigurationId = datadogContext.remoteConfigurationId
                     ),
                     profiling = resolveViewProfilingStatus(datadogContext)
                 ),

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
@@ -845,6 +845,16 @@ internal class ViewEventAssert(actual: ViewEvent) :
         return this
     }
 
+    fun hasRemoteConfigurationId(expected: String?): ViewEventAssert {
+        assertThat(actual.dd.configuration?.remoteConfigurationId)
+            .overridingErrorMessage(
+                "Expected RUM event to have remoteConfigurationId: $expected" +
+                    " but instead was: ${actual.dd.configuration?.remoteConfigurationId}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
     fun hasProfilingStatus(profilingStatus: ViewEvent.ProfilingStatus?): ViewEventAssert {
         assertThat(actual.dd.profiling?.status)
             .overridingErrorMessage(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -991,6 +991,48 @@ internal class RumViewScopeTest {
     }
 
     @Test
+    fun `M send view event with remoteConfigurationId W handleEvent(StopView) { RC ID configured }`(
+        @StringForgery fakeRcId: String
+    ) {
+        // Given
+        val contextWithRcId = fakeDatadogContext.copy(remoteConfigurationId = fakeRcId)
+
+        // When
+        testedScope.handleEvent(
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
+            contextWithRcId,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue).hasRemoteConfigurationId(fakeRcId)
+        }
+    }
+
+    @Test
+    fun `M send view event with null remoteConfigurationId W handleEvent(StopView) { no RC ID }`() {
+        // Given
+        val contextWithoutRcId = fakeDatadogContext.copy(remoteConfigurationId = null)
+
+        // When
+        testedScope.handleEvent(
+            RumRawEvent.StopView(fakeKey, emptyMap(), eventTime = fakeEventTime),
+            contextWithoutRcId,
+            mockEventWriteScope,
+            mockWriter
+        )
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(lastValue).hasRemoteConfigurationId(null)
+        }
+    }
+
+    @Test
     fun `M send event W handleEvent(StopView) on active view { pending attributes are negative }`(
         forge: Forge
     ) {


### PR DESCRIPTION
### What does this PR do?

Propagates the RC application UUID (`remoteConfigurationId`) through the SDK context pipeline and into RUM view events, mirroring the iOS implementation in [dd-sdk-ios#3040](https://github.com/DataDog/dd-sdk-ios/pull/3040).

- **`CoreFeature`** — reads `remoteConfigurationId` from `Configuration.Core` in `readConfigurationSettings()` and stores it as an internal field
- **`DatadogContext`** — adds `remoteConfigurationId: String?` field, populated from `CoreFeature`
- **`RumViewScope`** — passes `remoteConfigurationId` from `DatadogContext` into `ViewEvent.Configuration`, where it is serialized as `_dd.configuration.remote_configuration_id`

No JSON schema changes are needed — `_view-properties-schema.json` already defines the field and the generated `ViewEvent.Configuration` model already has `remoteConfigurationId: String?`.

### Motivation

[RUM-17738](https://datadoghq.atlassian.net/browse/RUM-17738) — allows Datadog to correlate which RC configuration drove the SDK behaviour for a given session/view. If no RC ID was configured, the field is `null` and omitted from the JSON payload — behaviour is identical to today.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

[RUM-17738]: https://datadoghq.atlassian.net/browse/RUM-17738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ