### PR TITLE
PANA-8391: Add embedded content wireframe model support

### DIFF
--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -24,6 +24,7 @@ const val WIREFRAME_TYPE_TEXT: String
 const val WIREFRAME_TYPE_IMAGE: String
 const val WIREFRAME_TYPE_PLACEHOLDER: String
 const val WIREFRAME_TYPE_WEBVIEW: String
+const val WIREFRAME_TYPE_EMBEDDED_CONTENT: String
 const val IMAGE_DIMEN_CONSIDERED_PII_IN_DP: Int
 interface com.datadog.android.sessionreplay.PrivacyLevel
 fun android.view.View.setSessionReplayHidden(Boolean)
@@ -192,14 +193,14 @@ data class com.datadog.android.sessionreplay.model.MobileSegment
   sealed class MobileRecord
     abstract fun toJson(): com.google.gson.JsonElement
     data class MobileFullSnapshotRecord : MobileRecord
-      constructor(kotlin.Long, Data)
+      constructor(kotlin.Long, Data, kotlin.String? = null)
       val type: kotlin.Long
       override fun toJson(): com.google.gson.JsonElement
       companion object 
         fun fromJson(kotlin.String): MobileFullSnapshotRecord
         fun fromJsonObject(com.google.gson.JsonObject): MobileFullSnapshotRecord
     data class MobileIncrementalSnapshotRecord : MobileRecord
-      constructor(kotlin.Long, MobileIncrementalData)
+      constructor(kotlin.Long, MobileIncrementalData, kotlin.String? = null)
       val type: kotlin.Long
       override fun toJson(): com.google.gson.JsonElement
       companion object 
@@ -330,6 +331,13 @@ data class com.datadog.android.sessionreplay.model.MobileSegment
       companion object 
         fun fromJson(kotlin.String): WebviewWireframe
         fun fromJsonObject(com.google.gson.JsonObject): WebviewWireframe
+    data class EmbeddedContentWireframe : Wireframe
+      constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, WireframeClip? = null, ShapeStyle? = null, ShapeBorder? = null, kotlin.String, kotlin.Boolean? = null, kotlin.String? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): EmbeddedContentWireframe
+        fun fromJsonObject(com.google.gson.JsonObject): EmbeddedContentWireframe
     companion object 
       fun fromJson(kotlin.String): Wireframe
       fun fromJsonElement(com.google.gson.JsonElement): Wireframe
@@ -382,6 +390,13 @@ data class com.datadog.android.sessionreplay.model.MobileSegment
       companion object 
         fun fromJson(kotlin.String): WebviewWireframeUpdate
         fun fromJsonObject(com.google.gson.JsonObject): WebviewWireframeUpdate
