### PR TITLE
Fix ConcurrentModificationException in TouchPrivacyManager

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/TouchPrivacyManager.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/TouchPrivacyManager.kt
@@ -30,37 +30,46 @@ class TouchPrivacyManager(
     // the overrides when they are no longer needed.
     private val nextOverrideAreas = HashMap<Rect, TouchPrivacy>()
 
+    // Each recorded window runs the snapshot pipeline on the Looper thread its view hierarchy is
+    // attached to. This could not be the main thread so these maps can be accessed concurrently.
+    private val lock = Any()
+
     /**
      * Adds touch area with [TouchPrivacy] override.
      */
     @UiThread
     fun addTouchOverrideArea(bounds: Rect, touchPrivacy: TouchPrivacy) {
-        nextOverrideAreas[bounds] = touchPrivacy
+        synchronized(lock) {
+            nextOverrideAreas[bounds] = touchPrivacy
+        }
     }
 
     @UiThread
     internal fun updateCurrentTouchOverrideAreas() {
-        currentOverrideAreas.clear()
-        // NPE cannot happen here
-        @Suppress("UnsafeThirdPartyFunctionCall")
-        currentOverrideAreas.putAll(nextOverrideAreas)
-        nextOverrideAreas.clear()
+        synchronized(lock) {
+            currentOverrideAreas.clear()
+            // NPE cannot happen here
+            @Suppress("UnsafeThirdPartyFunctionCall")
+            currentOverrideAreas.putAll(nextOverrideAreas)
+            nextOverrideAreas.clear()
+        }
     }
 
     @UiThread
     internal fun shouldRecordTouch(touchLocation: Point): Boolean {
         var isOverriddenToShowTouch = false
 
-        // Everything is UiThread, so ConcurrentModification cannot happen here
-        @Suppress("UnsafeThirdPartyFunctionCall")
-        currentOverrideAreas.forEach { entry ->
-            val area = entry.key
-            val overrideValue = entry.value
+        synchronized(lock) {
+            @Suppress("UnsafeThirdPartyFunctionCall")
+            currentOverrideAreas.forEach { entry ->
+                val area = entry.key
+                val overrideValue = entry.value
 
-            if (area.contains(touchLocation.x, touchLocation.y)) {
-                when (overrideValue) {
-                    TouchPrivacy.HIDE -> return false
-                    TouchPrivacy.SHOW -> isOverriddenToShowTouch = true
+                if (area.contains(touchLocation.x, touchLocation.y)) {
+                    when (overrideValue) {
+                        TouchPrivacy.HIDE -> return false
+                        TouchPrivacy.SHOW -> isOverriddenToShowTouch = true
+                    }
                 }
             }
         }
@@ -70,11 +79,19 @@ class TouchPrivacyManager(
 
     @VisibleForTesting
     internal fun getCurrentOverrideAreas(): Map<Rect, TouchPrivacy> {
-        return currentOverrideAreas
+        synchronized(lock) {
+            // NPE cannot happen here
+            @Suppress("UnsafeThirdPartyFunctionCall")
+            return HashMap(currentOverrideAreas)
+        }
     }
 
     @VisibleForTesting
     internal fun getNextOverrideAreas(): Map<Rect, TouchPrivacy> {
-        return nextOverrideAreas
+        synchronized(lock) {
+            // NPE cannot happen here
+            @Suppress("UnsafeThirdPartyFunctionCall")
+            return HashMap(nextOverrideAreas)
+        }
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/TouchPrivacyManagerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/TouchPrivacyManagerTest.kt
@@ -22,6 +22,8 @@ import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
+import java.util.Random
+import java.util.concurrent.CopyOnWriteArrayList
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -153,5 +155,50 @@ internal class TouchPrivacyManagerTest {
 
         // Then
         assertThat(testedManager.shouldRecordTouch(touchLocation)).isFalse()
+    }
+
+    @Test
+    fun `M not throw W updateCurrentTouchOverrideAreas() { concurrent addTouchOverrideArea }`(
+        forge: Forge
+    ) {
+        // Given
+        // Each recorded window runs the snapshot pipeline on the Looper thread its view
+        // hierarchy is attached to, so a traversal writing overrides can run concurrently
+        // with the copy-and-clear swap performed at the end of another window's snapshot.
+        val fakePrivacyOverride = forge.aValueFrom(TouchPrivacy::class.java)
+        val fakeOrigin = forge.anInt(min = 0, max = 1000)
+        val iterations = 10_000
+        val errors = CopyOnWriteArrayList<Throwable>()
+
+        // When
+        listOf(
+            Thread {
+                repeat(iterations) {
+                    try {
+                        testedManager.addTouchOverrideArea(
+                            Rect(fakeOrigin + it, fakeOrigin + it, fakeOrigin + it + 1, fakeOrigin + it + 1),
+                            fakePrivacyOverride
+                        )
+                    } catch (e: Throwable) {
+                        errors.add(e)
+                    }
+                }
+            },
+            Thread {
+                repeat(iterations) {
+                    try {
+                        testedManager.updateCurrentTouchOverrideAreas()
+                        testedManager.shouldRecordTouch(Point(fakeOrigin + it, fakeOrigin + it))
+                    } catch (e: Throwable) {
+                        errors.add(e)
+                    }
+                }
+            }
+        ).shuffled(Random(forge.seed))
+            .map { it.apply { start() } }
+            .forEach { it.join() }
+
+        // Then
+        assertThat(errors).isEmpty()
     }
 }


### PR DESCRIPTION
Fixes #3725

### What does this PR do?

Guards `TouchPrivacyManager`'s `currentOverrideAreas` and `nextOverrideAreas` with a
single lock and adds a concurrency regression test.

### Motivation

Fixes my filed issue #3725. Noticed in my apps production fleet via RUM, real user session crashing. 

The class documents a single-UI-thread claim that does not hold in all cases. It is a race condition and the result is
an uncaught `ConcurrentModificationException` inside `onDraw`, which kills the app. Most of the details are in the Issue so won't rehash them here for brevity. 

### Additional Notes

- I verified this pre and post patch using the repro I uploaded in the #3725 filing
- Added test is red without this patch ---> goes green

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

