### PR TITLE
Remove ineffective commit-signing policy from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,6 @@ Some modules generate Kotlin data classes from JSON schemas at build time (e.g. 
 # Commits
 
 - Default branch for PRs: **`develop`**
-- All commits must be **GPG-signed** (repo policy).
 - Commit title format: `RUM-XXXXX: <short description>` (ticket number prefix required)
 - Each commit must reference the ticket number in the title.
 


### PR DESCRIPTION
Test PR investigating a recurring false-positive comment from the `chatgpt-codex-connector[bot]` on this repo's PRs, claiming commits are "not GPG-signed" per `AGENTS.md`.

**Findings from testing on this PR:**
- Commits here are signed via **SSH**, not GPG. `git verify-commit` can exit non-zero even for a validly-signed commit if the local environment lacks a matching `allowed_signers` file (as seen on real PR #3736's commit `e3b2b4e3`, which GitHub's API confirms is `verified: true, reason: valid`, yet Codex flagged as unsigned).
- GitHub itself already blocks merging unsigned commits into `develop` natively, via the org-wide `require-signatures-github` ruleset (`required_signatures`, non-bypassable). This is enforced independently of anything written in `AGENTS.md`.
- Rewording `AGENTS.md` to describe SSH signing changed Codex's remedy wording (it started saying "SSH-signed" instead of "GPG"), but did **not** fix the underlying reliability problem: on a follow-up test commit that was genuinely, validly SSH-signed (confirmed by both local `git verify-commit`/`%G?=G` and GitHub's API), Codex still flagged it — this time by claiming the commit "has no `gpgsig` header," which is factually false for that commit.

**Conclusion**: since GitHub's native branch protection already enforces signing (and does so correctly), and the `AGENTS.md` policy text was only feeding an unreliable Codex check (false positives on both a real PR and a validly-signed test commit), the commit-signing bullet has been removed from `AGENTS.md` entirely. No loss of actual enforcement — only removes a doc line that wasn't helping.

Marking ready for review to see how Codex reacts once the policy text is gone. Will close/delete this branch once done.