### PR TITLE
Fix datadog-ci install failing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  CURRENT_CI_IMAGE: "26"
+  CURRENT_CI_IMAGE: "27"
   CI_IMAGE_DOCKER: registry.ddbuild.io/ci/dd-sdk-android:$CURRENT_CI_IMAGE
   GIT_DEPTH: 5
 

--- a/ci/Dockerfile.gitlab
+++ b/ci/Dockerfile.gitlab
@@ -18,7 +18,6 @@ RUN set -x \
     curl \
     git \
     unzip \
-    wget \
     openssh-client \
     expect \
     python3-distutils \
@@ -65,7 +64,7 @@ RUN mkdir /root/.android \
 
 # Android SDK
 RUN \
-    wget --quiet --output-document=android-sdk.zip https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_SDK_TOOLS}_latest.zip && \
+    curl -fsSLo android-sdk.zip https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_SDK_TOOLS}_latest.zip && \
     mkdir -p android-sdk-linux/cmdline-tools && \
     unzip -d android-sdk-linux/cmdline-tools android-sdk.zip && \
     mv android-sdk-linux/cmdline-tools/cmdline-tools android-sdk-linux/cmdline-tools/latest && \
@@ -76,12 +75,6 @@ RUN \
     echo y | android-sdk-linux/cmdline-tools/latest/bin/sdkmanager --install "cmake;${CMAKE_VERSION}" >/dev/null && \
     (yes || true) | android-sdk-linux/cmdline-tools/latest/bin/sdkmanager --licenses
 
