### PR TITLE
RUM-17139: Fix gesture target selection for elevated views

### DIFF
--- a/detekt_custom_safe_calls_android.yml
+++ b/detekt_custom_safe_calls_android.yml
@@ -140,7 +140,6 @@ datadog:
       - "android.view.ViewGroup.addView(android.view.View?, android.view.ViewGroup.LayoutParams?)"
       - "android.view.ViewGroup.findViewById(kotlin.Int)"
       - "android.view.ViewGroup.getChildAt(kotlin.Int)"
-      - "android.view.ViewGroup.indexOfChild(android.view.View?)"
       - "android.view.ViewGroup.LayoutParams.constructor(kotlin.Int, kotlin.Int)"
       - "android.view.ViewGroup.removeView(android.view.View?)"
       - "android.view.ViewPropertyAnimator.alpha(kotlin.Float)"

--- a/detekt_custom_safe_calls_android.yml
+++ b/detekt_custom_safe_calls_android.yml
@@ -140,6 +140,7 @@ datadog:
       - "android.view.ViewGroup.addView(android.view.View?, android.view.ViewGroup.LayoutParams?)"
       - "android.view.ViewGroup.findViewById(kotlin.Int)"
       - "android.view.ViewGroup.getChildAt(kotlin.Int)"
+      - "android.view.ViewGroup.indexOfChild(android.view.View?)"
       - "android.view.ViewGroup.LayoutParams.constructor(kotlin.Int, kotlin.Int)"
       - "android.view.ViewGroup.removeView(android.view.View?)"
       - "android.view.ViewPropertyAnimator.alpha(kotlin.Float)"

--- a/detekt_custom_safe_calls_third_party.yml
+++ b/detekt_custom_safe_calls_third_party.yml
@@ -984,6 +984,7 @@ datadog:
       - "kotlin.comparisons.maxOf(kotlin.Float, kotlin.Float)"
       - "kotlin.comparisons.maxOf(kotlin.Long, kotlin.Long)"
       - "kotlin.comparisons.minOf(kotlin.Float, kotlin.Float)"
+      - "kotlin.comparisons.minOf(kotlin.Int, kotlin.Int)"
       - "kotlin.comparisons.minOf(kotlin.Long, kotlin.Long)"
       - "kotlin.ranges.IntRange.all(kotlin.Function1)"
       - "kotlin.ranges.IntRange.map(kotlin.Function1)"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
