### PR TITLE
RUM-18101: Supporting `timeseries` apiUsage telemetry.

### DIFF
--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/utils/assertj/InternalApiUsageEventAssert.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/utils/assertj/InternalApiUsageEventAssert.kt
@@ -35,6 +35,12 @@ class InternalApiUsageEventAssert(actual: InternalTelemetryEvent.ApiUsage) :
                     .isEqualTo(expected as InternalTelemetryEvent.ApiUsage.TrackWebView)
             }
 
+            is InternalTelemetryEvent.ApiUsage.Timeseries -> {
+                InternalTimeseriesEventAssert
+                    .assertThat(actual as InternalTelemetryEvent.ApiUsage.Timeseries)
+                    .isEqualTo(expected as InternalTelemetryEvent.ApiUsage.Timeseries)
+            }
+
             is InternalTelemetryEvent.ApiUsage.NetworkInstrumentation -> {
                 InternalApiUsageNetworkInstrumentationEventAssert
                     .assertThat(actual as InternalTelemetryEvent.ApiUsage.NetworkInstrumentation)

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/utils/assertj/InternalTimeseriesEventAssert.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/utils/assertj/InternalTimeseriesEventAssert.kt
@@ -1,0 +1,37 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.assertj
+
+import com.datadog.android.internal.telemetry.InternalTelemetryEvent
+import org.assertj.core.api.AbstractAssert
+import org.assertj.core.api.Assertions
+
+private typealias TimeseriesApiUsage = InternalTelemetryEvent.ApiUsage.Timeseries
+
+internal class InternalTimeseriesEventAssert(actual: TimeseriesApiUsage) :
+    AbstractAssert<InternalTimeseriesEventAssert, TimeseriesApiUsage>(
+        actual,
+        InternalTimeseriesEventAssert::class.java
+    ) {
+
+    fun isEqualTo(expected: TimeseriesApiUsage) {
+        hasAdditionalProperties(expected.additionalProperties)
+    }
+
+    private fun hasAdditionalProperties(expected: Map<String, Any?>) = apply {
+        Assertions.assertThat(actual.additionalProperties)
+            .overridingErrorMessage(
+                "Expected Timeseries event to have" +
+                    " additionalProperties $expected but was ${actual.additionalProperties}"
+            )
+            .isEqualTo(expected)
+    }
+
+    companion object {
+        fun assertThat(actual: TimeseriesApiUsage) = InternalTimeseriesEventAssert(actual)
+    }
+}

--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -247,6 +247,8 @@ sealed class com.datadog.android.internal.telemetry.InternalTelemetryEvent
         - CRONET
         - OKHTTP
         - LEGACY_OKHTTP
+    class Timeseries : ApiUsage
+      constructor(MutableMap<String, Any?> = mutableMapOf())
   object InterceptorInstantiated : InternalTelemetryEvent
   class ResourceHeadersTrackingConfigured : InternalTelemetryEvent
     constructor(Mode)

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -543,6 +543,12 @@ public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent
 	public static fun values ()[Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$NetworkInstrumentation$LibraryType;
 }
 
+public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$Timeseries : com/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$TrackWebView : com/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage {
 	public fun <init> ()V
 	public fun <init> (Ljava/util/Map;)V

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/telemetry/InternalTelemetryEvent.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/telemetry/InternalTelemetryEvent.kt
@@ -82,6 +82,10 @@ sealed class InternalTelemetryEvent {
                 LEGACY_OKHTTP
             }
         }
+
+        class Timeseries(
+            additionalProperties: MutableMap<String, Any?> = mutableMapOf()
+        ) : ApiUsage(additionalProperties)
     }
 
     object InterceptorInstantiated : InternalTelemetryEvent()

--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/InternalTelemetryApiUsageForgeryFactory.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/InternalTelemetryApiUsageForgeryFactory.kt
@@ -35,6 +35,9 @@ class InternalTelemetryApiUsageForgeryFactory : ForgeryFactory<InternalTelemetry
                         .LibraryType::class.java
                 ),
                 additionalProperties = forge.aMap { aString() to aString() }.toMutableMap()
+            ),
+            InternalTelemetryEvent.ApiUsage.Timeseries(
+                additionalProperties = forge.aMap { aString() to aString() }.toMutableMap()
             )
         )
     }

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -3792,6 +3792,12 @@ data class com.datadog.android.telemetry.model.TelemetryUsageEvent
       companion object 
         fun fromJson(kotlin.String): TrackWebView
         fun fromJsonObject(com.google.gson.JsonObject): TrackWebView