+    data class EmbeddedContentWireframeUpdate : WireframeUpdateMutation
+      constructor(kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, WireframeClip? = null, ShapeStyle? = null, ShapeBorder? = null, kotlin.String, kotlin.Boolean? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): EmbeddedContentWireframeUpdate
+        fun fromJsonObject(com.google.gson.JsonObject): EmbeddedContentWireframeUpdate
     companion object 
       fun fromJson(kotlin.String): WireframeUpdateMutation
       fun fromJsonElement(com.google.gson.JsonElement): WireframeUpdateMutation

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -31,6 +31,7 @@ public final class com/datadog/android/sessionreplay/MobileSegmentConstantsKt {
 	public static final field RECORD_TYPE_META J
 	public static final field RECORD_TYPE_VIEW_END J
 	public static final field RECORD_TYPE_VISUAL_VIEWPORT J
+	public static final field WIREFRAME_TYPE_EMBEDDED_CONTENT Ljava/lang/String;
 	public static final field WIREFRAME_TYPE_IMAGE Ljava/lang/String;
 	public static final field WIREFRAME_TYPE_PLACEHOLDER Ljava/lang/String;
 	public static final field WIREFRAME_TYPE_SHAPE Ljava/lang/String;
@@ -560,15 +561,18 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$MobileR
 
 public final class com/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord : com/datadog/android/sessionreplay/model/MobileSegment$MobileRecord {
 	public static final field Companion Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord$Companion;
-	public fun <init> (JLcom/datadog/android/sessionreplay/model/MobileSegment$Data;)V
+	public fun <init> (JLcom/datadog/android/sessionreplay/model/MobileSegment$Data;Ljava/lang/String;)V
+	public synthetic fun <init> (JLcom/datadog/android/sessionreplay/model/MobileSegment$Data;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
 	public final fun component2 ()Lcom/datadog/android/sessionreplay/model/MobileSegment$Data;
-	public final fun copy (JLcom/datadog/android/sessionreplay/model/MobileSegment$Data;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord;
-	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord;JLcom/datadog/android/sessionreplay/model/MobileSegment$Data;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (JLcom/datadog/android/sessionreplay/model/MobileSegment$Data;Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord;JLcom/datadog/android/sessionreplay/model/MobileSegment$Data;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileFullSnapshotRecord;
 	public final fun getData ()Lcom/datadog/android/sessionreplay/model/MobileSegment$Data;
+	public final fun getSlotId ()Ljava/lang/String;
 	public final fun getTimestamp ()J
 	public final fun getType ()J
 	public fun hashCode ()I
@@ -583,15 +587,18 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$MobileR
 
 public final class com/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord : com/datadog/android/sessionreplay/model/MobileSegment$MobileRecord {
 	public static final field Companion Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord$Companion;
-	public fun <init> (JLcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;)V
+	public fun <init> (JLcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;Ljava/lang/String;)V
+	public synthetic fun <init> (JLcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
 	public final fun component2 ()Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;
-	public final fun copy (JLcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord;
-	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord;JLcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (JLcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord;JLcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileRecord$MobileIncrementalSnapshotRecord;
 	public final fun getData ()Lcom/datadog/android/sessionreplay/model/MobileSegment$MobileIncrementalData;
+	public final fun getSlotId ()Ljava/lang/String;
 	public final fun getTimestamp ()J
 	public final fun getType ()J
 	public fun hashCode ()I
@@ -958,6 +965,48 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$Wirefra
 	public final fun fromJsonElement (Lcom/google/gson/JsonElement;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe;
 }
 
+public final class com/datadog/android/sessionreplay/model/MobileSegment$Wireframe$EmbeddedContentWireframe : com/datadog/android/sessionreplay/model/MobileSegment$Wireframe {
+	public static final field Companion Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$EmbeddedContentWireframe$Companion;
+	public fun <init> (JJJJJLcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)V
+	public synthetic fun <init> (JJJJJLcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component10 ()Ljava/lang/Boolean;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()J
+	public final fun component6 ()Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;
+	public final fun component7 ()Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;
+	public final fun component8 ()Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (JJJJJLcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$EmbeddedContentWireframe;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$EmbeddedContentWireframe;JJJJJLcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$EmbeddedContentWireframe;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$EmbeddedContentWireframe;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$EmbeddedContentWireframe;
+	public final fun getBorder ()Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;
+	public final fun getClip ()Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;
+	public final fun getHeight ()J
+	public final fun getId ()J
+	public final fun getPermanentId ()Ljava/lang/String;
+	public final fun getShapeStyle ()Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;
+	public final fun getSlotId ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getWidth ()J
+	public final fun getX ()J
+	public final fun getY ()J
+	public fun hashCode ()I
+	public final fun isVisible ()Ljava/lang/Boolean;
+	public fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/sessionreplay/model/MobileSegment$Wireframe$EmbeddedContentWireframe$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$EmbeddedContentWireframe;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$EmbeddedContentWireframe;
+}
+
 public final class com/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe : com/datadog/android/sessionreplay/model/MobileSegment$Wireframe {
 	public static final field Companion Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe$Companion;
 	public fun <init> (JJJJJLcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)V
@@ -1208,6 +1257,46 @@ public abstract class com/datadog/android/sessionreplay/model/MobileSegment$Wire
 public final class com/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation;
 	public final fun fromJsonElement (Lcom/google/gson/JsonElement;)Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation;
+}
+
+public final class com/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$EmbeddedContentWireframeUpdate : com/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation {
+	public static final field Companion Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$EmbeddedContentWireframeUpdate$Companion;
+	public fun <init> (JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component10 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6 ()Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;
+	public final fun component7 ()Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;
+	public final fun component8 ()Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$EmbeddedContentWireframeUpdate;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$EmbeddedContentWireframeUpdate;JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$EmbeddedContentWireframeUpdate;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$EmbeddedContentWireframeUpdate;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$EmbeddedContentWireframeUpdate;
+	public final fun getBorder ()Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;
+	public final fun getClip ()Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;
+	public final fun getHeight ()Ljava/lang/Long;
+	public final fun getId ()J
+	public final fun getShapeStyle ()Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;
+	public final fun getSlotId ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getWidth ()Ljava/lang/Long;
+	public final fun getX ()Ljava/lang/Long;
+	public final fun getY ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public final fun isVisible ()Ljava/lang/Boolean;
+	public fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$EmbeddedContentWireframeUpdate$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$EmbeddedContentWireframeUpdate;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$EmbeddedContentWireframeUpdate;
 }
 
 public final class com/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$ImageWireframeUpdate : com/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation {

--- a/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/embedded-content-wireframe-schema.json
+++ b/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/embedded-content-wireframe-schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/embedded-content-wireframe-schema.json",
+  "title": "EmbeddedContentWireframe",
+  "type": "object",
+  "description": "Schema of all properties of an EmbeddedContentWireframe.",
+  "allOf": [
+    {
+      "$ref": "_common-shape-wireframe-schema.json"
+    },
+    {
+      "required": ["type", "slotId"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of the wireframe.",
+          "const": "embedded_content",
+          "readOnly": true
+        },
+        "slotId": {
+          "type": "string",
+          "description": "Unique Id of the slot containing this embedded content.",
+          "readOnly": true
+        },
+        "isVisible": {
+          "type": "boolean",
+          "description": "Whether this embedded content is visible or not.",
+          "readOnly": true
+        },
+        "permanentId": {
+          "type": "string",
+          "description": "A globally unique and stable identifier for this UI element, computed as the hash of the element's path. Used to correlate wireframes with RUM action events.",
+          "readOnly": true
+        }
+      }
+    }
+  ]
+}

--- a/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/embedded-content-wireframe-update-schema.json
+++ b/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/embedded-content-wireframe-update-schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/embedded-content-wireframe-update-schema.json",
+  "title": "EmbeddedContentWireframeUpdate",
+  "type": "object",
+  "description": "Schema of all properties of an EmbeddedContentWireframeUpdate.",
+  "allOf": [
+    {
+      "$ref": "_common-shape-wireframe-update-schema.json"
+    },
+    {
+      "required": ["type", "slotId"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of the wireframe.",
+          "const": "embedded_content",
+          "readOnly": true
+        },
+        "slotId": {
+          "type": "string",
+          "description": "Unique Id of the slot containing this embedded content.",
+          "readOnly": true
+        },
+        "isVisible": {
+          "type": "boolean",
+          "description": "Whether this embedded content is visible or not.",
+          "readOnly": true
+        }
+      }
+    }
+  ]
+}

--- a/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/full-snapshot-record-schema.json
+++ b/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/full-snapshot-record-schema.json
@@ -31,6 +31,11 @@
               "readOnly": true
             }
           }
+        },
+        "slotId": {
+          "type": "string",
+          "description": "Unique ID of the slot that generated this record.",
+          "readOnly": true
         }
       }
     }

--- a/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/incremental-snapshot-record-schema.json
+++ b/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/incremental-snapshot-record-schema.json
@@ -19,6 +19,11 @@
         },
         "data": {
           "$ref": "incremental-data-schema.json"
+        },
+        "slotId": {
+          "type": "string",
+          "description": "Unique ID of the slot that generated this record.",
+          "readOnly": true
         }
       }
     }

--- a/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/wireframe-schema.json
+++ b/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/wireframe-schema.json
@@ -19,6 +19,9 @@
     },
     {
       "$ref": "webview-wireframe-schema.json"
+    },
+    {
+      "$ref": "embedded-content-wireframe-schema.json"
     }
   ]
 }

--- a/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/wireframe-update-mutation-schema.json
+++ b/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/wireframe-update-mutation-schema.json
@@ -19,6 +19,9 @@
     },
     {
       "$ref": "webview-wireframe-update-schema.json"
+    },
+    {
+      "$ref": "embedded-content-wireframe-update-schema.json"
     }
   ]
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/MobileSegmentConstants.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/MobileSegmentConstants.kt
@@ -75,3 +75,9 @@ const val WIREFRAME_TYPE_PLACEHOLDER: String = "placeholder"
  * @see com.datadog.android.sessionreplay.model.MobileSegment.Wireframe.WebviewWireframe
  */
 const val WIREFRAME_TYPE_WEBVIEW: String = "webview"
+
+/**
+ * EmbeddedContentWireframe type.
+ * @see com.datadog.android.sessionreplay.model.MobileSegment.Wireframe.EmbeddedContentWireframe
+ */
+const val WIREFRAME_TYPE_EMBEDDED_CONTENT: String = "embedded_content"

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/BoundsUtils.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/BoundsUtils.kt
@@ -17,6 +17,7 @@ internal object BoundsUtils {
             is MobileSegment.Wireframe.ImageWireframe -> wireframe.bounds()
             is MobileSegment.Wireframe.PlaceholderWireframe -> wireframe.bounds()
             is MobileSegment.Wireframe.WebviewWireframe -> wireframe.bounds()
+            is MobileSegment.Wireframe.EmbeddedContentWireframe -> wireframe.bounds()
         }
     }
 
