### PR TITLE
Remove multi-instance support from Profiling feature

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/DdProfilingContentProvider.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/DdProfilingContentProvider.kt
@@ -39,23 +39,21 @@ class DdProfilingContentProvider(
 
     internal fun onStart(context: Context) {
         if (buildSdkVersionProvider.isAtLeastVanillaIceCream) {
-            val instanceNames = ProfilingStorage.getProfilingEnabledInstanceNames(context)
-            if (instanceNames.isNotEmpty()) {
-                sampleProfiling(context, instanceNames)
+            if (ProfilingStorage.isProfilingEnabled(context)) {
+                sampleProfiling(context)
             }
         }
     }
 
     @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
-    private fun sampleProfiling(context: Context, instanceNames: Set<String>) {
+    private fun sampleProfiling(context: Context) {
         val appStartInfo = getAppStartInfo(context) ?: return
         val sampleRate = ProfilingStorage.getSampleRate(context)
         if (RateBasedSampler<Unit>(sampleRate).sample(Unit)) {
             Profiling.start(
                 context = context,
                 startReason = ProfilingStartReason.APPLICATION_LAUNCH,
-                additionalAttributes = mapOf(PerfettoProfiler.TELEMETRY_KEY_APP_START_INFO to appStartInfo),
-                sdkInstanceNames = instanceNames
+                additionalAttributes = mapOf(PerfettoProfiler.TELEMETRY_KEY_APP_START_INFO to appStartInfo)
             )
         }
         ProfilingStorage.removeSampleRate(context)

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/Profiling.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/Profiling.kt
@@ -9,7 +9,9 @@ package com.datadog.android.profiling
 import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.annotation.VisibleForTesting
 import com.datadog.android.Datadog
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.internal.time.DefaultTimeProvider
@@ -20,6 +22,8 @@ import com.datadog.android.profiling.internal.ProfilingStartReason
 import com.datadog.android.profiling.internal.ProfilingStorage
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
 import com.datadog.android.profiling.internal.time.MutableTimeProvider
+import java.lang.ref.WeakReference
+import java.util.Locale
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -33,8 +37,22 @@ object Profiling {
     internal var profiler: Profiler = NoOpProfiler()
     internal val isProfilerInitialized = AtomicBoolean(false)
 
+    @VisibleForTesting
+    internal var currentRegisteredCore: WeakReference<SdkCore>? = null
+
+    internal const val IS_ALREADY_REGISTERED_WARNING =
+        "Profiling is already enabled and does not support multiple instances. " +
+            "The existing instance will continue to be used."
+
+    internal const val IS_ALREADY_REGISTERED_USER_WARNING =
+        "Profiling is already enabled and does not support multiple instances. " +
+            "The existing instance (registered with SDK core \"%s\") will continue to be used."
+
     /**
      * Enables the profiling feature.
+     *
+     * Profiling supports a single SDK instance. If profiling is already enabled on another active
+     * SDK instance, this call is ignored and a warning is logged.
      *
      * @param configuration Configuration to use for the feature.
      * @param sdkCore SDK instance to register feature in. If not provided, default SDK instance
@@ -48,60 +66,67 @@ object Profiling {
         sdkCore: SdkCore = Datadog.getInstance()
     ) {
         val featureSdkCore = sdkCore as FeatureSdkCore
+        // Serialize the check-and-set so two concurrent enable() calls with different cores cannot
+        // both pass the guard and register competing features against the single shared profiler.
+        synchronized(this) {
+            if (isAlreadyRegistered()) {
+                logAlreadyRegisteredWarning(featureSdkCore.internalLogger)
+                return
+            }
+            initializeProfiler()
+            val profilingFeature = ProfilingFeature(
+                sdkCore = featureSdkCore,
+                configuration = configuration,
+                profiler = profiler
+            )
+            currentRegisteredCore = WeakReference(sdkCore)
+            featureSdkCore.registerFeature(profilingFeature)
+        }
+    }
+
+    /**
+     * Start profiling.
+     *
+     * @param context application context
+     * @param startReason reason to start a profiling session
+     * @param additionalAttributes additional attributes to include in the profiling telemetry
+     */
+    @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+    internal fun start(
+        context: Context,
+        startReason: ProfilingStartReason,
+        additionalAttributes: Map<String, String>
+    ) {
         initializeProfiler()
-        val profilingFeature = ProfilingFeature(
-            sdkCore = featureSdkCore,
-            configuration = configuration,
-            profiler = profiler
+        profiler.start(context, startReason, additionalAttributes)
+        ProfilingStorage.removeProfilingFlag(context)
+    }
+
+    /**
+     * Stop profiling.
+     */
+    internal fun stop() {
+        profiler.stop()
+    }
+
+    private fun isAlreadyRegistered() =
+        currentRegisteredCore?.get()?.isCoreActive() == true
+
+    private fun logAlreadyRegisteredWarning(internalLogger: InternalLogger) {
+        val registeredInstanceName = currentRegisteredCore?.get()?.name
+        internalLogger.log(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.USER),
+            messageBuilder = {
+                IS_ALREADY_REGISTERED_USER_WARNING.format(Locale.US, registeredInstanceName)
+            }
         )
-        featureSdkCore.registerFeature(profilingFeature)
-    }
 
-    /**
-     * Start profiling with given SDK instances names.
-     *
-     * @param context application context
-     * @param startReason reason to start a profiling session
-     * @param additionalAttributes additional attributes to include in the profiling telemetry
-     * @param sdkInstanceNames the set of the SDK instances name
-     */
-    @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
-    internal fun start(
-        context: Context,
-        startReason: ProfilingStartReason,
-        additionalAttributes: Map<String, String>,
-        sdkInstanceNames: Set<String>
-    ) {
-        initializeProfiler()
-        profiler.start(context, startReason, additionalAttributes, sdkInstanceNames)
-        ProfilingStorage.removeProfilingFlag(context, sdkInstanceNames)
-    }
-
-    /**
-     * Start profiling for a given SDK instance.
-     *
-     * @param context application context
-     * @param startReason reason to start a profiling session
-     * @param additionalAttributes additional attributes to include in the profiling telemetry
-     * @param sdkCore SDK instance to start profiling with. If not provided, default SDK instance.
-     */
-    @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
-    internal fun start(
-        context: Context,
-        startReason: ProfilingStartReason,
-        additionalAttributes: Map<String, String>,
-        sdkCore: SdkCore = Datadog.getInstance()
-    ) {
-        start(context, startReason, additionalAttributes, setOf(sdkCore.name))
-    }
-
-    /**
-     * Stop profiling for a given SDK instance.
-     *
-     * @param sdkCore SDK instance to stop profiling. If not provided, default SDK instance.
-     */
-    internal fun stop(sdkCore: SdkCore = Datadog.getInstance()) {
-        profiler.stop(sdkCore.name)
+        internalLogger.log(
+            level = InternalLogger.Level.DEBUG,
+            targets = listOf(InternalLogger.Target.TELEMETRY),
+            messageBuilder = { IS_ALREADY_REGISTERED_WARNING }
+        )
     }
 
     @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ContinuousProfilingScheduler.kt
@@ -227,7 +227,7 @@ internal class ContinuousProfilingScheduler(
     private fun onGracePeriodExpired() {
         state = State.PAUSED_AFTER_GRACE
         isActive = false
-        profiler.stop(sdkCore.name)
+        profiler.stop()
         logToUser { LOG_GRACE_PERIOD_EXPIRED }
     }
 
@@ -254,11 +254,10 @@ internal class ContinuousProfilingScheduler(
                 appContext = appContext,
                 startReason = ProfilingStartReason.CONTINUOUS,
                 additionalAttributes = emptyMap(),
-                sdkInstanceNames = setOf(sdkCore.name),
                 durationMs = activeMs.toInt()
             )
             sdkCore.updateFeatureContext(Feature.PROFILING_FEATURE_NAME) { context ->
-                context[FeatureContextKeys.PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
+                context[FeatureContextKeys.PROFILER_IS_RUNNING] = profiler.isRunning()
             }
         } else {
             logToUser { LOG_ACTIVE_WINDOW_SKIPPED }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/NoOpProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/NoOpProfiler.kt
@@ -25,21 +25,19 @@ internal class NoOpProfiler : Profiler {
         appContext: Context,
         startReason: ProfilingStartReason,
         additionalAttributes: Map<String, String>,
-        sdkInstanceNames: Set<String>,
         durationMs: Int
     ) = Unit
 
-    override fun stop(sdkInstanceName: String) = Unit
+    override fun stop() = Unit
 
-    override fun isRunning(sdkInstanceName: String): Boolean = false
+    override fun isRunning(): Boolean = false
 
     override fun registerProfilingCallback(
         appContext: Context,
-        sdkInstanceName: String,
         callback: ProfilerCallback
     ) = Unit
 
-    override fun unregisterProfilingCallback(appContext: Context, sdkInstanceName: String) = Unit
+    override fun unregisterProfilingCallback(appContext: Context) = Unit
 
     override fun setExtendLaunchSession(extend: Boolean) = Unit
 

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/Profiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/Profiler.kt
@@ -23,17 +23,16 @@ internal interface Profiler {
         appContext: Context,
         startReason: ProfilingStartReason,
         additionalAttributes: Map<String, String>,
-        sdkInstanceNames: Set<String>,
         durationMs: Int = 0
     )
 
-    fun stop(sdkInstanceName: String)
+    fun stop()
 
-    fun isRunning(sdkInstanceName: String): Boolean
+    fun isRunning(): Boolean
 
-    fun registerProfilingCallback(appContext: Context, sdkInstanceName: String, callback: ProfilerCallback)
+    fun registerProfilingCallback(appContext: Context, callback: ProfilerCallback)
 
-    fun unregisterProfilingCallback(appContext: Context, sdkInstanceName: String)
+    fun unregisterProfilingCallback(appContext: Context)
 
     /**
      * Controls whether an app launch profiling session should extend past the 10-second

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -98,15 +98,15 @@ internal class ProfilingFeature(
             setProfilingPackageVersionCode(
                 appContext.packageManager.getProfilingModuleLongVersionCode(sdkCore.internalLogger)
             )
-            registerProfilingCallback(appContext, sdkCore.name, this@ProfilingFeature)
+            registerProfilingCallback(appContext, this@ProfilingFeature)
         }
         setMinimumSampleRate(appContext, configuration.applicationLaunchSampleRate)
         // Set the profiling flag in SharedPreferences to profile for the next app launch
-        ProfilingStorage.addProfilingFlag(appContext, sdkCore.name)
-        isLaunchProfilingActive = profiler.isRunning(sdkCore.name)
+        ProfilingStorage.addProfilingFlag(appContext)
+        isLaunchProfilingActive = profiler.isRunning()
         sdkCore.setEventReceiver(name, this)
         sdkCore.updateFeatureContext(Feature.PROFILING_FEATURE_NAME) { context ->
-            context[FeatureContextKeys.PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
+            context[FeatureContextKeys.PROFILER_IS_RUNNING] = profiler.isRunning()
         }
         dataWriter = createDataWriter(sdkCore)
 
@@ -130,7 +130,7 @@ internal class ProfilingFeature(
             sampleRate = configuration.continuousSampleRate,
             onActiveWindowStarted = pendingRumEvents::clear
         ).apply {
-            start(launchProfilingActive = profiler.isRunning(sdkCore.name))
+            start(launchProfilingActive = profiler.isRunning())
         }
         continuousProfilingScheduler = scheduler
 
@@ -150,8 +150,8 @@ internal class ProfilingFeature(
         processLifecycleMonitor = null
         continuousProfilingScheduler?.stop()
         profiler.apply {
-            stop(sdkCore.name)
-            unregisterProfilingCallback(appContext, sdkCore.name)
+            stop()
+            unregisterProfilingCallback(appContext)
         }
         sdkCore.removeEventReceiver(name)
         sdkCore.removeContextUpdateReceiver(this)
@@ -207,7 +207,7 @@ internal class ProfilingFeature(
         perfettoResult = result
         tryWriteProfilingEvent()
         sdkCore.updateFeatureContext(Feature.PROFILING_FEATURE_NAME) { context ->
-            context[FeatureContextKeys.PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
+            context[FeatureContextKeys.PROFILER_IS_RUNNING] = profiler.isRunning()
         }
     }
 
@@ -222,7 +222,7 @@ internal class ProfilingFeature(
             continuousProfilingScheduler?.onActiveWindowEnded()
         }
         sdkCore.updateFeatureContext(Feature.PROFILING_FEATURE_NAME) { context ->
-            context[FeatureContextKeys.PROFILER_IS_RUNNING] = profiler.isRunning(sdkCore.name)
+            context[FeatureContextKeys.PROFILER_IS_RUNNING] = profiler.isRunning()
         }
     }
 
@@ -237,7 +237,7 @@ internal class ProfilingFeature(
         if (isTtidVitalReceived.getAndSet(true)) return
 
         if (continuousProfilingScheduler?.currentSessionSampled != true) {
-            profiler.stop(sdkCore.name)
+            profiler.stop()
             tryWriteProfilingEvent()
             sdkCore.internalLogger.log(
                 InternalLogger.Level.INFO,

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingStorage.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingStorage.kt
@@ -30,36 +30,18 @@ internal object ProfilingStorage {
     }
 
     @JvmStatic
-    internal fun addProfilingFlag(appContext: Context, sdkInstanceName: String) {
-        getStorage(appContext).apply {
-            synchronized(this) {
-                val oldValue = getStringSet(KEY_PROFILING_ENABLED, emptySet())
-                val newSet = oldValue + sdkInstanceName
-                putStringSet(KEY_PROFILING_ENABLED, newSet)
-            }
-        }
+    internal fun addProfilingFlag(appContext: Context) {
+        getStorage(appContext).putBoolean(KEY_PROFILING_ENABLED, true)
     }
 
     @JvmStatic
-    internal fun getProfilingEnabledInstanceNames(appContext: Context): Set<String> {
-        return getStorage(appContext).let {
-            synchronized(it) {
-                it.getStringSet(KEY_PROFILING_ENABLED)
-            }
-        }
+    internal fun isProfilingEnabled(appContext: Context): Boolean {
+        return getStorage(appContext).getBoolean(KEY_PROFILING_ENABLED, false)
     }
 
     @JvmStatic
-    internal fun removeProfilingFlag(appContext: Context, sdkInstanceNames: Set<String>) {
-        getStorage(appContext).apply {
-            synchronized(this) {
-                val value = getStringSet(KEY_PROFILING_ENABLED).toMutableSet()
-                val removed = value.removeAll(sdkInstanceNames)
-                if (removed) {
-                    putStringSet(KEY_PROFILING_ENABLED, value)
-                }
-            }
-        }
+    internal fun removeProfilingFlag(appContext: Context) {
+        getStorage(appContext).remove(KEY_PROFILING_ENABLED)
     }
 
     @Suppress("ReturnCount")

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
@@ -27,10 +27,9 @@ import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetry
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetryEvent
 import com.datadog.android.profiling.internal.time.MutableTimeProvider
 import com.datadog.android.profiling.internal.utils.fileSizeSafe
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Consumer
 import kotlin.random.Random
 
@@ -44,8 +43,8 @@ import kotlin.random.Random
  * @param profilingTelemetry shared telemetry helper that buffers metric events until a logger is
  * available and dispatches them through the unified `[Mobile Metric] Profiling Session` envelope.
  * @param anrTriggerRegistrar registrar that owns the system ANR profiling-trigger lifecycle.
- * The profiler passes its internal fan-out listener to it at register time; the listener
- * captures the profiler's `callbackMap` so all SDK instances receive the detection.
+ * The profiler passes its internal listener to it at register time; the listener
+ * captures the profiler's `callback` so the registered SDK instance receives the detection.
  * @param buildSdkVersionProvider Build.VERSION.SDK_INT provider used for the test.
  */
 @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
@@ -61,8 +60,8 @@ internal class PerfettoProfiler(
     internal var stopSignal: CancellationSignal? = null
     private val resultCallback: Consumer<ProfilingResult>
 
-    // This flag represents which instance of this class is working for.
-    private val runningInstances: AtomicReference<Set<String>> = AtomicReference(emptySet())
+    // Whether a profiling session is currently running.
+    private val isRunning: AtomicBoolean = AtomicBoolean(false)
 
     @Volatile
     private var profilingStartTime = 0L
@@ -88,16 +87,14 @@ internal class PerfettoProfiler(
         }
 
     internal val anrListener = AnrListener { event ->
-        callbackMap.values.forEach { callback ->
-            callback.onAnrDetected(event)
-        }
+        callback?.onAnrDetected(event)
     }
 
     @Volatile
     private var extendLaunchSession = false
 
-    // Map of <InstanceName, ProfilerCallback>
-    private val callbackMap: MutableMap<String, ProfilerCallback> = ConcurrentHashMap()
+    @Volatile
+    private var callback: ProfilerCallback? = null
 
     init {
         resultCallback = Consumer<ProfilingResult> { result ->
@@ -128,7 +125,7 @@ internal class PerfettoProfiler(
             } else {
                 notifyCallbacks { onFailure(startReason) }
             }
-            runningInstances.set(emptySet())
+            isRunning.set(false)
             profilingTelemetry.report(
                 ProfilingTelemetryEvent.SessionEnd(
                     startReason = profilingStartReason.value,
@@ -174,9 +171,8 @@ internal class PerfettoProfiler(
     }
 
     private fun notifyCallbacks(dispatch: ProfilerCallback.() -> Unit) {
-        val running = runningInstances.get()
-        callbackMap.forEach { (key, callback) ->
-            if (running.contains(key)) callback.dispatch()
+        if (isRunning.get()) {
+            callback?.dispatch()
         }
     }
 
@@ -184,13 +180,12 @@ internal class PerfettoProfiler(
         appContext: Context,
         startReason: ProfilingStartReason,
         additionalAttributes: Map<String, String>,
-        sdkInstanceNames: Set<String>,
         durationMs: Int
     ) {
         val effectiveDurationMs =
             if (durationMs > 0) durationMs else getDefaultDurationMs(startReason)
-        // profiling will be launched when no instance is currently running profiling.
-        if (runningInstances.compareAndSet(emptySet(), sdkInstanceNames)) {
+        // profiling will be launched when no session is currently running.
+        if (isRunning.compareAndSet(false, true)) {
             profilingStartTime = timeProvider.getDeviceTimestampMillis()
             profilingStopTime = 0L
             profilingStartReason = startReason
@@ -221,8 +216,8 @@ internal class PerfettoProfiler(
         }
     }
 
-    override fun stop(sdkInstanceName: String) {
-        if (runningInstances.get().contains(sdkInstanceName)) {
+    override fun stop() {
+        if (isRunning.get()) {
             // note: if we call this while another request is being built, stopSignal will be
             // overwritten by that time. Probably need to allow a single profiler instance and stop profiler before
             // starting another request.
@@ -231,28 +226,26 @@ internal class PerfettoProfiler(
         }
     }
 
-    override fun isRunning(sdkInstanceName: String): Boolean {
-        return runningInstances.get().contains(sdkInstanceName)
+    override fun isRunning(): Boolean {
+        return isRunning.get()
     }
 
     override fun registerProfilingCallback(
         appContext: Context,
-        sdkInstanceName: String,
         callback: ProfilerCallback
     ) {
-        synchronized(callbackMap) {
-            callbackMap[sdkInstanceName] = callback
+        synchronized(this) {
+            this.callback = callback
             if (buildSdkVersionProvider.isAtLeastBaklava) {
                 anrTriggerRegistrar.register(appContext, anrListener)
             }
         }
     }
 
-    override fun unregisterProfilingCallback(appContext: Context, sdkInstanceName: String) {
-        synchronized(callbackMap) {
-            callbackMap.remove(sdkInstanceName)
-            // Unregister the ANR triggers only when all the SDK instances have unregistered.
-            if (callbackMap.isEmpty() && buildSdkVersionProvider.isAtLeastBaklava) {
+    override fun unregisterProfilingCallback(appContext: Context) {
+        synchronized(this) {
+            callback = null
+            if (buildSdkVersionProvider.isAtLeastBaklava) {
                 anrTriggerRegistrar.unregister(appContext)
             }
         }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/DdProfilingContentProviderTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/DdProfilingContentProviderTest.kt
@@ -20,7 +20,6 @@ import com.datadog.android.profiling.internal.Profiler
 import com.datadog.android.profiling.internal.ProfilingStartReason
 import com.datadog.android.profiling.internal.ProfilingStorage
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler.Companion.TELEMETRY_KEY_APP_START_INFO
-import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.junit.jupiter.api.AfterEach
@@ -72,9 +71,6 @@ class DdProfilingContentProviderTest {
     @Mock
     private lateinit var mockSharedPreferencesStorage: SharedPreferencesStorage
 
-    @StringForgery
-    private lateinit var fakeInstanceName: String
-
     @BeforeEach
     fun `set up`() {
         whenever(mockBuildSdkVersionProvider.isAtLeastVanillaIceCream).doReturn(true)
@@ -86,8 +82,8 @@ class DdProfilingContentProviderTest {
 
         whenever(mockSharedPreferencesStorage.getFloat(any(), any())).doReturn(100f)
 
-        whenever(mockSharedPreferencesStorage.getStringSet(any(), any()))
-            .doReturn(setOf(fakeInstanceName))
+        whenever(mockSharedPreferencesStorage.getBoolean(any(), any()))
+            .doReturn(true)
 
         ProfilingStorage.sharedPreferencesStorage = mockSharedPreferencesStorage
         Profiling.profiler = mockProfiler
@@ -119,8 +115,7 @@ class DdProfilingContentProviderTest {
         verify(mockProfiler).start(
             mockContext,
             ProfilingStartReason.APPLICATION_LAUNCH,
-            mapOf(TELEMETRY_KEY_APP_START_INFO to expectedTelemetryValue),
-            setOf(fakeInstanceName)
+            mapOf(TELEMETRY_KEY_APP_START_INFO to expectedTelemetryValue)
         )
     }
 

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -324,14 +324,14 @@ internal class ProfilingFeatureTest {
         testedFeature.onReceive(fakeTTID)
 
         // Then
-        verify(mockProfiler).stop(fakeInstanceName)
+        verify(mockProfiler).stop()
     }
 
     @Test
     fun `M not stop Profiling W receive TTID event {current session sampled in}`() {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         testedFeature.onInitialize(mockContext)
         testedFeature.dispatchRumSession(UUID.randomUUID().toString(), 100f)
 
@@ -339,28 +339,28 @@ internal class ProfilingFeatureTest {
         testedFeature.onReceive(fakeTTID)
 
         // Then — scheduler takes over, profiler is NOT stopped here
-        verify(mockProfiler, never()).stop(fakeInstanceName)
+        verify(mockProfiler, never()).stop()
     }
 
     @Test
     fun `M stop Profiling W receive TTID event {continuous enabled, no session renewal yet}`() {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         testedFeature.onInitialize(mockContext)
 
         // When
         testedFeature.onReceive(fakeTTID)
 
         // Then
-        verify(mockProfiler).stop(fakeInstanceName)
+        verify(mockProfiler).stop()
     }
 
     @Test
     fun `M stop Profiling W receive TTID event {continuous enabled, session sampled out}`() {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         testedFeature.onInitialize(mockContext)
 
         testedFeature.dispatchRumSession(UUID.randomUUID().toString(), 0f)
@@ -369,7 +369,7 @@ internal class ProfilingFeatureTest {
         testedFeature.onReceive(fakeTTID)
 
         // Then
-        verify(mockProfiler).stop(fakeInstanceName)
+        verify(mockProfiler).stop()
     }
 
     @Test
@@ -396,7 +396,7 @@ internal class ProfilingFeatureTest {
             ),
             mockProfiler
         )
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn false
+        whenever(mockProfiler.isRunning()) doReturn false
         testedFeature.onInitialize(mockContext)
 
         // When
@@ -463,7 +463,7 @@ internal class ProfilingFeatureTest {
     fun `M sample session out W onContextUpdate {session_sample_rate missing from context}`() {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn false
+        whenever(mockProfiler.isRunning()) doReturn false
         testedFeature.onInitialize(mockContext)
         val sessionId = UUID.randomUUID().toString()
 
@@ -486,7 +486,7 @@ internal class ProfilingFeatureTest {
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn false
+        whenever(mockProfiler.isRunning()) doReturn false
         testedFeature.onInitialize(mockContext)
         val sessionId = UUID.randomUUID().toString()
         val firstSampleRate = forge.aFloat(min = 0.1f, max = 100f)
@@ -538,12 +538,11 @@ internal class ProfilingFeatureTest {
     fun `M start continuous cycle W profiler result received {TTID session unsampled}`() {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
 
@@ -572,7 +571,6 @@ internal class ProfilingFeatureTest {
             appContext = eq(mockContext),
             startReason = eq(ProfilingStartReason.CONTINUOUS),
             additionalAttributes = any(),
-            sdkInstanceNames = any(),
             durationMs = any()
         )
     }
@@ -581,12 +579,11 @@ internal class ProfilingFeatureTest {
     fun `M start continuous cycle W profiler failure received {APPLICATION_LAUNCH tag}`() {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
         testedFeature.dispatchRumSession(fakeSessionId, 100f)
@@ -606,7 +603,6 @@ internal class ProfilingFeatureTest {
             appContext = eq(mockContext),
             startReason = eq(ProfilingStartReason.CONTINUOUS),
             additionalAttributes = any(),
-            sdkInstanceNames = any(),
             durationMs = any()
         )
     }
@@ -615,12 +611,11 @@ internal class ProfilingFeatureTest {
     fun `M not start continuous cycle W profiler failure received {CONTINUOUS tag}`() {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn false
+        whenever(mockProfiler.isRunning()) doReturn false
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
 
@@ -632,7 +627,6 @@ internal class ProfilingFeatureTest {
             appContext = any(),
             startReason = any(),
             additionalAttributes = any(),
-            sdkInstanceNames = any(),
             durationMs = any()
         )
     }
@@ -643,13 +637,12 @@ internal class ProfilingFeatureTest {
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         testedFeature.dataWriter = mockDataWriter
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
 
@@ -684,13 +677,12 @@ internal class ProfilingFeatureTest {
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         testedFeature.dataWriter = mockDataWriter
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
         // Open the continuous accumulation window
@@ -726,13 +718,12 @@ internal class ProfilingFeatureTest {
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         testedFeature.dataWriter = mockDataWriter
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
         // Open the continuous accumulation window
@@ -766,12 +757,11 @@ internal class ProfilingFeatureTest {
     fun `M accumulate RUM events in feature lists W continuous active window open`() {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
         // Close launch window
@@ -813,7 +803,7 @@ internal class ProfilingFeatureTest {
             ),
             mockProfiler
         )
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn false
+        whenever(mockProfiler.isRunning()) doReturn false
         testedFeature.onInitialize(mockContext)
 
         // When
@@ -829,7 +819,7 @@ internal class ProfilingFeatureTest {
     fun `M accumulate vital event W onReceive {launch profiling active}`() {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         testedFeature.onInitialize(mockContext)
 
         // When
@@ -845,12 +835,11 @@ internal class ProfilingFeatureTest {
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
         // Close launch window
@@ -890,7 +879,7 @@ internal class ProfilingFeatureTest {
             ),
             mockProfiler
         )
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn false
+        whenever(mockProfiler.isRunning()) doReturn false
         testedFeature.onInitialize(mockContext)
 
         // When
@@ -914,7 +903,7 @@ internal class ProfilingFeatureTest {
             ),
             mockProfiler
         )
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         testedFeature.onInitialize(mockContext)
 
         // When
@@ -923,7 +912,7 @@ internal class ProfilingFeatureTest {
         )
 
         // Then
-        verify(mockProfiler, never()).stop(fakeInstanceName)
+        verify(mockProfiler, never()).stop()
     }
 
     @Test
@@ -940,7 +929,7 @@ internal class ProfilingFeatureTest {
             ),
             mockProfiler
         )
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         testedFeature.onInitialize(mockContext)
 
         // When
@@ -949,7 +938,7 @@ internal class ProfilingFeatureTest {
         )
 
         // Then
-        verify(mockProfiler, never()).stop(fakeInstanceName)
+        verify(mockProfiler, never()).stop()
     }
 
     @Test
@@ -959,13 +948,12 @@ internal class ProfilingFeatureTest {
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         testedFeature.dataWriter = mockDataWriter
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
         testedFeature.onReceive(
@@ -985,12 +973,11 @@ internal class ProfilingFeatureTest {
     fun `M clear RUM events W new continuous active window starts`() {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
         // Close launch window
@@ -1047,13 +1034,12 @@ internal class ProfilingFeatureTest {
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         testedFeature.dataWriter = mockDataWriter
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
         testedFeature.dispatchRumSession(fakeSessionId, 100f)
@@ -1083,13 +1069,12 @@ internal class ProfilingFeatureTest {
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         testedFeature.dataWriter = mockDataWriter
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
         testedFeature.onReceive(fakeRumLongTaskEvent)
@@ -1116,13 +1101,12 @@ internal class ProfilingFeatureTest {
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         testedFeature.dataWriter = mockDataWriter
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
         testedFeature.onReceive(fakeRumLongTaskEvent)
@@ -1144,13 +1128,12 @@ internal class ProfilingFeatureTest {
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         testedFeature.dataWriter = mockDataWriter
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
         testedFeature.onReceive(fakeRumAnrEvent)
@@ -1175,7 +1158,7 @@ internal class ProfilingFeatureTest {
     fun `M not accumulate RUM events W profiler not running {launch profiling not active}`() {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn false
+        whenever(mockProfiler.isRunning()) doReturn false
         testedFeature.onInitialize(mockContext)
 
         // When
@@ -1191,7 +1174,7 @@ internal class ProfilingFeatureTest {
     fun `M clear pending RUM events W app-launch profiling failed`() {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         testedFeature.onInitialize(mockContext)
         testedFeature.onReceive(fakeRumLongTaskEvent)
         testedFeature.onReceive(fakeRumAnrEvent)
@@ -1210,13 +1193,12 @@ internal class ProfilingFeatureTest {
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         testedFeature.dataWriter = mockDataWriter
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
         testedFeature.onReceive(fakeTTID)
@@ -1240,13 +1222,12 @@ internal class ProfilingFeatureTest {
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         testedFeature.dataWriter = mockDataWriter
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
         testedFeature.onReceive(fakeRumLongTaskEvent)
@@ -1268,7 +1249,7 @@ internal class ProfilingFeatureTest {
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         testedFeature.onInitialize(mockContext)
 
         // When
@@ -1284,7 +1265,7 @@ internal class ProfilingFeatureTest {
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn false
+        whenever(mockProfiler.isRunning()) doReturn false
         testedFeature.onInitialize(mockContext)
 
         // When
@@ -1311,7 +1292,7 @@ internal class ProfilingFeatureTest {
         )
         assertThat(argumentCaptor.firstValue.invoke())
             .isEqualTo("Profiling feature received an event of unsupported type=${String::class.java.canonicalName}.")
-        verify(mockProfiler, never()).stop(fakeInstanceName)
+        verify(mockProfiler, never()).stop()
     }
 
     @Test
@@ -1323,7 +1304,7 @@ internal class ProfilingFeatureTest {
         testedFeature.onStop()
 
         // Then
-        verify(mockProfiler).unregisterProfilingCallback(mockContext, fakeInstanceName)
+        verify(mockProfiler).unregisterProfilingCallback(mockContext)
     }
 
     @Test
@@ -1418,13 +1399,12 @@ internal class ProfilingFeatureTest {
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         testedFeature.dataWriter = mockDataWriter
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
         testedFeature.propagateQuotaResult(QuotaResult.QUOTA_EXCEEDED)
@@ -1451,13 +1431,12 @@ internal class ProfilingFeatureTest {
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         testedFeature.dataWriter = mockDataWriter
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
         testedFeature.propagateQuotaResult(QuotaResult(QuotaResult.Decision.ALLOWED, QuotaReason.QUOTA_OK))
@@ -1485,13 +1464,12 @@ internal class ProfilingFeatureTest {
         // Given — no quota decision is ever propagated (e.g. the quota check could not be
         // scheduled). The launch event must still be written (fail open) rather than stalled.
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
-        whenever(mockProfiler.isRunning(fakeInstanceName)) doReturn true
+        whenever(mockProfiler.isRunning()) doReturn true
         val callbackCaptor = argumentCaptor<ProfilerCallback>()
         testedFeature.onInitialize(mockContext)
         testedFeature.dataWriter = mockDataWriter
         verify(mockProfiler).registerProfilingCallback(
             eq(mockContext),
-            eq(fakeInstanceName),
             callbackCaptor.capture()
         )
         testedFeature.onReceive(fakeRumLongTaskEvent)

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
@@ -19,6 +19,7 @@ import com.datadog.android.profiling.internal.ProfilingStartReason
 import com.datadog.android.profiling.internal.ProfilingStorage
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
 import com.datadog.android.profiling.utils.config.MainLooperTestConfiguration
+import com.datadog.android.utils.verifyLog
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
@@ -38,9 +39,11 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.Locale
 import java.util.concurrent.ExecutorService
 
 @OptIn(ExperimentalProfilingApi::class)
@@ -89,17 +92,15 @@ class ProfilingTest {
     @AfterEach
     fun `tear down`() {
         resetProfilerField()
+        Profiling.currentRegisteredCore = null
         ProfilingStorage.sharedPreferencesStorage = null
     }
 
     @Test
     fun `M use PerfettoProfiler W enable called before start`() {
-        // Given
-        val sdkInstanceNames = setOf(fakeInstanceName)
-
         // When
         Profiling.enable(fakeConfiguration, mockSdkCore)
-        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), sdkInstanceNames)
+        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
 
         // Then
         verify(mockSdkCore).registerFeature(any<ProfilingFeature>())
@@ -122,11 +123,8 @@ class ProfilingTest {
 
     @Test
     fun `M use PerfettoProfiler W start called before enable`() {
-        // Given
-        val sdkInstanceNames = setOf(fakeInstanceName)
-
         // When
-        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), sdkInstanceNames)
+        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
         Profiling.enable(fakeConfiguration, mockSdkCore)
 
         // Then
@@ -138,15 +136,12 @@ class ProfilingTest {
 
     @Test
     fun `M keep same profiler instance W start called multiple times`() {
-        // Given
-        val sdkInstanceNames = setOf(fakeInstanceName)
-
         // When
-        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), sdkInstanceNames)
+        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
 
         val firstProfiler = Profiling.profiler
 
-        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), sdkInstanceNames)
+        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
 
         val secondProfiler = Profiling.profiler
 
@@ -157,37 +152,17 @@ class ProfilingTest {
     }
 
     @Test
-    fun `M start profiler W call Profiling start(with instance names)`() {
-        // Given
-        val sdkInstanceNames = setOf(fakeInstanceName)
-        val mockProfiler = mock<Profiler>()
-        Profiling.profiler = mockProfiler
-        Profiling.isProfilerInitialized.set(true)
-
-        // When
-        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), sdkInstanceNames)
-
-        // Then
-        verify(mockProfiler).start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), sdkInstanceNames)
-    }
-
-    @Test
-    fun `M start profiler W call Profiling start(with sdk core)`() {
+    fun `M start profiler W call Profiling start`() {
         // Given
         val mockProfiler = mock<Profiler>()
         Profiling.profiler = mockProfiler
         Profiling.isProfilerInitialized.set(true)
 
         // When
-        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), mockSdkCore)
+        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
 
         // Then
-        verify(mockProfiler).start(
-            mockContext,
-            ProfilingStartReason.APPLICATION_LAUNCH,
-            emptyMap(),
-            setOf(fakeInstanceName)
-        )
+        verify(mockProfiler).start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
     }
 
     @Test
@@ -198,11 +173,62 @@ class ProfilingTest {
         Profiling.isProfilerInitialized.set(true)
 
         // When
-        Profiling.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), mockSdkCore)
-        Profiling.stop(mockSdkCore)
+        Profiling.stop()
 
         // Then
-        verify(mockProfiler).stop(fakeInstanceName)
+        verify(mockProfiler).stop()
+    }
+
+    @Test
+    fun `M warn and skip W enable { profiling already registered with another active core }`(
+        @StringForgery fakeCore1Name: String
+    ) {
+        // Given
+        val mockCore1 = mock<InternalSdkCore>()
+        val mockCore2 = mock<InternalSdkCore>()
+        whenever(mockCore1.isCoreActive()) doReturn true
+        whenever(mockCore1.name) doReturn fakeCore1Name
+        whenever(mockCore1.internalLogger) doReturn mockInternalLogger
+        whenever(mockCore2.internalLogger) doReturn mockInternalLogger
+        Profiling.enable(fakeConfiguration, mockCore1)
+
+        // When
+        Profiling.enable(fakeConfiguration, mockCore2)
+
+        // Then
+        verify(mockCore1).registerFeature(any<ProfilingFeature>())
+        verify(mockCore2, never()).registerFeature(any())
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.USER),
+            message = Profiling.IS_ALREADY_REGISTERED_USER_WARNING.format(Locale.US, fakeCore1Name)
+        )
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.DEBUG,
+            targets = listOf(InternalLogger.Target.TELEMETRY),
+            message = Profiling.IS_ALREADY_REGISTERED_WARNING
+        )
+        assertThat(Profiling.currentRegisteredCore?.get()).isEqualTo(mockCore1)
+    }
+
+    @Test
+    fun `M allow changing cores W enable { profiling enabled but old core inactive }`() {
+        // Given
+        val mockCore1 = mock<InternalSdkCore>()
+        val mockCore2 = mock<InternalSdkCore>()
+        whenever(mockCore1.internalLogger) doReturn mockInternalLogger
+        whenever(mockCore2.internalLogger) doReturn mockInternalLogger
+        whenever(mockCore1.isCoreActive()) doReturn true
+        Profiling.enable(fakeConfiguration, mockCore1)
+        assertThat(Profiling.currentRegisteredCore?.get()).isEqualTo(mockCore1)
+
+        // When
+        whenever(mockCore1.isCoreActive()) doReturn false
+        Profiling.enable(fakeConfiguration, mockCore2)
+
+        // Then
+        verify(mockCore2).registerFeature(any<ProfilingFeature>())
+        assertThat(Profiling.currentRegisteredCore?.get()).isEqualTo(mockCore2)
     }
 
     private fun resetProfilerField() {

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ContinuousProfilingSchedulerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ContinuousProfilingSchedulerTest.kt
@@ -155,7 +155,6 @@ internal class ContinuousProfilingSchedulerTest {
             appContext = eq(mockApplication),
             startReason = eq(ProfilingStartReason.CONTINUOUS),
             additionalAttributes = eq(emptyMap()),
-            sdkInstanceNames = eq(setOf(fakeInstanceName)),
             durationMs = durationCaptor.capture()
         )
         val captured = durationCaptor.firstValue.toLong()
@@ -169,7 +168,7 @@ internal class ContinuousProfilingSchedulerTest {
         testedScheduler.start(launchProfilingActive = true)
 
         // Then
-        verify(mockProfiler, never()).start(any(), any(), any(), any(), any())
+        verify(mockProfiler, never()).start(any(), any(), any(), any())
         verifyNoInteractions(mockSchedulerExecutor)
     }
 
@@ -198,7 +197,7 @@ internal class ContinuousProfilingSchedulerTest {
         testedScheduler.start(launchProfilingActive = false)
 
         // Then
-        verify(mockProfiler, never()).start(any(), any(), any(), any(), any())
+        verify(mockProfiler, never()).start(any(), any(), any(), any())
     }
 
     @Test
@@ -239,7 +238,7 @@ internal class ContinuousProfilingSchedulerTest {
         testedScheduler.onAppLaunchProfilingComplete()
 
         // Then
-        verify(mockProfiler, never()).start(any(), any(), any(), any(), any())
+        verify(mockProfiler, never()).start(any(), any(), any(), any())
     }
 
     @Test
@@ -252,7 +251,7 @@ internal class ContinuousProfilingSchedulerTest {
         testedScheduler.onAppLaunchProfilingComplete()
 
         // Then — profiling must not start until the cooldown fires
-        verify(mockProfiler, never()).start(any(), any(), any(), any(), any())
+        verify(mockProfiler, never()).start(any(), any(), any(), any())
     }
 
     @Test
@@ -272,7 +271,6 @@ internal class ContinuousProfilingSchedulerTest {
             appContext = eq(mockApplication),
             startReason = eq(ProfilingStartReason.CONTINUOUS),
             additionalAttributes = eq(emptyMap()),
-            sdkInstanceNames = eq(setOf(fakeInstanceName)),
             durationMs = any()
         )
     }
@@ -341,7 +339,7 @@ internal class ContinuousProfilingSchedulerTest {
         runnableCaptor.firstValue.run()
 
         // Then
-        verify(mockProfiler, never()).start(any(), any(), any(), any(), any())
+        verify(mockProfiler, never()).start(any(), any(), any(), any())
     }
 
     @Test
@@ -353,7 +351,7 @@ internal class ContinuousProfilingSchedulerTest {
         testedScheduler.onRumSessionRenewed(sessionId = fakeSessionId, rumSessionSampleRate = 0f)
 
         // Then
-        verify(mockProfiler, never()).stop(any())
+        verify(mockProfiler, never()).stop()
     }
 
     @Test
@@ -366,7 +364,7 @@ internal class ContinuousProfilingSchedulerTest {
         testedScheduler.onRumSessionRenewed(sessionId = fakeSessionId, rumSessionSampleRate = 0f)
 
         // Then
-        verify(mockProfiler, never()).stop(any())
+        verify(mockProfiler, never()).stop()
         assertThat(testedScheduler.currentSessionSampled).isFalse()
     }
 
@@ -508,7 +506,7 @@ internal class ContinuousProfilingSchedulerTest {
         runnableCaptor.firstValue.run()
 
         // Then
-        verify(mockProfiler, never()).start(any(), any(), any(), any(), any())
+        verify(mockProfiler, never()).start(any(), any(), any(), any())
         assertThat(testedScheduler.state).isEqualTo(ContinuousProfilingScheduler.State.COOLDOWN)
         assertThat(testedScheduler.isActive).isFalse()
         assertThat(activeWindowStartedCount).isEqualTo(0)
@@ -539,7 +537,7 @@ internal class ContinuousProfilingSchedulerTest {
         runnableCaptor.firstValue.run()
 
         // Then — the window is skipped until the decision lands
-        verify(mockProfiler, never()).start(any(), any(), any(), any(), any())
+        verify(mockProfiler, never()).start(any(), any(), any(), any())
         assertThat(testedScheduler.state).isEqualTo(ContinuousProfilingScheduler.State.COOLDOWN)
         assertThat(testedScheduler.isActive).isFalse()
         assertThat(activeWindowStartedCount).isEqualTo(0)
@@ -573,7 +571,6 @@ internal class ContinuousProfilingSchedulerTest {
             appContext = eq(mockApplication),
             startReason = eq(ProfilingStartReason.CONTINUOUS),
             additionalAttributes = eq(emptyMap()),
-            sdkInstanceNames = eq(setOf(fakeInstanceName)),
             durationMs = any()
         )
         assertThat(testedScheduler.isActive).isTrue()
@@ -622,7 +619,6 @@ internal class ContinuousProfilingSchedulerTest {
 
         // Then
         verify(mockProfiler, atLeastOnce()).start(
-            any(),
             any(),
             any(),
             any(),
@@ -706,7 +702,7 @@ internal class ContinuousProfilingSchedulerTest {
         testedScheduler.onBackground()
 
         // Then
-        verify(mockProfiler, never()).stop(any())
+        verify(mockProfiler, never()).stop()
     }
 
     @Test
@@ -720,7 +716,7 @@ internal class ContinuousProfilingSchedulerTest {
 
         // Then
         assertThat(testedScheduler.state).isEqualTo(ContinuousProfilingScheduler.State.ACTIVE)
-        verify(mockProfiler, never()).start(any(), any(), any(), any(), eq(0))
+        verify(mockProfiler, never()).start(any(), any(), any(), eq(0))
     }
 
     @Test
@@ -739,7 +735,7 @@ internal class ContinuousProfilingSchedulerTest {
         runnableCaptor.lastValue.run()
 
         // Then
-        verify(mockProfiler).stop(fakeInstanceName)
+        verify(mockProfiler).stop()
     }
 
     @Test
@@ -801,7 +797,7 @@ internal class ContinuousProfilingSchedulerTest {
         testedScheduler.onBackground()
 
         // Then
-        verify(mockProfiler, never()).stop(any())
+        verify(mockProfiler, never()).stop()
         verify(mockFuture, never()).cancel(any())
     }
 
@@ -811,7 +807,7 @@ internal class ContinuousProfilingSchedulerTest {
         testedScheduler.onForeground()
 
         // Then
-        verify(mockProfiler, never()).start(any(), any(), any(), any(), any())
+        verify(mockProfiler, never()).start(any(), any(), any(), any())
         verify(mockSchedulerExecutor, never()).schedule(any<Runnable>(), any(), any())
     }
 

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -89,16 +89,10 @@ class PerfettoProfilerTest {
     private lateinit var mockProfilerCallback: ProfilerCallback
 
     @Mock
-    private lateinit var mockOtherProfilerCallback: ProfilerCallback
-
-    @Mock
     private lateinit var mockAnrRegistrar: AnrTriggerRegistrar
 
     @Mock
     private lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
-
-    @StringForgery
-    private lateinit var fakeInstanceName: String
 
     private val callbackCaptor = argumentCaptor<Consumer<ProfilingResult>>()
 
@@ -107,9 +101,6 @@ class PerfettoProfilerTest {
 
     @StringForgery
     private lateinit var fakePath: String
-
-    private val otherInstanceName: String
-        get() = "$fakeInstanceName.suffix"
 
     private val stubTimeProvider: StubTimeProvider = StubTimeProvider()
 
@@ -130,14 +121,13 @@ class PerfettoProfilerTest {
             }
         )
         testedProfiler.internalLogger = mockInternalLogger
-        testedProfiler.registerProfilingCallback(mockContext, fakeInstanceName, mockProfilerCallback)
-        testedProfiler.registerProfilingCallback(mockContext, otherInstanceName, mockOtherProfilerCallback)
+        testedProfiler.registerProfilingCallback(mockContext, mockProfilerCallback)
     }
 
     @Test
     fun `M request profiling stack sampling W start()`() {
         // When
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
 
         // Then
         verify(mockService)
@@ -166,26 +156,8 @@ class PerfettoProfilerTest {
     @Test
     fun `M request profiling stack sampling only once W several call start(){ same instance }`() {
         // When
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
-
-        // Then
-        verify(mockService)
-            .requestProfiling(
-                eq(ProfilingManager.PROFILING_TYPE_STACK_SAMPLING),
-                any<Bundle>(),
-                any<String>(),
-                any<CancellationSignal>(),
-                any(),
-                any()
-            )
-    }
-
-    @Test
-    fun `M request profiling stack sampling only once W several call start(){ different instance }`() {
-        // When
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(otherInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
 
         // Then
         verify(mockService)
@@ -210,7 +182,7 @@ class PerfettoProfilerTest {
         stubTimeProvider.stopTime = fakeStartTime + fakeDuration
 
         // When
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
 
         // Then
         val stopSignalCaptor = argumentCaptor<CancellationSignal>()
@@ -275,7 +247,7 @@ class PerfettoProfilerTest {
         stubTimeProvider.stopTime = fakeStartTime + fakeDuration
 
         // When
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
 
         // Then
         verify(mockService)
@@ -339,7 +311,7 @@ class PerfettoProfilerTest {
         testedProfiler.internalLogger = null
 
         // When
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
         testedProfiler.internalLogger = mockInternalLogger
 
         verify(mockService)
@@ -402,7 +374,7 @@ class PerfettoProfilerTest {
         stubTimeProvider.stopTime = fakeStartTime + fakeDuration
 
         // When
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
 
         verify(mockService)
             .requestProfiling(
@@ -421,7 +393,7 @@ class PerfettoProfilerTest {
         callbackCaptor.firstValue.accept(mockResult)
 
         // Then
-        assertThat(testedProfiler.isRunning(fakeInstanceName)).isFalse
+        assertThat(testedProfiler.isRunning()).isFalse
     }
 
     @Test
@@ -435,7 +407,7 @@ class PerfettoProfilerTest {
         stubTimeProvider.stopTime = fakeStartTime + fakeDuration
 
         // When
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
 
         verify(mockService)
             .requestProfiling(
@@ -454,13 +426,13 @@ class PerfettoProfilerTest {
         callbackCaptor.firstValue.accept(mockResult)
 
         // Then
-        assertThat(testedProfiler.isRunning(fakeInstanceName)).isFalse
+        assertThat(testedProfiler.isRunning()).isFalse
     }
 
     @Test
     fun `M return false W isRunning { profiler not started }`() {
         // When
-        val status = testedProfiler.isRunning(fakeInstanceName)
+        val status = testedProfiler.isRunning()
 
         // Then
         assertThat(status).isFalse
@@ -471,7 +443,7 @@ class PerfettoProfilerTest {
         @IntForgery(min = 1) fakeErrorCode: Int
     ) {
         // Given
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
         verify(mockService).requestProfiling(any(), any(), any(), any(), any(), callbackCaptor.capture())
 
         val mockResult = mock<ProfilingResult> {
@@ -490,7 +462,7 @@ class PerfettoProfilerTest {
     @Test
     fun `M call onFailure W callback is called {null file path}`() {
         // Given
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
         verify(mockService).requestProfiling(any(), any(), any(), any(), any(), callbackCaptor.capture())
 
         val mockResult = mock<ProfilingResult> {
@@ -512,7 +484,7 @@ class PerfettoProfilerTest {
         @StringForgery fakePath: String
     ) {
         // Given
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
         verify(mockService).requestProfiling(any(), any(), any(), any(), any(), callbackCaptor.capture())
 
         val mockResult = mock<ProfilingResult> {
@@ -532,32 +504,20 @@ class PerfettoProfilerTest {
     @Test
     fun `M return true W isRunning { profiler started }`() {
         // Given
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
 
         // When
-        val status = testedProfiler.isRunning(fakeInstanceName)
+        val status = testedProfiler.isRunning()
 
         // Then
         assertThat(status).isTrue
     }
 
     @Test
-    fun `M return false W isRunning in other instance`() {
+    fun `M return false W isRunning { profiler stopped}`() {
         // Given
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(otherInstanceName))
-
-        // When
-        val status = testedProfiler.isRunning(fakeInstanceName)
-
-        // Then
-        assertThat(status).isFalse
-    }
-
-    @Test
-    fun `M return false W isRunning { profiler stopped by same instance}`() {
-        // Given
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
-        testedProfiler.stop(fakeInstanceName)
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
+        testedProfiler.stop()
 
         // When
         verify(mockService)
@@ -577,31 +537,17 @@ class PerfettoProfilerTest {
         callbackCaptor.firstValue.accept(successResult)
 
         // Then
-        val status = testedProfiler.isRunning(fakeInstanceName)
+        val status = testedProfiler.isRunning()
         assertThat(status).isFalse
     }
 
     @Test
-    fun `M return true W isRunning { profiler stopped by other instance}`() {
-        // Given
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
-        testedProfiler.stop(otherInstanceName)
-
-        // When
-        val status = testedProfiler.isRunning(fakeInstanceName)
-
-        // Then
-        assertThat(status).isTrue
-    }
-
-    @Test
-    fun `M call the all the instance's callback W several call start()`() {
+    fun `M call the registered callback W start()`() {
         // When
         testedProfiler.start(
             mockContext,
             ProfilingStartReason.APPLICATION_LAUNCH,
-            emptyMap(),
-            setOf(fakeInstanceName, otherInstanceName)
+            emptyMap()
         )
 
         // Then
@@ -621,33 +567,6 @@ class PerfettoProfilerTest {
             on { resultFilePath } doReturn fakePath
         }
         callbackCaptor.firstValue.accept(successResult)
-        verify(mockOtherProfilerCallback).onSuccess(any())
-        verify(mockProfilerCallback).onSuccess(any())
-    }
-
-    @Test
-    fun `M not call the instance's callback W call start without it()`() {
-        // When
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
-
-        // Then
-        val callbackCaptor = argumentCaptor<Consumer<ProfilingResult>>()
-        verify(mockService)
-            .requestProfiling(
-                eq(ProfilingManager.PROFILING_TYPE_STACK_SAMPLING),
-                any<Bundle>(),
-                any<String>(),
-                any<CancellationSignal>(),
-                any(),
-                callbackCaptor.capture()
-            )
-
-        val successResult = mock<ProfilingResult> {
-            on { errorCode } doReturn ProfilingResult.ERROR_NONE
-            on { resultFilePath } doReturn fakePath
-        }
-        callbackCaptor.firstValue.accept(successResult)
-        verifyNoInteractions(mockOtherProfilerCallback)
         verify(mockProfilerCallback).onSuccess(any())
     }
 
@@ -661,8 +580,8 @@ class PerfettoProfilerTest {
         stubTimeProvider.stopTime = fakeStartTime + fakeDuration
 
         // When
-        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap(), setOf(fakeInstanceName))
-        testedProfiler.unregisterProfilingCallback(mockContext, fakeInstanceName)
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
+        testedProfiler.unregisterProfilingCallback(mockContext)
 
         // Then
         verify(mockService)
@@ -692,11 +611,10 @@ class PerfettoProfilerTest {
             testedProfiler.start(
                 mockContext,
                 ProfilingStartReason.APPLICATION_LAUNCH,
-                emptyMap(),
-                setOf(fakeInstanceName)
+                emptyMap()
             )
             val stopSignalCaptor = argumentCaptor<CancellationSignal>()
-            testedProfiler.stop(fakeInstanceName)
+            testedProfiler.stop()
 
             verify(mockService).requestProfiling(
                 eq(ProfilingManager.PROFILING_TYPE_STACK_SAMPLING),
@@ -717,8 +635,7 @@ class PerfettoProfilerTest {
             testedProfiler.start(
                 mockContext,
                 ProfilingStartReason.APPLICATION_LAUNCH,
-                emptyMap(),
-                setOf(fakeInstanceName)
+                emptyMap()
             )
             verify(mockService).requestProfiling(
                 eq(ProfilingManager.PROFILING_TYPE_STACK_SAMPLING),
@@ -746,8 +663,7 @@ class PerfettoProfilerTest {
         testedProfiler.start(
             mockContext,
             ProfilingStartReason.APPLICATION_LAUNCH,
-            mapOf(PerfettoProfiler.TELEMETRY_KEY_APP_START_INFO to fakeAppStartInfo),
-            setOf(fakeInstanceName)
+            mapOf(PerfettoProfiler.TELEMETRY_KEY_APP_START_INFO to fakeAppStartInfo)
         )
 
         // Then
@@ -809,7 +725,7 @@ class PerfettoProfilerTest {
         stubTimeProvider.stopTime = fakeStartTime + fakeDuration
 
         // When
-        testedProfiler.start(mockContext, startReason, emptyMap(), setOf(fakeInstanceName))
+        testedProfiler.start(mockContext, startReason, emptyMap())
 
         // Then
         verify(mockService)
@@ -879,10 +795,9 @@ class PerfettoProfilerTest {
         testedProfiler.start(
             mockContext,
             ProfilingStartReason.APPLICATION_LAUNCH,
-            emptyMap(),
-            setOf(fakeInstanceName)
+            emptyMap()
         )
-        testedProfiler.stop(fakeInstanceName)
+        testedProfiler.stop()
 
         verify(mockService)
             .requestProfiling(
@@ -946,10 +861,9 @@ class PerfettoProfilerTest {
         testedProfiler.start(
             mockContext,
             ProfilingStartReason.APPLICATION_LAUNCH,
-            emptyMap(),
-            setOf(fakeInstanceName)
+            emptyMap()
         )
-        testedProfiler.stop(fakeInstanceName)
+        testedProfiler.stop()
 
         verify(mockService)
             .requestProfiling(
@@ -976,8 +890,7 @@ class PerfettoProfilerTest {
         testedProfiler.start(
             mockContext,
             ProfilingStartReason.CONTINUOUS,
-            emptyMap(),
-            setOf(fakeInstanceName)
+            emptyMap()
         )
 
         val callbackCaptor2 = argumentCaptor<Consumer<ProfilingResult>>()
@@ -1031,8 +944,7 @@ class PerfettoProfilerTest {
         testedProfiler.start(
             mockContext,
             ProfilingStartReason.APPLICATION_LAUNCH,
-            emptyMap(),
-            setOf(fakeInstanceName)
+            emptyMap()
         )
 
         // Then
@@ -1056,8 +968,7 @@ class PerfettoProfilerTest {
         testedProfiler.start(
             mockContext,
             startReason,
-            emptyMap(),
-            setOf(fakeInstanceName)
+            emptyMap()
         )
 
         // Then
@@ -1072,8 +983,7 @@ class PerfettoProfilerTest {
         testedProfiler.start(
             mockContext,
             ProfilingStartReason.APPLICATION_LAUNCH,
-            emptyMap(),
-            setOf(fakeInstanceName)
+            emptyMap()
         )
         val timerRunnableCaptor = argumentCaptor<Runnable>()
         verify(mockExecutorService).schedule(timerRunnableCaptor.capture(), any(), any())
@@ -1094,8 +1004,7 @@ class PerfettoProfilerTest {
         testedProfiler.start(
             mockContext,
             ProfilingStartReason.APPLICATION_LAUNCH,
-            emptyMap(),
-            setOf(fakeInstanceName)
+            emptyMap()
         )
         val timerRunnableCaptor = argumentCaptor<Runnable>()
         verify(mockExecutorService).schedule(timerRunnableCaptor.capture(), any(), any())
@@ -1113,28 +1022,22 @@ class PerfettoProfilerTest {
 
     @Test
     fun `M delegate to registrar W registerProfilingCallback`() {
-        // Set-up performs 2 registerProfilingCallback calls. Each delegates to the registrar,
-        // passing the profiler's fan-out listener; the registrar handles its own idempotency.
-        verify(mockAnrRegistrar, times(2)).register(mockContext, testedProfiler.anrListener)
+        // Set-up performs 1 registerProfilingCallback call, which delegates to the registrar,
+        // passing the profiler's listener.
+        verify(mockAnrRegistrar).register(mockContext, testedProfiler.anrListener)
     }
 
     @Test
-    fun `M call registrar unregister W last callback removed`() {
+    fun `M call registrar unregister W callback removed`() {
         // When
-        testedProfiler.unregisterProfilingCallback(mockContext, fakeInstanceName)
-
-        // Then
-        verify(mockAnrRegistrar, never()).unregister(any())
-
-        // When
-        testedProfiler.unregisterProfilingCallback(mockContext, otherInstanceName)
+        testedProfiler.unregisterProfilingCallback(mockContext)
 
         // Then
         verify(mockAnrRegistrar).unregister(mockContext)
     }
 
     @Test
-    fun `M fan out to all callbacks W AnrListener fires`(
+    fun `M dispatch to registered callback W AnrListener fires`(
         @Forgery fakeEvent: ProfilingAnrDetectedEvent
     ) {
         // When
@@ -1142,7 +1045,6 @@ class PerfettoProfilerTest {
 
         // Then
         verify(mockProfilerCallback).onAnrDetected(fakeEvent)
-        verify(mockOtherProfilerCallback).onAnrDetected(fakeEvent)
     }
 
     @Test
@@ -1158,29 +1060,14 @@ class PerfettoProfilerTest {
     }
 
     @Test
-    fun `M not call registrar unregister W unregisterProfilingCallback {unknown sdkInstanceName}`(
-        @StringForgery fakeUnknownInstance: String
-    ) {
+    fun `M not delegate to registrar W registerProfilingCallback {SDK below BAKLAVA}`() {
         // Given
-
-        // When
-        testedProfiler.unregisterProfilingCallback(mockContext, fakeUnknownInstance)
-
-        // Then
-        verify(mockAnrRegistrar, never()).unregister(any())
-    }
-
-    @Test
-    fun `M not delegate to registrar W registerProfilingCallback {SDK below BAKLAVA}`(
-        @StringForgery anotherInstanceName: String
-    ) {
-        // Given
-        // Drop interactions recorded by the BAKLAVA-stubbed set-up calls.
+        // Drop interactions recorded by the BAKLAVA-stubbed set-up call.
         reset(mockAnrRegistrar)
         whenever(mockBuildSdkVersionProvider.isAtLeastBaklava) doReturn false
 
         // When
-        testedProfiler.registerProfilingCallback(mockContext, anotherInstanceName, mockProfilerCallback)
+        testedProfiler.registerProfilingCallback(mockContext, mockProfilerCallback)
 
         // Then
         verify(mockAnrRegistrar, never()).register(any(), any())
@@ -1192,8 +1079,7 @@ class PerfettoProfilerTest {
         whenever(mockBuildSdkVersionProvider.isAtLeastBaklava) doReturn false
 
         // When
-        testedProfiler.unregisterProfilingCallback(mockContext, fakeInstanceName)
-        testedProfiler.unregisterProfilingCallback(mockContext, otherInstanceName)
+        testedProfiler.unregisterProfilingCallback(mockContext)
 
         // Then
         verify(mockAnrRegistrar, never()).unregister(any())

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingStorageTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingStorageTest.kt
@@ -9,7 +9,6 @@ package com.datadog.android.profiling.internal
 import android.content.Context
 import android.content.SharedPreferences
 import fr.xgouchet.elmyr.annotation.FloatForgery
-import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -21,7 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.never
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -44,14 +43,8 @@ internal class ProfilingStorageTest {
     @Mock
     lateinit var mockEditor: SharedPreferences.Editor
 
-    @StringForgery
-    lateinit var fakeInstanceName: String
-
     @FloatForgery(min = 0f, max = 100f)
     var fakeSampleRate: Float = 0f
-
-    private val otherInstanceName: String
-        get() = "$fakeInstanceName.suffix"
 
     @BeforeEach
     fun `set up`() {
@@ -66,76 +59,64 @@ internal class ProfilingStorageTest {
         whenever(mockEditor.putFloat(any(), any())) doReturn mockEditor
         whenever(mockEditor.putInt(any(), any())) doReturn mockEditor
         whenever(mockEditor.putString(any(), any())) doReturn mockEditor
-        whenever(mockEditor.putStringSet(any(), any())) doReturn mockEditor
     }
 
     @Test
     fun `M add flag W addProfilingFlag()`() {
         // When
-        ProfilingStorage.addProfilingFlag(mockContext, fakeInstanceName)
+        ProfilingStorage.addProfilingFlag(mockContext)
 
         // Then
-        verify(mockEditor).putStringSet("dd_profiling_enabled", setOf(fakeInstanceName))
+        verify(mockEditor).putBoolean("dd_profiling_enabled", true)
         verify(mockEditor).apply()
     }
 
     @Test
     fun `M return true W isProfilingEnabled() {flag is set}`() {
         // Given
-        whenever(mockPrefs.getStringSet("dd_profiling_enabled", emptySet())) doReturn setOf(
-            fakeInstanceName
-        )
+        whenever(mockPrefs.getBoolean("dd_profiling_enabled", false)) doReturn true
 
         // When
-        val actualInstanceName = ProfilingStorage.getProfilingEnabledInstanceNames(mockContext)
+        val actual = ProfilingStorage.isProfilingEnabled(mockContext)
 
         // Then
-        assertThat(actualInstanceName).isEqualTo(setOf(fakeInstanceName))
+        assertThat(actual).isTrue
     }
 
     @Test
     fun `M return false W isProfilingEnabled() {flag is not set}`() {
         // Given
-        whenever(mockPrefs.getString("dd_profiling_enabled", null)) doReturn null
+        whenever(mockPrefs.getBoolean("dd_profiling_enabled", false)) doReturn false
 
         // When
-        val actualInstanceName = ProfilingStorage.getProfilingEnabledInstanceNames(mockContext)
+        val actual = ProfilingStorage.isProfilingEnabled(mockContext)
 
         // Then
-        assertThat(actualInstanceName).isEqualTo(emptySet<String>())
+        assertThat(actual).isFalse
     }
 
     @Test
-    fun `M remove flag W removeProfilingFlag(){ same instance name }`() {
+    fun `M return false W isProfilingEnabled() {stale StringSet value stored}`() {
         // Given
-        whenever(
-            mockPrefs
-                .getStringSet("dd_profiling_enabled", emptySet())
-        ).doReturn(setOf(fakeInstanceName))
+        // An app upgrading from a version that stored a StringSet under the same key would hit a
+        // ClassCastException on getBoolean; SharedPreferencesStorage swallows it and returns default.
+        whenever(mockPrefs.getBoolean("dd_profiling_enabled", false)) doThrow ClassCastException()
 
         // When
-        ProfilingStorage.removeProfilingFlag(mockContext, setOf(fakeInstanceName))
+        val actual = ProfilingStorage.isProfilingEnabled(mockContext)
 
         // Then
-        verify(mockEditor).putStringSet("dd_profiling_enabled", emptySet<String>())
+        assertThat(actual).isFalse
+    }
+
+    @Test
+    fun `M remove flag W removeProfilingFlag()`() {
+        // When
+        ProfilingStorage.removeProfilingFlag(mockContext)
+
+        // Then
+        verify(mockEditor).remove("dd_profiling_enabled")
         verify(mockEditor).apply()
-    }
-
-    @Test
-    fun `M remove flag W removeProfilingFlag(){ different instance name }`() {
-        // Given
-        whenever(
-            mockPrefs
-                .getStringSet("dd_profiling_enabled", null)
-        ) doReturn setOf(
-            fakeInstanceName
-        )
-
-        // When
-        ProfilingStorage.removeProfilingFlag(mockContext, setOf(otherInstanceName))
-
-        // Then
-        verify(mockEditor, never()).putStringSet("dd_profiling_enabled", emptySet<String>())
     }
 
     @Test
@@ -146,7 +127,7 @@ internal class ProfilingStorageTest {
         // When
         repeat(10) {
             Thread {
-                ProfilingStorage.addProfilingFlag(mockContext, fakeInstanceName)
+                ProfilingStorage.addProfilingFlag(mockContext)
                 latch.countDown()
             }.start()
         }
@@ -157,27 +138,6 @@ internal class ProfilingStorageTest {
             DATADOG_PREFERENCES_FILE_NAME,
             Context.MODE_PRIVATE
         )
-    }
-
-    @Test
-    fun `M preserved the existing instance name W adding a new instance name`() {
-        // Given
-        whenever(
-            mockPrefs
-                .getStringSet("dd_profiling_enabled", emptySet<String>())
-        ) doReturn setOf(
-            otherInstanceName
-        )
-
-        // When
-        ProfilingStorage.addProfilingFlag(mockContext, fakeInstanceName)
-
-        // Then
-        verify(mockEditor).putStringSet(
-            "dd_profiling_enabled",
-            setOf(fakeInstanceName, otherInstanceName)
-        )
-        verify(mockEditor).apply()
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

Removes multi-instance support from the Profiling feature. Profiling now supports a single SDK instance:

- `Profiling.enable()` warns (to USER) and skips registration if profiling is already enabled on another still-active SDK core, mirroring the existing `SessionReplay.enable()` guard (WeakReference<SdkCore> + isCoreActive()). The check-and-set is synchronized to guard against concurrent enable() calls.
- Internal per-instance machinery is collapsed: Profiler.start/stop/isRunning/registerProfilingCallback/unregisterProfilingCallback drop their instance-name/Set<String> params; PerfettoProfiler uses a single AtomicBoolean + single callback instead of a Set + ConcurrentHashMap; ProfilingStorage uses a boolean flag under dd_profiling_enabled instead of a StringSet.

### Motivation

We decided to drop the multi-instance capability. Enabling profiling from multiple SDK instances is now unsupported and should fail safely with a clear warning rather than silently sharing one profiler.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

