### PR TITLE
RUM-17796: Periodic full view checkpoints for Partial View Updates

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
@@ -102,15 +102,20 @@ internal class RumDataWriter(
         eventData: DiffThenFullView,
         eventType: EventType
     ): Boolean {
-        // Write the partial diff — skip crash-recovery write since the full view below will do it
-        writeViewUpdateEvent(
+        // Write the partial diff first — skip crash-recovery write since the full view below will do it
+        val diffWritten = writeViewUpdateEvent(
             writer,
             RumViewUpdateData(eventData.viewUpdate, eventData.viewEvent),
             eventType,
             writeCrashRecovery = false
         )
-        // Then write the full view as ground-truth checkpoint (single crash-recovery write)
-        return writeMappedViewEvent(writer, eventData.viewEvent, eventType)
+        // Only write the full view checkpoint if the diff was persisted
+        if (diffWritten) {
+            writeMappedViewEvent(writer, eventData.viewEvent, eventType)
+        }
+        // Always return diffWritten so prevViewEvent is updated whenever the diff was
+        // persisted, keeping the baseline consistent regardless of full view write outcome
+        return diffWritten
     }
 
     @WorkerThread

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
@@ -17,6 +17,7 @@ import com.datadog.android.core.persistence.serializeToByteArray
 import com.datadog.android.rum.internal.domain.event.RumEventMapper
 import com.datadog.android.rum.internal.domain.event.RumEventMeta
 import com.datadog.android.rum.internal.domain.event.RumEventSerializer
+import com.datadog.android.rum.internal.domain.scope.DiffThenFullView
 import com.datadog.android.rum.internal.domain.scope.MappedViewEvent
 import com.datadog.android.rum.internal.domain.scope.RumViewUpdateData
 import com.datadog.android.rum.model.ViewEvent
@@ -39,6 +40,7 @@ internal class RumDataWriter(
             is MappedViewEvent -> writeMappedViewEvent(writer, element.viewEvent, eventType)
             is ViewEvent -> writeRawViewEvent(writer, element, eventType)
             is RumViewUpdateData -> writeViewUpdateEvent(writer, element, eventType)
+            is DiffThenFullView -> writeDiffThenFullView(writer, element, eventType)
             else -> writeOtherEvent(writer, element, eventType)
         }
     }
