### PR TITLE
RUM-17639: Automate attaching the verification-metadata.xml to GitHub release

### DIFF
--- a/.github/chainguard/self.gitlab.release.create-release.sts.yaml
+++ b/.github/chainguard/self.gitlab.release.create-release.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/dd-sdk-android:ref_type:tag:ref:[0-9]+\\.[0-9]+\\.[0-9]+.*"
+
+claim_pattern:
+  ci_config_ref_uri: 'gitlab\.ddbuild\.io/DataDog/dd-sdk-android//\.gitlab-ci\.yml@refs/tags/.*'
+  pipeline_source: "push"
+  project_path: "DataDog/dd-sdk-android"
+  ref_path: 'refs/tags/[0-9]+\.[0-9]+\.[0-9]+.*'
+
+permissions:
+  contents: write

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  CURRENT_CI_IMAGE: "27"
+  CURRENT_CI_IMAGE: "28"
   CI_IMAGE_DOCKER: registry.ddbuild.io/ci/dd-sdk-android:$CURRENT_CI_IMAGE
   GIT_DEPTH: 5
 

--- a/ci/Dockerfile.gitlab
+++ b/ci/Dockerfile.gitlab
@@ -104,6 +104,24 @@ ENV DD_TRACER_FOLDER $PWD/dd-java-agent
 RUN mkdir -p $DD_TRACER_FOLDER
 RUN curl -fsSLo $DD_TRACER_FOLDER/dd-java-agent.jar https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/$DD_TRACER_VERSION/dd-java-agent-$DD_TRACER_VERSION.jar
 
+# Install GitHub CLI
+ENV GH_CLI_VERSION=2.97.0
+ENV GH_CLI_SHA256_amd64=a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112
+ENV GH_CLI_SHA256_arm64=73ea440ecad9c9e284429997ee6f93577bc6f7bc6fba357ef62c53ad8fb641a5
+RUN set -x \
+  && case "${TARGETARCH}" in \
+       amd64) sha256="${GH_CLI_SHA256_amd64}"; arch=amd64 ;; \
+       arm64) sha256="${GH_CLI_SHA256_arm64}"; arch=arm64 ;; \
+     esac \
+  && curl -fsSLo gh.tar.gz \
+        "${GITHUB_RELEASES_BASE}/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_${arch}.tar.gz" \
+  && echo "${sha256}  gh.tar.gz" | sha256sum -c \
+  && mkdir gh-cli \
+  && tar -xzf gh.tar.gz -C gh-cli \
+  && mv "$(find gh-cli -type f -name gh)" /usr/local/bin/gh \
+  && rm -rf gh.tar.gz gh-cli \
+  && gh --version
+
 COPY --from=registry.ddbuild.io/dd-octo-sts:v1.8.2 /usr/local/bin/dd-octo-sts /usr/local/bin/dd-octo-sts
 COPY --from=registry.ddbuild.io/commit-headless:v2.0.1 /commit-headless /usr/local/bin/commit-headless
 

--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -710,3 +710,34 @@ notify:merge-verification-metadata:
     paths:
       - verification-metadata.xml
 
+notify:github-release:
+  tags: [ "arch:amd64" ]
+  interruptible: false
+  only:
+    - tags
+  image: $CI_IMAGE_DOCKER
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
+  stage: notify
+  when: on_success
+  needs:
+    - notify:merge-verification-metadata
+  script:
+    - export GITHUB_TOKEN=$(dd-octo-sts token --scope DataDog/dd-sdk-android --policy self.gitlab.release.create-release)
+    - >-
+        if gh release view "$CI_COMMIT_TAG" --repo DataDog/dd-sdk-android >/dev/null 2>&1; then
+          gh release upload "$CI_COMMIT_TAG" --repo DataDog/dd-sdk-android --clobber verification-metadata.xml;
+        else
+          # Extract out the tag's changelog entry
+          start_line=$(grep -Fn "# ${CI_COMMIT_TAG} /" CHANGELOG.md | head -1 | cut -d: -f1 || true);
+          if [ -n "$start_line" ]; then
+            tail -n "+$((start_line + 1))" CHANGELOG.md | sed -n '/^# /q;p' > release-notes.md || true;
+          else
+            echo "No CHANGELOG.md entry found for tag $CI_COMMIT_TAG" >&2;
+            echo "Fill this in" > release-notes.md;
+          fi;
+      
+          gh release create "$CI_COMMIT_TAG" --repo DataDog/dd-sdk-android --draft --verify-tag --title "$CI_COMMIT_TAG" --notes-file release-notes.md verification-metadata.xml;
+        fi
+


### PR DESCRIPTION
### What does this PR do?
Auto-create the GitHub release for the release's tag with the verification-metadata.xml attached. If the release already exists, just try to upload it. Install GitHub CLI into docker image to support this

The created release will be in draft mode, and also include the CHANGELOG.md entry for convenience 

### Motivation
Automate a step in the release that is often overlooked