### PR TITLE
Always apply configured app launch sample rate in Profiling feature

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -100,7 +100,7 @@ internal class ProfilingFeature(
             )
             registerProfilingCallback(appContext, this@ProfilingFeature)
         }
-        setMinimumSampleRate(appContext, configuration.applicationLaunchSampleRate)
+        ProfilingStorage.setSampleRate(appContext, configuration.applicationLaunchSampleRate)
         // Set the profiling flag in SharedPreferences to profile for the next app launch
         ProfilingStorage.addProfilingFlag(appContext)
         isLaunchProfilingActive = profiler.isRunning()
@@ -268,15 +268,6 @@ internal class ProfilingFeature(
             sessionId = sessionId,
             rumSessionSampleRate = sampleRate
         )
-    }
-
-    private fun setMinimumSampleRate(appContext: Context, sampleRate: Float) {
-        val oldValue = ProfilingStorage.getSampleRate(appContext)
-        // if old value doesn't exist (we use negative default value in case of absence) or
-        // the value is bigger than the sample rate, we update the sample rate.
-        if (oldValue !in 0f..sampleRate) {
-            ProfilingStorage.setSampleRate(appContext, configuration.applicationLaunchSampleRate)
-        }
     }
 
     @Suppress("ReturnCount")

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -252,54 +252,21 @@ internal class ProfilingFeatureTest {
     }
 
     @Test
-    fun `M set Profiling sample rate W initialize {sample rate not exists}()`() {
+    fun `M set Profiling sample rate W initialize()`(
+        @FloatForgery(min = 0f, max = 100f) fakeStoredSampleRate: Float
+    ) {
         // Given
+        // Whatever was previously stored, only one SDK instance can initialize the feature, so the
+        // configured sample rate always wins.
         whenever(
             mockSharedPreferencesStorage
                 .getFloat("dd_profiling_sample_rate", -1f)
-        ) doReturn (-1f)
+        ) doReturn fakeStoredSampleRate
 
         // When
         testedFeature.onInitialize(mockContext)
 
         // Then
-        verify(mockSharedPreferencesStorage).putFloat(
-            "dd_profiling_sample_rate",
-            fakeConfiguration.applicationLaunchSampleRate
-        )
-    }
-
-    @Test
-    fun `M not set Profiling sample rate W initialize() {smaller sample rate exists}`() {
-        // Given
-        // A non-negative existing rate that is <= the configured rate (the configured rate is
-        // forged in 0f..100f, so subtracting would underflow below the "unset" sentinel).
-        whenever(
-            mockSharedPreferencesStorage
-                .getFloat("dd_profiling_sample_rate", -1f)
-        ) doReturn fakeConfiguration.applicationLaunchSampleRate / 2f
-
-        // When
-        testedFeature.onInitialize(mockContext)
-
-        // Then
-        verify(mockSharedPreferencesStorage, never()).putFloat(
-            "dd_profiling_sample_rate",
-            fakeConfiguration.applicationLaunchSampleRate
-        )
-    }
-
-    @Test
-    fun `M set Profiling sample rate W initialize() {bigger sample rate exists}`() {
-        whenever(
-            mockSharedPreferencesStorage.getFloat("dd_profiling_sample_rate", -1f)
-        ) doReturn fakeConfiguration.applicationLaunchSampleRate + 1f
-
-        // When
-        testedFeature.onInitialize(mockContext)
-
-        // Then
-        // Since the existing value was higher, it should be updated to the configuration value
         verify(mockSharedPreferencesStorage).putFloat(
             "dd_profiling_sample_rate",
             fakeConfiguration.applicationLaunchSampleRate


### PR DESCRIPTION
### What does this PR do?

Multi SDK instances support was removed in previous PR, in this case the `ProfilingFeature` doesn't need to protect against the concurrent sample rate among different SDK instances, the sample rate can always be applied during the initialization.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

