### PR TITLE
RUM-18032: Make setRemoteConfigurationId accessible only through InternalProxy

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -38,6 +38,7 @@ class com.datadog.android._InternalProxy
   fun flushAndShutdownExecutors()
   companion object 
     fun allowClearTextHttp(com.datadog.android.core.configuration.Configuration.Builder): com.datadog.android.core.configuration.Configuration.Builder
+    fun setRemoteConfigurationId(com.datadog.android.core.configuration.Configuration.Builder, String): com.datadog.android.core.configuration.Configuration.Builder
 interface com.datadog.android.api.InternalLogger
   enum Level
     - VERBOSE
@@ -285,7 +286,6 @@ data class com.datadog.android.core.configuration.Configuration
     fun setBackpressureStrategy(BackPressureStrategy): Builder
     fun setUploadSchedulerStrategy(UploadSchedulerStrategy?): Builder
     fun setVersion(String): Builder
-    fun setRemoteConfigurationId(String): Builder
   companion object 
 class com.datadog.android.core.configuration.HostPatternSanitizer
   constructor(com.datadog.android.api.InternalLogger)

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -83,6 +83,7 @@ public final class com/datadog/android/_InternalProxy {
 
 public final class com/datadog/android/_InternalProxy$Companion {
 	public final fun allowClearTextHttp (Lcom/datadog/android/core/configuration/Configuration$Builder;)Lcom/datadog/android/core/configuration/Configuration$Builder;
+	public final fun setRemoteConfigurationId (Lcom/datadog/android/core/configuration/Configuration$Builder;Ljava/lang/String;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 }
 
 public final class com/datadog/android/_InternalProxy$_TelemetryProxy {
@@ -770,7 +771,6 @@ public final class com/datadog/android/core/configuration/Configuration$Builder 
 	public final fun setFirstPartyHostsWithHeaderType (Ljava/util/Map;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setPersistenceStrategyFactory (Lcom/datadog/android/core/persistence/PersistenceStrategy$Factory;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setProxy (Ljava/net/Proxy;Lokhttp3/Authenticator;)Lcom/datadog/android/core/configuration/Configuration$Builder;
-	public final fun setRemoteConfigurationId (Ljava/lang/String;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setUploadFrequency (Lcom/datadog/android/core/configuration/UploadFrequency;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setUploadSchedulerStrategy (Lcom/datadog/android/core/configuration/UploadSchedulerStrategy;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setUseDeveloperModeWhenDebuggable (Z)Lcom/datadog/android/core/configuration/Configuration$Builder;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/_InternalProxy.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/_InternalProxy.kt
@@ -98,5 +98,12 @@ class _InternalProxy internal constructor(
         fun allowClearTextHttp(builder: Configuration.Builder): Configuration.Builder {
             return builder.allowClearTextHttp()
         }
+
+        fun setRemoteConfigurationId(
+            builder: Configuration.Builder,
+            remoteConfigurationId: String
+        ): Configuration.Builder {
+            return builder.setRemoteConfigurationId(remoteConfigurationId)
+        }
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -300,13 +300,7 @@ internal constructor(
             return this
         }
 
-        /**
-         * Sets the remote configuration ID used to fetch SDK settings from the Datadog CDN.
-         *
-         * @param remoteConfigurationId the opaque identifier assigned during application
-         * onboarding in the Datadog UI.
-         */
-        fun setRemoteConfigurationId(remoteConfigurationId: String): Builder {
+        internal fun setRemoteConfigurationId(remoteConfigurationId: String): Builder {
             coreConfig = coreConfig.copy(remoteConfigurationId = remoteConfigurationId)
             return this
         }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -15,6 +15,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModelProvider
 import com.datadog.android.Datadog
 import com.datadog.android.DatadogSite
+import com.datadog.android._InternalProxy
 import com.datadog.android.compose.enableComposeActionTracking
 import com.datadog.android.core.configuration.BackPressureMitigation
 import com.datadog.android.core.configuration.BackPressureStrategy
@@ -446,7 +447,7 @@ class SampleApplication : Application() {
             .setUploadFrequency(UploadFrequency.FREQUENT)
             .apply {
                 if (BuildConfig.DD_REMOTE_CONFIGURATION_ID.isNotBlank()) {
-                    setRemoteConfigurationId(BuildConfig.DD_REMOTE_CONFIGURATION_ID)
+                    _InternalProxy.setRemoteConfigurationId(this, BuildConfig.DD_REMOTE_CONFIGURATION_ID)
                 }
             }
 


### PR DESCRIPTION
### What does this PR do?

Making remote config available only through InternalProxy so that we could merge the code to `develop` and start dogfooding. Without making the feature available to our customers just yet.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

