### PR TITLE
RUM-17226: Prevent profiling on package versions producing empty profiles

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/NoOpProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/NoOpProfiler.kt
@@ -41,7 +41,7 @@ internal class NoOpProfiler : Profiler {
 
     override fun setExtendLaunchSession(extend: Boolean) = Unit
 
-    override fun setProfilingPackageVersionCode(versionCode: Long) = Unit
+    override fun resolveProfilingPackageVersionCode(appContext: Context) = Unit
 
     class NoOpScheduledExecutorService : ScheduledExecutorService {
         override fun schedule(

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/Profiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/Profiler.kt
@@ -41,5 +41,11 @@ internal interface Profiler {
      */
     fun setExtendLaunchSession(extend: Boolean)
 
-    fun setProfilingPackageVersionCode(versionCode: Long)
+    /**
+     * Resolves the version of the profiling system package, if it is not known yet, and keeps it
+     * for the whole process lifetime. The profiler can be started before the SDK is initialized,
+     * so it resolves the version on its own; this only makes sure it is also known when profiling
+     * never starts.
+     */
+    fun resolveProfilingPackageVersionCode(appContext: Context)
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -93,11 +93,11 @@ internal class ProfilingFeature(
     override fun onInitialize(appContext: Context) {
         this.appContext = appContext
         profiler.apply {
-            this.internalLogger = sdkCore.internalLogger
             this.timeProvider.delegate = sdkCore.timeProvider
             setProfilingPackageVersionCode(
                 appContext.packageManager.getProfilingModuleLongVersionCode(sdkCore.internalLogger)
             )
+            this.internalLogger = sdkCore.internalLogger
             registerProfilingCallback(appContext, this@ProfilingFeature)
         }
         ProfilingStorage.setSampleRate(appContext, configuration.applicationLaunchSampleRate)

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -31,7 +31,6 @@ import com.datadog.android.profiling.internal.quota.NoOpQuotaChecker
 import com.datadog.android.profiling.internal.quota.ProfilingQuotaChecker
 import com.datadog.android.profiling.internal.quota.QuotaChecker
 import com.datadog.android.profiling.internal.quota.QuotaResult
-import com.datadog.android.profiling.internal.utils.getProfilingModuleLongVersionCode
 import java.util.Locale
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
@@ -94,9 +93,7 @@ internal class ProfilingFeature(
         this.appContext = appContext
         profiler.apply {
             this.timeProvider.delegate = sdkCore.timeProvider
-            setProfilingPackageVersionCode(
-                appContext.packageManager.getProfilingModuleLongVersionCode(sdkCore.internalLogger)
-            )
+            resolveProfilingPackageVersionCode(appContext)
             this.internalLogger = sdkCore.internalLogger
             registerProfilingCallback(appContext, this@ProfilingFeature)
         }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
@@ -27,6 +27,8 @@ import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetry
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetryEvent
 import com.datadog.android.profiling.internal.time.MutableTimeProvider
 import com.datadog.android.profiling.internal.utils.fileSizeSafe
+import com.datadog.android.profiling.internal.utils.getProfilingModuleLongVersionCode
+import com.datadog.android.profiling.internal.utils.isProfilingModuleVersionBlocked
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -62,6 +64,14 @@ internal class PerfettoProfiler(
 
     // Whether a profiling session is currently running.
     private val isRunning: AtomicBoolean = AtomicBoolean(false)
+
+    // Whether the blocked system package version was already reported (reported once per process).
+    private val isBlockedReported: AtomicBoolean = AtomicBoolean(false)
+
+    @Volatile
+    private var isPackageVersionResolved = false
+
+    private val packageVersionLock = Any()
 
     @Volatile
     private var profilingStartTime = 0L
@@ -184,6 +194,13 @@ internal class PerfettoProfiler(
     ) {
         val effectiveDurationMs =
             if (durationMs > 0) durationMs else getDefaultDurationMs(startReason)
+        if (isProfilingModuleVersionBlocked(profilingPackageVersionCode(appContext))) {
+            if (isBlockedReported.compareAndSet(false, true)) {
+                profilingTelemetry.report(ProfilingTelemetryEvent.Blocked(startReason.value))
+            }
+            callback?.onFailure(startReason)
+            return
+        }
         // profiling will be launched when no session is currently running.
         if (isRunning.compareAndSet(false, true)) {
             profilingStartTime = timeProvider.getDeviceTimestampMillis()
@@ -255,8 +272,23 @@ internal class PerfettoProfiler(
         this.extendLaunchSession = extend
     }
 
-    override fun setProfilingPackageVersionCode(versionCode: Long) {
-        profilingTelemetry.profilingPackageVersionCode = versionCode
+    override fun resolveProfilingPackageVersionCode(appContext: Context) {
+        profilingPackageVersionCode(appContext)
+    }
+
+    private fun profilingPackageVersionCode(appContext: Context): Long {
+        if (!isPackageVersionResolved) {
+            synchronized(packageVersionLock) {
+                if (!isPackageVersionResolved) {
+                    profilingTelemetry.profilingPackageVersionCode =
+                        appContext.packageManager.getProfilingModuleLongVersionCode(
+                            internalLogger ?: InternalLogger.UNBOUND
+                        )
+                    isPackageVersionResolved = true
+                }
+            }
+        }
+        return profilingTelemetry.profilingPackageVersionCode
     }
 
     private fun resolveStopReason(errorCode: Int): String {

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/telemetry/ProfilingTelemetry.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/telemetry/ProfilingTelemetry.kt
@@ -51,6 +51,7 @@ internal class ProfilingTelemetry {
         when (event) {
             is ProfilingTelemetryEvent.SessionEnd -> dispatchSessionEnd(logger, event)
             is ProfilingTelemetryEvent.AnrTriggerResult -> dispatchAnrTriggerResult(logger, event)
+            is ProfilingTelemetryEvent.Blocked -> dispatchBlocked(logger, event)
         }
     }
 
@@ -76,6 +77,25 @@ internal class ProfilingTelemetry {
                 KEY_PROFILING_CONFIG to mapOf(
                     KEY_BUFFER_SIZE to event.bufferSizeKb,
                     KEY_SAMPLING_FREQUENCY to event.samplingFrequencyHz,
+                    KEY_PROFILING_PACKAGE_VERSION_CODE to profilingPackageVersionCode
+                )
+            ),
+            samplingRate = MethodCallSamplingRate.ALL.rate
+        )
+    }
+
+    private fun dispatchBlocked(
+        logger: InternalLogger,
+        event: ProfilingTelemetryEvent.Blocked
+    ) {
+        logger.logMetric(
+            messageBuilder = { TELEMETRY_MSG_PROFILING_SESSION },
+            additionalProperties = mapOf(
+                KEY_METRIC_TYPE to METRIC_TYPE_PROFILING_BLOCKED,
+                KEY_PROFILING_SESSION to mapOf(
+                    KEY_START_REASON to event.startReason
+                ),
+                KEY_PROFILING_CONFIG to mapOf(
                     KEY_PROFILING_PACKAGE_VERSION_CODE to profilingPackageVersionCode
                 )
             ),
@@ -131,6 +151,7 @@ internal class ProfilingTelemetry {
 
         internal const val METRIC_TYPE_PROFILING_SESSION = "profiling session"
         internal const val METRIC_TYPE_PROFILING_TRIGGER = "profiling trigger"
+        internal const val METRIC_TYPE_PROFILING_BLOCKED = "profiling blocked"
         internal const val ANR_PROFILING_TRIGGER_START_REASON = "anr_profiling_trigger"
 
         internal const val STOPPED_REASON_MANUAL = "manual"

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/telemetry/ProfilingTelemetryEvent.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/telemetry/ProfilingTelemetryEvent.kt
@@ -22,6 +22,10 @@ internal sealed class ProfilingTelemetryEvent {
         val samplingFrequencyHz: Int
     ) : ProfilingTelemetryEvent()
 
+    data class Blocked(
+        val startReason: String
+    ) : ProfilingTelemetryEvent()
+
     data class AnrTriggerResult(
         val errorCode: Int,
         val errorMessage: String?,

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/utils/ProfilingModuleBlocklist.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/utils/ProfilingModuleBlocklist.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling.internal.utils
+
+/**
+ * Version of the `com.google.android.profiling` system package known to be broken: profiling
+ * requests succeed but the recorded traces are empty, so there is nothing to report.
+ */
+private const val EMPTY_TRACE_MODULE_VERSION_CODE = 370546200L
+
+/**
+ * Whether profiling must not be started at all because the device runs a broken version of the
+ * profiling system package. Additional versions can be added to the check as they are found.
+ */
+internal fun isProfilingModuleVersionBlocked(versionCode: Long): Boolean {
+    return versionCode == EMPTY_TRACE_MODULE_VERSION_CODE
+}

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -75,6 +75,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -262,6 +263,31 @@ internal class ProfilingFeatureTest {
         // Then
         verify(mockProfiler).internalLogger = mockInternalLogger
         verify(mockProfiler.timeProvider).delegate = mockTimeProvider
+    }
+
+    @Test
+    fun `M query the package manager once W start() then initialize()`() {
+        // Given a profiler already started by the content provider, before initialization
+        val profiler = PerfettoProfiler(
+            timeProvider = MutableTimeProvider.create(mockTimeProvider),
+            scheduledExecutorService = mockSchedulerExecutor,
+            profilingTelemetry = ProfilingTelemetry(),
+            anrTriggerRegistrar = mockAnrTriggerRegistrar,
+            buildSdkVersionProvider = mockBuildSdkVersionProvider
+        )
+        val feature = ProfilingFeature(
+            sdkCore = mockSdkCore,
+            configuration = fakeConfiguration.copy(continuousSampleRate = 0f),
+            profiler = profiler
+        )
+        profiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
+
+        // When
+        feature.onInitialize(mockContext)
+
+        // Then
+        verify(mockPackageManager, times(1))
+            .getPackageInfo("com.google.android.profiling", PackageManager.MATCH_APEX)
     }
 
     @Test

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -16,6 +16,7 @@ import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.core.sampling.DeterministicSampler
 import com.datadog.android.internal.FeatureContextKeys
 import com.datadog.android.internal.data.SharedPreferencesStorage
@@ -23,6 +24,7 @@ import com.datadog.android.internal.profiling.ProfilerEvent
 import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 import com.datadog.android.internal.rum.RumSessionConstants
 import com.datadog.android.internal.sampling.SessionSamplingIdProvider
+import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.profiling.forge.Configurator
 import com.datadog.android.profiling.internal.Profiler
@@ -32,11 +34,15 @@ import com.datadog.android.profiling.internal.ProfilingRequestFactory
 import com.datadog.android.profiling.internal.ProfilingStartReason
 import com.datadog.android.profiling.internal.ProfilingStorage
 import com.datadog.android.profiling.internal.ProfilingWriter
+import com.datadog.android.profiling.internal.anr.AnrTriggerRegistrar
+import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 import com.datadog.android.profiling.internal.quota.NoOpQuotaChecker
 import com.datadog.android.profiling.internal.quota.QuotaChecker
 import com.datadog.android.profiling.internal.quota.QuotaReason
 import com.datadog.android.profiling.internal.quota.QuotaResult
+import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetry
+import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetryEvent
 import com.datadog.android.profiling.internal.time.MutableTimeProvider
 import com.datadog.android.profiling.utils.config.MainLooperTestConfiguration
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
@@ -45,6 +51,7 @@ import com.datadog.tools.unit.extensions.config.TestConfiguration
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.FloatForgery
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -141,6 +148,12 @@ internal class ProfilingFeatureTest {
 
     @Mock
     private lateinit var mockPackageManager: PackageManager
+
+    @Mock
+    private lateinit var mockAnrTriggerRegistrar: AnrTriggerRegistrar
+
+    @Mock
+    private lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
 
     @Forgery
     private lateinit var fakeConfiguration: ProfilingConfiguration
@@ -249,6 +262,59 @@ internal class ProfilingFeatureTest {
         // Then
         verify(mockProfiler).internalLogger = mockInternalLogger
         verify(mockProfiler.timeProvider).delegate = mockTimeProvider
+    }
+
+    @Test
+    fun `M report the package version code W initialize() {telemetry reported before init}`(
+        @IntForgery(min = 1, max = 8) fakeErrorCode: Int,
+        @StringForgery fakeErrorMessage: String
+    ) {
+        // Given a profiling session that ended before the SDK was initialized: the profiler has
+        // no logger yet, so its telemetry is buffered and only dispatched on initialization.
+        val profilingTelemetry = ProfilingTelemetry()
+        val profiler = PerfettoProfiler(
+            timeProvider = MutableTimeProvider.create(mockTimeProvider),
+            scheduledExecutorService = mockSchedulerExecutor,
+            profilingTelemetry = profilingTelemetry,
+            anrTriggerRegistrar = mockAnrTriggerRegistrar,
+            buildSdkVersionProvider = mockBuildSdkVersionProvider
+        )
+        profilingTelemetry.report(
+            ProfilingTelemetryEvent.SessionEnd(
+                startReason = ProfilingStartReason.APPLICATION_LAUNCH.value,
+                appStartInfo = null,
+                errorCode = fakeErrorCode,
+                errorMessage = fakeErrorMessage,
+                fileSize = 0L,
+                durationMs = 0L,
+                resultCallbackDelayMs = 0L,
+                clientClockDriftMs = 0L,
+                stopReason = ProfilingTelemetry.STOPPED_REASON_ERROR,
+                bufferSizeKb = 0,
+                samplingFrequencyHz = 0
+            )
+        )
+        val feature = ProfilingFeature(
+            sdkCore = mockSdkCore,
+            // continuous profiling disabled, so initialization doesn't schedule anything
+            configuration = fakeConfiguration.copy(continuousSampleRate = 0f),
+            profiler = profiler
+        )
+
+        // When
+        feature.onInitialize(mockContext)
+
+        // Then
+        val propertiesCaptor = argumentCaptor<Map<String, Any?>>()
+        verify(mockInternalLogger).logMetric(
+            any(),
+            propertiesCaptor.capture(),
+            eq(MethodCallSamplingRate.ALL.rate),
+            isNull()
+        )
+        val profilingConfig = propertiesCaptor.firstValue["profiling_config"] as Map<*, *>
+        assertThat(profilingConfig["profiling_package_version_code"])
+            .isEqualTo(fakeProfilingPackageVersionCode)
     }
 
     @Test

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.profiling
 
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.ProfilingManager
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.InternalSdkCore
@@ -66,6 +67,9 @@ class ProfilingTest {
     private lateinit var mockContext: Context
 
     @Mock
+    private lateinit var mockPackageManager: PackageManager
+
+    @Mock
     private lateinit var mockProfilingExecutor: ExecutorService
 
     @Mock
@@ -86,6 +90,7 @@ class ProfilingTest {
         whenever(mockSdkCore.name) doReturn fakeInstanceName
         whenever(mockSdkCore.createSingleThreadExecutorService(any())) doReturn mockProfilingExecutor
         whenever(mockContext.getSystemService(ProfilingManager::class.java)) doReturn mockProfilingManager
+        whenever(mockContext.packageManager) doReturn mockPackageManager
         ProfilingStorage.sharedPreferencesStorage = mockSharedPreferencesStorage
     }
 

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -7,6 +7,8 @@
 package com.datadog.android.profiling.internal
 
 import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.os.CancellationSignal
 import android.os.ProfilingManager
@@ -44,7 +46,9 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
@@ -58,6 +62,7 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
@@ -75,6 +80,9 @@ class PerfettoProfilerTest {
 
     @Mock
     private lateinit var mockService: ProfilingManager
+
+    @Mock
+    private lateinit var mockPackageManager: PackageManager
 
     @Mock
     private lateinit var mockInternalLogger: InternalLogger
@@ -109,6 +117,8 @@ class PerfettoProfilerTest {
     @BeforeEach
     fun `set up`() {
         whenever(mockContext.getSystemService(ProfilingManager::class.java)).doReturn(mockService)
+        whenever(mockContext.packageManager) doReturn mockPackageManager
+        stubProfilingModuleVersionCode(fakeProfilingPackageLongVersionCode)
         // ANR registration is only delegated on BAKLAVA+; opt-in for tests.
         whenever(mockBuildSdkVersionProvider.isAtLeastBaklava) doReturn true
         testedProfiler = PerfettoProfiler(
@@ -1086,6 +1096,187 @@ class PerfettoProfilerTest {
     }
 
     // endregion
+
+    // region blocked profiling module version
+
+    @Test
+    fun `M not request profiling W start() {blocked profiling module version}`() {
+        // Given
+        stubProfilingModuleVersionCode(BLOCKED_VERSION_CODE)
+
+        // When
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
+
+        // Then
+        verify(mockService, never()).requestProfiling(any(), any(), any(), any(), any(), any())
+        assertThat(testedProfiler.isRunning()).isFalse()
+    }
+
+    @Test
+    fun `M notify failure W start() {blocked profiling module version}`() {
+        // Given
+        stubProfilingModuleVersionCode(BLOCKED_VERSION_CODE)
+
+        // When
+        testedProfiler.start(mockContext, ProfilingStartReason.CONTINUOUS, emptyMap())
+
+        // Then no result callback will ever fire, so the caller must be told the window is over.
+        verify(mockProfilerCallback).onFailure(ProfilingStartReason.CONTINUOUS)
+        verifyNoMoreInteractions(mockProfilerCallback)
+    }
+
+    @Test
+    fun `M report blocked telemetry W start() {blocked profiling module version}`() {
+        // Given
+        stubProfilingModuleVersionCode(BLOCKED_VERSION_CODE)
+
+        // When
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
+
+        // Then
+        val messageCaptor = argumentCaptor<() -> String>()
+        val expectedProps = mapOf(
+            "metric_type" to "profiling blocked",
+            "profiling_session" to mapOf(
+                "start_reason" to ProfilingStartReason.APPLICATION_LAUNCH.value
+            ),
+            "profiling_config" to mapOf(
+                "profiling_package_version_code" to BLOCKED_VERSION_CODE
+            )
+        )
+        verify(mockInternalLogger).logMetric(
+            messageCaptor.capture(),
+            eq(expectedProps),
+            eq(MethodCallSamplingRate.ALL.rate),
+            isNull()
+        )
+        assertThat(messageCaptor.firstValue.invoke()).isEqualTo("[Mobile Metric] Profiling Session")
+    }
+
+    @Test
+    fun `M report blocked telemetry only once W start() {blocked version, several calls}`(
+        forge: Forge
+    ) {
+        // Given
+        stubProfilingModuleVersionCode(BLOCKED_VERSION_CODE)
+
+        // When
+        repeat(forge.anInt(min = 2, max = 5)) {
+            testedProfiler.start(mockContext, ProfilingStartReason.CONTINUOUS, emptyMap())
+        }
+
+        // Then
+        verify(mockInternalLogger).logMetric(any(), any(), any(), anyOrNull())
+    }
+
+    @Test
+    fun `M report blocked telemetry with version code W start() {blocked version, before init}`() {
+        // Given a profiler started from the content provider, before the SDK is initialized:
+        // no logger is attached yet and the version code was never pushed by the feature.
+        val profiler = PerfettoProfiler(
+            timeProvider = stubTimeProvider,
+            scheduledExecutorService = mockExecutorService,
+            anrTriggerRegistrar = mockAnrRegistrar,
+            buildSdkVersionProvider = mockBuildSdkVersionProvider,
+            profilingTelemetry = ProfilingTelemetry()
+        )
+        stubProfilingModuleVersionCode(BLOCKED_VERSION_CODE)
+
+        // When
+        profiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
+        profiler.internalLogger = mockInternalLogger
+
+        // Then
+        val propertiesCaptor = argumentCaptor<Map<String, Any?>>()
+        verify(mockInternalLogger).logMetric(
+            any(),
+            propertiesCaptor.capture(),
+            eq(MethodCallSamplingRate.ALL.rate),
+            isNull()
+        )
+        val profilingConfig = propertiesCaptor.firstValue["profiling_config"] as Map<*, *>
+        assertThat(profilingConfig["profiling_package_version_code"])
+            .isEqualTo(BLOCKED_VERSION_CODE)
+    }
+
+    @Test
+    fun `M request profiling W start() {profiling module version is not blocked}`() {
+        // Given
+        stubProfilingModuleVersionCode(fakeProfilingPackageLongVersionCode)
+
+        // When
+        testedProfiler.start(mockContext, ProfilingStartReason.APPLICATION_LAUNCH, emptyMap())
+
+        // Then
+        verify(mockService).requestProfiling(any(), any(), any(), any(), any(), any())
+    }
+
+    // endregion
+
+    // region profiling module version resolution
+
+    @Test
+    fun `M query the package manager once W resolveProfilingPackageVersionCode() {concurrent}`() {
+        // Given a lookup that is already in flight when a second caller arrives: the profiler is
+        // shared between the content provider, the scheduler executor and the SDK initialization.
+        val lookupStarted = CountDownLatch(1)
+        val releaseLookup = CountDownLatch(1)
+        val mockPackageInfo = mock<PackageInfo> {
+            on { longVersionCode } doReturn fakeProfilingPackageLongVersionCode
+        }
+        whenever(
+            mockPackageManager.getPackageInfo(
+                "com.google.android.profiling",
+                PackageManager.MATCH_APEX
+            )
+        ) doAnswer {
+            lookupStarted.countDown()
+            releaseLookup.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            mockPackageInfo
+        }
+        val firstCaller = Thread { testedProfiler.resolveProfilingPackageVersionCode(mockContext) }
+        val secondCaller = Thread { testedProfiler.resolveProfilingPackageVersionCode(mockContext) }
+
+        // When
+        firstCaller.start()
+        check(lookupStarted.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)) { "lookup never started" }
+        secondCaller.start()
+        Thread.sleep(CONTENTION_WINDOW_MS)
+        releaseLookup.countDown()
+        firstCaller.join(JOIN_TIMEOUT_MS)
+        secondCaller.join(JOIN_TIMEOUT_MS)
+
+        // Then
+        verify(mockPackageManager)
+            .getPackageInfo("com.google.android.profiling", PackageManager.MATCH_APEX)
+        assertThat(testedProfiler.profilingTelemetry.profilingPackageVersionCode)
+            .isEqualTo(fakeProfilingPackageLongVersionCode)
+    }
+
+    // endregion
+
+    private fun stubProfilingModuleVersionCode(versionCode: Long) {
+        val mockPackageInfo = mock<PackageInfo> {
+            on { longVersionCode } doReturn versionCode
+        }
+        whenever(
+            mockPackageManager.getPackageInfo(
+                "com.google.android.profiling",
+                PackageManager.MATCH_APEX
+            )
+        ) doReturn mockPackageInfo
+    }
+
+    companion object {
+        // Version of the profiling system package known to produce empty profiles.
+        private const val BLOCKED_VERSION_CODE = 370546200L
+
+        private const val LATCH_TIMEOUT_SECONDS = 5L
+        private const val JOIN_TIMEOUT_MS = 5000L
+
+        // Time left to the second caller to reach the lookup while the first one holds it.
+        private const val CONTENTION_WINDOW_MS = 200L
+    }
 
     private class StubTimeProvider : MutableTimeProvider {
         // not really used


### PR DESCRIPTION
### What does this PR do?

1. Fixes `profiling_package_version_code` being reported as 0. `ProfilingTelemetry` buffers events until an `InternalLogger` is attached, and `ProfilingFeature.onInitialize` attached the logger before setting the version code — so every event buffered before initialization (typically the app-launch session started by `DdProfilingContentProvider`) flushed with 0. The version is now resolved first, and the `PackageManager` lookup moved into the profiler so it happens at most once per process regardless of whether the content provider or the SDK initialization gets there first.
2. Stops profiling on system package version `370546200`, which records empty traces. The check sits in `PerfettoProfiler.start()` — the single choke point covering the pre-init content-provider launch, the continuous scheduler and RUM-triggered starts — and emits one "profiling blocked" telemetry event per process carrying the offending version code.

### Motivation

RUM-17226
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