@@ -45,6 +46,10 @@ internal object BoundsUtils {
         return resolveBounds(x, y, width, height, clip)
     }
     private fun MobileSegment.Wireframe.WebviewWireframe.bounds(): WireframeBounds {
+        return resolveBounds(x, y, width, height, clip)
+    }
+
+    private fun MobileSegment.Wireframe.EmbeddedContentWireframe.bounds(): WireframeBounds {
         return resolveBounds(x, y, width, height, clip)
     }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/HeatmapWireframeExt.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/HeatmapWireframeExt.kt
@@ -15,6 +15,7 @@ internal fun MobileSegment.Wireframe.permanentId(): String? {
         is MobileSegment.Wireframe.ImageWireframe -> this.permanentId
         is MobileSegment.Wireframe.PlaceholderWireframe -> this.permanentId
         is MobileSegment.Wireframe.WebviewWireframe -> this.permanentId
+        is MobileSegment.Wireframe.EmbeddedContentWireframe -> this.permanentId
     }
 }
 
@@ -27,5 +28,6 @@ internal fun MobileSegment.Wireframe.copyWithPermanentId(
         is MobileSegment.Wireframe.ImageWireframe -> this.copy(permanentId = permanentId)
         is MobileSegment.Wireframe.PlaceholderWireframe -> this.copy(permanentId = permanentId)
         is MobileSegment.Wireframe.WebviewWireframe -> this.copy(permanentId = permanentId)
+        is MobileSegment.Wireframe.EmbeddedContentWireframe -> this.copy(permanentId = permanentId)
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/MobileSegmentExt.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/MobileSegmentExt.kt
@@ -16,6 +16,7 @@ internal fun MobileSegment.Wireframe.copy(clip: MobileSegment.WireframeClip?): M
         is MobileSegment.Wireframe.ImageWireframe -> this.copy(clip = clip)
         is MobileSegment.Wireframe.PlaceholderWireframe -> this.copy(clip = clip)
         is MobileSegment.Wireframe.WebviewWireframe -> this.copy(clip = clip)
+        is MobileSegment.Wireframe.EmbeddedContentWireframe -> this.copy(clip = clip)
     }
 }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/MutationResolver.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/MutationResolver.kt
@@ -150,6 +150,16 @@ internal class MutationResolver(private val internalLogger: InternalLogger) {
                             )
                         )
                     }
+                } else if (oldWireframe is MobileSegment.Wireframe.EmbeddedContentWireframe) {
+                    if (oldWireframe.isVisible != false) {
+                        updates.add(
+                            MobileSegment.WireframeUpdateMutation.EmbeddedContentWireframeUpdate(
+                                id = oldWireframe.id,
+                                slotId = oldWireframe.slotId,
+                                isVisible = false
+                            )
+                        )
+                    }
                 } else {
                     // Old element was removed
                     removes.add(MobileSegment.Remove(oldWireframe.id()))
@@ -345,6 +355,53 @@ internal class MutationResolver(private val internalLogger: InternalLogger) {
         return mutation
     }
 
+    private fun resolveEmbeddedContentWireframeMutation(
+        prevWireframe: MobileSegment.Wireframe.EmbeddedContentWireframe,
+        currentWireframe: MobileSegment.Wireframe.EmbeddedContentWireframe
+    ): MobileSegment.WireframeUpdateMutation? {
+        var mutation = MobileSegment.WireframeUpdateMutation
+            .EmbeddedContentWireframeUpdate(currentWireframe.id, slotId = currentWireframe.slotId)
+        var hasMutation = prevWireframe.slotId != currentWireframe.slotId
+        if (prevWireframe.x != currentWireframe.x) {
+            mutation = mutation.copy(x = currentWireframe.x)
+            hasMutation = true
+        }
+        if (prevWireframe.y != currentWireframe.y) {
+            mutation = mutation.copy(y = currentWireframe.y)
+            hasMutation = true
+        }
+        if (prevWireframe.width != currentWireframe.width) {
+            mutation = mutation.copy(width = currentWireframe.width)
+            hasMutation = true
+        }
+        if (prevWireframe.height != currentWireframe.height) {
+            mutation = mutation.copy(height = currentWireframe.height)
+            hasMutation = true
+        }
+        if (prevWireframe.border != currentWireframe.border) {
+            mutation = mutation.copy(border = currentWireframe.border)
+            hasMutation = true
+        }
+        if (prevWireframe.shapeStyle != currentWireframe.shapeStyle) {
+            mutation = mutation.copy(shapeStyle = currentWireframe.shapeStyle)
+            hasMutation = true
+        }
+        if (prevWireframe.clip != currentWireframe.clip) {
+            mutation = mutation.copy(
+                clip = currentWireframe.clip
+                    ?: MobileSegment.WireframeClip(0, 0, 0, 0)
+            )
+            hasMutation = true
+        }
+        val wasVisible = prevWireframe.isVisible != false
+        val isVisible = currentWireframe.isVisible != false
+        if (wasVisible != isVisible) {
+            mutation = mutation.copy(isVisible = isVisible)
+            hasMutation = true
+        }
+        return mutation.takeIf { hasMutation }
+    }
+
     private fun recordChangedWireframeMutations(
         oldElement: MobileSegment.Wireframe,
         newElement: MobileSegment.Wireframe,
@@ -414,6 +471,11 @@ internal class MutationResolver(private val internalLogger: InternalLogger) {
                         prevWireframe,
                         currentWireframe as MobileSegment.Wireframe.WebviewWireframe
                     )
+
+                    is MobileSegment.Wireframe.EmbeddedContentWireframe -> resolveEmbeddedContentWireframeMutation(
+                        prevWireframe,
+                        currentWireframe as MobileSegment.Wireframe.EmbeddedContentWireframe
+                    )
                 }
             }
         }
@@ -472,6 +534,7 @@ internal class MutationResolver(private val internalLogger: InternalLogger) {
             is MobileSegment.Wireframe.ImageWireframe -> this.id
             is MobileSegment.Wireframe.PlaceholderWireframe -> this.id
             is MobileSegment.Wireframe.WebviewWireframe -> this.id
+            is MobileSegment.Wireframe.EmbeddedContentWireframe -> this.id
         }
     }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/RecordedDataProcessor.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/RecordedDataProcessor.kt
