### PR TITLE
RUM-17743: Guard `featureContext.clear()` call in `DatadogCore`

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -34,6 +34,8 @@ import com.datadog.android.core.internal.time.DefaultAppStartTimeProvider
 import com.datadog.android.core.internal.time.composeTimeInfo
 import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.core.internal.utils.getSafe
+import com.datadog.android.core.internal.utils.safeTryWithLock
+import com.datadog.android.core.internal.utils.safeWithLock
 import com.datadog.android.core.internal.utils.scheduleSafe
 import com.datadog.android.core.internal.utils.submitSafe
 import com.datadog.android.core.thread.FlushableExecutorService
@@ -55,7 +57,6 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.locks.Lock
 
 /**
  * Internal implementation of the [SdkCore] interface.
@@ -231,7 +232,7 @@ internal class DatadogCore(
     ) {
         val runnable = runnable@{
             val feature = features[featureName] ?: return@runnable
-            feature.featureContextLock.writeLock().safeTryWithLock(1, TimeUnit.SECONDS) {
+            feature.featureContextLock.writeLock().safeTryWithLock(1, TimeUnit.SECONDS, internalLogger) {
                 val currentContext = feature.featureContext
                 updateCallback(currentContext)
                 featureContextUpdateReceivers.forEach {
@@ -254,7 +255,7 @@ internal class DatadogCore(
     override fun getFeatureContext(featureName: String, useContextThread: Boolean): Map<String, Any?> {
         val callable = Callable {
             val feature = features[featureName] ?: return@Callable emptyMap()
-            return@Callable feature.featureContextLock.readLock().safeWithLock {
+            return@Callable feature.featureContextLock.readLock().safeWithLock(internalLogger) {
                 // Creating copy here is VERY important - this will make
                 // independent snapshot of the features context which is not affected by the
                 // changes which can be made later by another thread.
@@ -630,63 +631,6 @@ internal class DatadogCore(
             internalLogger,
             runnable
         )
-    }
-
-    private fun Lock.safeTryWithLock(time: Long, unit: TimeUnit, block: () -> Unit) {
-        val locked = try {
-            // NullPointerException cannot happen, time unit is not null
-            @Suppress("UnsafeThirdPartyFunctionCall")
-            tryLock(time, unit)
-        } catch (e: InterruptedException) {
-            internalLogger.log(
-                InternalLogger.Level.ERROR,
-                listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-                { "Couldn't acquire ${javaClass.simpleName} due to the exception thrown, aborting operation." },
-                e
-            )
-            return
-        }
-        if (!locked) {
-            internalLogger.log(
-                InternalLogger.Level.ERROR,
-                listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-                {
-                    "Couldn't acquire ${javaClass.simpleName} due to" +
-                        " timeout ($time $unit), aborting operation."
-                }
-            )
-            return
-        }
-        try {
-            block()
-        } finally {
-            if (locked) {
-                // IllegalMonitorStateException cannot happen, we check locked flag
-                @Suppress("UnsafeThirdPartyFunctionCall")
-                unlock()
-            }
-        }
-    }
-
-    private fun <T> Lock.safeWithLock(block: () -> T): T? {
-        try {
-            lock()
-        } catch (e: InterruptedException) {
-            internalLogger.log(
-                InternalLogger.Level.ERROR,
-                listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-                { "Couldn't acquire ${javaClass.simpleName} lock due to the exception thrown, aborting operation." },
-                e
-            )
-            return null
-        }
-        return try {
-            block()
-        } finally {
-            // IllegalMonitorStateException cannot happen, lock() call above succeeded
-            @Suppress("UnsafeThirdPartyFunctionCall")
-            unlock()
-        }
     }
 
     /**

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -52,6 +52,7 @@ import com.datadog.android.core.internal.persistence.file.batch.BatchFileReaderW
 import com.datadog.android.core.internal.persistence.tlvformat.TLVBlockFileReader
 import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.core.internal.utils.getSafe
+import com.datadog.android.core.internal.utils.safeTryWithLock
 import com.datadog.android.core.internal.utils.submitSafe
 import com.datadog.android.core.persistence.PersistenceStrategy
 import com.datadog.android.internal.lifecycle.ProcessLifecycleMonitor
@@ -62,6 +63,7 @@ import com.datadog.android.security.Encryption
 import java.util.Locale
 import java.util.concurrent.Callable
 import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReadWriteLock
@@ -163,7 +165,9 @@ internal class SdkFeature(
             (coreFeature.appContext as? Application)
                 ?.unregisterActivityLifecycleCallbacks(processLifecycleMonitor)
             processLifecycleMonitor = null
-            featureContext.clear()
+            featureContextLock.writeLock().safeTryWithLock(1, TimeUnit.SECONDS, internalLogger) {
+                featureContext.clear()
+            }
             initialized.set(false)
         }
     }
@@ -178,7 +182,7 @@ internal class SdkFeature(
     ) {
         coreFeature.contextExecutorService
             .executeSafe("withWriteContext-${wrappedFeature.name}", internalLogger) {
-                if (coreFeature.initialized.get() == false) return@executeSafe
+                if (!coreFeature.initialized.get()) return@executeSafe
                 val context = contextProvider.getContext(withFeatureContexts)
                 val eventBatchWriteScope = storage.getEventWriteScope(context)
                 callback(context, eventBatchWriteScope)
@@ -191,7 +195,7 @@ internal class SdkFeature(
     ) {
         coreFeature.contextExecutorService
             .executeSafe("withContext-${wrappedFeature.name}", internalLogger) {
-                if (coreFeature.initialized.get() == false) return@executeSafe
+                if (!coreFeature.initialized.get()) return@executeSafe
                 val context = contextProvider.getContext(withFeatureContexts)
                 callback(context)
             }
@@ -220,7 +224,7 @@ internal class SdkFeature(
                 operationName,
                 internalLogger,
                 Callable {
-                    if (coreFeature.initialized.get() == false) return@Callable null
+                    if (!coreFeature.initialized.get()) return@Callable null
                     val context = contextProvider.getContext(withFeatureContexts)
                     val eventBatchWriteScope = storage.getEventWriteScope(context)
                     context to eventBatchWriteScope

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/LockExt.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/LockExt.kt
@@ -1,0 +1,83 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.utils
+
+import com.datadog.android.api.InternalLogger
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.Lock
+
+/**
+ * Tries to acquire the lock within the given timeout and runs [block] if it succeeds, without
+ * throwing if the lock cannot be acquired or the thread is interrupted while waiting.
+ *
+ * @param time Amount of time to wait for the lock.
+ * @param unit Time unit of [time].
+ * @param internalLogger Internal logger.
+ * @param block Action to run once the lock is acquired.
+ */
+internal fun Lock.safeTryWithLock(time: Long, unit: TimeUnit, internalLogger: InternalLogger, block: () -> Unit) {
+    val locked = try {
+        // NullPointerException cannot happen, time unit is not null
+        @Suppress("UnsafeThirdPartyFunctionCall")
+        tryLock(time, unit)
+    } catch (e: InterruptedException) {
+        internalLogger.log(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            { "Couldn't acquire ${javaClass.simpleName} due to the exception thrown, aborting operation." },
+            e
+        )
+        return
+    }
+    if (!locked) {
+        internalLogger.log(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            {
+                "Couldn't acquire ${javaClass.simpleName} due to" +
+                    " timeout ($time $unit), aborting operation."
+            }
+        )
+        return
+    }
+    try {
+        block()
+    } finally {
+        // IllegalMonitorStateException cannot happen, we returned early above if not locked
+        @Suppress("UnsafeThirdPartyFunctionCall")
+        unlock()
+    }
+}
+
+/**
+ * Acquires the lock and runs [block], without throwing if the thread is interrupted while
+ * waiting for the lock.
+ *
+ * @param T Result type.
+ * @param internalLogger Internal logger.
+ * @param block Action to run once the lock is acquired.
+ */
+internal fun <T> Lock.safeWithLock(internalLogger: InternalLogger, block: () -> T): T? {
+    try {
+        lock()
+    } catch (e: InterruptedException) {
+        internalLogger.log(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            { "Couldn't acquire ${javaClass.simpleName} lock due to the exception thrown, aborting operation." },
+            e
+        )
+        return null
+    }
+    return try {
+        block()
+    } finally {
+        // IllegalMonitorStateException cannot happen, lock() call above succeeded
+        @Suppress("UnsafeThirdPartyFunctionCall")
+        unlock()
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Guards `SdkFeature.featureContext.clear()` with the feature's write lock so it can no longer race the read-locked snapshot in `DatadogCore.getFeatureContext`.               

### Motivation

#3666                                                              

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

