### PR TITLE
Fix ConcurrentModificationException races across Session Replay windows

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/LazyHeatmapIdentifierRegistry.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/LazyHeatmapIdentifierRegistry.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.sessionreplay.internal
 
-import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
@@ -19,15 +18,17 @@ import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
  * This wrapper defers the `getFeature(RUM)` lookup to the first heatmap operation and caches
  * the result once resolved so the lookup cost is paid at most once.
  *
- * All methods are `@UiThread`: the SR snapshot traversal drives writes from the UI thread and
- * [HeatmapIdentifierResolver] is annotated `@UiThread`, so no locking is needed here.
+ * Each recorded window drives its snapshot traversal on its own Looper thread, so [delegate] can
+ * be entered concurrently from multiple threads. The cached resolution is `@Volatile` so a
+ * resolution made on one thread is visible to the others; a redundant [FeatureSdkCore.getFeature]
+ * lookup racing on first use is harmless since the result is deterministic.
  */
-@UiThread
 internal class LazyHeatmapIdentifierRegistry(
     private val sdkCore: FeatureSdkCore
 ) : HeatmapIdentifierRegistry {
 
     // null = not yet attempted; UNAVAILABLE = permanently failed; anything else = real registry
+    @Volatile
     private var resolved: HeatmapIdentifierRegistry? = null
 
     private fun delegate(): HeatmapIdentifierRegistry? {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/TouchPrivacyManager.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/TouchPrivacyManager.kt
@@ -23,44 +23,64 @@ class TouchPrivacyManager(
     // areas on screen where overrides are applied
     private val currentOverrideAreas = HashMap<Rect, TouchPrivacy>()
 
-    // Built during the view traversal and copied to currentOverrideAreas at the end
-    // We use two hashmaps because touch handling happens in parallel to the view traversal
-    // and we don't know which will happen first.
-    // Secondly, because we don't want to have to keep track of the lifecycle of the overridden views in order to remove
-    // the overrides when they are no longer needed.
-    private val nextOverrideAreas = HashMap<Rect, TouchPrivacy>()
+    // Built during the view traversal and copied to currentOverrideAreas at the end.
+    // ThreadLocal because each window's onDraw pass rebuilds this on its own thread: a shared
+    // map would let one pass's clear() wipe another's still-in-progress entries.
+    // initialValue() (not withInitial(), which needs API 26) keeps this working below minSdk.
+    private val nextOverrideAreas = object : ThreadLocal<HashMap<Rect, TouchPrivacy>>() {
+        override fun initialValue(): HashMap<Rect, TouchPrivacy> = HashMap()
+    }
+
+    // ThreadLocal#get() is a platform type from Kotlin's view; initialValue() always supplies a
+    // value, but falling back to a fresh map here (never crashing) is safer than asserting it.
+    private fun currentPass(): HashMap<Rect, TouchPrivacy> {
+        val existing = nextOverrideAreas.get()
+        if (existing != null) return existing
+        val fresh = HashMap<Rect, TouchPrivacy>()
+        nextOverrideAreas.set(fresh)
+        return fresh
+    }
+
+    // Each recorded window runs the snapshot pipeline on the Looper thread its view hierarchy is
+    // attached to. This could not be the main thread so currentOverrideAreas can be accessed
+    // concurrently.
+    private val lock = Any()
 
     /**
      * Adds touch area with [TouchPrivacy] override.
      */
     @UiThread
     fun addTouchOverrideArea(bounds: Rect, touchPrivacy: TouchPrivacy) {
-        nextOverrideAreas[bounds] = touchPrivacy
+        currentPass()[bounds] = touchPrivacy
     }
 
     @UiThread
     internal fun updateCurrentTouchOverrideAreas() {
-        currentOverrideAreas.clear()
-        // NPE cannot happen here
-        @Suppress("UnsafeThirdPartyFunctionCall")
-        currentOverrideAreas.putAll(nextOverrideAreas)
-        nextOverrideAreas.clear()
+        val builtByThisPass = currentPass()
+        synchronized(lock) {
+            currentOverrideAreas.clear()
+            // NPE cannot happen here
+            @Suppress("UnsafeThirdPartyFunctionCall")
+            currentOverrideAreas.putAll(builtByThisPass)
+        }
+        builtByThisPass.clear()
     }
 
     @UiThread
     internal fun shouldRecordTouch(touchLocation: Point): Boolean {
         var isOverriddenToShowTouch = false
 
-        // Everything is UiThread, so ConcurrentModification cannot happen here
-        @Suppress("UnsafeThirdPartyFunctionCall")
-        currentOverrideAreas.forEach { entry ->
-            val area = entry.key
-            val overrideValue = entry.value
+        synchronized(lock) {
+            @Suppress("UnsafeThirdPartyFunctionCall")
+            currentOverrideAreas.forEach { entry ->
+                val area = entry.key
+                val overrideValue = entry.value
 
-            if (area.contains(touchLocation.x, touchLocation.y)) {
-                when (overrideValue) {
-                    TouchPrivacy.HIDE -> return false
-                    TouchPrivacy.SHOW -> isOverriddenToShowTouch = true
+                if (area.contains(touchLocation.x, touchLocation.y)) {
+                    when (overrideValue) {
+                        TouchPrivacy.HIDE -> return false
+                        TouchPrivacy.SHOW -> isOverriddenToShowTouch = true
+                    }
                 }
             }
         }
@@ -70,11 +90,17 @@ class TouchPrivacyManager(
 
     @VisibleForTesting
     internal fun getCurrentOverrideAreas(): Map<Rect, TouchPrivacy> {
-        return currentOverrideAreas
+        synchronized(lock) {
+            // NPE cannot happen here
+            @Suppress("UnsafeThirdPartyFunctionCall")
+            return HashMap(currentOverrideAreas)
+        }
     }
 
     @VisibleForTesting
     internal fun getNextOverrideAreas(): Map<Rect, TouchPrivacy> {
-        return nextOverrideAreas
+        // NPE cannot happen here
+        @Suppress("UnsafeThirdPartyFunctionCall")
+        return HashMap(currentPass())
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/HeatmapIdentifierResolver.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/HeatmapIdentifierResolver.kt
@@ -27,6 +27,10 @@ internal class HeatmapIdentifierResolver(
     private val lastPublishedEntries: MutableMap<Long, CachedHeatmapEntry> = mutableMapOf()
     private val resourceNameCache: HashMap<Int, String> = HashMap()
 
+    // Each recorded window runs its own traversal on the Looper thread its view hierarchy is
+    // attached to, so the maps above can be read/written from multiple threads concurrently.
+    private val lock = Any()
+
     @UiThread
     fun beginTraversal(viewUrl: String): TraversalContext = TraversalContext(viewUrl)
 
@@ -43,8 +47,9 @@ internal class HeatmapIdentifierResolver(
 
         val identityHash = heatmapViewKey(view)
         val pathComponent = pathComponentFor(view, typeIndex)
-        val cachedEntry = lastPublishedEntries[identityHash]
-            ?.takeIf { context.viewUrl == lastPublishedScreenName }
+        val cachedEntry = synchronized(lock) {
+            lastPublishedEntries[identityHash]?.takeIf { context.viewUrl == lastPublishedScreenName }
+        }
             // Guards against stale entries when a view or any ancestor shifts among same-type
             // siblings without being detached (e.g. notifyItemMoved with an in-place animator).
             ?.takeIf { it.viewPath == nodePath + pathComponent }
@@ -72,7 +77,8 @@ internal class HeatmapIdentifierResolver(
     internal fun pathComponentFor(view: View, typeIndex: Int): String {
         val viewId = view.id
         if (viewId != View.NO_ID) {
-            val name = resourceNameCache[viewId] ?: resolveAndCacheResourceName(viewId, view.resources)
+            val cachedName = synchronized(lock) { resourceNameCache[viewId] }
+            val name = cachedName ?: resolveAndCacheResourceName(viewId, view.resources)
             if (!name.isNullOrEmpty()) {
                 return "$name#$typeIndex"
             }
@@ -89,8 +95,15 @@ internal class HeatmapIdentifierResolver(
                 null
             }
         }
-        if (resolved != null) resourceNameCache[viewId] = resolved
+        if (resolved != null) synchronized(lock) { resourceNameCache[viewId] = resolved }
         return resolved
+    }
+
+    @VisibleForTesting
+    internal fun getLastPublishedScreenName(): String? {
+        synchronized(lock) {
+            return lastPublishedScreenName
+        }
     }
 
     @VisibleForTesting
@@ -109,10 +122,18 @@ internal class HeatmapIdentifierResolver(
 
     @UiThread
     private fun publishIfChanged(context: TraversalContext) {
-        if (context.entries.isEmpty()) {
-            lastPublishedScreenName = null
-            lastPublishedEntries.clear()
-        } else {
+        // registry.setHeatmapIdentifiers() is called inside the lock, not after releasing it:
+        // two concurrent traversals' cache updates and registry publications must happen in the
+        // same relative order, or the resolver's cache and the registry's snapshot can end up
+        // pointing at different screens (the registry is a single global "current snapshot",
+        // not scoped per screen). The registry write is a cheap in-memory operation with its own
+        // lock and no reentrancy into this resolver, so holding this lock during the call is safe.
+        synchronized(lock) {
+            if (context.entries.isEmpty()) {
+                lastPublishedScreenName = null
+                lastPublishedEntries.clear()
+                return
+            }
             val anyIdentifierChangedOrNew = context.entries.any { (k, v) ->
                 lastPublishedEntries[k]?.identifier != v.identifier
             }
@@ -123,10 +144,7 @@ internal class HeatmapIdentifierResolver(
                 lastPublishedScreenName = context.viewUrl
                 lastPublishedEntries.clear()
                 lastPublishedEntries.putAll(context.entries)
-                registry.setHeatmapIdentifiers(
-                    context.entries.mapValues { it.value.identifier },
-                    context.viewUrl
-                )
+                registry.setHeatmapIdentifiers(context.entries.mapValues { it.value.identifier }, context.viewUrl)
             }
         }
     }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/TouchPrivacyManagerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/TouchPrivacyManagerTest.kt
@@ -22,6 +22,8 @@ import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
+import java.util.Random
+import java.util.concurrent.CopyOnWriteArrayList
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -153,5 +155,94 @@ internal class TouchPrivacyManagerTest {
 
         // Then
         assertThat(testedManager.shouldRecordTouch(touchLocation)).isFalse()
+    }
+
+    @Test
+    fun `M not throw W updateCurrentTouchOverrideAreas() { concurrent addTouchOverrideArea }`(
+        forge: Forge
+    ) {
+        // Given
+        // Each recorded window runs the snapshot pipeline on the Looper thread its view
+        // hierarchy is attached to, so a traversal writing overrides can run concurrently
+        // with the copy-and-clear swap performed at the end of another window's snapshot.
+        val fakePrivacyOverride = forge.aValueFrom(TouchPrivacy::class.java)
+        val fakeOrigin = forge.anInt(min = 0, max = 1000)
+        val iterations = 10_000
+        val errors = CopyOnWriteArrayList<Throwable>()
+
+        // When
+        listOf(
+            Thread {
+                repeat(iterations) {
+                    try {
+                        testedManager.addTouchOverrideArea(
+                            Rect(fakeOrigin + it, fakeOrigin + it, fakeOrigin + it + 1, fakeOrigin + it + 1),
+                            fakePrivacyOverride
+                        )
+                    } catch (e: Throwable) {
+                        errors.add(e)
+                    }
+                }
+            },
+            Thread {
+                repeat(iterations) {
+                    try {
+                        testedManager.updateCurrentTouchOverrideAreas()
+                        testedManager.shouldRecordTouch(Point(fakeOrigin + it, fakeOrigin + it))
+                    } catch (e: Throwable) {
+                        errors.add(e)
+                    }
+                }
+            }
+        ).shuffled(Random(forge.seed))
+            .map { it.apply { start() } }
+            .forEach { it.join() }
+
+        // Then
+        assertThat(errors).isEmpty()
+    }
+
+    @Test
+    fun `M never publish a partial mix W concurrent windows rebuild and swap`(forge: Forge) {
+        // Given
+        // In production, one WindowsOnDrawListener instance is shared across every recorded
+        // window. Each window's onDraw pass rebuilds the FULL override set (across all windows)
+        // on its own thread, then swaps it into currentOverrideAreas once. Two windows' passes
+        // running concurrently must never leave currentOverrideAreas holding a mix of one
+        // pass's entries and another's partially-built entries -- only ever one pass's complete,
+        // self-consistent set.
+        val privacyA = forge.aValueFrom(TouchPrivacy::class.java)
+        val privacyB = forge.aValueFrom(TouchPrivacy::class.java)
+        val rangeSize = forge.anInt(min = 10, max = 30)
+        val originA = forge.anInt(min = 0, max = 1000)
+        val originB = originA + rangeSize + forge.anInt(min = 50, max = 200)
+        val setA = (originA until originA + rangeSize).associate { Rect(it, it, it + 1, it + 1) to privacyA }
+        val setB = (originB until originB + rangeSize).associate { Rect(it, it, it + 1, it + 1) to privacyB }
+        val iterations = 2_000
+        val errors = CopyOnWriteArrayList<Throwable>()
+        val invalidSnapshots = CopyOnWriteArrayList<Map<Rect, TouchPrivacy>>()
+
+        fun runOnePass(overrides: Map<Rect, TouchPrivacy>) {
+            overrides.forEach { (rect, privacy) -> testedManager.addTouchOverrideArea(rect, privacy) }
+            testedManager.updateCurrentTouchOverrideAreas()
+            val snapshot = testedManager.getCurrentOverrideAreas()
+            if (snapshot != setA && snapshot != setB) {
+                invalidSnapshots.add(snapshot)
+            }
+        }
+
+        // When
+        listOf(
+            Thread { repeat(iterations) { try { runOnePass(setA) } catch (e: Throwable) { errors.add(e) } } },
+            Thread { repeat(iterations) { try { runOnePass(setB) } catch (e: Throwable) { errors.add(e) } } }
+        ).shuffled(Random(forge.seed))
+            .map { it.apply { start() } }
+            .forEach { it.join() }
+
+        // Then
+        assertThat(errors).isEmpty()
+        assertThat(invalidSnapshots)
+            .describedAs("currentOverrideAreas must always equal one pass's complete set, never a partial mix")
+            .isEmpty()
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/HeatmapIdentifierContractTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/HeatmapIdentifierContractTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.heatmaps.HeatmapIdentifierRegistryProvider
 import com.datadog.android.heatmaps.heatmapViewKey
+import com.datadog.android.internal.heatmaps.HeatmapIdentifier
 import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
@@ -43,6 +44,9 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * Contract test for the SR → RUM heatmap identifier pipeline.
@@ -67,6 +71,8 @@ internal class HeatmapIdentifierContractTest {
     private lateinit var realRegistry: HeatmapIdentifierRegistry
 
     private lateinit var testedSnapshotProducer: SnapshotProducer
+
+    private lateinit var testedHeatmapResolver: HeatmapIdentifierResolver
 
     @Mock lateinit var mockSdkCore: FeatureSdkCore
 
@@ -101,17 +107,18 @@ internal class HeatmapIdentifierContractTest {
         whenever(mockTreeViewTraversal.traverse(any(), any(), any())).thenReturn(
             TreeViewTraversal.TraversedTreeView(fakeViewWireframes, TraversalStrategy.TRAVERSE_ALL_CHILDREN)
         )
+        testedHeatmapResolver = HeatmapIdentifierResolver(
+            appPackageName = fakeAppPackageName,
+            registry = LazyHeatmapIdentifierRegistry(mockSdkCore),
+            internalLogger = mockInternalLogger
+        )
         testedSnapshotProducer = SnapshotProducer(
             imageWireframeHelper = mockImageWireframeHelper,
             treeViewTraversal = mockTreeViewTraversal,
             optionSelectorDetector = mockOptionSelectorDetector,
             touchPrivacyManager = mockTouchPrivacyManager,
             internalLogger = mockInternalLogger,
-            heatmapResolver = HeatmapIdentifierResolver(
-                appPackageName = fakeAppPackageName,
-                registry = LazyHeatmapIdentifierRegistry(mockSdkCore),
-                internalLogger = mockInternalLogger
-            )
+            heatmapResolver = testedHeatmapResolver
         )
     }
 
@@ -267,6 +274,95 @@ internal class HeatmapIdentifierContractTest {
         assertThat(localRegistry.getHeatmapIdentifier(heatmapViewKey(mockButton), fakeViewUrl)).isNotNull()
     }
 
+    @Test
+    fun `M keep registry consistent with resolver cache W concurrent traversals for different screens`(
+        forge: Forge
+    ) {
+        // Given
+        // Two windows recording different RUM screens concurrently, each on its own thread.
+        // publishIfChanged() must update the resolver's own cache and call registry
+        // .setHeatmapIdentifiers() as a single locked operation -- otherwise one traversal's
+        // cache update and its registry publish can be split apart by the other traversal's
+        // full cache-update-and-publish sequence, leaving the resolver's cache pointing at one
+        // screen while the registry (a single global "current snapshot") points at the other.
+        //
+        // Deliberately delaying screen A's registry write (rather than just hammering both
+        // threads and hoping for a lucky interleave) forces the exact window this bug lives in:
+        // if the write happens outside the resolver's lock, screen B's whole publish can run to
+        // completion while A is delayed, landing A's now-stale write last. If the write happens
+        // inside the lock (the fix), B is blocked from even starting until A's delay is over, so
+        // no interleaving is possible -- this deadlocks-free because B never needs anything
+        // from A to make progress, it only waits for the lock A already holds.
+        val screenA = "screen-${forge.anAlphabeticalString()}"
+        val screenB = "screen-${forge.anAlphabeticalString()}"
+        val viewA = forge.aMockTappableViewWithResourceId(
+            viewId = forge.anInt(min = 1, max = Int.MAX_VALUE),
+            resourceName = "com.example.app:id/${forge.anAlphabeticalString()}"
+        )
+        val viewB = forge.aMockTappableViewWithResourceId(
+            viewId = forge.anInt(min = 1, max = Int.MAX_VALUE),
+            resourceName = "com.example.app:id/${forge.anAlphabeticalString()}"
+        )
+        val screenAWriteStarted = CountDownLatch(1)
+        val delayingRegistry = object : HeatmapIdentifierRegistry {
+            override fun setHeatmapIdentifiers(identifiers: Map<Long, HeatmapIdentifier>, screenName: String) {
+                if (screenName == screenA) {
+                    screenAWriteStarted.countDown()
+                    Thread.sleep(SCREEN_A_WRITE_DELAY_MS)
+                }
+                realRegistry.setHeatmapIdentifiers(identifiers, screenName)
+            }
+
+            override fun getHeatmapIdentifier(heatmapViewKey: Long, currentScreenName: String) =
+                realRegistry.getHeatmapIdentifier(heatmapViewKey, currentScreenName)
+        }
+        val delayedResolver = HeatmapIdentifierResolver(
+            appPackageName = fakeAppPackageName,
+            registry = delayingRegistry,
+            internalLogger = mockInternalLogger
+        )
+        val delayedProducer = SnapshotProducer(
+            imageWireframeHelper = mockImageWireframeHelper,
+            treeViewTraversal = mockTreeViewTraversal,
+            optionSelectorDetector = mockOptionSelectorDetector,
+            touchPrivacyManager = mockTouchPrivacyManager,
+            internalLogger = mockInternalLogger,
+            heatmapResolver = delayedResolver
+        )
+        val errors = CopyOnWriteArrayList<Throwable>()
+
+        fun produceFor(view: View, screenName: String) {
+            delayedProducer.produce(
+                rootView = view,
+                systemInformation = fakeSystemInformation,
+                textAndInputPrivacy = fakeTextAndInputPrivacy,
+                imagePrivacy = fakeImagePrivacy,
+                recordedDataQueueRefs = mockRecordedDataQueueRefs,
+                activeRumViewUrl = screenName
+            )
+        }
+
+        // When
+        val threadA = Thread { try { produceFor(viewA, screenA) } catch (e: Throwable) { errors.add(e) } }
+        threadA.start()
+        assertThat(screenAWriteStarted.await(2, TimeUnit.SECONDS))
+            .describedAs("screen A's write should have started")
+            .isTrue()
+        val threadB = Thread { try { produceFor(viewB, screenB) } catch (e: Throwable) { errors.add(e) } }
+        threadB.start()
+        threadA.join()
+        threadB.join()
+
+        // Then
+        assertThat(errors).isEmpty()
+        val cachedScreen = delayedResolver.getLastPublishedScreenName()
+        val viewForCachedScreen = if (cachedScreen == screenA) viewA else viewB
+        assertThat(cachedScreen).isEqualTo(screenB)
+        assertThat(realRegistry.getHeatmapIdentifier(heatmapViewKey(viewForCachedScreen), cachedScreen!!))
+            .describedAs("the registry must agree with the resolver's own cache about which screen is current")
+            .isNotNull()
+    }
+
     // region helpers
 
     private fun stubRumFeatureWithRegistry(registry: HeatmapIdentifierRegistry): FeatureScope {
@@ -308,4 +404,8 @@ internal class HeatmapIdentifierContractTest {
     }
 
     // endregion
+
+    companion object {
+        private const val SCREEN_A_WRITE_DELAY_MS = 300L
+    }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/HeatmapIdentifierResolverTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/HeatmapIdentifierResolverTest.kt
@@ -30,6 +30,9 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.Random
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeUnit
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -237,6 +240,70 @@ internal class HeatmapIdentifierResolverTest {
         assertThat(indices[0]).isEqualTo(0)
         assertThat(indices[1]).isEqualTo(0) // slot left at default; not a real child
         assertThat(indices[2]).isEqualTo(1)
+    }
+
+    // endregion
+
+    // region concurrency
+
+    @Test
+    fun `M not throw W concurrent traversals from multiple windows`(forge: Forge) {
+        // Given
+        // Each recorded window runs its own traversal on the Looper thread its view hierarchy is
+        // attached to, so two windows' traversals — including the resolveIdentity/publish
+        // read-then-write sequence over the shared lastPublished* maps — can interleave on
+        // different threads.
+        //
+        // lastPublishedEntries is only ever touched via get()/clear()/putAll(), never an
+        // external iterator, so an unsynchronized race here does not reliably throw
+        // ConcurrentModificationException the way an iterated HashMap does. Verified: this
+        // exact test (300 entries/pass, 20 reps/thread) still passes 5/5 with synchronization
+        // stripped out -- it is kept as a smoke check on the happy path, not as proof this race
+        // is caught. The `synchronized` blocks in the production code are the actual defense;
+        // don't rely on this test to validate them. Scale is capped below ~15k total
+        // mock-intercepted calls because this environment's Mockito setup gets measurably,
+        // sometimes catastrophically (OOM/livelock-like CPU spin), slower beyond that.
+        val repetitions = 20
+        val entriesPerPass = 300
+        val errors = CopyOnWriteArrayList<Throwable>()
+        val baseViewId = forge.anInt(min = 1, max = 100_000)
+        val views = (0 until entriesPerPass).map { offset ->
+            val viewId = baseViewId + offset
+            val resourceName = "com.example.app:id/${forge.anAlphabeticalString()}"
+            val mockResources: Resources = mock {
+                whenever(it.getResourceName(viewId)).thenReturn(resourceName)
+            }
+            val mockView: View = mock {
+                whenever(it.id).thenReturn(viewId)
+                whenever(it.resources).thenReturn(mockResources)
+                whenever(it.isClickable).thenReturn(true)
+                whenever(it.visibility).thenReturn(View.VISIBLE)
+            }
+            mockView
+        }
+        val screenA = "screen-${forge.anAlphabeticalString()}"
+        val screenB = "screen-${forge.anAlphabeticalString()}"
+
+        fun runTraversal(screenName: String) {
+            val context = testedResolver.beginTraversal(screenName)
+            views.forEachIndexed { index, view -> context.resolveIdentity(view, emptyList(), index) }
+            context.publish()
+        }
+
+        // When
+        val threads = listOf(
+            Thread { repeat(repetitions) { try { runTraversal(screenA) } catch (e: Throwable) { errors.add(e) } } },
+            Thread { repeat(repetitions) { try { runTraversal(screenB) } catch (e: Throwable) { errors.add(e) } } }
+        ).shuffled(Random(forge.seed))
+        threads.forEach { it.start() }
+        threads.forEach { it.join(TimeUnit.SECONDS.toMillis(30)) }
+        threads.filter { it.isAlive }.forEach { it.interrupt() }
+        assertThat(threads.none { it.isAlive })
+            .describedAs("a thread failed to complete within the timeout -- treat as a failure, not a hang")
+            .isTrue()
+
+        // Then
+        assertThat(errors).isEmpty()
     }
 
     // endregion


### PR DESCRIPTION
## What does this PR do?

Fixes two `ConcurrentModificationException` races in the Session Replay recorder, both from the
same root cause: a class instantiated once per recording session, sharing unsynchronized
`HashMap`/`var` state across every recorded window's snapshot callback. Each window's callback
runs on the Looper thread its own view hierarchy is attached to — not guaranteed to be the main
thread — so two windows can mutate that shared state concurrently.

- **`TouchPrivacyManager`** (fix by [@gabecorso](https://github.com/gabecorso), cherry-picked from
  [#3726](https://github.com/DataDog/dd-sdk-android/pull/3726)): a confirmed, reported crash —
  Fixes [#3725](https://github.com/DataDog/dd-sdk-android/issues/3725). The original fix guarded
  both override maps with a single lock per access. Review caught that this doesn't make the
  build-then-swap sequence atomic across a whole traversal: two windows' passes can still
  interleave, with one pass's `clear()` wiping out another still-in-progress pass's entries before
  it finishes, silently dropping `HIDE` overrides. Fixed by making `nextOverrideAreas` a
  `ThreadLocal`, so each window's pass builds its own thread-confined map and only the final swap
  into `currentOverrideAreas` needs a lock.
- **`HeatmapIdentifierResolver`** / **`LazyHeatmapIdentifierRegistry`**: not a reported crash —
  found by auditing for the same shared-across-windows shape while reviewing #3726, not from a
  field report or telemetry signal. `lastPublishedEntries`/`resourceNameCache` guarded per access
  site; `LazyHeatmapIdentifierRegistry`'s cached registry reference is now `@Volatile`. Review
  also caught that `registry.setHeatmapIdentifiers()` was being called *after* releasing the
  lock — since the registry is a single global "current snapshot" keyed by screen name (not
  scoped per screen), two concurrent traversals' cache updates and registry publishes could get
  reordered relative to each other, leaving the resolver's cache and the registry pointing at
  different screens until the next hierarchy change. Fixed by moving the registry call inside the
  same lock as the cache update.

### Additional Notes

- Locking is applied per-access-site (or via `ThreadLocal`, for `TouchPrivacyManager`'s build
  phase) rather than one lock around a whole traversal, to avoid serializing all windows'
  traversals unnecessarily.