@@ -142,16 +142,16 @@ internal class RecordedDataProcessor(
         if (fullSnapshotRequired) {
             records.add(
                 MobileSegment.MobileRecord.MobileFullSnapshotRecord(
-                    timestamp,
-                    MobileSegment.Data(wireframes)
+                    timestamp = timestamp,
+                    data = MobileSegment.Data(wireframes)
                 )
             )
         } else {
             mutationResolver.resolveMutations(prevSnapshot, wireframes)?.let {
                 records.add(
                     MobileSegment.MobileRecord.MobileIncrementalSnapshotRecord(
-                        timestamp,
-                        it
+                        timestamp = timestamp,
+                        data = it
                     )
                 )
             }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/WireframeUtils.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/WireframeUtils.kt
@@ -78,6 +78,7 @@ internal class WireframeUtils(private val boundsUtils: BoundsUtils = BoundsUtils
             is MobileSegment.Wireframe.ImageWireframe -> this.clip
             is MobileSegment.Wireframe.PlaceholderWireframe -> this.clip
             is MobileSegment.Wireframe.WebviewWireframe -> this.clip
+            is MobileSegment.Wireframe.EmbeddedContentWireframe -> this.clip
         }
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/WireframeExt.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/WireframeExt.kt
@@ -17,6 +17,7 @@ internal fun MobileSegment.Wireframe.hasOpaqueBackground(): Boolean {
         is MobileSegment.Wireframe.TextWireframe -> this.hasOpaqueBackground()
         is MobileSegment.Wireframe.PlaceholderWireframe -> true
         is MobileSegment.Wireframe.WebviewWireframe -> true
+        is MobileSegment.Wireframe.EmbeddedContentWireframe -> true
     }
 }
 
@@ -39,6 +40,7 @@ internal fun MobileSegment.Wireframe.shapeStyle(): MobileSegment.ShapeStyle? {
         is MobileSegment.Wireframe.ImageWireframe -> this.shapeStyle
         is MobileSegment.Wireframe.PlaceholderWireframe -> null
         is MobileSegment.Wireframe.WebviewWireframe -> this.shapeStyle
+        is MobileSegment.Wireframe.EmbeddedContentWireframe -> this.shapeStyle
     }
 }
 
@@ -49,5 +51,6 @@ internal fun MobileSegment.Wireframe.copy(shapeStyle: MobileSegment.ShapeStyle?)
         is MobileSegment.Wireframe.ImageWireframe -> this.copy(shapeStyle = shapeStyle)
         is MobileSegment.Wireframe.PlaceholderWireframe -> this
         is MobileSegment.Wireframe.WebviewWireframe -> this.copy(shapeStyle = shapeStyle)
+        is MobileSegment.Wireframe.EmbeddedContentWireframe -> this.copy(shapeStyle = shapeStyle)
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/WireframeExt.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/WireframeExt.kt
@@ -17,7 +17,7 @@ internal fun MobileSegment.Wireframe.hasOpaqueBackground(): Boolean {
         is MobileSegment.Wireframe.TextWireframe -> this.hasOpaqueBackground()
         is MobileSegment.Wireframe.PlaceholderWireframe -> true
         is MobileSegment.Wireframe.WebviewWireframe -> true
-        is MobileSegment.Wireframe.EmbeddedContentWireframe -> true
+        is MobileSegment.Wireframe.EmbeddedContentWireframe -> this.isVisible != false
     }
 }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/EmbeddedContentWireframeForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/EmbeddedContentWireframeForgeryFactory.kt
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.forge
+
+import com.datadog.android.sessionreplay.model.MobileSegment
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class EmbeddedContentWireframeForgeryFactory :
+    ForgeryFactory<MobileSegment.Wireframe.EmbeddedContentWireframe> {
+    override fun getForgery(forge: Forge): MobileSegment.Wireframe.EmbeddedContentWireframe {
+        return MobileSegment.Wireframe.EmbeddedContentWireframe(
+            id = forge.aPositiveInt().toLong(),
+            x = forge.aPositiveLong(),
+            y = forge.aPositiveLong(),
+            width = forge.aPositiveLong(strict = true),
+            height = forge.aPositiveLong(strict = true),
+            clip = forge.aNullable { getForgery() },
+            shapeStyle = forge.aNullable { getForgery() },
+            border = forge.aNullable { getForgery() },
+            slotId = forge.aPositiveLong().toString()
+        )
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/EmbeddedContentWireframeUpdateForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/EmbeddedContentWireframeUpdateForgeryFactory.kt
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.forge
+
+import com.datadog.android.sessionreplay.model.MobileSegment
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class EmbeddedContentWireframeUpdateForgeryFactory :
+    ForgeryFactory<MobileSegment.WireframeUpdateMutation.EmbeddedContentWireframeUpdate> {
+    override fun getForgery(
+        forge: Forge
+    ): MobileSegment.WireframeUpdateMutation.EmbeddedContentWireframeUpdate {
+        return MobileSegment.WireframeUpdateMutation.EmbeddedContentWireframeUpdate(
+            id = forge.aPositiveInt().toLong(),
+            x = forge.aNullable { aLong() },
+            y = forge.aNullable { aLong() },
+            width = forge.aNullable { aPositiveLong(strict = true) },
+            height = forge.aNullable { aPositiveLong(strict = true) },
+            clip = forge.aNullable { getForgery() },
+            shapeStyle = forge.aNullable { getForgery() },
+            border = forge.aNullable { getForgery() },
+            slotId = forge.aPositiveLong().toString(),
+            isVisible = forge.aNullable { aBool() }
+        )
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/ForgeConfigurator.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/ForgeConfigurator.kt
@@ -55,6 +55,8 @@ internal class ForgeConfigurator : BaseConfigurator() {
         forge.addFactory(TouchEventRecordedDataQueueItemForgeryFactory())
         forge.addFactory(WireframeBoundsForgeryFactory())
         forge.addFactory(WebViewWireframeForgeryFactory())
+        forge.addFactory(EmbeddedContentWireframeForgeryFactory())
+        forge.addFactory(EmbeddedContentWireframeUpdateForgeryFactory())
 
         forge.useJvmFactories()
     }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/BoundUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/BoundUtilsTest.kt
@@ -148,6 +148,7 @@ internal class BoundUtilsTest {
             is MobileSegment.Wireframe.ImageWireframe -> this.x
             is MobileSegment.Wireframe.PlaceholderWireframe -> this.x
             is MobileSegment.Wireframe.WebviewWireframe -> this.x
+            is MobileSegment.Wireframe.EmbeddedContentWireframe -> this.x
         }
     }
 
@@ -158,6 +159,7 @@ internal class BoundUtilsTest {
             is MobileSegment.Wireframe.ImageWireframe -> this.y
             is MobileSegment.Wireframe.PlaceholderWireframe -> this.y
             is MobileSegment.Wireframe.WebviewWireframe -> this.y
+            is MobileSegment.Wireframe.EmbeddedContentWireframe -> this.y
         }
     }
 
@@ -168,6 +170,7 @@ internal class BoundUtilsTest {
             is MobileSegment.Wireframe.ImageWireframe -> this.width
             is MobileSegment.Wireframe.PlaceholderWireframe -> this.width
             is MobileSegment.Wireframe.WebviewWireframe -> this.width
+            is MobileSegment.Wireframe.EmbeddedContentWireframe -> this.width
         }
     }
 
@@ -178,6 +181,7 @@ internal class BoundUtilsTest {
             is MobileSegment.Wireframe.ImageWireframe -> this.height
             is MobileSegment.Wireframe.PlaceholderWireframe -> this.height
             is MobileSegment.Wireframe.WebviewWireframe -> this.height
+            is MobileSegment.Wireframe.EmbeddedContentWireframe -> this.height
         }
     }
 
