### PR TITLE
RUM-18168: Fix DataFlusher racing the upload scheduler and duplicating events

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -359,7 +359,7 @@ internal class CoreFeature(
         contextExecutorService.queue.drainTo(contextTasks)
 
         contextExecutorService.shutdown()
-        contextExecutorService.awaitTermination(DRAIN_WAIT_SECONDS, TimeUnit.SECONDS)
+        awaitTerminationLogged(contextExecutorService, "contextExecutorService", DRAIN_WAIT_SECONDS, TimeUnit.SECONDS)
         contextTasks.forEach {
             it.run()
         }
@@ -376,11 +376,35 @@ internal class CoreFeature(
         persistenceExecutorService.shutdown()
         uploadExecutorService.shutdown()
 
-        persistenceExecutorService.awaitTermination(DRAIN_WAIT_SECONDS, TimeUnit.SECONDS)
-        uploadExecutorService.awaitTermination(DRAIN_WAIT_SECONDS, TimeUnit.SECONDS)
+        awaitTerminationLogged(
+            persistenceExecutorService,
+            "persistenceExecutorService",
+            DRAIN_WAIT_SECONDS,
+            TimeUnit.SECONDS
+        )
+        // uploadExecutorService can be mid-upload when this runs, and only NETWORK_TIMEOUT_MS
+        // bounds how long that upload can take. Failing to wait long enough here can lead to
+        // a DataFlusher race where it uploads the same batch twice. See RUM-18168.
+        awaitTerminationLogged(
+            uploadExecutorService,
+            "uploadExecutorService",
+            NETWORK_TIMEOUT_MS,
+            TimeUnit.MILLISECONDS
+        )
 
         ioTasks.forEach {
             it.run()
+        }
+    }
+
+    @Suppress("UnsafeThirdPartyFunctionCall") // Used in Nightly tests only
+    private fun awaitTerminationLogged(executor: ExecutorService, executorName: String, wait: Long, unit: TimeUnit) {
+        if (!executor.awaitTermination(wait, unit)) {
+            internalLogger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.MAINTAINER,
+                { "drainAndShutdownExecutors: $executorName did not terminate within $wait $unit" }
+            )
         }
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -1555,8 +1555,37 @@ internal class CoreFeatureTest {
         // Then
         inOrder(mockUploadService) {
             verify(mockUploadService).shutdown()
-            verify(mockUploadService).awaitTermination(10, TimeUnit.SECONDS)
+            verify(mockUploadService).awaitTermination(CoreFeature.NETWORK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
         }
+    }
+
+    @Test
+    fun `M log a warning W drainAndShutdownExecutors() { upload executor doesn't terminate in time }`() {
+        // Given
+        testedFeature.initialize(
+            appContext.mockInstance,
+            fakeSdkInstanceId,
+            fakeConfig,
+            fakeConsent
+        )
+
+        val blockingQueue = LinkedBlockingQueue<Runnable>()
+        val mockUploadService: ScheduledThreadPoolExecutor = mock()
+        whenever(mockUploadService.queue).thenReturn(blockingQueue)
+        whenever(mockUploadService.awaitTermination(any(), any())) doReturn false
+        testedFeature.uploadExecutorService = mockUploadService
+
+        // When
+        testedFeature.drainAndShutdownExecutors()
+
+        // Then
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.MAINTAINER,
+            "drainAndShutdownExecutors: uploadExecutorService did not terminate " +
+                "within ${CoreFeature.NETWORK_TIMEOUT_MS} ${TimeUnit.MILLISECONDS}",
+            mode = atLeastOnce()
+        )
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
DataFlusher.flush() read batch files directly from FileOrchestrator.getFlushableFiles(), bypassing ConsentAwareStorage's lockedReadBatches tracking. This let an explicit Flush() call and the SDK's own regular periodic upload scheduler independently claim and upload the same on-disk batch file at the same time, producing duplicate RUM events (confirmed via emulator repro with event-hash-level instrumentation).

Fix: route DataFlusher through Storage.readNextBatch()/confirmBatchRead() instead of FileOrchestrator directly, so a flush participates in the same lockedReadBatches coordination as every other reader.

At the old 10s bound, awaitTermination() timed out on every one of 8 on-device runs and reproduced the duplicate event in 2 of them; at the new bound (matching NETWORK_TIMEOUT_MS, 45s), 0 of 8 runs produced a duplicate.

### Motivation
This should stabilize the RUM FIT test case `test_multipage_navigation_with_resource_loading` for MAUI-Android

```
FAILED scenarios/test_multipage_navigation.py::test_multipage_navigation_with_resource_loading - AssertionError: Expected image resource with URL containing 'imgix.datadoghq.com/img/about/presskit/usage/logousage_purple.png'. Found 2 resources: ['https://imgix.datadoghq.com/img/about/presskit/usage/logousage_purple.png?auto=format&fit=max&w=847&dpr=2', 'https://imgix.datadoghq.com/img/about/presskit/usage/logousage_purple.png?auto=format&fit=max&w=847&dpr=2']
assert 2 == 1
 +  where 2 = len([
    RumResourceEvent(
        type='resource',
        date=1787061879863,
        session=Session(id='27096e2b-4cd7-48f6-8473-291183610696', type='user', ...),
        view=View(id='fa619c25-5a82-43f9-bd88-59c90dc3ed84', url='RumTestApp/Scenarios/MultipageNavigation/Page2', name='page2', ...),
        resource=ResourceDetails(
            type='image',
            url='https://imgix.datadoghq.com/img/about/presskit/usage/logousage_purple.png?auto=format&fit=max&w=847&dpr=2',
            method='GET',
            status_code=200,
            duration=1333153375,
            size=118067,
            id='5bc74488-7fdf-43e3-9366-dc4acda58fc6',
        ),
        ...
    ),
    RumResourceEvent(
        type='resource',
        date=1787061879863,
        session=Session(id='27096e2b-4cd7-48f6-8473-291183610696', t
        view=View(id='fa619c25-5a82-43f9-bd88-59c90dc3ed84', url='RugeNavigation/Page2', name='page2', ...),
        resource=ResourceDetails(
            type='image',
            url='https://imgix.datadoghq.com/img/about/presskit/usage/logousage_purple.png?auto=format&fit=max&w=847&dpr=2',
            method='GET',
            status_code=200,
            duration=1333153375,
            size=118067,
            id='5bc74488-7fdf-43e3-9366-dc4acda58fc6',
        ),
        ...
    ),
])
```

Both events are byte-identical, confirming a duplicate upload of a single logical resource event rather than two distinct events.

Reproduction log:
```
12:26:55.953  Thread-4 (DataFlusher.flush)      READ  file=1787167593155  hashes=[-1353918861, ...]
12:26:55.954  Thread-4 (DataFlusher.flush)      UPLOAD requestId=28859dbf...  hashes=[-1353918861, ...]
12:26:56.455  datadog-upload-thread-1 (periodic) UPLOAD requestId=f0274407... hashes=[-1353918861, ...]  ← same file, same hashes
12:26:56.729  Thread-4 (DataFlusher.flush)      DELETE file=1787167593155
12:26:57.228  datadog-upload-thread-1           confirmBatchRead file=1787167593155 deleteBatch=true

Both uploads succeeded independently. The raw intake JSONL confirms two identical resource events, same resource.id (f9f07fa4-b4e1-40d0-8aff-706f0f5a77be). 
```

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