@@ -71,7 +73,8 @@ internal class RumDataWriter(
     private fun writeViewUpdateEvent(
         writer: EventBatchWriter,
         eventData: RumViewUpdateData,
-        eventType: EventType
+        eventType: EventType,
+        writeCrashRecovery: Boolean = true
     ): Boolean {
         val event = eventData.viewUpdate
         val byteArray = eventSerializer.serializeToByteArray(event, sdkCore.internalLogger)
@@ -85,10 +88,29 @@ internal class RumDataWriter(
             ?: EMPTY_BYTE_ARRAY
 
         return writeBatchEvent(writer, RawBatchEvent(data = byteArray, metadata = serializedEventMeta), eventType) {
-            // serialize the full ViewEvent only on successful write, for crash recovery
-            val byteArrayView = eventSerializer.serializeToByteArray(eventData.viewEvent, sdkCore.internalLogger)
-            if (byteArrayView != null) sdkCore.writeLastViewEvent(byteArrayView)
+            if (writeCrashRecovery) {
+                // serialize the full ViewEvent only on successful write, for crash recovery
+                val byteArrayView = eventSerializer.serializeToByteArray(eventData.viewEvent, sdkCore.internalLogger)
+                if (byteArrayView != null) sdkCore.writeLastViewEvent(byteArrayView)
+            }
         }
+    }
+
+    @WorkerThread
+    private fun writeDiffThenFullView(
+        writer: EventBatchWriter,
+        eventData: DiffThenFullView,
+        eventType: EventType
+    ): Boolean {
+        // Write the partial diff — skip crash-recovery write since the full view below will do it
+        writeViewUpdateEvent(
+            writer,
+            RumViewUpdateData(eventData.viewUpdate, eventData.viewEvent),
+            eventType,
+            writeCrashRecovery = false
+        )
+        // Then write the full view as ground-truth checkpoint (single crash-recovery write)
+        return writeMappedViewEvent(writer, eventData.viewEvent, eventType)
     }
 
     @WorkerThread

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriter.kt
@@ -91,7 +91,8 @@ internal class RumViewEventWriterImpl(
                 when (config) {
                     RumViewEventWriteConfig.AlwaysFullView -> MappedViewEvent(mapped)
                     RumViewEventWriteConfig.FullViewOnlyAtStart -> {
-                        if (prev == null) {
+                        // First update of the view, or periodic checkpoint (every FULL_VIEW_EVERY_N_UPDATES versions)
+                        if (prev == null || mapped.dd.documentVersion % FULL_VIEW_EVERY_N_UPDATES == 0L) {
                             MappedViewEvent(mapped)
                         } else {
                             RumViewUpdateData(
@@ -110,5 +111,6 @@ internal class RumViewEventWriterImpl(
     companion object {
         internal const val VIEW_EVENT_MAPPER_FALLBACK_WARNING_MESSAGE =
             "ViewEventMapper failed, using original ViewEvent."
+        internal const val FULL_VIEW_EVERY_N_UPDATES = 4L
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriter.kt
@@ -91,8 +91,7 @@ internal class RumViewEventWriterImpl(
                 when (config) {
                     RumViewEventWriteConfig.AlwaysFullView -> MappedViewEvent(mapped)
                     RumViewEventWriteConfig.FullViewOnlyAtStart -> {
-                        // First update of the view, or periodic checkpoint (every FULL_VIEW_EVERY_N_UPDATES versions)
-                        if (prev == null || mapped.dd.documentVersion % FULL_VIEW_EVERY_N_UPDATES == 0L) {
+                        if (prev == null || shouldWriteFullView(mapped.dd.documentVersion, mapped.view.isActive)) {
                             MappedViewEvent(mapped)
                         } else {
                             RumViewUpdateData(
@@ -106,6 +105,14 @@ internal class RumViewEventWriterImpl(
         ).onSuccess {
             mappedViewEvent?.let { event -> prevViewEvent = event }
         }.submit()
+    }
+
+    // Returns true when a full ViewEvent must be sent instead of a diff:
+    // - Periodic checkpoint (every FULL_VIEW_EVERY_N_UPDATES versions)
+    // - View is closing (isActive transitions to false)
+    private fun shouldWriteFullView(documentVersion: Long, isActive: Boolean?): Boolean {
+        return documentVersion % FULL_VIEW_EVERY_N_UPDATES == 0L ||
+            isActive == false
     }
 
     companion object {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriter.kt
@@ -28,6 +28,11 @@ internal data class MappedViewEvent(
     val viewEvent: ViewEvent
 )
 
+internal data class DiffThenFullView(
+    val viewUpdate: ViewUpdateEvent,
+    val viewEvent: ViewEvent
+)
+
 internal interface RumViewEventWriter {
     fun writeViewEvent(
         viewEvent: ViewEvent,
@@ -91,8 +96,14 @@ internal class RumViewEventWriterImpl(
                 when (config) {
                     RumViewEventWriteConfig.AlwaysFullView -> MappedViewEvent(mapped)
                     RumViewEventWriteConfig.FullViewOnlyAtStart -> {
-                        if (prev == null || shouldWriteFullView(mapped.dd.documentVersion, mapped.view.isActive)) {
+                        if (prev == null) {
                             MappedViewEvent(mapped)
+                        } else if (shouldWriteFullView(mapped.dd.documentVersion, mapped.view.isActive)) {
+                            // Send the last partial diff followed immediately by the full view checkpoint
+                            DiffThenFullView(
+                                viewUpdate = diffViewEvent(prev, mapped),
+                                viewEvent = mapped
+                            )
                         } else {
                             RumViewUpdateData(
                                 viewUpdate = diffViewEvent(prev, mapped),

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
@@ -14,6 +14,7 @@ import com.datadog.android.core.persistence.Serializer
 import com.datadog.android.rum.internal.domain.event.RumEventMapper
 import com.datadog.android.rum.internal.domain.event.RumEventMeta
 import com.datadog.android.rum.internal.domain.event.RumEventSerializer
+import com.datadog.android.rum.internal.domain.scope.DiffThenFullView
 import com.datadog.android.rum.internal.domain.scope.MappedViewEvent
 import com.datadog.android.rum.internal.domain.scope.RumViewUpdateData
 import com.datadog.android.rum.model.ActionEvent
@@ -46,7 +47,10 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -613,6 +617,341 @@ internal class RumDataWriterTest {
 
         // Then
         verify(rumMonitor.mockSdkCore, never()).writeLastViewEvent(any<ByteArray>())
+    }
+
+    // endregion
+
+    // region writeDiffThenFullView
+
+    @Test
+    fun `M write diff then full view W write() { DiffThenFullView, diff succeeds }`(
+        @Forgery fakeViewUpdateEvent: ViewUpdateEvent,
+        @Forgery fakeViewEvent: ViewEvent,
+        @StringForgery fakeDiffSerializedEvent: String,
+        @StringForgery fakeFullSerializedEvent: String,
+        forge: Forge
+    ) {
+        // Given
+        val fakeData = DiffThenFullView(
+            viewUpdate = fakeViewUpdateEvent,
+            viewEvent = fakeViewEvent
+        )
+        val fakeDiffBytes = fakeDiffSerializedEvent.toByteArray(Charsets.UTF_8)
+        val fakeFullBytes = fakeFullSerializedEvent.toByteArray(Charsets.UTF_8)
+        val fakeSerializedMeta = forge.aString()
+        val fakeFullMeta = forge.aString()
+        val diffMeta = RumEventMeta.ViewUpdate(
+            viewId = fakeViewUpdateEvent.view.id,
+            documentVersion = fakeViewUpdateEvent.dd.documentVersion
+        )
+        val fullMeta = RumEventMeta.View(
+            viewId = fakeViewEvent.view.id,
+            documentVersion = fakeViewEvent.dd.documentVersion,
+            hasAccessibility = fakeViewEvent.view.accessibility != null
+        )
+        whenever(mockEventSerializer.serialize(fakeViewUpdateEvent)) doReturn fakeDiffSerializedEvent
+        whenever(mockEventSerializer.serialize(fakeViewEvent)) doReturn fakeFullSerializedEvent
+        whenever(mockEventMetaSerializer.serialize(diffMeta)) doReturn fakeSerializedMeta
+        whenever(mockEventMetaSerializer.serialize(fullMeta)) doReturn fakeFullMeta
+        whenever(
+            mockEventBatchWriter.write(
+                RawBatchEvent(
+                    data = fakeDiffBytes,
+                    metadata = fakeSerializedMeta.toByteArray(Charsets.UTF_8)
+                ),
+                null,
+                fakeEventType
+            )
+        ) doReturn true
+        whenever(
+            mockEventBatchWriter.write(
+                RawBatchEvent(
+                    data = fakeFullBytes,
+                    metadata = fakeFullMeta.toByteArray(Charsets.UTF_8)
+                ),
+                null,
+                fakeEventType
+            )
+        ) doReturn true
+
+        // When
+        val result = testedWriter.write(mockEventBatchWriter, fakeData, fakeEventType)
+
+        // Then
+        assertThat(result).isTrue()
+        val captor = argumentCaptor<RawBatchEvent>()
+        verify(mockEventBatchWriter, times(2)).write(captor.capture(), isNull(), eq(fakeEventType))
+        // diff is written first, then the full view
+        assertThat(captor.firstValue.data).isEqualTo(fakeDiffBytes)
+        assertThat(captor.secondValue.data).isEqualTo(fakeFullBytes)
+    }
+
+    @Test
+    fun `M NOT call writeLastViewEvent for diff W write() { DiffThenFullView, diff succeeds }`(
+        @Forgery fakeViewUpdateEvent: ViewUpdateEvent,
+        @Forgery fakeViewEvent: ViewEvent,
+        @StringForgery fakeDiffSerializedEvent: String,
+        @StringForgery fakeFullSerializedEvent: String,
+        forge: Forge
+    ) {
+        // Given — the diff write succeeds but crash-recovery must NOT fire for the diff step
+        val fakeData = DiffThenFullView(
+            viewUpdate = fakeViewUpdateEvent,
+            viewEvent = fakeViewEvent
+        )
+        val fakeDiffBytes = fakeDiffSerializedEvent.toByteArray(Charsets.UTF_8)
+        val fakeFullBytes = fakeFullSerializedEvent.toByteArray(Charsets.UTF_8)
+        val fakeSerializedMeta = forge.aString()
+        val fakeFullMeta = forge.aString()
+        val diffMeta = RumEventMeta.ViewUpdate(
+            viewId = fakeViewUpdateEvent.view.id,
+            documentVersion = fakeViewUpdateEvent.dd.documentVersion
+        )
+        val fullMeta = RumEventMeta.View(
+            viewId = fakeViewEvent.view.id,
+            documentVersion = fakeViewEvent.dd.documentVersion,
+            hasAccessibility = fakeViewEvent.view.accessibility != null
+        )
+        whenever(mockEventSerializer.serialize(fakeViewUpdateEvent)) doReturn fakeDiffSerializedEvent
+        whenever(mockEventSerializer.serialize(fakeViewEvent)) doReturn fakeFullSerializedEvent
+        whenever(mockEventMetaSerializer.serialize(diffMeta)) doReturn fakeSerializedMeta
+        whenever(mockEventMetaSerializer.serialize(fullMeta)) doReturn fakeFullMeta
+        whenever(
+            mockEventBatchWriter.write(
+                RawBatchEvent(
+                    data = fakeDiffBytes,
+                    metadata = fakeSerializedMeta.toByteArray(Charsets.UTF_8)
+                ),
+                null,
+                fakeEventType
+            )
+        ) doReturn true
+        whenever(
+            mockEventBatchWriter.write(
+                RawBatchEvent(
+                    data = fakeFullBytes,
+                    metadata = fakeFullMeta.toByteArray(Charsets.UTF_8)
+                ),
+                null,
+                fakeEventType
+            )
+        ) doReturn true
+
+        // When
+        testedWriter.write(mockEventBatchWriter, fakeData, fakeEventType)
+
+        // Then — writeLastViewEvent is called exactly once: for the full view via writeMappedViewEvent
+        verify(rumMonitor.mockSdkCore).writeLastViewEvent(fakeFullBytes)
+    }
+
+    @Test
+    fun `M call writeLastViewEvent with full ViewEvent W write() { DiffThenFullView, diff and full succeed }`(
+        @Forgery fakeViewUpdateEvent: ViewUpdateEvent,
+        @Forgery fakeViewEvent: ViewEvent,
+        @StringForgery fakeDiffSerializedEvent: String,
+        @StringForgery fakeFullSerializedEvent: String,
+        forge: Forge
+    ) {
+        // Given
+        val fakeData = DiffThenFullView(
+            viewUpdate = fakeViewUpdateEvent,
+            viewEvent = fakeViewEvent
+        )
+        val fakeDiffBytes = fakeDiffSerializedEvent.toByteArray(Charsets.UTF_8)
+        val fakeFullBytes = fakeFullSerializedEvent.toByteArray(Charsets.UTF_8)
+        val fakeSerializedMeta = forge.aString()
+        val fakeFullMeta = forge.aString()
+        val diffMeta = RumEventMeta.ViewUpdate(
+            viewId = fakeViewUpdateEvent.view.id,
+            documentVersion = fakeViewUpdateEvent.dd.documentVersion
+        )
+        val fullMeta = RumEventMeta.View(
+            viewId = fakeViewEvent.view.id,
+            documentVersion = fakeViewEvent.dd.documentVersion,
+            hasAccessibility = fakeViewEvent.view.accessibility != null
+        )
+        whenever(mockEventSerializer.serialize(fakeViewUpdateEvent)) doReturn fakeDiffSerializedEvent
+        whenever(mockEventSerializer.serialize(fakeViewEvent)) doReturn fakeFullSerializedEvent
+        whenever(mockEventMetaSerializer.serialize(diffMeta)) doReturn fakeSerializedMeta
+        whenever(mockEventMetaSerializer.serialize(fullMeta)) doReturn fakeFullMeta
+        whenever(
+            mockEventBatchWriter.write(
+                RawBatchEvent(data = fakeDiffBytes, metadata = fakeSerializedMeta.toByteArray(Charsets.UTF_8)),
+                null,
+                fakeEventType
+            )
+        ) doReturn true
+        whenever(
+            mockEventBatchWriter.write(
+                RawBatchEvent(data = fakeFullBytes, metadata = fakeFullMeta.toByteArray(Charsets.UTF_8)),
+                null,
+                fakeEventType
+            )
+        ) doReturn true
+
+        // When
+        testedWriter.write(mockEventBatchWriter, fakeData, fakeEventType)
+
+        // Then
+        verify(rumMonitor.mockSdkCore).writeLastViewEvent(fakeFullBytes)
+    }
+
+    @Test
+    fun `M return true W write() { DiffThenFullView, diff succeeds, full view write fails }`(
+        @Forgery fakeViewUpdateEvent: ViewUpdateEvent,
+        @Forgery fakeViewEvent: ViewEvent,
+        @StringForgery fakeDiffSerializedEvent: String,
+        @StringForgery fakeFullSerializedEvent: String,
+        forge: Forge
+    ) {
+        // Given — diff persisted, full view batch write fails; return value must still be true
+        val fakeData = DiffThenFullView(
+            viewUpdate = fakeViewUpdateEvent,
+            viewEvent = fakeViewEvent
+        )
+        val fakeDiffBytes = fakeDiffSerializedEvent.toByteArray(Charsets.UTF_8)
+        val fakeFullBytes = fakeFullSerializedEvent.toByteArray(Charsets.UTF_8)
+        val fakeSerializedMeta = forge.aString()
+        val fakeFullMeta = forge.aString()
+        val diffMeta = RumEventMeta.ViewUpdate(
+            viewId = fakeViewUpdateEvent.view.id,
+            documentVersion = fakeViewUpdateEvent.dd.documentVersion
+        )
+        val fullMeta = RumEventMeta.View(
+            viewId = fakeViewEvent.view.id,
+            documentVersion = fakeViewEvent.dd.documentVersion,
+            hasAccessibility = fakeViewEvent.view.accessibility != null
+        )
+        whenever(mockEventSerializer.serialize(fakeViewUpdateEvent)) doReturn fakeDiffSerializedEvent
+        whenever(mockEventSerializer.serialize(fakeViewEvent)) doReturn fakeFullSerializedEvent
+        whenever(mockEventMetaSerializer.serialize(diffMeta)) doReturn fakeSerializedMeta
+        whenever(mockEventMetaSerializer.serialize(fullMeta)) doReturn fakeFullMeta
+        whenever(
+            mockEventBatchWriter.write(
+                RawBatchEvent(data = fakeDiffBytes, metadata = fakeSerializedMeta.toByteArray(Charsets.UTF_8)),
+                null,
+                fakeEventType
+            )
+        ) doReturn true
+        whenever(
+            mockEventBatchWriter.write(
+                RawBatchEvent(data = fakeFullBytes, metadata = fakeFullMeta.toByteArray(Charsets.UTF_8)),
+                null,
+                fakeEventType
+            )
+        ) doReturn false
+
+        // When
+        val result = testedWriter.write(mockEventBatchWriter, fakeData, fakeEventType)
+
+        // Then — diffWritten=true, so result is true even though full view write failed
+        assertThat(result).isTrue()
+        verify(rumMonitor.mockSdkCore, never()).writeLastViewEvent(any<ByteArray>())
+    }
+
+    @Test
+    fun `M NOT write full view W write() { DiffThenFullView, diff write fails }`(
+        @Forgery fakeViewUpdateEvent: ViewUpdateEvent,
+        @Forgery fakeViewEvent: ViewEvent,
+        @StringForgery fakeDiffSerializedEvent: String,
+        forge: Forge
+    ) {
+        // Given — diff write fails; writeMappedViewEvent must not be called at all
+        val fakeData = DiffThenFullView(
+            viewUpdate = fakeViewUpdateEvent,
+            viewEvent = fakeViewEvent
+        )
+        val fakeDiffBytes = fakeDiffSerializedEvent.toByteArray(Charsets.UTF_8)
+        val fakeSerializedMeta = forge.aString()
+        val diffMeta = RumEventMeta.ViewUpdate(
+            viewId = fakeViewUpdateEvent.view.id,
+            documentVersion = fakeViewUpdateEvent.dd.documentVersion
+        )
+        whenever(mockEventSerializer.serialize(fakeViewUpdateEvent)) doReturn fakeDiffSerializedEvent
+        whenever(mockEventMetaSerializer.serialize(diffMeta)) doReturn fakeSerializedMeta
+        whenever(
+            mockEventBatchWriter.write(
+                RawBatchEvent(data = fakeDiffBytes, metadata = fakeSerializedMeta.toByteArray(Charsets.UTF_8)),
+                null,
+                fakeEventType
+            )
+        ) doReturn false
+
+        // When
+        testedWriter.write(mockEventBatchWriter, fakeData, fakeEventType)
+
+        // Then — only one batch write (the diff); full view batch write never attempted
+        verify(mockEventBatchWriter, times(1)).write(any(), isNull(), any())
+    }
+
+    @Test
+    fun `M NOT call writeLastViewEvent W write() { DiffThenFullView, diff write fails }`(
+        @Forgery fakeViewUpdateEvent: ViewUpdateEvent,
+        @Forgery fakeViewEvent: ViewEvent,
+        @StringForgery fakeDiffSerializedEvent: String,
+        forge: Forge
+    ) {
+        // Given
+        val fakeData = DiffThenFullView(
+            viewUpdate = fakeViewUpdateEvent,
+            viewEvent = fakeViewEvent
+        )
+        val fakeDiffBytes = fakeDiffSerializedEvent.toByteArray(Charsets.UTF_8)
+        val fakeSerializedMeta = forge.aString()
+        val diffMeta = RumEventMeta.ViewUpdate(
+            viewId = fakeViewUpdateEvent.view.id,
+            documentVersion = fakeViewUpdateEvent.dd.documentVersion
+        )
+        whenever(mockEventSerializer.serialize(fakeViewUpdateEvent)) doReturn fakeDiffSerializedEvent
+        whenever(mockEventMetaSerializer.serialize(diffMeta)) doReturn fakeSerializedMeta
+        whenever(
+            mockEventBatchWriter.write(
+                RawBatchEvent(data = fakeDiffBytes, metadata = fakeSerializedMeta.toByteArray(Charsets.UTF_8)),
+                null,
+                fakeEventType
+            )
+        ) doReturn false
+
+        // When
+        testedWriter.write(mockEventBatchWriter, fakeData, fakeEventType)
+
+        // Then
+        verify(rumMonitor.mockSdkCore, never()).writeLastViewEvent(any<ByteArray>())
+    }
+
+    @Test
+    fun `M return false W write() { DiffThenFullView, diff write fails }`(
+        @Forgery fakeViewUpdateEvent: ViewUpdateEvent,
+        @Forgery fakeViewEvent: ViewEvent,
+        @StringForgery fakeDiffSerializedEvent: String,
+        forge: Forge
+    ) {
+        // Given
+        val fakeData = DiffThenFullView(
+            viewUpdate = fakeViewUpdateEvent,
+            viewEvent = fakeViewEvent
+        )
+        val fakeDiffBytes = fakeDiffSerializedEvent.toByteArray(Charsets.UTF_8)
+        val fakeSerializedMeta = forge.aString()
+        val diffMeta = RumEventMeta.ViewUpdate(
+            viewId = fakeViewUpdateEvent.view.id,
+            documentVersion = fakeViewUpdateEvent.dd.documentVersion
+        )
+        whenever(mockEventSerializer.serialize(fakeViewUpdateEvent)) doReturn fakeDiffSerializedEvent
+        whenever(mockEventMetaSerializer.serialize(diffMeta)) doReturn fakeSerializedMeta
+        whenever(
+            mockEventBatchWriter.write(
+                RawBatchEvent(data = fakeDiffBytes, metadata = fakeSerializedMeta.toByteArray(Charsets.UTF_8)),
+                null,
+                fakeEventType
+            )
+        ) doReturn false
+
+        // When
+        val result = testedWriter.write(mockEventBatchWriter, fakeData, fakeEventType)
+
+        // Then
+        assertThat(result).isFalse()
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriterTest.kt
@@ -318,7 +318,7 @@ internal class RumViewEventWriterTest {
     }
 
     @Test
-    fun `M write diff then full view W documentVersion is multiple of FULL_VIEW_EVERY_N_UPDATES`(
+    fun `M write diff then full view W writeViewEvent() {documentVersion is multiple of FULL_VIEW_EVERY_N_UPDATES}`(
         @Forgery fakeViewEvent: ViewEvent
     ) {
         // Given
@@ -360,7 +360,7 @@ internal class RumViewEventWriterTest {
     }
 
     @Test
-    fun `M write view update W documentVersion is not multiple of FULL_VIEW_EVERY_N_UPDATES`(
+    fun `M write view update W writeViewEvent() {documentVersion is not multiple of FULL_VIEW_EVERY_N_UPDATES}`(
         @Forgery fakeViewEvent: ViewEvent
     ) {
         // Given
@@ -415,7 +415,7 @@ internal class RumViewEventWriterTest {
     }
 
     @Test
-    fun `M write diff then full view W documentVersion is multiple of FULL_VIEW_EVERY_N_UPDATES then resume diffs`(
+    fun `M write diff then full view W writeViewEvent() {checkpoint, then resume diffs}`(
         @Forgery fakeViewEvent: ViewEvent
     ) {
         // Given
@@ -470,7 +470,7 @@ internal class RumViewEventWriterTest {
     }
 
     @Test
-    fun `M write diff then full view W view is closing {isActive is false}`(
+    fun `M write diff then full view W writeViewEvent() {isActive is false}`(
         @Forgery fakeViewEvent: ViewEvent
     ) {
         // Given
@@ -512,7 +512,7 @@ internal class RumViewEventWriterTest {
     }
 
     @Test
-    fun `M write view update W view is active {isActive is true}`(
+    fun `M write view update W writeViewEvent() {isActive is true}`(
         @Forgery fakeViewEvent: ViewEvent
     ) {
         // Given
@@ -554,7 +554,7 @@ internal class RumViewEventWriterTest {
     }
 
     @Test
-    fun `M write diff then full view W documentVersion is multiple of FULL_VIEW_EVERY_N_UPDATES {carries diff}`(
+    fun `M write diff then full view W writeViewEvent() {checkpoint carries diff}`(
         @Forgery fakeViewEvent: ViewEvent
     ) {
         // Given
@@ -597,7 +597,7 @@ internal class RumViewEventWriterTest {
     }
 
     @Test
-    fun `M write diff then full view W view is closing {diff contains previous state}`(
+    fun `M write diff then full view W writeViewEvent() {isActive is false, carries diff}`(
         @Forgery fakeViewEvent: ViewEvent
     ) {
         // Given

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriterTest.kt
@@ -92,26 +92,26 @@ internal class RumViewEventWriterTest {
         forge: Forge
     ) {
         // Given
-        val secondEvent = fakeViewEvent.copy(
-            view = fakeViewEvent.view.copy(
-                action = ViewEvent.Action(fakeViewEvent.view.action.count + forge.aPositiveLong(strict = true))
-            )
+        val firstEvent = fakeViewEvent.copy(
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L)
         )
-        whenever(mockViewEventMapper.map(fakeViewEvent)) doReturn fakeViewEvent
+        val secondEvent = firstEvent.copy(
+            view = firstEvent.view.copy(
+                action = ViewEvent.Action(firstEvent.view.action.count + forge.aPositiveLong(strict = true))
+            ),
+            dd = firstEvent.dd.copy(documentVersion = 2L)
+        )
+        whenever(mockViewEventMapper.map(firstEvent)) doReturn firstEvent
         whenever(mockViewEventMapper.map(secondEvent)) doReturn secondEvent
         val writtenEvents = mutableListOf<Any>()
         whenever(mockDataWriter.write(eq(mockEventBatchWriter), any(), eq(fakeEventType))) doAnswer {
             writtenEvents += it.getArgument<Any>(1)
-            if (writtenEvents.size == 1) {
-                false
-            } else {
-                true
-            }
+            writtenEvents.size != 1
         }
 
         // When
         testedWriter.writeViewEvent(
-            viewEvent = fakeViewEvent,
+            viewEvent = firstEvent,
             datadogContext = fakeDatadogContext,
             writeScope = mockEventWriteScope,
             writer = mockDataWriter,
@@ -136,12 +136,16 @@ internal class RumViewEventWriterTest {
         forge: Forge
     ) {
         // Given
-        val secondEvent = fakeViewEvent.copy(
-            view = fakeViewEvent.view.copy(
-                action = ViewEvent.Action(fakeViewEvent.view.action.count + forge.aPositiveLong(strict = true))
-            )
+        val firstEvent = fakeViewEvent.copy(
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L)
         )
-        whenever(mockViewEventMapper.map(fakeViewEvent)) doReturn fakeViewEvent
+        val secondEvent = firstEvent.copy(
+            view = firstEvent.view.copy(
+                action = ViewEvent.Action(firstEvent.view.action.count + forge.aPositiveLong(strict = true))
+            ),
+            dd = firstEvent.dd.copy(documentVersion = 2L)
+        )
+        whenever(mockViewEventMapper.map(firstEvent)) doReturn firstEvent
         whenever(mockViewEventMapper.map(secondEvent)) doReturn secondEvent
         val writtenEvents = mutableListOf<Any>()
         whenever(mockDataWriter.write(eq(mockEventBatchWriter), any(), eq(fakeEventType))) doAnswer {
@@ -151,7 +155,7 @@ internal class RumViewEventWriterTest {
 
         // When
         testedWriter.writeViewEvent(
-            viewEvent = fakeViewEvent,
+            viewEvent = firstEvent,
             datadogContext = fakeDatadogContext,
             writeScope = mockEventWriteScope,
             writer = mockDataWriter,
@@ -176,17 +180,22 @@ internal class RumViewEventWriterTest {
         forge: Forge
     ) {
         // Given
-        val secondEvent = fakeViewEvent.copy(
-            view = fakeViewEvent.view.copy(
-                action = ViewEvent.Action(fakeViewEvent.view.action.count + forge.aPositiveLong(strict = true))
-            )
+        val firstEvent = fakeViewEvent.copy(
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L)
+        )
+        val secondEvent = firstEvent.copy(
+            view = firstEvent.view.copy(
+                action = ViewEvent.Action(firstEvent.view.action.count + forge.aPositiveLong(strict = true))
+            ),
+            dd = firstEvent.dd.copy(documentVersion = 2L)
         )
         val thirdEvent = secondEvent.copy(
             view = secondEvent.view.copy(
                 action = ViewEvent.Action(secondEvent.view.action.count + forge.aPositiveLong(strict = true))
-            )
+            ),
+            dd = secondEvent.dd.copy(documentVersion = 3L)
         )
-        whenever(mockViewEventMapper.map(fakeViewEvent)) doReturn fakeViewEvent
+        whenever(mockViewEventMapper.map(firstEvent)) doReturn firstEvent
         whenever(mockViewEventMapper.map(secondEvent)) doReturn secondEvent
         whenever(mockViewEventMapper.map(thirdEvent)) doReturn thirdEvent
         val writtenEvents = mutableListOf<Any>()
@@ -197,7 +206,7 @@ internal class RumViewEventWriterTest {
 
         // When
         testedWriter.writeViewEvent(
-            viewEvent = fakeViewEvent,
+            viewEvent = firstEvent,
             datadogContext = fakeDatadogContext,
             writeScope = mockEventWriteScope,
             writer = mockDataWriter,
@@ -234,12 +243,16 @@ internal class RumViewEventWriterTest {
         whenever(mockEventWriteScope.invoke(any())) doAnswer {
             pendingWrites += it.getArgument<(EventBatchWriter) -> Unit>(0)
         }
-        val secondEvent = fakeViewEvent.copy(
-            view = fakeViewEvent.view.copy(
-                action = ViewEvent.Action(fakeViewEvent.view.action.count + forge.aPositiveLong(strict = true))
-            )
+        val firstEvent = fakeViewEvent.copy(
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L)
         )
-        whenever(mockViewEventMapper.map(fakeViewEvent)) doReturn fakeViewEvent
+        val secondEvent = firstEvent.copy(
+            view = firstEvent.view.copy(
+                action = ViewEvent.Action(firstEvent.view.action.count + forge.aPositiveLong(strict = true))
+            ),
+            dd = firstEvent.dd.copy(documentVersion = 2L)
+        )
+        whenever(mockViewEventMapper.map(firstEvent)) doReturn firstEvent
         whenever(mockViewEventMapper.map(secondEvent)) doReturn secondEvent
         val writtenEvents = mutableListOf<Any>()
         whenever(mockDataWriter.write(eq(mockEventBatchWriter), any(), eq(fakeEventType))) doAnswer {
@@ -249,7 +262,7 @@ internal class RumViewEventWriterTest {
 
         // When
         testedWriter.writeViewEvent(
-            viewEvent = fakeViewEvent,
+            viewEvent = firstEvent,
             datadogContext = fakeDatadogContext,
             writeScope = mockEventWriteScope,
             writer = mockDataWriter,
@@ -293,6 +306,150 @@ internal class RumViewEventWriterTest {
         // Then
         assertThat(writtenEvents).hasSize(1)
         assertThat(writtenEvents[0]).isEqualTo(MappedViewEvent(fakeViewEvent))
+    }
+
+    @Test
+    fun `M write full view W documentVersion is multiple of FULL_VIEW_EVERY_N_UPDATES`(
+        @Forgery fakeViewEvent: ViewEvent
+    ) {
+        // Given
+        val firstEvent = fakeViewEvent.copy(
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L)
+        )
+        val checkpointEvent = firstEvent.copy(
+            dd = firstEvent.dd.copy(documentVersion = RumViewEventWriterImpl.FULL_VIEW_EVERY_N_UPDATES)
+        )
+        whenever(mockViewEventMapper.map(firstEvent)) doReturn firstEvent
+        whenever(mockViewEventMapper.map(checkpointEvent)) doReturn checkpointEvent
+        val writtenEvents = mutableListOf<Any>()
+        whenever(mockDataWriter.write(eq(mockEventBatchWriter), any(), eq(fakeEventType))) doAnswer {
+            writtenEvents += it.getArgument<Any>(1)
+            true
+        }
+
+        // When
+        testedWriter.writeViewEvent(
+            viewEvent = firstEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+        testedWriter.writeViewEvent(
+            viewEvent = checkpointEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+
+        // Then
+        assertThat(writtenEvents[0]).isInstanceOf(MappedViewEvent::class.java)
+        assertThat(writtenEvents[1]).isInstanceOf(MappedViewEvent::class.java)
+    }
+
+    @Test
+    fun `M write view update W documentVersion is not multiple of FULL_VIEW_EVERY_N_UPDATES`(
+        @Forgery fakeViewEvent: ViewEvent
+    ) {
+        // Given
+        val firstEvent = fakeViewEvent.copy(
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L)
+        )
+        val beforeCheckpoint = firstEvent.copy(
+            dd = firstEvent.dd.copy(documentVersion = RumViewEventWriterImpl.FULL_VIEW_EVERY_N_UPDATES - 1L)
+        )
+        val afterCheckpoint = firstEvent.copy(
+            dd = firstEvent.dd.copy(documentVersion = RumViewEventWriterImpl.FULL_VIEW_EVERY_N_UPDATES + 1L)
+        )
+        whenever(mockViewEventMapper.map(firstEvent)) doReturn firstEvent
+        whenever(mockViewEventMapper.map(beforeCheckpoint)) doReturn beforeCheckpoint
+        whenever(mockViewEventMapper.map(afterCheckpoint)) doReturn afterCheckpoint
+        val writtenEvents = mutableListOf<Any>()
+        whenever(mockDataWriter.write(eq(mockEventBatchWriter), any(), eq(fakeEventType))) doAnswer {
+            writtenEvents += it.getArgument<Any>(1)
+            true
+        }
+
+        // When
+        testedWriter.writeViewEvent(
+            viewEvent = firstEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+        testedWriter.writeViewEvent(
+            viewEvent = beforeCheckpoint,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+        testedWriter.writeViewEvent(
+            viewEvent = afterCheckpoint,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+
+        // Then
+        assertThat(writtenEvents[0]).isInstanceOf(MappedViewEvent::class.java)
+        assertThat(writtenEvents[1]).isInstanceOf(RumViewUpdateData::class.java)
+        assertThat(writtenEvents[2]).isInstanceOf(RumViewUpdateData::class.java)
+    }
+
+    @Test
+    fun `M write full view W documentVersion is multiple of FULL_VIEW_EVERY_N_UPDATES then resume diffs`(
+        @Forgery fakeViewEvent: ViewEvent
+    ) {
+        // Given
+        val firstEvent = fakeViewEvent.copy(
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L)
+        )
+        val checkpointEvent = firstEvent.copy(
+            dd = firstEvent.dd.copy(documentVersion = RumViewEventWriterImpl.FULL_VIEW_EVERY_N_UPDATES)
+        )
+        val afterCheckpoint = firstEvent.copy(
+            dd = firstEvent.dd.copy(documentVersion = RumViewEventWriterImpl.FULL_VIEW_EVERY_N_UPDATES + 1L)
+        )
+        whenever(mockViewEventMapper.map(firstEvent)) doReturn firstEvent
+        whenever(mockViewEventMapper.map(checkpointEvent)) doReturn checkpointEvent
+        whenever(mockViewEventMapper.map(afterCheckpoint)) doReturn afterCheckpoint
+        val writtenEvents = mutableListOf<Any>()
+        whenever(mockDataWriter.write(eq(mockEventBatchWriter), any(), eq(fakeEventType))) doAnswer {
+            writtenEvents += it.getArgument<Any>(1)
+            true
+        }
+
+        // When
+        testedWriter.writeViewEvent(
+            viewEvent = firstEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+        testedWriter.writeViewEvent(
+            viewEvent = checkpointEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+        testedWriter.writeViewEvent(
+            viewEvent = afterCheckpoint,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+
+        // Then
+        assertThat(writtenEvents[0]).isInstanceOf(MappedViewEvent::class.java) // baseline
+        assertThat(writtenEvents[1]).isInstanceOf(MappedViewEvent::class.java) // checkpoint
+        assertThat(writtenEvents[2]).isInstanceOf(RumViewUpdateData::class.java) // diff resumes
     }
 
     companion object {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriterTest.kt
@@ -318,7 +318,7 @@ internal class RumViewEventWriterTest {
     }
 
     @Test
-    fun `M write full view W documentVersion is multiple of FULL_VIEW_EVERY_N_UPDATES`(
+    fun `M write diff then full view W documentVersion is multiple of FULL_VIEW_EVERY_N_UPDATES`(
         @Forgery fakeViewEvent: ViewEvent
     ) {
         // Given
@@ -356,7 +356,7 @@ internal class RumViewEventWriterTest {
 
         // Then
         assertThat(writtenEvents[0]).isInstanceOf(MappedViewEvent::class.java)
-        assertThat(writtenEvents[1]).isInstanceOf(MappedViewEvent::class.java)
+        assertThat(writtenEvents[1]).isInstanceOf(DiffThenFullView::class.java)
     }
 
     @Test
@@ -415,7 +415,7 @@ internal class RumViewEventWriterTest {
     }
 
     @Test
-    fun `M write full view W documentVersion is multiple of FULL_VIEW_EVERY_N_UPDATES then resume diffs`(
+    fun `M write diff then full view W documentVersion is multiple of FULL_VIEW_EVERY_N_UPDATES then resume diffs`(
         @Forgery fakeViewEvent: ViewEvent
     ) {
         // Given
@@ -465,12 +465,12 @@ internal class RumViewEventWriterTest {
 
         // Then
         assertThat(writtenEvents[0]).isInstanceOf(MappedViewEvent::class.java) // baseline
-        assertThat(writtenEvents[1]).isInstanceOf(MappedViewEvent::class.java) // checkpoint
+        assertThat(writtenEvents[1]).isInstanceOf(DiffThenFullView::class.java) // diff + full view checkpoint
         assertThat(writtenEvents[2]).isInstanceOf(RumViewUpdateData::class.java) // diff resumes
     }
 
     @Test
-    fun `M write full view W view is closing {isActive is false}`(
+    fun `M write diff then full view W view is closing {isActive is false}`(
         @Forgery fakeViewEvent: ViewEvent
     ) {
         // Given
@@ -508,7 +508,7 @@ internal class RumViewEventWriterTest {
 
         // Then
         assertThat(writtenEvents[0]).isInstanceOf(MappedViewEvent::class.java) // baseline
-        assertThat(writtenEvents[1]).isInstanceOf(MappedViewEvent::class.java) // closing → full view
+        assertThat(writtenEvents[1]).isInstanceOf(DiffThenFullView::class.java) // closing → diff + full view
     }
 
     @Test
@@ -551,6 +551,92 @@ internal class RumViewEventWriterTest {
         // Then
         assertThat(writtenEvents[0]).isInstanceOf(MappedViewEvent::class.java) // baseline
         assertThat(writtenEvents[1]).isInstanceOf(RumViewUpdateData::class.java) // active → diff
+    }
+
+    @Test
+    fun `M write diff then full view W documentVersion is multiple of FULL_VIEW_EVERY_N_UPDATES {carries diff}`(
+        @Forgery fakeViewEvent: ViewEvent
+    ) {
+        // Given
+        val firstEvent = fakeViewEvent.copy(
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L),
+            view = fakeViewEvent.view.copy(isActive = true)
+        )
+        val checkpointEvent = firstEvent.copy(
+            dd = firstEvent.dd.copy(documentVersion = RumViewEventWriterImpl.FULL_VIEW_EVERY_N_UPDATES),
+            view = firstEvent.view.copy(isActive = true)
+        )
+        whenever(mockViewEventMapper.map(firstEvent)) doReturn firstEvent
+        whenever(mockViewEventMapper.map(checkpointEvent)) doReturn checkpointEvent
+        val writtenEvents = mutableListOf<Any>()
+        whenever(mockDataWriter.write(eq(mockEventBatchWriter), any(), eq(fakeEventType))) doAnswer {
+            writtenEvents += it.getArgument<Any>(1)
+            true
+        }
+
+        // When
+        testedWriter.writeViewEvent(
+            viewEvent = firstEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+        testedWriter.writeViewEvent(
+            viewEvent = checkpointEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+
+        // Then
+        assertThat(writtenEvents[1]).isInstanceOf(DiffThenFullView::class.java)
+        val diffThenFull = writtenEvents[1] as DiffThenFullView
+        assertThat(diffThenFull.viewEvent).isEqualTo(checkpointEvent)
+    }
+
+    @Test
+    fun `M write diff then full view W view is closing {diff contains previous state}`(
+        @Forgery fakeViewEvent: ViewEvent
+    ) {
+        // Given
+        val firstEvent = fakeViewEvent.copy(
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L),
+            view = fakeViewEvent.view.copy(isActive = true)
+        )
+        val closingEvent = firstEvent.copy(
+            dd = firstEvent.dd.copy(documentVersion = 2L),
+            view = firstEvent.view.copy(isActive = false)
+        )
+        whenever(mockViewEventMapper.map(firstEvent)) doReturn firstEvent
+        whenever(mockViewEventMapper.map(closingEvent)) doReturn closingEvent
+        val writtenEvents = mutableListOf<Any>()
+        whenever(mockDataWriter.write(eq(mockEventBatchWriter), any(), eq(fakeEventType))) doAnswer {
+            writtenEvents += it.getArgument<Any>(1)
+            true
+        }
+
+        // When
+        testedWriter.writeViewEvent(
+            viewEvent = firstEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+        testedWriter.writeViewEvent(
+            viewEvent = closingEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+
+        // Then
+        assertThat(writtenEvents[1]).isInstanceOf(DiffThenFullView::class.java)
+        val diffThenFull = writtenEvents[1] as DiffThenFullView
+        assertThat(diffThenFull.viewEvent).isEqualTo(closingEvent)
     }
 
     companion object {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriterTest.kt
@@ -93,11 +93,13 @@ internal class RumViewEventWriterTest {
     ) {
         // Given
         val firstEvent = fakeViewEvent.copy(
-            dd = fakeViewEvent.dd.copy(documentVersion = 1L)
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L),
+            view = fakeViewEvent.view.copy(isActive = true)
         )
         val secondEvent = firstEvent.copy(
             view = firstEvent.view.copy(
-                action = ViewEvent.Action(firstEvent.view.action.count + forge.aPositiveLong(strict = true))
+                action = ViewEvent.Action(firstEvent.view.action.count + forge.aPositiveLong(strict = true)),
+                isActive = true
             ),
             dd = firstEvent.dd.copy(documentVersion = 2L)
         )
@@ -137,11 +139,13 @@ internal class RumViewEventWriterTest {
     ) {
         // Given
         val firstEvent = fakeViewEvent.copy(
-            dd = fakeViewEvent.dd.copy(documentVersion = 1L)
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L),
+            view = fakeViewEvent.view.copy(isActive = true)
         )
         val secondEvent = firstEvent.copy(
             view = firstEvent.view.copy(
-                action = ViewEvent.Action(firstEvent.view.action.count + forge.aPositiveLong(strict = true))
+                action = ViewEvent.Action(firstEvent.view.action.count + forge.aPositiveLong(strict = true)),
+                isActive = true
             ),
             dd = firstEvent.dd.copy(documentVersion = 2L)
         )
@@ -181,17 +185,20 @@ internal class RumViewEventWriterTest {
     ) {
         // Given
         val firstEvent = fakeViewEvent.copy(
-            dd = fakeViewEvent.dd.copy(documentVersion = 1L)
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L),
+            view = fakeViewEvent.view.copy(isActive = true)
         )
         val secondEvent = firstEvent.copy(
             view = firstEvent.view.copy(
-                action = ViewEvent.Action(firstEvent.view.action.count + forge.aPositiveLong(strict = true))
+                action = ViewEvent.Action(firstEvent.view.action.count + forge.aPositiveLong(strict = true)),
+                isActive = true
             ),
             dd = firstEvent.dd.copy(documentVersion = 2L)
         )
         val thirdEvent = secondEvent.copy(
             view = secondEvent.view.copy(
-                action = ViewEvent.Action(secondEvent.view.action.count + forge.aPositiveLong(strict = true))
+                action = ViewEvent.Action(secondEvent.view.action.count + forge.aPositiveLong(strict = true)),
+                isActive = true
             ),
             dd = secondEvent.dd.copy(documentVersion = 3L)
         )
@@ -244,11 +251,13 @@ internal class RumViewEventWriterTest {
             pendingWrites += it.getArgument<(EventBatchWriter) -> Unit>(0)
         }
         val firstEvent = fakeViewEvent.copy(
-            dd = fakeViewEvent.dd.copy(documentVersion = 1L)
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L),
+            view = fakeViewEvent.view.copy(isActive = true)
         )
         val secondEvent = firstEvent.copy(
             view = firstEvent.view.copy(
-                action = ViewEvent.Action(firstEvent.view.action.count + forge.aPositiveLong(strict = true))
+                action = ViewEvent.Action(firstEvent.view.action.count + forge.aPositiveLong(strict = true)),
+                isActive = true
             ),
             dd = firstEvent.dd.copy(documentVersion = 2L)
         )
@@ -314,10 +323,12 @@ internal class RumViewEventWriterTest {
     ) {
         // Given
         val firstEvent = fakeViewEvent.copy(
-            dd = fakeViewEvent.dd.copy(documentVersion = 1L)
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L),
+            view = fakeViewEvent.view.copy(isActive = true)
         )
         val checkpointEvent = firstEvent.copy(
-            dd = firstEvent.dd.copy(documentVersion = RumViewEventWriterImpl.FULL_VIEW_EVERY_N_UPDATES)
+            dd = firstEvent.dd.copy(documentVersion = RumViewEventWriterImpl.FULL_VIEW_EVERY_N_UPDATES),
+            view = firstEvent.view.copy(isActive = true)
         )
         whenever(mockViewEventMapper.map(firstEvent)) doReturn firstEvent
         whenever(mockViewEventMapper.map(checkpointEvent)) doReturn checkpointEvent
@@ -354,13 +365,16 @@ internal class RumViewEventWriterTest {
     ) {
         // Given
         val firstEvent = fakeViewEvent.copy(
-            dd = fakeViewEvent.dd.copy(documentVersion = 1L)
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L),
+            view = fakeViewEvent.view.copy(isActive = true)
         )
         val beforeCheckpoint = firstEvent.copy(
-            dd = firstEvent.dd.copy(documentVersion = RumViewEventWriterImpl.FULL_VIEW_EVERY_N_UPDATES - 1L)
+            dd = firstEvent.dd.copy(documentVersion = RumViewEventWriterImpl.FULL_VIEW_EVERY_N_UPDATES - 1L),
+            view = firstEvent.view.copy(isActive = true)
         )
         val afterCheckpoint = firstEvent.copy(
-            dd = firstEvent.dd.copy(documentVersion = RumViewEventWriterImpl.FULL_VIEW_EVERY_N_UPDATES + 1L)
+            dd = firstEvent.dd.copy(documentVersion = RumViewEventWriterImpl.FULL_VIEW_EVERY_N_UPDATES + 1L),
+            view = firstEvent.view.copy(isActive = true)
         )
         whenever(mockViewEventMapper.map(firstEvent)) doReturn firstEvent
         whenever(mockViewEventMapper.map(beforeCheckpoint)) doReturn beforeCheckpoint
@@ -406,13 +420,16 @@ internal class RumViewEventWriterTest {
     ) {
         // Given
         val firstEvent = fakeViewEvent.copy(
-            dd = fakeViewEvent.dd.copy(documentVersion = 1L)
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L),
+            view = fakeViewEvent.view.copy(isActive = true)
         )
         val checkpointEvent = firstEvent.copy(
-            dd = firstEvent.dd.copy(documentVersion = RumViewEventWriterImpl.FULL_VIEW_EVERY_N_UPDATES)
+            dd = firstEvent.dd.copy(documentVersion = RumViewEventWriterImpl.FULL_VIEW_EVERY_N_UPDATES),
+            view = firstEvent.view.copy(isActive = true)
         )
         val afterCheckpoint = firstEvent.copy(
-            dd = firstEvent.dd.copy(documentVersion = RumViewEventWriterImpl.FULL_VIEW_EVERY_N_UPDATES + 1L)
+            dd = firstEvent.dd.copy(documentVersion = RumViewEventWriterImpl.FULL_VIEW_EVERY_N_UPDATES + 1L),
+            view = firstEvent.view.copy(isActive = true)
         )
         whenever(mockViewEventMapper.map(firstEvent)) doReturn firstEvent
         whenever(mockViewEventMapper.map(checkpointEvent)) doReturn checkpointEvent
@@ -450,6 +467,90 @@ internal class RumViewEventWriterTest {
         assertThat(writtenEvents[0]).isInstanceOf(MappedViewEvent::class.java) // baseline
         assertThat(writtenEvents[1]).isInstanceOf(MappedViewEvent::class.java) // checkpoint
         assertThat(writtenEvents[2]).isInstanceOf(RumViewUpdateData::class.java) // diff resumes
+    }
+
+    @Test
+    fun `M write full view W view is closing {isActive is false}`(
+        @Forgery fakeViewEvent: ViewEvent
+    ) {
+        // Given
+        val firstEvent = fakeViewEvent.copy(
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L),
+            view = fakeViewEvent.view.copy(isActive = true)
+        )
+        val closingEvent = firstEvent.copy(
+            dd = firstEvent.dd.copy(documentVersion = 2L),
+            view = firstEvent.view.copy(isActive = false)
+        )
+        whenever(mockViewEventMapper.map(firstEvent)) doReturn firstEvent
+        whenever(mockViewEventMapper.map(closingEvent)) doReturn closingEvent
+        val writtenEvents = mutableListOf<Any>()
+        whenever(mockDataWriter.write(eq(mockEventBatchWriter), any(), eq(fakeEventType))) doAnswer {
+            writtenEvents += it.getArgument<Any>(1)
+            true
+        }
+
+        // When
+        testedWriter.writeViewEvent(
+            viewEvent = firstEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+        testedWriter.writeViewEvent(
+            viewEvent = closingEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+
+        // Then
+        assertThat(writtenEvents[0]).isInstanceOf(MappedViewEvent::class.java) // baseline
+        assertThat(writtenEvents[1]).isInstanceOf(MappedViewEvent::class.java) // closing → full view
+    }
+
+    @Test
+    fun `M write view update W view is active {isActive is true}`(
+        @Forgery fakeViewEvent: ViewEvent
+    ) {
+        // Given
+        val firstEvent = fakeViewEvent.copy(
+            dd = fakeViewEvent.dd.copy(documentVersion = 1L),
+            view = fakeViewEvent.view.copy(isActive = true)
+        )
+        val secondEvent = firstEvent.copy(
+            dd = firstEvent.dd.copy(documentVersion = 2L),
+            view = firstEvent.view.copy(isActive = true)
+        )
+        whenever(mockViewEventMapper.map(firstEvent)) doReturn firstEvent
+        whenever(mockViewEventMapper.map(secondEvent)) doReturn secondEvent
+        val writtenEvents = mutableListOf<Any>()
+        whenever(mockDataWriter.write(eq(mockEventBatchWriter), any(), eq(fakeEventType))) doAnswer {
+            writtenEvents += it.getArgument<Any>(1)
+            true
+        }
+
+        // When
+        testedWriter.writeViewEvent(
+            viewEvent = firstEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+        testedWriter.writeViewEvent(
+            viewEvent = secondEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+
+        // Then
+        assertThat(writtenEvents[0]).isInstanceOf(MappedViewEvent::class.java) // baseline
+        assertThat(writtenEvents[1]).isInstanceOf(RumViewUpdateData::class.java) // active → diff
     }
 
     companion object {

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/RumTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/RumTest.kt
@@ -57,7 +57,7 @@ internal abstract class RumTest<R : Activity, T : MockServerActivityTestRule<R>>
                     }
                     rumPayload
                         .forEach {
-                            if (it.isEventRelatedToApplicationLaunch) {
+                            if (it.isEventRelatedToApplicationLaunch && !it.isClosingViewEvent) {
                                 sentLaunchEvents += it
                             } else if (it.isViewUpdateEventRelatedToApplicationLaunch) {
                                 sentLaunchUpdateEvents += it

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/RumTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/RumTest.kt
@@ -57,16 +57,18 @@ internal abstract class RumTest<R : Activity, T : MockServerActivityTestRule<R>>
                     }
                     rumPayload
                         .forEach {
-                            if (it.isEventRelatedToApplicationLaunch && !it.isClosingViewEvent) {
+                            if (it.isEventRelatedToApplicationLaunch) {
+                                // All ApplicationLaunch full views (initial and closing) are kept.
+                                // reduceViewEvents() retains the highest docVersion per viewId,
+                                // which is the closing view and satisfies the exact docVersion check.
                                 sentLaunchEvents += it
                             } else if (it.isViewUpdateEventRelatedToApplicationLaunch) {
                                 sentLaunchUpdateEvents += it
-                            } else if (it.isViewEvent && !it.isClosingViewEvent) {
-                                // Exclude closing full ViewEvents emitted by DiffThenFullView
-                                // (isActive=false). These have a higher documentVersion than the
-                                // initial ViewEvent and would replace it after reduceViewEvents(),
-                                // causing assertions on the initial view to fail. The closing full
-                                // view behaviour is already covered by unit and reliability tests.
+                            } else if (it.isViewEvent && !it.isClosingViewEvent && !it.isPeriodicCheckpointFullView) {
+                                // Exclude closing views (is_active=false): they would win in
+                                // reduceViewEvents() and fail the session.is_active=true assertion.
+                                // Exclude periodic checkpoint views (docVersion%4==0, is_active=true):
+                                // they are mid-session snapshots covered by reliability tests.
                                 sentViewEvents += it
                             } else if (it.isViewUpdateEvent) {
                                 sentViewUpdateEvents += it
@@ -154,6 +156,15 @@ internal abstract class RumTest<R : Activity, T : MockServerActivityTestRule<R>>
             getAsJsonObject("view").has("is_active") &&
             !getAsJsonObject("view").get("is_active").asBoolean
 
+    // Full ViewEvents emitted as periodic checkpoints (docVersion % FULL_VIEW_EVERY_N_UPDATES == 0, is_active=true).
+    private val JsonObject.isPeriodicCheckpointFullView
+        get() = isViewEvent &&
+            has("_dd") &&
+            has("view") &&
+            getAsJsonObject("view").get("is_active")?.asBoolean != false &&
+            getAsJsonObject("_dd").get("document_version")?.asLong
+                ?.let { it % FULL_VIEW_EVERY_N_UPDATES == 0L } == true
+
     private val JsonObject.isViewUpdateEvent
         get() = get("type")?.asString == "view_update"
 
@@ -221,5 +232,8 @@ internal abstract class RumTest<R : Activity, T : MockServerActivityTestRule<R>>
 
     companion object {
         internal val FINAL_WAIT_MS = TimeUnit.SECONDS.toMillis(60)
+
+        // Keep in sync with RumViewEventWriterImpl.FULL_VIEW_EVERY_N_UPDATES.
+        private const val FULL_VIEW_EVERY_N_UPDATES = 4L
     }
 }

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/RumTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/RumTest.kt
@@ -61,7 +61,12 @@ internal abstract class RumTest<R : Activity, T : MockServerActivityTestRule<R>>
                                 sentLaunchEvents += it
                             } else if (it.isViewUpdateEventRelatedToApplicationLaunch) {
                                 sentLaunchUpdateEvents += it
-                            } else if (it.isViewEvent) {
+                            } else if (it.isViewEvent && !it.isClosingViewEvent) {
+                                // Exclude closing full ViewEvents emitted by DiffThenFullView
+                                // (isActive=false). These have a higher documentVersion than the
+                                // initial ViewEvent and would replace it after reduceViewEvents(),
+                                // causing assertions on the initial view to fail. The closing full
+                                // view behaviour is already covered by unit and reliability tests.
                                 sentViewEvents += it
                             } else if (it.isViewUpdateEvent) {
                                 sentViewUpdateEvents += it
@@ -142,6 +147,12 @@ internal abstract class RumTest<R : Activity, T : MockServerActivityTestRule<R>>
 
     private val JsonObject.isViewEvent
         get() = get("type")?.asString == "view"
+
+    private val JsonObject.isClosingViewEvent
+        get() = isViewEvent &&
+            has("view") &&
+            getAsJsonObject("view").has("is_active") &&
+            !getAsJsonObject("view").get("is_active").asBoolean
 
     private val JsonObject.isViewUpdateEvent
         get() = get("type")?.asString == "view_update"

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ActivityViewTrackingStrategyTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ActivityViewTrackingStrategyTest.kt
@@ -124,7 +124,7 @@ class ActivityViewTrackingStrategyTest {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(2)
+            .hasSize(3)
             .hasRumEvent(index = 0) {
                 hasService(stubSdkCore.getDatadogContext().service)
                 hasApplicationId(fakeApplicationId)
@@ -159,6 +159,12 @@ class ActivityViewTrackingStrategyTest {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 2) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl("com/datadog/android/rum/integration/ActivityViewTrackingStrategyTest/StubActivity")
+                hasViewIsActive(false)
             }
     }
 

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingRumTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingRumTest.kt
@@ -141,7 +141,7 @@ class ManualTrackingRumTest {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(2)
+            .hasSize(3)
             .hasRumEvent(index = 0) {
                 hasService(stubSdkCore.getDatadogContext().service)
                 hasApplicationId(fakeApplicationId)
@@ -176,6 +176,12 @@ class ManualTrackingRumTest {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 2) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
             }
     }
 
@@ -267,7 +273,7 @@ class ManualTrackingRumTest {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(4)
+            .hasSize(5)
             .hasRumEvent(index = 0) {
                 hasService(stubSdkCore.getDatadogContext().service)
                 hasApplicationId(fakeApplicationId)
@@ -339,6 +345,12 @@ class ManualTrackingRumTest {
                 }
                 hasNoOptionalFields()
             }
+            .hasRumEvent(index = 4) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
+            }
     }
 
     @Test
@@ -363,7 +375,7 @@ class ManualTrackingRumTest {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(5)
+            .hasSize(6)
             .hasRumEvent(index = 0) {
                 // Initial view
                 hasService(stubSdkCore.getDatadogContext().service)
@@ -424,7 +436,7 @@ class ManualTrackingRumTest {
                 hasActionName(actionName2)
             }
             .hasRumViewUpdateEvent(index = 4) {
-                // View updated with second action
+                // View updated with second action (diff part of DiffThenFullView at docVersion=4)
                 application { hasId(fakeApplicationId) }
                 session {
                     hasType(ViewUpdateEvent.ViewUpdateEventSessionType.USER)
@@ -447,6 +459,12 @@ class ManualTrackingRumTest {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 5) {
+                // Full view checkpoint at docVersion=4
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(true)
             }
     }
 
@@ -471,7 +489,7 @@ class ManualTrackingRumTest {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(4)
+            .hasSize(5)
             .hasRumEvent(index = 0) {
                 hasService(stubSdkCore.getDatadogContext().service)
                 hasApplicationId(fakeApplicationId)
@@ -542,6 +560,12 @@ class ManualTrackingRumTest {
                 }
                 hasNoOptionalFields()
             }
+            .hasRumEvent(index = 4) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
+            }
     }
 
     @RepeatedTest(16)
@@ -567,7 +591,7 @@ class ManualTrackingRumTest {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(4)
+            .hasSize(5)
             .hasRumEvent(index = 0) {
                 hasService(stubSdkCore.getDatadogContext().service)
                 hasApplicationId(fakeApplicationId)
@@ -638,6 +662,12 @@ class ManualTrackingRumTest {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 4) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(key)
+                hasViewIsActive(false)
             }
     }
 
@@ -666,7 +696,7 @@ class ManualTrackingRumTest {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(4)
+            .hasSize(5)
             .hasRumEvent(index = 0) {
                 hasService(stubSdkCore.getDatadogContext().service)
                 hasApplicationId(fakeApplicationId)
@@ -737,6 +767,12 @@ class ManualTrackingRumTest {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 4) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(key)
+                hasViewIsActive(false)
             }
     }
 
@@ -820,7 +856,7 @@ class ManualTrackingRumTest {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(2)
+            .hasSize(3)
             .hasRumEvent(index = 0) {
                 hasService(stubSdkCore.getDatadogContext().service)
                 hasApplicationId(fakeApplicationId)
@@ -857,6 +893,12 @@ class ManualTrackingRumTest {
                 }
                 hasNoOptionalFields()
             }
+            .hasRumEvent(index = 2) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(key)
+                hasViewIsActive(false)
+            }
     }
 
     @OptIn(ExperimentalRumApi::class)
@@ -881,7 +923,7 @@ class ManualTrackingRumTest {
         val expectedSecondViewLoadingTime = TimeUnit.MILLISECONDS.toNanos(100)
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(3)
+            .hasSize(4)
             .hasRumEvent(index = 0) {
                 hasService(stubSdkCore.getDatadogContext().service)
                 hasApplicationId(fakeApplicationId)
@@ -919,6 +961,7 @@ class ManualTrackingRumTest {
                 hasNoOptionalFields()
             }
             .hasRumViewUpdateEvent(index = 2) {
+                // diff part of DiffThenFullView at docVersion=4
                 application { hasId(fakeApplicationId) }
                 session {
                     hasType(ViewUpdateEvent.ViewUpdateEventSessionType.USER)
@@ -944,6 +987,12 @@ class ManualTrackingRumTest {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 3) {
+                // Full view checkpoint at docVersion=4
+                hasType("view")
+                hasViewUrl(key)
+                hasViewIsActive(true)
             }
     }
 

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ViewLoadingTimeMetricsTests.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ViewLoadingTimeMetricsTests.kt
@@ -126,7 +126,7 @@ class ViewLoadingTimeMetricsTests {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(4)
+            .hasSize(5)
             .hasRumEvent(index = 0) {
                 // Initial view
                 hasService(stubSdkCore.getDatadogContext().service)
@@ -198,6 +198,12 @@ class ViewLoadingTimeMetricsTests {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 4) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
             }
     }
 
@@ -227,7 +233,7 @@ class ViewLoadingTimeMetricsTests {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(6)
+            .hasSize(8)
             .hasRumEvent(index = 0) {
                 // Initial view
                 hasService(stubSdkCore.getDatadogContext().service)
@@ -276,7 +282,7 @@ class ViewLoadingTimeMetricsTests {
                 hasNoOptionalFields()
             }
             .hasRumViewUpdateEvent(index = 3) {
-                // View updated with event
+                // View updated with addTiming1 (diff part of DiffThenFullView at docVersion=4)
                 application { hasId(fakeApplicationId) }
                 session {
                     hasType(ViewUpdateEvent.ViewUpdateEventSessionType.USER)
@@ -299,8 +305,14 @@ class ViewLoadingTimeMetricsTests {
                 }
                 hasNoOptionalFields()
             }
-            .hasRumViewUpdateEvent(index = 4) {
-                // View updated with event
+            .hasRumEvent(index = 4) {
+                // Full view checkpoint at docVersion=4 (DiffThenFullView from addTiming1)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(true)
+            }
+            .hasRumViewUpdateEvent(index = 5) {
+                // View updated with addTiming2
                 application { hasId(fakeApplicationId) }
                 session {
                     hasType(ViewUpdateEvent.ViewUpdateEventSessionType.USER)
@@ -323,8 +335,8 @@ class ViewLoadingTimeMetricsTests {
                 }
                 hasNoOptionalFields()
             }
-            .hasRumViewUpdateEvent(index = 5) {
-                // View stopped
+            .hasRumViewUpdateEvent(index = 6) {
+                // View stopped (diff part of DiffThenFullView on close)
                 application { hasId(fakeApplicationId) }
                 session {
                     hasType(ViewUpdateEvent.ViewUpdateEventSessionType.USER)
@@ -347,6 +359,12 @@ class ViewLoadingTimeMetricsTests {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 7) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
             }
     }
 
@@ -374,7 +392,7 @@ class ViewLoadingTimeMetricsTests {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(4)
+            .hasSize(5)
             .hasRumEvent(index = 0) {
                 // Initial view
                 hasService(stubSdkCore.getDatadogContext().service)
@@ -446,6 +464,12 @@ class ViewLoadingTimeMetricsTests {
                 }
                 hasNoOptionalFields()
             }
+            .hasRumEvent(index = 4) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
+            }
     }
 
     @RepeatedTest(10)
@@ -472,7 +496,7 @@ class ViewLoadingTimeMetricsTests {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(2)
+            .hasSize(3)
             .hasRumEvent(index = 0) {
                 // Initial view
                 hasService(stubSdkCore.getDatadogContext().service)
@@ -510,6 +534,12 @@ class ViewLoadingTimeMetricsTests {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 2) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
             }
     }
 
@@ -533,7 +563,7 @@ class ViewLoadingTimeMetricsTests {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(2)
+            .hasSize(3)
             .hasRumEvent(index = 0) {
                 // Initial view
                 hasService(stubSdkCore.getDatadogContext().service)
@@ -571,6 +601,12 @@ class ViewLoadingTimeMetricsTests {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 2) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
             }
     }
 
@@ -595,7 +631,7 @@ class ViewLoadingTimeMetricsTests {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(4)
+            .hasSize(5)
             .hasRumEvent(index = 0) {
                 // Initial view
                 hasService(stubSdkCore.getDatadogContext().service)
@@ -669,6 +705,12 @@ class ViewLoadingTimeMetricsTests {
                 }
                 hasNoOptionalFields()
             }
+            .hasRumEvent(index = 4) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
+            }
     }
 
     @RepeatedTest(10)
@@ -695,7 +737,7 @@ class ViewLoadingTimeMetricsTests {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(4)
+            .hasSize(5)
             .hasRumEvent(index = 0) {
                 // Initial view
                 hasService(stubSdkCore.getDatadogContext().service)
@@ -769,6 +811,12 @@ class ViewLoadingTimeMetricsTests {
                 }
                 hasNoOptionalFields()
             }
+            .hasRumEvent(index = 4) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
+            }
     }
 
     @RepeatedTest(10)
@@ -795,7 +843,7 @@ class ViewLoadingTimeMetricsTests {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(4)
+            .hasSize(5)
             .hasRumEvent(index = 0) {
                 // Initial view
                 hasService(stubSdkCore.getDatadogContext().service)
@@ -869,6 +917,12 @@ class ViewLoadingTimeMetricsTests {
                 }
                 hasNoOptionalFields()
             }
+            .hasRumEvent(index = 4) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
+            }
     }
 
     // endregion
@@ -891,7 +945,7 @@ class ViewLoadingTimeMetricsTests {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(6)
+            .hasSize(8)
             .hasRumEvent(index = 0) {
                 // Initial previous view
                 hasService(stubSdkCore.getDatadogContext().service)
@@ -964,6 +1018,12 @@ class ViewLoadingTimeMetricsTests {
                 hasNoOptionalFields()
             }
             .hasRumEvent(index = 4) {
+                // Full view checkpoint (closing previousView)
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewIsActive(false)
+            }
+            .hasRumEvent(index = 5) {
                 // New View Event
                 hasService(stubSdkCore.getDatadogContext().service)
                 hasApplicationId(fakeApplicationId)
@@ -974,7 +1034,7 @@ class ViewLoadingTimeMetricsTests {
                 hasViewName(viewName)
                 hasInteractionToNextViewTime(appExpectedItnvTime, ITNV_METRIC_OFFSET_IN_NANOSECONDS)
             }
-            .hasRumViewUpdateEvent(index = 5) {
+            .hasRumViewUpdateEvent(index = 6) {
                 // View stopped
                 application { hasId(fakeApplicationId) }
                 session {
@@ -998,6 +1058,12 @@ class ViewLoadingTimeMetricsTests {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 7) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
             }
     }
 
@@ -1017,7 +1083,7 @@ class ViewLoadingTimeMetricsTests {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(6)
+            .hasSize(8)
             .hasRumEvent(index = 0) {
                 // Initial previous view
                 hasService(stubSdkCore.getDatadogContext().service)
@@ -1090,6 +1156,12 @@ class ViewLoadingTimeMetricsTests {
                 hasNoOptionalFields()
             }
             .hasRumEvent(index = 4) {
+                // Full view checkpoint (closing previousView)
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewIsActive(false)
+            }
+            .hasRumEvent(index = 5) {
                 // New View Event
                 hasService(stubSdkCore.getDatadogContext().service)
                 hasApplicationId(fakeApplicationId)
@@ -1100,7 +1172,7 @@ class ViewLoadingTimeMetricsTests {
                 hasViewName(viewName)
                 doesNotHaveInteractionToNextViewTime()
             }
-            .hasRumViewUpdateEvent(index = 5) {
+            .hasRumViewUpdateEvent(index = 6) {
                 // View stopped
                 application { hasId(fakeApplicationId) }
                 session {
@@ -1124,6 +1196,12 @@ class ViewLoadingTimeMetricsTests {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 7) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
             }
     }
 
@@ -1145,7 +1223,7 @@ class ViewLoadingTimeMetricsTests {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(4)
+            .hasSize(6)
             .hasRumEvent(index = 0) {
                 // Initial previous view
                 hasService(stubSdkCore.getDatadogContext().service)
@@ -1184,6 +1262,12 @@ class ViewLoadingTimeMetricsTests {
                 hasNoOptionalFields()
             }
             .hasRumEvent(index = 2) {
+                // Full view checkpoint (closing previousView)
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewIsActive(false)
+            }
+            .hasRumEvent(index = 3) {
                 // New View Event
                 hasService(stubSdkCore.getDatadogContext().service)
                 hasApplicationId(fakeApplicationId)
@@ -1194,7 +1278,7 @@ class ViewLoadingTimeMetricsTests {
                 hasViewName(viewName)
                 doesNotHaveInteractionToNextViewTime()
             }
-            .hasRumViewUpdateEvent(index = 3) {
+            .hasRumViewUpdateEvent(index = 4) {
                 // View stopped
                 application { hasId(fakeApplicationId) }
                 session {
@@ -1218,6 +1302,12 @@ class ViewLoadingTimeMetricsTests {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 5) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
             }
     }
 
@@ -1243,7 +1333,7 @@ class ViewLoadingTimeMetricsTests {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(6)
+            .hasSize(8)
             .hasRumEvent(index = 0) {
                 // Initial previous view
                 hasService(stubSdkCore.getDatadogContext().service)
@@ -1316,6 +1406,12 @@ class ViewLoadingTimeMetricsTests {
                 hasNoOptionalFields()
             }
             .hasRumEvent(index = 4) {
+                // Full view checkpoint (closing previousView)
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewIsActive(false)
+            }
+            .hasRumEvent(index = 5) {
                 // New View Event
                 hasService(stubSdkCore.getDatadogContext().service)
                 hasApplicationId(fakeApplicationId)
@@ -1326,7 +1422,7 @@ class ViewLoadingTimeMetricsTests {
                 hasViewName(viewName)
                 hasInteractionToNextViewTime(appExpectedItnvTime, ITNV_METRIC_OFFSET_IN_NANOSECONDS)
             }
-            .hasRumViewUpdateEvent(index = 5) {
+            .hasRumViewUpdateEvent(index = 6) {
                 // View stopped
                 application { hasId(fakeApplicationId) }
                 session {
@@ -1350,6 +1446,12 @@ class ViewLoadingTimeMetricsTests {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 7) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
             }
     }
 
@@ -1375,7 +1477,7 @@ class ViewLoadingTimeMetricsTests {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(6)
+            .hasSize(8)
             .hasRumEvent(index = 0) {
                 // Initial previous view
                 hasService(stubSdkCore.getDatadogContext().service)
@@ -1448,6 +1550,12 @@ class ViewLoadingTimeMetricsTests {
                 hasNoOptionalFields()
             }
             .hasRumEvent(index = 4) {
+                // Full view checkpoint (closing previousView)
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewIsActive(false)
+            }
+            .hasRumEvent(index = 5) {
                 // New View Event
                 hasService(stubSdkCore.getDatadogContext().service)
                 hasApplicationId(fakeApplicationId)
@@ -1458,7 +1566,7 @@ class ViewLoadingTimeMetricsTests {
                 hasViewName(viewName)
                 doesNotHaveInteractionToNextViewTime()
             }
-            .hasRumViewUpdateEvent(index = 5) {
+            .hasRumViewUpdateEvent(index = 6) {
                 // View stopped
                 application { hasId(fakeApplicationId) }
                 session {
@@ -1482,6 +1590,12 @@ class ViewLoadingTimeMetricsTests {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 7) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
             }
     }
 
@@ -1501,7 +1615,7 @@ class ViewLoadingTimeMetricsTests {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(6)
+            .hasSize(8)
             .hasRumEvent(index = 0) {
                 // Initial previous view
                 hasService(stubSdkCore.getDatadogContext().service)
@@ -1574,6 +1688,12 @@ class ViewLoadingTimeMetricsTests {
                 hasNoOptionalFields()
             }
             .hasRumEvent(index = 4) {
+                // Full view checkpoint (closing previousView)
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewIsActive(false)
+            }
+            .hasRumEvent(index = 5) {
                 // New View Event
                 hasService(stubSdkCore.getDatadogContext().service)
                 hasApplicationId(fakeApplicationId)
@@ -1584,7 +1704,7 @@ class ViewLoadingTimeMetricsTests {
                 hasViewName(viewName)
                 hasInteractionToNextViewTime(appExpectedItnvTime, ITNV_METRIC_OFFSET_IN_NANOSECONDS)
             }
-            .hasRumViewUpdateEvent(index = 5) {
+            .hasRumViewUpdateEvent(index = 6) {
                 // View stopped
                 application { hasId(fakeApplicationId) }
                 session {
@@ -1608,6 +1728,12 @@ class ViewLoadingTimeMetricsTests {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 7) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
             }
     }
 
@@ -1639,7 +1765,7 @@ class ViewLoadingTimeMetricsTests {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(6)
+            .hasSize(8)
             .hasRumEvent(index = 0) {
                 // Initial previous view
                 hasService(stubSdkCore.getDatadogContext().service)
@@ -1712,6 +1838,12 @@ class ViewLoadingTimeMetricsTests {
                 hasNoOptionalFields()
             }
             .hasRumEvent(index = 4) {
+                // Full view checkpoint (closing previousView)
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewIsActive(false)
+            }
+            .hasRumEvent(index = 5) {
                 // New View Event
                 hasService(stubSdkCore.getDatadogContext().service)
                 hasApplicationId(fakeApplicationId)
@@ -1722,7 +1854,7 @@ class ViewLoadingTimeMetricsTests {
                 hasViewName(viewName)
                 doesNotHaveInteractionToNextViewTime()
             }
-            .hasRumViewUpdateEvent(index = 5) {
+            .hasRumViewUpdateEvent(index = 6) {
                 // View stopped
                 application { hasId(fakeApplicationId) }
                 session {
@@ -1746,6 +1878,12 @@ class ViewLoadingTimeMetricsTests {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 7) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
             }
     }
 
@@ -1778,7 +1916,7 @@ class ViewLoadingTimeMetricsTests {
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)
         assertThat(eventsWritten)
-            .hasSize(6)
+            .hasSize(8)
             .hasRumEvent(index = 0) {
                 // Initial previous view
                 hasService(stubSdkCore.getDatadogContext().service)
@@ -1851,6 +1989,12 @@ class ViewLoadingTimeMetricsTests {
                 hasNoOptionalFields()
             }
             .hasRumEvent(index = 4) {
+                // Full view checkpoint (closing previousView)
+                hasType("view")
+                hasViewUrl(previousViewKey)
+                hasViewIsActive(false)
+            }
+            .hasRumEvent(index = 5) {
                 // New View Event
                 hasService(stubSdkCore.getDatadogContext().service)
                 hasApplicationId(fakeApplicationId)
@@ -1861,7 +2005,7 @@ class ViewLoadingTimeMetricsTests {
                 hasViewName(viewName)
                 doesNotHaveInteractionToNextViewTime()
             }
-            .hasRumViewUpdateEvent(index = 5) {
+            .hasRumViewUpdateEvent(index = 6) {
                 // View stopped
                 application { hasId(fakeApplicationId) }
                 session {
@@ -1885,6 +2029,12 @@ class ViewLoadingTimeMetricsTests {
                     hasNoOptionalViewFields()
                 }
                 hasNoOptionalFields()
+            }
+            .hasRumEvent(index = 7) {
+                // Full view checkpoint (closing)
+                hasType("view")
+                hasViewUrl(viewKey)
+                hasViewIsActive(false)
             }
     }
 


### PR DESCRIPTION
### What does this PR do?

Implements three behaviours required to unblock GA of Partial View Updates (PVU) on Android:

1. **Periodic full-view checkpoint** — Under `FullViewOnlyAtStart`, sends a full `ViewEvent` every 4 partial updates (`documentVersion % 4 == 0`), giving the backend a ground-truth snapshot to detect reconstruction drift.
2. **Full view on close** — Sends a full `ViewEvent` (not a diff) when `view.isActive` transitions to `false`, matching Browser SDK behaviour.
3. **Diff before full view** — Introduces `DiffThenFullView` to emit the latest `ViewUpdateEvent` diff immediately before each full-view checkpoint or close, so the backend receives the most up-to-date incremental state before the ground-truth snapshot.

### Motivation

The backend correctness check RFC requires Android to periodically send full views so reconstruction drift can be detected.

### Additional Notes

- **No schema changes, no API surface changes.** All changes are internal (`internal` visibility).
- `FULL_VIEW_EVERY_N_UPDATES = 4L` constant is defined in `RumViewEventWriterImpl.companion object`.
- `shouldWriteFullView()` private method encapsulates the checkpoint + close conditions; `prev == null` (first event guard) stays inline for Kotlin smart-cast correctness.
- `DiffThenFullView` is a new internal type in `RumViewEventWriter.kt` with the same fields as `RumViewUpdateData` but distinct semantics — `RumDataWriter.writeDiffThenFullView()` writes the diff then the full view.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)