@@ -199,6 +203,8 @@ internal class BoundUtilsTest {
                 this.copy(clip = clip, x = x, y = y, width = width, height = height)
             is MobileSegment.Wireframe.WebviewWireframe ->
                 this.copy(clip = clip, x = x, y = y, width = width, height = height)
+            is MobileSegment.Wireframe.EmbeddedContentWireframe ->
+                this.copy(clip = clip, x = x, y = y, width = width, height = height)
         }
     }
 
@@ -211,7 +217,8 @@ internal class BoundUtilsTest {
                 WireframeExtTest.forge.getForgery<MobileSegment.Wireframe.TextWireframe>(),
                 WireframeExtTest.forge.getForgery<MobileSegment.Wireframe.ImageWireframe>(),
                 WireframeExtTest.forge.getForgery<MobileSegment.Wireframe.PlaceholderWireframe>(),
-                WireframeExtTest.forge.getForgery<MobileSegment.Wireframe.WebviewWireframe>()
+                WireframeExtTest.forge.getForgery<MobileSegment.Wireframe.WebviewWireframe>(),
+                WireframeExtTest.forge.getForgery<MobileSegment.Wireframe.EmbeddedContentWireframe>()
             )
         }
     }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/MutationResolverTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/MutationResolverTest.kt
@@ -295,6 +295,38 @@ internal class MutationResolverTest {
         assertThat(mutations?.updates).isEqualTo(mutationTestData.expectedMutation)
     }
 
+    @ParameterizedTest
+    @MethodSource("embeddedContentIsVisibleMutationData")
+    fun `M identify the updated wireframes W resolveMutations {EmbeddedContent, isVisible}`(
+        mutationTestData: MutationTestData
+    ) {
+        // When
+        val mutations = testedMutationResolver.resolveMutations(
+            mutationTestData.prevSnapshot,
+            mutationTestData.newSnapshot
+        )
+
+        // Then
+        assertThat(mutations?.adds).isNullOrEmpty()
+        assertThat(mutations?.removes).isNullOrEmpty()
+        assertThat(mutations?.updates).isEqualTo(mutationTestData.expectedMutation)
+    }
+
+    @ParameterizedTest
+    @MethodSource("embeddedContentEquivalentVisibilityData")
+    fun `M return null W resolveMutations {EmbeddedContent, equivalent isVisible}`(
+        mutationTestData: MutationTestData
+    ) {
+        // When
+        val mutations = testedMutationResolver.resolveMutations(
+            mutationTestData.prevSnapshot,
+            mutationTestData.newSnapshot
+        )
+
+        // Then
+        assertThat(mutations).isNull()
+    }
+
     // endregion
 
     // region permanentId changed mutations
@@ -684,6 +716,66 @@ internal class MutationResolverTest {
 
     // endregion
 
+    // region EmbeddedContent "remove" mutations
+
+    @Test
+    fun `M identify the updated wireframes W resolveMutations {EmbeddedContent removed at beginning}`(forge: Forge) {
+        // Given
+        val fakePrevSnapshot = forge.aList(size = forge.anInt(min = 3, max = 10)) {
+            forge.getForgery(MobileSegment.Wireframe.EmbeddedContentWireframe::class.java)
+        }
+        val fakeHiddenWireframes = forge.anInt(min = 1, max = fakePrevSnapshot.size - 1)
+        val fakeCurrentSnapshot = fakePrevSnapshot.drop(fakeHiddenWireframes)
+        val expectedUpdates = fakePrevSnapshot.take(fakeHiddenWireframes).map {
+            MobileSegment.WireframeUpdateMutation.EmbeddedContentWireframeUpdate(
+                id = it.id(),
+                slotId = it.slotId,
+                isVisible = false
+            )
+        }
+
+        // When
+        val mutations = testedMutationResolver.resolveMutations(
+            fakePrevSnapshot,
+            fakeCurrentSnapshot
+        )
+
+        // Then
+        assertThat(mutations?.adds).isNullOrEmpty()
+        assertThat(mutations?.removes).isNullOrEmpty()
+        assertThat(mutations?.updates).isEqualTo(expectedUpdates)
+    }
+
+    @Test
+    fun `M identify the updated wireframes W resolveMutations {EmbeddedContent removed at end}`(forge: Forge) {
+        // Given
+        val fakePrevSnapshot = forge.aList(size = forge.anInt(min = 3, max = 10)) {
+            forge.getForgery(MobileSegment.Wireframe.EmbeddedContentWireframe::class.java)
+        }
+        val fakeHiddenWireframes = forge.anInt(min = 1, max = fakePrevSnapshot.size - 1)
+        val fakeCurrentSnapshot = fakePrevSnapshot.dropLast(fakeHiddenWireframes)
+        val expectedUpdates = fakePrevSnapshot.takeLast(fakeHiddenWireframes).map {
+            MobileSegment.WireframeUpdateMutation.EmbeddedContentWireframeUpdate(
+                id = it.id(),
+                slotId = it.slotId,
+                isVisible = false
+            )
+        }
+
+        // When
+        val mutations = testedMutationResolver.resolveMutations(
+            fakePrevSnapshot,
+            fakeCurrentSnapshot
+        )
+
+        // Then
+        assertThat(mutations?.adds).isNullOrEmpty()
+        assertThat(mutations?.removes).isNullOrEmpty()
+        assertThat(mutations?.updates).isEqualTo(expectedUpdates)
+    }
+
+    // endregion
+
     // region no mutation
 
     @Test
@@ -777,6 +869,7 @@ internal class MutationResolverTest {
             is MobileSegment.Wireframe.ImageWireframe -> this.id
             is MobileSegment.Wireframe.PlaceholderWireframe -> this.id
             is MobileSegment.Wireframe.WebviewWireframe -> this.id
+            is MobileSegment.Wireframe.EmbeddedContentWireframe -> this.id
         }
     }
 
@@ -798,6 +891,7 @@ internal class MutationResolverTest {
                 is MobileSegment.Wireframe.ImageWireframe -> this.id
                 is MobileSegment.Wireframe.PlaceholderWireframe -> this.id
                 is MobileSegment.Wireframe.WebviewWireframe -> this.id
+                is MobileSegment.Wireframe.EmbeddedContentWireframe -> this.id
             }
         }
 
@@ -879,6 +973,22 @@ internal class MutationResolverTest {
                 )
             }
 
