### PR TITLE
RUM-18161: Send the serial ID on exposure events

### DIFF
--- a/features/dd-sdk-android-flags/api/apiSurface
+++ b/features/dd-sdk-android-flags/api/apiSurface
@@ -73,8 +73,9 @@ interface com.datadog.android.flags.model.UnparsedFlag
   val variationKey: String
   val extraLogging: org.json.JSONObject
   val reason: String
+  val serialId: Long?
 data class com.datadog.android.flags.model.ExposureEvent
-  constructor(kotlin.Long, Identifier, Identifier, Identifier, Subject)
+  constructor(kotlin.Long, Identifier, Identifier, Identifier, Subject, kotlin.Long? = null)
   fun toJson(): com.google.gson.JsonElement
   companion object 
     fun fromJson(kotlin.String): ExposureEvent

--- a/features/dd-sdk-android-flags/api/dd-sdk-android-flags.api
+++ b/features/dd-sdk-android-flags/api/dd-sdk-android-flags.api
@@ -111,19 +111,22 @@ public final class com/datadog/android/flags/model/EvaluationContext$Companion {
 
 public final class com/datadog/android/flags/model/ExposureEvent {
 	public static final field Companion Lcom/datadog/android/flags/model/ExposureEvent$Companion;
-	public fun <init> (JLcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Subject;)V
+	public fun <init> (JLcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Subject;Ljava/lang/Long;)V
+	public synthetic fun <init> (JLcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Subject;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
 	public final fun component2 ()Lcom/datadog/android/flags/model/ExposureEvent$Identifier;
 	public final fun component3 ()Lcom/datadog/android/flags/model/ExposureEvent$Identifier;
 	public final fun component4 ()Lcom/datadog/android/flags/model/ExposureEvent$Identifier;
 	public final fun component5 ()Lcom/datadog/android/flags/model/ExposureEvent$Subject;
-	public final fun copy (JLcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Subject;)Lcom/datadog/android/flags/model/ExposureEvent;
-	public static synthetic fun copy$default (Lcom/datadog/android/flags/model/ExposureEvent;JLcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Subject;ILjava/lang/Object;)Lcom/datadog/android/flags/model/ExposureEvent;
+	public final fun component6 ()Ljava/lang/Long;
+	public final fun copy (JLcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Subject;Ljava/lang/Long;)Lcom/datadog/android/flags/model/ExposureEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/flags/model/ExposureEvent;JLcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Identifier;Lcom/datadog/android/flags/model/ExposureEvent$Subject;Ljava/lang/Long;ILjava/lang/Object;)Lcom/datadog/android/flags/model/ExposureEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/flags/model/ExposureEvent;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/flags/model/ExposureEvent;
 	public final fun getAllocation ()Lcom/datadog/android/flags/model/ExposureEvent$Identifier;
 	public final fun getFlag ()Lcom/datadog/android/flags/model/ExposureEvent$Identifier;
+	public final fun getSerialId ()Ljava/lang/Long;
 	public final fun getSubject ()Lcom/datadog/android/flags/model/ExposureEvent$Subject;
 	public final fun getTimestamp ()J
 	public final fun getVariant ()Lcom/datadog/android/flags/model/ExposureEvent$Identifier;
@@ -495,6 +498,7 @@ public abstract interface class com/datadog/android/flags/model/UnparsedFlag {
 	public abstract fun getDoLog ()Z
 	public abstract fun getExtraLogging ()Lorg/json/JSONObject;
 	public abstract fun getReason ()Ljava/lang/String;
+	public abstract fun getSerialId ()Ljava/lang/Long;
 	public abstract fun getVariationKey ()Ljava/lang/String;
 	public abstract fun getVariationType ()Ljava/lang/String;
 	public abstract fun getVariationValue ()Ljava/lang/String;

--- a/features/dd-sdk-android-flags/src/main/json/flags/exposure-event-schema.json
+++ b/features/dd-sdk-android-flags/src/main/json/flags/exposure-event-schema.json
@@ -51,6 +51,10 @@
         }
       },
       "required": ["id", "attributes"]
+    },
+    "serial_id": {
+      "type": "integer",
+      "description": "Serial identifier of the split that the subject was assigned to"
     }
   },
   "required": ["timestamp", "allocation", "flag", "variant", "subject"]

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/ExposureEventsProcessor.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/ExposureEventsProcessor.kt
@@ -23,7 +23,8 @@ internal class ExposureEventsProcessor(private val writer: RecordWriter, private
 
     private data class CacheValue(
         val allocationKey: String,
-        val variationKey: String
+        val variationKey: String,
+        val serialId: Long?
     )
 
     @Suppress("UnsafeThirdPartyFunctionCall") // maxSize > 0
@@ -36,7 +37,8 @@ internal class ExposureEventsProcessor(private val writer: RecordWriter, private
         )
         val cacheValue = CacheValue(
             allocationKey = data.allocationKey,
-            variationKey = data.variationKey
+            variationKey = data.variationKey,
+            serialId = data.serialId
         )
 
         synchronized(exposuresSentCache) {
@@ -62,7 +64,8 @@ internal class ExposureEventsProcessor(private val writer: RecordWriter, private
                 attributes = ExposureEvent.Attributes(
                     additionalProperties = context.attributes.toMutableMap()
                 )
-            )
+            ),
+            serialId = data.serialId
         )
     }
 

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/model/PrecomputedFlag.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/model/PrecomputedFlag.kt
@@ -16,5 +16,6 @@ internal data class PrecomputedFlag(
     override val allocationKey: String,
     override val variationKey: String,
     override val extraLogging: JSONObject,
-    override val reason: String
+    override val reason: String,
+    override val serialId: Long? = null
 ) : UnparsedFlag

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/model/PrecomputedFlagConstants.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/model/PrecomputedFlagConstants.kt
@@ -23,7 +23,8 @@ internal enum class JsonKeys(val value: String) {
     ALLOCATION_KEY("allocationKey"),
     VARIATION_KEY("variationKey"),
     EXTRA_LOGGING("extraLogging"),
-    REASON("reason")
+    REASON("reason"),
+    SERIAL_ID("serialId")
 }
 
 internal enum class VariationType(val value: String) {

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/persistence/FlagsStateDeserializer.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/persistence/FlagsStateDeserializer.kt
@@ -109,7 +109,8 @@ internal class FlagsStateDeserializer(private val internalLogger: InternalLogger
             allocationKey = flagJson.getString(JsonKeys.ALLOCATION_KEY.value),
             variationKey = flagJson.getString(JsonKeys.VARIATION_KEY.value),
             extraLogging = flagJson.getJSONObject(JsonKeys.EXTRA_LOGGING.value),
-            reason = flagJson.getString(JsonKeys.REASON.value)
+            reason = flagJson.getString(JsonKeys.REASON.value),
+            serialId = (flagJson.opt(JsonKeys.SERIAL_ID.value) as? Number)?.toLong()
         )
     } catch (e: JSONException) {
         internalLogger.log(

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/persistence/FlagsStateSerializer.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/persistence/FlagsStateSerializer.kt
@@ -66,5 +66,6 @@ internal class FlagsStateSerializer(private val internalLogger: InternalLogger) 
         put(JsonKeys.VARIATION_KEY.value, flag.variationKey)
         put(JsonKeys.EXTRA_LOGGING.value, flag.extraLogging)
         put(JsonKeys.REASON.value, flag.reason)
+        flag.serialId?.let { put(JsonKeys.SERIAL_ID.value, it) }
     }
 }

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/repository/net/PrecomputeMapper.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/repository/net/PrecomputeMapper.kt
@@ -44,7 +44,8 @@ internal class PrecomputeMapper(private val internalLogger: InternalLogger) {
                 allocationKey = flagData.getString(JsonKeys.ALLOCATION_KEY.value),
                 variationKey = flagData.getString(JsonKeys.VARIATION_KEY.value),
                 extraLogging = flagData.getJSONObject(JsonKeys.EXTRA_LOGGING.value),
-                reason = flagData.getString(JsonKeys.REASON.value)
+                reason = flagData.getString(JsonKeys.REASON.value),
+                serialId = (flagData.opt(JsonKeys.SERIAL_ID.value) as? Number)?.toLong()
             )
 
             flagsMap[flagKey] = precomputedFlag

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/model/UnparsedFlag.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/model/UnparsedFlag.kt
@@ -24,4 +24,5 @@ interface UnparsedFlag {
     val variationKey: String
     val extraLogging: JSONObject
     val reason: String
+    val serialId: Long?
 }

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/ExposureEventsProcessorTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/ExposureEventsProcessorTest.kt
@@ -442,6 +442,111 @@ internal class ExposureEventsProcessorTest {
 
     // endregion
 
+    // region Serial Id
+
+    @Test
+    fun `M send the serial id W processEvent() { flag carries a serial id }`(forge: Forge) {
+        // Given
+        val fakeSerialId = forge.aLong(min = 1L)
+        val fakeContext = EvaluationContext(targetingKey = fakeTargetingKey)
+        val flag = fakeFlag.copy(serialId = fakeSerialId)
+
+        // When
+        testedProcessor.processEvent(fakeFlagKey, fakeContext, flag)
+
+        // Then
+        val eventCaptor = argumentCaptor<ExposureEvent>()
+        verify(mockRecordWriter).write(eventCaptor.capture())
+        assertThat(eventCaptor.firstValue.serialId).isEqualTo(fakeSerialId)
+        assertThat(eventCaptor.firstValue.toJson().asJsonObject.get("serial_id").asLong)
+            .isEqualTo(fakeSerialId)
+    }
+
+    @Test
+    fun `M send the serial id W processEvent() { serial id is zero }`() {
+        // Given
+        val fakeContext = EvaluationContext(targetingKey = fakeTargetingKey)
+        val flag = fakeFlag.copy(serialId = 0L)
+
+        // When
+        testedProcessor.processEvent(fakeFlagKey, fakeContext, flag)
+
+        // Then
+        val eventCaptor = argumentCaptor<ExposureEvent>()
+        verify(mockRecordWriter).write(eventCaptor.capture())
+        assertThat(eventCaptor.firstValue.serialId).isEqualTo(0L)
+    }
+
+    @Test
+    fun `M send no serial id W processEvent() { flag has no serial id }`() {
+        // Given
+        val fakeContext = EvaluationContext(targetingKey = fakeTargetingKey)
+        val flag = fakeFlag.copy(serialId = null)
+
+        // When
+        testedProcessor.processEvent(fakeFlagKey, fakeContext, flag)
+
+        // Then
+        val eventCaptor = argumentCaptor<ExposureEvent>()
+        verify(mockRecordWriter).write(eventCaptor.capture())
+        assertThat(eventCaptor.firstValue.serialId).isNull()
+        assertThat(eventCaptor.firstValue.toJson().asJsonObject.has("serial_id")).isFalse()
+    }
+
+    @Test
+    fun `M process exposure again W processEvent() { serial id appears }`(forge: Forge) {
+        // Given
+        val fakeSerialId = forge.aLong(min = 1L)
+        val fakeContext = EvaluationContext(targetingKey = fakeTargetingKey)
+        val flagWithoutSerialId = fakeFlag.copy(serialId = null)
+        val flagWithSerialId = flagWithoutSerialId.copy(serialId = fakeSerialId)
+
+        // When
+        testedProcessor.processEvent(fakeFlagKey, fakeContext, flagWithoutSerialId)
+        testedProcessor.processEvent(fakeFlagKey, fakeContext, flagWithSerialId)
+
+        // Then
+        val eventCaptor = argumentCaptor<ExposureEvent>()
+        verify(mockRecordWriter, times(2)).write(eventCaptor.capture())
+        assertThat(eventCaptor.firstValue.serialId).isNull()
+        assertThat(eventCaptor.secondValue.serialId).isEqualTo(fakeSerialId)
+    }
+
+    @Test
+    fun `M process exposure again W processEvent() { serial id changes }`(forge: Forge) {
+        // Given
+        val fakeSerialId = forge.aLong(min = 1L)
+        val fakeContext = EvaluationContext(targetingKey = fakeTargetingKey)
+        val flag = fakeFlag.copy(serialId = fakeSerialId)
+        val flagWithNewSerialId = flag.copy(serialId = fakeSerialId + 1)
+
+        // When
+        testedProcessor.processEvent(fakeFlagKey, fakeContext, flag)
+        testedProcessor.processEvent(fakeFlagKey, fakeContext, flagWithNewSerialId)
+
+        // Then
+        val eventCaptor = argumentCaptor<ExposureEvent>()
+        verify(mockRecordWriter, times(2)).write(eventCaptor.capture())
+        assertThat(eventCaptor.firstValue.serialId).isEqualTo(fakeSerialId)
+        assertThat(eventCaptor.secondValue.serialId).isEqualTo(fakeSerialId + 1)
+    }
+
+    @Test
+    fun `M not process duplicate exposure W processEvent() { same serial id }`(forge: Forge) {
+        // Given
+        val fakeContext = EvaluationContext(targetingKey = fakeTargetingKey)
+        val flag = fakeFlag.copy(serialId = forge.aLong(min = 1L))
+
+        // When
+        testedProcessor.processEvent(fakeFlagKey, fakeContext, flag)
+        testedProcessor.processEvent(fakeFlagKey, fakeContext, flag)
+
+        // Then
+        verify(mockRecordWriter).write(any())
+    }
+
+    // endregion
+
     // region Concurrency Tests
 
     @Test

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/persistence/FlagsStateDeserializerTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/persistence/FlagsStateDeserializerTest.kt
@@ -104,6 +104,29 @@ internal class FlagsStateDeserializerTest {
     }
 
     @Test
+    fun `M deserialize the serial id W deserialize() { flags carry a serial id }`(forge: Forge) {
+        // Given
+        val json = buildStateJson(
+            targetingKey = forge.anAlphabeticalString(),
+            flags = JSONObject().apply {
+                put("withSerialId", buildFlagJson().apply { put("serialId", 0L) })
+                put("withNullSerialId", buildFlagJson().apply { put("serialId", JSONObject.NULL) })
+                put("withoutSerialId", buildFlagJson())
+            }
+        )
+
+        // When
+        val result = testedDeserializer.deserialize(json)
+
+        // Then
+        checkNotNull(result)
+        assertThat(result.flags).hasSize(3)
+        assertThat(result.flags.getValue("withSerialId").serialId).isEqualTo(0L)
+        assertThat(result.flags.getValue("withNullSerialId").serialId).isNull()
+        assertThat(result.flags.getValue("withoutSerialId").serialId).isNull()
+    }
+
+    @Test
     fun `M deserialize empty state W deserialize() { valid JSON with empty data }`(forge: Forge) {
         // Given
         val targetingKey = forge.anAlphabeticalString()
@@ -295,4 +318,26 @@ internal class FlagsStateDeserializerTest {
         assertThat(result.evaluationContext.attributes["valid_number"]).isEqualTo(validNumber)
         assertThat(result.evaluationContext.attributes["valid_boolean"]).isEqualTo(validBoolean)
     }
+
+    private fun buildFlagJson(): JSONObject = JSONObject().apply {
+        put("variationType", "boolean")
+        put("variationValue", "true")
+        put("doLog", true)
+        put("allocationKey", "allocation1")
+        put("variationKey", "variation1")
+        put("extraLogging", JSONObject())
+        put("reason", "TARGETING_MATCH")
+    }
+
+    private fun buildStateJson(targetingKey: String, flags: JSONObject): String = JSONObject().apply {
+        put(
+            "evaluationContext",
+            JSONObject().apply {
+                put("targetingKey", targetingKey)
+                put("attributes", JSONObject())
+            }
+        )
+        put("flags", flags)
+        put("lastUpdateTimestamp", System.currentTimeMillis())
+    }.toString()
 }

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/persistence/FlagsStateSerializerTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/persistence/FlagsStateSerializerTest.kt
@@ -85,6 +85,43 @@ internal class FlagsStateSerializerTest {
     }
 
     @Test
+    fun `M serialize the serial id W serialize() { flag carries a serial id }`(forge: Forge) {
+        // Given
+        val evaluationContext = EvaluationContext(forge.anAlphabeticalString(), emptyMap())
+        val flags = mapOf(
+            "flag1" to PrecomputedFlag(
+                variationType = "boolean",
+                variationValue = "true",
+                doLog = true,
+                allocationKey = forge.anAlphabeticalString(),
+                variationKey = "variation1",
+                extraLogging = JSONObject(),
+                reason = "TARGETING_MATCH",
+                serialId = 0L
+            ),
+            "flag2" to PrecomputedFlag(
+                variationType = "string",
+                variationValue = forge.anAlphabeticalString(),
+                doLog = false,
+                allocationKey = forge.anAlphabeticalString(),
+                variationKey = "variation2",
+                extraLogging = JSONObject(),
+                reason = "DEFAULT",
+                serialId = null
+            )
+        )
+        val flagsState = FlagsStateEntry(evaluationContext, flags, fakeTimestamp)
+
+        // When
+        val serialized = testedSerializer.serialize(flagsState)
+
+        // Then
+        SerializedFlagsStateAssert.assertThatSerializedFlagsState(serialized)
+            .hasFlagSerialId("flag1", 0L)
+            .hasNoFlagSerialId("flag2")
+    }
+
+    @Test
     fun `M serialize empty flags state W serialize()`(forge: Forge) {
         // Given
         val targetingKey = forge.anAlphabeticalString()

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/persistence/SerializedFlagsStateAssert.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/persistence/SerializedFlagsStateAssert.kt
@@ -37,6 +37,27 @@ internal class SerializedFlagsStateAssert(actual: JSONObject) :
         return this
     }
 
+    fun hasFlagSerialId(flagKey: String, expected: Long): SerializedFlagsStateAssert {
+        val flag = actual.getJSONObject("flags").getJSONObject(flagKey)
+        assertThat(flag.getLong("serialId"))
+            .overridingErrorMessage(
+                "Expected flag $flagKey to have serialId $expected " +
+                    "but was ${flag.opt("serialId")}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasNoFlagSerialId(flagKey: String): SerializedFlagsStateAssert {
+        val flag = actual.getJSONObject("flags").getJSONObject(flagKey)
+        assertThat(flag.has("serialId"))
+            .overridingErrorMessage(
+                "Expected flag $flagKey to have no serialId but was ${flag.opt("serialId")}"
+            )
+            .isFalse()
+        return this
+    }
+
     fun hasEmptyFlags(): SerializedFlagsStateAssert {
         val flags = actual.getJSONObject("flags")
         assertThat(flags.length())

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/net/PrecomputeMapperTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/repository/net/PrecomputeMapperTest.kt
@@ -13,6 +13,7 @@ import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.DoubleForgery
 import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -56,6 +57,9 @@ internal class PrecomputeMapperTest {
 
     @DoubleForgery
     var fakeDoubleValue: Double = 0.0
+
+    @LongForgery(min = 1L)
+    var fakeSerialId: Long = 0L
 
     private lateinit var testedMapper: PrecomputeMapper
 
@@ -304,6 +308,89 @@ internal class PrecomputeMapperTest {
 
         // Then
         assertThat(result).isEmpty()
+        verifyNoInteractions(mockInternalLogger)
+    }
+
+    // endregion
+
+    // region Serial Id
+
+    @Test
+    fun `M parse serial id W map() { flag carries a serial id }`() {
+        // Given
+        val flagJson = buildFlagJson(
+            variationType = VariationType.STRING.value,
+            variationValue = "test-value"
+        ).apply { put("serialId", fakeSerialId) }
+        val json = buildValidJson(mapOf(fakeFlagKey to flagJson))
+
+        // When
+        val result = testedMapper.map(json)
+
+        // Then
+        val flag = result[fakeFlagKey]
+        checkNotNull(flag)
+        assertThat(flag.serialId).isEqualTo(fakeSerialId)
+        verifyNoInteractions(mockInternalLogger)
+    }
+
+    @Test
+    fun `M parse serial id W map() { serial id is zero }`() {
+        // Given
+        val flagJson = buildFlagJson(
+            variationType = VariationType.STRING.value,
+            variationValue = "test-value"
+        ).apply { put("serialId", 0L) }
+        val json = buildValidJson(mapOf(fakeFlagKey to flagJson))
+
+        // When
+        val result = testedMapper.map(json)
+
+        // Then
+        val flag = result[fakeFlagKey]
+        checkNotNull(flag)
+        assertThat(flag.serialId).isEqualTo(0L)
+        verifyNoInteractions(mockInternalLogger)
+    }
+
+    @Test
+    fun `M parse no serial id W map() { serial id is null }`() {
+        // Given
+        val flagJson = buildFlagJson(
+            variationType = VariationType.STRING.value,
+            variationValue = "test-value"
+        ).apply { put("serialId", JSONObject.NULL) }
+        val json = buildValidJson(mapOf(fakeFlagKey to flagJson))
+
+        // When
+        val result = testedMapper.map(json)
+
+        // Then
+        val flag = result[fakeFlagKey]
+        checkNotNull(flag)
+        assertThat(flag.serialId).isNull()
+        verifyNoInteractions(mockInternalLogger)
+    }
+
+    @Test
+    fun `M parse no serial id W map() { no serial id key }`() {
+        // Given
+        val json = buildValidJson(
+            mapOf(
+                fakeFlagKey to buildFlagJson(
+                    variationType = VariationType.STRING.value,
+                    variationValue = "test-value"
+                )
+            )
+        )
+
+        // When
+        val result = testedMapper.map(json)
+
+        // Then
+        val flag = result[fakeFlagKey]
+        checkNotNull(flag)
+        assertThat(flag.serialId).isNull()
         verifyNoInteractions(mockInternalLogger)
     }
 

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/utils/forge/PrecomputedFlagForgeryFactory.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/utils/forge/PrecomputedFlagForgeryFactory.kt
@@ -46,7 +46,8 @@ internal class PrecomputedFlagForgeryFactory : ForgeryFactory<PrecomputedFlag> {
                     }
                 }
             } ?: JSONObject(),
-            reason = reason
+            reason = reason,
+            serialId = forge.aNullable { aLong(min = 0L) }
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?

Adds a `serial_id` field to the exposure event that `dd-sdk-android` sends.

The precompute service already sends a `serialId` on each flag. The SDK discarded the value. This change keeps it and puts it on the exposure event.

| File | Change |
|---|---|
| `json/flags/exposure-event-schema.json` | Add the optional `serial_id` field. |
| `model/UnparsedFlag.kt` | Add the optional serial ID to the flag contract. |
| `internal/model/PrecomputedFlag.kt` | Implement the new property. |
| `internal/model/PrecomputedFlagConstants.kt` | Add the `serialId` JSON key. |
| `internal/repository/net/PrecomputeMapper.kt` | Read the serial ID from the precompute response. |
| `internal/persistence/FlagsStateSerializer.kt` | Write the serial ID to the datastore. |
| `internal/persistence/FlagsStateDeserializer.kt` | Read the serial ID from the datastore. |
| `internal/ExposureEventsProcessor.kt` | Set the field, and add it to the exposure cache. |

The server sends an explicit `null` when a flag has no serial ID. The model accepts a null value and an absent key. The SDK sends no field when the value is absent. The SDK does not validate the value, because the flag configuration layer validates it.

The datastore must keep the value, because the SDK reads the flag state from the disk after a cold start.

### Motivation

The exposures intake uses the serial ID to find the holdout that an allocation comes from. A holdout becomes a usual allocation before an SDK receives the flag configuration, so the exposure event records no holdout. The serial ID is the only link back to it.

### Additional Notes

The exposure cache now compares the serial ID in addition to the allocation key and the variant key. A subject therefore sends one more exposure when its serial ID appears or changes. This behaviour is necessary: a configuration refresh can add a serial ID while both keys stay the same, and the intake must receive the value.

Serial IDs start at zero for each organization, so a zero value is common. The code tests for presence, and not for a true value.

Fifteen new tests cover the four hops. Six tests use the value zero.

`api/apiSurface` and `api/dd-sdk-android-flags.api` are regenerated.

Related: EX-3419.

*This description was generated by Claude.*

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)
