### PR TITLE
[FFL-2929] Add Flags initialization timeout

### DIFF
--- a/features/dd-sdk-android-flags-openfeature/src/main/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProvider.kt
+++ b/features/dd-sdk-android-flags-openfeature/src/main/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProvider.kt
@@ -10,6 +10,7 @@ import com.datadog.android.Datadog
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.flags.FlagsClient
+import com.datadog.android.flags.FlagsInitializationTimeoutException
 import com.datadog.android.flags.FlagsStateListener
 import com.datadog.android.flags.model.FlagsClientState
 import com.datadog.android.flags.openfeature.internal.adapters.convertToValue
@@ -98,7 +99,7 @@ class DatadogFlagsProvider private constructor(private val flagsClient: FlagsCli
      * The method suspends while the [FlagsClient] in turn, takes the context and fetches the flags from the server.
      *
      * @param initialContext The initial evaluation context to set (optional)
-     * @throws OpenFeatureError if initialization fails
+     * @throws OpenFeatureError if initialization fails or reaches the configured Flags initialization timeout
      */
     override suspend fun initialize(initialContext: OpenFeatureEvaluationContext?) {
         val datadogContext = initialContext?.toDatadogEvaluationContext() ?: DatadogEvaluationContext.EMPTY
@@ -219,9 +220,15 @@ class DatadogFlagsProvider private constructor(private val flagsClient: FlagsCli
                     FlagsClientState.Reconciling -> null // SDK emits PROVIDER_RECONCILING
                     FlagsClientState.Ready -> OpenFeatureProviderEvents.ProviderReady
                     FlagsClientState.Stale -> OpenFeatureProviderEvents.ProviderStale
-                    is FlagsClientState.Error -> OpenFeatureProviderEvents.ProviderError(
-                        error = OpenFeatureError.ProviderFatalError()
-                    )
+                    is FlagsClientState.Error -> newState.error.let { cause ->
+                        OpenFeatureProviderEvents.ProviderError(
+                            error = if (cause is FlagsInitializationTimeoutException) {
+                                OpenFeatureError.GeneralError(cause.message ?: "Flags initialization timed out")
+                            } else {
+                                OpenFeatureError.ProviderFatalError()
+                            }
+                        )
+                    }
                 }
                 providerEvent?.let { trySend(it) }
             }

--- a/features/dd-sdk-android-flags-openfeature/src/main/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProvider.kt
+++ b/features/dd-sdk-android-flags-openfeature/src/main/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProvider.kt
@@ -100,6 +100,7 @@ class DatadogFlagsProvider private constructor(private val flagsClient: FlagsCli
      *
      * @param initialContext The initial evaluation context to set (optional)
      * @throws OpenFeatureError if initialization fails or reaches the configured Flags initialization timeout
+     * without matching cached assignments
      */
     override suspend fun initialize(initialContext: OpenFeatureEvaluationContext?) {
         val datadogContext = initialContext?.toDatadogEvaluationContext() ?: DatadogEvaluationContext.EMPTY

--- a/features/dd-sdk-android-flags-openfeature/src/main/kotlin/com/datadog/android/flags/openfeature/internal/FlagsClientExt.kt
+++ b/features/dd-sdk-android-flags-openfeature/src/main/kotlin/com/datadog/android/flags/openfeature/internal/FlagsClientExt.kt
@@ -21,7 +21,8 @@ import kotlin.coroutines.suspendCoroutine
  * to [resume]/[resumeWithException].
  *
  * @param context The evaluation context to set
- * @throws [OpenFeatureError.GeneralError] if setting the context fails or times out.
+ * @throws [OpenFeatureError.GeneralError] if setting the context fails. The first context operation also
+ * fails when the configured Flags initialization timeout elapses.
  */
 internal suspend fun FlagsClient.setEvaluationContextSuspend(context: EvaluationContext) {
     // Subsequent invocation of any resume function will produce
@@ -42,7 +43,6 @@ internal suspend fun FlagsClient.setEvaluationContextSuspend(context: Evaluation
             }
         }
 
-        // setEvaluationContext is guaranteed to return within the configured timeout.
         setEvaluationContext(context, callback)
     }
 }

--- a/features/dd-sdk-android-flags-openfeature/src/main/kotlin/com/datadog/android/flags/openfeature/internal/FlagsClientExt.kt
+++ b/features/dd-sdk-android-flags-openfeature/src/main/kotlin/com/datadog/android/flags/openfeature/internal/FlagsClientExt.kt
@@ -8,7 +8,9 @@ package com.datadog.android.flags.openfeature.internal
 
 import com.datadog.android.flags.EvaluationContextCallback
 import com.datadog.android.flags.FlagsClient
+import com.datadog.android.flags.FlagsInitializationTimeoutException
 import com.datadog.android.flags.model.EvaluationContext
+import com.datadog.android.flags.model.FlagsClientState
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -20,9 +22,11 @@ import kotlin.coroutines.suspendCoroutine
  * Wraps the callback API in a [suspendCoroutine], converting success/failure callbacks
  * to [resume]/[resumeWithException].
  *
+ * A timeout with matching cached assignments completes successfully and leaves the provider stale.
+ *
  * @param context The evaluation context to set
  * @throws [OpenFeatureError.GeneralError] if setting the context fails. The first context operation also
- * fails when the configured Flags initialization timeout elapses.
+ * fails when the configured Flags initialization timeout elapses without matching cached assignments.
  */
 internal suspend fun FlagsClient.setEvaluationContextSuspend(context: EvaluationContext) {
     // Subsequent invocation of any resume function will produce
@@ -35,11 +39,17 @@ internal suspend fun FlagsClient.setEvaluationContextSuspend(context: Evaluation
             }
 
             override fun onFailure(error: Throwable) {
-                continuation.resumeWithException(
-                    OpenFeatureError.GeneralError(
-                        error.message ?: "Unknown error: ${error::class.simpleName}"
+                if (error is FlagsInitializationTimeoutException &&
+                    state.getCurrentState() == FlagsClientState.Stale
+                ) {
+                    continuation.resume(Unit)
+                } else {
+                    continuation.resumeWithException(
+                        OpenFeatureError.GeneralError(
+                            error.message ?: "Unknown error: ${error::class.simpleName}"
+                        )
                     )
-                )
+                }
             }
         }
 

--- a/features/dd-sdk-android-flags-openfeature/src/main/kotlin/com/datadog/android/flags/openfeature/internal/FlagsClientExt.kt
+++ b/features/dd-sdk-android-flags-openfeature/src/main/kotlin/com/datadog/android/flags/openfeature/internal/FlagsClientExt.kt
@@ -39,9 +39,12 @@ internal suspend fun FlagsClient.setEvaluationContextSuspend(context: Evaluation
             }
 
             override fun onFailure(error: Throwable) {
-                if (error is FlagsInitializationTimeoutException &&
-                    state.getCurrentState() == FlagsClientState.Stale
-                ) {
+                val isUsableTimeout = error is FlagsInitializationTimeoutException &&
+                    when (state.getCurrentState()) {
+                        FlagsClientState.Ready, FlagsClientState.Stale -> true
+                        else -> false
+                    }
+                if (isUsableTimeout) {
                     continuation.resume(Unit)
                 } else {
                     continuation.resumeWithException(

--- a/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProviderTest.kt
+++ b/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProviderTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.flags.EvaluationContextCallback
 import com.datadog.android.flags.FlagsClient
+import com.datadog.android.flags.FlagsInitializationTimeoutException
 import com.datadog.android.flags.FlagsStateListener
 import com.datadog.android.flags.StateObservable
 import com.datadog.android.flags.model.ErrorCode
@@ -22,14 +23,19 @@ import com.datadog.android.flags.model.ResolutionDetails
 import com.datadog.android.flags.model.ResolutionReason
 import com.datadog.tools.unit.forge.BaseConfigurator
 import dev.openfeature.kotlin.sdk.ImmutableContext
+import dev.openfeature.kotlin.sdk.OpenFeatureAPI
+import dev.openfeature.kotlin.sdk.OpenFeatureStatus
 import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -369,6 +375,36 @@ internal class DatadogFlagsProviderTest {
         assertThat(contextCaptor.firstValue).isEqualTo(EvaluationContext.EMPTY)
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `M settle with Error status W setProviderAndWait() {initialization times out}`() = runTest {
+        // Given
+        val timeoutMessage = "Flags initialization timed out after 250ms"
+        whenever(mockFlagsClient.setEvaluationContext(any(), any())).doAnswer { invocation ->
+            val callback = invocation.getArgument<EvaluationContextCallback>(1)
+            callback.onFailure(FlagsInitializationTimeoutException(250L))
+            Unit
+        }
+
+        try {
+            // When
+            OpenFeatureAPI.setProviderAndWait(
+                provider = provider,
+                initialContext = ImmutableContext(targetingKey = "user-123"),
+                dispatcher = UnconfinedTestDispatcher(testScheduler)
+            )
+
+            // Then
+            val status = OpenFeatureAPI.getStatus()
+            assertThat(status).isInstanceOf(OpenFeatureStatus.Error::class.java)
+            val error = (status as OpenFeatureStatus.Error).error
+            assertThat(error).isInstanceOf(OpenFeatureError.GeneralError::class.java)
+            assertThat(error).hasMessage(timeoutMessage)
+        } finally {
+            OpenFeatureAPI.shutdown()
+        }
+    }
+
     @Test
     fun `M delegate to FlagsClient W onContextSet()`() = runTest {
         // Given
@@ -444,10 +480,11 @@ internal class DatadogFlagsProviderTest {
     }
 
     @Test
-    fun `M emit ProviderError event W observe() {state changes to Error}`() = runTest {
+    fun `M emit recoverable ProviderError then ProviderReady W observe() {timeout recovers}`() = runTest {
         // Given
         val events = mutableListOf<OpenFeatureProviderEvents>()
-        val errorState = FlagsClientState.Error(RuntimeException("test error"))
+        val timeoutMessage = "Flags initialization timed out after 250ms"
+        val errorState = FlagsClientState.Error(FlagsInitializationTimeoutException(250L))
 
         // When
         val job = launch {
@@ -455,12 +492,16 @@ internal class DatadogFlagsProviderTest {
         }
         testScheduler.runCurrent()
         checkNotNull(capturedStateListener).onStateChanged(errorState)
+        checkNotNull(capturedStateListener).onStateChanged(FlagsClientState.Ready)
         testScheduler.runCurrent()
         job.cancel()
 
-        // Then - Error state is converted to ProviderError event
-        assertThat(events).hasSize(1)
-        assertThat(events[0]).isInstanceOf(OpenFeatureProviderEvents.ProviderError::class.java)
+        // Then - the timeout is recoverable and a late result restores readiness
+        assertThat(events).hasSize(2)
+        val providerError = events[0] as OpenFeatureProviderEvents.ProviderError
+        assertThat(providerError.error).isInstanceOf(OpenFeatureError.GeneralError::class.java)
+        assertThat(providerError.error).hasMessage(timeoutMessage)
+        assertThat(events[1]).isInstanceOf(OpenFeatureProviderEvents.ProviderReady::class.java)
     }
 
     @Test

--- a/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProviderTest.kt
+++ b/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProviderTest.kt
@@ -411,11 +411,11 @@ internal class DatadogFlagsProviderTest {
     @Test
     fun `M complete initialization W initialize() {timeout with matching cached assignments}`() = runTest {
         // Given
-        val timeoutError = mock<FlagsInitializationTimeoutException>()
+        val fakeTimeoutError = mock<FlagsInitializationTimeoutException>()
         whenever(mockStateObservable.getCurrentState()).thenReturn(FlagsClientState.Stale)
         whenever(mockFlagsClient.setEvaluationContext(any(), any())).doAnswer { invocation ->
             val callback = invocation.getArgument<EvaluationContextCallback>(1)
-            callback.onFailure(timeoutError)
+            callback.onFailure(fakeTimeoutError)
             Unit
         }
 

--- a/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProviderTest.kt
+++ b/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProviderTest.kt
@@ -52,6 +52,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -380,9 +381,11 @@ internal class DatadogFlagsProviderTest {
     fun `M settle with Error status W setProviderAndWait() {initialization times out}`() = runTest {
         // Given
         val timeoutMessage = "Flags initialization timed out after 250ms"
+        val timeoutError = mock<FlagsInitializationTimeoutException>()
+        whenever(timeoutError.message).thenReturn(timeoutMessage)
         whenever(mockFlagsClient.setEvaluationContext(any(), any())).doAnswer { invocation ->
             val callback = invocation.getArgument<EvaluationContextCallback>(1)
-            callback.onFailure(FlagsInitializationTimeoutException(250L))
+            callback.onFailure(timeoutError)
             Unit
         }
 
@@ -403,6 +406,29 @@ internal class DatadogFlagsProviderTest {
         } finally {
             OpenFeatureAPI.shutdown()
         }
+    }
+
+    @Test
+    fun `M complete initialization W initialize() {timeout with matching cached assignments}`() = runTest {
+        // Given
+        val timeoutError = mock<FlagsInitializationTimeoutException>()
+        whenever(mockStateObservable.getCurrentState()).thenReturn(FlagsClientState.Stale)
+        whenever(mockFlagsClient.setEvaluationContext(any(), any())).doAnswer { invocation ->
+            val callback = invocation.getArgument<EvaluationContextCallback>(1)
+            callback.onFailure(timeoutError)
+            Unit
+        }
+
+        // When
+        var initializationError: OpenFeatureError.GeneralError? = null
+        try {
+            provider.initialize(ImmutableContext(targetingKey = "user-123"))
+        } catch (error: OpenFeatureError.GeneralError) {
+            initializationError = error
+        }
+
+        // Then
+        assertThat(initializationError).isNull()
     }
 
     @Test
@@ -484,7 +510,9 @@ internal class DatadogFlagsProviderTest {
         // Given
         val events = mutableListOf<OpenFeatureProviderEvents>()
         val timeoutMessage = "Flags initialization timed out after 250ms"
-        val errorState = FlagsClientState.Error(FlagsInitializationTimeoutException(250L))
+        val timeoutError = mock<FlagsInitializationTimeoutException>()
+        whenever(timeoutError.message).thenReturn(timeoutMessage)
+        val errorState = FlagsClientState.Error(timeoutError)
 
         // When
         val job = launch {

--- a/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProviderTest.kt
+++ b/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/DatadogFlagsProviderTest.kt
@@ -381,11 +381,11 @@ internal class DatadogFlagsProviderTest {
     fun `M settle with Error status W setProviderAndWait() {initialization times out}`() = runTest {
         // Given
         val timeoutMessage = "Flags initialization timed out after 250ms"
-        val timeoutError = mock<FlagsInitializationTimeoutException>()
-        whenever(timeoutError.message).thenReturn(timeoutMessage)
+        val stubTimeoutError = mock<FlagsInitializationTimeoutException>()
+        whenever(stubTimeoutError.message).thenReturn(timeoutMessage)
         whenever(mockFlagsClient.setEvaluationContext(any(), any())).doAnswer { invocation ->
             val callback = invocation.getArgument<EvaluationContextCallback>(1)
-            callback.onFailure(timeoutError)
+            callback.onFailure(stubTimeoutError)
             Unit
         }
 
@@ -510,9 +510,9 @@ internal class DatadogFlagsProviderTest {
         // Given
         val events = mutableListOf<OpenFeatureProviderEvents>()
         val timeoutMessage = "Flags initialization timed out after 250ms"
-        val timeoutError = mock<FlagsInitializationTimeoutException>()
-        whenever(timeoutError.message).thenReturn(timeoutMessage)
-        val errorState = FlagsClientState.Error(timeoutError)
+        val stubTimeoutError = mock<FlagsInitializationTimeoutException>()
+        whenever(stubTimeoutError.message).thenReturn(timeoutMessage)
+        val errorState = FlagsClientState.Error(stubTimeoutError)
 
         // When
         val job = launch {

--- a/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/internal/FlagsClientExtTest.kt
+++ b/features/dd-sdk-android-flags-openfeature/src/test/kotlin/com/datadog/android/flags/openfeature/internal/FlagsClientExtTest.kt
@@ -8,7 +8,10 @@ package com.datadog.android.flags.openfeature.internal
 
 import com.datadog.android.flags.EvaluationContextCallback
 import com.datadog.android.flags.FlagsClient
+import com.datadog.android.flags.FlagsInitializationTimeoutException
+import com.datadog.android.flags.StateObservable
 import com.datadog.android.flags.model.EvaluationContext
+import com.datadog.android.flags.model.FlagsClientState
 import com.datadog.tools.unit.forge.BaseConfigurator
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -27,6 +30,8 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -62,6 +67,28 @@ internal class FlagsClientExtTest {
         // Then - verify the correct context was passed
         verify(mockFlagsClient).setEvaluationContext(contextCaptor.capture(), any())
         assertThat(contextCaptor.firstValue).isEqualTo(context)
+    }
+
+    @Test
+    fun `M complete successfully W setEvaluationContextSuspend() {timeout callback races ready state}`(
+        @StringForgery targetingKey: String
+    ) = runTest {
+        // Given
+        val context = EvaluationContext(targetingKey = targetingKey)
+        val stubState = mock<StateObservable>()
+        val stubTimeoutError = mock<FlagsInitializationTimeoutException>()
+        whenever(mockFlagsClient.state).thenReturn(stubState)
+        whenever(stubState.getCurrentState()).thenReturn(FlagsClientState.Ready)
+        doAnswer { invocation ->
+            invocation.getArgument<EvaluationContextCallback>(1).onFailure(stubTimeoutError)
+            Unit
+        }.whenever(mockFlagsClient).setEvaluationContext(eq(context), any())
+
+        // When
+        mockFlagsClient.setEvaluationContextSuspend(context)
+
+        // Then
+        verify(mockFlagsClient).setEvaluationContext(eq(context), any())
     }
 
     @Test

--- a/features/dd-sdk-android-flags/api/apiSurface
+++ b/features/dd-sdk-android-flags/api/apiSurface
@@ -19,6 +19,7 @@ interface com.datadog.android.flags.FlagsClient
   companion object 
     fun get(String = DEFAULT_CLIENT_NAME, com.datadog.android.api.SdkCore = Datadog.getInstance()): FlagsClient
 data class com.datadog.android.flags.FlagsConfiguration
+  fun copy(Boolean = this.trackExposures, Boolean = this.trackEvaluations, String? = this.customExposureEndpoint, String? = this.customEvaluationEndpoint, String? = this.customFlagEndpoint, Long = this.evaluationFlushIntervalMs, Boolean = this.rumIntegrationEnabled, Boolean = this.gracefulModeEnabled): FlagsConfiguration
   class Builder
     fun trackExposures(Boolean): Builder
     fun trackEvaluations(Boolean): Builder
@@ -26,9 +27,12 @@ data class com.datadog.android.flags.FlagsConfiguration
     fun useCustomEvaluationEndpoint(String): Builder
     fun evaluationFlushInterval(Long): Builder
     fun useCustomFlagEndpoint(String): Builder
+    fun initializationTimeout(Long): Builder
     fun rumIntegrationEnabled(Boolean): Builder
     fun gracefulModeEnabled(Boolean): Builder
     fun build(): FlagsConfiguration
+class com.datadog.android.flags.FlagsInitializationTimeoutException : RuntimeException
+  constructor(Long)
 interface com.datadog.android.flags.FlagsStateListener
   fun onStateChanged(com.datadog.android.flags.model.FlagsClientState)
 interface com.datadog.android.flags.StateObservable

--- a/features/dd-sdk-android-flags/api/apiSurface
+++ b/features/dd-sdk-android-flags/api/apiSurface
@@ -32,7 +32,6 @@ data class com.datadog.android.flags.FlagsConfiguration
     fun gracefulModeEnabled(Boolean): Builder
     fun build(): FlagsConfiguration
 class com.datadog.android.flags.FlagsInitializationTimeoutException : RuntimeException
-  constructor(Long)
 interface com.datadog.android.flags.FlagsStateListener
   fun onStateChanged(com.datadog.android.flags.model.FlagsClientState)
 interface com.datadog.android.flags.StateObservable

--- a/features/dd-sdk-android-flags/api/dd-sdk-android-flags.api
+++ b/features/dd-sdk-android-flags/api/dd-sdk-android-flags.api
@@ -57,12 +57,17 @@ public final class com/datadog/android/flags/FlagsConfiguration$Builder {
 	public final fun build ()Lcom/datadog/android/flags/FlagsConfiguration;
 	public final fun evaluationFlushInterval (J)Lcom/datadog/android/flags/FlagsConfiguration$Builder;
 	public final fun gracefulModeEnabled (Z)Lcom/datadog/android/flags/FlagsConfiguration$Builder;
+	public final fun initializationTimeout (J)Lcom/datadog/android/flags/FlagsConfiguration$Builder;
 	public final fun rumIntegrationEnabled (Z)Lcom/datadog/android/flags/FlagsConfiguration$Builder;
 	public final fun trackEvaluations (Z)Lcom/datadog/android/flags/FlagsConfiguration$Builder;
 	public final fun trackExposures (Z)Lcom/datadog/android/flags/FlagsConfiguration$Builder;
 	public final fun useCustomEvaluationEndpoint (Ljava/lang/String;)Lcom/datadog/android/flags/FlagsConfiguration$Builder;
 	public final fun useCustomExposureEndpoint (Ljava/lang/String;)Lcom/datadog/android/flags/FlagsConfiguration$Builder;
 	public final fun useCustomFlagEndpoint (Ljava/lang/String;)Lcom/datadog/android/flags/FlagsConfiguration$Builder;
+}
+
+public final class com/datadog/android/flags/FlagsInitializationTimeoutException : java/lang/RuntimeException {
+	public fun <init> (J)V
 }
 
 public abstract interface class com/datadog/android/flags/FlagsStateListener {

--- a/features/dd-sdk-android-flags/api/dd-sdk-android-flags.api
+++ b/features/dd-sdk-android-flags/api/dd-sdk-android-flags.api
@@ -67,7 +67,6 @@ public final class com/datadog/android/flags/FlagsConfiguration$Builder {
 }
 
 public final class com/datadog/android/flags/FlagsInitializationTimeoutException : java/lang/RuntimeException {
-	public fun <init> (J)V
 }
 
 public abstract interface class com/datadog/android/flags/FlagsStateListener {

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/EvaluationContextCallback.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/EvaluationContextCallback.kt
@@ -10,8 +10,9 @@ package com.datadog.android.flags
  * Callback interface for asynchronous evaluation context update operations.
  *
  * This callback is invoked on a background thread after the [FlagsClient.setEvaluationContext]
- * operation completes. The callback is guaranteed to be invoked after the corresponding
- * [FlagsClientState] transition.
+ * operation completes. It is normally invoked after the corresponding [FlagsClientState]
+ * transition. The first operation can fail with [FlagsInitializationTimeoutException].
+ * The request continues and can transition the client to [FlagsClientState.Ready] later.
  */
 interface EvaluationContextCallback {
     /**
@@ -26,9 +27,11 @@ interface EvaluationContextCallback {
     /**
      * Invoked when the evaluation context update fails.
      *
-     * This method is called on a background executor thread after the state transitions
+     * This method is normally called on a background executor thread after the state transitions
      * to either [FlagsClientState.Stale] (network failed but cached flags available) or
-     * [FlagsClientState.Error] (network failed with no cached flags).
+     * [FlagsClientState.Error] (network failed with no cached flags). An initialization timeout
+     * also transitions the client to [FlagsClientState.Error]. The request continues and can
+     * transition the client to [FlagsClientState.Ready] later.
      *
      * @param error A [Throwable] containing details about the failure, typically including
      * a message explaining the network request failure.

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/EvaluationContextCallback.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/EvaluationContextCallback.kt
@@ -29,8 +29,8 @@ interface EvaluationContextCallback {
      *
      * This method is normally called on a background executor thread after the state transitions
      * to either [FlagsClientState.Stale] (network failed but cached flags available) or
-     * [FlagsClientState.Error] (network failed with no cached flags). An initialization timeout
-     * also transitions the client to [FlagsClientState.Error]. The request continues and can
+     * [FlagsClientState.Error] (network failed with no cached flags). An initialization timeout uses
+     * the same state selection based on matching cached assignments. The request continues and can
      * transition the client to [FlagsClientState.Ready] later.
      *
      * @param error A [Throwable] containing details about the failure, typically including

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsClient.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsClient.kt
@@ -70,6 +70,8 @@ interface FlagsClient {
      *
      * This method returns immediately without blocking. The actual context update and flag
      * fetching happen asynchronously on a background thread.
+     * For the first context, the configured initialization timeout bounds the callback wait.
+     * The operation continues after a timeout and can make the client ready later.
      *
      * @param context The [EvaluationContext] containing targeting key and attributes.
      * @param callback Optional callback to notify when the operation completes or fails.
@@ -431,7 +433,9 @@ interface FlagsClient {
                 flagsRepository = flagsRepository,
                 assignmentsReader = assignmentsDownloader,
                 precomputeMapper = precomputeMapper,
-                flagStateManager = flagStateManager
+                flagStateManager = flagStateManager,
+                initializationTimeoutMs = configuration.initializationTimeoutMs,
+                initializationTimeoutScheduler = flagsFeature.initializationTimeoutScheduler
             )
 
             val rumEvaluationLogger = createRumEvaluationLogger(featureSdkCore)

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsConfiguration.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsConfiguration.kt
@@ -6,10 +6,12 @@
 
 package com.datadog.android.flags
 
+private const val DEFAULT_INITIALIZATION_TIMEOUT_MS = 5_000L
+
 /**
  * Describes configuration to be used for the Flags feature.
  */
-@ExposedCopyVisibility
+@ConsistentCopyVisibility
 data class FlagsConfiguration internal constructor(
     internal val trackExposures: Boolean,
     internal val trackEvaluations: Boolean,
@@ -18,8 +20,35 @@ data class FlagsConfiguration internal constructor(
     internal val customFlagEndpoint: String?,
     internal val evaluationFlushIntervalMs: Long,
     internal val rumIntegrationEnabled: Boolean,
-    internal val gracefulModeEnabled: Boolean
+    internal val gracefulModeEnabled: Boolean,
+    internal val initializationTimeoutMs: Long?
 ) {
+    /**
+     * Copies this configuration and preserves the initialization timeout.
+     *
+     * This overload keeps the public JVM signature that existed before the initialization timeout was added.
+     */
+    fun copy(
+        trackExposures: Boolean = this.trackExposures,
+        trackEvaluations: Boolean = this.trackEvaluations,
+        customExposureEndpoint: String? = this.customExposureEndpoint,
+        customEvaluationEndpoint: String? = this.customEvaluationEndpoint,
+        customFlagEndpoint: String? = this.customFlagEndpoint,
+        evaluationFlushIntervalMs: Long = this.evaluationFlushIntervalMs,
+        rumIntegrationEnabled: Boolean = this.rumIntegrationEnabled,
+        gracefulModeEnabled: Boolean = this.gracefulModeEnabled
+    ): FlagsConfiguration = FlagsConfiguration(
+        trackExposures = trackExposures,
+        trackEvaluations = trackEvaluations,
+        customExposureEndpoint = customExposureEndpoint,
+        customEvaluationEndpoint = customEvaluationEndpoint,
+        customFlagEndpoint = customFlagEndpoint,
+        evaluationFlushIntervalMs = evaluationFlushIntervalMs,
+        rumIntegrationEnabled = rumIntegrationEnabled,
+        gracefulModeEnabled = gracefulModeEnabled,
+        initializationTimeoutMs = initializationTimeoutMs
+    )
+
     /**
      * A Builder class for a [FlagsConfiguration].
      */
@@ -32,6 +61,7 @@ data class FlagsConfiguration internal constructor(
         private var evaluationFlushIntervalMs: Long = DEFAULT_EVALUATION_FLUSH_INTERVAL_MS
         private var rumIntegrationEnabled: Boolean = true
         private var gracefulModeEnabled: Boolean = true
+        private var initializationTimeoutMs: Long? = DEFAULT_INITIALIZATION_TIMEOUT_MS
 
         /**
          * Sets whether exposures should be logged to the dedicated exposures intake endpoint.
@@ -117,6 +147,24 @@ data class FlagsConfiguration internal constructor(
         }
 
         /**
+         * Sets the maximum time to wait for the first evaluation context to become ready.
+         *
+         * This timeout covers the complete initialization operation. It includes loading cached data,
+         * fetching assignments, reading the response body, decoding JSON, storing assignments, and publishing
+         * the ready state. It does not change the HTTP client's timeout. The assignment operation continues after
+         * this timeout and can update the client to [com.datadog.android.flags.model.FlagsClientState.Ready].
+         *
+         * Negative values are coerced to zero.
+         *
+         * @param timeoutMs The initialization timeout in milliseconds. The default is 5,000 milliseconds.
+         * @return this [Builder] instance for method chaining.
+         */
+        fun initializationTimeout(timeoutMs: Long): Builder {
+            initializationTimeoutMs = timeoutMs.coerceAtLeast(0)
+            return this
+        }
+
+        /**
          * Sets whether RUM evaluation logging is enabled.
          * This adds the result of evaluating a feature flag to the view.
          * Enabled by default.
@@ -160,7 +208,8 @@ data class FlagsConfiguration internal constructor(
             customFlagEndpoint = customFlagEndpoint,
             evaluationFlushIntervalMs = evaluationFlushIntervalMs,
             rumIntegrationEnabled = rumIntegrationEnabled,
-            gracefulModeEnabled = gracefulModeEnabled
+            gracefulModeEnabled = gracefulModeEnabled,
+            initializationTimeoutMs = initializationTimeoutMs
         )
 
         internal companion object {

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsConfiguration.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsConfiguration.kt
@@ -154,13 +154,20 @@ data class FlagsConfiguration internal constructor(
          * the ready state. It does not change the HTTP client's timeout. The assignment operation continues after
          * this timeout and can update the client to [com.datadog.android.flags.model.FlagsClientState.Ready].
          *
-         * Negative values are coerced to zero.
+         * The timeout applies to the first [FlagsClient.setEvaluationContext] call only. That call consumes the
+         * timeout even if the operation fails or never starts. Later calls, including retries, have no timer.
+         *
+         * When the timeout expires, the client becomes
+         * [com.datadog.android.flags.model.FlagsClientState.Stale] if matching cached assignments are available.
+         * Otherwise, it becomes [com.datadog.android.flags.model.FlagsClientState.Error].
+         *
+         * A value of zero, or any negative value, disables the initialization timeout.
          *
          * @param timeoutMs The initialization timeout in milliseconds. The default is 5,000 milliseconds.
          * @return this [Builder] instance for method chaining.
          */
         fun initializationTimeout(timeoutMs: Long): Builder {
-            initializationTimeoutMs = timeoutMs.coerceAtLeast(0)
+            initializationTimeoutMs = timeoutMs.takeIf { it > 0 }
             return this
         }
 

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsConfiguration.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsConfiguration.kt
@@ -166,9 +166,8 @@ data class FlagsConfiguration internal constructor(
          * @param timeoutMs The initialization timeout in milliseconds. The default is 5,000 milliseconds.
          * @return this [Builder] instance for method chaining.
          */
-        fun initializationTimeout(timeoutMs: Long): Builder {
+        fun initializationTimeout(timeoutMs: Long): Builder = apply {
             initializationTimeoutMs = timeoutMs.takeIf { it > 0 }
-            return this
         }
 
         /**

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsInitializationTimeoutException.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsInitializationTimeoutException.kt
@@ -1,0 +1,15 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.flags
+
+/**
+ * Indicates that the first evaluation context did not complete before the initialization timeout.
+ *
+ * The request continues and can make the client ready later.
+ */
+class FlagsInitializationTimeoutException(timeoutMs: Long) :
+    RuntimeException("Flags initialization timed out after ${timeoutMs}ms")

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsInitializationTimeoutException.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsInitializationTimeoutException.kt
@@ -11,5 +11,5 @@ package com.datadog.android.flags
  *
  * The request continues and can make the client ready later.
  */
-class FlagsInitializationTimeoutException(timeoutMs: Long) :
+class FlagsInitializationTimeoutException internal constructor(timeoutMs: Long) :
     RuntimeException("Flags initialization timed out after ${timeoutMs}ms")

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/DatadogFlagsClient.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/DatadogFlagsClient.kt
@@ -71,7 +71,7 @@ internal class DatadogFlagsClient(
      * @param context The evaluation context containing targeting key and attributes.
      * Must contain a valid targeting key; invalid contexts are logged and ignored.
      * @param callback Optional callback to notify when the operation completes or fails.
-     * Invoked on a background executor thread after the state transition.
+     * Invoked on a background executor thread. See [EvaluationContextCallback] for timeout behavior.
      */
     override fun setEvaluationContext(context: EvaluationContext, callback: EvaluationContextCallback?) {
         evaluationsManager.updateEvaluationsForContext(context, callback)

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/FlagsFeature.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/FlagsFeature.kt
@@ -24,6 +24,7 @@ import com.datadog.android.flags.internal.storage.ExposureEventRecordWriter
 import com.datadog.android.flags.internal.storage.NoOpRecordWriter
 import com.datadog.android.flags.internal.storage.RecordWriter
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
 /**
@@ -46,9 +47,6 @@ internal class FlagsFeature(
 
     @Volatile
     private var isInitialized = false
-
-    @Volatile
-    private var initializationTimeoutExecutor: ScheduledExecutorService? = null
 
     /**
      * Indicates whether the app is running in debug mode.
@@ -84,20 +82,27 @@ internal class FlagsFeature(
         )
 
     internal val initializationTimeoutScheduler = InitializationTimeoutScheduler { timeoutMs, action ->
-        val executor = synchronized(this) {
-            initializationTimeoutExecutor
-                ?: sdkCore.createScheduledExecutorService(INITIALIZATION_TIMEOUT_EXECUTOR_NAME).also {
-                    initializationTimeoutExecutor = it
-                }
+        val executor = sdkCore.createScheduledExecutorService(INITIALIZATION_TIMEOUT_EXECUTOR_NAME)
+        if (executor is ScheduledThreadPoolExecutor) {
+            executor.removeOnCancelPolicy = true
         }
         val future = executor.scheduleSafe(
             operationName = INITIALIZATION_TIMEOUT_OPERATION_NAME,
             delay = timeoutMs.coerceAtLeast(0),
             unit = TimeUnit.MILLISECONDS,
             internalLogger = sdkCore.internalLogger,
-            runnable = Runnable { action() }
+            runnable = Runnable {
+                try {
+                    action()
+                } finally {
+                    executor.shutdownSafely()
+                }
+            }
         )
-        val cancellation: () -> Unit = { future?.cancel(false) }
+        val cancellation: () -> Unit = {
+            future?.cancel(false)
+            executor.shutdownSafely()
+        }
         cancellation
     }
 
@@ -126,11 +131,6 @@ internal class FlagsFeature(
     override fun onStop() {
         dataWriter = NoOpRecordWriter()
         isInitialized = false // Allow re-initialization if feature is restarted
-        val timeoutExecutor = synchronized(this) {
-            initializationTimeoutExecutor.also { initializationTimeoutExecutor = null }
-        }
-        @Suppress("UnsafeThirdPartyFunctionCall") // Android does not use a SecurityManager.
-        timeoutExecutor?.shutdownNow()
         synchronized(registeredClients) {
             registeredClients.clear()
         }
@@ -231,4 +231,9 @@ internal class FlagsFeature(
         private const val INITIALIZATION_TIMEOUT_EXECUTOR_NAME = "flags-initialization-timeout"
         private const val INITIALIZATION_TIMEOUT_OPERATION_NAME = "Wait for Flags initialization"
     }
+}
+
+@Suppress("UnsafeThirdPartyFunctionCall") // Android does not use a SecurityManager.
+private fun ScheduledExecutorService.shutdownSafely() {
+    shutdown()
 }

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/FlagsFeature.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/FlagsFeature.kt
@@ -14,13 +14,17 @@ import com.datadog.android.api.feature.Feature.Companion.FLAGS_FEATURE_NAME
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.feature.StorageBackedFeature
 import com.datadog.android.api.storage.FeatureStorageConfiguration
+import com.datadog.android.core.internal.utils.scheduleSafe
 import com.datadog.android.flags.FlagsClient
 import com.datadog.android.flags.FlagsConfiguration
+import com.datadog.android.flags.internal.evaluation.InitializationTimeoutScheduler
 import com.datadog.android.flags.internal.net.ExposuresRequestFactory
 import com.datadog.android.flags.internal.net.PrecomputedAssignmentsRequestFactory
 import com.datadog.android.flags.internal.storage.ExposureEventRecordWriter
 import com.datadog.android.flags.internal.storage.NoOpRecordWriter
 import com.datadog.android.flags.internal.storage.RecordWriter
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 
 /**
  * Type alias for a function that logs a message with a given level.
@@ -42,6 +46,9 @@ internal class FlagsFeature(
 
     @Volatile
     private var isInitialized = false
+
+    @Volatile
+    private var initializationTimeoutExecutor: ScheduledExecutorService? = null
 
     /**
      * Indicates whether the app is running in debug mode.
@@ -76,6 +83,24 @@ internal class FlagsFeature(
             customFlagEndpoint = flagsConfiguration.customFlagEndpoint
         )
 
+    internal val initializationTimeoutScheduler = InitializationTimeoutScheduler { timeoutMs, action ->
+        val executor = synchronized(this) {
+            initializationTimeoutExecutor
+                ?: sdkCore.createScheduledExecutorService(INITIALIZATION_TIMEOUT_EXECUTOR_NAME).also {
+                    initializationTimeoutExecutor = it
+                }
+        }
+        val future = executor.scheduleSafe(
+            operationName = INITIALIZATION_TIMEOUT_OPERATION_NAME,
+            delay = timeoutMs.coerceAtLeast(0),
+            unit = TimeUnit.MILLISECONDS,
+            internalLogger = sdkCore.internalLogger,
+            runnable = Runnable { action() }
+        )
+        val cancellation: () -> Unit = { future?.cancel(false) }
+        cancellation
+    }
+
     // endregion
 
     override val name: String = FLAGS_FEATURE_NAME
@@ -101,6 +126,11 @@ internal class FlagsFeature(
     override fun onStop() {
         dataWriter = NoOpRecordWriter()
         isInitialized = false // Allow re-initialization if feature is restarted
+        val timeoutExecutor = synchronized(this) {
+            initializationTimeoutExecutor.also { initializationTimeoutExecutor = null }
+        }
+        @Suppress("UnsafeThirdPartyFunctionCall") // Android does not use a SecurityManager.
+        timeoutExecutor?.shutdownNow()
         synchronized(registeredClients) {
             registeredClients.clear()
         }
@@ -198,5 +228,7 @@ internal class FlagsFeature(
 
     internal companion object {
         private const val LOG_TAG = "[Datadog Flags]"
+        private const val INITIALIZATION_TIMEOUT_EXECUTOR_NAME = "flags-initialization-timeout"
+        private const val INITIALIZATION_TIMEOUT_OPERATION_NAME = "Wait for Flags initialization"
     }
 }

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/FlagsFeature.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/FlagsFeature.kt
@@ -84,9 +84,9 @@ internal class FlagsFeature(
     internal val initializationTimeoutScheduler = InitializationTimeoutScheduler { timeoutMs, action ->
         val executor = sdkCore.createScheduledExecutorService(INITIALIZATION_TIMEOUT_EXECUTOR_NAME)
         if (executor is ScheduledThreadPoolExecutor) {
-            executor.removeOnCancelPolicy = true
+            executor.executeExistingDelayedTasksAfterShutdownPolicy = false
         }
-        val future = executor.scheduleSafe(
+        executor.scheduleSafe(
             operationName = INITIALIZATION_TIMEOUT_OPERATION_NAME,
             delay = timeoutMs.coerceAtLeast(0),
             unit = TimeUnit.MILLISECONDS,
@@ -100,7 +100,6 @@ internal class FlagsFeature(
             }
         )
         val cancellation: () -> Unit = {
-            future?.cancel(false)
             executor.shutdownSafely()
         }
         cancellation

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/FlagsFeature.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/FlagsFeature.kt
@@ -93,7 +93,7 @@ internal class FlagsFeature(
             delay = timeoutMs.coerceAtLeast(0),
             unit = TimeUnit.MILLISECONDS,
             internalLogger = sdkCore.internalLogger,
-            runnable = Runnable {
+            runnable = {
                 try {
                     action()
                 } finally {

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/FlagsFeature.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/FlagsFeature.kt
@@ -83,6 +83,8 @@ internal class FlagsFeature(
 
     internal val initializationTimeoutScheduler = InitializationTimeoutScheduler { timeoutMs, action ->
         val executor = sdkCore.createScheduledExecutorService(INITIALIZATION_TIMEOUT_EXECUTOR_NAME)
+        // Cancellation shuts down this executor. Dropping delayed tasks prevents the worker from
+        // remaining alive until the original timeout and avoids reporting cancellation as an error.
         if (executor is ScheduledThreadPoolExecutor) {
             executor.executeExistingDelayedTasksAfterShutdownPolicy = false
         }

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManager.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManager.kt
@@ -32,6 +32,7 @@ private class InitializationCompletion(private var callback: EvaluationContextCa
     private val lock = Any()
     private var isPending = true
     private var cancelTimeout: (() -> Unit)? = null
+    private var cancelTimeoutWhenArmed = false
 
     fun armTimeoutCancellation(cancellation: () -> Unit) {
         val cancelNow = synchronized(lock) {
@@ -39,17 +40,19 @@ private class InitializationCompletion(private var callback: EvaluationContextCa
                 cancelTimeout = cancellation
                 false
             } else {
-                true
+                cancelTimeoutWhenArmed
             }
         }
         if (cancelNow) cancellation()
     }
 
-    fun take(): InitializationResult? {
+    fun take(shouldCancelTimeout: Boolean = true): InitializationResult? {
         val outcome = synchronized(lock) {
             if (!isPending) return null
             isPending = false
-            val outcome = callback to cancelTimeout
+            val timeoutCancellation = cancelTimeout
+            cancelTimeoutWhenArmed = shouldCancelTimeout && timeoutCancellation == null
+            val outcome = callback to if (shouldCancelTimeout) timeoutCancellation else null
             callback = null
             cancelTimeout = null
             outcome
@@ -104,8 +107,8 @@ internal class EvaluationsManager(
      * @param callback Optional callback invoked when the context is set and the flags have been fetched successfully or not.
      */
     fun updateEvaluationsForContext(context: EvaluationContext, callback: EvaluationContextCallback? = null) {
-        val initializationCompletion = startInitializationTimeout(callback)
         flagStateManager.updateState(FlagsClientState.Reconciling)
+        val initializationCompletion = startInitializationTimeout(callback)
 
         sdkCore.getFeature(Feature.FLAGS_FEATURE_NAME)
             ?.withContext(withFeatureContexts = setOf(Feature.RUM_FEATURE_NAME)) { datadogContext ->
@@ -130,9 +133,9 @@ internal class EvaluationsManager(
                             { "Successfully processed context ${context.targetingKey} with ${flagsMap.size} flags" }
                         )
 
-                        flagStateManager.updateState(FlagsClientState.Ready)
                         val completionCallback = initializationCompletion?.take()?.callback
                             ?: if (initializationCompletion == null) callback else null
+                        flagStateManager.updateState(FlagsClientState.Ready)
                         completionCallback?.onSuccess()
                     } else {
                         internalLogger.log(
@@ -142,6 +145,8 @@ internal class EvaluationsManager(
                         )
 
                         val throwable = NetworkRequestFailedException(NETWORK_REQUEST_FAILED_MESSAGE)
+                        val completionCallback = initializationCompletion?.take()?.callback
+                            ?: if (initializationCompletion == null) callback else null
                         // Only use cached flags if they match the requested context to avoid
                         // serving flags from a different user/context.
                         val cachedContextMatches = flagsRepository.getEvaluationContext() == context
@@ -150,8 +155,6 @@ internal class EvaluationsManager(
                         } else {
                             flagStateManager.updateState(FlagsClientState.Error(throwable))
                         }
-                        val completionCallback = initializationCompletion?.take()?.callback
-                            ?: if (initializationCompletion == null) callback else null
                         completionCallback?.onFailure(throwable)
                     }
                 }
@@ -164,7 +167,7 @@ internal class EvaluationsManager(
 
         return InitializationCompletion(callback).also { completion ->
             val cancelTimeout = initializationTimeoutScheduler.schedule(timeoutMs) {
-                completion.take()?.let { result ->
+                completion.take(shouldCancelTimeout = false)?.let { result ->
                     val error = FlagsInitializationTimeoutException(timeoutMs)
                     val currentState = flagStateManager.getCurrentState()
                     if (currentState != FlagsClientState.Ready && currentState != FlagsClientState.Stale) {

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManager.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManager.kt
@@ -108,7 +108,8 @@ internal class EvaluationsManager(
      */
     fun updateEvaluationsForContext(context: EvaluationContext, callback: EvaluationContextCallback? = null) {
         flagStateManager.updateState(FlagsClientState.Reconciling)
-        val initializationCompletion = startInitializationTimeout(callback)
+        val matchingCachedAssignments = AtomicBoolean(false)
+        val initializationCompletion = startInitializationTimeout(callback, matchingCachedAssignments)
 
         sdkCore.getFeature(Feature.FLAGS_FEATURE_NAME)
             ?.withContext(withFeatureContexts = setOf(Feature.RUM_FEATURE_NAME)) { datadogContext ->
@@ -123,6 +124,9 @@ internal class EvaluationsManager(
                     )
 
                     val hadFlags = flagsRepository.hasFlags()
+                    matchingCachedAssignments.set(
+                        hadFlags && flagsRepository.getEvaluationContext() == context
+                    )
                     val response = assignmentsReader.readPrecomputedFlags(context, datadogContext)
                     if (response != null) {
                         val flagsMap = precomputeMapper.map(response)
@@ -149,8 +153,7 @@ internal class EvaluationsManager(
                             ?: if (initializationCompletion == null) callback else null
                         // Only use cached flags if they match the requested context to avoid
                         // serving flags from a different user/context.
-                        val cachedContextMatches = flagsRepository.getEvaluationContext() == context
-                        if (hadFlags && cachedContextMatches) {
+                        if (matchingCachedAssignments.get()) {
                             flagStateManager.updateState(FlagsClientState.Stale)
                         } else {
                             flagStateManager.updateState(FlagsClientState.Error(throwable))
@@ -161,7 +164,10 @@ internal class EvaluationsManager(
             }
     }
 
-    private fun startInitializationTimeout(callback: EvaluationContextCallback?): InitializationCompletion? {
+    private fun startInitializationTimeout(
+        callback: EvaluationContextCallback?,
+        matchingCachedAssignments: AtomicBoolean
+    ): InitializationCompletion? {
         val timeoutMs = initializationTimeoutMs
         if (!didStartInitialization.compareAndSet(false, true) || timeoutMs == null) return null
 
@@ -171,7 +177,12 @@ internal class EvaluationsManager(
                     val error = FlagsInitializationTimeoutException(timeoutMs)
                     val currentState = flagStateManager.getCurrentState()
                     if (currentState != FlagsClientState.Ready && currentState != FlagsClientState.Stale) {
-                        flagStateManager.updateState(FlagsClientState.Error(error))
+                        val timeoutState = if (matchingCachedAssignments.get()) {
+                            FlagsClientState.Stale
+                        } else {
+                            FlagsClientState.Error(error)
+                        }
+                        flagStateManager.updateState(timeoutState)
                     }
                     result.callback?.onFailure(error)
                 }

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManager.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManager.kt
@@ -92,7 +92,6 @@ internal class EvaluationsManager(
 ) {
     private val didStartInitialization = AtomicBoolean(false)
     private val initializationTerminalLock = Any()
-    private var contextGeneration = 0L
 
     /**
      * Processes a new evaluation context by fetching flags and storing atomically.
@@ -110,7 +109,10 @@ internal class EvaluationsManager(
      */
     fun updateEvaluationsForContext(context: EvaluationContext, callback: EvaluationContextCallback? = null) {
         val matchingCachedAssignments = AtomicBoolean(false)
-        val initializationCompletion = startContextUpdate(context, callback, matchingCachedAssignments)
+        val initializationCompletion = startInitializationTimeout(context, callback, matchingCachedAssignments) {
+            flagStateManager.updateState(FlagsClientState.Reconciling)
+        }
+        if (initializationCompletion == null) flagStateManager.updateState(FlagsClientState.Reconciling)
 
         sdkCore.getFeature(Feature.FLAGS_FEATURE_NAME)
             ?.withContext(withFeatureContexts = setOf(Feature.RUM_FEATURE_NAME)) { datadogContext ->
@@ -171,27 +173,8 @@ internal class EvaluationsManager(
             }
     }
 
-    private fun startContextUpdate(
-        context: EvaluationContext,
-        callback: EvaluationContextCallback?,
-        matchingCachedAssignments: AtomicBoolean
-    ): InitializationCompletion? = synchronized(initializationTerminalLock) {
-        contextGeneration += 1
-        val completion = startInitializationTimeout(
-            context,
-            contextGeneration,
-            callback,
-            matchingCachedAssignments
-        ) {
-            flagStateManager.updateState(FlagsClientState.Reconciling)
-        }
-        if (completion == null) flagStateManager.updateState(FlagsClientState.Reconciling)
-        completion
-    }
-
     private fun startInitializationTimeout(
         context: EvaluationContext,
-        generation: Long,
         callback: EvaluationContextCallback?,
         matchingCachedAssignments: AtomicBoolean,
         beforeScheduling: () -> Unit
@@ -207,13 +190,9 @@ internal class EvaluationsManager(
                     val claimedResult = completion.take(shouldCancelTimeout = false)
                         ?: return@synchronized null
                     val currentState = flagStateManager.getCurrentState()
-                    if (
-                        contextGeneration == generation &&
-                        currentState != FlagsClientState.Ready &&
-                        currentState != FlagsClientState.Stale
-                    ) {
+                    if (currentState != FlagsClientState.Ready && currentState != FlagsClientState.Stale) {
                         val hasMatchingCachedAssignments = matchingCachedAssignments.get() ||
-                            (flagsRepository.hasFlags() && flagsRepository.getEvaluationContext() == context)
+                            flagsRepository.hasLoadedFlagsForContext(context)
                         val timeoutState = if (hasMatchingCachedAssignments) {
                             FlagsClientState.Stale
                         } else {

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManager.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManager.kt
@@ -92,6 +92,7 @@ internal class EvaluationsManager(
 ) {
     private val didStartInitialization = AtomicBoolean(false)
     private val initializationTerminalLock = Any()
+    private var contextGeneration = 0L
 
     /**
      * Processes a new evaluation context by fetching flags and storing atomically.
@@ -109,10 +110,7 @@ internal class EvaluationsManager(
      */
     fun updateEvaluationsForContext(context: EvaluationContext, callback: EvaluationContextCallback? = null) {
         val matchingCachedAssignments = AtomicBoolean(false)
-        val initializationCompletion = startInitializationTimeout(callback, matchingCachedAssignments) {
-            flagStateManager.updateState(FlagsClientState.Reconciling)
-        }
-        if (initializationCompletion == null) flagStateManager.updateState(FlagsClientState.Reconciling)
+        val initializationCompletion = startContextUpdate(context, callback, matchingCachedAssignments)
 
         sdkCore.getFeature(Feature.FLAGS_FEATURE_NAME)
             ?.withContext(withFeatureContexts = setOf(Feature.RUM_FEATURE_NAME)) { datadogContext ->
@@ -173,7 +171,27 @@ internal class EvaluationsManager(
             }
     }
 
+    private fun startContextUpdate(
+        context: EvaluationContext,
+        callback: EvaluationContextCallback?,
+        matchingCachedAssignments: AtomicBoolean
+    ): InitializationCompletion? = synchronized(initializationTerminalLock) {
+        contextGeneration += 1
+        val completion = startInitializationTimeout(
+            context,
+            contextGeneration,
+            callback,
+            matchingCachedAssignments
+        ) {
+            flagStateManager.updateState(FlagsClientState.Reconciling)
+        }
+        if (completion == null) flagStateManager.updateState(FlagsClientState.Reconciling)
+        completion
+    }
+
     private fun startInitializationTimeout(
+        context: EvaluationContext,
+        generation: Long,
         callback: EvaluationContextCallback?,
         matchingCachedAssignments: AtomicBoolean,
         beforeScheduling: () -> Unit
@@ -189,8 +207,14 @@ internal class EvaluationsManager(
                     val claimedResult = completion.take(shouldCancelTimeout = false)
                         ?: return@synchronized null
                     val currentState = flagStateManager.getCurrentState()
-                    if (currentState != FlagsClientState.Ready && currentState != FlagsClientState.Stale) {
-                        val timeoutState = if (matchingCachedAssignments.get()) {
+                    if (
+                        contextGeneration == generation &&
+                        currentState != FlagsClientState.Ready &&
+                        currentState != FlagsClientState.Stale
+                    ) {
+                        val hasMatchingCachedAssignments = matchingCachedAssignments.get() ||
+                            (flagsRepository.hasFlags() && flagsRepository.getEvaluationContext() == context)
+                        val timeoutState = if (hasMatchingCachedAssignments) {
                             FlagsClientState.Stale
                         } else {
                             FlagsClientState.Error(error)

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManager.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManager.kt
@@ -91,6 +91,7 @@ internal class EvaluationsManager(
     private val initializationTimeoutScheduler: InitializationTimeoutScheduler
 ) {
     private val didStartInitialization = AtomicBoolean(false)
+    private val initializationTerminalLock = Any()
 
     /**
      * Processes a new evaluation context by fetching flags and storing atomically.
@@ -107,9 +108,11 @@ internal class EvaluationsManager(
      * @param callback Optional callback invoked when the context is set and the flags have been fetched successfully or not.
      */
     fun updateEvaluationsForContext(context: EvaluationContext, callback: EvaluationContextCallback? = null) {
-        flagStateManager.updateState(FlagsClientState.Reconciling)
         val matchingCachedAssignments = AtomicBoolean(false)
-        val initializationCompletion = startInitializationTimeout(callback, matchingCachedAssignments)
+        val initializationCompletion = startInitializationTimeout(callback, matchingCachedAssignments) {
+            flagStateManager.updateState(FlagsClientState.Reconciling)
+        }
+        if (initializationCompletion == null) flagStateManager.updateState(FlagsClientState.Reconciling)
 
         sdkCore.getFeature(Feature.FLAGS_FEATURE_NAME)
             ?.withContext(withFeatureContexts = setOf(Feature.RUM_FEATURE_NAME)) { datadogContext ->
@@ -137,9 +140,12 @@ internal class EvaluationsManager(
                             { "Successfully processed context ${context.targetingKey} with ${flagsMap.size} flags" }
                         )
 
-                        val completionCallback = initializationCompletion?.take()?.callback
-                            ?: if (initializationCompletion == null) callback else null
-                        flagStateManager.updateState(FlagsClientState.Ready)
+                        val completionCallback = synchronized(initializationTerminalLock) {
+                            val result = initializationCompletion?.take()?.callback
+                                ?: if (initializationCompletion == null) callback else null
+                            flagStateManager.updateState(FlagsClientState.Ready)
+                            result
+                        }
                         completionCallback?.onSuccess()
                     } else {
                         internalLogger.log(
@@ -149,14 +155,17 @@ internal class EvaluationsManager(
                         )
 
                         val throwable = NetworkRequestFailedException(NETWORK_REQUEST_FAILED_MESSAGE)
-                        val completionCallback = initializationCompletion?.take()?.callback
-                            ?: if (initializationCompletion == null) callback else null
                         // Only use cached flags if they match the requested context to avoid
                         // serving flags from a different user/context.
-                        if (matchingCachedAssignments.get()) {
-                            flagStateManager.updateState(FlagsClientState.Stale)
-                        } else {
-                            flagStateManager.updateState(FlagsClientState.Error(throwable))
+                        val completionCallback = synchronized(initializationTerminalLock) {
+                            val result = initializationCompletion?.take()?.callback
+                                ?: if (initializationCompletion == null) callback else null
+                            if (matchingCachedAssignments.get()) {
+                                flagStateManager.updateState(FlagsClientState.Stale)
+                            } else {
+                                flagStateManager.updateState(FlagsClientState.Error(throwable))
+                            }
+                            result
                         }
                         completionCallback?.onFailure(throwable)
                     }
@@ -166,15 +175,19 @@ internal class EvaluationsManager(
 
     private fun startInitializationTimeout(
         callback: EvaluationContextCallback?,
-        matchingCachedAssignments: AtomicBoolean
+        matchingCachedAssignments: AtomicBoolean,
+        beforeScheduling: () -> Unit
     ): InitializationCompletion? {
         val timeoutMs = initializationTimeoutMs
         if (!didStartInitialization.compareAndSet(false, true) || timeoutMs == null) return null
 
+        beforeScheduling()
         return InitializationCompletion(callback).also { completion ->
             val cancelTimeout = initializationTimeoutScheduler.schedule(timeoutMs) {
-                completion.take(shouldCancelTimeout = false)?.let { result ->
-                    val error = FlagsInitializationTimeoutException(timeoutMs)
+                val error = FlagsInitializationTimeoutException(timeoutMs)
+                val result = synchronized(initializationTerminalLock) {
+                    val claimedResult = completion.take(shouldCancelTimeout = false)
+                        ?: return@synchronized null
                     val currentState = flagStateManager.getCurrentState()
                     if (currentState != FlagsClientState.Ready && currentState != FlagsClientState.Stale) {
                         val timeoutState = if (matchingCachedAssignments.get()) {
@@ -184,8 +197,9 @@ internal class EvaluationsManager(
                         }
                         flagStateManager.updateState(timeoutState)
                     }
-                    result.callback?.onFailure(error)
+                    claimedResult
                 }
+                result?.callback?.onFailure(error)
             }
             completion.armTimeoutCancellation(cancelTimeout)
         }

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManager.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManager.kt
@@ -11,6 +11,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.flags.EvaluationContextCallback
+import com.datadog.android.flags.FlagsInitializationTimeoutException
 import com.datadog.android.flags.internal.FlagsStateManager
 import com.datadog.android.flags.internal.net.NetworkRequestFailedException
 import com.datadog.android.flags.internal.net.PrecomputedAssignmentsReader
@@ -19,6 +20,44 @@ import com.datadog.android.flags.internal.repository.net.PrecomputeMapper
 import com.datadog.android.flags.model.EvaluationContext
 import com.datadog.android.flags.model.FlagsClientState
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal fun interface InitializationTimeoutScheduler {
+    fun schedule(timeoutMs: Long, action: () -> Unit): () -> Unit
+}
+
+private data class InitializationResult(val callback: EvaluationContextCallback?)
+
+private class InitializationCompletion(private var callback: EvaluationContextCallback?) {
+    private val lock = Any()
+    private var isPending = true
+    private var cancelTimeout: (() -> Unit)? = null
+
+    fun armTimeoutCancellation(cancellation: () -> Unit) {
+        val cancelNow = synchronized(lock) {
+            if (isPending) {
+                cancelTimeout = cancellation
+                false
+            } else {
+                true
+            }
+        }
+        if (cancelNow) cancellation()
+    }
+
+    fun take(): InitializationResult? {
+        val outcome = synchronized(lock) {
+            if (!isPending) return null
+            isPending = false
+            val outcome = callback to cancelTimeout
+            callback = null
+            cancelTimeout = null
+            outcome
+        }
+        outcome.second?.invoke()
+        return InitializationResult(outcome.first)
+    }
+}
 
 /**
  * Orchestrates evaluations for a given context and stores the results in the repository.
@@ -34,6 +73,8 @@ import java.util.concurrent.ExecutorService
  * @param assignmentsReader handles reading assignments for the context.
  * @param precomputeMapper transforms network responses into internal flag format
  * @param flagStateManager channel for notifying state change listeners
+ * @param initializationTimeoutMs optional maximum duration of the first context operation
+ * @param initializationTimeoutScheduler schedules the first context timeout
  */
 internal class EvaluationsManager(
     private val sdkCore: FeatureSdkCore,
@@ -42,8 +83,12 @@ internal class EvaluationsManager(
     private val flagsRepository: FlagsRepository,
     private val assignmentsReader: PrecomputedAssignmentsReader,
     private val precomputeMapper: PrecomputeMapper,
-    private val flagStateManager: FlagsStateManager
+    private val flagStateManager: FlagsStateManager,
+    private val initializationTimeoutMs: Long?,
+    private val initializationTimeoutScheduler: InitializationTimeoutScheduler
 ) {
+    private val didStartInitialization = AtomicBoolean(false)
+
     /**
      * Processes a new evaluation context by fetching flags and storing atomically.
      *
@@ -59,6 +104,7 @@ internal class EvaluationsManager(
      * @param callback Optional callback invoked when the context is set and the flags have been fetched successfully or not.
      */
     fun updateEvaluationsForContext(context: EvaluationContext, callback: EvaluationContextCallback? = null) {
+        val initializationCompletion = startInitializationTimeout(callback)
         flagStateManager.updateState(FlagsClientState.Reconciling)
 
         sdkCore.getFeature(Feature.FLAGS_FEATURE_NAME)
@@ -85,7 +131,9 @@ internal class EvaluationsManager(
                         )
 
                         flagStateManager.updateState(FlagsClientState.Ready)
-                        callback?.onSuccess()
+                        val completionCallback = initializationCompletion?.take()?.callback
+                            ?: if (initializationCompletion == null) callback else null
+                        completionCallback?.onSuccess()
                     } else {
                         internalLogger.log(
                             InternalLogger.Level.WARN,
@@ -102,10 +150,31 @@ internal class EvaluationsManager(
                         } else {
                             flagStateManager.updateState(FlagsClientState.Error(throwable))
                         }
-                        callback?.onFailure(throwable)
+                        val completionCallback = initializationCompletion?.take()?.callback
+                            ?: if (initializationCompletion == null) callback else null
+                        completionCallback?.onFailure(throwable)
                     }
                 }
             }
+    }
+
+    private fun startInitializationTimeout(callback: EvaluationContextCallback?): InitializationCompletion? {
+        val timeoutMs = initializationTimeoutMs
+        if (!didStartInitialization.compareAndSet(false, true) || timeoutMs == null) return null
+
+        return InitializationCompletion(callback).also { completion ->
+            val cancelTimeout = initializationTimeoutScheduler.schedule(timeoutMs) {
+                completion.take()?.let { result ->
+                    val error = FlagsInitializationTimeoutException(timeoutMs)
+                    val currentState = flagStateManager.getCurrentState()
+                    if (currentState != FlagsClientState.Ready && currentState != FlagsClientState.Stale) {
+                        flagStateManager.updateState(FlagsClientState.Error(error))
+                    }
+                    result.callback?.onFailure(error)
+                }
+            }
+            completion.armTimeoutCancellation(cancelTimeout)
+        }
     }
 
     companion object {

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepository.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepository.kt
@@ -107,6 +107,11 @@ internal class DefaultFlagsRepository(
         return atomicState.get()?.flags?.isNotEmpty() ?: false
     }
 
+    override fun hasLoadedFlagsForContext(context: EvaluationContext): Boolean {
+        val state = atomicState.get()
+        return state?.context == context && state.flags.isNotEmpty()
+    }
+
     @Suppress("ReturnCount")
     override fun getPrecomputedFlagWithContext(key: String): Pair<PrecomputedFlag, EvaluationContext>? {
         waitForPersistenceLoad()

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/repository/FlagsRepository.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/repository/FlagsRepository.kt
@@ -17,5 +17,6 @@ internal interface FlagsRepository {
     fun setFlagsAndContext(context: EvaluationContext, flags: Map<String, PrecomputedFlag>)
     fun getPrecomputedFlagWithContext(key: String): Pair<PrecomputedFlag, EvaluationContext>?
     fun hasFlags(): Boolean
+    fun hasLoadedFlagsForContext(context: EvaluationContext): Boolean
     fun getFlagsSnapshot(): Map<String, PrecomputedFlag>
 }

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/model/FlagsClientState.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/model/FlagsClientState.kt
@@ -37,8 +37,8 @@ sealed class FlagsClientState {
     object Stale : FlagsClientState()
 
     /**
-     * An unrecoverable error has occurred.
-     * The client cannot provide flag evaluations in this state.
+     * An error has occurred.
+     * The client can recover when a later operation loads valid flag assignments.
      *
      * @param error The error that caused the transition to this state, or null if unknown.
      */

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/FlagsConfigurationTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/FlagsConfigurationTest.kt
@@ -29,6 +29,7 @@ internal class FlagsConfigurationTest {
         assertThat(configuration.customExposureEndpoint).isNull()
         assertThat(configuration.customFlagEndpoint).isNull()
         assertThat(configuration.gracefulModeEnabled).isTrue()
+        assertThat(configuration.initializationTimeoutMs).isEqualTo(5_000L)
     }
 
     @Test
@@ -140,6 +141,42 @@ internal class FlagsConfigurationTest {
 
         // Then
         assertThat(returnedBuilder).isSameAs(builder)
+    }
+
+    @Test
+    fun `M set initialization timeout W initializationTimeout()`() {
+        // When
+        val configuration = FlagsConfiguration.Builder()
+            .initializationTimeout(2_500L)
+            .build()
+
+        // Then
+        assertThat(configuration.initializationTimeoutMs).isEqualTo(2_500L)
+    }
+
+    @Test
+    fun `M coerce initialization timeout to zero W initializationTimeout() { negative value }`() {
+        // When
+        val configuration = FlagsConfiguration.Builder()
+            .initializationTimeout(-1L)
+            .build()
+
+        // Then
+        assertThat(configuration.initializationTimeoutMs).isZero()
+    }
+
+    @Test
+    fun `M preserve initialization timeout W copy() { legacy parameters }`() {
+        // Given
+        val configuration = FlagsConfiguration.Builder()
+            .initializationTimeout(2_500L)
+            .build()
+
+        // When
+        val copiedConfiguration = configuration.copy(trackExposures = false)
+
+        // Then
+        assertThat(copiedConfiguration.initializationTimeoutMs).isEqualTo(2_500L)
     }
 
     // endregion

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/FlagsConfigurationTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/FlagsConfigurationTest.kt
@@ -146,36 +146,36 @@ internal class FlagsConfigurationTest {
     @Test
     fun `M set initialization timeout W initializationTimeout()`() {
         // When
-        val configuration = FlagsConfiguration.Builder()
+        val testedConfiguration = FlagsConfiguration.Builder()
             .initializationTimeout(2_500L)
             .build()
 
         // Then
-        assertThat(configuration.initializationTimeoutMs).isEqualTo(2_500L)
+        assertThat(testedConfiguration.initializationTimeoutMs).isEqualTo(2_500L)
     }
 
     @Test
     fun `M disable initialization timeout W initializationTimeout() { non-positive value }`() {
         listOf(0L, -1L).forEach { timeoutMs ->
             // When
-            val configuration = FlagsConfiguration.Builder()
+            val testedConfiguration = FlagsConfiguration.Builder()
                 .initializationTimeout(timeoutMs)
                 .build()
 
             // Then
-            assertThat(configuration.initializationTimeoutMs).isNull()
+            assertThat(testedConfiguration.initializationTimeoutMs).isNull()
         }
     }
 
     @Test
     fun `M preserve initialization timeout W copy() { legacy parameters }`() {
         // Given
-        val configuration = FlagsConfiguration.Builder()
+        val testedConfiguration = FlagsConfiguration.Builder()
             .initializationTimeout(2_500L)
             .build()
 
         // When
-        val copiedConfiguration = configuration.copy(trackExposures = false)
+        val copiedConfiguration = testedConfiguration.copy(trackExposures = false)
 
         // Then
         assertThat(copiedConfiguration.initializationTimeoutMs).isEqualTo(2_500L)

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/FlagsConfigurationTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/FlagsConfigurationTest.kt
@@ -155,14 +155,16 @@ internal class FlagsConfigurationTest {
     }
 
     @Test
-    fun `M coerce initialization timeout to zero W initializationTimeout() { negative value }`() {
-        // When
-        val configuration = FlagsConfiguration.Builder()
-            .initializationTimeout(-1L)
-            .build()
+    fun `M disable initialization timeout W initializationTimeout() { non-positive value }`() {
+        listOf(0L, -1L).forEach { timeoutMs ->
+            // When
+            val configuration = FlagsConfiguration.Builder()
+                .initializationTimeout(timeoutMs)
+                .build()
 
-        // Then
-        assertThat(configuration.initializationTimeoutMs).isZero()
+            // Then
+            assertThat(configuration.initializationTimeoutMs).isNull()
+        }
     }
 
     @Test

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/FlagsFeatureTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/FlagsFeatureTest.kt
@@ -34,7 +34,10 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
 
 @ExtendWith(MockitoExtension::class, ForgeExtension::class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -110,6 +113,74 @@ internal class FlagsFeatureTest {
 
         // Then
         assertThat(testedFeature.dataWriter).isInstanceOf(NoOpRecordWriter::class.java)
+    }
+
+    @Test
+    fun `M isolate timeout actions W initializationTimeoutScheduler() { first action blocks }`() {
+        // Given
+        val executors = mutableListOf<ScheduledThreadPoolExecutor>()
+        whenever(mockSdkCore.createScheduledExecutorService(any())).thenAnswer {
+            ScheduledThreadPoolExecutor(1).also { executor -> executors += executor }
+        }
+        val firstStarted = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val secondCompleted = CountDownLatch(1)
+
+        try {
+            testedFeature.initializationTimeoutScheduler.schedule(0) {
+                firstStarted.countDown()
+                releaseFirst.await(1, TimeUnit.SECONDS)
+            }
+            assertThat(firstStarted.await(1, TimeUnit.SECONDS)).isTrue()
+
+            // When
+            testedFeature.initializationTimeoutScheduler.schedule(0) {
+                secondCompleted.countDown()
+            }
+
+            // Then
+            assertThat(secondCompleted.await(250, TimeUnit.MILLISECONDS)).isTrue()
+        } finally {
+            releaseFirst.countDown()
+            executors.forEach { it.shutdownNow() }
+        }
+    }
+
+    @Test
+    fun `M remove scheduled task W initializationTimeoutScheduler() { timeout is canceled }`() {
+        // Given
+        val executor = ScheduledThreadPoolExecutor(1)
+        whenever(mockSdkCore.createScheduledExecutorService(any())) doReturn executor
+
+        try {
+            val cancelTimeout = testedFeature.initializationTimeoutScheduler.schedule(60_000) {}
+
+            // When
+            cancelTimeout()
+
+            // Then
+            assertThat(executor.queue).isEmpty()
+            assertThat(executor.isShutdown).isTrue()
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `M execute pending timeout W onStop()`() {
+        // Given
+        val executor = ScheduledThreadPoolExecutor(1)
+        whenever(mockSdkCore.createScheduledExecutorService(any())) doReturn executor
+        val timeoutCompleted = CountDownLatch(1)
+        testedFeature.initializationTimeoutScheduler.schedule(100) {
+            timeoutCompleted.countDown()
+        }
+
+        // When
+        testedFeature.onStop()
+
+        // Then
+        assertThat(timeoutCompleted.await(1, TimeUnit.SECONDS)).isTrue()
     }
 
     // endregion

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/FlagsFeatureTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/FlagsFeatureTest.kt
@@ -36,8 +36,10 @@ import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.Future
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 @ExtendWith(MockitoExtension::class, ForgeExtension::class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -162,6 +164,45 @@ internal class FlagsFeatureTest {
             assertThat(executor.queue).isEmpty()
             assertThat(executor.isShutdown).isTrue()
         } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `M not cancel running task W initializationTimeoutScheduler() { completion races timeout }`() {
+        // Given
+        val executionError = AtomicReference<Throwable?>()
+        val executor = object : ScheduledThreadPoolExecutor(1) {
+            override fun afterExecute(runnable: Runnable, throwable: Throwable?) {
+                super.afterExecute(runnable, throwable)
+                executionError.set(
+                    throwable ?: runCatching { (runnable as Future<*>).get() }.exceptionOrNull()
+                )
+            }
+        }
+        whenever(mockSdkCore.createScheduledExecutorService(any())) doReturn executor
+        val timeoutStarted = CountDownLatch(1)
+        val releaseTimeout = CountDownLatch(1)
+        val timeoutCompleted = CountDownLatch(1)
+
+        try {
+            val cancelTimeout = testedFeature.initializationTimeoutScheduler.schedule(0) {
+                timeoutStarted.countDown()
+                releaseTimeout.await(1, TimeUnit.SECONDS)
+                timeoutCompleted.countDown()
+            }
+            check(timeoutStarted.await(1, TimeUnit.SECONDS))
+
+            // When
+            cancelTimeout()
+            releaseTimeout.countDown()
+
+            // Then
+            assertThat(timeoutCompleted.await(1, TimeUnit.SECONDS)).isTrue()
+            assertThat(executor.awaitTermination(1, TimeUnit.SECONDS)).isTrue()
+            assertThat(executionError.get()).isNull()
+        } finally {
+            releaseTimeout.countDown()
             executor.shutdownNow()
         }
     }

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/FlagsFeatureTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/FlagsFeatureTest.kt
@@ -169,6 +169,41 @@ internal class FlagsFeatureTest {
     }
 
     @Test
+    fun `M release executor threads W initializationTimeoutScheduler() { multiple clients finish or time out }`() {
+        // Given
+        val clientCount = 20
+        val executors = mutableListOf<ScheduledThreadPoolExecutor>()
+        whenever(mockSdkCore.createScheduledExecutorService(any())).thenAnswer {
+            ScheduledThreadPoolExecutor(1).also { executor -> executors += executor }
+        }
+        val timedOutClients = CountDownLatch(clientCount / 2)
+
+        try {
+            val cancellations = List(clientCount / 2) {
+                testedFeature.initializationTimeoutScheduler.schedule(60_000) {}
+            }
+            repeat(clientCount / 2) {
+                testedFeature.initializationTimeoutScheduler.schedule(1) {
+                    timedOutClients.countDown()
+                }
+            }
+
+            // When
+            cancellations.forEach { it() }
+
+            // Then
+            assertThat(timedOutClients.await(1, TimeUnit.SECONDS)).isTrue()
+            assertThat(executors).hasSize(clientCount)
+            executors.forEach { executor ->
+                assertThat(executor.awaitTermination(1, TimeUnit.SECONDS)).isTrue()
+                assertThat(executor.queue).isEmpty()
+            }
+        } finally {
+            executors.forEach { it.shutdownNow() }
+        }
+    }
+
+    @Test
     fun `M not cancel running task W initializationTimeoutScheduler() { completion races timeout }`() {
         // Given
         val executionError = AtomicReference<Throwable?>()

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.api.storage.datastore.DataStoreHandler
 import com.datadog.android.api.storage.datastore.DataStoreReadCallback
 import com.datadog.android.core.persistence.datastore.DataStoreContent
 import com.datadog.android.flags.EvaluationContextCallback
+import com.datadog.android.flags.FlagsInitializationTimeoutException
 import com.datadog.android.flags.FlagsStateListener
 import com.datadog.android.flags.internal.FlagsStateManager
 import com.datadog.android.flags.internal.model.FlagsStateEntry
@@ -114,7 +115,9 @@ internal class EvaluationsManagerTest {
             flagsRepository = mockFlagsRepository,
             assignmentsReader = mockAssignmentsDownloader,
             precomputeMapper = mockPrecomputeMapper,
-            flagStateManager = mockFlagsStateManager
+            flagStateManager = mockFlagsStateManager,
+            initializationTimeoutMs = null,
+            initializationTimeoutScheduler = InitializationTimeoutScheduler { _, _ -> {} }
         )
 
         whenever(mockSdkCore.getFeature(Feature.FLAGS_FEATURE_NAME)) doReturn mockFlagsFeatureScope
@@ -431,6 +434,231 @@ internal class EvaluationsManagerTest {
     }
 
     @Test
+    fun `M fail initialization callback W timeout { operation completes late }`() {
+        // Given
+        val context = EvaluationContext(fakeTargetingKey, emptyMap())
+        val callback = mock<EvaluationContextCallback>()
+        var scheduledTimeoutMs: Long? = null
+        var timeoutAction: (() -> Unit)? = null
+        var operation: Runnable? = null
+        whenever(mockExecutorService.execute(any())).thenAnswer {
+            operation = it.getArgument(0)
+            null
+        }
+        whenever(mockAssignmentsDownloader.readPrecomputedFlags(context, fakeDatadogContext))
+            .thenReturn(EMPTY_FLAGS_RESPONSE_JSON)
+        whenever(mockPrecomputeMapper.map(EMPTY_FLAGS_RESPONSE_JSON)).thenReturn(emptyMap())
+        val manager = createManager(
+            initializationTimeoutMs = 2_500L,
+            scheduler = InitializationTimeoutScheduler { timeoutMs, action ->
+                scheduledTimeoutMs = timeoutMs
+                timeoutAction = action
+                {}
+            }
+        )
+
+        // When
+        manager.updateEvaluationsForContext(context, callback)
+        checkNotNull(timeoutAction).invoke()
+
+        // Then
+        assertThat(scheduledTimeoutMs).isEqualTo(2_500L)
+        argumentCaptor<Throwable>().apply {
+            verify(callback).onFailure(capture())
+            assertThat(firstValue).isInstanceOf(FlagsInitializationTimeoutException::class.java)
+            assertThat(firstValue.message).isEqualTo("Flags initialization timed out after 2500ms")
+            verify(mockFlagsStateManager).updateState(FlagsClientState.Error(firstValue))
+        }
+        verify(callback, times(0)).onSuccess()
+
+        // When
+        checkNotNull(operation).run()
+
+        // Then
+        verify(mockFlagsStateManager).updateState(FlagsClientState.Ready)
+        verify(callback, times(0)).onSuccess()
+        verify(callback, times(1)).onFailure(any())
+    }
+
+    @Test
+    fun `M keep ready state W timeout { newer request completed }`() {
+        // Given
+        val firstCallback = mock<EvaluationContextCallback>()
+        val operations = mutableListOf<Runnable>()
+        var timeoutAction: (() -> Unit)? = null
+        whenever(mockExecutorService.execute(any())).thenAnswer {
+            operations += it.getArgument<Runnable>(0)
+            null
+        }
+        whenever(mockAssignmentsDownloader.readPrecomputedFlags(any(), eq(fakeDatadogContext)))
+            .thenReturn(EMPTY_FLAGS_RESPONSE_JSON)
+        whenever(mockPrecomputeMapper.map(EMPTY_FLAGS_RESPONSE_JSON)).thenReturn(emptyMap())
+        val stateManager = FlagsStateManager(
+            DDCoreStateHolder.create(
+                initialState = FlagsClientState.NotReady,
+                onStateChanged = FlagsStateListener::onStateChanged
+            )
+        )
+        val manager = createManager(
+            flagStateManager = stateManager,
+            initializationTimeoutMs = 2_500L,
+            scheduler = InitializationTimeoutScheduler { _, action ->
+                timeoutAction = action
+                {}
+            }
+        )
+
+        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), firstCallback)
+        manager.updateEvaluationsForContext(EvaluationContext("newer", emptyMap()))
+
+        // When
+        operations[1].run()
+        assertThat(stateManager.getCurrentState()).isEqualTo(FlagsClientState.Ready)
+        checkNotNull(timeoutAction).invoke()
+
+        // Then
+        verify(firstCallback).onFailure(any<FlagsInitializationTimeoutException>())
+        assertThat(stateManager.getCurrentState()).isEqualTo(FlagsClientState.Ready)
+    }
+
+    @Test
+    fun `M cancel initialization timeout W operation completes first`() {
+        // Given
+        val context = EvaluationContext(fakeTargetingKey, emptyMap())
+        val callback = mock<EvaluationContextCallback>()
+        var timeoutAction: (() -> Unit)? = null
+        var cancellationCount = 0
+        whenever(mockAssignmentsDownloader.readPrecomputedFlags(context, fakeDatadogContext))
+            .thenReturn(EMPTY_FLAGS_RESPONSE_JSON)
+        whenever(mockPrecomputeMapper.map(EMPTY_FLAGS_RESPONSE_JSON)).thenReturn(emptyMap())
+        val manager = createManager(
+            initializationTimeoutMs = 2_500L,
+            scheduler = InitializationTimeoutScheduler { _, action ->
+                timeoutAction = action
+                { cancellationCount += 1 }
+            }
+        )
+
+        // When
+        manager.updateEvaluationsForContext(context, callback)
+        checkNotNull(timeoutAction).invoke()
+
+        // Then
+        assertThat(cancellationCount).isEqualTo(1)
+        verify(callback).onSuccess()
+        verify(callback, times(0)).onFailure(any())
+    }
+
+    @Test
+    fun `M keep initialization timeout active W decoding assignments`() {
+        // Given
+        val context = EvaluationContext(fakeTargetingKey, emptyMap())
+        val callback = mock<EvaluationContextCallback>()
+        var timeoutAction: (() -> Unit)? = null
+        whenever(mockAssignmentsDownloader.readPrecomputedFlags(context, fakeDatadogContext))
+            .thenReturn(EMPTY_FLAGS_RESPONSE_JSON)
+        whenever(mockPrecomputeMapper.map(EMPTY_FLAGS_RESPONSE_JSON)).thenAnswer {
+            checkNotNull(timeoutAction).invoke()
+            emptyMap<String, PrecomputedFlag>()
+        }
+        val manager = createManager(
+            initializationTimeoutMs = 2_500L,
+            scheduler = InitializationTimeoutScheduler { _, action ->
+                timeoutAction = action
+                {}
+            }
+        )
+
+        // When
+        manager.updateEvaluationsForContext(context, callback)
+
+        // Then
+        verify(callback).onFailure(any<FlagsInitializationTimeoutException>())
+        verify(callback, times(0)).onSuccess()
+        verify(mockFlagsRepository).setFlagsAndContext(context, emptyMap())
+        verify(mockFlagsStateManager).updateState(FlagsClientState.Ready)
+    }
+
+    @Test
+    fun `M schedule timeout once W context changes after initialization`() {
+        // Given
+        val callback = mock<EvaluationContextCallback>()
+        var scheduleCount = 0
+        whenever(mockAssignmentsDownloader.readPrecomputedFlags(any(), eq(fakeDatadogContext)))
+            .thenReturn(EMPTY_FLAGS_RESPONSE_JSON)
+        whenever(mockPrecomputeMapper.map(EMPTY_FLAGS_RESPONSE_JSON)).thenReturn(emptyMap())
+        val manager = createManager(
+            initializationTimeoutMs = 2_500L,
+            scheduler = InitializationTimeoutScheduler { _, _ ->
+                scheduleCount += 1
+                {}
+            }
+        )
+
+        // When
+        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), callback)
+        manager.updateEvaluationsForContext(EvaluationContext("second", emptyMap()), callback)
+
+        // Then
+        assertThat(scheduleCount).isEqualTo(1)
+        verify(callback, times(2)).onSuccess()
+    }
+
+    @Test
+    fun `M not schedule timeout W initialization timeout is not configured`() {
+        // Given
+        val callback = mock<EvaluationContextCallback>()
+        var scheduleCount = 0
+        whenever(mockAssignmentsDownloader.readPrecomputedFlags(any(), eq(fakeDatadogContext)))
+            .thenReturn(EMPTY_FLAGS_RESPONSE_JSON)
+        whenever(mockPrecomputeMapper.map(EMPTY_FLAGS_RESPONSE_JSON)).thenReturn(emptyMap())
+        val manager = createManager(
+            initializationTimeoutMs = null,
+            scheduler = InitializationTimeoutScheduler { _, _ ->
+                scheduleCount += 1
+                {}
+            }
+        )
+
+        // When
+        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), callback)
+
+        // Then
+        assertThat(scheduleCount).isZero()
+        verify(callback).onSuccess()
+    }
+
+    @Test
+    fun `M update state to ERROR W timeout {callback is null}`() {
+        // Given
+        var timeoutAction: (() -> Unit)? = null
+        var operation: Runnable? = null
+        whenever(mockExecutorService.execute(any())).thenAnswer {
+            operation = it.getArgument(0)
+            null
+        }
+        val manager = createManager(
+            initializationTimeoutMs = 2_500L,
+            scheduler = InitializationTimeoutScheduler { _, action ->
+                timeoutAction = action
+                {}
+            }
+        )
+
+        // When
+        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), callback = null)
+        checkNotNull(timeoutAction).invoke()
+
+        // Then
+        argumentCaptor<FlagsClientState>().apply {
+            verify(mockFlagsStateManager, times(2)).updateState(capture())
+            val errorState = allValues.filterIsInstance<FlagsClientState.Error>().single()
+            assertThat(errorState.error).isInstanceOf(FlagsInitializationTimeoutException::class.java)
+        }
+        assertThat(operation).isNotNull()
+    }
+
+    @Test
     fun `M have state READY when callback invoked W updateEvaluationsForContext() { success }`() {
         // Given
         val realStateManager = FlagsStateManager(
@@ -447,7 +675,9 @@ internal class EvaluationsManagerTest {
             flagsRepository = mockFlagsRepository,
             assignmentsReader = mockAssignmentsDownloader,
             precomputeMapper = mockPrecomputeMapper,
-            flagStateManager = realStateManager
+            flagStateManager = realStateManager,
+            initializationTimeoutMs = null,
+            initializationTimeoutScheduler = InitializationTimeoutScheduler { _, _ -> {} }
         )
 
         val publicContext = EvaluationContext(fakeTargetingKey, emptyMap())
@@ -532,7 +762,9 @@ internal class EvaluationsManagerTest {
             flagsRepository = realRepository,
             assignmentsReader = mockAssignmentsDownloader,
             precomputeMapper = mockPrecomputeMapper,
-            flagStateManager = mockFlagsStateManager
+            flagStateManager = mockFlagsStateManager,
+            initializationTimeoutMs = null,
+            initializationTimeoutScheduler = InitializationTimeoutScheduler { _, _ -> {} }
         )
 
         // When
@@ -546,6 +778,22 @@ internal class EvaluationsManagerTest {
     }
 
     // endregion
+
+    private fun createManager(
+        flagStateManager: FlagsStateManager = mockFlagsStateManager,
+        initializationTimeoutMs: Long? = null,
+        scheduler: InitializationTimeoutScheduler
+    ): EvaluationsManager = EvaluationsManager(
+        sdkCore = mockSdkCore,
+        executorService = mockExecutorService,
+        internalLogger = mockInternalLogger,
+        flagsRepository = mockFlagsRepository,
+        assignmentsReader = mockAssignmentsDownloader,
+        precomputeMapper = mockPrecomputeMapper,
+        flagStateManager = flagStateManager,
+        initializationTimeoutMs = initializationTimeoutMs,
+        initializationTimeoutScheduler = scheduler
+    )
 
     companion object {
         private const val EMPTY_FLAGS_RESPONSE_JSON = "{\"data\": {\"attributes\": {\"flags\": {}}}}"

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
@@ -531,6 +531,49 @@ internal class EvaluationsManagerTest {
     }
 
     @Test
+    fun `M notify STALE W updateEvaluationsForContext() { cache loads before timeout }`() {
+        // Given
+        val context = EvaluationContext(fakeTargetingKey, emptyMap())
+        var timeoutAction: (() -> Unit)? = null
+        var stateAtTimeoutCallback: FlagsClientState? = null
+        val stateManager = FlagsStateManager(
+            DDCoreStateHolder.create(
+                initialState = FlagsClientState.NotReady,
+                onStateChanged = FlagsStateListener::onStateChanged
+            )
+        )
+        whenever(mockFlagsRepository.hasFlags()).thenReturn(false, true)
+        whenever(mockFlagsRepository.getEvaluationContext()).thenReturn(context)
+        whenever(mockAssignmentsDownloader.readPrecomputedFlags(context, fakeDatadogContext)).thenAnswer {
+            checkNotNull(timeoutAction).invoke()
+            null
+        }
+        val callback = object : EvaluationContextCallback {
+            override fun onSuccess() {
+                fail<Unit>("onSuccess should not be called")
+            }
+
+            override fun onFailure(error: Throwable) {
+                stateAtTimeoutCallback = stateManager.getCurrentState()
+            }
+        }
+        val manager = createManager(
+            flagStateManager = stateManager,
+            initializationTimeoutMs = 2_500L,
+            scheduler = InitializationTimeoutScheduler { _, action ->
+                timeoutAction = action
+                {}
+            }
+        )
+
+        // When
+        manager.updateEvaluationsForContext(context, callback)
+
+        // Then
+        assertThat(stateAtTimeoutCallback).isEqualTo(FlagsClientState.Stale)
+    }
+
+    @Test
     fun `M keep ready state W updateEvaluationsForContext() { newer request completed before timeout }`() {
         // Given
         val mockFirstCallback = mock<EvaluationContextCallback>()
@@ -572,10 +615,65 @@ internal class EvaluationsManagerTest {
     }
 
     @Test
+    fun `M keep reconciling state W updateEvaluationsForContext() { newer request starts before timeout }`() {
+        // Given
+        val firstContext = EvaluationContext("first", emptyMap())
+        val newerContext = EvaluationContext("newer", emptyMap())
+        val mockFirstCallback = mock<EvaluationContextCallback>()
+        val operations = mutableListOf<Runnable>()
+        val firstFetchStarted = CountDownLatch(1)
+        val releaseFirstFetch = CountDownLatch(1)
+        var timeoutAction: (() -> Unit)? = null
+        whenever(mockExecutorService.execute(any())).thenAnswer {
+            operations += it.getArgument<Runnable>(0)
+            null
+        }
+        whenever(mockFlagsRepository.hasFlags()).thenReturn(true)
+        whenever(mockFlagsRepository.getEvaluationContext()).thenReturn(firstContext)
+        whenever(mockAssignmentsDownloader.readPrecomputedFlags(firstContext, fakeDatadogContext)).thenAnswer {
+            firstFetchStarted.countDown()
+            check(releaseFirstFetch.await(5, TimeUnit.SECONDS))
+            null
+        }
+        val stateManager = FlagsStateManager(
+            DDCoreStateHolder.create(
+                initialState = FlagsClientState.NotReady,
+                onStateChanged = FlagsStateListener::onStateChanged
+            )
+        )
+        val manager = createManager(
+            flagStateManager = stateManager,
+            initializationTimeoutMs = 2_500L,
+            scheduler = InitializationTimeoutScheduler { _, action ->
+                timeoutAction = action
+                {}
+            }
+        )
+
+        manager.updateEvaluationsForContext(firstContext, mockFirstCallback)
+        val firstOperationThread = Thread { operations[0].run() }
+        firstOperationThread.start()
+        check(firstFetchStarted.await(5, TimeUnit.SECONDS))
+        manager.updateEvaluationsForContext(newerContext)
+
+        try {
+            // When
+            checkNotNull(timeoutAction).invoke()
+
+            // Then
+            verify(mockFirstCallback).onFailure(any<FlagsInitializationTimeoutException>())
+            assertThat(stateManager.getCurrentState()).isEqualTo(FlagsClientState.Reconciling)
+        } finally {
+            releaseFirstFetch.countDown()
+            firstOperationThread.join(TimeUnit.SECONDS.toMillis(5))
+        }
+    }
+
+    @Test
     fun `M timeout first callback W updateEvaluationsForContext() { reconciling listener re-enters }`() {
         // Given
-        val firstCallback = mock<EvaluationContextCallback>()
-        val nestedCallback = mock<EvaluationContextCallback>()
+        val mockFirstCallback = mock<EvaluationContextCallback>()
+        val mockNestedCallback = mock<EvaluationContextCallback>()
         var timeoutAction: (() -> Unit)? = null
         whenever(mockExecutorService.execute(any())).thenAnswer { null }
         val stateManager = FlagsStateManager(
@@ -592,7 +690,7 @@ internal class EvaluationsManagerTest {
                     if (newState == FlagsClientState.Reconciling && didReenter.compareAndSet(false, true)) {
                         manager.updateEvaluationsForContext(
                             EvaluationContext("nested", emptyMap()),
-                            nestedCallback
+                            mockNestedCallback
                         )
                     }
                 }
@@ -608,19 +706,19 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), firstCallback)
+        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockFirstCallback)
         checkNotNull(timeoutAction).invoke()
 
         // Then
-        verify(firstCallback).onFailure(any<FlagsInitializationTimeoutException>())
-        verify(nestedCallback, times(0)).onFailure(any())
+        verify(mockFirstCallback).onFailure(any<FlagsInitializationTimeoutException>())
+        verify(mockNestedCallback, times(0)).onFailure(any())
     }
 
     @Test
     fun `M keep ready state W updateEvaluationsForContext() { success races timeout publication }`() {
         // Given
         val context = EvaluationContext(fakeTargetingKey, emptyMap())
-        val callback = mock<EvaluationContextCallback>()
+        val mockCallback = mock<EvaluationContextCallback>()
         var timeoutAction: (() -> Unit)? = null
         var operation: Runnable? = null
         val currentState = AtomicReference<FlagsClientState>(FlagsClientState.NotReady)
@@ -655,7 +753,7 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(context, callback)
+        manager.updateEvaluationsForContext(context, mockCallback)
         val timeoutThread = Thread { checkNotNull(timeoutAction).invoke() }
         timeoutThread.start()
         check(timeoutReadState.await(5, TimeUnit.SECONDS))

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
@@ -57,7 +57,11 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 @ExtendWith(MockitoExtension::class, ForgeExtension::class)
 @ForgeConfiguration(ForgeConfigurator::class)
@@ -565,6 +569,114 @@ internal class EvaluationsManagerTest {
         // Then
         verify(mockFirstCallback).onFailure(any<FlagsInitializationTimeoutException>())
         assertThat(stateManager.getCurrentState()).isEqualTo(FlagsClientState.Ready)
+    }
+
+    @Test
+    fun `M timeout first callback W updateEvaluationsForContext() { reconciling listener re-enters }`() {
+        // Given
+        val firstCallback = mock<EvaluationContextCallback>()
+        val nestedCallback = mock<EvaluationContextCallback>()
+        var timeoutAction: (() -> Unit)? = null
+        whenever(mockExecutorService.execute(any())).thenAnswer { null }
+        val stateManager = FlagsStateManager(
+            DDCoreStateHolder.create(
+                initialState = FlagsClientState.NotReady,
+                onStateChanged = FlagsStateListener::onStateChanged
+            )
+        )
+        lateinit var manager: EvaluationsManager
+        val didReenter = AtomicBoolean(false)
+        stateManager.addListener(
+            object : FlagsStateListener {
+                override fun onStateChanged(newState: FlagsClientState) {
+                    if (newState == FlagsClientState.Reconciling && didReenter.compareAndSet(false, true)) {
+                        manager.updateEvaluationsForContext(
+                            EvaluationContext("nested", emptyMap()),
+                            nestedCallback
+                        )
+                    }
+                }
+            }
+        )
+        manager = createManager(
+            flagStateManager = stateManager,
+            initializationTimeoutMs = 2_500L,
+            scheduler = InitializationTimeoutScheduler { _, action ->
+                timeoutAction = action
+                {}
+            }
+        )
+
+        // When
+        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), firstCallback)
+        checkNotNull(timeoutAction).invoke()
+
+        // Then
+        verify(firstCallback).onFailure(any<FlagsInitializationTimeoutException>())
+        verify(nestedCallback, times(0)).onFailure(any())
+    }
+
+    @Test
+    fun `M keep ready state W updateEvaluationsForContext() { success races timeout publication }`() {
+        // Given
+        val context = EvaluationContext(fakeTargetingKey, emptyMap())
+        val callback = mock<EvaluationContextCallback>()
+        var timeoutAction: (() -> Unit)? = null
+        var operation: Runnable? = null
+        val currentState = AtomicReference<FlagsClientState>(FlagsClientState.NotReady)
+        val timeoutReadState = CountDownLatch(1)
+        val releaseTimeout = CountDownLatch(1)
+        val readyPublished = CountDownLatch(1)
+        whenever(mockExecutorService.execute(any())).thenAnswer {
+            operation = it.getArgument(0)
+            null
+        }
+        whenever(mockFlagsStateManager.getCurrentState()).thenAnswer {
+            val observedState = currentState.get()
+            timeoutReadState.countDown()
+            check(releaseTimeout.await(5, TimeUnit.SECONDS))
+            observedState
+        }
+        doAnswer {
+            val newState = it.getArgument<FlagsClientState>(0)
+            currentState.set(newState)
+            if (newState == FlagsClientState.Ready) readyPublished.countDown()
+            null
+        }.whenever(mockFlagsStateManager).updateState(any())
+        whenever(mockAssignmentsDownloader.readPrecomputedFlags(context, fakeDatadogContext))
+            .thenReturn(EMPTY_FLAGS_RESPONSE_JSON)
+        whenever(mockPrecomputeMapper.map(EMPTY_FLAGS_RESPONSE_JSON)).thenReturn(emptyMap())
+        val manager = createManager(
+            initializationTimeoutMs = 2_500L,
+            scheduler = InitializationTimeoutScheduler { _, action ->
+                timeoutAction = action
+                {}
+            }
+        )
+
+        // When
+        manager.updateEvaluationsForContext(context, callback)
+        val timeoutThread = Thread { checkNotNull(timeoutAction).invoke() }
+        timeoutThread.start()
+        check(timeoutReadState.await(5, TimeUnit.SECONDS))
+        val operationThread = Thread { checkNotNull(operation).run() }
+        operationThread.start()
+        val waitDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (
+            readyPublished.count > 0 &&
+            operationThread.state != Thread.State.BLOCKED &&
+            System.nanoTime() < waitDeadline
+        ) {
+            Thread.yield()
+        }
+        releaseTimeout.countDown()
+        timeoutThread.join(TimeUnit.SECONDS.toMillis(5))
+        operationThread.join(TimeUnit.SECONDS.toMillis(5))
+
+        // Then
+        assertThat(timeoutThread.isAlive).isFalse()
+        assertThat(operationThread.isAlive).isFalse()
+        assertThat(currentState.get()).isEqualTo(FlagsClientState.Ready)
     }
 
     @Test

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
@@ -542,8 +542,8 @@ internal class EvaluationsManagerTest {
                 onStateChanged = FlagsStateListener::onStateChanged
             )
         )
-        whenever(mockFlagsRepository.hasFlags()).thenReturn(false, true)
-        whenever(mockFlagsRepository.getEvaluationContext()).thenReturn(context)
+        whenever(mockFlagsRepository.hasFlags()).thenReturn(false)
+        whenever(mockFlagsRepository.hasLoadedFlagsForContext(context)).thenReturn(true)
         whenever(mockAssignmentsDownloader.readPrecomputedFlags(context, fakeDatadogContext)).thenAnswer {
             checkNotNull(timeoutAction).invoke()
             null
@@ -615,57 +615,48 @@ internal class EvaluationsManagerTest {
     }
 
     @Test
-    fun `M keep reconciling state W updateEvaluationsForContext() { newer request starts before timeout }`() {
+    fun `M not wait for cache W updateEvaluationsForContext() { initialization timeout expires }`() {
         // Given
-        val firstContext = EvaluationContext("first", emptyMap())
-        val newerContext = EvaluationContext("newer", emptyMap())
-        val mockFirstCallback = mock<EvaluationContextCallback>()
-        val operations = mutableListOf<Runnable>()
-        val firstFetchStarted = CountDownLatch(1)
-        val releaseFirstFetch = CountDownLatch(1)
+        val context = EvaluationContext(fakeTargetingKey, emptyMap())
+        val cacheReadStarted = CountDownLatch(1)
+        val releaseCacheRead = CountDownLatch(1)
+        val callbackCompleted = CountDownLatch(1)
         var timeoutAction: (() -> Unit)? = null
-        whenever(mockExecutorService.execute(any())).thenAnswer {
-            operations += it.getArgument<Runnable>(0)
-            null
+        whenever(mockExecutorService.execute(any())).thenAnswer { null }
+        whenever(mockFlagsRepository.hasFlags()).thenAnswer {
+            cacheReadStarted.countDown()
+            check(releaseCacheRead.await(1, TimeUnit.SECONDS))
+            false
         }
-        whenever(mockFlagsRepository.hasFlags()).thenReturn(true)
-        whenever(mockFlagsRepository.getEvaluationContext()).thenReturn(firstContext)
-        whenever(mockAssignmentsDownloader.readPrecomputedFlags(firstContext, fakeDatadogContext)).thenAnswer {
-            firstFetchStarted.countDown()
-            check(releaseFirstFetch.await(5, TimeUnit.SECONDS))
-            null
+        val callback = object : EvaluationContextCallback {
+            override fun onSuccess() {
+                fail<Unit>("onSuccess should not be called")
+            }
+
+            override fun onFailure(error: Throwable) {
+                callbackCompleted.countDown()
+            }
         }
-        val stateManager = FlagsStateManager(
-            DDCoreStateHolder.create(
-                initialState = FlagsClientState.NotReady,
-                onStateChanged = FlagsStateListener::onStateChanged
-            )
-        )
         val manager = createManager(
-            flagStateManager = stateManager,
-            initializationTimeoutMs = 2_500L,
+            initializationTimeoutMs = 0,
             scheduler = InitializationTimeoutScheduler { _, action ->
                 timeoutAction = action
                 {}
             }
         )
-
-        manager.updateEvaluationsForContext(firstContext, mockFirstCallback)
-        val firstOperationThread = Thread { operations[0].run() }
-        firstOperationThread.start()
-        check(firstFetchStarted.await(5, TimeUnit.SECONDS))
-        manager.updateEvaluationsForContext(newerContext)
+        manager.updateEvaluationsForContext(context, callback)
+        val timeoutThread = Thread { checkNotNull(timeoutAction).invoke() }
 
         try {
             // When
-            checkNotNull(timeoutAction).invoke()
+            timeoutThread.start()
 
             // Then
-            verify(mockFirstCallback).onFailure(any<FlagsInitializationTimeoutException>())
-            assertThat(stateManager.getCurrentState()).isEqualTo(FlagsClientState.Reconciling)
+            assertThat(callbackCompleted.await(250, TimeUnit.MILLISECONDS)).isTrue()
+            assertThat(cacheReadStarted.count).isEqualTo(1)
         } finally {
-            releaseFirstFetch.countDown()
-            firstOperationThread.join(TimeUnit.SECONDS.toMillis(5))
+            releaseCacheRead.countDown()
+            timeoutThread.join(TimeUnit.SECONDS.toMillis(2))
         }
     }
 

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
@@ -481,6 +481,52 @@ internal class EvaluationsManagerTest {
     }
 
     @Test
+    fun `M notify STALE before timeout callback W updateEvaluationsForContext() { cached flags match context }`() {
+        // Given
+        val context = EvaluationContext(fakeTargetingKey, emptyMap())
+        var timeoutAction: (() -> Unit)? = null
+        val stateManager = FlagsStateManager(
+            DDCoreStateHolder.create(
+                initialState = FlagsClientState.NotReady,
+                onStateChanged = FlagsStateListener::onStateChanged
+            )
+        )
+        var stateAtTimeoutCallback: FlagsClientState? = null
+        var callbackError: Throwable? = null
+        val callback = object : EvaluationContextCallback {
+            override fun onSuccess() {
+                fail<Unit>("onSuccess should not be called")
+            }
+
+            override fun onFailure(error: Throwable) {
+                stateAtTimeoutCallback = stateManager.getCurrentState()
+                callbackError = error
+            }
+        }
+        whenever(mockFlagsRepository.hasFlags()).thenReturn(true)
+        whenever(mockFlagsRepository.getEvaluationContext()).thenReturn(context)
+        whenever(mockAssignmentsDownloader.readPrecomputedFlags(context, fakeDatadogContext)).thenAnswer {
+            checkNotNull(timeoutAction).invoke()
+            null
+        }
+        val manager = createManager(
+            flagStateManager = stateManager,
+            initializationTimeoutMs = 2_500L,
+            scheduler = InitializationTimeoutScheduler { _, action ->
+                timeoutAction = action
+                {}
+            }
+        )
+
+        // When
+        manager.updateEvaluationsForContext(context, callback)
+
+        // Then
+        assertThat(callbackError).isInstanceOf(FlagsInitializationTimeoutException::class.java)
+        assertThat(stateAtTimeoutCallback).isEqualTo(FlagsClientState.Stale)
+    }
+
+    @Test
     fun `M keep ready state W updateEvaluationsForContext() { newer request completed before timeout }`() {
         // Given
         val mockFirstCallback = mock<EvaluationContextCallback>()

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
@@ -434,10 +434,10 @@ internal class EvaluationsManagerTest {
     }
 
     @Test
-    fun `M fail initialization callback W timeout { operation completes late }`() {
+    fun `M fail initialization callback W updateEvaluationsForContext() { timeout, operation completes late }`() {
         // Given
         val context = EvaluationContext(fakeTargetingKey, emptyMap())
-        val callback = mock<EvaluationContextCallback>()
+        val mockCallback = mock<EvaluationContextCallback>()
         var scheduledTimeoutMs: Long? = null
         var timeoutAction: (() -> Unit)? = null
         var operation: Runnable? = null
@@ -458,32 +458,32 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(context, callback)
+        manager.updateEvaluationsForContext(context, mockCallback)
         checkNotNull(timeoutAction).invoke()
 
         // Then
         assertThat(scheduledTimeoutMs).isEqualTo(2_500L)
         argumentCaptor<Throwable>().apply {
-            verify(callback).onFailure(capture())
+            verify(mockCallback).onFailure(capture())
             assertThat(firstValue).isInstanceOf(FlagsInitializationTimeoutException::class.java)
             assertThat(firstValue.message).isEqualTo("Flags initialization timed out after 2500ms")
             verify(mockFlagsStateManager).updateState(FlagsClientState.Error(firstValue))
         }
-        verify(callback, times(0)).onSuccess()
+        verify(mockCallback, times(0)).onSuccess()
 
         // When
         checkNotNull(operation).run()
 
         // Then
         verify(mockFlagsStateManager).updateState(FlagsClientState.Ready)
-        verify(callback, times(0)).onSuccess()
-        verify(callback, times(1)).onFailure(any())
+        verify(mockCallback, times(0)).onSuccess()
+        verify(mockCallback, times(1)).onFailure(any())
     }
 
     @Test
-    fun `M keep ready state W timeout { newer request completed }`() {
+    fun `M keep ready state W updateEvaluationsForContext() { newer request completed before timeout }`() {
         // Given
-        val firstCallback = mock<EvaluationContextCallback>()
+        val mockFirstCallback = mock<EvaluationContextCallback>()
         val operations = mutableListOf<Runnable>()
         var timeoutAction: (() -> Unit)? = null
         whenever(mockExecutorService.execute(any())).thenAnswer {
@@ -508,7 +508,7 @@ internal class EvaluationsManagerTest {
             }
         )
 
-        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), firstCallback)
+        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockFirstCallback)
         manager.updateEvaluationsForContext(EvaluationContext("newer", emptyMap()))
 
         // When
@@ -517,15 +517,15 @@ internal class EvaluationsManagerTest {
         checkNotNull(timeoutAction).invoke()
 
         // Then
-        verify(firstCallback).onFailure(any<FlagsInitializationTimeoutException>())
+        verify(mockFirstCallback).onFailure(any<FlagsInitializationTimeoutException>())
         assertThat(stateManager.getCurrentState()).isEqualTo(FlagsClientState.Ready)
     }
 
     @Test
-    fun `M cancel initialization timeout W operation completes first`() {
+    fun `M cancel initialization timeout W updateEvaluationsForContext() { operation completes first }`() {
         // Given
         val context = EvaluationContext(fakeTargetingKey, emptyMap())
-        val callback = mock<EvaluationContextCallback>()
+        val mockCallback = mock<EvaluationContextCallback>()
         var timeoutAction: (() -> Unit)? = null
         var cancellationCount = 0
         whenever(mockAssignmentsDownloader.readPrecomputedFlags(context, fakeDatadogContext))
@@ -540,20 +540,20 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(context, callback)
+        manager.updateEvaluationsForContext(context, mockCallback)
         checkNotNull(timeoutAction).invoke()
 
         // Then
         assertThat(cancellationCount).isEqualTo(1)
-        verify(callback).onSuccess()
-        verify(callback, times(0)).onFailure(any())
+        verify(mockCallback).onSuccess()
+        verify(mockCallback, times(0)).onFailure(any())
     }
 
     @Test
-    fun `M keep initialization timeout active W decoding assignments`() {
+    fun `M keep initialization timeout active W updateEvaluationsForContext() { decoding assignments }`() {
         // Given
         val context = EvaluationContext(fakeTargetingKey, emptyMap())
-        val callback = mock<EvaluationContextCallback>()
+        val mockCallback = mock<EvaluationContextCallback>()
         var timeoutAction: (() -> Unit)? = null
         whenever(mockAssignmentsDownloader.readPrecomputedFlags(context, fakeDatadogContext))
             .thenReturn(EMPTY_FLAGS_RESPONSE_JSON)
@@ -570,19 +570,19 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(context, callback)
+        manager.updateEvaluationsForContext(context, mockCallback)
 
         // Then
-        verify(callback).onFailure(any<FlagsInitializationTimeoutException>())
-        verify(callback, times(0)).onSuccess()
+        verify(mockCallback).onFailure(any<FlagsInitializationTimeoutException>())
+        verify(mockCallback, times(0)).onSuccess()
         verify(mockFlagsRepository).setFlagsAndContext(context, emptyMap())
         verify(mockFlagsStateManager).updateState(FlagsClientState.Ready)
     }
 
     @Test
-    fun `M schedule timeout once W context changes after initialization`() {
+    fun `M schedule timeout once W updateEvaluationsForContext() { context changes after initialization }`() {
         // Given
-        val callback = mock<EvaluationContextCallback>()
+        val mockCallback = mock<EvaluationContextCallback>()
         var scheduleCount = 0
         whenever(mockAssignmentsDownloader.readPrecomputedFlags(any(), eq(fakeDatadogContext)))
             .thenReturn(EMPTY_FLAGS_RESPONSE_JSON)
@@ -596,18 +596,18 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), callback)
-        manager.updateEvaluationsForContext(EvaluationContext("second", emptyMap()), callback)
+        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockCallback)
+        manager.updateEvaluationsForContext(EvaluationContext("second", emptyMap()), mockCallback)
 
         // Then
         assertThat(scheduleCount).isEqualTo(1)
-        verify(callback, times(2)).onSuccess()
+        verify(mockCallback, times(2)).onSuccess()
     }
 
     @Test
-    fun `M not schedule timeout W initialization timeout is not configured`() {
+    fun `M not schedule timeout W updateEvaluationsForContext() { initialization timeout is not configured }`() {
         // Given
-        val callback = mock<EvaluationContextCallback>()
+        val mockCallback = mock<EvaluationContextCallback>()
         var scheduleCount = 0
         whenever(mockAssignmentsDownloader.readPrecomputedFlags(any(), eq(fakeDatadogContext)))
             .thenReturn(EMPTY_FLAGS_RESPONSE_JSON)
@@ -621,15 +621,15 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), callback)
+        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockCallback)
 
         // Then
         assertThat(scheduleCount).isZero()
-        verify(callback).onSuccess()
+        verify(mockCallback).onSuccess()
     }
 
     @Test
-    fun `M update state to ERROR W timeout {callback is null}`() {
+    fun `M update state to ERROR W updateEvaluationsForContext() { timeout, callback is null }`() {
         // Given
         var timeoutAction: (() -> Unit)? = null
         var operation: Runnable? = null
@@ -656,6 +656,98 @@ internal class EvaluationsManagerTest {
             assertThat(errorState.error).isInstanceOf(FlagsInitializationTimeoutException::class.java)
         }
         assertThat(operation).isNotNull()
+    }
+
+    @Test
+    fun `M claim success W updateEvaluationsForContext() { timeout fires from ready listener }`() {
+        // Given
+        val context = EvaluationContext(fakeTargetingKey, emptyMap())
+        val mockCallback = mock<EvaluationContextCallback>()
+        var timeoutAction: (() -> Unit)? = null
+        whenever(mockAssignmentsDownloader.readPrecomputedFlags(context, fakeDatadogContext))
+            .thenReturn(EMPTY_FLAGS_RESPONSE_JSON)
+        whenever(mockPrecomputeMapper.map(EMPTY_FLAGS_RESPONSE_JSON)).thenReturn(emptyMap())
+        val stateManager = FlagsStateManager(
+            DDCoreStateHolder.create(
+                initialState = FlagsClientState.NotReady,
+                onStateChanged = FlagsStateListener::onStateChanged
+            )
+        )
+        stateManager.addListener(
+            object : FlagsStateListener {
+                override fun onStateChanged(newState: FlagsClientState) {
+                    if (newState == FlagsClientState.Ready) timeoutAction?.invoke()
+                }
+            }
+        )
+        val manager = createManager(
+            flagStateManager = stateManager,
+            initializationTimeoutMs = 2_500L,
+            scheduler = InitializationTimeoutScheduler { _, action ->
+                timeoutAction = action
+                {}
+            }
+        )
+
+        // When
+        manager.updateEvaluationsForContext(context, mockCallback)
+
+        // Then
+        verify(mockCallback).onSuccess()
+        verify(mockCallback, times(0)).onFailure(any())
+        assertThat(stateManager.getCurrentState()).isEqualTo(FlagsClientState.Ready)
+    }
+
+    @Test
+    fun `M keep ERROR state W updateEvaluationsForContext() { immediate initialization timeout }`() {
+        // Given
+        val mockCallback = mock<EvaluationContextCallback>()
+        whenever(mockExecutorService.execute(any())).thenAnswer { null }
+        val stateManager = FlagsStateManager(
+            DDCoreStateHolder.create(
+                initialState = FlagsClientState.NotReady,
+                onStateChanged = FlagsStateListener::onStateChanged
+            )
+        )
+        val manager = createManager(
+            flagStateManager = stateManager,
+            initializationTimeoutMs = 0,
+            scheduler = InitializationTimeoutScheduler { _, action ->
+                action()
+                val cancelTimeout: () -> Unit = {}
+                cancelTimeout
+            }
+        )
+
+        // When
+        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockCallback)
+
+        // Then
+        verify(mockCallback).onFailure(any<FlagsInitializationTimeoutException>())
+        assertThat(stateManager.getCurrentState()).isInstanceOf(FlagsClientState.Error::class.java)
+    }
+
+    @Test
+    fun `M not cancel timeout W updateEvaluationsForContext() { timeout expires }`() {
+        // Given
+        val mockCallback = mock<EvaluationContextCallback>()
+        var cancellationCount = 0
+        whenever(mockExecutorService.execute(any())).thenAnswer { null }
+        val manager = createManager(
+            initializationTimeoutMs = 2_500L,
+            scheduler = InitializationTimeoutScheduler { _, action ->
+                action()
+                val cancelTimeout: () -> Unit = { cancellationCount += 1 }
+                cancelTimeout
+            }
+        )
+
+        // When
+        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockCallback)
+
+        // Then
+        assertThat(cancellationCount).isZero()
+        verify(mockCallback).onFailure(any<FlagsInitializationTimeoutException>())
     }
 
     @Test

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
@@ -121,7 +121,7 @@ internal class EvaluationsManagerTest {
             precomputeMapper = mockPrecomputeMapper,
             flagStateManager = mockFlagsStateManager,
             initializationTimeoutMs = null,
-            initializationTimeoutScheduler = InitializationTimeoutScheduler { _, _ -> {} }
+            initializationTimeoutScheduler = { _, _ -> {} }
         )
 
         whenever(mockSdkCore.getFeature(Feature.FLAGS_FEATURE_NAME)) doReturn mockFlagsFeatureScope
@@ -1016,7 +1016,7 @@ internal class EvaluationsManagerTest {
             precomputeMapper = mockPrecomputeMapper,
             flagStateManager = realStateManager,
             initializationTimeoutMs = null,
-            initializationTimeoutScheduler = InitializationTimeoutScheduler { _, _ -> {} }
+            initializationTimeoutScheduler = { _, _ -> {} }
         )
 
         val publicContext = EvaluationContext(fakeTargetingKey, emptyMap())
@@ -1103,7 +1103,7 @@ internal class EvaluationsManagerTest {
             precomputeMapper = mockPrecomputeMapper,
             flagStateManager = mockFlagsStateManager,
             initializationTimeoutMs = null,
-            initializationTimeoutScheduler = InitializationTimeoutScheduler { _, _ -> {} }
+            initializationTimeoutScheduler = { _, _ -> {} }
         )
 
         // When

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/evaluation/EvaluationsManagerTest.kt
@@ -452,7 +452,7 @@ internal class EvaluationsManagerTest {
         whenever(mockAssignmentsDownloader.readPrecomputedFlags(context, fakeDatadogContext))
             .thenReturn(EMPTY_FLAGS_RESPONSE_JSON)
         whenever(mockPrecomputeMapper.map(EMPTY_FLAGS_RESPONSE_JSON)).thenReturn(emptyMap())
-        val manager = createManager(
+        val testedManager = createManager(
             initializationTimeoutMs = 2_500L,
             scheduler = InitializationTimeoutScheduler { timeoutMs, action ->
                 scheduledTimeoutMs = timeoutMs
@@ -462,7 +462,7 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(context, mockCallback)
+        testedManager.updateEvaluationsForContext(context, mockCallback)
         checkNotNull(timeoutAction).invoke()
 
         // Then
@@ -513,7 +513,7 @@ internal class EvaluationsManagerTest {
             checkNotNull(timeoutAction).invoke()
             null
         }
-        val manager = createManager(
+        val testedManager = createManager(
             flagStateManager = stateManager,
             initializationTimeoutMs = 2_500L,
             scheduler = InitializationTimeoutScheduler { _, action ->
@@ -523,7 +523,7 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(context, callback)
+        testedManager.updateEvaluationsForContext(context, callback)
 
         // Then
         assertThat(callbackError).isInstanceOf(FlagsInitializationTimeoutException::class.java)
@@ -557,7 +557,7 @@ internal class EvaluationsManagerTest {
                 stateAtTimeoutCallback = stateManager.getCurrentState()
             }
         }
-        val manager = createManager(
+        val testedManager = createManager(
             flagStateManager = stateManager,
             initializationTimeoutMs = 2_500L,
             scheduler = InitializationTimeoutScheduler { _, action ->
@@ -567,7 +567,7 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(context, callback)
+        testedManager.updateEvaluationsForContext(context, callback)
 
         // Then
         assertThat(stateAtTimeoutCallback).isEqualTo(FlagsClientState.Stale)
@@ -592,7 +592,7 @@ internal class EvaluationsManagerTest {
                 onStateChanged = FlagsStateListener::onStateChanged
             )
         )
-        val manager = createManager(
+        val testedManager = createManager(
             flagStateManager = stateManager,
             initializationTimeoutMs = 2_500L,
             scheduler = InitializationTimeoutScheduler { _, action ->
@@ -601,8 +601,8 @@ internal class EvaluationsManagerTest {
             }
         )
 
-        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockFirstCallback)
-        manager.updateEvaluationsForContext(EvaluationContext("newer", emptyMap()))
+        testedManager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockFirstCallback)
+        testedManager.updateEvaluationsForContext(EvaluationContext("newer", emptyMap()))
 
         // When
         operations[1].run()
@@ -637,14 +637,14 @@ internal class EvaluationsManagerTest {
                 callbackCompleted.countDown()
             }
         }
-        val manager = createManager(
+        val testedManager = createManager(
             initializationTimeoutMs = 0,
             scheduler = InitializationTimeoutScheduler { _, action ->
                 timeoutAction = action
                 {}
             }
         )
-        manager.updateEvaluationsForContext(context, callback)
+        testedManager.updateEvaluationsForContext(context, callback)
         val timeoutThread = Thread { checkNotNull(timeoutAction).invoke() }
 
         try {
@@ -673,13 +673,13 @@ internal class EvaluationsManagerTest {
                 onStateChanged = FlagsStateListener::onStateChanged
             )
         )
-        lateinit var manager: EvaluationsManager
+        lateinit var testedManager: EvaluationsManager
         val didReenter = AtomicBoolean(false)
         stateManager.addListener(
             object : FlagsStateListener {
                 override fun onStateChanged(newState: FlagsClientState) {
                     if (newState == FlagsClientState.Reconciling && didReenter.compareAndSet(false, true)) {
-                        manager.updateEvaluationsForContext(
+                        testedManager.updateEvaluationsForContext(
                             EvaluationContext("nested", emptyMap()),
                             mockNestedCallback
                         )
@@ -687,7 +687,7 @@ internal class EvaluationsManagerTest {
                 }
             }
         )
-        manager = createManager(
+        testedManager = createManager(
             flagStateManager = stateManager,
             initializationTimeoutMs = 2_500L,
             scheduler = InitializationTimeoutScheduler { _, action ->
@@ -697,7 +697,7 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockFirstCallback)
+        testedManager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockFirstCallback)
         checkNotNull(timeoutAction).invoke()
 
         // Then
@@ -735,7 +735,7 @@ internal class EvaluationsManagerTest {
         whenever(mockAssignmentsDownloader.readPrecomputedFlags(context, fakeDatadogContext))
             .thenReturn(EMPTY_FLAGS_RESPONSE_JSON)
         whenever(mockPrecomputeMapper.map(EMPTY_FLAGS_RESPONSE_JSON)).thenReturn(emptyMap())
-        val manager = createManager(
+        val testedManager = createManager(
             initializationTimeoutMs = 2_500L,
             scheduler = InitializationTimeoutScheduler { _, action ->
                 timeoutAction = action
@@ -744,7 +744,7 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(context, mockCallback)
+        testedManager.updateEvaluationsForContext(context, mockCallback)
         val timeoutThread = Thread { checkNotNull(timeoutAction).invoke() }
         timeoutThread.start()
         check(timeoutReadState.await(5, TimeUnit.SECONDS))
@@ -778,7 +778,7 @@ internal class EvaluationsManagerTest {
         whenever(mockAssignmentsDownloader.readPrecomputedFlags(context, fakeDatadogContext))
             .thenReturn(EMPTY_FLAGS_RESPONSE_JSON)
         whenever(mockPrecomputeMapper.map(EMPTY_FLAGS_RESPONSE_JSON)).thenReturn(emptyMap())
-        val manager = createManager(
+        val testedManager = createManager(
             initializationTimeoutMs = 2_500L,
             scheduler = InitializationTimeoutScheduler { _, action ->
                 timeoutAction = action
@@ -787,7 +787,7 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(context, mockCallback)
+        testedManager.updateEvaluationsForContext(context, mockCallback)
         checkNotNull(timeoutAction).invoke()
 
         // Then
@@ -808,7 +808,7 @@ internal class EvaluationsManagerTest {
             checkNotNull(timeoutAction).invoke()
             emptyMap<String, PrecomputedFlag>()
         }
-        val manager = createManager(
+        val testedManager = createManager(
             initializationTimeoutMs = 2_500L,
             scheduler = InitializationTimeoutScheduler { _, action ->
                 timeoutAction = action
@@ -817,7 +817,7 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(context, mockCallback)
+        testedManager.updateEvaluationsForContext(context, mockCallback)
 
         // Then
         verify(mockCallback).onFailure(any<FlagsInitializationTimeoutException>())
@@ -834,7 +834,7 @@ internal class EvaluationsManagerTest {
         whenever(mockAssignmentsDownloader.readPrecomputedFlags(any(), eq(fakeDatadogContext)))
             .thenReturn(EMPTY_FLAGS_RESPONSE_JSON)
         whenever(mockPrecomputeMapper.map(EMPTY_FLAGS_RESPONSE_JSON)).thenReturn(emptyMap())
-        val manager = createManager(
+        val testedManager = createManager(
             initializationTimeoutMs = 2_500L,
             scheduler = InitializationTimeoutScheduler { _, _ ->
                 scheduleCount += 1
@@ -843,8 +843,8 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockCallback)
-        manager.updateEvaluationsForContext(EvaluationContext("second", emptyMap()), mockCallback)
+        testedManager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockCallback)
+        testedManager.updateEvaluationsForContext(EvaluationContext("second", emptyMap()), mockCallback)
 
         // Then
         assertThat(scheduleCount).isEqualTo(1)
@@ -859,7 +859,7 @@ internal class EvaluationsManagerTest {
         whenever(mockAssignmentsDownloader.readPrecomputedFlags(any(), eq(fakeDatadogContext)))
             .thenReturn(EMPTY_FLAGS_RESPONSE_JSON)
         whenever(mockPrecomputeMapper.map(EMPTY_FLAGS_RESPONSE_JSON)).thenReturn(emptyMap())
-        val manager = createManager(
+        val testedManager = createManager(
             initializationTimeoutMs = null,
             scheduler = InitializationTimeoutScheduler { _, _ ->
                 scheduleCount += 1
@@ -868,7 +868,7 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockCallback)
+        testedManager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockCallback)
 
         // Then
         assertThat(scheduleCount).isZero()
@@ -884,7 +884,7 @@ internal class EvaluationsManagerTest {
             operation = it.getArgument(0)
             null
         }
-        val manager = createManager(
+        val testedManager = createManager(
             initializationTimeoutMs = 2_500L,
             scheduler = InitializationTimeoutScheduler { _, action ->
                 timeoutAction = action
@@ -893,7 +893,7 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), callback = null)
+        testedManager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), callback = null)
         checkNotNull(timeoutAction).invoke()
 
         // Then
@@ -927,7 +927,7 @@ internal class EvaluationsManagerTest {
                 }
             }
         )
-        val manager = createManager(
+        val testedManager = createManager(
             flagStateManager = stateManager,
             initializationTimeoutMs = 2_500L,
             scheduler = InitializationTimeoutScheduler { _, action ->
@@ -937,7 +937,7 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(context, mockCallback)
+        testedManager.updateEvaluationsForContext(context, mockCallback)
 
         // Then
         verify(mockCallback).onSuccess()
@@ -956,7 +956,7 @@ internal class EvaluationsManagerTest {
                 onStateChanged = FlagsStateListener::onStateChanged
             )
         )
-        val manager = createManager(
+        val testedManager = createManager(
             flagStateManager = stateManager,
             initializationTimeoutMs = 0,
             scheduler = InitializationTimeoutScheduler { _, action ->
@@ -967,7 +967,7 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockCallback)
+        testedManager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockCallback)
 
         // Then
         verify(mockCallback).onFailure(any<FlagsInitializationTimeoutException>())
@@ -980,7 +980,7 @@ internal class EvaluationsManagerTest {
         val mockCallback = mock<EvaluationContextCallback>()
         var cancellationCount = 0
         whenever(mockExecutorService.execute(any())).thenAnswer { null }
-        val manager = createManager(
+        val testedManager = createManager(
             initializationTimeoutMs = 2_500L,
             scheduler = InitializationTimeoutScheduler { _, action ->
                 action()
@@ -990,7 +990,7 @@ internal class EvaluationsManagerTest {
         )
 
         // When
-        manager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockCallback)
+        testedManager.updateEvaluationsForContext(EvaluationContext("first", emptyMap()), mockCallback)
 
         // Then
         assertThat(cancellationCount).isZero()

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepositoryTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepositoryTest.kt
@@ -35,6 +35,8 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -133,6 +135,38 @@ internal class DefaultFlagsRepositoryTest {
 
         // Then
         assertThat(result).isEqualTo(context)
+    }
+
+    @Test
+    fun `M not wait for persistence W hasLoadedFlagsForContext() { persistence is loading }`(forge: Forge) {
+        // Given
+        doAnswer { null }.whenever(mockDataStore).value<FlagsStateEntry>(
+            key = any(),
+            version = anyOrNull(),
+            callback = any(),
+            deserializer = any()
+        )
+        val repository = DefaultFlagsRepository(
+            featureSdkCore = mockFeatureSdkCore,
+            dataStore = mockDataStore,
+            instanceName = "loading",
+            persistenceLoadTimeoutMs = TimeUnit.SECONDS.toMillis(10)
+        )
+        val result = AtomicReference<Boolean>()
+        val completed = CountDownLatch(1)
+        val context = EvaluationContext(forge.anAlphabeticalString(), emptyMap())
+        val readThread = Thread {
+            result.set(repository.hasLoadedFlagsForContext(context))
+            completed.countDown()
+        }.apply { isDaemon = true }
+
+        // When
+        readThread.start()
+
+        // Then
+        assertThat(completed.await(1, TimeUnit.SECONDS)).isTrue()
+        readThread.join(TimeUnit.SECONDS.toMillis(1))
+        assertThat(result.get()).isFalse()
     }
 
     @Test

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepositoryTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/DefaultFlagsRepositoryTest.kt
@@ -146,7 +146,7 @@ internal class DefaultFlagsRepositoryTest {
             callback = any(),
             deserializer = any()
         )
-        val repository = DefaultFlagsRepository(
+        val testedRepository = DefaultFlagsRepository(
             featureSdkCore = mockFeatureSdkCore,
             dataStore = mockDataStore,
             instanceName = "loading",
@@ -156,7 +156,7 @@ internal class DefaultFlagsRepositoryTest {
         val completed = CountDownLatch(1)
         val context = EvaluationContext(forge.anAlphabeticalString(), emptyMap())
         val readThread = Thread {
-            result.set(repository.hasLoadedFlagsForContext(context))
+            result.set(testedRepository.hasLoadedFlagsForContext(context))
             completed.countDown()
         }.apply { isDaemon = true }
 


### PR DESCRIPTION
## Motivation

The first Flags context operation can wait without a limit. Mobile applications need a bounded initialization wait during normal onboarding.

## Changes and Decisions

- Add `FlagsConfiguration.Builder.initializationTimeout(timeoutMs)`.
- Use 5,000 milliseconds by default.
- Use a positive value to enable the timeout. Zero and negative values disable it.
- Apply the timeout only to the first `setEvaluationContext` call. That call consumes the timeout even if it fails or never starts.
- Report `FlagsInitializationTimeoutException` when the timeout expires. Keep its constructor internal.
- Publish `Stale` when matching cached assignments are available.
- Otherwise, publish `Error` unless another operation already published `Ready` or `Stale`.
- Complete OpenFeature initialization with matching cached assignments. Keep the provider stale until recovery.
- Map a timeout without matching cached assignments to OpenFeature `GeneralError`.
- Keep the initialization operation running. A late success can publish `Ready`.
- Do not change the HTTP client timeout.
- Preserve the existing public eight-parameter `FlagsConfiguration.copy(...)` signature.

### LOC Breakdown

| Category | Files | Added | Deleted |
|---|---:|---:|---:|
| Production source | 12 | 270 | 30 |
| Tests | 5 | 849 | 8 |
| Generated API snapshots | 2 | 7 | 0 |
| **Total** | **19** | **1,126** | **38** |

```mermaid
flowchart TD
    A[First setEvaluationContext] --> B{Completes within timeout?}
    B -->|Yes| C[Report success and publish Ready]
    B -->|No| D[Report initialization timeout]
    D --> E{Matching cached assignments?}
    E -->|Yes| F[Publish Stale]
    E -->|No| G[Publish Error]
    F --> H[OpenFeature initialization completes]
    G --> I[OpenFeature receives GeneralError]
    D --> J[Initialization continues]
    J -->|Late success| C
    K[Later setEvaluationContext calls] --> L[No initialization timer]
```

Direct Flags use applies the 5,000-millisecond default:

```kotlin
Flags.enable(FlagsConfiguration.Builder().build())
```

OpenFeature uses the same configuration and timeout:

```kotlin
import com.datadog.android.flags.Flags
import com.datadog.android.flags.FlagsClient
import com.datadog.android.flags.FlagsConfiguration
import com.datadog.android.flags.openfeature.asOpenFeatureProvider
import dev.openfeature.kotlin.sdk.ImmutableContext
import dev.openfeature.kotlin.sdk.OpenFeatureAPI

val configuration = FlagsConfiguration.Builder()
    .initializationTimeout(2_000)
    .build()
Flags.enable(configuration)

val provider = FlagsClient.Builder()
    .build()
    .asOpenFeatureProvider()

OpenFeatureAPI.setProviderAndWait(
    provider = provider,
    initialContext = ImmutableContext(targetingKey = "user-123")
)
```