+            val fakePrevEmbeddedContentSnapshot =
+                forgePrevSnapshot<MobileSegment.Wireframe.EmbeddedContentWireframe>()
+            val fakeEmbeddedContentUpdatedWireframes = forgeMutatedWireframes(fakePrevEmbeddedContentSnapshot) {
+                it.copy(x = forge.aLong(), y = forge.aLong())
+            }
+            val fakeCurrentEmbeddedContentSnapshot = fakeEmbeddedContentUpdatedWireframes +
+                fakePrevEmbeddedContentSnapshot.drop(fakeEmbeddedContentUpdatedWireframes.size)
+            val expectedEmbeddedContentUpdates = fakeEmbeddedContentUpdatedWireframes.map {
+                MobileSegment.WireframeUpdateMutation.EmbeddedContentWireframeUpdate(
+                    id = it.id(),
+                    slotId = it.slotId,
+                    x = it.x,
+                    y = it.y
+                )
+            }
+
             return listOf(
                 MutationTestData(
                     prevSnapshot = fakePrevShapeSnapshot,
@@ -904,6 +1014,11 @@ internal class MutationResolverTest {
                     prevSnapshot = fakePrevWebViewSnapshot,
                     newSnapshot = fakeCurrentWebViewSnapshot,
                     expectedMutation = expectedWebViewUpdates
+                ),
+                MutationTestData(
+                    prevSnapshot = fakePrevEmbeddedContentSnapshot,
+                    newSnapshot = fakeCurrentEmbeddedContentSnapshot,
+                    expectedMutation = expectedEmbeddedContentUpdates
                 )
             )
         }
@@ -986,6 +1101,22 @@ internal class MutationResolverTest {
                 )
             }
 
+            val fakePrevEmbeddedContentSnapshot =
+                forgePrevSnapshot<MobileSegment.Wireframe.EmbeddedContentWireframe>()
+            val fakeEmbeddedContentUpdatedWireframes = forgeMutatedWireframes(fakePrevEmbeddedContentSnapshot) {
+                it.copy(width = forge.aLong(), height = forge.aLong())
+            }
+            val fakeCurrentEmbeddedContentSnapshot = fakeEmbeddedContentUpdatedWireframes +
+                fakePrevEmbeddedContentSnapshot.drop(fakeEmbeddedContentUpdatedWireframes.size)
+            val expectedEmbeddedContentUpdates = fakeEmbeddedContentUpdatedWireframes.map {
+                MobileSegment.WireframeUpdateMutation.EmbeddedContentWireframeUpdate(
+                    id = it.id(),
+                    slotId = it.slotId,
+                    width = it.width,
+                    height = it.height
+                )
+            }
+
             return listOf(
                 MutationTestData(
                     prevSnapshot = fakePrevShapeSnapshot,
@@ -1011,6 +1142,11 @@ internal class MutationResolverTest {
                     prevSnapshot = fakePrevWebViewSnapshot,
                     newSnapshot = fakeCurrentWebViewSnapshot,
                     expectedMutation = expectedWebViewUpdates
+                ),
+                MutationTestData(
+                    prevSnapshot = fakePrevEmbeddedContentSnapshot,
+                    newSnapshot = fakeCurrentEmbeddedContentSnapshot,
+                    expectedMutation = expectedEmbeddedContentUpdates
                 )
             )
         }
@@ -1088,6 +1224,21 @@ internal class MutationResolverTest {
                 )
             }
 
+            val fakePrevEmbeddedContentSnapshot =
+                forgePrevSnapshot<MobileSegment.Wireframe.EmbeddedContentWireframe>()
+            val fakeEmbeddedContentUpdatedWireframes = forgeMutatedWireframes(fakePrevEmbeddedContentSnapshot) {
+                it.copy(clip = forge.forgeDifferent(it.clip))
+            }
+            val fakeCurrentEmbeddedContentSnapshot = fakeEmbeddedContentUpdatedWireframes +
+                fakePrevEmbeddedContentSnapshot.drop(fakeEmbeddedContentUpdatedWireframes.size)
+            val expectedEmbeddedContentUpdates = fakeEmbeddedContentUpdatedWireframes.map {
+                MobileSegment.WireframeUpdateMutation.EmbeddedContentWireframeUpdate(
+                    id = it.id(),
+                    clip = it.clip,
+                    slotId = it.slotId
+                )
+            }
+
             return listOf(
                 MutationTestData(
                     prevSnapshot = fakePrevShapeSnapshot,
@@ -1113,6 +1264,11 @@ internal class MutationResolverTest {
                     prevSnapshot = fakePrevWebViewSnapshot,
                     newSnapshot = fakeCurrentWebViewSnapshot,
                     expectedMutation = expectedWebViewUpdates
+                ),
+                MutationTestData(
+                    prevSnapshot = fakePrevEmbeddedContentSnapshot,
+                    newSnapshot = fakeCurrentEmbeddedContentSnapshot,
+                    expectedMutation = expectedEmbeddedContentUpdates
                 )
             )
         }
@@ -1195,6 +1351,22 @@ internal class MutationResolverTest {
                 )
             }
 
+            val fakePrevEmbeddedContentSnapshot =
+                forgePrevSnapshot<MobileSegment.Wireframe.EmbeddedContentWireframe>()
+                    .map { it.copy(clip = forge.getForgery()) }
+            val fakeEmbeddedContentUpdatedWireframes = forgeMutatedWireframes(fakePrevEmbeddedContentSnapshot) {
+                it.copy(clip = null)
+            }
+            val fakeCurrentEmbeddedContentSnapshot = fakeEmbeddedContentUpdatedWireframes +
+                fakePrevEmbeddedContentSnapshot.drop(fakeEmbeddedContentUpdatedWireframes.size)
+            val expectedEmbeddedContentUpdates = fakeEmbeddedContentUpdatedWireframes.map {
+                MobileSegment.WireframeUpdateMutation.EmbeddedContentWireframeUpdate(
+                    id = it.id(),
+                    clip = nullClipWireframe,
+                    slotId = it.slotId
+                )
+            }
+
             return listOf(
                 MutationTestData(
                     prevSnapshot = fakePrevShapeSnapshot,
@@ -1220,6 +1392,11 @@ internal class MutationResolverTest {
                     prevSnapshot = fakePrevWebViewSnapshot,
                     newSnapshot = fakeCurrentWebViewSnapshot,
                     expectedMutation = expectedWebViewUpdates
+                ),
+                MutationTestData(
+                    prevSnapshot = fakePrevEmbeddedContentSnapshot,
+                    newSnapshot = fakeCurrentEmbeddedContentSnapshot,
+                    expectedMutation = expectedEmbeddedContentUpdates
                 )
             )
         }
@@ -1344,6 +1521,21 @@ internal class MutationResolverTest {
                 )
             }
 
