### PR TITLE
RUM-17877: Support SPLIT resolution reason

### DIFF
--- a/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/internal/adapters/ConvertersTest.kt
+++ b/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/internal/adapters/ConvertersTest.kt
@@ -116,6 +116,30 @@ internal class ConvertersTest {
     }
 
     @Test
+    fun `M convert SPLIT reason W toProviderEvaluation() {resolution with SPLIT reason}`(
+        @StringForgery variant: String,
+        forge: Forge
+    ) {
+        // Given
+        val value = forge.aBool()
+        val resolution = ResolutionDetails(
+            value = value,
+            variant = variant,
+            reason = ResolutionReason.SPLIT
+        )
+
+        // When
+        val result = resolution.toProviderEvaluation()
+
+        // Then
+        assertThat(result.value).isEqualTo(value)
+        assertThat(result.variant).isEqualTo(variant)
+        assertThat(result.reason).isEqualTo("SPLIT")
+        assertThat(result.errorCode).isNull()
+        assertThat(result.errorMessage).isNull()
+    }
+
+    @Test
     fun `M convert error resolution W toProviderEvaluation() {with error code}`(@StringForgery errorMessage: String) {
         // Given
         val resolution = ResolutionDetails(

--- a/features/dd-sdk-android-flags/api/apiSurface
+++ b/features/dd-sdk-android-flags/api/apiSurface
@@ -61,6 +61,7 @@ enum com.datadog.android.flags.model.ResolutionReason
   - STATIC
   - DEFAULT
   - TARGETING_MATCH
+  - SPLIT
   - RULE_MATCH
   - PREREQUISITE_FAILED
   - ERROR

--- a/features/dd-sdk-android-flags/api/dd-sdk-android-flags.api
+++ b/features/dd-sdk-android-flags/api/dd-sdk-android-flags.api
@@ -483,6 +483,7 @@ public final class com/datadog/android/flags/model/ResolutionReason : java/lang/
 	public static final field ERROR Lcom/datadog/android/flags/model/ResolutionReason;
 	public static final field PREREQUISITE_FAILED Lcom/datadog/android/flags/model/ResolutionReason;
 	public static final field RULE_MATCH Lcom/datadog/android/flags/model/ResolutionReason;
+	public static final field SPLIT Lcom/datadog/android/flags/model/ResolutionReason;
 	public static final field STATIC Lcom/datadog/android/flags/model/ResolutionReason;
 	public static final field TARGETING_MATCH Lcom/datadog/android/flags/model/ResolutionReason;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/flags/model/ResolutionReason;

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/model/ResolutionReason.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/model/ResolutionReason.kt
@@ -31,6 +31,11 @@ enum class ResolutionReason {
     TARGETING_MATCH,
 
     /**
+     * A traffic split selected the resolved value.
+     */
+    SPLIT,
+
+    /**
      * The resolved value matched a specific evaluation rule.
      */
     RULE_MATCH,

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/DatadogFlagsClientTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/DatadogFlagsClientTest.kt
@@ -980,6 +980,36 @@ internal class DatadogFlagsClientTest {
     }
 
     @Test
+    fun `M return ResolutionDetails with SPLIT reason W resolve() { flag has SPLIT reason }`(forge: Forge) {
+        // Given
+        val fakeFlagKey = forge.anAlphabeticalString()
+        val fakeDefaultValue = forge.aBool()
+        val fakeFlagValue = !fakeDefaultValue
+        val fakeVariationKey = forge.anAlphabeticalString()
+        val fakeFlag = forge.getForgery<PrecomputedFlag>().copy(
+            variationType = VariationType.BOOLEAN.value,
+            variationValue = fakeFlagValue.toString(),
+            variationKey = fakeVariationKey,
+            reason = "SPLIT"
+        )
+        val fakeContext = EvaluationContext(
+            targetingKey = forge.anAlphabeticalString(),
+            attributes = emptyMap()
+        )
+        whenever(mockFlagsRepository.getPrecomputedFlagWithContext(fakeFlagKey)) doReturn (fakeFlag to fakeContext)
+
+        // When
+        val result = testedClient.resolve(fakeFlagKey, fakeDefaultValue)
+
+        // Then
+        assertThat(result.value).isEqualTo(fakeFlagValue)
+        assertThat(result.variant).isEqualTo(fakeVariationKey)
+        assertThat(result.reason).isEqualTo(ResolutionReason.SPLIT)
+        assertThat(result.errorCode).isNull()
+        assertThat(result.errorMessage).isNull()
+    }
+
+    @Test
     fun `M return ResolutionDetails with error W resolve() { type mismatch }`(forge: Forge) {
         // Given
         val fakeFlagKey = forge.anAlphabeticalString()


### PR DESCRIPTION
### Motivation

The Feature Flags backend returns `SPLIT` when a traffic split selects a flag value. Android does not define this reason. The SDK returns the correct value, but it emits repeated telemetry errors and omits the OpenFeature resolution reason.

This change addresses RUM-17877.

### Changes and Decisions

This change adds `SPLIT` to the public `ResolutionReason` enum. The existing parser can now pass the backend reason through without special-case mapping.

Tests cover the direct Flags client and the OpenFeature adapter. The generated API files record the new public enum value.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)
