### PR TITLE
[Flutter hybrid support] Add slotId support to Full/Incremental snapshot records

### DIFF
--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -192,14 +192,14 @@ data class com.datadog.android.sessionreplay.model.MobileSegment
   sealed class MobileRecord
     abstract fun toJson(): com.google.gson.JsonElement
     data class MobileFullSnapshotRecord : MobileRecord
-      constructor(kotlin.Long, Data)
+      constructor(kotlin.Long, kotlin.String? = null, Data)
       val type: kotlin.Long
       override fun toJson(): com.google.gson.JsonElement
       companion object 
         fun fromJson(kotlin.String): MobileFullSnapshotRecord
         fun fromJsonObject(com.google.gson.JsonObject): MobileFullSnapshotRecord
     data class MobileIncrementalSnapshotRecord : MobileRecord
-      constructor(kotlin.Long, MobileIncrementalData)
+      constructor(kotlin.Long, kotlin.String? = null, MobileIncrementalData)
       val type: kotlin.Long
       override fun toJson(): com.google.gson.JsonElement
       companion object 

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -560,15 +560,18 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$MobileR
 
 public final class com/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord : com/datadog/android/sessionreplay/model/MobileSegment$MobileRecord {
 	public static final field Companion Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord$Companion;
-	public fun <init> (JLcom/datadog/android/sessionreplay/model/MobileSegment$Data;)V
+	public fun <init> (JLjava/lang/String;Lcom/datadog/android/sessionreplay/model/MobileSegment$Data;)V
+	public synthetic fun <init> (JLjava/lang/String;Lcom/datadog/android/sessionreplay/model/MobileSegment$Data;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
-	public final fun component2 ()Lcom/datadog/android/sessionreplay/model/MobileSegment$Data;
-	public final fun copy (JLcom/datadog/android/sessionreplay/model/MobileSegment$Data;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord;
-	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord;JLcom/datadog/android/sessionreplay/model/MobileSegment$Data;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/datadog/android/sessionreplay/model/MobileSegment$Data;
+	public final fun copy (JLjava/lang/String;Lcom/datadog/android/sessionreplay/model/MobileSegment$Data;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord;JLjava/lang/String;Lcom/datadog/android/sessionreplay/model/MobileSegment$Data;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord;
 	public final fun getData ()Lcom/datadog/android/sessionreplay/model/MobileSegment$Data;
+	public final fun getSlotId ()Ljava/lang/String;
 	public final fun getTimestamp ()J
 	public final fun getType ()J
 	public fun hashCode ()I
@@ -583,15 +586,18 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$MobileR
 
 public final class com/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord : com/datadog/android/sessionreplay/model/MobileSegment$MobileRecord {
 	public static final field Companion Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord$Companion;
-	public fun <init> (JLcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;)V
+	public fun <init> (JLjava/lang/String;Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;)V
+	public synthetic fun <init> (JLjava/lang/String;Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
-	public final fun component2 ()Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;
-	public final fun copy (JLcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord;
-	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord;JLcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;
+	public final fun copy (JLjava/lang/String;Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord;JLjava/lang/String;Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord;
 	public final fun getData ()Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;
+	public final fun getSlotId ()Ljava/lang/String;
 	public final fun getTimestamp ()J
 	public final fun getType ()J
 	public fun hashCode ()I

--- a/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/full-snapshot-record-schema.json
+++ b/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/full-snapshot-record-schema.json
@@ -6,7 +6,7 @@
   "description": "Mobile-specific. Schema of a Record type which contains the full snapshot of a screen.",
   "allOf": [
     {
-      "$ref": "../common/_common-record-schema.json"
+      "$ref": "../common/_slot-supported-common-record-schema.json"
     },
     {
       "required": ["type", "data"],

--- a/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/incremental-snapshot-record-schema.json
+++ b/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/incremental-snapshot-record-schema.json
@@ -6,7 +6,7 @@
   "description": "Mobile-specific. Schema of a Record type which contains mutations of a screen.",
   "allOf": [
     {
-      "$ref": "../common/_common-record-schema.json"
+      "$ref": "../common/_slot-supported-common-record-schema.json"
     },
     {
       "required": ["type", "data"],

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/RecordedDataProcessor.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/RecordedDataProcessor.kt
@@ -142,16 +142,16 @@ internal class RecordedDataProcessor(
         if (fullSnapshotRequired) {
             records.add(
                 MobileSegment.MobileRecord.MobileFullSnapshotRecord(
-                    timestamp,
-                    MobileSegment.Data(wireframes)
+                    timestamp = timestamp,
+                    data = MobileSegment.Data(wireframes)
                 )
             )
         } else {
             mutationResolver.resolveMutations(prevSnapshot, wireframes)?.let {
                 records.add(
                     MobileSegment.MobileRecord.MobileIncrementalSnapshotRecord(
-                        timestamp,
-                        it
+                        timestamp = timestamp,
+                        data = it
                     )
                 )
             }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/FullSnapshotRecordForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/FullSnapshotRecordForgeryFactory.kt
@@ -14,8 +14,9 @@ internal class FullSnapshotRecordForgeryFactory :
     ForgeryFactory<MobileSegment.MobileRecord.MobileFullSnapshotRecord> {
     override fun getForgery(forge: Forge): MobileSegment.MobileRecord.MobileFullSnapshotRecord {
         return MobileSegment.MobileRecord.MobileFullSnapshotRecord(
-            forge.aPositiveLong(),
-            MobileSegment.Data(forge.aList { forge.getForgery() })
+            timestamp = forge.aPositiveLong(),
+            slotId = forge.aNullable { aPositiveLong().toString() },
+            data = MobileSegment.Data(forge.aList { forge.getForgery() })
         )
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/IncrementalSnapshotRecordForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/IncrementalSnapshotRecordForgeryFactory.kt
@@ -14,8 +14,9 @@ internal class IncrementalSnapshotRecordForgeryFactory :
     ForgeryFactory<MobileSegment.MobileRecord.MobileIncrementalSnapshotRecord> {
     override fun getForgery(forge: Forge): MobileSegment.MobileRecord.MobileIncrementalSnapshotRecord {
         return MobileSegment.MobileRecord.MobileIncrementalSnapshotRecord(
-            forge.aPositiveLong(),
-            forge.getForgery()
+            timestamp = forge.aPositiveLong(),
+            slotId = forge.aNullable { aPositiveLong().toString() },
+            data = forge.getForgery()
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?

Extends the slotId field (already present on MetaRecord/FocusRecord) to MobileFullSnapshotRecord and MobileIncrementalSnapshotRecord, so full and incremental snapshot records can also be tagged with a slot identifier.

### Motivation

Groundwork for correlating Session Replay records produced by an embedded rendering engine (e.g. Flutter) back to their placeholder slot on the native side.

### Additional Notes

- slotId is optional and defaults to null; when null it's omitted from serialization (slotId?.let { ... } in generated toJson()), so existing record payloads are byte-for-byte unchanged.
- Public constructor signature for both record types changes (slotId inserted between timestamp and data) — same precedent already shipped for MetaRecord/FocusRecord, not a new risk category.
- No behavioral change to any existing recorder flow; verified full test suite passes in isolation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