+            val fakePrevEmbeddedContentSnapshot =
+                forgePrevSnapshot<MobileSegment.Wireframe.EmbeddedContentWireframe>()
+            val fakeEmbeddedContentUpdatedWireframes = forgeMutatedWireframes(fakePrevEmbeddedContentSnapshot) {
+                it.copy(shapeStyle = forge.getForgery())
+            }
+            val fakeCurrentEmbeddedContentSnapshot = fakeEmbeddedContentUpdatedWireframes +
+                fakePrevEmbeddedContentSnapshot.drop(fakeEmbeddedContentUpdatedWireframes.size)
+            val expectedEmbeddedContentUpdates = fakeEmbeddedContentUpdatedWireframes.map {
+                MobileSegment.WireframeUpdateMutation.EmbeddedContentWireframeUpdate(
+                    id = it.id(),
+                    shapeStyle = it.shapeStyle,
+                    slotId = it.slotId
+                )
+            }
+
             return listOf(
                 MutationTestData(
                     prevSnapshot = fakePrevShapeSnapshot,
@@ -1364,8 +1556,58 @@ internal class MutationResolverTest {
                     prevSnapshot = fakePrevWebViewSnapshot,
                     newSnapshot = fakeCurrentWebViewSnapshot,
                     expectedMutation = expectedWebViewUpdates
+                ),
+                MutationTestData(
+                    prevSnapshot = fakePrevEmbeddedContentSnapshot,
+                    newSnapshot = fakeCurrentEmbeddedContentSnapshot,
+                    expectedMutation = expectedEmbeddedContentUpdates
                 )
             )
+        }
+
+        @JvmStatic
+        fun embeddedContentIsVisibleMutationData(): List<MutationTestData> {
+            ForgeConfigurator().configure(forge)
+
+            val visibilityChanges: List<Triple<Boolean?, Boolean?, Boolean>> = listOf(
+                Triple(false, true, true),
+                Triple(true, false, false),
+                Triple(false, null, true),
+                Triple(null, false, false)
+            )
+            return visibilityChanges.map { (previousVisibility, currentVisibility, expectedVisibility) ->
+                val fakePrevWireframe =
+                    forge.getForgery<MobileSegment.Wireframe.EmbeddedContentWireframe>()
+                        .copy(isVisible = previousVisibility)
+                val fakeCurrentWireframe = fakePrevWireframe.copy(isVisible = currentVisibility)
+                MutationTestData(
+                    prevSnapshot = listOf(fakePrevWireframe),
+                    newSnapshot = listOf(fakeCurrentWireframe),
+                    expectedMutation = listOf(
+                        MobileSegment.WireframeUpdateMutation.EmbeddedContentWireframeUpdate(
+                            id = fakeCurrentWireframe.id,
+                            slotId = fakeCurrentWireframe.slotId,
+                            isVisible = expectedVisibility
+                        )
+                    )
+                )
+            }
+        }
+
+        @JvmStatic
+        fun embeddedContentEquivalentVisibilityData(): List<MutationTestData> {
+            ForgeConfigurator().configure(forge)
+
+            return listOf(true to null, null to true).map { (previousVisibility, currentVisibility) ->
+                val fakePrevWireframe =
+                    forge.getForgery<MobileSegment.Wireframe.EmbeddedContentWireframe>()
+                        .copy(isVisible = previousVisibility)
+                MutationTestData(
+                    prevSnapshot = listOf(fakePrevWireframe),
+                    newSnapshot = listOf(fakePrevWireframe.copy(isVisible = currentVisibility)),
+                    expectedMutation = emptyList()
+                )
+            }
         }
 
         @JvmStatic
@@ -1399,6 +1641,14 @@ internal class MutationResolverTest {
                     id = it.id
                 )
             }
+
+            val fakePrevEmbeddedContentSnapshot =
+                forgePrevSnapshot<MobileSegment.Wireframe.EmbeddedContentWireframe>()
+            val fakeCurrentEmbeddedContentSnapshot = fakePrevEmbeddedContentSnapshot.map {
+                forge.getForgery<MobileSegment.Wireframe.ShapeWireframe>().copy(
+                    id = it.id
+                )
+            }
             return listOf(
                 MutationTestData(
                     prevSnapshot = fakePrevShapeSnapshot,
@@ -1423,6 +1673,11 @@ internal class MutationResolverTest {
                 MutationTestData(
                     prevSnapshot = fakePrevWebViewSnapshot,
                     newSnapshot = fakeCurrentWebViewSnapshot,
+                    expectedMutation = emptyList()
+                ),
+                MutationTestData(
+                    prevSnapshot = fakePrevEmbeddedContentSnapshot,
+                    newSnapshot = fakeCurrentEmbeddedContentSnapshot,
                     expectedMutation = emptyList()
                 )
             )

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/NodeFlattenerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/NodeFlattenerTest.kt
@@ -332,6 +332,8 @@ internal class NodeFlattenerTest {
                 this.copy(id = id)
             is MobileSegment.Wireframe.WebviewWireframe ->
                 this.copy(id = id)
+            is MobileSegment.Wireframe.EmbeddedContentWireframe ->
+                this.copy(id = id)
         }
     }
 
@@ -411,6 +413,14 @@ internal class NodeFlattenerTest {
                 height = height,
                 clip = null
             )
+            is MobileSegment.Wireframe.EmbeddedContentWireframe -> fakeWireframe.copy(
+                id = id,
+                x = x,
+                y = y,
+                width = width,
+                height = height,
+                clip = null
+            )
         }
     }
 
@@ -425,6 +435,8 @@ internal class NodeFlattenerTest {
             is MobileSegment.Wireframe.PlaceholderWireframe ->
                 Bounds(this.x, this.y, this.width, this.height)
             is MobileSegment.Wireframe.WebviewWireframe ->
+                Bounds(this.x, this.y, this.width, this.height)
+            is MobileSegment.Wireframe.EmbeddedContentWireframe ->
                 Bounds(this.x, this.y, this.width, this.height)
         }
     }
@@ -441,6 +453,8 @@ internal class NodeFlattenerTest {
                 clip
             is MobileSegment.Wireframe.WebviewWireframe ->
                 clip
+            is MobileSegment.Wireframe.EmbeddedContentWireframe ->
+                clip
         }
     }
 
@@ -453,6 +467,7 @@ internal class NodeFlattenerTest {
             is MobileSegment.Wireframe.ImageWireframe -> this.id
             is MobileSegment.Wireframe.PlaceholderWireframe -> this.id
             is MobileSegment.Wireframe.WebviewWireframe -> this.id
+            is MobileSegment.Wireframe.EmbeddedContentWireframe -> this.id
         }
     }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/NodeFlattenerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/NodeFlattenerTest.kt
@@ -137,6 +137,35 @@ internal class NodeFlattenerTest {
     }
 
     @Test
