### PR TITLE
Fix resource hash cache expiration time

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/resources/ResourceDataStoreManager.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/resources/ResourceDataStoreManager.kt
@@ -27,7 +27,7 @@ internal class ResourceDataStoreManager(
 ) {
     @Suppress("UnsafeThirdPartyFunctionCall") // map is initialized empty
     private val knownResources = Collections.newSetFromMap(ConcurrentHashMap<String, Boolean>())
-    private val storedLastUpdateDateNs = AtomicLong(featureSdkCore.timeProvider.getDeviceElapsedTimeNanos())
+    private val storedLastUpdateTimestampMs = AtomicLong(featureSdkCore.timeProvider.getDeviceTimestampMillis())
     private val isInitialized = AtomicBoolean(false) // has init finished executing its async actions
 
     init {
@@ -40,10 +40,12 @@ internal class ResourceDataStoreManager(
                     return@lambda
                 }
 
-                val lastUpdateDateNs = storedData.lastUpdateDateNs.toLong()
+                val lastUpdateTimestampMs = storedData.lastUpdateDateNs.toLong()
                 val storedHashes = storedData.resourceHashes
 
-                if (didDataStoreExpire(lastUpdateDateNs)) {
+                if (storedEntry.versionCode != DATASTORE_VERSION ||
+                    didDataStoreExpire(lastUpdateTimestampMs)
+                ) {
                     deleteStoredHashesEntry(
                         callback = object : DataStoreWriteCallback {
                             override fun onSuccess() {
@@ -56,7 +58,7 @@ internal class ResourceDataStoreManager(
                         }
                     )
                 } else {
-                    storedLastUpdateDateNs.set(lastUpdateDateNs)
+                    storedLastUpdateTimestampMs.set(lastUpdateTimestampMs)
                     knownResources.addAll(storedHashes)
                     finishedInitializingManager()
                 }
@@ -85,8 +87,14 @@ internal class ResourceDataStoreManager(
     }
 
     private fun writeResourcesToStore() {
+        // Refresh on every write, otherwise the persisted timestamp only reflects when the store
+        // was last loaded, not when it was last used, causing premature expiration on next init.
+        storedLastUpdateTimestampMs.set(featureSdkCore.timeProvider.getDeviceTimestampMillis())
+
         val data = ResourceHashesEntry(
-            lastUpdateDateNs = storedLastUpdateDateNs,
+            // This generated model property keeps its legacy name for persisted-data compatibility.
+            // The datastore version identifies version 0 values as nanoseconds and version 1 as milliseconds.
+            lastUpdateDateNs = storedLastUpdateTimestampMs.get(),
             resourceHashes = knownResources.toList()
         )
 
@@ -95,6 +103,7 @@ internal class ResourceDataStoreManager(
         )?.dataStore?.setValue(
             data = data,
             key = DATASTORE_HASHES_ENTRY_NAME,
+            version = DATASTORE_VERSION,
             serializer = resourceHashesSerializer
         )
     }
@@ -128,14 +137,19 @@ internal class ResourceDataStoreManager(
             callback = callback
         )
 
-    private fun didDataStoreExpire(lastUpdateDate: Long): Boolean =
-        featureSdkCore.timeProvider.getDeviceElapsedTimeNanos() - lastUpdateDate > DATASTORE_EXPIRATION_NS
+    private fun didDataStoreExpire(lastUpdateTimestampMs: Long): Boolean {
+        val currentTimestampMs = featureSdkCore.timeProvider.getDeviceTimestampMillis()
+
+        return lastUpdateTimestampMs <= 0 ||
+            lastUpdateTimestampMs > currentTimestampMs ||
+            currentTimestampMs - lastUpdateTimestampMs > DATASTORE_EXPIRATION_MS
+    }
 
     // endregion
 
     internal companion object {
-        internal const val DATASTORE_EXPIRATION_NS =
-            DateUtils.DAY_IN_MILLIS * 30 * 1000 * 1000 // 30 days in nanoseconds
+        internal const val DATASTORE_EXPIRATION_MS = DateUtils.DAY_IN_MILLIS * 30
         internal const val DATASTORE_HASHES_ENTRY_NAME = "resource-hash-store"
+        internal const val DATASTORE_VERSION = 1
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/resources/ResourceDataStoreManagerMigrationTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/resources/ResourceDataStoreManagerMigrationTest.kt
@@ -1,0 +1,190 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.resources
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureScope
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.api.storage.datastore.DataStoreHandler
+import com.datadog.android.api.storage.datastore.DataStoreReadCallback
+import com.datadog.android.api.storage.datastore.DataStoreWriteCallback
+import com.datadog.android.core.internal.persistence.Deserializer
+import com.datadog.android.core.persistence.Serializer
+import com.datadog.android.core.persistence.datastore.DataStoreContent
+import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.sessionreplay.internal.resources.ResourceDataStoreManager.Companion.DATASTORE_EXPIRATION_MS
+import com.datadog.android.sessionreplay.internal.resources.ResourceDataStoreManager.Companion.DATASTORE_VERSION
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+internal class ResourceDataStoreManagerMigrationTest {
+
+    @Mock
+    lateinit var mockFeatureSdkCore: FeatureSdkCore
+
+    @Mock
+    lateinit var mockFeatureScope: FeatureScope
+
+    @Mock
+    lateinit var mockTimeProvider: TimeProvider
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    private lateinit var resourceHashesSerializer: ResourceHashesEntrySerializer
+    private lateinit var resourceHashesDeserializer: ResourceHashesEntryDeserializer
+    private lateinit var dataStore: InMemoryDataStoreHandler
+
+    @BeforeEach
+    fun setup() {
+        resourceHashesSerializer = ResourceHashesEntrySerializer()
+        resourceHashesDeserializer = ResourceHashesEntryDeserializer(mockInternalLogger)
+        dataStore = InMemoryDataStoreHandler(
+            entry = StoredEntry(
+                version = LEGACY_DATASTORE_VERSION,
+                serializedData = LEGACY_DATASTORE_JSON
+            )
+        )
+
+        whenever(mockFeatureSdkCore.timeProvider).thenReturn(mockTimeProvider)
+        whenever(mockTimeProvider.getDeviceTimestampMillis()).thenReturn(CURRENT_TIMESTAMP_MS)
+        whenever(mockFeatureSdkCore.getFeature(Feature.SESSION_REPLAY_RESOURCES_FEATURE_NAME))
+            .thenReturn(mockFeatureScope)
+        whenever(mockFeatureScope.dataStore).thenReturn(dataStore)
+    }
+
+    @Test
+    fun `M migrate persisted data W init { legacy datastore entry }`() {
+        // When
+        val testedManager = createManager()
+
+        // Then
+        assertThat(testedManager.isReady()).isTrue()
+        assertThat(testedManager.isPreviouslySentResource(LEGACY_RESOURCE_HASH)).isFalse()
+        assertThat(dataStore.entry).isNull()
+        assertThat(dataStore.removeCount).isEqualTo(1)
+
+        // When
+        testedManager.cacheResourceHash(NEW_RESOURCE_HASH)
+
+        // Then
+        val migratedEntry = checkNotNull(dataStore.entry)
+        val migratedData = resourceHashesDeserializer.deserialize(migratedEntry.serializedData)
+
+        assertThat(migratedEntry.version).isEqualTo(DATASTORE_VERSION)
+        assertThat(migratedData?.lastUpdateDateNs?.toLong()).isEqualTo(CURRENT_TIMESTAMP_MS)
+        assertThat(migratedData?.resourceHashes).containsExactly(NEW_RESOURCE_HASH)
+
+        // When
+        val recreatedManager = createManager()
+
+        // Then
+        assertThat(recreatedManager.isReady()).isTrue()
+        assertThat(recreatedManager.isPreviouslySentResource(NEW_RESOURCE_HASH)).isTrue()
+        assertThat(dataStore.removeCount).isEqualTo(1)
+
+        // When
+        whenever(mockTimeProvider.getDeviceTimestampMillis())
+            .thenReturn(CURRENT_TIMESTAMP_MS + DATASTORE_EXPIRATION_MS + 1)
+        val expiredManager = createManager()
+
+        // Then
+        assertThat(expiredManager.isReady()).isTrue()
+        assertThat(expiredManager.isPreviouslySentResource(NEW_RESOURCE_HASH)).isFalse()
+        assertThat(dataStore.entry).isNull()
+        assertThat(dataStore.removeCount).isEqualTo(2)
+        verify(mockTimeProvider, never()).getDeviceElapsedTimeNanos()
+    }
+
+    private fun createManager(): ResourceDataStoreManager {
+        return ResourceDataStoreManager(
+            featureSdkCore = mockFeatureSdkCore,
+            resourceHashesSerializer = resourceHashesSerializer,
+            resourceHashesDeserializer = resourceHashesDeserializer
+        )
+    }
+
+    private data class StoredEntry(
+        val version: Int,
+        val serializedData: String
+    )
+
+    private class InMemoryDataStoreHandler(
+        var entry: StoredEntry?
+    ) : DataStoreHandler {
+
+        var removeCount: Int = 0
+            private set
+
+        override fun <T : Any> setValue(
+            key: String,
+            data: T,
+            version: Int,
+            callback: DataStoreWriteCallback?,
+            serializer: Serializer<T>
+        ) {
+            val serializedData = serializer.serialize(data)
+            if (serializedData == null) {
+                callback?.onFailure()
+            } else {
+                entry = StoredEntry(version, serializedData)
+                callback?.onSuccess()
+            }
+        }
+
+        override fun <T : Any> value(
+            key: String,
+            version: Int?,
+            callback: DataStoreReadCallback<T>,
+            deserializer: Deserializer<String, T>
+        ) {
+            val storedEntry = entry
+            if (storedEntry == null || version != null && version != storedEntry.version) {
+                callback.onSuccess(null)
+            } else {
+                callback.onSuccess(
+                    DataStoreContent(
+                        versionCode = storedEntry.version,
+                        data = deserializer.deserialize(storedEntry.serializedData)
+                    )
+                )
+            }
+        }
+
+        override fun removeValue(key: String, callback: DataStoreWriteCallback?) {
+            removeCount++
+            entry = null
+            callback?.onSuccess()
+        }
+
+        override fun clearAllData() {
+            entry = null
+        }
+    }
+
+    private companion object {
+        private const val LEGACY_DATASTORE_VERSION = 0
+        private const val LEGACY_RESOURCE_HASH = "legacy-resource-hash"
+        private const val NEW_RESOURCE_HASH = "new-resource-hash"
+        private const val CURRENT_TIMESTAMP_MS = 1_800_000_000_000L
+        private const val LEGACY_DATASTORE_JSON = """
+            {
+              "last_update_date_ns": 86400000000000,
+              "resource_hashes": ["legacy-resource-hash"]
+            }
+        """
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/resources/ResourceDataStoreManagerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/resources/ResourceDataStoreManagerTest.kt
@@ -17,8 +17,9 @@ import com.datadog.android.core.persistence.Serializer
 import com.datadog.android.core.persistence.datastore.DataStoreContent
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
-import com.datadog.android.sessionreplay.internal.resources.ResourceDataStoreManager.Companion.DATASTORE_EXPIRATION_NS
+import com.datadog.android.sessionreplay.internal.resources.ResourceDataStoreManager.Companion.DATASTORE_EXPIRATION_MS
 import com.datadog.android.sessionreplay.internal.resources.ResourceDataStoreManager.Companion.DATASTORE_HASHES_ENTRY_NAME
+import com.datadog.android.sessionreplay.internal.resources.ResourceDataStoreManager.Companion.DATASTORE_VERSION
 import com.datadog.android.sessionreplay.model.ResourceHashesEntry
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.LongForgery
@@ -73,8 +74,8 @@ internal class ResourceDataStoreManagerTest {
     @StringForgery
     lateinit var fakeHash: String
 
-    @LongForgery(min = DATASTORE_EXPIRATION_NS + 1)
-    var fakeCurrentTimeNs: Long = 0L
+    @LongForgery(min = DATASTORE_EXPIRATION_MS + 1, max = Long.MAX_VALUE - 1)
+    var fakeCurrentTimestampMs: Long = 0L
 
     @BeforeEach
     fun setup() {
@@ -83,7 +84,7 @@ internal class ResourceDataStoreManagerTest {
 
         whenever(mockFeatureScope.dataStore).thenReturn(mockDataStoreHandler)
         whenever(mockFeatureSdkCore.timeProvider).thenReturn(mockTimeProvider)
-        whenever(mockTimeProvider.getDeviceElapsedTimeNanos()).thenReturn(fakeCurrentTimeNs)
+        whenever(mockTimeProvider.getDeviceTimestampMillis()).thenReturn(fakeCurrentTimestampMs)
 
         setRemoveDataSuccess()
     }
@@ -137,7 +138,7 @@ internal class ResourceDataStoreManagerTest {
         verify(mockFeatureScope.dataStore).setValue(
             key = eq(DATASTORE_HASHES_ENTRY_NAME),
             data = any(),
-            version = anyOrNull(),
+            version = eq(DATASTORE_VERSION),
             callback = anyOrNull(),
             serializer = eq(mockResourceHashesEntrySerializer)
         )
@@ -148,7 +149,7 @@ internal class ResourceDataStoreManagerTest {
         forge: Forge
     ) {
         // Given
-        val mockDataStoreContent = generateDataStoreContent(forge, isExpired = true, fakeCurrentTimeNs)
+        val mockDataStoreContent = generateDataStoreContent(forge, isExpired = true, fakeCurrentTimestampMs)
         setFetchDataSuccess(mockDataStoreContent)
 
         // When
@@ -165,14 +166,51 @@ internal class ResourceDataStoreManagerTest {
         verify(mockDataStoreHandler).setValue(
             key = eq(DATASTORE_HASHES_ENTRY_NAME),
             data = resourceHashesEntryCaptor.capture(),
-            version = anyOrNull(),
+            version = eq(DATASTORE_VERSION),
             callback = anyOrNull(),
             serializer = eq(mockResourceHashesEntrySerializer)
         )
 
         assertThat(
-            resourceHashesEntryCaptor.firstValue.lastUpdateDateNs
-        ).isNotEqualTo(mockDataStoreContent.data?.lastUpdateDateNs)
+            resourceHashesEntryCaptor.firstValue.lastUpdateDateNs.toLong()
+        ).isEqualTo(fakeCurrentTimestampMs)
+    }
+
+    @Test
+    fun `M refresh stored date W cacheResourceHash { valid entry was loaded }`(
+        forge: Forge
+    ) {
+        // Given
+        val mockDataStoreContent = generateDataStoreContent(
+            forge = forge,
+            isExpired = false,
+            currentTime = fakeCurrentTimestampMs,
+            storedTimestamp = fakeCurrentTimestampMs - 1
+        )
+        setFetchDataSuccess(mockDataStoreContent)
+
+        testedDataStoreManager = ResourceDataStoreManager(
+            featureSdkCore = mockFeatureSdkCore,
+            resourceHashesSerializer = mockResourceHashesEntrySerializer,
+            resourceHashesDeserializer = mockResourceHashesEntryDeserializer
+        )
+
+        // When
+        testedDataStoreManager.cacheResourceHash(fakeHash)
+
+        // Then
+        val resourceHashesEntryCaptor = argumentCaptor<ResourceHashesEntry>()
+        verify(mockDataStoreHandler).setValue(
+            key = eq(DATASTORE_HASHES_ENTRY_NAME),
+            data = resourceHashesEntryCaptor.capture(),
+            version = eq(DATASTORE_VERSION),
+            callback = anyOrNull(),
+            serializer = eq(mockResourceHashesEntrySerializer)
+        )
+
+        assertThat(
+            resourceHashesEntryCaptor.firstValue.lastUpdateDateNs.toLong()
+        ).isEqualTo(fakeCurrentTimestampMs)
     }
 
     // region init
@@ -200,7 +238,64 @@ internal class ResourceDataStoreManagerTest {
         forge: Forge
     ) {
         // Given
-        val mockDataStoreContent = generateDataStoreContent(forge, isExpired = true, fakeCurrentTimeNs)
+        val mockDataStoreContent = generateDataStoreContent(forge, isExpired = true, fakeCurrentTimestampMs)
+        setFetchDataSuccess(mockDataStoreContent)
+
+        // When
+        testedDataStoreManager = ResourceDataStoreManager(
+            featureSdkCore = mockFeatureSdkCore,
+            resourceHashesSerializer = mockResourceHashesEntrySerializer,
+            resourceHashesDeserializer = mockResourceHashesEntryDeserializer
+        )
+
+        // Then
+        verify(mockDataStoreHandler).removeValue(
+            key = eq(DATASTORE_HASHES_ENTRY_NAME),
+            callback = anyOrNull()
+        )
+    }
+
+    @Test
+    fun `M remove datastore entry W init { legacy datastore version }`(
+        forge: Forge
+    ) {
+        // Given
+        val mockDataStoreContent = generateDataStoreContent(
+            forge = forge,
+            isExpired = false,
+            currentTime = fakeCurrentTimestampMs,
+            version = 0
+        )
+        setFetchDataSuccess(mockDataStoreContent)
+
+        // When
+        testedDataStoreManager = ResourceDataStoreManager(
+            featureSdkCore = mockFeatureSdkCore,
+            resourceHashesSerializer = mockResourceHashesEntrySerializer,
+            resourceHashesDeserializer = mockResourceHashesEntryDeserializer
+        )
+
+        // Then
+        verify(mockDataStoreHandler).removeValue(
+            key = eq(DATASTORE_HASHES_ENTRY_NAME),
+            callback = anyOrNull()
+        )
+        mockDataStoreContent.data?.resourceHashes?.forEach {
+            assertThat(testedDataStoreManager.isPreviouslySentResource(it)).isFalse()
+        }
+    }
+
+    @Test
+    fun `M remove datastore entry W init { timestamp is in the future }`(
+        forge: Forge
+    ) {
+        // Given
+        val mockDataStoreContent = generateDataStoreContent(
+            forge = forge,
+            isExpired = false,
+            currentTime = fakeCurrentTimestampMs,
+            storedTimestamp = fakeCurrentTimestampMs + 1
+        )
         setFetchDataSuccess(mockDataStoreContent)
 
         // When
@@ -222,7 +317,7 @@ internal class ResourceDataStoreManagerTest {
         forge: Forge
     ) {
         // Given
-        val mockDataStoreContentEntry = generateDataStoreContent(forge, isExpired = false, fakeCurrentTimeNs)
+        val mockDataStoreContentEntry = generateDataStoreContent(forge, isExpired = false, fakeCurrentTimestampMs)
         setFetchDataSuccess(mockDataStoreContentEntry)
 
         // When
@@ -259,7 +354,7 @@ internal class ResourceDataStoreManagerTest {
         forge: Forge
     ) {
         // Given
-        val mockDataStoreContent = generateDataStoreContent(forge, isExpired = false, fakeCurrentTimeNs)
+        val mockDataStoreContent = generateDataStoreContent(forge, isExpired = false, fakeCurrentTimestampMs)
         setFetchDataSuccess(mockDataStoreContent)
 
         // When
@@ -294,7 +389,7 @@ internal class ResourceDataStoreManagerTest {
         forge: Forge
     ) {
         // Given
-        val mockDataStoreContent = generateDataStoreContent(forge, isExpired = true, fakeCurrentTimeNs)
+        val mockDataStoreContent = generateDataStoreContent(forge, isExpired = true, fakeCurrentTimestampMs)
         setFetchDataSuccess(mockDataStoreContent)
         setRemoveDataSuccess()
 
@@ -314,7 +409,7 @@ internal class ResourceDataStoreManagerTest {
         forge: Forge
     ) {
         // Given
-        val mockDataStoreContent = generateDataStoreContent(forge, isExpired = true, fakeCurrentTimeNs)
+        val mockDataStoreContent = generateDataStoreContent(forge, isExpired = true, fakeCurrentTimestampMs)
         setFetchDataSuccess(mockDataStoreContent)
         setRemoveDataFailure()
 
@@ -334,12 +429,13 @@ internal class ResourceDataStoreManagerTest {
     private fun generateDataStoreContent(
         forge: Forge,
         isExpired: Boolean,
-        currentTime: Long
+        currentTime: Long,
+        version: Int = DATASTORE_VERSION,
+        storedTimestamp: Long? = null
     ): DataStoreContent<ResourceHashesEntry> {
         val resourceHashes = forge.aList { aString() }.distinct()
-        val fakeVersionCode = forge.anInt(min = 0)
-        val entryTime = if (isExpired) {
-            currentTime - DATASTORE_EXPIRATION_NS - 1
+        val entryTime = storedTimestamp ?: if (isExpired) {
+            currentTime - DATASTORE_EXPIRATION_MS - 1
         } else {
             currentTime
         }
@@ -349,7 +445,7 @@ internal class ResourceDataStoreManagerTest {
             whenever(it.lastUpdateDateNs).thenReturn(entryTime)
         }
         val mockDataStoreContentEntry: DataStoreContent<ResourceHashesEntry> = mock {
-            whenever(it.versionCode).thenReturn(fakeVersionCode)
+            whenever(it.versionCode).thenReturn(version)
             whenever(it.data).thenReturn(mockResourceHashesEntry)
         }
 


### PR DESCRIPTION
### What does this PR do?
Fixes resource hash cache expiration by using wall-clock milliseconds instead of monotonic nanoseconds.

Legacy version-0 caches are safely invalidated, while new caches are stored as version 1 and remain valid across process restarts and device reboots.

### Motivation

Persisted monotonic timestamps can reset after a device reboot, preventing stale resource hash caches from expiring correctly.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

