### PR TITLE
RUM-17206: Capture `cf-cache-status` and `x-vercel-cache` response headers by default

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/resource/ResourceHeadersExtractor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/resource/ResourceHeadersExtractor.kt
@@ -174,7 +174,9 @@ class ResourceHeadersExtractor private constructor(
             "vary",
             "content-length",
             "server-timing",
-            "x-cache"
+            "x-cache",
+            "cf-cache-status",
+            "x-vercel-cache"
         )
 
         /**


### PR DESCRIPTION
### What does this PR do?

Adds `cf-cache-status` and `x-vercel-cache` to the default-captured response headers in `ResourceHeadersExtractor`.

### Motivation

Lets the RUM backend's shared-cache detection flag CDN hits from Cloudflare and Vercel, similar to the existing `x-cache` capture. Mirrors [dd-sdk-ios#3049](https://github.com/DataDog/dd-sdk-ios/pull/3049).

### Additional Notes

No test changes needed — `ResourceHeadersExtractorTest` asserts against `DEFAULT_RESPONSE_HEADERS` dynamically.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)