### PR TITLE
RUM-18142: Add setAnrTriggerEnabled opt-out API for ANR-triggered profiling

### DIFF
--- a/features/dd-sdk-android-profiling/api/apiSurface
+++ b/features/dd-sdk-android-profiling/api/apiSurface
@@ -14,6 +14,7 @@ data class com.datadog.android.profiling.ProfilingConfiguration
     fun setApplicationLaunchSampleRate(Float): Builder
     fun setContinuousSampleRate(Float): Builder
     fun useCustomEndpoint(String): Builder
+    fun setAnrTriggerEnabled(Boolean): Builder
     fun build(): ProfilingConfiguration
   companion object 
     val DEFAULT: ProfilingConfiguration

--- a/features/dd-sdk-android-profiling/api/dd-sdk-android-profiling.api
+++ b/features/dd-sdk-android-profiling/api/dd-sdk-android-profiling.api
@@ -23,8 +23,8 @@ public final class com/datadog/android/profiling/Profiling {
 
 public final class com/datadog/android/profiling/ProfilingConfiguration {
 	public static final field Companion Lcom/datadog/android/profiling/ProfilingConfiguration$Companion;
-	public final fun copy (Ljava/lang/String;FF)Lcom/datadog/android/profiling/ProfilingConfiguration;
-	public static synthetic fun copy$default (Lcom/datadog/android/profiling/ProfilingConfiguration;Ljava/lang/String;FFILjava/lang/Object;)Lcom/datadog/android/profiling/ProfilingConfiguration;
+	public final fun copy (Ljava/lang/String;FFZ)Lcom/datadog/android/profiling/ProfilingConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/profiling/ProfilingConfiguration;Ljava/lang/String;FFZILjava/lang/Object;)Lcom/datadog/android/profiling/ProfilingConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -33,6 +33,7 @@ public final class com/datadog/android/profiling/ProfilingConfiguration {
 public final class com/datadog/android/profiling/ProfilingConfiguration$Builder {
 	public fun <init> ()V
 	public final fun build ()Lcom/datadog/android/profiling/ProfilingConfiguration;
+	public final fun setAnrTriggerEnabled (Z)Lcom/datadog/android/profiling/ProfilingConfiguration$Builder;
 	public final fun setApplicationLaunchSampleRate (F)Lcom/datadog/android/profiling/ProfilingConfiguration$Builder;
 	public final fun setContinuousSampleRate (F)Lcom/datadog/android/profiling/ProfilingConfiguration$Builder;
 	public final fun useCustomEndpoint (Ljava/lang/String;)Lcom/datadog/android/profiling/ProfilingConfiguration$Builder;

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/ProfilingConfiguration.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/ProfilingConfiguration.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.profiling
 
+import android.os.ProfilingTrigger
 import androidx.annotation.FloatRange
 
 /**
@@ -15,7 +16,8 @@ import androidx.annotation.FloatRange
 data class ProfilingConfiguration internal constructor(
     internal val customEndpointUrl: String?,
     internal val applicationLaunchSampleRate: Float,
-    internal val continuousSampleRate: Float
+    internal val continuousSampleRate: Float,
+    internal val anrTriggerEnabled: Boolean = DEFAULT_ANR_TRIGGER_ENABLED
 ) {
 
     /**
@@ -26,6 +28,7 @@ data class ProfilingConfiguration internal constructor(
         private var customEndpointUrl: String? = null
         private var applicationLaunchSampleRate: Float = DEFAULT_APPLICATION_LAUNCH_SAMPLE_RATE
         private var continuousSampleRate: Float = DEFAULT_CONTINUOUS_SAMPLE_RATE
+        private var anrTriggerEnabled: Boolean = DEFAULT_ANR_TRIGGER_ENABLED
 
         /**
          * Sets the sampling rate for Application Launch profiling. It will be applied on the next application launch.
@@ -66,13 +69,27 @@ data class ProfilingConfiguration internal constructor(
         }
 
         /**
+         * Enables or disables the ANR triggered profiling.
+         *
+         * When enabled, the SDK registers [ProfilingTrigger.TRIGGER_TYPE_ANR] so that a
+         * profile is captured automatically when an ANR occurs.
+         *
+         * @param enabled `true` to enable ANR-triggered profiling (default), `false` to disable it.
+         */
+        fun setAnrTriggerEnabled(enabled: Boolean): Builder {
+            this.anrTriggerEnabled = enabled
+            return this
+        }
+
+        /**
          * Builds a [ProfilingConfiguration] based on the current state of this Builder.
          */
         fun build(): ProfilingConfiguration {
             return ProfilingConfiguration(
                 customEndpointUrl = customEndpointUrl,
                 applicationLaunchSampleRate = applicationLaunchSampleRate,
-                continuousSampleRate = continuousSampleRate
+                continuousSampleRate = continuousSampleRate,
+                anrTriggerEnabled = anrTriggerEnabled
             )
         }
     }
@@ -85,6 +102,12 @@ data class ProfilingConfiguration internal constructor(
          * Default sampling rate for Continuous Profiling.
          */
         internal const val DEFAULT_CONTINUOUS_SAMPLE_RATE: Float = 15f
+
+        /**
+         * ANR-triggered profiling is enabled by default to preserve the existing behavior,
+         * making this an opt-out capability.
+         */
+        internal const val DEFAULT_ANR_TRIGGER_ENABLED: Boolean = true
 
         /**
          * A default configuration for the Profiling feature.

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/NoOpProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/NoOpProfiler.kt
@@ -39,6 +39,8 @@ internal class NoOpProfiler : Profiler {
 
     override fun unregisterProfilingCallback(appContext: Context) = Unit
 
+    override fun setAnrTriggerEnabled(enabled: Boolean) = Unit
+
     override fun setExtendLaunchSession(extend: Boolean) = Unit
 
     override fun resolveProfilingPackageVersionCode(appContext: Context) = Unit

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/Profiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/Profiler.kt
@@ -34,6 +34,8 @@ internal interface Profiler {
 
     fun unregisterProfilingCallback(appContext: Context)
 
+    fun setAnrTriggerEnabled(enabled: Boolean)
+
     /**
      * Controls whether an app launch profiling session should extend past the 10-second
      * TTID threshold. Set to `true` when continuous profiling is enabled for the session

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -95,6 +95,7 @@ internal class ProfilingFeature(
             this.timeProvider.delegate = sdkCore.timeProvider
             resolveProfilingPackageVersionCode(appContext)
             this.internalLogger = sdkCore.internalLogger
+            setAnrTriggerEnabled(configuration.anrTriggerEnabled)
             registerProfilingCallback(appContext, this@ProfilingFeature)
         }
         ProfilingStorage.setSampleRate(appContext, configuration.applicationLaunchSampleRate)

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
@@ -96,6 +96,9 @@ internal class PerfettoProfiler(
             profilingTelemetry.internalLogger = value
         }
 
+    @Volatile
+    internal var anrTriggerEnabled: Boolean = true
+
     internal val anrListener = AnrListener { event ->
         callback?.onAnrDetected(event)
     }
@@ -253,7 +256,7 @@ internal class PerfettoProfiler(
     ) {
         synchronized(this) {
             this.callback = callback
-            if (buildSdkVersionProvider.isAtLeastBaklava) {
+            if (buildSdkVersionProvider.isAtLeastBaklava && anrTriggerEnabled) {
                 anrTriggerRegistrar.register(appContext, anrListener)
             }
         }
@@ -262,7 +265,7 @@ internal class PerfettoProfiler(
     override fun unregisterProfilingCallback(appContext: Context) {
         synchronized(this) {
             callback = null
-            if (buildSdkVersionProvider.isAtLeastBaklava) {
+            if (buildSdkVersionProvider.isAtLeastBaklava && anrTriggerEnabled) {
                 anrTriggerRegistrar.unregister(appContext)
             }
         }
@@ -270,6 +273,10 @@ internal class PerfettoProfiler(
 
     override fun setExtendLaunchSession(extend: Boolean) {
         this.extendLaunchSession = extend
+    }
+
+    override fun setAnrTriggerEnabled(enabled: Boolean) {
+        this.anrTriggerEnabled = enabled
     }
 
     override fun resolveProfilingPackageVersionCode(appContext: Context) {

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -478,6 +478,32 @@ internal class ProfilingFeatureTest {
     }
 
     @Test
+    fun `M propagate ANR trigger enabled flag W onInitialize()`() {
+        // Given
+        val config = fakeConfiguration.copy(anrTriggerEnabled = false)
+        testedFeature = ProfilingFeature(mockSdkCore, config, mockProfiler)
+
+        // When
+        testedFeature.onInitialize(mockContext)
+
+        // Then
+        verify(mockProfiler).setAnrTriggerEnabled(false)
+    }
+
+    @Test
+    fun `M propagate ANR trigger enabled flag W onInitialize {enabled}`() {
+        // Given
+        val config = fakeConfiguration.copy(anrTriggerEnabled = true)
+        testedFeature = ProfilingFeature(mockSdkCore, config, mockProfiler)
+
+        // When
+        testedFeature.onInitialize(mockContext)
+
+        // Then
+        verify(mockProfiler).setAnrTriggerEnabled(true)
+    }
+
+    @Test
     fun `M ignore context update W onContextUpdate {non-RUM feature}`(
         @StringForgery fakeOtherFeatureName: String,
         @FloatForgery(min = 0f, max = 100f) fakeSessionRate: Float

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/ProfilingConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/ProfilingConfigurationForgeryFactory.kt
@@ -20,7 +20,8 @@ class ProfilingConfigurationForgeryFactory :
             continuousSampleRate = forge.aFloat(min = 0f, max = 100f),
             customEndpointUrl = forge.aNullable {
                 aStringMatching("http(s?)://[a-z]+\\.com/\\w+")
-            }
+            },
+            anrTriggerEnabled = forge.aBool()
         )
     }
 }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -1084,6 +1084,32 @@ class PerfettoProfilerTest {
     }
 
     @Test
+    fun `M not delegate to registrar W registerProfilingCallback {ANR trigger disabled}`() {
+        // Given
+        // Drop interactions recorded by the set-up call (which used the default enabled state).
+        reset(mockAnrRegistrar)
+        testedProfiler.setAnrTriggerEnabled(false)
+
+        // When
+        testedProfiler.registerProfilingCallback(mockContext, mockProfilerCallback)
+
+        // Then
+        verify(mockAnrRegistrar, never()).register(any(), any())
+    }
+
+    @Test
+    fun `M not delegate to registrar W unregisterProfilingCallback {ANR trigger disabled}`() {
+        // Given
+        testedProfiler.setAnrTriggerEnabled(false)
+
+        // When
+        testedProfiler.unregisterProfilingCallback(mockContext)
+
+        // Then
+        verify(mockAnrRegistrar, never()).unregister(any())
+    }
+
+    @Test
     fun `M not delegate to registrar W unregisterProfilingCallback {SDK below BAKLAVA}`() {
         // Given
         whenever(mockBuildSdkVersionProvider.isAtLeastBaklava) doReturn false

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingConfigurationBuilderTest.kt
@@ -44,6 +44,7 @@ internal class ProfilingConfigurationBuilderTest {
         // Then
         assertThat(configuration.customEndpointUrl).isNull()
         assertThat(configuration.continuousSampleRate).isEqualTo(DEFAULT_CONTINUOUS_SAMPLE_RATE)
+        assertThat(configuration.anrTriggerEnabled).isTrue()
     }
 
     @Test
@@ -70,5 +71,27 @@ internal class ProfilingConfigurationBuilderTest {
 
         // Then
         assertThat(configuration.customEndpointUrl).isEqualTo(endpoint)
+    }
+
+    @Test
+    fun `M build config with ANR trigger disabled W setAnrTriggerEnabled(false) and build()`() {
+        // When
+        val configuration = testedBuilder
+            .setAnrTriggerEnabled(false)
+            .build()
+
+        // Then
+        assertThat(configuration.anrTriggerEnabled).isFalse()
+    }
+
+    @Test
+    fun `M build config with ANR trigger enabled W setAnrTriggerEnabled(true) and build()`() {
+        // When
+        val configuration = testedBuilder
+            .setAnrTriggerEnabled(true)
+            .build()
+
+        // Then
+        assertThat(configuration.anrTriggerEnabled).isTrue()
     }
 }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingConfigurationTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingConfigurationTest.kt
@@ -30,6 +30,7 @@ internal class ProfilingConfigurationTest {
         // Then
         assertThat(config.customEndpointUrl).isNull()
         assertThat(config.applicationLaunchSampleRate).isEqualTo(15f)
+        assertThat(config.anrTriggerEnabled).isTrue()
     }
 
     @Test
@@ -77,5 +78,19 @@ internal class ProfilingConfigurationTest {
         assertThat(original.applicationLaunchSampleRate).isEqualTo(15f)
         assertThat(modified.customEndpointUrl).isEqualTo(endpoint)
         assertThat(modified.applicationLaunchSampleRate).isEqualTo(sampleRate)
+    }
+
+    @Test
+    fun `M preserve ANR trigger flag W data class copy()`() {
+        // Given
+        val original = ProfilingConfiguration.Builder()
+            .setAnrTriggerEnabled(false)
+            .build()
+
+        // When
+        val copied = original.copy(continuousSampleRate = 50f)
+
+        // Then
+        assertThat(copied.anrTriggerEnabled).isFalse()
     }
 }


### PR DESCRIPTION
### What does this PR do?

 Adds a new `ProfilingConfiguration.Builder.setAnrTriggerEnabled(Boolean)` API (default true) allowing customers to opt out of           
 ANR-triggered profiling.  

 ### Why                                                                                                                               
                                                                                                                                       
 - Billing: ANR-triggered profiles are uploaded and billed as profiling sessions. Customers now have a choice to disable them.         
 - Trigger conflicts: Customers registering their own `ProfilingTriggers` can disable the SDK's ANR trigger to avoid cleanup conflicts.  
      

### Motivation

RUM-18142

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

