### PR TITLE
RUM-17613: `timeseries` [3/5] Pass the live RUM context to timeseries pipelines

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -201,7 +201,11 @@ internal class RumSessionScope(
             }
         }
 
-        timeseriesCollector.onViewTypeUpdate(getActiveRumContext().viewType)
+        // getActiveRumContext() copies the whole context chain, so it is only built when there is a
+        // collector to feed: timeseries collection is opt-in and this runs on every RUM event.
+        if (timeseriesCollector !is NoOpTimeseriesCollector) {
+            timeseriesCollector.onRumContextUpdate(getActiveRumContext())
+        }
 
         return if (isSessionComplete()) {
             null

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/DefaultTimeseriesCollector.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/DefaultTimeseriesCollector.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.internal.timeseries
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.utils.scheduleSafe
+import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.scope.RumViewType
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
@@ -24,11 +25,11 @@ import java.util.concurrent.atomic.AtomicReference
  *  - After [onSessionStop], the instance must not be restarted; create a new instance.
  *
  * Background sampling:
- *  - When [collectInBackground] is `false`, [onViewTypeUpdate] pauses sampling on leaving foreground
+ *  - When [collectInBackground] is `false`, [onRumContextUpdate] pauses sampling on leaving foreground
  *    and resumes it on returning to foreground.
  *
  * Threading:
- *  - [onSessionStart] / [onSessionStop] / [onViewTypeUpdate] are called from the RUM event-handler thread.
+ *  - [onSessionStart] / [onSessionStop] / [onRumContextUpdate] are called from the RUM event-handler thread.
  *  - Sampling tasks run on a [scheduledExecutorService] shared with other RUM components
  *    (owned by the SDK core); the instance neither owns nor shuts it down.
  *  - [Pipeline] is responsible for its own thread safety via internal synchronization.
@@ -40,7 +41,10 @@ internal class DefaultTimeseriesCollector(
     private val internalLogger: InternalLogger,
     internal val pipelines: List<Pipeline<*>>,
     private val collectInBackground: Boolean,
-    internal val scheduledExecutorService: ScheduledExecutorService
+    internal val scheduledExecutorService: ScheduledExecutorService,
+    // Read by the sampling ticks so every batch is attributed to the view that was active when it
+    // was drained, not to the one active when the collector was created.
+    @Volatile private var rumContext: RumContext
 ) : TimeseriesCollector {
 
     private enum class State { IDLE, RUNNING, SUSPENDED, STOPPED }
@@ -48,9 +52,6 @@ internal class DefaultTimeseriesCollector(
 
     // Incremented on every start/resume. Ticks carrying a stale generation self-terminate.
     private val currentGeneration = AtomicInteger(0)
-
-    @Volatile
-    private var currentViewType: RumViewType? = null
 
     @WorkerThread
     override fun onSessionStart() {
@@ -64,7 +65,7 @@ internal class DefaultTimeseriesCollector(
         if (state.getAndSet(State.STOPPED) != State.STOPPED) {
             pipelines.forEach { pipeline ->
                 try {
-                    synchronized(pipeline, pipeline::flush)
+                    pipeline.flush(rumContext)
                 } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
                     internalLogger.log(
                         level = InternalLogger.Level.ERROR,
@@ -78,10 +79,13 @@ internal class DefaultTimeseriesCollector(
     }
 
     @WorkerThread
-    override fun onViewTypeUpdate(newViewType: RumViewType) {
-        if (newViewType == currentViewType) return
-        val isEnterForeground = !currentViewType.isForeground && newViewType.isForeground
-        currentViewType = newViewType
+    override fun onRumContextUpdate(newRumContext: RumContext) {
+        val oldViewType = rumContext.viewType
+        val newViewType = newRumContext.viewType
+        val isEnterForeground = !oldViewType.isForeground && newViewType.isForeground
+
+        rumContext = newRumContext
+
         if (!collectInBackground) {
             if (isEnterForeground && state.compareAndSet(State.SUSPENDED, State.RUNNING)) {
                 startSampling()
@@ -105,9 +109,7 @@ internal class DefaultTimeseriesCollector(
         ) {
             if (!isActive(generation)) return@scheduleSafe
             try {
-                synchronized(pipeline) {
-                    if (isActive(generation)) pipeline.execute()
-                }
+                pipeline.execute(rumContext)
             } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
                 internalLogger.log(
                     level = InternalLogger.Level.ERROR,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/DefaultTimeseriesCollectorFactory.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/DefaultTimeseriesCollectorFactory.kt
@@ -44,12 +44,12 @@ internal class DefaultTimeseriesCollectorFactory(
         val pipelines = mutableListOf<Pipeline<*>>()
 
         if (TimeseriesType.CPU in configuration.enabledTypes) {
-            pipelines += createCpuPipeline(sessionType, rumContext)
+            pipelines += createCpuPipeline(sessionType)
         }
 
         if (TimeseriesType.MEMORY in configuration.enabledTypes) {
             if (totalRamBytes > 0L) {
-                pipelines += createMemoryPipeline(sessionType, rumContext)
+                pipelines += createMemoryPipeline(sessionType)
             } else {
                 sdkCore.internalLogger.log(
                     InternalLogger.Level.WARN,
@@ -64,14 +64,12 @@ internal class DefaultTimeseriesCollectorFactory(
             internalLogger = sdkCore.internalLogger,
             collectInBackground = configuration.collectInBackground,
             scheduledExecutorService = scheduledExecutorService,
+            rumContext = rumContext,
             pipelines = pipelines
         )
     }
 
-    private fun createMemoryPipeline(
-        sessionType: RumSessionType,
-        rumContext: RumContext
-    ) = Pipeline(
+    private fun createMemoryPipeline(sessionType: RumSessionType) = Pipeline(
         sdkCore = sdkCore,
         reader = VitalReaderWrapper(
             vitalReader = MemoryVitalReader(internalLogger = sdkCore.internalLogger),
@@ -88,14 +86,10 @@ internal class DefaultTimeseriesCollectorFactory(
             internalLogger = sdkCore.internalLogger
         ),
         dataWriter = dataWriter,
-        rumContext = rumContext,
         insightsCollector = insightsCollector
     )
 
-    private fun createCpuPipeline(
-        sessionType: RumSessionType,
-        rumContext: RumContext
-    ) = Pipeline(
+    private fun createCpuPipeline(sessionType: RumSessionType) = Pipeline(
         sdkCore = sdkCore,
         reader = CpuDatapointReader(
             cpuStatReader = CpuStatReader(internalLogger = sdkCore.internalLogger),
@@ -111,7 +105,6 @@ internal class DefaultTimeseriesCollectorFactory(
             internalLogger = sdkCore.internalLogger
         ),
         dataWriter = dataWriter,
-        rumContext = rumContext,
         insightsCollector = insightsCollector
     )
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/Pipeline.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/Pipeline.kt
@@ -27,21 +27,25 @@ internal class Pipeline<T : Any>(
     private val buffer: Buffer<T>,
     private val eventFactory: EventFactory<T, *>,
     private val dataWriter: DataWriter<Any>,
-    private val rumContext: RumContext,
     private val insightsCollector: InsightsCollector = NoOpInsightsCollector()
 ) {
     val intervalMs: Long get() = reader.intervalMs
 
     @WorkerThread
-    fun execute() {
-        reader.read()?.let(buffer::add)
-        if (buffer.isFull()) drainAndWrite()
+    fun execute(rumContext: RumContext) {
+        // reader.read() may hit the filesystem (/proc); kept outside the lock so a concurrent
+        // flush() waits only for the buffer and never for I/O.
+        val dataPoint = reader.read()
+        synchronized(this) {
+            dataPoint?.let(buffer::add)
+            if (buffer.isFull()) drainAndWrite(rumContext)
+        }
     }
 
     @WorkerThread
-    fun flush() = drainAndWrite()
+    fun flush(rumContext: RumContext) = synchronized(this) { drainAndWrite(rumContext) }
 
-    private fun drainAndWrite() {
+    private fun drainAndWrite(rumContext: RumContext) {
         val dataPoints = buffer.drain().ifEmpty { return }
         sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
             ?.withWriteContext(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/TimeseriesCollector.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/timeseries/TimeseriesCollector.kt
@@ -8,14 +8,13 @@ package com.datadog.android.rum.internal.timeseries
 
 import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.domain.RumContext
-import com.datadog.android.rum.internal.domain.scope.RumViewType
 import com.datadog.tools.annotation.NoOpImplementation
 
 @NoOpImplementation
 internal interface TimeseriesCollector {
     fun onSessionStart()
     fun onSessionStop()
-    fun onViewTypeUpdate(newViewType: RumViewType)
+    fun onRumContextUpdate(newRumContext: RumContext)
 
     @NoOpImplementation
     interface Factory {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -1958,9 +1958,9 @@ internal class RumSessionScopeTest {
         // Then — one timeseries per tracked session, updates go to the live one only
         verify(mockTimeseriesCollectorFactory, times(2)).create(any(), any())
         verify(firstTimeseriesCollector).onSessionStop()
-        verify(firstTimeseriesCollector, times(1)).onViewTypeUpdate(fakeViewContext.viewType)
+        verify(firstTimeseriesCollector, times(1)).onRumContextUpdate(fakeViewContext)
         verify(secondTimeseriesCollector).onSessionStart()
-        verify(secondTimeseriesCollector).onViewTypeUpdate(fakeViewContext.viewType)
+        verify(secondTimeseriesCollector).onRumContextUpdate(fakeViewContext)
     }
 
     @Test
@@ -2018,14 +2018,14 @@ internal class RumSessionScopeTest {
         // When
         testedScope.handleEvent(forge.addErrorEvent(), fakeDatadogContext, mockEventWriteScope, mockWriter)
 
-        // Then — the session scope view type, once per handled event
-        val viewTypeCaptor = argumentCaptor<RumViewType>()
-        verify(mockTimeseriesCollector, times(2)).onViewTypeUpdate(viewTypeCaptor.capture())
-        assertThat(viewTypeCaptor.allValues).containsOnly(testedScope.getRumContext().viewType)
+        // Then — the session scope context, once per handled event
+        val rumContextCaptor = argumentCaptor<RumContext>()
+        verify(mockTimeseriesCollector, times(2)).onRumContextUpdate(rumContextCaptor.capture())
+        assertThat(rumContextCaptor.allValues).containsOnly(testedScope.getRumContext())
     }
 
     @Test
-    fun `M pass active view type W onViewTypeUpdate() { StartView creates a foreground view }`(forge: Forge) {
+    fun `M pass active view context W onRumContextUpdate() { StartView creates a foreground view }`(forge: Forge) {
         // Given — a real view manager child scope, so the context comes from an actual RumViewScope
         initializeTestedScope(
             withMockChildScope = false,
@@ -2042,9 +2042,12 @@ internal class RumSessionScopeTest {
         )
 
         // Then
-        val viewTypeCaptor = argumentCaptor<RumViewType>()
-        verify(mockTimeseriesCollector).onViewTypeUpdate(viewTypeCaptor.capture())
-        assertThat(viewTypeCaptor.firstValue).isEqualTo(RumViewType.FOREGROUND)
+        val rumContextCaptor = argumentCaptor<RumContext>()
+        verify(mockTimeseriesCollector).onRumContextUpdate(rumContextCaptor.capture())
+        assertThat(rumContextCaptor.firstValue.viewType).isEqualTo(RumViewType.FOREGROUND)
+        assertThat(rumContextCaptor.firstValue.viewName).isEqualTo(fakeStartViewEvent.key.name)
+        assertThat(rumContextCaptor.firstValue.viewId).isNotNull
+        assertThat(rumContextCaptor.firstValue.sessionId).isEqualTo(testedScope.sessionId)
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -2971,6 +2971,23 @@ internal class DatadogRumMonitorTest {
 
     // endregion
 
+    // region timeseries
+
+    @Test
+    fun `M stop the active session timeseries W stopTimeseries()`() {
+        // Given
+        val mockSessionScope = mock<RumSessionScope>()
+        whenever(mockApplicationScope.activeSession) doReturn mockSessionScope
+
+        // When
+        testedMonitor.stopTimeseries()
+
+        // Then
+        verify(mockSessionScope).stopTimeseries()
+    }
+
+    // endregion
+
     @OptIn(ExperimentalRumApi::class)
     @Test
     fun `M produce StartOperation event W startOperation`(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/DefaultTimeseriesCollectorFactoryTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/DefaultTimeseriesCollectorFactoryTest.kt
@@ -221,7 +221,7 @@ internal class DefaultTimeseriesCollectorFactoryTest {
     }
 
     @Test
-    fun `M propagate executor to the collector and rum context to the pipelines W create()`(
+    fun `M propagate executor and rum context to the collector W create()`(
         @LongForgery(min = 1L) fakeTotalRamBytes: Long
     ) {
         // Given
@@ -234,8 +234,8 @@ internal class DefaultTimeseriesCollectorFactoryTest {
         check(timeseries is DefaultTimeseriesCollector)
         assertThat(timeseries.scheduledExecutorService).isSameAs(mockExecutor)
         assertThat(
-            timeseries.pipelines.map { it.getFieldValue<RumContext, Pipeline<*>>("rumContext") }
-        ).containsOnly(fakeRumContext)
+            timeseries.getFieldValue<RumContext, DefaultTimeseriesCollector>("rumContext")
+        ).isSameAs(fakeRumContext)
     }
 
     @ParameterizedTest

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/DefaultTimeseriesCollectorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/DefaultTimeseriesCollectorTest.kt
@@ -47,6 +47,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.UUID
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -112,6 +113,20 @@ internal class DefaultTimeseriesCollectorTest {
     @IntForgery(min = 2, max = 16)
     var fakeBufferSize: Int = 0
 
+    private fun fakeRumContextOf(viewType: RumViewType) = fakeRumContext.copy(viewType = viewType)
+
+    private fun createTimeseries(
+        initialViewType: RumViewType,
+        collectInBackground: Boolean = false,
+        pipelines: List<Pipeline<*>> = listOf(pipelineA, pipelineB)
+    ) = DefaultTimeseriesCollector(
+        pipelines = pipelines,
+        internalLogger = mockInternalLogger,
+        collectInBackground = collectInBackground,
+        scheduledExecutorService = mockExecutor,
+        rumContext = fakeRumContextOf(initialViewType)
+    )
+
     @BeforeEach
     fun `set up`() {
         whenever(mockReaderA.intervalMs) doReturn fakeIntervalAMs
@@ -132,14 +147,8 @@ internal class DefaultTimeseriesCollectorTest {
         pipelineA = createPipeline(mockReaderA, bufferA, mockEventFactoryA)
         pipelineB = createPipeline(mockReaderB, bufferB, mockEventFactoryB)
 
-        testedTimeseriesCollector = DefaultTimeseriesCollector(
-            pipelines = listOf(pipelineA, pipelineB),
-            internalLogger = mockInternalLogger,
-            collectInBackground = false,
-            scheduledExecutorService = mockExecutor
-        )
         // Seed FOREGROUND so sampling tests don't suspend on first tick
-        testedTimeseriesCollector.onViewTypeUpdate(RumViewType.FOREGROUND)
+        testedTimeseriesCollector = createTimeseries(RumViewType.FOREGROUND)
     }
 
     @Test
@@ -228,7 +237,7 @@ internal class DefaultTimeseriesCollectorTest {
         testedTimeseriesCollector.onSessionStop()
 
         // Then
-        verify(mockEventFactoryA).create(any(), any(), any())
+        verify(mockEventFactoryA).create(any(), eq(fakeRumContextOf(RumViewType.FOREGROUND)), any())
         verify(mockDataWriter).write(any(), eq(fakeJson), eq(EventType.DEFAULT))
     }
 
@@ -248,8 +257,32 @@ internal class DefaultTimeseriesCollectorTest {
         repeat(fakeBufferSize) { runnableA.run() }
 
         // Then
-        verify(mockEventFactoryA).create(any(), any(), any())
+        verify(mockEventFactoryA).create(
+            any(),
+            eq(fakeRumContextOf(RumViewType.FOREGROUND)),
+            eq(dataPoints)
+        )
         verify(mockDataWriter).write(any(), eq(fakeJson), eq(EventType.DEFAULT))
+    }
+
+    @Test
+    fun `M use updated context W sample tick fills buffer { foreground view changed }`(forge: Forge) {
+        // Given
+        val fakePoint = forge.getForgery<DataPoint<Double>>()
+        val fakeNextContext = fakeRumContextOf(RumViewType.FOREGROUND).copy(
+            viewId = forge.getForgery<UUID>().toString()
+        )
+        whenever(mockReaderA.read()) doReturn fakePoint
+        whenever(mockEventFactoryA.create(any(), eq(fakeNextContext), any())) doReturn JsonObject()
+        testedTimeseriesCollector.onSessionStart()
+        testedTimeseriesCollector.onRumContextUpdate(fakeNextContext)
+        val runnableA = captureScheduledRunnableForInterval(fakeIntervalAMs)
+
+        // When
+        repeat(fakeBufferSize) { runnableA.run() }
+
+        // Then
+        verify(mockEventFactoryA).create(any(), eq(fakeNextContext), eq(List(fakeBufferSize) { fakePoint }))
     }
 
     @Test
@@ -399,13 +432,7 @@ internal class DefaultTimeseriesCollectorTest {
         whenever(mockBuffer.drain()) doThrow fakeError
         whenever(mockReaderA.read()) doReturn forge.getForgery<DataPoint<Double>>()
         val pipeline = createPipeline(mockReaderA, mockBuffer, mockEventFactoryA)
-        val timeseries = DefaultTimeseriesCollector(
-            pipelines = listOf(pipeline),
-            internalLogger = mockInternalLogger,
-            collectInBackground = false,
-            scheduledExecutorService = mockExecutor
-        )
-        timeseries.onViewTypeUpdate(RumViewType.FOREGROUND)
+        val timeseries = createTimeseries(RumViewType.FOREGROUND, pipelines = listOf(pipeline))
         timeseries.onSessionStart()
         val runnableA = captureScheduledRunnableForInterval(fakeIntervalAMs)
 
@@ -497,7 +524,7 @@ internal class DefaultTimeseriesCollectorTest {
         // Given
         whenever(mockReaderA.read()) doReturn forge.getForgery<DataPoint<Double>>()
         testedTimeseriesCollector.onSessionStart()
-        testedTimeseriesCollector.onViewTypeUpdate(RumViewType.BACKGROUND)
+        testedTimeseriesCollector.onRumContextUpdate(fakeRumContextOf(RumViewType.BACKGROUND))
         val runnableA = captureScheduledRunnableForInterval(fakeIntervalAMs)
 
         // When
@@ -516,14 +543,9 @@ internal class DefaultTimeseriesCollectorTest {
     fun `M sample W sample tick { background, collectInBackground = true }`(forge: Forge) {
         // Given
         whenever(mockReaderA.read()) doReturn forge.getForgery<DataPoint<Double>>()
-        val bgTimeseries = DefaultTimeseriesCollector(
-            pipelines = listOf(pipelineA, pipelineB),
-            internalLogger = mockInternalLogger,
-            collectInBackground = true,
-            scheduledExecutorService = mockExecutor
-        )
+        val bgTimeseries = createTimeseries(RumViewType.FOREGROUND, collectInBackground = true)
         bgTimeseries.onSessionStart()
-        bgTimeseries.onViewTypeUpdate(RumViewType.BACKGROUND)
+        bgTimeseries.onRumContextUpdate(fakeRumContextOf(RumViewType.BACKGROUND))
         val runnableA = captureScheduledRunnableForInterval(fakeIntervalAMs)
 
         // When
@@ -534,17 +556,17 @@ internal class DefaultTimeseriesCollectorTest {
     }
 
     @Test
-    fun `M resume scheduling W onViewTypeUpdate() { background → foreground }`() {
+    fun `M resume scheduling W onRumContextUpdate() { background → foreground }`() {
         // Given
         testedTimeseriesCollector.onSessionStart()
         // Transition to background: suspends chains
-        testedTimeseriesCollector.onViewTypeUpdate(RumViewType.BACKGROUND)
+        testedTimeseriesCollector.onRumContextUpdate(fakeRumContextOf(RumViewType.BACKGROUND))
         val runnableA = captureScheduledRunnableForInterval(fakeIntervalAMs)
         runnableA.run() // State is already SUSPENDED; tick exits without reschedule
         val schedulesAfterSuspend = 1 // only the one from start()
 
         // When — app returns to foreground
-        testedTimeseriesCollector.onViewTypeUpdate(RumViewType.FOREGROUND)
+        testedTimeseriesCollector.onRumContextUpdate(fakeRumContextOf(RumViewType.FOREGROUND))
 
         // Then — scheduling resumed (one new schedule per pipeline)
         verify(mockExecutor, times(schedulesAfterSuspend + 1))
@@ -561,13 +583,13 @@ internal class DefaultTimeseriesCollectorTest {
         testedTimeseriesCollector.onSessionStart()
 
         // Pipeline A suspends the instance (short interval fires first in background)
-        testedTimeseriesCollector.onViewTypeUpdate(RumViewType.BACKGROUND)
+        testedTimeseriesCollector.onRumContextUpdate(fakeRumContextOf(RumViewType.BACKGROUND))
         val oldRunnableA = captureScheduledRunnableForInterval(fakeIntervalAMs)
         val oldRunnableB = captureScheduledRunnableForInterval(fakeIntervalBMs)
-        oldRunnableA.run() // State is already SUSPENDED (set by onViewTypeUpdate); B's tick is still queued
+        oldRunnableA.run() // State is already SUSPENDED (set by onRumContextUpdate); B's tick is still queued
 
         // Resume creates a new generation and schedules fresh ticks for both pipelines
-        testedTimeseriesCollector.onViewTypeUpdate(RumViewType.FOREGROUND)
+        testedTimeseriesCollector.onRumContextUpdate(fakeRumContextOf(RumViewType.FOREGROUND))
 
         // When — B's old (stale) runnable fires despite the new generation
         oldRunnableB.run()
@@ -586,10 +608,10 @@ internal class DefaultTimeseriesCollectorTest {
         //
         // Given
         testedTimeseriesCollector.onSessionStart()
-        testedTimeseriesCollector.onViewTypeUpdate(RumViewType.BACKGROUND)
+        testedTimeseriesCollector.onRumContextUpdate(fakeRumContextOf(RumViewType.BACKGROUND))
         val oldRunnableB = captureScheduledRunnableForInterval(fakeIntervalBMs)
         // Resume: state = RUNNING, gen = 2; A and B each get a new schedule
-        testedTimeseriesCollector.onViewTypeUpdate(RumViewType.FOREGROUND)
+        testedTimeseriesCollector.onRumContextUpdate(fakeRumContextOf(RumViewType.FOREGROUND))
 
         // When — B's stale gen-1 tick fires while state is RUNNING
         oldRunnableB.run()
@@ -610,8 +632,7 @@ internal class DefaultTimeseriesCollectorTest {
         reader = reader,
         buffer = buffer,
         eventFactory = eventFactory,
-        dataWriter = mockDataWriter,
-        rumContext = fakeRumContext
+        dataWriter = mockDataWriter
     )
 
     private fun captureScheduledRunnableForInterval(intervalMs: Long): Runnable {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/PipelineTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/PipelineTest.kt
@@ -47,6 +47,11 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -116,7 +121,6 @@ internal class PipelineTest {
             buffer = buffer,
             eventFactory = mockEventFactory,
             dataWriter = mockDataWriter,
-            rumContext = fakeRumContext,
             insightsCollector = mockInsightsCollector
         )
     }
@@ -139,7 +143,7 @@ internal class PipelineTest {
         whenever(mockReader.read()) doReturn fakePoint
 
         // When
-        testedPipeline.execute()
+        testedPipeline.execute(fakeRumContext)
 
         // Then
         assertThat(buffer.drain()).containsExactly(fakePoint)
@@ -151,10 +155,33 @@ internal class PipelineTest {
         whenever(mockReader.read()) doReturn null
 
         // When
-        testedPipeline.execute()
+        testedPipeline.execute(fakeRumContext)
 
         // Then
         assertThat(buffer.drain()).isEmpty()
+    }
+
+    @Test
+    fun `M not hold the lock while reading W execute()`(forge: Forge) {
+        // Given — a concurrent flush() races the reader and must not wait for the read to finish
+        var flushedWhileReading = false
+        whenever(mockReader.read()) doAnswer {
+            val flushed = CountDownLatch(1)
+            Thread {
+                testedPipeline.flush(fakeRumContext)
+                flushed.countDown()
+            }.start()
+            flushedWhileReading = flushed.await(CONCURRENT_FLUSH_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            forge.getForgery<DataPoint<Double>>()
+        }
+
+        // When
+        testedPipeline.execute(fakeRumContext)
+
+        // Then
+        assertThat(flushedWhileReading)
+            .describedAs("flush() completed while reader.read() was still running")
+            .isTrue()
     }
 
     // endregion
@@ -170,10 +197,10 @@ internal class PipelineTest {
         whenever(mockReader.read()) doReturn fakePoint
         whenever(mockEventFactory.create(any(), any(), any())) doReturn fakeJson
         whenever(mockEventFactory.eventName) doReturn fakeTimeseriesName
-        repeat(fakeBufferSize - 1) { testedPipeline.execute() }
+        repeat(fakeBufferSize - 1) { testedPipeline.execute(fakeRumContext) }
 
         // When
-        testedPipeline.execute()
+        testedPipeline.execute(fakeRumContext)
 
         // Then
         verify(mockDataWriter).write(mockEventBatchWriter, fakeJson, EventType.DEFAULT)
@@ -187,7 +214,7 @@ internal class PipelineTest {
         whenever(mockReader.read()) doReturn forge.getForgery<DataPoint<Double>>()
 
         // When
-        repeat(fakeBufferSize - 1) { testedPipeline.execute() }
+        repeat(fakeBufferSize - 1) { testedPipeline.execute(fakeRumContext) }
 
         // Then
         verifyNoInteractions(mockDataWriter)
@@ -199,10 +226,10 @@ internal class PipelineTest {
         // Given
         whenever(mockReader.read()) doReturn forge.getForgery<DataPoint<Double>>()
         whenever(mockEventFactory.create(any(), any(), any())) doReturn null
-        repeat(fakeBufferSize - 1) { testedPipeline.execute() }
+        repeat(fakeBufferSize - 1) { testedPipeline.execute(fakeRumContext) }
 
         // When
-        testedPipeline.execute()
+        testedPipeline.execute(fakeRumContext)
 
         // Then
         verifyNoInteractions(mockDataWriter)
@@ -223,10 +250,10 @@ internal class PipelineTest {
         whenever(mockEventFactory.create(any(), any(), any())) doReturn fakeJson
         whenever(mockEventFactory.eventName) doReturn fakeTimeseriesName
         val sampleCount = fakeBufferSize - 1
-        repeat(sampleCount) { testedPipeline.execute() }
+        repeat(sampleCount) { testedPipeline.execute(fakeRumContext) }
 
         // When
-        testedPipeline.flush()
+        testedPipeline.flush(fakeRumContext)
 
         // Then
         val captor = argumentCaptor<List<DataPoint<Double>>>()
@@ -244,10 +271,10 @@ internal class PipelineTest {
         whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer { Unit }
         whenever(mockEventFactory.create(any(), any(), any())) doReturn fakeTimeseriesJson("view.cpu")
         whenever(mockReader.read()) doReturn fakePoint
-        testedPipeline.execute()
+        testedPipeline.execute(fakeRumContext)
 
         // When
-        testedPipeline.flush()
+        testedPipeline.flush(fakeRumContext)
 
         // Then
         assertThat(buffer.drain()).isEmpty()
@@ -267,12 +294,12 @@ internal class PipelineTest {
         whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer { Unit }
         whenever(mockEventFactory.create(any(), any(), any())) doReturn fakeTimeseriesJson("view.cpu")
         whenever(mockReader.read()) doReturn fakePoint
-        testedPipeline.execute()
-        testedPipeline.flush()
+        testedPipeline.execute(fakeRumContext)
+        testedPipeline.flush(fakeRumContext)
         whenever(mockReader.read()) doReturn fakeNextPoint
 
         // When
-        testedPipeline.execute()
+        testedPipeline.execute(fakeRumContext)
         verify(mockRumFeatureScope).withWriteContext(any(), callbackCaptor.capture())
         callbackCaptor.firstValue.invoke(mockDatadogContext, mockEventWriteScope)
 
@@ -288,10 +315,10 @@ internal class PipelineTest {
         // Given
         whenever(mockReader.read()) doReturn forge.getForgery<DataPoint<Double>>()
         whenever(mockEventFactory.create(any(), any(), any())) doReturn fakeTimeseriesJson("view.cpu")
-        testedPipeline.execute()
+        testedPipeline.execute(fakeRumContext)
 
         // When
-        testedPipeline.flush()
+        testedPipeline.flush(fakeRumContext)
 
         // Then
         verify(mockEventFactory).create(eq(mockDatadogContext), eq(fakeRumContext), any())
@@ -302,10 +329,10 @@ internal class PipelineTest {
         // Given
         whenever(mockReader.read()) doReturn forge.getForgery<DataPoint<Double>>()
         whenever(mockEventFactory.create(any(), any(), any())) doReturn fakeTimeseriesJson("view.cpu")
-        testedPipeline.execute()
+        testedPipeline.execute(fakeRumContext)
 
         // When
-        testedPipeline.flush()
+        testedPipeline.flush(fakeRumContext)
 
         // Then
         verify(mockRumFeatureScope).withWriteContext(
@@ -317,7 +344,7 @@ internal class PipelineTest {
     @Test
     fun `M not write W flush() { buffer empty }`() {
         // When
-        testedPipeline.flush()
+        testedPipeline.flush(fakeRumContext)
 
         // Then
         verifyNoInteractions(mockDataWriter)
@@ -330,10 +357,10 @@ internal class PipelineTest {
         val fakeThrowable = forge.aThrowable()
         whenever(mockReader.read()) doReturn forge.getForgery<DataPoint<Double>>()
         whenever(mockEventFactory.create(any(), any(), any())) doThrow fakeThrowable
-        testedPipeline.execute()
+        testedPipeline.execute(fakeRumContext)
 
         // When
-        testedPipeline.flush()
+        testedPipeline.flush(fakeRumContext)
 
         // Then
         mockInternalLogger.verifyLog(
@@ -356,10 +383,10 @@ internal class PipelineTest {
         whenever(mockEventFactory.create(any(), any(), any())) doReturn fakeJson
         whenever(mockDataWriter.write(any(), any(), any())) doThrow fakeThrowable
         whenever(mockEventWriteScope.invoke(any())) doAnswer { Unit }
-        testedPipeline.execute()
+        testedPipeline.execute(fakeRumContext)
 
         // When
-        testedPipeline.flush()
+        testedPipeline.flush(fakeRumContext)
         verify(mockEventWriteScope).invoke(writeBlockCaptor.capture())
         writeBlockCaptor.firstValue.invoke(mockEventBatchWriter)
 
@@ -380,10 +407,10 @@ internal class PipelineTest {
         whenever(mockReader.read()) doReturn forge.getForgery<DataPoint<Double>>()
         whenever(mockEventFactory.create(any(), any(), any())) doReturn fakeJson
         whenever(mockDataWriter.write(any(), any(), any())) doReturn false
-        testedPipeline.execute()
+        testedPipeline.execute(fakeRumContext)
 
         // When
-        testedPipeline.flush()
+        testedPipeline.flush(fakeRumContext)
 
         // Then
         verify(mockDataWriter).write(mockEventBatchWriter, fakeJson, EventType.DEFAULT)
@@ -392,9 +419,124 @@ internal class PipelineTest {
 
     // endregion
 
+    // region concurrency
+
+    @Test
+    fun `M not lose or duplicate points W execute() { concurrent samplers }`() {
+        // Given — every read() yields a unique point, every drained batch is recorded
+        val counter = AtomicLong()
+        val batches = CopyOnWriteArrayList<List<DataPoint<Double>>>()
+        stubUniqueReads(counter)
+        stubBatchRecording(batches)
+
+        // When
+        runConcurrently { testedPipeline.execute(fakeRumContext) }
+        val batchesBeforeFlush = batches.toList()
+        testedPipeline.flush(fakeRumContext)
+
+        // Then
+        assertThat(batchesBeforeFlush.map { it.size })
+            .describedAs("batches drained by execute() are always exactly one buffer worth")
+            .containsOnly(fakeBufferSize)
+        assertThat(batches.flatten().map { it.timestampNs }.sorted())
+            .isEqualTo((1L..counter.get()).toList())
+    }
+
+    @Test
+    fun `M not lose or duplicate points W execute() and flush() { concurrent }`() {
+        // Given
+        val counter = AtomicLong()
+        val batches = CopyOnWriteArrayList<List<DataPoint<Double>>>()
+        stubUniqueReads(counter)
+        stubBatchRecording(batches)
+
+        // When — one thread keeps flushing while the others keep sampling
+        runConcurrently { threadIndex ->
+            if (threadIndex == 0) {
+                testedPipeline.flush(fakeRumContext)
+            } else {
+                testedPipeline.execute(fakeRumContext)
+            }
+        }
+        testedPipeline.flush(fakeRumContext)
+
+        // Then
+        assertThat(batches.flatten().map { it.timestampNs }.sorted())
+            .isEqualTo((1L..counter.get()).toList())
+    }
+
+    @Test
+    fun `M eventually capture point W flush() races execute() { flush between read() and add() }`(
+        forge: Forge
+    ) {
+        // Given — reader.read() blocks until released, forcing execute() to sit between
+        // its (unsynchronized) read() and the synchronized buffer add()
+        val readStarted = CountDownLatch(1)
+        val releaseRead = CountDownLatch(1)
+        val fakePoint = forge.getForgery<DataPoint<Double>>()
+        whenever(mockReader.read()) doAnswer {
+            readStarted.countDown()
+            releaseRead.await(CONCURRENT_FLUSH_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            fakePoint
+        }
+        val batches = CopyOnWriteArrayList<List<DataPoint<Double>>>()
+        stubBatchRecording(batches)
+        val executor = Executors.newSingleThreadExecutor()
+
+        // When
+        executor.execute { testedPipeline.execute(fakeRumContext) }
+        readStarted.await(CONCURRENT_FLUSH_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        testedPipeline.flush(fakeRumContext) // races execute(): read() is in flight, not yet added
+        releaseRead.countDown()
+        executor.shutdown()
+        check(executor.awaitTermination(CONCURRENT_FLUSH_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+            "execute() did not complete in time"
+        }
+        testedPipeline.flush(fakeRumContext) // point survives for the next flush
+
+        // Then
+        assertThat(batches.flatten()).containsExactly(fakePoint)
+    }
+
+    // endregion
+
+    private fun stubUniqueReads(counter: AtomicLong) {
+        whenever(mockReader.read()) doAnswer { DataPoint(counter.incrementAndGet(), 0.0) }
+    }
+
+    private fun stubBatchRecording(batches: MutableList<List<DataPoint<Double>>>) {
+        whenever(mockEventFactory.create(any(), any(), any())) doAnswer { invocation ->
+            batches.add(invocation.getArgument(2))
+            fakeTimeseriesJson("view.cpu")
+        }
+    }
+
+    private fun runConcurrently(task: (threadIndex: Int) -> Unit) {
+        val executor = Executors.newFixedThreadPool(CONCURRENT_THREADS)
+        val start = CountDownLatch(1)
+        val done = CountDownLatch(CONCURRENT_THREADS)
+        repeat(CONCURRENT_THREADS) { threadIndex ->
+            executor.execute {
+                start.await()
+                repeat(ITERATIONS_PER_THREAD) { task(threadIndex) }
+                done.countDown()
+            }
+        }
+        start.countDown()
+        val finished = done.await(CONCURRENT_FLUSH_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        executor.shutdownNow()
+        check(finished) { "concurrent tasks did not complete in time" }
+    }
+
     // Pipeline forwards whatever the event factory returns without inspecting it, so the shape
     // only needs to be a distinct non-null object per name.
     private fun fakeTimeseriesJson(name: String): JsonObject = JsonObject().apply {
         addProperty("name", name)
+    }
+
+    private companion object {
+        const val CONCURRENT_FLUSH_TIMEOUT_MS = 2000L
+        const val CONCURRENT_THREADS = 4
+        const val ITERATIONS_PER_THREAD = 200
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/csv/CsvCollector.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/csv/CsvCollector.kt
@@ -16,7 +16,6 @@ import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.battery.BatteryInfo
 import com.datadog.android.rum.internal.domain.display.DisplayInfo
 import com.datadog.android.rum.internal.domain.event.RumEventSerializer
-import com.datadog.android.rum.internal.domain.scope.RumViewType
 import com.datadog.android.rum.internal.timeseries.Buffer
 import com.datadog.android.rum.internal.timeseries.TimeseriesCollector
 import com.datadog.android.rum.internal.timeseries.factory.CpuEventFactory
@@ -66,7 +65,7 @@ internal class CsvCollector(
 
     override fun onSessionStop() = Unit
 
-    override fun onViewTypeUpdate(newViewType: RumViewType) = Unit
+    override fun onRumContextUpdate(newRumContext: RumContext) = Unit
 
     companion object {
 


### PR DESCRIPTION
### What does this PR do?

Timeseries batches carried the `RumContext` captured when `RumSessionScope` created the collector, so every event was attributed to whatever view happened to be active at session start. The collector now tracks the context and hands it to `Pipeline.execute()` / `Pipeline.flush()` per call, and `RumSessionScope` feeds it the active context on every handled event.

`Pipeline` takes over its own synchronization as part of that: `reader.read()` stays outside the lock, so a concurrent `flush()` waits only for the buffer and never for `/proc` I/O.

The sampling lifecycle is unchanged here — background suspension still behaves exactly as before, gated on `TimeseriesConfiguration.collectInBackground`. [4/5] reworks it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

Ref: RUM-17613