-RUN set -x \
- && curl -OL https://s3.amazonaws.com/dd-package-public/dd-package.deb && dpkg -i dd-package.deb && rm dd-package.deb \
- && apt-get update \
- && apt-get -y clean \
- && rm -rf /var/lib/apt/lists/*
-
 ENV ANDROID_SDK_ROOT $PWD/android-sdk-linux
 ENV ANDROID_HOME $PWD/android-sdk-linux
 ENV GRADLE_HOME /usr/local/gradle-${GRADLE_VERSION}
@@ -90,23 +83,26 @@ ENV PATH $PATH:$GRADLE_HOME/bin
 ENV PATH $PATH:$ANDROID_HOME/platform-tools
 ENV PATH $PATH:$ANDROID_SDK_ROOT/build-tools/${ANDROID_BUILD_TOOLS}:$ANDROID_NDK
 
-# Install Node
-ENV NODENV_VERSION 22.19.0
-ENV NODENV_ROOT /root/.nodenv
-ENV PATH "$NODENV_ROOT/shims:$NODENV_ROOT/bin:$PATH"
-RUN set -x \
-    && curl -fsSL https://github.com/nodenv/nodenv-installer/raw/master/bin/nodenv-installer | bash \
-    && nodenv install $NODENV_VERSION \
-    && nodenv rehash
-
 # Install Datadog CI
-RUN npm install -g npm@9.6.5
-RUN npm install -g @datadog/datadog-ci
+ARG GITHUB_RELEASES_BASE=https://depot-read-api-github-releases.us1.ddbuild.io/internal/mirror/github-releases
+ENV DATADOG_CI_VERSION=5.21.2
+ENV DATADOG_CI_SHA256_amd64=b163d332679b677410e05389700874a7e73b8fcb4d29dbc94c904637a9665b79
+ENV DATADOG_CI_SHA256_arm64=526d92541ef6990211f9da96d828394db956a3b12bdadc68a687b114f21918f7
+RUN set -x \
+  && case "${TARGETARCH}" in \
+       amd64) sha256="${DATADOG_CI_SHA256_amd64}"; arch=x64 ;; \
+       arm64) sha256="${DATADOG_CI_SHA256_arm64}"; arch=arm64 ;; \
+     esac \
+  && curl -fsSLo /usr/local/bin/datadog-ci \
+        "${GITHUB_RELEASES_BASE}/DataDog/datadog-ci/releases/download/v${DATADOG_CI_VERSION}/datadog-ci_linux-${arch}" \
+  && echo "${sha256}  /usr/local/bin/datadog-ci" | sha256sum -c \
+  && chmod +x /usr/local/bin/datadog-ci \
+  && datadog-ci version
 
 # Install Datadog Java tracer
 ENV DD_TRACER_FOLDER $PWD/dd-java-agent
 RUN mkdir -p $DD_TRACER_FOLDER
-RUN wget -O $DD_TRACER_FOLDER/dd-java-agent.jar https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/$DD_TRACER_VERSION/dd-java-agent-$DD_TRACER_VERSION.jar
+RUN curl -fsSLo $DD_TRACER_FOLDER/dd-java-agent.jar https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/$DD_TRACER_VERSION/dd-java-agent-$DD_TRACER_VERSION.jar
 
 COPY --from=registry.ddbuild.io/dd-octo-sts:v1.8.2 /usr/local/bin/dd-octo-sts /usr/local/bin/dd-octo-sts
 COPY --from=registry.ddbuild.io/commit-headless:v2.0.1 /commit-headless /usr/local/bin/commit-headless

--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -253,7 +253,6 @@ test:kover:
   script:
     - !reference [.snippets, source-secrets]
     - !reference [.snippets, setup-gradle]
-    - pip3 install datadog
     - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
     - export DD_API_KEY=$(get_secret $DD_ANDROID_SECRET__API_KEY)
     - export DD_APP_KEY=$(get_secret $DD_ANDROID_SECRET__APP_KEY)
@@ -265,8 +264,7 @@ test:kover:
         :koverReportFeatures
         :koverReportIntegrations
     - bash <(cat ./ci/scripts/codecov.sh) -t $CODECOV_TOKEN
-    - npm install -g @datadog/datadog-ci
-    - datadog-ci coverage upload --format=jacoco . || true
+    - datadog-ci coverage upload . || true
   artifacts:
     when: always
     expire_in: 1 week
@@ -487,9 +485,7 @@ test-pyramid:publish-e2e-synthetics:
     - export E2E_MOBILE_APP_ID=$(get_secret $DD_ANDROID_SECRET__E2E_MOBILE_APP_ID)
     - !reference [ .snippets, setup-gradle ]
     - ./gradlew :sample:kotlin:packageUs1Release
-    - npm update -g @datadog/datadog-ci
-    - echo "Using datadog-ci $(npx @datadog/datadog-ci version)"
-    - npx @datadog/datadog-ci synthetics upload-application --appKey "$E2E_DD_APP_KEY" --apiKey "$E2E_DD_API_KEY" --mobileApp "sample/kotlin/build/outputs/apk/us1/release/kotlin-us1-release.apk" --mobileApplicationId "$E2E_MOBILE_APP_ID" --versionName "$CI_COMMIT_SHORT_SHA" --latest
+    - datadog-ci synthetics upload-application --appKey "$E2E_DD_APP_KEY" --apiKey "$E2E_DD_API_KEY" --mobileApp "sample/kotlin/build/outputs/apk/us1/release/kotlin-us1-release.apk" --mobileApplicationId "$E2E_MOBILE_APP_ID" --versionName "$CI_COMMIT_SHORT_SHA" --latest
   artifacts:
     when: always
     expire_in: 1 week
@@ -516,9 +512,7 @@ test-pyramid:publish-webview-synthetics:
     - export E2E_MOBILE_APP_ID=$(get_secret $DD_ANDROID_SECRET__WEBVIEW_MOBILE_APP_ID)
     - !reference [ .snippets, setup-gradle ]
     - ./gradlew :sample:kotlin:packageUs1Release
-    - npm update -g @datadog/datadog-ci
-    - echo "Using datadog-ci $(npx @datadog/datadog-ci version)"
-    - npx @datadog/datadog-ci synthetics upload-application --appKey "$E2E_DD_APP_KEY" --apiKey "$E2E_DD_API_KEY" --mobileApp "sample/kotlin/build/outputs/apk/us1/release/kotlin-us1-release.apk" --mobileApplicationId "$E2E_MOBILE_APP_ID" --versionName "$CI_COMMIT_SHORT_SHA" --latest
+    - datadog-ci synthetics upload-application --appKey "$E2E_DD_APP_KEY" --apiKey "$E2E_DD_API_KEY" --mobileApp "sample/kotlin/build/outputs/apk/us1/release/kotlin-us1-release.apk" --mobileApplicationId "$E2E_MOBILE_APP_ID" --versionName "$CI_COMMIT_SHORT_SHA" --latest
   artifacts:
     when: always
     expire_in: 1 week
@@ -545,9 +539,7 @@ test-pyramid:publish-staging-synthetics:
     - export E2E_MOBILE_APP_ID=$(get_secret $DD_ANDROID_SECRET__E2E_STAGING_APP_ID)
     - !reference [ .snippets, setup-gradle ]
     - ./gradlew :sample:kotlin:packageStagingRelease
-    - npm update -g @datadog/datadog-ci
-    - echo "Using datadog-ci $(npx @datadog/datadog-ci version)"
-    - npx @datadog/datadog-ci synthetics upload-application --appKey "$E2E_DD_APP_KEY" --apiKey "$E2E_DD_API_KEY" --mobileApp "sample/kotlin/build/outputs/apk/staging/release/kotlin-staging-release.apk" --mobileApplicationId "$E2E_MOBILE_APP_ID" --versionName "$CI_COMMIT_SHORT_SHA" --latest --datadogSite "datad0g.com"
+    - datadog-ci synthetics upload-application --appKey "$E2E_DD_APP_KEY" --apiKey "$E2E_DD_API_KEY" --mobileApp "sample/kotlin/build/outputs/apk/staging/release/kotlin-staging-release.apk" --mobileApplicationId "$E2E_MOBILE_APP_ID" --versionName "$CI_COMMIT_SHORT_SHA" --latest --datadogSite "datad0g.com"
   artifacts:
     when: always
     expire_in: 1 week
@@ -574,9 +566,7 @@ test-pyramid:publish-benchmark-synthetics:
     - export BM_MOBILE_APP_ID=$(get_secret $DD_ANDROID_SECRET__BENCHMARK_MOBILE_APP_ID)
     - !reference [ .snippets, setup-gradle ]
     - ./gradlew :sample:benchmark:packageRelease
-    - npm update -g @datadog/datadog-ci
-    - echo "Using datadog-ci $(npx @datadog/datadog-ci version)"
-    - npx @datadog/datadog-ci synthetics upload-application --appKey "$BM_DD_APP_KEY" --apiKey "$BM_DD_API_KEY" --mobileApp "sample/benchmark/build/outputs/apk/release/benchmark-release.apk" --mobileApplicationId "$BM_MOBILE_APP_ID" --versionName "$CI_COMMIT_SHORT_SHA" --latest
+    - datadog-ci synthetics upload-application --appKey "$BM_DD_APP_KEY" --apiKey "$BM_DD_API_KEY" --mobileApp "sample/benchmark/build/outputs/apk/release/benchmark-release.apk" --mobileApplicationId "$BM_MOBILE_APP_ID" --versionName "$CI_COMMIT_SHORT_SHA" --latest
   artifacts:
     when: always
     expire_in: 1 week


### PR DESCRIPTION
### What does this PR do?
Gitlab Job changes:
* Removed the manual install of datadog-ci per job and instead rely on the docker image
* For test:kover, we do not need the python `datadog` library install command
* Invoke datadog-ci correctly to avoid spam about invalid file format

Docker changes:
* Our docker image should have datadog-ci already, but it was not working correctly. Switched to installing the pre-built binary version
* Removed NodeJS / NPM
* Standardize on curl so we don't need curl and wget
* Remove dd-package install, its usage was removed in #324 and prevented the docker image working on arm64

### Motivation

Our jobs are failing with 
```
$ npm update -g @datadog/datadog-ci
npm ERR! code ECONNRESET
npm ERR! network aborted
npm ERR! network This is a problem related to network connectivity.
npm ERR! network In most cases you are behind a proxy or have bad network settings.
npm ERR! network 
npm ERR! network If you are behind a proxy, please make sure that the
npm ERR! network 'proxy' config is set properly.  See: 'npm help config'
npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2026-07-31T14_58_12_913Z-debug-0.log
```

----

**Note**: The command may have installed before, but it never worked:
```
$ npm install -g @datadog/datadog-ci
changed 1 package in 912ms
$ datadog-ci coverage upload --format=jacoco . || true
/scripts-1238-1912225152/step_script: line 259: datadog-ci: command not found
```

Now that I installed it correctly, it spammed 
```
❌ Invalid coverage report file [./tools/unit/src/test/kotlin/com/datadog/tools/unit/extensions/JavaClassWithStaticMock.java]: char '/' is not expected.
❌ Invalid coverage report file [./tools/unit/src/test/kotlin/com/datadog/tools/unit/extensions/ProhibitLeavingStaticMocksExtensionTest.kt]: char '/' is not expected.
❌ Invalid coverage report file [./tools/unit/src/test/kotlin/com/datadog/tools/unit/extensions/TestConfigurationExtensionTest.kt]: char '/' is not expected.
Uploading code coverage report file(s) in ./dd-sdk-android-core/build/reports/kover/reportRelease.xml,./dd-sdk-android-internal/build/reports/kover/reportRelease.xml,./features/dd-sdk-android-flags/build/reports/kover/reportRelease.xml,./features/dd-sdk-android-flags-openfeature/build/reports/kover/reportRelease.xml,./features/dd-sdk-android-logs/build/reports/kover/reportRelease.xml,./features/dd-sdk-android-ndk/build/reports/kover/reportRelease.xml,./features/dd-sdk-android-profiling/build/reports/kover/reportRelease.xml
❌ Upload failed for ./dd-sdk-android-core/build/reports/kover/reportRelease.xml,./dd-sdk-android-internal/build/reports/kover/reportRelease.xml,./features/dd-sdk-android-flags/build/reports/kover/reportRelease.xml,./features/dd-sdk-android-flags-openfeature/build/reports/kover/reportRelease.xml,./features/dd-sdk-android-logs/build/reports/kover/reportRelease.xml,./features/dd-sdk-android-ndk/build/reports/kover/reportRelease.xml,./features/dd-sdk-android-profiling/build/reports/kover/reportRelease.xml: RequestError: Request failed with status code 403
```

I fixed that too by dropping the `--format` and letting it deal with it [automatically](https://github.com/DataDog/datadog-ci/blob/v5.21.2/packages/plugin-coverage/src/utils.ts#L49-L86) based on the file name

But there still remains a problem, the API/App key seems to be invalid so we always get a 403. I did **NOT** fix that since we should probably fix it correctly with RUM-17393

### Additional Notes
DD Pipeline Run showing tests are still uploaded: [link](https://app.datadoghq.com/ci/ci-cd/explorer?query=ci_level%3Apipeline%20%40git.repository.id_v2%3Agithub.com%2Fdatadog%2Fdd-sdk-android&agg_m=count&agg_m_source=base&agg_t=count&buildId=AwAAAZ-5l8wobuaJHQAAABhBWi01bDh3b0FBQWQ0VUNYYW9BcXpmTUYAAAAkMDE5ZmI5YTAtODMwZC00MTk2LTkzMTctOWRiNmY4NGE1ODU0AAAr0w&ci_cd_explorer_tab=pipelines&downstream_pipelines=false&fromUser=false&index=cipipeline&partial_retries=false&refresh_mode=sliding&span_id=457644090776696522&tab=tests&trace=AwAAAZ-5l8wobuaJHQAAABhBWi01bDh3b0FBQWQ0VUNYYW9BcXpmTUYAAAAkMDE5ZmI5YTAtODMwZC00MTk2LTkzMTctOWRiNmY4NGE1ODU0AAAr0w&start=1785524043386&end=1785525843386&paused=false)
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

