### PR TITLE
Catch RuntimeException in SystemSettingsWrapper

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/display/SystemSettingsWrapper.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/display/SystemSettingsWrapper.kt
@@ -25,6 +25,14 @@ internal class SystemSettingsWrapper(
                 throwable = e
             )
             Integer.MIN_VALUE
+        } catch (@Suppress("TooGenericExceptionCaught") e: RuntimeException) {
+            internalLogger.log(
+                target = InternalLogger.Target.MAINTAINER,
+                level = InternalLogger.Level.WARN,
+                messageBuilder = { "Problem retrieving system value for $name" },
+                throwable = e
+            )
+            Integer.MIN_VALUE
         }
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/display/SystemSettingsWrapperTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/display/SystemSettingsWrapperTest.kt
@@ -1,0 +1,141 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.domain.display
+
+import android.content.ContentResolver
+import android.content.Context
+import android.provider.Settings
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.utils.verifyLog
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@ExtendWith(MockitoExtension::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class SystemSettingsWrapperTest {
+
+    private lateinit var testedWrapper: SystemSettingsWrapper
+
+    @Mock
+    lateinit var mockApplicationContext: Context
+
+    @Mock
+    lateinit var mockContentResolver: ContentResolver
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @BeforeEach
+    fun setUp() {
+        whenever(mockApplicationContext.contentResolver) doReturn mockContentResolver
+
+        testedWrapper = SystemSettingsWrapper(
+            applicationContext = mockApplicationContext,
+            internalLogger = mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `M return setting value W getInt() { setting exists }`() {
+        // Given
+        val fakeName = Settings.System.SCREEN_BRIGHTNESS
+        val fakeValue = 128
+
+        Mockito.mockStatic(Settings.System::class.java).use { mockedSettings ->
+            mockedSettings.`when`<Int> {
+                Settings.System.getInt(mockContentResolver, fakeName)
+            }.thenReturn(fakeValue)
+
+            // When
+            val result = testedWrapper.getInt(fakeName)
+
+            // Then
+            assertThat(result).isEqualTo(fakeValue)
+        }
+    }
+
+    @Test
+    fun `M return MIN_VALUE and log W getInt() { setting not found }`() {
+        // Given
+        val fakeName = Settings.System.SCREEN_BRIGHTNESS
+
+        Mockito.mockStatic(Settings.System::class.java).use { mockedSettings ->
+            mockedSettings.`when`<Int> {
+                Settings.System.getInt(mockContentResolver, fakeName)
+            }.thenThrow(Settings.SettingNotFoundException(fakeName))
+
+            // When
+            val result = testedWrapper.getInt(fakeName)
+
+            // Then
+            assertThat(result).isEqualTo(Integer.MIN_VALUE)
+            mockInternalLogger.verifyLog(
+                level = InternalLogger.Level.WARN,
+                target = InternalLogger.Target.MAINTAINER,
+                message = "Problem retrieving system value for $fakeName",
+                throwableClass = Settings.SettingNotFoundException::class.java
+            )
+        }
+    }
+
+    @Test
+    fun `M return MIN_VALUE and log W getInt() { RuntimeException thrown unparceling MemoryIntArray }`() {
+        // Given
+        val fakeName = Settings.System.SCREEN_BRIGHTNESS
+
+        Mockito.mockStatic(Settings.System::class.java).use { mockedSettings ->
+            mockedSettings.`when`<Int> {
+                Settings.System.getInt(mockContentResolver, fakeName)
+            }.thenThrow(IllegalArgumentException("Error unparceling MemoryIntArray"))
+
+            // When
+            val result = testedWrapper.getInt(fakeName)
+
+            // Then
+            assertThat(result).isEqualTo(Integer.MIN_VALUE)
+            mockInternalLogger.verifyLog(
+                level = InternalLogger.Level.WARN,
+                target = InternalLogger.Target.MAINTAINER,
+                message = "Problem retrieving system value for $fakeName",
+                throwableClass = IllegalArgumentException::class.java
+            )
+        }
+    }
+
+    @Test
+    fun `M return MIN_VALUE and log W getInt() { SecurityException thrown by ContentProvider }`() {
+        // Given
+        val fakeName = Settings.System.SCREEN_BRIGHTNESS
+
+        Mockito.mockStatic(Settings.System::class.java).use { mockedSettings ->
+            mockedSettings.`when`<Int> {
+                Settings.System.getInt(mockContentResolver, fakeName)
+            }.thenThrow(SecurityException("permission denied"))
+
+            // When
+            val result = testedWrapper.getInt(fakeName)
+
+            // Then
+            assertThat(result).isEqualTo(Integer.MIN_VALUE)
+            mockInternalLogger.verifyLog(
+                level = InternalLogger.Level.WARN,
+                target = InternalLogger.Target.MAINTAINER,
+                message = "Problem retrieving system value for $fakeName",
+                throwableClass = SecurityException::class.java
+            )
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Catches `RuntimeException` in `SystemSettingsWrapper.getInt()` in addition to the already-handled `Settings.SettingNotFoundException`.

### Motivation

`Settings.System.getInt()` can throw `IllegalArgumentException` (a `RuntimeException`) when the internal `MemoryIntArray` backing the Settings cache fails to unparcel.

Some links in AOSP to illustrate how this might happen:
- [`MemoryIntArray.java`](https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/util/MemoryIntArray.java;l=250)
- [`Settings.java` — `NameValueCache.getStringForUser()`](https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/provider/Settings.java;l=3712)

**Stacktrace:**

This error is visible in Error Tracking.

```
java.lang.IllegalArgumentException: Error unparceling MemoryIntArray
    at android.util.MemoryIntArray$1.createFromParcel(MemoryIntArray.java:250)
    at android.util.MemoryIntArray$1.createFromParcel(MemoryIntArray.java:244)
    at android.os.Parcel.readParcelableInternal(Parcel.java:5214)
    at android.os.Parcel.readValue(Parcel.java:4965)
    at android.os.BaseBundle.getValueAt(BaseBundle.java:426)
    at android.os.Bundle.getParcelable(Bundle.java:1121)
    at android.provider.Settings$NameValueCache.getStringForUser(Settings.java:3734)
    at android.provider.Settings$System.getStringForUser(Settings.java:4337)
    at android.provider.Settings$System.getIntForUser(Settings.java:4553)
    at android.provider.Settings$System.getInt(Settings.java:4546)
    at com.datadog.android.rum.internal.domain.display.SystemSettingsWrapper.getInt(SystemSettingsWrapper.java:19)
    at com.datadog.android.rum.internal.domain.display.DefaultDisplayInfoProvider$brightnessObserver$1.onChange(DefaultDisplayInfoProvider.kt:36)
    ...
```