+    class Timeseries : Usage
+      val feature: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): Timeseries
+        fun fromJsonObject(com.google.gson.JsonObject): Timeseries
     data class AndroidNetworkInstrumentation : Usage
       constructor(Type)
       val feature: kotlin.String

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -12284,6 +12284,20 @@ public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$StopSession;
 }
 
+public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$Timeseries : com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage {
+	public static final field Companion Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$Timeseries$Companion;
+	public fun <init> ()V
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$Timeseries;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$Timeseries;
+	public final fun getFeature ()Ljava/lang/String;
+	public fun toJson ()Lcom/google/gson/JsonElement;
+}
+
+public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$Timeseries$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$Timeseries;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$Timeseries;
+}
+
 public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$TrackWebView : com/datadog/android/telemetry/model/TelemetryUsageEvent$Usage {
 	public static final field Companion Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Usage$TrackWebView$Companion;
 	public fun <init> ()V

--- a/features/dd-sdk-android-rum/src/main/json/telemetry/usage/mobile-features-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/telemetry/usage/mobile-features-schema.json
@@ -40,6 +40,17 @@
       }
     },
     {
+      "required": ["feature"],
+      "title": "Timeseries",
+      "properties": {
+        "feature": {
+          "type": "string",
+          "description": "Timeseries tracking enabled",
+          "const": "timeseries"
+        }
+      }
+    },
+    {
       "required": ["feature", "type"],
       "title": "AndroidNetworkInstrumentation",
       "properties": {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
@@ -18,8 +18,10 @@ import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.sampling.DeterministicSampler
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.internal.sampling.SessionSamplingIdProvider
+import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.rum.internal.RumAnonymousIdentifierManager
 import com.datadog.android.rum.internal.RumFeature
+import com.datadog.android.rum.internal.RumFeature.Configuration
 import com.datadog.android.rum.internal.domain.scope.RumVitalAppLaunchEventHelper
 import com.datadog.android.rum.internal.metric.SessionEndedMetricDispatcher
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
@@ -106,6 +108,12 @@ object Rum {
         //  and before it is registered, but with current code (internal RUM scopes using the
         //  `GlobalRumMonitor`) it is impossible to break cycle dependency.
         rumMonitor.start()
+
+        // Reported here and not in RumFeature.onInitialize: telemetry events are dropped while the
+        // global RUM monitor is not registered yet (see RumFeature.handleTelemetryEvent).
+        if (rumConfiguration.featureConfiguration.isTimeseriesConfigured()) {
+            sdkCore.internalLogger.logApiUsage { InternalTelemetryEvent.ApiUsage.Timeseries() }
+        }
     }
 
     // region private
@@ -197,6 +205,10 @@ object Rum {
 
     internal const val RUM_FEATURE_ALREADY_ENABLED =
         "RUM Feature is already enabled in this SDK core, ignoring the call to enable it."
+
+    private fun Configuration.isTimeseriesConfigured(): Boolean {
+        return timeseriesConfiguration?.enabledTypes?.isNotEmpty() == true
+    }
 
     // endregion
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -446,6 +446,9 @@ internal class TelemetryEventHandler(
             is InternalTelemetryEvent.ApiUsage.TrackWebView -> {
                 TelemetryUsageEvent.Usage.TrackWebView()
             }
+            is InternalTelemetryEvent.ApiUsage.Timeseries -> {
+                TelemetryUsageEvent.Usage.Timeseries()
+            }
             is InternalTelemetryEvent.ApiUsage.NetworkInstrumentation -> {
                 TelemetryUsageEvent.Usage.AndroidNetworkInstrumentation(
                     type = when (event.type) {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
@@ -14,18 +14,23 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.sampling.DeterministicSampler
 import com.datadog.android.core.sampling.RateBasedSampler
+import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
 import com.datadog.android.rum.internal.monitor.NoOpAdvancedRumMonitor
 import com.datadog.android.rum.internal.net.RumRequestFactory
+import com.datadog.android.rum.timeseries.TimeseriesConfiguration
+import com.datadog.android.rum.timeseries.TimeseriesType
 import com.datadog.android.rum.tracking.NoOpTrackingStrategy
 import com.datadog.android.rum.tracking.NoOpViewTrackingStrategy
 import com.datadog.android.rum.utils.config.MainLooperTestConfiguration
 import com.datadog.android.rum.utils.forge.Configurator
+import com.datadog.android.utils.verifyApiUsage
 import com.datadog.android.utils.verifyLog
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
+import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -55,14 +60,18 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
+@OptIn(ExperimentalRumApi::class)
 internal class RumTest {
 
     @Mock
     lateinit var mockSdkCore: InternalSdkCore
 
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
     @BeforeEach
     fun `set up`() {
-        whenever(mockSdkCore.internalLogger) doReturn mock()
+        whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockSdkCore.timeProvider) doReturn mock()
         whenever(mockSdkCore.firstPartyHostResolver) doReturn mock()
         whenever(mockSdkCore.createSingleThreadExecutorService(any())) doReturn mock()
@@ -184,11 +193,80 @@ internal class RumTest {
     }
 
     @Test
+    fun `M send timeseries api usage W enable() { timeseries collection enabled }`(
+        @StringForgery fakePackageName: String,
+        @Forgery fakeRumConfiguration: RumConfiguration
+    ) {
+        // Given
+        stubFeatureInitialization(fakePackageName)
+
+        // When
+        Rum.enable(fakeRumConfiguration.withTimeseries(TimeseriesConfiguration.DEFAULT), mockSdkCore)
+
+        // Then
+        mockInternalLogger.verifyApiUsage(
+            apiUsage = InternalTelemetryEvent.ApiUsage.Timeseries(),
+            samplingRate = API_USAGE_SAMPLING_RATE
+        )
+    }
+
+    @Test
+    fun `M send timeseries api usage W enable() { timeseries collection subset }`(
+        @StringForgery fakePackageName: String,
+        @Forgery fakeRumConfiguration: RumConfiguration,
+        forge: Forge
+    ) {
+        // Given
+        stubFeatureInitialization(fakePackageName)
+        val fakeType = forge.aValueFrom(TimeseriesType::class.java)
+        val timeseriesConfiguration = TimeseriesConfiguration.Builder().collectOnly(fakeType).build()
+
+        // When
+        Rum.enable(fakeRumConfiguration.withTimeseries(timeseriesConfiguration), mockSdkCore)
+
+        // Then
+        mockInternalLogger.verifyApiUsage(
+            apiUsage = InternalTelemetryEvent.ApiUsage.Timeseries(),
+            samplingRate = API_USAGE_SAMPLING_RATE
+        )
+    }
+
+    @Test
+    fun `M not send timeseries api usage W enable() { timeseries collection disabled }`(
+        @StringForgery fakePackageName: String,
+        @Forgery fakeRumConfiguration: RumConfiguration
+    ) {
+        // Given
+        stubFeatureInitialization(fakePackageName)
+        val fakeTimeseriesConfiguration = TimeseriesConfiguration.Builder().collectOnly().build()
+
+        // When
+        Rum.enable(fakeRumConfiguration.withTimeseries(fakeTimeseriesConfiguration), mockSdkCore)
+
+        // Then
+        verify(mockInternalLogger, never()).logApiUsage(any(), any())
+    }
+
+    @Test
+    fun `M not send timeseries api usage W enable() { no timeseries configuration }`(
+        @StringForgery fakePackageName: String,
+        @Forgery fakeRumConfiguration: RumConfiguration
+    ) {
+        // Given
+        stubFeatureInitialization(fakePackageName)
+
+        // When
+        Rum.enable(fakeRumConfiguration.withTimeseries(null), mockSdkCore)
+
+        // Then
+        verify(mockInternalLogger, never()).logApiUsage(any(), any())
+    }
+
+    @Test
     fun `M register nothing W enable() { SDK instance doesn't implement InternalSdkCore }`(
         @Forgery fakeRumConfiguration: RumConfiguration
     ) {
         // Given
-        val mockInternalLogger = mock<InternalLogger>()
         val wrongSdkCore = mock<FeatureSdkCore>()
         whenever(wrongSdkCore.internalLogger) doReturn mockInternalLogger
 
@@ -210,10 +288,6 @@ internal class RumTest {
         @Forgery fakeRumConfiguration: RumConfiguration,
         @StringForgery(regex = "\\s*") fakeApplicationId: String
     ) {
-        // Given
-        val mockInternalLogger = mock<InternalLogger>()
-        whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
-
         // When
         Rum.enable(
             rumConfiguration = fakeRumConfiguration.copy(applicationId = fakeApplicationId),
@@ -235,8 +309,6 @@ internal class RumTest {
         @Forgery fakeRumConfiguration: RumConfiguration
     ) {
         // Given
-        val mockInternalLogger = mock<InternalLogger>()
-        whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mock()
 
         // When
@@ -251,7 +323,27 @@ internal class RumTest {
         verify(mockSdkCore, never()).registerFeature(any())
     }
 
+    private fun stubFeatureInitialization(packageName: String) {
+        whenever(mockSdkCore.registerFeature(any())) doAnswer {
+            val mockApplication = mock<Application> { application ->
+                whenever(application.packageName) doReturn packageName
+                whenever(application.resources) doReturn mock()
+                whenever(application.contentResolver) doReturn mock()
+                whenever(application.resources.configuration) doReturn mock()
+            }
+            whenever(mockApplication.applicationContext) doReturn mockApplication
+
+            it.getArgument<RumFeature>(0).onInitialize(appContext = mockApplication)
+        }
+    }
+
+    private fun RumConfiguration.withTimeseries(configuration: TimeseriesConfiguration?) = copy(
+        featureConfiguration = featureConfiguration.copy(timeseriesConfiguration = configuration)
+    )
+
     companion object {
+        private const val API_USAGE_SAMPLING_RATE = 15f
+
         private val mainLooper = MainLooperTestConfiguration()
 
         @TestConfigurationsProvider

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryUsageEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryUsageEventAssert.kt
@@ -181,6 +181,11 @@ internal class TelemetryUsageEventAssert(actual: TelemetryUsageEvent) :
                     .isInstanceOf(TelemetryUsageEvent.Usage.TrackWebView::class.java)
             }
 
+            is InternalTelemetryEvent.ApiUsage.Timeseries -> {
+                assertThat(actual.telemetry.usage)
+                    .isInstanceOf(TelemetryUsageEvent.Usage.Timeseries::class.java)
+            }
+
             is InternalTelemetryEvent.ApiUsage.NetworkInstrumentation -> {
                 val actualUsage =
                     actual.telemetry.usage as TelemetryUsageEvent.Usage.AndroidNetworkInstrumentation

--- a/instrumented/integration/src/main/AndroidManifest.xml
+++ b/instrumented/integration/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
             android:windowSoftInputMode="adjustResize"/>
         <activity
             android:name=".rum.TimeseriesTrackingPlaygroundActivity"
-            android:label="RUM timeseries end-to-end" />
+            android:label="@string/rum_activity_timeseries_end_to_end" />
         <activity
             android:name=".rum.KioskSplashPlaygroundActivity"
             android:label="@string/activity_kiosk_end_to_end"

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/TimeseriesTrackingPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/TimeseriesTrackingPlaygroundActivity.kt
@@ -39,9 +39,7 @@ internal class TimeseriesTrackingPlaygroundActivity : Activity() {
             sdkCore = sdkCore,
             rumConfiguration = RuntimeConfig.rumConfigBuilder()
                 .useViewTrackingStrategy(ActivityViewTrackingStrategy(trackExtras = false))
-                .setTimeseriesConfiguration(
-                    TimeseriesConfiguration.Builder().build()
-                )
+                .setTimeseriesConfiguration(TimeseriesConfiguration.DEFAULT)
                 .build()
         )
     }

--- a/instrumented/integration/src/main/res/values/strings.xml
+++ b/instrumented/integration/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="button1">Button1</string>
     <string name="rum_gestures_tracking_end_to_end">Rum Gestures (End to End)</string>
     <string name="rum_activity_view_tracking_end_to_end">Rum Activity View (End to End)</string>
+    <string name="rum_activity_timeseries_end_to_end">RUM timeseries end-to-end</string>
     <string name="activity_telemetry_end_to_end">Telemetry (End to End)</string>
     <string name="session_replay_end_to_end">Session Replay (End to End)</string>
     <string name="session_replay_text_fields_end_to_end">Session Replay Text Fields (End to End)</string>


### PR DESCRIPTION
### What does this PR do?

Sending apiUsage event for `timeseries` if they are enabled

### Motivation

We want to see the adoption of the `timeseries` feature.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

