### PR TITLE
RUM-17619: Fix deadlock/ANR in DatadogRumMonitor.handleEvent on JVM crash

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -130,7 +130,7 @@ interface com.datadog.android.api.feature.FeatureScope
   val dataStore: com.datadog.android.api.storage.datastore.DataStoreHandler
   fun withWriteContext(Set<String> = emptySet(), (com.datadog.android.api.context.DatadogContext) -> Unit)
   fun withContext(Set<String> = emptySet(), (com.datadog.android.api.context.DatadogContext) -> Unit)
-  fun getWriteContextSync(Set<String> = emptySet()): Pair<com.datadog.android.api.context.DatadogContext, EventWriteScope>?
+  fun withWriteContextSync(Set<String> = emptySet(), (com.datadog.android.api.context.DatadogContext) -> Unit): Boolean
   fun sendEvent(Any)
   fun <T: Feature> unwrap(): T
 typealias EventWriteScope = ((com.datadog.android.api.storage.EventBatchWriter) -> Unit) -> Unit

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -414,17 +414,17 @@ public abstract interface class com/datadog/android/api/feature/FeatureEventRece
 
 public abstract interface class com/datadog/android/api/feature/FeatureScope {
 	public abstract fun getDataStore ()Lcom/datadog/android/api/storage/datastore/DataStoreHandler;
-	public abstract fun getWriteContextSync (Ljava/util/Set;)Lkotlin/Pair;
 	public abstract fun sendEvent (Ljava/lang/Object;)V
 	public abstract fun unwrap ()Lcom/datadog/android/api/feature/Feature;
 	public abstract fun withContext (Ljava/util/Set;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun withWriteContext (Ljava/util/Set;Lkotlin/jvm/functions/Function2;)V
+	public abstract fun withWriteContextSync (Ljava/util/Set;Lkotlin/jvm/functions/Function2;)Z
 }
 
 public final class com/datadog/android/api/feature/FeatureScope$DefaultImpls {
-	public static synthetic fun getWriteContextSync$default (Lcom/datadog/android/api/feature/FeatureScope;Ljava/util/Set;ILjava/lang/Object;)Lkotlin/Pair;
 	public static synthetic fun withContext$default (Lcom/datadog/android/api/feature/FeatureScope;Ljava/util/Set;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun withWriteContext$default (Lcom/datadog/android/api/feature/FeatureScope;Ljava/util/Set;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static synthetic fun withWriteContextSync$default (Lcom/datadog/android/api/feature/FeatureScope;Ljava/util/Set;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Z
 }
 
 public final class com/datadog/android/api/feature/FeatureScopeExtKt {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureScope.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureScope.kt
@@ -52,7 +52,6 @@ interface FeatureScope {
         callback: (datadogContext: DatadogContext) -> Unit
     )
 
-    // TODO RUM-9852 Implement better passthrough mechanism for the JVM crash scenario
     /**
      * Same as [withWriteContext] but will be executed in the blocking manner.
      *

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureScope.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureScope.kt
@@ -53,17 +53,30 @@ interface FeatureScope {
     )
 
     /**
-     * Same as [withWriteContext] but will be executed in the blocking manner.
+     * Same as [withWriteContext], but blocks the calling thread until [callback] has returned.
+     *
+     * The callback still runs on the context processing worker thread, so the calling thread must not
+     * hold any lock that [callback] may need, otherwise the two will deadlock.
      *
      * @param withFeatureContexts Feature contexts ([DatadogContext.featuresContext] property) to include
      * in the [DatadogContext] provided. The value should be the feature names as declared by [Feature.name].
      * Default is empty, meaning that no feature contexts will be included.
+     * @param callback an operation called with an up-to-date [DatadogContext]
+     * and an [EventWriteScope]. Callback will be executed on a single context processing worker thread. Execution of
+     * [EventWriteScope] will be done on a worker thread from I/O pool.
+     * [DatadogContext] is a snapshot taken when [callback] starts executing, which is once every context
+     * operation scheduled before this call has completed.
+     * @return `true` if [callback] was executed, `false` if it could not be, for example because the
+     * SDK core is not initialized or the operation could not be scheduled.
      *
      * **NOTE**: This API is for the internal use only and is not guaranteed to be stable.
      */
     @AnyThread
     @InternalApi
-    fun getWriteContextSync(withFeatureContexts: Set<String> = emptySet()): Pair<DatadogContext, EventWriteScope>?
+    fun withWriteContextSync(
+        withFeatureContexts: Set<String> = emptySet(),
+        callback: (datadogContext: DatadogContext, write: EventWriteScope) -> Unit
+    ): Boolean
 
     /**
      * Send event to a given feature. It will be sent in a synchronous way.

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -215,22 +215,24 @@ internal class SdkFeature(
         )
     }
 
-    override fun getWriteContextSync(
-        withFeatureContexts: Set<String>
-    ): Pair<DatadogContext, EventWriteScope>? {
-        val operationName = "getWriteContextSync-${wrappedFeature.name}"
+    override fun withWriteContextSync(
+        withFeatureContexts: Set<String>,
+        callback: (DatadogContext, EventWriteScope) -> Unit
+    ): Boolean {
+        val operationName = "withWriteContextSync-${wrappedFeature.name}"
         return coreFeature.contextExecutorService
             .submitSafe(
                 operationName,
                 internalLogger,
                 Callable {
-                    if (!coreFeature.initialized.get()) return@Callable null
+                    if (!coreFeature.initialized.get()) return@Callable false
                     val context = contextProvider.getContext(withFeatureContexts)
                     val eventBatchWriteScope = storage.getEventWriteScope(context)
-                    context to eventBatchWriteScope
+                    callback(context, eventBatchWriteScope)
+                    true
                 }
             )
-            .getSafe(operationName, internalLogger)
+            .getSafe(operationName, internalLogger) ?: false
     }
 
     override fun sendEvent(event: Any) {

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -565,7 +565,36 @@ internal class SdkFeatureTest {
     }
 
     @Test
-    fun `M provide write context W getWriteContextSync()`(
+    fun `M provide write context W withWriteContextSync(callback)`(
+        @Forgery fakeContext: DatadogContext,
+        @StringForgery fakeWithFeatureContexts: Set<String>,
+        @Mock mockEventWriteScope: EventWriteScope
+    ) {
+        // Given
+        testedFeature.storage = mockStorage
+        val callback = mock<(DatadogContext, EventWriteScope) -> Unit>()
+        whenever(mockContextProvider.getContext(fakeWithFeatureContexts)) doReturn fakeContext
+        whenever(coreFeature.mockInstance.contextExecutorService.submit(any<Callable<Boolean>>())) doAnswer {
+            val result = it.getArgument<Callable<Boolean>>(0).call()
+            mock<Future<Boolean>>().apply {
+                whenever(get()) doReturn result
+            }
+        }
+
+        whenever(
+            mockStorage.getEventWriteScope(fakeContext)
+        ) doReturn mockEventWriteScope
+
+        // When
+        val result = testedFeature.withWriteContextSync(fakeWithFeatureContexts, callback = callback)
+
+        // Then
+        verify(callback).invoke(fakeContext, mockEventWriteScope)
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `M wait for the callback W withWriteContextSync(callback)`(
         @Forgery fakeContext: DatadogContext,
         @StringForgery fakeWithFeatureContexts: Set<String>,
         @Mock mockEventWriteScope: EventWriteScope
@@ -573,89 +602,91 @@ internal class SdkFeatureTest {
         // Given
         testedFeature.storage = mockStorage
         whenever(mockContextProvider.getContext(fakeWithFeatureContexts)) doReturn fakeContext
-        whenever(coreFeature.mockInstance.contextExecutorService.submit(any<Callable<*>>())) doAnswer {
-            val callable = it.getArgument<Callable<Pair<DatadogContext, EventWriteScope>>>(0)
-            mock<Future<*>>().apply {
-                whenever(get()) doAnswer { callable.call() }
+        whenever(mockStorage.getEventWriteScope(fakeContext)) doReturn mockEventWriteScope
+        // the submitted task only runs when the future is awaited, so the callback can only have been
+        // invoked if withWriteContextSync blocked on it
+        whenever(coreFeature.mockInstance.contextExecutorService.submit(any<Callable<Boolean>>())) doAnswer {
+            val submittedTask = it.getArgument<Callable<Boolean>>(0)
+            mock<Future<Boolean>>().apply {
+                whenever(get()) doAnswer { submittedTask.call() }
             }
         }
-
-        whenever(
-            mockStorage.getEventWriteScope(fakeContext)
-        ) doReturn mockEventWriteScope
+        var callbackInvoked = false
 
         // When
-        val writeContext = testedFeature.getWriteContextSync(fakeWithFeatureContexts)
+        testedFeature.withWriteContextSync(fakeWithFeatureContexts) { _, _ -> callbackInvoked = true }
 
         // Then
-        checkNotNull(writeContext)
-        assertThat(writeContext.first).isEqualTo(fakeContext)
-        assertThat(writeContext.second).isEqualTo(mockEventWriteScope)
+        assertThat(callbackInvoked).isTrue()
     }
 
     @Test
-    fun `M provide null write context W getWriteContextSync() { task rejected }`(
-        @Forgery fakeContext: DatadogContext,
-        @Mock mockEventWriteScope: EventWriteScope
+    fun `M not provide write context W withWriteContextSync(callback) { task rejected }`(
+        @StringForgery fakeWithFeatureContexts: Set<String>
     ) {
         // Given
         testedFeature.storage = mockStorage
+        val callback = mock<(DatadogContext, EventWriteScope) -> Unit>()
         whenever(
-            coreFeature.mockInstance.contextExecutorService.submit(any<Callable<*>>())
+            coreFeature.mockInstance.contextExecutorService.submit(any<Callable<Boolean>>())
         ) doThrow RejectedExecutionException()
 
-        whenever(
-            mockStorage.getEventWriteScope(fakeContext)
-        ) doReturn mockEventWriteScope
-
         // When
-        val writeContext = testedFeature.getWriteContextSync()
+        val result = testedFeature.withWriteContextSync(fakeWithFeatureContexts, callback = callback)
 
         // Then
-        assertThat(writeContext).isNull()
+        verifyNoInteractions(callback, mockContextProvider, mockStorage)
+        assertThat(result).isFalse()
     }
 
     @Test
-    fun `M provide null write context W getWriteContextSync() { failed to get task result }`(
-        @Forgery fakeContext: DatadogContext,
-        @Mock mockEventWriteScope: EventWriteScope,
+    fun `M not throw W withWriteContextSync(callback) { failed to get task result }`(
+        @StringForgery fakeWithFeatureContexts: Set<String>,
         forge: Forge
     ) {
         // Given
         testedFeature.storage = mockStorage
+        val callback = mock<(DatadogContext, EventWriteScope) -> Unit>()
         val throwable = forge.anElementFrom(
             CancellationException(),
             ExecutionException(forge.aThrowable()),
             InterruptedException()
         )
-        whenever(coreFeature.mockInstance.contextExecutorService.submit(any<Callable<*>>())) doAnswer {
-            mock<Future<*>>().apply {
+        whenever(coreFeature.mockInstance.contextExecutorService.submit(any<Callable<Boolean>>())) doAnswer {
+            mock<Future<Boolean>>().apply {
                 whenever(get()) doThrow throwable
             }
         }
 
-        whenever(
-            mockStorage.getEventWriteScope(fakeContext)
-        ) doReturn mockEventWriteScope
-
         // When
-        val writeContext = testedFeature.getWriteContextSync()
+        val result = testedFeature.withWriteContextSync(fakeWithFeatureContexts, callback = callback)
 
         // Then
-        assertThat(writeContext).isNull()
+        verifyNoInteractions(callback)
+        assertThat(result).isFalse()
     }
 
     @Test
-    fun `M provide null write context W getWriteContextSync() { CoreFeature is not initialized }`() {
+    fun `M not provide write context W withWriteContextSync(callback) { CoreFeature is not initialized }`(
+        @StringForgery fakeWithFeatureContexts: Set<String>
+    ) {
         // Given
+        testedFeature.storage = mockStorage
+        val callback = mock<(DatadogContext, EventWriteScope) -> Unit>()
         whenever(coreFeature.mockInstance.initialized) doReturn AtomicBoolean(false)
+        whenever(coreFeature.mockInstance.contextExecutorService.submit(any<Callable<Boolean>>())) doAnswer {
+            val taskResult = it.getArgument<Callable<Boolean>>(0).call()
+            mock<Future<Boolean>>().apply {
+                whenever(get()) doReturn taskResult
+            }
+        }
 
         // When
-        val writeContext = testedFeature.getWriteContextSync()
+        val result = testedFeature.withWriteContextSync(fakeWithFeatureContexts, callback = callback)
 
         // Then
-        assertThat(writeContext).isNull()
-        verifyNoInteractions(mockContextProvider, mockStorage)
+        verifyNoInteractions(callback, mockContextProvider, mockStorage)
+        assertThat(result).isFalse()
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -917,19 +917,24 @@ internal class DatadogRumMonitor(
         }
     }
 
-    internal fun handleEvent(event: RumRawEvent) {
-        if (event is RumRawEvent.AddError && event.isFatal) {
-            // Fetch the write context BEFORE acquiring the rootScope lock (RUM-17619).
-            // The normal-event path acquires the lock inside the context-thread callback, i.e.
-            // context-thread → pipeline-thread → synchronized(rootScope).
-            // If we called getWriteContextSync while holding the lock we would invert that order:
-            // synchronized(rootScope) → getWriteContextSync (waits for context thread) → deadlock.
-            val writeContext = sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
-                ?.getWriteContextSync(withFeatureContexts = setOf(Feature.SESSION_REPLAY_FEATURE_NAME))
-            if (writeContext != null) {
-                val (datadogContext, eventWriteScope) = writeContext
+    @Suppress("NestedBlockDepth", "LongMethod")
+    private fun handleFatalEvent(event: RumRawEvent.AddError) {
+        // The normal-event path acquires resources in this order:
+        //   context-thread → pipeline-thread → synchronized(rootScope)
+        // Calling getWriteContextSync while holding synchronized(rootScope) would
+        // invert that order and deadlock. Fetch the write context first (no lock held),
+        // then inject the crash task into the pipeline queue via put() so it is
+        // serialized correctly and never dropped by back-pressure.
+        val writeContext = sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
+            ?.getWriteContextSync(withFeatureContexts = setOf(Feature.SESSION_REPLAY_FEATURE_NAME))
+        if (writeContext != null) {
+            val (datadogContext, eventWriteScope) = writeContext
+
+            @Suppress("UnsafeThirdPartyFunctionCall") // count is 1, cannot throw
+            val latch = CountDownLatch(1)
+            val crashTask = Runnable {
                 synchronized(rootScope) {
-                    @Suppress("ThreadSafety") // Crash handling, can't delegate to another thread
+                    @Suppress("ThreadSafety") // runs on the pipeline thread via crashTask
                     rootScope.handleEvent(event, datadogContext, eventWriteScope, writer)
                     val rumContext = currentRumContext()
                     sdkCore.updateFeatureContext(Feature.RUM_FEATURE_NAME) {
@@ -937,13 +942,59 @@ internal class DatadogRumMonitor(
                         rumContext?.toMap()?.let(it::putAll)
                     }
                 }
-            } else {
+                latch.countDown()
+            }
+            // put() blocks until a slot is available without dropping, unlike submit() which uses offer().
+            val pipelineQueue = (executorService as? ThreadPoolExecutor)?.queue
+            try {
+                if (pipelineQueue != null) {
+                    @Suppress("UnsafeThirdPartyFunctionCall") // InterruptedException is caught below
+                    pipelineQueue.put(crashTask)
+                } else {
+                    // Fallback for non-ThreadPoolExecutor implementations (e.g. tests).
+                    val submitted = executorService.submitSafe("Rum crash handling", sdkCore.internalLogger, crashTask)
+                    if (submitted == null) {
+                        sdkCore.internalLogger.log(
+                            InternalLogger.Level.WARN,
+                            InternalLogger.Target.USER,
+                            { CRASH_REPORTING_REJECTED_WARNING }
+                        )
+                        return
+                    }
+                }
+                val written = latch.await(CRASH_WRITE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                if (!written) {
+                    // Pipeline thread did not finish in time — run the crash task directly
+                    // on the crash thread as a best-effort fallback before the process dies.
+                    sdkCore.internalLogger.log(
+                        InternalLogger.Level.WARN,
+                        InternalLogger.Target.USER,
+                        { CRASH_REPORTING_TIMEOUT_WARNING }
+                    )
+                    crashTask.run()
+                }
+            } catch (e: InterruptedException) {
                 sdkCore.internalLogger.log(
                     InternalLogger.Level.WARN,
                     InternalLogger.Target.USER,
-                    { CANNOT_WRITE_CRASH_WRITE_CONTEXT_IS_NOT_AVAILABLE }
+                    { CRASH_REPORTING_INTERRUPTED_WARNING },
+                    e
                 )
+                @Suppress("UnsafeThirdPartyFunctionCall") // SecurityException not expected here
+                Thread.currentThread().interrupt()
             }
+        } else {
+            sdkCore.internalLogger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.USER,
+                { CANNOT_WRITE_CRASH_WRITE_CONTEXT_IS_NOT_AVAILABLE }
+            )
+        }
+    }
+
+    internal fun handleEvent(event: RumRawEvent) {
+        if (event is RumRawEvent.AddError && event.isFatal) {
+            handleFatalEvent(event)
         } else if (event is RumRawEvent.TelemetryEventWrapper) {
             telemetryEventHandler.handleEvent(event, writer)
         } else {
@@ -1083,11 +1134,23 @@ internal class DatadogRumMonitor(
         // should be aligned with CoreFeature#DRAIN_WAIT_SECONDS, but not a requirement
         internal const val DRAIN_WAIT_SECONDS = 10L
 
+        // Maximum time the crash thread waits for the pipeline to write the crash event.
+        internal const val CRASH_WRITE_TIMEOUT_MS = 500L
+
         internal const val RUM_DEBUG_RUM_NOT_ENABLED_WARNING =
             "Cannot switch RUM debugging, because RUM feature is not enabled."
 
         internal const val CANNOT_WRITE_CRASH_WRITE_CONTEXT_IS_NOT_AVAILABLE =
             "Cannot write JVM crash, because write context is not available."
+
+        internal const val CRASH_REPORTING_INTERRUPTED_WARNING =
+            "JVM crash reporting was interrupted, crash event may be lost."
+
+        internal const val CRASH_REPORTING_REJECTED_WARNING =
+            "JVM crash reporting was rejected by the executor, crash event may be lost."
+
+        internal const val CRASH_REPORTING_TIMEOUT_WARNING =
+            "JVM crash reporting timed out waiting for the pipeline, retrying on crash thread."
 
         internal const val OPERATION_ERROR_INVALID_NAME =
             "Operation name cannot be an empty or blank string but was \"%s\". Vital event won't be sent."

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -917,84 +917,29 @@ internal class DatadogRumMonitor(
         }
     }
 
-    @Suppress("NestedBlockDepth", "LongMethod")
-    private fun handleFatalEvent(event: RumRawEvent.AddError) {
-        // The normal-event path acquires resources in this order:
-        //   context-thread → pipeline-thread → synchronized(rootScope)
-        // Calling getWriteContextSync while holding synchronized(rootScope) would
-        // invert that order and deadlock. Fetch the write context first (no lock held),
-        // then inject the crash task into the pipeline queue via put() so it is
-        // serialized correctly and never dropped by back-pressure.
-        val writeContext = sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
-            ?.getWriteContextSync(withFeatureContexts = setOf(Feature.SESSION_REPLAY_FEATURE_NAME))
-        if (writeContext != null) {
-            val (datadogContext, eventWriteScope) = writeContext
-
-            @Suppress("UnsafeThirdPartyFunctionCall") // count is 1, cannot throw
-            val latch = CountDownLatch(1)
-            val crashTask = Runnable {
-                synchronized(rootScope) {
-                    @Suppress("ThreadSafety") // runs on the pipeline thread via crashTask
-                    rootScope.handleEvent(event, datadogContext, eventWriteScope, writer)
-                    val rumContext = currentRumContext()
-                    sdkCore.updateFeatureContext(Feature.RUM_FEATURE_NAME) {
-                        it.clear()
-                        rumContext?.toMap()?.let(it::putAll)
+    internal fun handleEvent(event: RumRawEvent) {
+        if (event is RumRawEvent.AddError && event.isFatal) {
+            val handled = sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
+                ?.withWriteContextSync(
+                    withFeatureContexts = setOf(Feature.SESSION_REPLAY_FEATURE_NAME)
+                ) { datadogContext, eventWriteScope ->
+                    synchronized(rootScope) {
+                        @Suppress("ThreadSafety") // Crash handling, can't delegate to another thread
+                        rootScope.handleEvent(event, datadogContext, eventWriteScope, writer)
+                        val rumContext = currentRumContext()
+                        sdkCore.updateFeatureContext(Feature.RUM_FEATURE_NAME, useContextThread = false) {
+                            it.clear()
+                            rumContext?.toMap()?.let(it::putAll)
+                        }
                     }
                 }
-                latch.countDown()
-            }
-            // put() blocks until a slot is available without dropping, unlike submit() which uses offer().
-            val pipelineQueue = (executorService as? ThreadPoolExecutor)?.queue
-            try {
-                if (pipelineQueue != null) {
-                    @Suppress("UnsafeThirdPartyFunctionCall") // InterruptedException is caught below
-                    pipelineQueue.put(crashTask)
-                } else {
-                    // Fallback for non-ThreadPoolExecutor implementations (e.g. tests).
-                    val submitted = executorService.submitSafe("Rum crash handling", sdkCore.internalLogger, crashTask)
-                    if (submitted == null) {
-                        sdkCore.internalLogger.log(
-                            InternalLogger.Level.WARN,
-                            InternalLogger.Target.USER,
-                            { CRASH_REPORTING_REJECTED_WARNING }
-                        )
-                        return
-                    }
-                }
-                val written = latch.await(CRASH_WRITE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-                if (!written) {
-                    // Pipeline thread did not finish in time — run the crash task directly
-                    // on the crash thread as a best-effort fallback before the process dies.
-                    sdkCore.internalLogger.log(
-                        InternalLogger.Level.WARN,
-                        InternalLogger.Target.USER,
-                        { CRASH_REPORTING_TIMEOUT_WARNING }
-                    )
-                    crashTask.run()
-                }
-            } catch (e: InterruptedException) {
+            if (handled != true) {
                 sdkCore.internalLogger.log(
                     InternalLogger.Level.WARN,
                     InternalLogger.Target.USER,
-                    { CRASH_REPORTING_INTERRUPTED_WARNING },
-                    e
+                    { CANNOT_WRITE_CRASH_WRITE_CONTEXT_IS_NOT_AVAILABLE }
                 )
-                @Suppress("UnsafeThirdPartyFunctionCall") // SecurityException not expected here
-                Thread.currentThread().interrupt()
             }
-        } else {
-            sdkCore.internalLogger.log(
-                InternalLogger.Level.WARN,
-                InternalLogger.Target.USER,
-                { CANNOT_WRITE_CRASH_WRITE_CONTEXT_IS_NOT_AVAILABLE }
-            )
-        }
-    }
-
-    internal fun handleEvent(event: RumRawEvent) {
-        if (event is RumRawEvent.AddError && event.isFatal) {
-            handleFatalEvent(event)
         } else if (event is RumRawEvent.TelemetryEventWrapper) {
             telemetryEventHandler.handleEvent(event, writer)
         } else {
@@ -1134,23 +1079,11 @@ internal class DatadogRumMonitor(
         // should be aligned with CoreFeature#DRAIN_WAIT_SECONDS, but not a requirement
         internal const val DRAIN_WAIT_SECONDS = 10L
 
-        // Maximum time the crash thread waits for the pipeline to write the crash event.
-        internal const val CRASH_WRITE_TIMEOUT_MS = 500L
-
         internal const val RUM_DEBUG_RUM_NOT_ENABLED_WARNING =
             "Cannot switch RUM debugging, because RUM feature is not enabled."
 
         internal const val CANNOT_WRITE_CRASH_WRITE_CONTEXT_IS_NOT_AVAILABLE =
             "Cannot write JVM crash, because write context is not available."
-
-        internal const val CRASH_REPORTING_INTERRUPTED_WARNING =
-            "JVM crash reporting was interrupted, crash event may be lost."
-
-        internal const val CRASH_REPORTING_REJECTED_WARNING =
-            "JVM crash reporting was rejected by the executor, crash event may be lost."
-
-        internal const val CRASH_REPORTING_TIMEOUT_WARNING =
-            "JVM crash reporting timed out waiting for the pipeline, retrying on crash thread."
 
         internal const val OPERATION_ERROR_INVALID_NAME =
             "Operation name cannot be an empty or blank string but was \"%s\". Vital event won't be sent."

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -919,12 +919,16 @@ internal class DatadogRumMonitor(
 
     internal fun handleEvent(event: RumRawEvent) {
         if (event is RumRawEvent.AddError && event.isFatal) {
-            synchronized(rootScope) {
-                // TODO RUM-9852 Implement better passthrough mechanism for the JVM crash scenario
-                val writeContext = sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
-                    ?.getWriteContextSync(withFeatureContexts = setOf(Feature.SESSION_REPLAY_FEATURE_NAME))
-                if (writeContext != null) {
-                    val (datadogContext, eventWriteScope) = writeContext
+            // Fetch the write context BEFORE acquiring the rootScope lock (RUM-17619).
+            // The normal-event path acquires the lock inside the context-thread callback, i.e.
+            // context-thread → pipeline-thread → synchronized(rootScope).
+            // If we called getWriteContextSync while holding the lock we would invert that order:
+            // synchronized(rootScope) → getWriteContextSync (waits for context thread) → deadlock.
+            val writeContext = sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
+                ?.getWriteContextSync(withFeatureContexts = setOf(Feature.SESSION_REPLAY_FEATURE_NAME))
+            if (writeContext != null) {
+                val (datadogContext, eventWriteScope) = writeContext
+                synchronized(rootScope) {
                     @Suppress("ThreadSafety") // Crash handling, can't delegate to another thread
                     rootScope.handleEvent(event, datadogContext, eventWriteScope, writer)
                     val rumContext = currentRumContext()
@@ -932,13 +936,13 @@ internal class DatadogRumMonitor(
                         it.clear()
                         rumContext?.toMap()?.let(it::putAll)
                     }
-                } else {
-                    sdkCore.internalLogger.log(
-                        InternalLogger.Level.WARN,
-                        InternalLogger.Target.USER,
-                        { CANNOT_WRITE_CRASH_WRITE_CONTEXT_IS_NOT_AVAILABLE }
-                    )
                 }
+            } else {
+                sdkCore.internalLogger.log(
+                    InternalLogger.Level.WARN,
+                    InternalLogger.Target.USER,
+                    { CANNOT_WRITE_CRASH_WRITE_CONTEXT_IS_NOT_AVAILABLE }
+                )
             }
         } else if (event is RumRawEvent.TelemetryEventWrapper) {
             telemetryEventHandler.handleEvent(event, writer)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -162,6 +162,7 @@ internal class RumViewManagerScopeTest {
         fakeSampleRate = forge.aFloat(min = 0.0f, max = 100.0f)
 
         whenever(mockSdkCore.time) doReturn fakeTime
+        whenever(mockSdkCore.timeProvider) doReturn mock()
 
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
         whenever(mockChildScope.handleEvent(any(), any(), any(), any())) doReturn mockChildScope

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -273,8 +273,15 @@ internal class DatadogRumMonitorTest {
             callback.invoke(fakeDatadogContext, mockEventWriteScope)
         }
         whenever(
-            mockRumFeatureScope.getWriteContextSync(setOf(Feature.SESSION_REPLAY_FEATURE_NAME))
-        ) doReturn (fakeDatadogContext to mockEventWriteScope)
+            mockRumFeatureScope.withWriteContextSync(
+                eq(setOf(Feature.SESSION_REPLAY_FEATURE_NAME)),
+                any()
+            )
+        ) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(it.arguments.lastIndex)
+            callback.invoke(fakeDatadogContext, mockEventWriteScope)
+            true
+        }
 
         fakeAttributes = forge.exhaustiveAttributes()
 
@@ -1355,16 +1362,14 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
-    fun `M delegate event to rootScope on current thread W addCrash()`(
+    fun `M delegate event to rootScope W addCrash()`(
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable,
         forge: Forge
     ) {
         // Given
-        whenever(
-            mockRumFeatureScope.getWriteContextSync(setOf(Feature.SESSION_REPLAY_FEATURE_NAME))
-        ) doReturn (fakeDatadogContext to mockEventWriteScope)
+        // the fatal event is handled without the RUM pipeline, so a drained executor changes nothing
         testedMonitor.drainExecutorService()
         val now = System.nanoTime()
         val appStartTimeNs = forge.aLong(min = 0L, max = now)
@@ -1402,7 +1407,12 @@ internal class DatadogRumMonitorTest {
         @Forgery throwable: Throwable
     ) {
         // Given
-        whenever(mockRumFeatureScope.getWriteContextSync(setOf(Feature.SESSION_REPLAY_FEATURE_NAME))) doReturn null
+        whenever(
+            mockRumFeatureScope.withWriteContextSync(
+                eq(setOf(Feature.SESSION_REPLAY_FEATURE_NAME)),
+                any()
+            )
+        ) doReturn false
 
         // When
         testedMonitor.addCrash(message, source, throwable, threads = emptyList())
@@ -1417,31 +1427,56 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
-    fun `M fetch write context before acquiring rootScope lock W addCrash() { fatal error }`(
+    fun `M not hold rootScope lock W addCrash() { fatal error }`(
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable
     ) {
         // Given
-        var rootScopeHeldDuringContextFetch = false
+        var rootScopeHeldWhileWaiting = true
         whenever(
-            mockRumFeatureScope.getWriteContextSync(setOf(Feature.SESSION_REPLAY_FEATURE_NAME))
+            mockRumFeatureScope.withWriteContextSync(
+                eq(setOf(Feature.SESSION_REPLAY_FEATURE_NAME)),
+                any()
+            )
         ) doAnswer {
-            // Check whether the rootScope lock is held at the moment getWriteContextSync is called
-            rootScopeHeldDuringContextFetch = Thread.holdsLock(testedMonitor.rootScope)
-            fakeDatadogContext to mockEventWriteScope
+            rootScopeHeldWhileWaiting = Thread.holdsLock(testedMonitor.rootScope)
+            val callback = it.getArgument<(DatadogContext, EventWriteScope) -> Unit>(it.arguments.lastIndex)
+            callback.invoke(fakeDatadogContext, mockEventWriteScope)
+            true
         }
 
         // When
         testedMonitor.addCrash(message, source, throwable, threads = emptyList())
 
         // Then
-        assertThat(rootScopeHeldDuringContextFetch)
+        assertThat(rootScopeHeldWhileWaiting)
             .withFailMessage(
-                "getWriteContextSync must not be called while holding the rootScope lock" +
-                    " — lock-ordering inversion causes deadlock (RUM-17619)"
+                "The crashing thread must not hold the rootScope lock while waiting on the context" +
+                    " thread — lock-ordering inversion causes a deadlock (RUM-17619)"
             )
             .isFalse()
+    }
+
+    @Test
+    fun `M not delegate to the RUM executor W addCrash() { fatal error }`(
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @Forgery throwable: Throwable
+    ) {
+        // When
+        testedMonitor.addCrash(message, source, throwable, threads = emptyList())
+
+        // Then
+        // the crash is handled on the context thread: the extra hop would only add latency and expose the
+        // event to the RUM executor back-pressure, and ordering is already guaranteed by the context thread
+        verify(mockExecutorService, never()).submit(any<Callable<RumContext?>>())
+        verify(mockApplicationScope).handleEvent(
+            any(),
+            same(fakeDatadogContext),
+            same(mockEventWriteScope),
+            same(mockWriter)
+        )
     }
 
     @Test
@@ -2959,7 +2994,6 @@ internal class DatadogRumMonitorTest {
     ) {
         // Given
         val mockFeatureScope = mock<FeatureScope>()
-        whenever(mockFeatureScope.getWriteContextSync(setOf(Feature.SESSION_REPLAY_FEATURE_NAME))) doReturn null
         whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockFeatureScope
         whenever(mockExecutorService.submit(any<Callable<RumContext>>())) doAnswer {
             mock<Future<RumContext>>().apply { whenever(get()) doReturn null }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -1413,6 +1413,34 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
+    fun `M fetch write context before acquiring rootScope lock W addCrash() { fatal error }`(
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @Forgery throwable: Throwable
+    ) {
+        // Given
+        var rootScopeHeldDuringContextFetch = false
+        whenever(
+            mockRumFeatureScope.getWriteContextSync(setOf(Feature.SESSION_REPLAY_FEATURE_NAME))
+        ) doAnswer {
+            // Check whether the rootScope lock is held at the moment getWriteContextSync is called
+            rootScopeHeldDuringContextFetch = Thread.holdsLock(testedMonitor.rootScope)
+            fakeDatadogContext to mockEventWriteScope
+        }
+
+        // When
+        testedMonitor.addCrash(message, source, throwable, threads = emptyList())
+
+        // Then
+        assertThat(rootScopeHeldDuringContextFetch)
+            .withFailMessage(
+                "getWriteContextSync must not be called while holding the rootScope lock" +
+                    " — lock-ordering inversion causes deadlock (RUM-17619)"
+            )
+            .isFalse()
+    }
+
+    @Test
     fun `M delegate event to rootScope W resetSession()`() {
         // When
         testedMonitor.resetSession()

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -237,6 +237,10 @@ internal class DatadogRumMonitorTest {
         whenever(mockExecutorService.execute(any<Runnable>())) doAnswer {
             it.getArgument<Runnable>(0).run()
         }
+        whenever(mockExecutorService.submit(any<Runnable>())) doAnswer {
+            it.getArgument<Runnable>(0).run()
+            mock<Future<*>>()
+        }
         whenever(mockExecutorService.submit(any<Callable<RumContext?>>())) doAnswer {
             val rumContext = it.getArgument<Callable<RumContext?>>(0).call()
             mock<Future<RumContext?>>().apply { whenever(get()) doReturn rumContext }

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubFeatureScope.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubFeatureScope.kt
@@ -71,8 +71,15 @@ internal class StubFeatureScope(
         callback(datadogContextProvider())
     }
 
-    override fun getWriteContextSync(withFeatureContexts: Set<String>): Pair<DatadogContext, EventWriteScope>? {
-        return datadogContextProvider() to { it.invoke(eventBatchWriter) }
+    override fun withWriteContextSync(
+        withFeatureContexts: Set<String>,
+        callback: (DatadogContext, EventWriteScope) -> Unit
+    ): Boolean {
+        callback(
+            datadogContextProvider(),
+            { it.invoke(eventBatchWriter) }
+        )
+        return true
     }
 
     override fun sendEvent(event: Any) {


### PR DESCRIPTION
### What does this PR do?

Fixes a deadlock/ANR that occurs when a JVM crash is reported while a normal RUM event is in-flight (#3652).

On the fatal-crash path, `getWriteContextSync` was called while holding `synchronized(rootScope)`, inverting the lock-acquisition order of the normal-event path (`context-thread → pipeline-thread → synchronized(rootScope)`). This created a 3-way circular wait:

| Thread | Holds | Waits for |
|---|---|---|
| `main` (crashing) | `rootScope` monitor | context thread to complete `getWriteContextSync` task |
| `datadog-context-thread-1` | — | pipeline thread's future |
| `datadog-rum-pipeline-thread-1` | — | `rootScope` monitor held by `main` |

`main → context-thread → pipeline-thread → main`. Because `getSafe` uses an untimed `Future.get()`, `main` hangs indefinitely → ANR, and the crash event is never written.

**Fix:** fetch the write context first (no lock held), then inject the crash task into the RUM pipeline queue via `BlockingQueue.put()` rather than calling `synchronized(rootScope)` directly on the crash thread. `put()` bypasses the `IGNORE_NEWEST` back-pressure drop policy — unlike `submit()`/`offer()`, it blocks until a slot is available and never discards. The crash is serialized after any events already in the pipeline, ensuring correct view attribution. The crash thread waits on a `CountDownLatch` until the pipeline thread completes the task, so the I/O thread receives the write operation before the process terminates.

### Motivation

Reported publicly as GitHub issue #3652. Present in 3.10.0 through 3.12.1 and `develop`. The deadlock is not a rare race — it only requires a normal RUM event to be in-flight at the moment of the crash, which is common on any active app.

### Additional Notes

Also removes two stale `// TODO RUM-9852` comments (that ticket is Dropped).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)