### PR TITLE
Fix flaky RumViewScopeTest heatmapData test

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -2935,9 +2935,10 @@ internal class RumViewScopeTest {
         assertThat(actionScope.sampleRate).isCloseTo(fakeSampleRate, Assertions.offset(0.001f))
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(RumActionType::class, names = ["CUSTOM"], mode = EnumSource.Mode.EXCLUDE)
     fun `M pass heatmapData through W handleEvent(StartAction) {heatmapData set}`(
-        @Forgery type: RumActionType,
+        type: RumActionType,
         @StringForgery name: String,
         @BoolForgery waitForStop: Boolean,
         @Forgery fakeHeatmapData: NativeHeatmapActionData,


### PR DESCRIPTION
### What does this PR do?

Fixes flaky RumViewScopeTest heatmapData test that NPE'd when Forge generated RumActionType.CUSTOM + waitForStop = false, which makes RumViewScope.onStartAction return early without setting activeActionScope. Excludes CUSTOM via @EnumSource, matching an existing sibling test's pattern. Test-only change.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