+    fun `M keep covered wireframe W flattenNode { covering embedded content is hidden }`(forge: Forge) {
+        // Given
+        val fakeBottomWireframe = forge.getForgery<MobileSegment.Wireframe.ShapeWireframe>().copy(
+            x = 0,
+            y = 0,
+            width = 100,
+            height = 100,
+            clip = null,
+            shapeStyle = forge.getForgery()
+        )
+        val fakeHiddenEmbeddedContent =
+            forge.getForgery<MobileSegment.Wireframe.EmbeddedContentWireframe>().copy(
+                x = 0,
+                y = 0,
+                width = 100,
+                height = 100,
+                clip = null,
+                isVisible = false
+            )
+        val fakeNode = Node(wireframes = listOf(fakeBottomWireframe, fakeHiddenEmbeddedContent))
+
+        // When
+        val wireframes = NodeFlattener().flattenNode(fakeNode)
+
+        // Then
+        assertThat(wireframes).containsExactly(fakeBottomWireframe, fakeHiddenEmbeddedContent)
+    }
+
+    @Test
     fun `M not have ConcurrentModificationException W modifying nodes concurrently`(forge: Forge) {
         // Given
         val maxWidth = forge.aLong(2, 1000)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/WireframeUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/WireframeUtilsTest.kt
@@ -694,6 +694,7 @@ internal class WireframeUtilsTest {
             is MobileSegment.Wireframe.ImageWireframe -> clip?.normalized()
             is MobileSegment.Wireframe.PlaceholderWireframe -> clip?.normalized()
             is MobileSegment.Wireframe.WebviewWireframe -> clip?.normalized()
+            is MobileSegment.Wireframe.EmbeddedContentWireframe -> clip?.normalized()
         }
     }
 
@@ -736,6 +737,7 @@ internal class WireframeUtilsTest {
 
             is MobileSegment.Wireframe.PlaceholderWireframe -> this
             is MobileSegment.Wireframe.WebviewWireframe -> this
+            is MobileSegment.Wireframe.EmbeddedContentWireframe -> this
         }
     }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/WireframeExtTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/WireframeExtTest.kt
@@ -207,6 +207,7 @@ internal class WireframeExtTest {
             is MobileSegment.Wireframe.ImageWireframe -> this.copy(shapeStyle = shapeStyle)
             is MobileSegment.Wireframe.PlaceholderWireframe -> this
             is MobileSegment.Wireframe.WebviewWireframe -> this.copy(shapeStyle = shapeStyle)
+            is MobileSegment.Wireframe.EmbeddedContentWireframe -> this.copy(shapeStyle = shapeStyle)
         }
     }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/WireframeExtTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/WireframeExtTest.kt
@@ -164,6 +164,21 @@ internal class WireframeExtTest {
         assertThat(fakeTestWireframe.hasOpaqueBackground()).isTrue
     }
 
+    @Test
+    fun `M return true W hasOpaqueBackground { visible EmbeddedContentWireframe }`(
+        @Forgery fakeWireframe: MobileSegment.Wireframe.EmbeddedContentWireframe
+    ) {
+        assertThat(fakeWireframe.copy(isVisible = true).hasOpaqueBackground()).isTrue
+        assertThat(fakeWireframe.copy(isVisible = null).hasOpaqueBackground()).isTrue
+    }
+
+    @Test
+    fun `M return false W hasOpaqueBackground { hidden EmbeddedContentWireframe }`(
+        @Forgery fakeWireframe: MobileSegment.Wireframe.EmbeddedContentWireframe
+    ) {
+        assertThat(fakeWireframe.copy(isVisible = false).hasOpaqueBackground()).isFalse
+    }
+
     // endregion
 
     // region shapeStyle

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/model/EmbeddedContentModelTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/model/EmbeddedContentModelTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.model
+
+import com.datadog.android.sessionreplay.WIREFRAME_TYPE_EMBEDDED_CONTENT
+import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ForgeExtension::class)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class EmbeddedContentModelTest {
+
+    @Test
+    fun `M round trip embedded content W serialize and deserialize`(
+        @Forgery fakeWireframe: MobileSegment.Wireframe.EmbeddedContentWireframe
+    ) {
+        // Given
+        val wireframeWithVisibility = fakeWireframe.copy(isVisible = false)
+
+        // When
+        val json = wireframeWithVisibility.toJson()
+
+        // Then
+        assertThat(json.asJsonObject.get("type").asString)
+            .isEqualTo(WIREFRAME_TYPE_EMBEDDED_CONTENT)
+        assertThat(MobileSegment.Wireframe.fromJsonElement(json)).isEqualTo(wireframeWithVisibility)
+    }
+
+    @Test
+    fun `M round trip embedded content update W serialize and deserialize`(
+        @Forgery fakeUpdate: MobileSegment.WireframeUpdateMutation.EmbeddedContentWireframeUpdate
+    ) {
+        // When
+        val json = fakeUpdate.toJson()
+
+        // Then
+        assertThat(json.asJsonObject.get("type").asString)
+            .isEqualTo(WIREFRAME_TYPE_EMBEDDED_CONTENT)
+        assertThat(MobileSegment.WireframeUpdateMutation.fromJsonElement(json)).isEqualTo(fakeUpdate)
+    }
+
+    @Test
+    fun `M round trip slot id W serialize and deserialize { full snapshot }`(
+        @LongForgery fakeTimestamp: Long,
+        @StringForgery fakeSlotId: String
+    ) {
+        // Given
+        val recordWithSlot = MobileSegment.MobileRecord.MobileFullSnapshotRecord(
+            timestamp = fakeTimestamp,
+            data = MobileSegment.Data(emptyList()),
+            slotId = fakeSlotId
+        )
+
+        // When
+        val deserialized = MobileSegment.MobileRecord.MobileFullSnapshotRecord.fromJson(
+            recordWithSlot.toJson().toString()
+        )
+
+        // Then
+        assertThat(deserialized).isEqualTo(recordWithSlot)
+    }
+
+    @Test
+    fun `M round trip slot id W serialize and deserialize { incremental snapshot }`(
+        @LongForgery fakeTimestamp: Long,
+        @LongForgery fakeWidth: Long,
+        @LongForgery fakeHeight: Long,
+        @StringForgery fakeSlotId: String
+    ) {
+        // Given
+        val recordWithSlot = MobileSegment.MobileRecord.MobileIncrementalSnapshotRecord(
+            timestamp = fakeTimestamp,
+            data = MobileSegment.MobileIncrementalData.ViewportResizeData(
+                width = fakeWidth,
+                height = fakeHeight
+            ),
+            slotId = fakeSlotId
+        )
+
+        // When
+        val deserialized = MobileSegment.MobileRecord.MobileIncrementalSnapshotRecord.fromJson(
+            recordWithSlot.toJson().toString()
+        )
+
+        // Then
+        assertThat(deserialized).isEqualTo(recordWithSlot)
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Adds embedded-content support to Session Replay by introducing embedded-content wireframes and mutations, propagating slot IDs through snapshot records, and handling visibility updates. Also preserves Kotlin source compatibility for existing snapshot-record constructors and adds serialization and mutation coverage for the new models.

### Motivation

Preparation for hybrid Flutter support.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

