### PR TITLE
RUM-17809: Enable Gradle configuration cache (warn mode)

### DIFF
--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -166,7 +166,8 @@ analysis:generated-files-check:
   timeout: 30m
   script:
     - !reference [.snippets, setup-gradle]
-    - ./gradlew checkGeneratedFiles
+    # TODO RUM-17809: configuration cache not supported by gradle-dependency-license-plugin; re-enable once fixed
+    - ./gradlew checkGeneratedFiles --no-configuration-cache
 
 analysis:ktlint:
   extends:

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,9 @@
 #
 org.gradle.jvmargs=-Xmx6144m
 org.gradle.caching=true
+org.gradle.configuration-cache=true
+# TODO RUM-17809: Let this soak for a bit before switching to enforcement
+org.gradle.configuration-cache.problems=warn
 org.gradle.parallel=true
 org.gradle.tooling.parallel=true
 android.useAndroidX=true

--- a/local_ci.sh
+++ b/local_ci.sh
@@ -108,7 +108,7 @@ if [[ $ANALYSIS == 1 ]]; then
     DEPS_CHANGED=$(git diff --name-only develop... -- 'gradle/libs.versions.toml' '**/build.gradle.kts' || true)
   fi
   if [ -n "$DEPS_CHANGED" ]; then
-    ./gradlew checkDependencyLicenses
+    ./gradlew checkDependencyLicenses --no-configuration-cache
   else
     echo "  No dependency changes"
   fi


### PR DESCRIPTION
### What does this PR do?
Enable the configuration cache but in warn mode so that if any issues arise we do not fail the build. 

We will switch back to the default behavior (fails the build) in the future

Note: `check-generated-files` is the only CI job that had issues:
```
- Exception at `com.datadog.gradle.plugin.licenses.tasks.CheckDependencyLicensesTask.applyTask(CheckDependencyLicensesTask.kt:55)`
org.gradle.api.InvalidUserCodeException: Invocation of 'Task.project' by task ':dd-sdk-android-core:checkDependencyLicenses' at execution time is unsupported with the configuration cache.
	at org.gradle.internal.configuration.problems.DefaultProblemFactory$problem$1$build$diagnostics$1.get(DefaultProblemFactory.kt:89)
	at org.gradle.internal.configuration.problems.DefaultProblemFactory$problem$1$build$diagnostics$1.get(DefaultProblemFactory.kt:89)
	at org.gradle.internal.problems.DefaultProblemDiagnosticsFactory$DefaultProblemStream.getImplicitThrowable(DefaultProblemDiagnosticsFactory.java:165)
	at org.gradle.internal.problems.DefaultProblemDiagnosticsFactory$DefaultProblemStream.forCurrentCaller(DefaultProblemDiagnosticsFactory.java:154)
	at org.gradle.internal.configuration.problems.DefaultProblemFactory$problem$1.build(DefaultProblemFactory.kt:89)
	at org.gradle.internal.cc.impl.initialization.DefaultConfigurationCacheProblemsListener.onTaskExecutionAccessProblem(ConfigurationCacheProblemsListener.kt:133)
	at org.gradle.internal.cc.impl.initialization.DefaultConfigurationCacheProblemsListener.onProjectAccess(ConfigurationCacheProblemsListener.kt:73)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
```

I looked into it and there doesn't appear to be a simple fix, the API it also uses (`ArtifactResolutionQuery`) will eventually be deprecated/removed as well https://redirect.github.com/gradle/gradle/issues/26365

### Motivation
Reduce time in local CI of re-configuring the project multiple times