@@ -147,7 +147,7 @@ internal class GesturesListener(
         @Suppress("UnsafeThirdPartyFunctionCall")
         queue.add(0, decorView)
         var scrollTarget: ViewTarget? = null
-        var tapTarget: LocatedTapTarget? = null
+        val tapTargetSelector = TapTargetSelector()
         var composeViewDetected = false
         while (queue.isNotEmpty()) {
             // removeAt(index) instead of removeFirst here is on purpose, to prevent issues
@@ -165,10 +165,7 @@ internal class GesturesListener(
                 if (isScroll) {
                     scrollTarget = newTarget
                 } else {
-                    tapTarget = selectTapTarget(
-                        tapTarget,
-                        LocatedTapTarget(newTarget, view)
-                    )
+                    tapTargetSelector.considerCandidate(newTarget, view)
                 }
             }
             if (view.isVisible && view is ViewGroup) {
@@ -179,7 +176,7 @@ internal class GesturesListener(
             }
         }
 
-        val target = scrollTarget ?: tapTarget?.target
+        val target = scrollTarget ?: tapTargetSelector.selectedTarget
         if (target == null) {
             val msg = if (composeViewDetected) {
                 MSG_NO_COMPOSE_TARGET
@@ -194,94 +191,6 @@ internal class GesturesListener(
         }
         return target
     }
-
-    private fun selectTapTarget(
-        currentTarget: LocatedTapTarget?,
-        candidateTarget: LocatedTapTarget
-    ): LocatedTapTarget {
-        return when {
-            currentTarget == null -> candidateTarget
-            currentTarget.hostView.isPreferredTapTargetOver(candidateTarget.hostView) -> currentTarget
-            else -> candidateTarget
-        }
-    }
-
-    private fun View.isPreferredTapTargetOver(candidateView: View): Boolean {
-        val currentPath = pathFromRoot()
-        val candidatePath = candidateView.pathFromRoot()
-        val commonPathSize = currentPath.commonPathSizeWith(candidatePath)
-        val viewsAreDisconnected = commonPathSize == 0
-        val currentIsSameOrAncestor = commonPathSize == currentPath.size
-        val candidateIsAncestor = commonPathSize == candidatePath.size
-
-        return when {
-            viewsAreDisconnected -> false
-            // Within the same branch, prefer the deepest clickable view. An ancestor's Z does not
-            // place it in front of its own descendants.
-            currentIsSameOrAncestor -> false
-            candidateIsAncestor -> true
-            else -> currentPath.isBranchDrawnOnTopOf(candidatePath, commonPathSize)
-        }
-    }
-
-    private fun List<View>.commonPathSizeWith(otherPath: List<View>): Int {
-        val maximumCommonPathSize = minOf(size, otherPath.size)
-        var commonPathSize = 0
-        while (
-            commonPathSize < maximumCommonPathSize &&
-            this[commonPathSize] === otherPath[commonPathSize]
-        ) {
-            commonPathSize++
-        }
-        return commonPathSize
-    }
-
-    private fun List<View>.isBranchDrawnOnTopOf(
-        candidatePath: List<View>,
-        commonPathSize: Int
-    ): Boolean {
-        val divergingBranchIndex = commonPathSize
-        val commonParent = this[divergingBranchIndex - 1] as? ViewGroup ?: return false
-        val currentBranch = this[divergingBranchIndex]
-        val candidateBranch = candidatePath[divergingBranchIndex]
-
-        // Target depth and Z within each branch are irrelevant after the paths diverge. Android
-        // draws the two sibling branches as units, so their ordering decides which target is on top.
-        return currentBranch.isDrawnOnTopOf(candidateBranch, commonParent)
-    }
-
-    private fun View.isDrawnOnTopOf(candidateView: View, parent: ViewGroup): Boolean {
-        return when {
-            z > candidateView.z -> true
-            z < candidateView.z -> false
-            // Both comparisons are also false for NaN, matching Android's child-order fallback.
-            else -> parent.isChildDrawnAfter(this, candidateView)
-        }
-    }
-
-    private fun ViewGroup.isChildDrawnAfter(child: View, candidateChild: View): Boolean {
-        val childIndex = indexOfChild(child)
-        val candidateChildIndex = indexOfChild(candidateChild)
-        return childIndex >= 0 && candidateChildIndex >= 0 && childIndex > candidateChildIndex
-    }
-
-    private fun View.pathFromRoot(): List<View> {
-        val path = mutableListOf<View>()
-        var current: View? = this
-        while (current != null) {
-            path += current
-            current = current.parent as? View
-        }
-        // path is backed by mutableListOf, so reverse cannot encounter an immutable implementation.
-        @Suppress("UnsafeThirdPartyFunctionCall")
-        path.reverse()
-        return path
-    }
-
-    private data class LocatedTapTarget(
-        val target: ViewTarget,
-        val hostView: View
-    )
 
     private fun findTargetForScroll(view: View, x: Float, y: Float): ViewTarget? {
         // return bottom-most scrollable element

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
@@ -161,7 +161,7 @@ internal class GesturesListener(
                 findTargetForTap(view, x, y)
             }
             if (newTarget != null) {
-                target = newTarget
+                target = if (isScroll) newTarget else selectTapTarget(target, newTarget)
             }
             if (view.isVisible && view is ViewGroup) {
                 for (i in 0 until view.childCount) {
@@ -184,6 +184,92 @@ internal class GesturesListener(
             )
         }
         return target
+    }
+
+    private fun selectTapTarget(currentTarget: ViewTarget?, candidateTarget: ViewTarget): ViewTarget {
+        val currentView = currentTarget?.viewRef?.get()
+        val candidateView = candidateTarget.viewRef.get()
+        if (currentTarget == null || currentView == null || candidateView == null) {
+            return candidateTarget
+        }
+
+        return if (currentView.isPreferredTapTargetOver(candidateView)) {
+            currentTarget
+        } else {
+            candidateTarget
+        }
+    }
+
+    private fun View.isPreferredTapTargetOver(candidateView: View): Boolean {
+        val currentPath = pathFromRoot()
+        val candidatePath = candidateView.pathFromRoot()
+        val commonPathSize = currentPath.commonPathSizeWith(candidatePath)
+        val viewsAreDisconnected = commonPathSize == 0
+        val currentIsSameOrAncestor = commonPathSize == currentPath.size
+        val candidateIsAncestor = commonPathSize == candidatePath.size
+
+        return when {
+            viewsAreDisconnected -> false
+            // Within the same branch, prefer the deepest clickable view. An ancestor's Z does not
+            // place it in front of its own descendants.
+            currentIsSameOrAncestor -> false
+            candidateIsAncestor -> true
+            else -> currentPath.isBranchDrawnOnTopOf(candidatePath, commonPathSize)
+        }
+    }
+
+    private fun List<View>.commonPathSizeWith(otherPath: List<View>): Int {
+        val maximumCommonPathSize = minOf(size, otherPath.size)
+        var commonPathSize = 0
+        while (
+            commonPathSize < maximumCommonPathSize &&
+            this[commonPathSize] === otherPath[commonPathSize]
+        ) {
+            commonPathSize++
+        }
+        return commonPathSize
+    }
+
+    private fun List<View>.isBranchDrawnOnTopOf(
+        candidatePath: List<View>,
+        commonPathSize: Int
+    ): Boolean {
+        val divergingBranchIndex = commonPathSize
+        val commonParent = this[divergingBranchIndex - 1] as? ViewGroup ?: return false
+        val currentBranch = this[divergingBranchIndex]
+        val candidateBranch = candidatePath[divergingBranchIndex]
+
+        // Target depth and Z within each branch are irrelevant after the paths diverge. Android
+        // draws the two sibling branches as units, so their ordering decides which target is on top.
+        return currentBranch.isDrawnOnTopOf(candidateBranch, commonParent)
+    }
+
+    private fun View.isDrawnOnTopOf(candidateView: View, parent: ViewGroup): Boolean {
+        return when {
+            z > candidateView.z -> true
+            z < candidateView.z -> false
+            // Both comparisons are also false for NaN, matching Android's child-order fallback.
+            else -> parent.isChildDrawnAfter(this, candidateView)
+        }
+    }
+
+    private fun ViewGroup.isChildDrawnAfter(child: View, candidateChild: View): Boolean {
+        val childIndex = indexOfChild(child)
+        val candidateChildIndex = indexOfChild(candidateChild)
+        return childIndex >= 0 && candidateChildIndex >= 0 && childIndex > candidateChildIndex
+    }
+
+    private fun View.pathFromRoot(): List<View> {
+        val path = mutableListOf<View>()
+        var current: View? = this
+        while (current != null) {
+            path += current
+            current = current.parent as? View
+        }
+        // path is backed by mutableListOf, so reverse cannot encounter an immutable implementation.
+        @Suppress("UnsafeThirdPartyFunctionCall")
+        path.reverse()
+        return path
     }
 
     private fun findTargetForScroll(view: View, x: Float, y: Float): ViewTarget? {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
@@ -51,6 +51,7 @@ internal class GesturesListener(
     private var onTouchDownYPos = 0f
 
     private val tapLocationBuffer = IntArray(2)
+    private val tapTargetSelector = TapTargetSelector()
 
     // region GesturesListener
 
@@ -146,8 +147,9 @@ internal class GesturesListener(
         // Index 0 is always safe
         @Suppress("UnsafeThirdPartyFunctionCall")
         queue.add(0, decorView)
+        var tapTarget: ViewTarget? = null
+        var tapTargetHost: View? = null
         var scrollTarget: ViewTarget? = null
-        val tapTargetSelector = TapTargetSelector()
         var composeViewDetected = false
         while (queue.isNotEmpty()) {
             // removeAt(index) instead of removeFirst here is on purpose, to prevent issues
@@ -164,8 +166,9 @@ internal class GesturesListener(
             if (newTarget != null) {
                 if (isScroll) {
                     scrollTarget = newTarget
-                } else {
-                    tapTargetSelector.considerCandidate(newTarget, view)
+                } else if (tapTargetSelector.shouldSelectCandidate(tapTargetHost, view)) {
+                    tapTarget = newTarget
+                    tapTargetHost = view
                 }
             }
             if (view.isVisible && view is ViewGroup) {
@@ -176,7 +179,7 @@ internal class GesturesListener(
             }
         }
 
-        val target = scrollTarget ?: tapTargetSelector.selectedTarget
+        val target = scrollTarget ?: tapTarget
         if (target == null) {
             val msg = if (composeViewDetected) {
                 MSG_NO_COMPOSE_TARGET

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
@@ -146,7 +146,8 @@ internal class GesturesListener(
         // Index 0 is always safe
         @Suppress("UnsafeThirdPartyFunctionCall")
         queue.add(0, decorView)
-        var target: ViewTarget? = null
+        var scrollTarget: ViewTarget? = null
+        var tapTarget: LocatedTapTarget? = null
         var composeViewDetected = false
         while (queue.isNotEmpty()) {
             // removeAt(index) instead of removeFirst here is on purpose, to prevent issues
@@ -161,7 +162,14 @@ internal class GesturesListener(
                 findTargetForTap(view, x, y)
             }
             if (newTarget != null) {
-                target = if (isScroll) newTarget else selectTapTarget(target, newTarget)
+                if (isScroll) {
+                    scrollTarget = newTarget
+                } else {
+                    tapTarget = selectTapTarget(
+                        tapTarget,
+                        LocatedTapTarget(newTarget, view)
+                    )
+                }
             }
             if (view.isVisible && view is ViewGroup) {
                 for (i in 0 until view.childCount) {
@@ -171,6 +179,7 @@ internal class GesturesListener(
             }
         }
 
+        val target = scrollTarget ?: tapTarget?.target
         if (target == null) {
             val msg = if (composeViewDetected) {
                 MSG_NO_COMPOSE_TARGET
@@ -186,17 +195,14 @@ internal class GesturesListener(
         return target
     }
 
-    private fun selectTapTarget(currentTarget: ViewTarget?, candidateTarget: ViewTarget): ViewTarget {
-        val currentView = currentTarget?.viewRef?.get()
-        val candidateView = candidateTarget.viewRef.get()
-        if (currentTarget == null || currentView == null || candidateView == null) {
-            return candidateTarget
-        }
-
-        return if (currentView.isPreferredTapTargetOver(candidateView)) {
-            currentTarget
-        } else {
-            candidateTarget
+    private fun selectTapTarget(
+        currentTarget: LocatedTapTarget?,
+        candidateTarget: LocatedTapTarget
+    ): LocatedTapTarget {
+        return when {
+            currentTarget == null -> candidateTarget
+            currentTarget.hostView.isPreferredTapTargetOver(candidateTarget.hostView) -> currentTarget
+            else -> candidateTarget
         }
     }
 
@@ -271,6 +277,11 @@ internal class GesturesListener(
         path.reverse()
         return path
     }
+
+    private data class LocatedTapTarget(
+        val target: ViewTarget,
+        val hostView: View
+    )
 
     private fun findTargetForScroll(view: View, x: Float, y: Float): ViewTarget? {
         // return bottom-most scrollable element

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/TapTargetSelector.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/TapTargetSelector.kt
@@ -6,20 +6,13 @@
 
 package com.datadog.android.rum.internal.instrumentation.gestures
 
-import android.os.Build
 import android.view.View
 import android.view.ViewGroup
-import androidx.annotation.RequiresApi
-import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.rum.tracking.ViewTarget
-import java.util.IdentityHashMap
 
-internal class TapTargetSelector(
-    private val buildSdkVersionProvider: BuildSdkVersionProvider = BuildSdkVersionProvider.DEFAULT
-) {
+internal class TapTargetSelector {
 
     private var selectedHostedTarget: HostedTapTarget? = null
-    private val drawingOrderCache = DrawingOrderCache()
 
     val selectedTarget: ViewTarget?
         get() = selectedHostedTarget?.target
@@ -82,30 +75,15 @@ internal class TapTargetSelector(
         return when {
             z > candidateView.z -> true
             z < candidateView.z -> false
-            // Both comparisons are also false for NaN, matching Android's child-order fallback.
-            else -> parent.isChildDrawnAfter(this, candidateView)
+            // Both comparisons are also false for NaN, so fall back to child index order.
+            else -> parent.isLaterChild(this, candidateView)
         }
     }
 
-    // Both indices are validated before accessing drawingRanks, so the array reads cannot fail.
-    @Suppress("UnsafeThirdPartyFunctionCall")
-    private fun ViewGroup.isChildDrawnAfter(child: View, candidateChild: View): Boolean {
+    private fun ViewGroup.isLaterChild(child: View, candidateChild: View): Boolean {
         val childIndex = childIndexOf(child)
         val candidateChildIndex = childIndexOf(candidateChild)
-        return if (childIndex != null && candidateChildIndex != null) {
-            val drawingRanks = drawingOrderCache.getOrCompute(this) { childDrawingRanks() }
-            if (
-                drawingRanks != null &&
-                childIndex in drawingRanks.indices &&
-                candidateChildIndex in drawingRanks.indices
-            ) {
-                drawingRanks[childIndex] > drawingRanks[candidateChildIndex]
-            } else {
-                childIndex > candidateChildIndex
-            }
-        } else {
-            false
-        }
+        return childIndex != null && candidateChildIndex != null && childIndex > candidateChildIndex
     }
 
     // indexOfChild is overridable, so exceptions from a custom ViewGroup are contained here.
@@ -114,41 +92,6 @@ internal class TapTargetSelector(
         return try {
             val childIndex = indexOfChild(child)
             if (childIndex >= 0) childIndex else null
-        } catch (_: Exception) {
-            null
-        }
-    }
-
-    // childCount cannot be negative, and every index is checked before accessing drawingRanks.
-    @Suppress("UnsafeThirdPartyFunctionCall")
-    private fun ViewGroup.childDrawingRanks(): IntArray? {
-        // Android only exposes child drawing order publicly from API 29.
-        if (!buildSdkVersionProvider.isAtLeastQ) return null
-
-        val drawingRanks = IntArray(childCount)
-        var drawingPosition = 0
-        var orderIsValid = true
-        while (drawingPosition < childCount && orderIsValid) {
-            val childIndex = childIndexAtDrawingPosition(drawingPosition)
-            val childIndexIsValid = childIndex != null &&
-                childIndex in drawingRanks.indices &&
-                drawingRanks[childIndex] == UNRANKED_CHILD
-            if (childIndexIsValid && childIndex != null) {
-                drawingRanks[childIndex] = drawingPosition + 1
-            } else {
-                orderIsValid = false
-            }
-            drawingPosition++
-        }
-        return if (orderIsValid) drawingRanks else null
-    }
-
-    @RequiresApi(Build.VERSION_CODES.Q)
-    // A custom ViewGroup may throw from getChildDrawingOrder; the exception is contained here.
-    @Suppress("UnsafeThirdPartyFunctionCall")
-    private fun ViewGroup.childIndexAtDrawingPosition(drawingPosition: Int): Int? {
-        return try {
-            getChildDrawingOrder(drawingPosition)
         } catch (_: Exception) {
             null
         }
@@ -171,31 +114,4 @@ internal class TapTargetSelector(
         val target: ViewTarget,
         val hostView: View
     )
-
-    private data class CachedDrawingRanks(val value: IntArray?)
-
-    private class DrawingOrderCache {
-
-        private val drawingRanksByParent = IdentityHashMap<ViewGroup, CachedDrawingRanks>()
-
-        // The map and non-null value wrapper are private to one traversal, so lookups cannot observe
-        // concurrent mutation or a stored null. computeDrawingRanks handles platform callback failures.
-        @Suppress("UnsafeThirdPartyFunctionCall")
-        fun getOrCompute(
-            parent: ViewGroup,
-            computeDrawingRanks: () -> IntArray?
-        ): IntArray? {
-            val cachedRanks = drawingRanksByParent[parent]
-            if (cachedRanks != null) return cachedRanks.value
-
-            val computedRanks = CachedDrawingRanks(computeDrawingRanks())
-            drawingRanksByParent[parent] = computedRanks
-            return computedRanks.value
-        }
-    }
-
-    private companion object {
-
-        private const val UNRANKED_CHILD = 0
-    }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/TapTargetSelector.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/TapTargetSelector.kt
@@ -8,23 +8,11 @@ package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.view.View
 import android.view.ViewGroup
-import com.datadog.android.rum.tracking.ViewTarget
 
 internal class TapTargetSelector {
 
-    private var selectedHostedTarget: HostedTapTarget? = null
-
-    val selectedTarget: ViewTarget?
-        get() = selectedHostedTarget?.target
-
-    fun considerCandidate(target: ViewTarget, hostView: View) {
-        val candidateTarget = HostedTapTarget(target, hostView)
-        val currentTarget = selectedHostedTarget
-        selectedHostedTarget = when {
-            currentTarget == null -> candidateTarget
-            currentTarget.hostView.isPreferredOver(candidateTarget.hostView) -> currentTarget
-            else -> candidateTarget
-        }
+    fun shouldSelectCandidate(currentHostView: View?, candidateHostView: View): Boolean {
+        return currentHostView == null || !currentHostView.isPreferredOver(candidateHostView)
     }
 
     private fun View.isPreferredOver(candidateView: View): Boolean {
@@ -109,9 +97,4 @@ internal class TapTargetSelector {
         path.reverse()
         return path
     }
-
-    private data class HostedTapTarget(
-        val target: ViewTarget,
-        val hostView: View
-    )
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/TapTargetSelector.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/TapTargetSelector.kt
@@ -1,0 +1,201 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.instrumentation.gestures
+
+import android.os.Build
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.RequiresApi
+import com.datadog.android.internal.system.BuildSdkVersionProvider
+import com.datadog.android.rum.tracking.ViewTarget
+import java.util.IdentityHashMap
+
+internal class TapTargetSelector(
+    private val buildSdkVersionProvider: BuildSdkVersionProvider = BuildSdkVersionProvider.DEFAULT
+) {
+
+    private var selectedHostedTarget: HostedTapTarget? = null
+    private val drawingOrderCache = DrawingOrderCache()
+
+    val selectedTarget: ViewTarget?
+        get() = selectedHostedTarget?.target
+
+    fun considerCandidate(target: ViewTarget, hostView: View) {
+        val candidateTarget = HostedTapTarget(target, hostView)
+        val currentTarget = selectedHostedTarget
+        selectedHostedTarget = when {
+            currentTarget == null -> candidateTarget
+            currentTarget.hostView.isPreferredOver(candidateTarget.hostView) -> currentTarget
+            else -> candidateTarget
+        }
+    }
+
+    private fun View.isPreferredOver(candidateView: View): Boolean {
+        val currentPath = pathFromRoot()
+        val candidatePath = candidateView.pathFromRoot()
+        val commonPathSize = currentPath.commonPathSizeWith(candidatePath)
+        val viewsAreDisconnected = commonPathSize == 0
+        val currentIsSameOrAncestor = commonPathSize == currentPath.size
+        val candidateIsAncestor = commonPathSize == candidatePath.size
+
+        return when {
+            viewsAreDisconnected -> false
+            // Within the same branch, prefer the deepest clickable view. An ancestor's Z does not
+            // place it in front of its own descendants.
+            currentIsSameOrAncestor -> false
+            candidateIsAncestor -> true
+            else -> currentPath.isBranchDrawnOnTopOf(candidatePath, commonPathSize)
+        }
+    }
+
+    private fun List<View>.commonPathSizeWith(otherPath: List<View>): Int {
+        val maximumCommonPathSize = minOf(size, otherPath.size)
+        var commonPathSize = 0
+        while (
+            commonPathSize < maximumCommonPathSize &&
+            this[commonPathSize] === otherPath[commonPathSize]
+        ) {
+            commonPathSize++
+        }
+        return commonPathSize
+    }
+
+    private fun List<View>.isBranchDrawnOnTopOf(
+        candidatePath: List<View>,
+        commonPathSize: Int
+    ): Boolean {
+        val divergingBranchIndex = commonPathSize
+        val commonParent = this[divergingBranchIndex - 1] as? ViewGroup ?: return false
+        val currentBranch = this[divergingBranchIndex]
+        val candidateBranch = candidatePath[divergingBranchIndex]
+
+        // Target depth and Z within each branch are irrelevant after the paths diverge. Android
+        // draws the two sibling branches as units, so their ordering decides which target is on top.
+        return currentBranch.isDrawnOnTopOf(candidateBranch, commonParent)
+    }
+
+    private fun View.isDrawnOnTopOf(candidateView: View, parent: ViewGroup): Boolean {
+        return when {
+            z > candidateView.z -> true
+            z < candidateView.z -> false
+            // Both comparisons are also false for NaN, matching Android's child-order fallback.
+            else -> parent.isChildDrawnAfter(this, candidateView)
+        }
+    }
+
+    // Both indices are validated before accessing drawingRanks, so the array reads cannot fail.
+    @Suppress("UnsafeThirdPartyFunctionCall")
+    private fun ViewGroup.isChildDrawnAfter(child: View, candidateChild: View): Boolean {
+        val childIndex = childIndexOf(child)
+        val candidateChildIndex = childIndexOf(candidateChild)
+        return if (childIndex != null && candidateChildIndex != null) {
+            val drawingRanks = drawingOrderCache.getOrCompute(this) { childDrawingRanks() }
+            if (
+                drawingRanks != null &&
+                childIndex in drawingRanks.indices &&
+                candidateChildIndex in drawingRanks.indices
+            ) {
+                drawingRanks[childIndex] > drawingRanks[candidateChildIndex]
+            } else {
+                childIndex > candidateChildIndex
+            }
+        } else {
+            false
+        }
+    }
+
+    // indexOfChild is overridable, so exceptions from a custom ViewGroup are contained here.
+    @Suppress("UnsafeThirdPartyFunctionCall")
+    private fun ViewGroup.childIndexOf(child: View): Int? {
+        return try {
+            val childIndex = indexOfChild(child)
+            if (childIndex >= 0) childIndex else null
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    // childCount cannot be negative, and every index is checked before accessing drawingRanks.
+    @Suppress("UnsafeThirdPartyFunctionCall")
+    private fun ViewGroup.childDrawingRanks(): IntArray? {
+        // Android only exposes child drawing order publicly from API 29.
+        if (!buildSdkVersionProvider.isAtLeastQ) return null
+
+        val drawingRanks = IntArray(childCount)
+        var drawingPosition = 0
+        var orderIsValid = true
+        while (drawingPosition < childCount && orderIsValid) {
+            val childIndex = childIndexAtDrawingPosition(drawingPosition)
+            val childIndexIsValid = childIndex != null &&
+                childIndex in drawingRanks.indices &&
+                drawingRanks[childIndex] == UNRANKED_CHILD
+            if (childIndexIsValid && childIndex != null) {
+                drawingRanks[childIndex] = drawingPosition + 1
+            } else {
+                orderIsValid = false
+            }
+            drawingPosition++
+        }
+        return if (orderIsValid) drawingRanks else null
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    // A custom ViewGroup may throw from getChildDrawingOrder; the exception is contained here.
+    @Suppress("UnsafeThirdPartyFunctionCall")
+    private fun ViewGroup.childIndexAtDrawingPosition(drawingPosition: Int): Int? {
+        return try {
+            getChildDrawingOrder(drawingPosition)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun View.pathFromRoot(): List<View> {
+        val path = mutableListOf<View>()
+        var current: View? = this
+        while (current != null) {
+            path += current
+            current = current.parent as? View
+        }
+        // path is backed by mutableListOf, so reverse cannot encounter an immutable implementation.
+        @Suppress("UnsafeThirdPartyFunctionCall")
+        path.reverse()
+        return path
+    }
+
+    private data class HostedTapTarget(
+        val target: ViewTarget,
+        val hostView: View
+    )
+
+    private data class CachedDrawingRanks(val value: IntArray?)
+
+    private class DrawingOrderCache {
+
+        private val drawingRanksByParent = IdentityHashMap<ViewGroup, CachedDrawingRanks>()
+
+        // The map and non-null value wrapper are private to one traversal, so lookups cannot observe
+        // concurrent mutation or a stored null. computeDrawingRanks handles platform callback failures.
+        @Suppress("UnsafeThirdPartyFunctionCall")
+        fun getOrCompute(
+            parent: ViewGroup,
+            computeDrawingRanks: () -> IntArray?
+        ): IntArray? {
+            val cachedRanks = drawingRanksByParent[parent]
+            if (cachedRanks != null) return cachedRanks.value
+
+            val computedRanks = CachedDrawingRanks(computeDrawingRanks())
+            drawingRanksByParent[parent] = computedRanks
+            return computedRanks.value
+        }
+    }
+
+    private companion object {
+
+        private const val UNRANKED_CHILD = 0
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerScrollSwipeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerScrollSwipeTest.kt
@@ -63,6 +63,58 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
 
     // region Tests
 
+    @Test
+    fun `M send later scroll target W onScroll {earlier target has higher Z}`(forge: Forge) {
+        // Given
+        val startDownEvent: MotionEvent = forge.getForgery()
+        val scrollEvent: MotionEvent = forge.getForgery()
+        val elevatedTarget: ScrollableView = mockView(
+            id = forge.anInt(),
+            forEvent = startDownEvent,
+            hitTest = true,
+            forge = forge
+        ) {
+            whenever(it.z).thenReturn(10f)
+        }
+        val laterTarget: ScrollableView = mockView(
+            id = forge.anInt(),
+            forEvent = startDownEvent,
+            hitTest = true,
+            forge = forge
+        ) {
+            whenever(it.z).thenReturn(0f)
+        }
+        mockDecorView = mockDecorView<ViewGroup>(
+            id = forge.anInt(),
+            forEvent = startDownEvent,
+            hitTest = false,
+            forge = forge
+        ) {
+            whenever(it.childCount).thenReturn(2)
+            whenever(it.getChildAt(0)).thenReturn(elevatedTarget)
+            whenever(it.getChildAt(1)).thenReturn(laterTarget)
+        }
+        val expectedResourceName = forge.anAlphabeticalString()
+        mockResourcesForTarget(laterTarget, expectedResourceName)
+        val expectedAttributes = mutableMapOf(
+            RumAttributes.ACTION_TARGET_CLASS_NAME to laterTarget.javaClass.canonicalName,
+            RumAttributes.ACTION_TARGET_RESOURCE_ID to expectedResourceName
+        )
+        testedListener = GesturesListener(
+            rumMonitor.mockSdkCore,
+            WeakReference(mockWindow),
+            contextRef = WeakReference(mockAppContext),
+            internalLogger = mockInternalLogger
+        )
+
+        // When
+        testedListener.onDown(startDownEvent)
+        testedListener.onScroll(startDownEvent, scrollEvent, forge.aFloat(), forge.aFloat())
+
+        // Then
+        verify(rumMonitor.mockInstance).startAction(RumActionType.SCROLL, "", expectedAttributes)
+    }
+
     @ParameterizedTest
     @ValueSource(
         strings = [

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
@@ -151,6 +151,340 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
     }
 
     @Test
+    fun `M send elevated target W onTap {lower child index has higher Z}`(forge: Forge) {
+        // Given
+        val mockEvent: MotionEvent = forge.getForgery()
+        val elevatedTarget: View = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            clickable = true,
+            forge = forge
+        ) {
+            whenever(it.z).thenReturn(10f)
+        }
+        val laterTarget: View = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            clickable = true,
+            forge = forge
+        ) {
+            whenever(it.z).thenReturn(0f)
+        }
+        mockDecorView = mockDecorView<ViewGroup>(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = false,
+            forge = forge
+        ) {
+            whenever(it.childCount).thenReturn(2)
+            whenever(it.getChildAt(0)).thenReturn(elevatedTarget)
+            whenever(it.getChildAt(1)).thenReturn(laterTarget)
+        }
+        whenever(elevatedTarget.parent).thenReturn(mockDecorView as ViewGroup)
+        whenever(laterTarget.parent).thenReturn(mockDecorView as ViewGroup)
+        val expectedResourceName = forge.anAlphabeticalString()
+        mockResourcesForTarget(elevatedTarget, expectedResourceName)
+        testedListener = GesturesListener(
+            rumMonitor.mockSdkCore,
+            WeakReference(mockWindow),
+            contextRef = WeakReference(mockAppContext),
+            internalLogger = mockInternalLogger
+        )
+
+        // When
+        testedListener.onSingleTapUp(mockEvent)
+
+        // Then
+        verifyMonitorCalledWithUserAction(elevatedTarget, "", expectedResourceName)
+    }
+
+    @Test
+    fun `M send target in elevated branch W onTap {leaf in lower branch has higher Z}`(
+        forge: Forge
+    ) {
+        // Given
+        val mockEvent: MotionEvent = forge.getForgery()
+        val elevatedBranchTarget: View = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            clickable = true,
+            forge = forge
+        ) {
+            whenever(it.z).thenReturn(0f)
+        }
+        val laterBranchTarget: View = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            clickable = true,
+            forge = forge
+        ) {
+            whenever(it.z).thenReturn(100f)
+        }
+        val elevatedBranch: ViewGroup = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = false,
+            forge = forge
+        ) {
+            whenever(it.z).thenReturn(10f)
+            whenever(it.childCount).thenReturn(1)
+            whenever(it.getChildAt(0)).thenReturn(elevatedBranchTarget)
+        }
+        val laterBranch: ViewGroup = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = false,
+            forge = forge
+        ) {
+            whenever(it.z).thenReturn(0f)
+            whenever(it.childCount).thenReturn(1)
+            whenever(it.getChildAt(0)).thenReturn(laterBranchTarget)
+        }
+        mockDecorView = mockDecorView<ViewGroup>(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = false,
+            forge = forge
+        ) {
+            whenever(it.childCount).thenReturn(2)
+            whenever(it.getChildAt(0)).thenReturn(elevatedBranch)
+            whenever(it.getChildAt(1)).thenReturn(laterBranch)
+        }
+        whenever(elevatedBranch.parent).thenReturn(mockDecorView as ViewGroup)
+        whenever(laterBranch.parent).thenReturn(mockDecorView as ViewGroup)
+        whenever(elevatedBranchTarget.parent).thenReturn(elevatedBranch)
+        whenever(laterBranchTarget.parent).thenReturn(laterBranch)
+        val expectedResourceName = forge.anAlphabeticalString()
+        mockResourcesForTarget(elevatedBranchTarget, expectedResourceName)
+        testedListener = GesturesListener(
+            rumMonitor.mockSdkCore,
+            WeakReference(mockWindow),
+            contextRef = WeakReference(mockAppContext),
+            internalLogger = mockInternalLogger
+        )
+
+        // When
+        testedListener.onSingleTapUp(mockEvent)
+
+        // Then
+        verifyMonitorCalledWithUserAction(elevatedBranchTarget, "", expectedResourceName)
+    }
+
+    @Test
+    fun `M send descendant target W onTap {ancestor has higher Z}`(forge: Forge) {
+        // Given
+        val mockEvent: MotionEvent = forge.getForgery()
+        val descendantTarget: View = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            clickable = true,
+            forge = forge
+        ) {
+            whenever(it.z).thenReturn(0f)
+        }
+        val ancestorTarget: ViewGroup = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            clickable = true,
+            forge = forge
+        ) {
+            whenever(it.z).thenReturn(10f)
+            whenever(it.childCount).thenReturn(1)
+            whenever(it.getChildAt(0)).thenReturn(descendantTarget)
+        }
+        whenever(descendantTarget.parent).thenReturn(ancestorTarget)
+        mockDecorView = mockDecorView<ViewGroup>(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = false,
+            forge = forge
+        ) {
+            whenever(it.childCount).thenReturn(1)
+            whenever(it.getChildAt(0)).thenReturn(ancestorTarget)
+        }
+        val expectedResourceName = forge.anAlphabeticalString()
+        mockResourcesForTarget(descendantTarget, expectedResourceName)
+        testedListener = GesturesListener(
+            rumMonitor.mockSdkCore,
+            WeakReference(mockWindow),
+            contextRef = WeakReference(mockAppContext),
+            internalLogger = mockInternalLogger
+        )
+
+        // When
+        testedListener.onSingleTapUp(mockEvent)
+
+        // Then
+        verifyMonitorCalledWithUserAction(descendantTarget, "", expectedResourceName)
+    }
+
+    @Test
+    fun `M send later target W onTap {unrelated targets have equal Z}`(forge: Forge) {
+        // Given
+        val mockEvent: MotionEvent = forge.getForgery()
+        val earlierTarget: View = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            clickable = true,
+            forge = forge
+        )
+        val laterTarget: View = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            clickable = true,
+            forge = forge
+        )
+        mockDecorView = mockDecorView<ViewGroup>(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = false,
+            forge = forge
+        ) {
+            whenever(it.childCount).thenReturn(2)
+            whenever(it.getChildAt(0)).thenReturn(earlierTarget)
+            whenever(it.getChildAt(1)).thenReturn(laterTarget)
+        }
+        whenever(earlierTarget.parent).thenReturn(mockDecorView as ViewGroup)
+        whenever(laterTarget.parent).thenReturn(mockDecorView as ViewGroup)
+        whenever((mockDecorView as ViewGroup).indexOfChild(earlierTarget)).thenReturn(0)
+        whenever((mockDecorView as ViewGroup).indexOfChild(laterTarget)).thenReturn(1)
+        val expectedResourceName = forge.anAlphabeticalString()
+        mockResourcesForTarget(laterTarget, expectedResourceName)
+        testedListener = GesturesListener(
+            rumMonitor.mockSdkCore,
+            WeakReference(mockWindow),
+            contextRef = WeakReference(mockAppContext),
+            internalLogger = mockInternalLogger
+        )
+
+        // When
+        testedListener.onSingleTapUp(mockEvent)
+
+        // Then
+        verifyMonitorCalledWithUserAction(laterTarget, "", expectedResourceName)
+    }
+
+    @Test
+    fun `M send target in later branch W onTap {earlier branch has deeper target with equal Z}`(
+        forge: Forge
+    ) {
+        // Given
+        val mockEvent: MotionEvent = forge.getForgery()
+        val earlierBranchTarget: View = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            clickable = true,
+            forge = forge
+        )
+        val earlierBranch: ViewGroup = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = false,
+            forge = forge
+        ) {
+            whenever(it.childCount).thenReturn(1)
+            whenever(it.getChildAt(0)).thenReturn(earlierBranchTarget)
+        }
+        val laterBranchTarget: View = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            clickable = true,
+            forge = forge
+        )
+        mockDecorView = mockDecorView<ViewGroup>(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = false,
+            forge = forge
+        ) {
+            whenever(it.childCount).thenReturn(2)
+            whenever(it.getChildAt(0)).thenReturn(earlierBranch)
+            whenever(it.getChildAt(1)).thenReturn(laterBranchTarget)
+        }
+        whenever(earlierBranch.parent).thenReturn(mockDecorView as ViewGroup)
+        whenever(earlierBranchTarget.parent).thenReturn(earlierBranch)
+        whenever(laterBranchTarget.parent).thenReturn(mockDecorView as ViewGroup)
+        whenever((mockDecorView as ViewGroup).indexOfChild(earlierBranch)).thenReturn(0)
+        whenever((mockDecorView as ViewGroup).indexOfChild(laterBranchTarget)).thenReturn(1)
+        val expectedResourceName = forge.anAlphabeticalString()
+        mockResourcesForTarget(laterBranchTarget, expectedResourceName)
+        testedListener = GesturesListener(
+            rumMonitor.mockSdkCore,
+            WeakReference(mockWindow),
+            contextRef = WeakReference(mockAppContext),
+            internalLogger = mockInternalLogger
+        )
+
+        // When
+        testedListener.onSingleTapUp(mockEvent)
+
+        // Then
+        verifyMonitorCalledWithUserAction(laterBranchTarget, "", expectedResourceName)
+    }
+
+    @Test
+    fun `M send later target W onTap {unrelated target has non-orderable Z}`(forge: Forge) {
+        // Given
+        val mockEvent: MotionEvent = forge.getForgery()
+        val earlierTarget: View = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            clickable = true,
+            forge = forge
+        ) {
+            whenever(it.z).thenReturn(Float.NaN)
+        }
+        val laterTarget: View = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            clickable = true,
+            forge = forge
+        ) {
+            whenever(it.z).thenReturn(0f)
+        }
+        mockDecorView = mockDecorView<ViewGroup>(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = false,
+            forge = forge
+        ) {
+            whenever(it.childCount).thenReturn(2)
+            whenever(it.getChildAt(0)).thenReturn(earlierTarget)
+            whenever(it.getChildAt(1)).thenReturn(laterTarget)
+        }
+        whenever(earlierTarget.parent).thenReturn(mockDecorView as ViewGroup)
+        whenever(laterTarget.parent).thenReturn(mockDecorView as ViewGroup)
+        whenever((mockDecorView as ViewGroup).indexOfChild(earlierTarget)).thenReturn(0)
+        whenever((mockDecorView as ViewGroup).indexOfChild(laterTarget)).thenReturn(1)
+        val expectedResourceName = forge.anAlphabeticalString()
+        mockResourcesForTarget(laterTarget, expectedResourceName)
+        testedListener = GesturesListener(
+            rumMonitor.mockSdkCore,
+            WeakReference(mockWindow),
+            contextRef = WeakReference(mockAppContext),
+            internalLogger = mockInternalLogger
+        )
+
+        // When
+        testedListener.onSingleTapUp(mockEvent)
+
+        // Then
+        verifyMonitorCalledWithUserAction(laterTarget, "", expectedResourceName)
+    }
+
+    @Test
     fun `onTap dispatches an UserAction if target is ViewGroup and clickable`(forge: Forge) {
         // Given
         val mockEvent: MotionEvent = forge.getForgery()

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
@@ -201,6 +201,122 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
     }
 
     @Test
+    fun `M send Compose target W onTap {Compose host has higher Z than later native target}`(
+        forge: Forge
+    ) {
+        // Given
+        val mockEvent: MotionEvent = forge.getForgery()
+        val composeHost: ComposeView = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            forge = forge
+        ) {
+            whenever(it.z).thenReturn(10f)
+        }
+        val nativeTarget: View = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            clickable = true,
+            forge = forge
+        ) {
+            whenever(it.z).thenReturn(0f)
+        }
+        mockDecorView = mockDecorView<ViewGroup>(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = false,
+            forge = forge
+        ) {
+            whenever(it.childCount).thenReturn(2)
+            whenever(it.getChildAt(0)).thenReturn(composeHost)
+            whenever(it.getChildAt(1)).thenReturn(nativeTarget)
+        }
+        whenever(composeHost.parent).thenReturn(mockDecorView as ViewGroup)
+        whenever(nativeTarget.parent).thenReturn(mockDecorView as ViewGroup)
+        val expectedTargetName = forge.anAlphabeticalString()
+        val composeActionTrackingStrategy: ActionTrackingStrategy = mock {
+            whenever(it.findTargetForTap(composeHost, mockEvent.x, mockEvent.y))
+                .thenReturn(ViewTarget(node = Node(expectedTargetName)))
+        }
+        testedListener = GesturesListener(
+            rumMonitor.mockSdkCore,
+            WeakReference(mockWindow),
+            contextRef = WeakReference(mockAppContext),
+            internalLogger = mockInternalLogger,
+            composeActionTrackingStrategy = composeActionTrackingStrategy
+        )
+
+        // When
+        testedListener.onSingleTapUp(mockEvent)
+
+        // Then
+        verify(rumMonitor.mockInstance as AdvancedRumMonitor).addActionWithHeatmap(
+            eq(RumActionType.TAP),
+            eq(expectedTargetName),
+            isNull(),
+            eq(emptyMap())
+        )
+    }
+
+    @Test
+    fun `M send native target W onTap {native target has higher Z than later Compose host}`(
+        forge: Forge
+    ) {
+        // Given
+        val mockEvent: MotionEvent = forge.getForgery()
+        val nativeTarget: View = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            clickable = true,
+            forge = forge
+        ) {
+            whenever(it.z).thenReturn(10f)
+        }
+        val composeHost: ComposeView = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            forge = forge
+        ) {
+            whenever(it.z).thenReturn(0f)
+        }
+        mockDecorView = mockDecorView<ViewGroup>(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = false,
+            forge = forge
+        ) {
+            whenever(it.childCount).thenReturn(2)
+            whenever(it.getChildAt(0)).thenReturn(nativeTarget)
+            whenever(it.getChildAt(1)).thenReturn(composeHost)
+        }
+        whenever(nativeTarget.parent).thenReturn(mockDecorView as ViewGroup)
+        whenever(composeHost.parent).thenReturn(mockDecorView as ViewGroup)
+        val expectedResourceName = forge.anAlphabeticalString()
+        mockResourcesForTarget(nativeTarget, expectedResourceName)
+        val composeActionTrackingStrategy: ActionTrackingStrategy = mock {
+            whenever(it.findTargetForTap(composeHost, mockEvent.x, mockEvent.y))
+                .thenReturn(ViewTarget(node = Node(forge.anAlphabeticalString())))
+        }
+        testedListener = GesturesListener(
+            rumMonitor.mockSdkCore,
+            WeakReference(mockWindow),
+            contextRef = WeakReference(mockAppContext),
+            internalLogger = mockInternalLogger,
+            composeActionTrackingStrategy = composeActionTrackingStrategy
+        )
+
+        // When
+        testedListener.onSingleTapUp(mockEvent)
+
+        // Then
+        verifyMonitorCalledWithUserAction(nativeTarget, "", expectedResourceName)
+    }
+
+    @Test
     fun `M send target in elevated branch W onTap {leaf in lower branch has higher Z}`(
         forge: Forge
     ) {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/TapTargetSelectorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/TapTargetSelectorTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.instrumentation.gestures
+
+import android.view.View
+import android.view.ViewGroup
+import com.datadog.android.internal.system.BuildSdkVersionProvider
+import com.datadog.android.rum.tracking.Node
+import com.datadog.android.rum.tracking.ViewTarget
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@ExtendWith(MockitoExtension::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class TapTargetSelectorTest {
+
+    @Test
+    fun `M select earlier target W considerCandidate {custom drawing order draws it last}`() {
+        // Given
+        val parent: ViewGroup = mock()
+        val earlierHost: View = mock { whenever(it.parent).thenReturn(parent) }
+        val laterHost: View = mock { whenever(it.parent).thenReturn(parent) }
+        val latestHost: View = mock { whenever(it.parent).thenReturn(parent) }
+        whenever(parent.childCount).thenReturn(3)
+        whenever(parent.indexOfChild(earlierHost)).thenReturn(0)
+        whenever(parent.indexOfChild(laterHost)).thenReturn(1)
+        whenever(parent.indexOfChild(latestHost)).thenReturn(2)
+        whenever(parent.getChildDrawingOrder(0)).thenReturn(2)
+        whenever(parent.getChildDrawingOrder(1)).thenReturn(1)
+        whenever(parent.getChildDrawingOrder(2)).thenReturn(0)
+        val buildSdkVersionProvider: BuildSdkVersionProvider = mock {
+            whenever(it.isAtLeastQ).thenReturn(true)
+        }
+        val earlierTarget = ViewTarget(node = Node("earlier"))
+        val testedSelector = TapTargetSelector(buildSdkVersionProvider)
+
+        // When
+        testedSelector.considerCandidate(earlierTarget, earlierHost)
+        testedSelector.considerCandidate(ViewTarget(node = Node("later")), laterHost)
+        testedSelector.considerCandidate(ViewTarget(node = Node("latest")), latestHost)
+
+        // Then
+        assertThat(testedSelector.selectedTarget).isSameAs(earlierTarget)
+        verify(parent).getChildDrawingOrder(0)
+        verify(parent).getChildDrawingOrder(1)
+        verify(parent).getChildDrawingOrder(2)
+    }
+
+    @Test
+    fun `M select later target W considerCandidate {custom drawing order is unavailable}`() {
+        // Given
+        val parent: ViewGroup = mock()
+        val earlierHost: View = mock { whenever(it.parent).thenReturn(parent) }
+        val laterHost: View = mock { whenever(it.parent).thenReturn(parent) }
+        whenever(parent.indexOfChild(earlierHost)).thenReturn(0)
+        whenever(parent.indexOfChild(laterHost)).thenReturn(1)
+        val buildSdkVersionProvider: BuildSdkVersionProvider = mock {
+            whenever(it.isAtLeastQ).thenReturn(false)
+        }
+        val laterTarget = ViewTarget(node = Node("later"))
+        val testedSelector = TapTargetSelector(buildSdkVersionProvider)
+
+        // When
+        testedSelector.considerCandidate(ViewTarget(node = Node("earlier")), earlierHost)
+        testedSelector.considerCandidate(laterTarget, laterHost)
+
+        // Then
+        assertThat(testedSelector.selectedTarget).isSameAs(laterTarget)
+        verify(parent, never()).getChildDrawingOrder(any())
+    }
+
+    @Test
+    fun `M select later target W considerCandidate {parent throws while resolving child index}`() {
+        // Given
+        val parent: ViewGroup = mock()
+        val earlierHost: View = mock { whenever(it.parent).thenReturn(parent) }
+        val laterHost: View = mock { whenever(it.parent).thenReturn(parent) }
+        whenever(parent.indexOfChild(earlierHost)).thenThrow(IllegalStateException())
+        whenever(parent.indexOfChild(laterHost)).thenReturn(1)
+        val laterTarget = ViewTarget(node = Node("later"))
+        val testedSelector = TapTargetSelector()
+
+        // When
+        testedSelector.considerCandidate(ViewTarget(node = Node("earlier")), earlierHost)
+        testedSelector.considerCandidate(laterTarget, laterHost)
+
+        // Then
+        assertThat(testedSelector.selectedTarget).isSameAs(laterTarget)
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/TapTargetSelectorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/TapTargetSelectorTest.kt
@@ -8,7 +8,6 @@ package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.view.View
 import android.view.ViewGroup
-import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.rum.tracking.Node
 import com.datadog.android.rum.tracking.ViewTarget
 import org.assertj.core.api.Assertions.assertThat
@@ -28,50 +27,17 @@ import org.mockito.quality.Strictness
 internal class TapTargetSelectorTest {
 
     @Test
-    fun `M select earlier target W considerCandidate {custom drawing order draws it last}`() {
-        // Given
-        val parent: ViewGroup = mock()
-        val earlierHost: View = mock { whenever(it.parent).thenReturn(parent) }
-        val laterHost: View = mock { whenever(it.parent).thenReturn(parent) }
-        val latestHost: View = mock { whenever(it.parent).thenReturn(parent) }
-        whenever(parent.childCount).thenReturn(3)
-        whenever(parent.indexOfChild(earlierHost)).thenReturn(0)
-        whenever(parent.indexOfChild(laterHost)).thenReturn(1)
-        whenever(parent.indexOfChild(latestHost)).thenReturn(2)
-        whenever(parent.getChildDrawingOrder(0)).thenReturn(2)
-        whenever(parent.getChildDrawingOrder(1)).thenReturn(1)
-        whenever(parent.getChildDrawingOrder(2)).thenReturn(0)
-        val buildSdkVersionProvider: BuildSdkVersionProvider = mock {
-            whenever(it.isAtLeastQ).thenReturn(true)
-        }
-        val earlierTarget = ViewTarget(node = Node("earlier"))
-        val testedSelector = TapTargetSelector(buildSdkVersionProvider)
-
-        // When
-        testedSelector.considerCandidate(earlierTarget, earlierHost)
-        testedSelector.considerCandidate(ViewTarget(node = Node("later")), laterHost)
-        testedSelector.considerCandidate(ViewTarget(node = Node("latest")), latestHost)
-
-        // Then
-        assertThat(testedSelector.selectedTarget).isSameAs(earlierTarget)
-        verify(parent).getChildDrawingOrder(0)
-        verify(parent).getChildDrawingOrder(1)
-        verify(parent).getChildDrawingOrder(2)
-    }
-
-    @Test
-    fun `M select later target W considerCandidate {custom drawing order is unavailable}`() {
+    fun `M select later target W considerCandidate {drawing order callback differs from child order}`() {
         // Given
         val parent: ViewGroup = mock()
         val earlierHost: View = mock { whenever(it.parent).thenReturn(parent) }
         val laterHost: View = mock { whenever(it.parent).thenReturn(parent) }
         whenever(parent.indexOfChild(earlierHost)).thenReturn(0)
         whenever(parent.indexOfChild(laterHost)).thenReturn(1)
-        val buildSdkVersionProvider: BuildSdkVersionProvider = mock {
-            whenever(it.isAtLeastQ).thenReturn(false)
-        }
+        whenever(parent.getChildDrawingOrder(0)).thenReturn(1)
+        whenever(parent.getChildDrawingOrder(1)).thenReturn(0)
         val laterTarget = ViewTarget(node = Node("later"))
-        val testedSelector = TapTargetSelector(buildSdkVersionProvider)
+        val testedSelector = TapTargetSelector()
 
         // When
         testedSelector.considerCandidate(ViewTarget(node = Node("earlier")), earlierHost)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/TapTargetSelectorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/TapTargetSelectorTest.kt
@@ -8,8 +8,6 @@ package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.view.View
 import android.view.ViewGroup
-import com.datadog.android.rum.tracking.Node
-import com.datadog.android.rum.tracking.ViewTarget
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -27,7 +25,29 @@ import org.mockito.quality.Strictness
 internal class TapTargetSelectorTest {
 
     @Test
-    fun `M select later target W considerCandidate {drawing order callback differs from child order}`() {
+    fun `M prefer candidate host W shouldSelectCandidate {candidate has higher Z}`() {
+        // Given
+        val parent: ViewGroup = mock()
+        val currentHost: View = mock {
+            whenever(it.parent).thenReturn(parent)
+            whenever(it.z).thenReturn(0f)
+        }
+        val candidateHost: View = mock {
+            whenever(it.parent).thenReturn(parent)
+            whenever(it.z).thenReturn(10f)
+        }
+        val testedSelector = TapTargetSelector()
+
+        // When
+        val result = testedSelector.shouldSelectCandidate(currentHost, candidateHost)
+
+        // Then
+        assertThat(result).isTrue()
+        verify(parent, never()).indexOfChild(any())
+    }
+
+    @Test
+    fun `M prefer later host W shouldSelectCandidate {drawing order callback differs from child order}`() {
         // Given
         val parent: ViewGroup = mock()
         val earlierHost: View = mock { whenever(it.parent).thenReturn(parent) }
@@ -36,34 +56,30 @@ internal class TapTargetSelectorTest {
         whenever(parent.indexOfChild(laterHost)).thenReturn(1)
         whenever(parent.getChildDrawingOrder(0)).thenReturn(1)
         whenever(parent.getChildDrawingOrder(1)).thenReturn(0)
-        val laterTarget = ViewTarget(node = Node("later"))
         val testedSelector = TapTargetSelector()
 
         // When
-        testedSelector.considerCandidate(ViewTarget(node = Node("earlier")), earlierHost)
-        testedSelector.considerCandidate(laterTarget, laterHost)
+        val result = testedSelector.shouldSelectCandidate(earlierHost, laterHost)
 
         // Then
-        assertThat(testedSelector.selectedTarget).isSameAs(laterTarget)
+        assertThat(result).isTrue()
         verify(parent, never()).getChildDrawingOrder(any())
     }
 
     @Test
-    fun `M select later target W considerCandidate {parent throws while resolving child index}`() {
+    fun `M prefer later host W shouldSelectCandidate {parent throws while resolving child index}`() {
         // Given
         val parent: ViewGroup = mock()
         val earlierHost: View = mock { whenever(it.parent).thenReturn(parent) }
         val laterHost: View = mock { whenever(it.parent).thenReturn(parent) }
         whenever(parent.indexOfChild(earlierHost)).thenThrow(IllegalStateException())
         whenever(parent.indexOfChild(laterHost)).thenReturn(1)
-        val laterTarget = ViewTarget(node = Node("later"))
         val testedSelector = TapTargetSelector()
 
         // When
-        testedSelector.considerCandidate(ViewTarget(node = Node("earlier")), earlierHost)
-        testedSelector.considerCandidate(laterTarget, laterHost)
+        val result = testedSelector.shouldSelectCandidate(earlierHost, laterHost)
 
         // Then
-        assertThat(testedSelector.selectedTarget).isSameAs(laterTarget)
+        assertThat(result).isTrue()
     }
 }


### PR DESCRIPTION
### What does this PR do?

Fixes RUM tap actions being attributed to an underlying view when overlapping views use elevation. Tap target selection now compares the first diverging view branches, preferring higher Z and falling back to child index order when Z is equal or non-orderable. Each target is compared using its host view, allowing the same ordering logic to work for mixed Compose and native targets. Existing behavior for nested views and scroll targets is preserved.

Custom child drawing order is not inspected because Android does not publicly expose whether it is enabled for an arbitrary ViewGroup; calling the drawing-order callback unconditionally could disagree with Android’s actual rendering order.

At a high level, when a tap occurs:
- GesturesListener walks the visible view hierarchy and evaluates matching tap targets as they are found.

- Each target is synchronously evaluated against the best target found so far.

- If both targets belong to the same view branch, the deeper target wins.

- If they belong to different branches, their first diverging sibling views determine which branch is visually on top:
Higher Z wins.
Equal or non-orderable Z falls back to the later child index.

- After the hierarchy has been fully traversed, the winning target is used for the RUM tap action.

For Compose targets, the selector uses the Compose host view to perform the same visual-order comparison. Scroll gestures continue using the existing selection behavior.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

