### PR TITLE
RUM-18149 Pt.1: Rename ANR profiling trigger classes to generic names for reuse

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/anr/ProfilingManagerTriggerRegistrar.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/anr/ProfilingManagerTriggerRegistrar.kt
@@ -25,15 +25,15 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Consumer
 
 /**
- * BAKLAVA+ implementation of [AnrTriggerRegistrar] backed by the system
+ * BAKLAVA+ implementation of [ProfilingTriggerRegistrar] backed by the system
  * [ProfilingManager.addProfilingTriggers] /
  * [ProfilingManager.registerForAllProfilingResults] APIs.
  */
-internal class AnrProfilingTriggerRegistrar(
+internal class ProfilingManagerTriggerRegistrar(
     private val timeProvider: TimeProvider,
     private val executorService: ExecutorService,
     private val profilingTelemetry: ProfilingTelemetry
-) : AnrTriggerRegistrar {
+) : ProfilingTriggerRegistrar {
 
     @Volatile
     internal var threadDumper: ThreadDumper = ThreadDumper()
@@ -48,7 +48,7 @@ internal class AnrProfilingTriggerRegistrar(
     private val registered = AtomicBoolean(false)
 
     @Volatile
-    private var listener: AnrListener? = null
+    private var listener: ProfilingTriggerListener? = null
 
     // Testable seam
     @RequiresApi(Build.VERSION_CODES.BAKLAVA)
@@ -63,7 +63,7 @@ internal class AnrProfilingTriggerRegistrar(
 
     @RequiresApi(Build.VERSION_CODES.BAKLAVA)
     @Suppress("ReturnCount")
-    override fun register(appContext: Context, listener: AnrListener) {
+    override fun register(appContext: Context, listener: ProfilingTriggerListener) {
         if (registered.get()) return
 
         val manager = appContext.getSystemService(ProfilingManager::class.java)

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/anr/ProfilingTriggerListener.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/anr/ProfilingTriggerListener.kt
@@ -8,6 +8,6 @@ package com.datadog.android.profiling.internal.anr
 
 import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 
-internal fun interface AnrListener {
+internal fun interface ProfilingTriggerListener {
     fun onAnrDetected(event: ProfilingAnrDetectedEvent)
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/anr/ProfilingTriggerRegistrar.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/anr/ProfilingTriggerRegistrar.kt
@@ -9,11 +9,11 @@ package com.datadog.android.profiling.internal.anr
 import android.content.Context
 import com.datadog.android.api.InternalLogger
 
-internal interface AnrTriggerRegistrar {
+internal interface ProfilingTriggerRegistrar {
 
     var internalLogger: InternalLogger?
 
-    fun register(appContext: Context, listener: AnrListener)
+    fun register(appContext: Context, listener: ProfilingTriggerListener)
 
     fun unregister(appContext: Context)
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
@@ -20,9 +20,9 @@ import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.profiling.internal.Profiler
 import com.datadog.android.profiling.internal.ProfilerCallback
 import com.datadog.android.profiling.internal.ProfilingStartReason
-import com.datadog.android.profiling.internal.anr.AnrListener
-import com.datadog.android.profiling.internal.anr.AnrProfilingTriggerRegistrar
-import com.datadog.android.profiling.internal.anr.AnrTriggerRegistrar
+import com.datadog.android.profiling.internal.anr.ProfilingManagerTriggerRegistrar
+import com.datadog.android.profiling.internal.anr.ProfilingTriggerListener
+import com.datadog.android.profiling.internal.anr.ProfilingTriggerRegistrar
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetry
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetryEvent
 import com.datadog.android.profiling.internal.time.MutableTimeProvider
@@ -44,7 +44,7 @@ import kotlin.random.Random
  * @param scheduledExecutorService the executor service to run the profiling task on.
  * @param profilingTelemetry shared telemetry helper that buffers metric events until a logger is
  * available and dispatches them through the unified `[Mobile Metric] Profiling Session` envelope.
- * @param anrTriggerRegistrar registrar that owns the system ANR profiling-trigger lifecycle.
+ * @param triggerRegistrar registrar that owns the system ANR profiling-trigger lifecycle.
  * The profiler passes its internal listener to it at register time; the listener
  * captures the profiler's `callback` so the registered SDK instance receives the detection.
  * @param buildSdkVersionProvider Build.VERSION.SDK_INT provider used for the test.
@@ -54,8 +54,8 @@ internal class PerfettoProfiler(
     override val timeProvider: MutableTimeProvider,
     override val scheduledExecutorService: ScheduledExecutorService,
     internal val profilingTelemetry: ProfilingTelemetry = ProfilingTelemetry(),
-    internal val anrTriggerRegistrar: AnrTriggerRegistrar =
-        AnrProfilingTriggerRegistrar(timeProvider, scheduledExecutorService, profilingTelemetry),
+    internal val triggerRegistrar: ProfilingTriggerRegistrar =
+        ProfilingManagerTriggerRegistrar(timeProvider, scheduledExecutorService, profilingTelemetry),
     private val buildSdkVersionProvider: BuildSdkVersionProvider = BuildSdkVersionProvider.DEFAULT
 ) : Profiler {
 
@@ -92,11 +92,11 @@ internal class PerfettoProfiler(
     override var internalLogger: InternalLogger? = null
         set(value) {
             field = value
-            anrTriggerRegistrar.internalLogger = value
+            triggerRegistrar.internalLogger = value
             profilingTelemetry.internalLogger = value
         }
 
-    internal val anrListener = AnrListener { event ->
+    internal val triggerListener = ProfilingTriggerListener { event ->
         callback?.onAnrDetected(event)
     }
 
@@ -254,7 +254,7 @@ internal class PerfettoProfiler(
         synchronized(this) {
             this.callback = callback
             if (buildSdkVersionProvider.isAtLeastBaklava) {
-                anrTriggerRegistrar.register(appContext, anrListener)
+                triggerRegistrar.register(appContext, triggerListener)
             }
         }
     }
@@ -263,7 +263,7 @@ internal class PerfettoProfiler(
         synchronized(this) {
             callback = null
             if (buildSdkVersionProvider.isAtLeastBaklava) {
-                anrTriggerRegistrar.unregister(appContext)
+                triggerRegistrar.unregister(appContext)
             }
         }
     }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -34,7 +34,7 @@ import com.datadog.android.profiling.internal.ProfilingRequestFactory
 import com.datadog.android.profiling.internal.ProfilingStartReason
 import com.datadog.android.profiling.internal.ProfilingStorage
 import com.datadog.android.profiling.internal.ProfilingWriter
-import com.datadog.android.profiling.internal.anr.AnrTriggerRegistrar
+import com.datadog.android.profiling.internal.anr.ProfilingTriggerRegistrar
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 import com.datadog.android.profiling.internal.quota.NoOpQuotaChecker
@@ -151,7 +151,7 @@ internal class ProfilingFeatureTest {
     private lateinit var mockPackageManager: PackageManager
 
     @Mock
-    private lateinit var mockAnrTriggerRegistrar: AnrTriggerRegistrar
+    private lateinit var mockTriggerRegistrar: ProfilingTriggerRegistrar
 
     @Mock
     private lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
@@ -272,7 +272,7 @@ internal class ProfilingFeatureTest {
             timeProvider = MutableTimeProvider.create(mockTimeProvider),
             scheduledExecutorService = mockSchedulerExecutor,
             profilingTelemetry = ProfilingTelemetry(),
-            anrTriggerRegistrar = mockAnrTriggerRegistrar,
+            triggerRegistrar = mockTriggerRegistrar,
             buildSdkVersionProvider = mockBuildSdkVersionProvider
         )
         val feature = ProfilingFeature(
@@ -302,7 +302,7 @@ internal class ProfilingFeatureTest {
             timeProvider = MutableTimeProvider.create(mockTimeProvider),
             scheduledExecutorService = mockSchedulerExecutor,
             profilingTelemetry = profilingTelemetry,
-            anrTriggerRegistrar = mockAnrTriggerRegistrar,
+            triggerRegistrar = mockTriggerRegistrar,
             buildSdkVersionProvider = mockBuildSdkVersionProvider
         )
         profilingTelemetry.report(

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -20,7 +20,7 @@ import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.profiling.forge.Configurator
-import com.datadog.android.profiling.internal.anr.AnrTriggerRegistrar
+import com.datadog.android.profiling.internal.anr.ProfilingTriggerRegistrar
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler.Companion.APP_LAUNCH_PROFILING_MAX_DURATION_MS
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler.Companion.PROFILING_SAMPLING_RATE_APP_LAUNCH
@@ -97,7 +97,7 @@ class PerfettoProfilerTest {
     private lateinit var mockProfilerCallback: ProfilerCallback
 
     @Mock
-    private lateinit var mockAnrRegistrar: AnrTriggerRegistrar
+    private lateinit var mockRegistrar: ProfilingTriggerRegistrar
 
     @Mock
     private lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
@@ -124,7 +124,7 @@ class PerfettoProfilerTest {
         testedProfiler = PerfettoProfiler(
             timeProvider = stubTimeProvider,
             scheduledExecutorService = mockExecutorService,
-            anrTriggerRegistrar = mockAnrRegistrar,
+            triggerRegistrar = mockRegistrar,
             buildSdkVersionProvider = mockBuildSdkVersionProvider,
             profilingTelemetry = ProfilingTelemetry().apply {
                 profilingPackageVersionCode = fakeProfilingPackageLongVersionCode
@@ -1034,7 +1034,7 @@ class PerfettoProfilerTest {
     fun `M delegate to registrar W registerProfilingCallback`() {
         // Set-up performs 1 registerProfilingCallback call, which delegates to the registrar,
         // passing the profiler's listener.
-        verify(mockAnrRegistrar).register(mockContext, testedProfiler.anrListener)
+        verify(mockRegistrar).register(mockContext, testedProfiler.triggerListener)
     }
 
     @Test
@@ -1043,22 +1043,22 @@ class PerfettoProfilerTest {
         testedProfiler.unregisterProfilingCallback(mockContext)
 
         // Then
-        verify(mockAnrRegistrar).unregister(mockContext)
+        verify(mockRegistrar).unregister(mockContext)
     }
 
     @Test
-    fun `M dispatch to registered callback W AnrListener fires`(
+    fun `M dispatch to registered callback W triggerListener fires`(
         @Forgery fakeEvent: ProfilingAnrDetectedEvent
     ) {
         // When
-        testedProfiler.anrListener.onAnrDetected(fakeEvent)
+        testedProfiler.triggerListener.onAnrDetected(fakeEvent)
 
         // Then
         verify(mockProfilerCallback).onAnrDetected(fakeEvent)
     }
 
     @Test
-    fun `M propagate logger to anrTriggerRegistrar W internalLogger setter`() {
+    fun `M propagate logger to triggerRegistrar W internalLogger setter`() {
         // Given
         val anotherLogger = mock<InternalLogger>()
 
@@ -1066,21 +1066,21 @@ class PerfettoProfilerTest {
         testedProfiler.internalLogger = anotherLogger
 
         // Then
-        verify(mockAnrRegistrar).internalLogger = anotherLogger
+        verify(mockRegistrar).internalLogger = anotherLogger
     }
 
     @Test
     fun `M not delegate to registrar W registerProfilingCallback {SDK below BAKLAVA}`() {
         // Given
         // Drop interactions recorded by the BAKLAVA-stubbed set-up call.
-        reset(mockAnrRegistrar)
+        reset(mockRegistrar)
         whenever(mockBuildSdkVersionProvider.isAtLeastBaklava) doReturn false
 
         // When
         testedProfiler.registerProfilingCallback(mockContext, mockProfilerCallback)
 
         // Then
-        verify(mockAnrRegistrar, never()).register(any(), any())
+        verify(mockRegistrar, never()).register(any(), any())
     }
 
     @Test
@@ -1092,7 +1092,7 @@ class PerfettoProfilerTest {
         testedProfiler.unregisterProfilingCallback(mockContext)
 
         // Then
-        verify(mockAnrRegistrar, never()).unregister(any())
+        verify(mockRegistrar, never()).unregister(any())
     }
 
     // endregion
@@ -1176,7 +1176,7 @@ class PerfettoProfilerTest {
         val profiler = PerfettoProfiler(
             timeProvider = stubTimeProvider,
             scheduledExecutorService = mockExecutorService,
-            anrTriggerRegistrar = mockAnrRegistrar,
+            triggerRegistrar = mockRegistrar,
             buildSdkVersionProvider = mockBuildSdkVersionProvider,
             profilingTelemetry = ProfilingTelemetry()
         )

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/anr/ProfilingManagerTriggerRegistrarTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/anr/ProfilingManagerTriggerRegistrarTest.kt
@@ -54,7 +54,7 @@ import java.util.function.Consumer
     ExtendWith(ForgeExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
-internal class AnrProfilingTriggerRegistrarTest {
+internal class ProfilingManagerTriggerRegistrarTest {
 
     @Mock
     private lateinit var mockContext: Context
@@ -69,7 +69,7 @@ internal class AnrProfilingTriggerRegistrarTest {
     private lateinit var mockExecutorService: ExecutorService
 
     @Mock
-    private lateinit var mockAnrListener: AnrListener
+    private lateinit var mockListener: ProfilingTriggerListener
 
     @Mock
     private lateinit var mockTimeProvider: TimeProvider
@@ -77,12 +77,12 @@ internal class AnrProfilingTriggerRegistrarTest {
     @Mock
     private lateinit var mockProfilingTelemetry: ProfilingTelemetry
 
-    private lateinit var testedRegistrar: AnrProfilingTriggerRegistrar
+    private lateinit var testedRegistrar: ProfilingManagerTriggerRegistrar
 
     @BeforeEach
     fun `set up`() {
         whenever(mockContext.getSystemService(ProfilingManager::class.java)).doReturn(mockService)
-        testedRegistrar = AnrProfilingTriggerRegistrar(
+        testedRegistrar = ProfilingManagerTriggerRegistrar(
             timeProvider = mockTimeProvider,
             executorService = mockExecutorService,
             profilingTelemetry = mockProfilingTelemetry
@@ -100,7 +100,7 @@ internal class AnrProfilingTriggerRegistrarTest {
     @Test
     fun `M register system ANR trigger W register()`() {
         // When
-        testedRegistrar.register(mockContext, mockAnrListener)
+        testedRegistrar.register(mockContext, mockListener)
 
         // Then
         val triggersCaptor = argumentCaptor<List<ProfilingTrigger>>()
@@ -118,8 +118,8 @@ internal class AnrProfilingTriggerRegistrarTest {
     @Test
     fun `M register only once W register() {called twice}`() {
         // When
-        testedRegistrar.register(mockContext, mockAnrListener)
-        testedRegistrar.register(mockContext, mockAnrListener)
+        testedRegistrar.register(mockContext, mockListener)
+        testedRegistrar.register(mockContext, mockListener)
 
         // Then
         verify(mockService).addProfilingTriggers(any())
@@ -132,7 +132,7 @@ internal class AnrProfilingTriggerRegistrarTest {
     @Test
     fun `M ignore result W trigger callback fires {non-ANR trigger type}`() {
         // Given
-        testedRegistrar.register(mockContext, mockAnrListener)
+        testedRegistrar.register(mockContext, mockListener)
         val triggerCallbackCaptor = argumentCaptor<Consumer<ProfilingResult>>()
         verify(mockService).registerForAllProfilingResults(any(), triggerCallbackCaptor.capture())
         val nonAnrResult = mock<ProfilingResult> {
@@ -143,7 +143,7 @@ internal class AnrProfilingTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(nonAnrResult)
 
         // Then
-        verify(mockAnrListener, never()).onAnrDetected(any())
+        verify(mockListener, never()).onAnrDetected(any())
     }
 
     @Test
@@ -152,7 +152,7 @@ internal class AnrProfilingTriggerRegistrarTest {
     ) {
         // Given a path that doesn't exist on disk: getFileCreationTimeMs returns null, so the
         // registrar can't compute callbackDelayMs and treats droppedAsStale as false.
-        testedRegistrar.register(mockContext, mockAnrListener)
+        testedRegistrar.register(mockContext, mockListener)
         val triggerCallbackCaptor = argumentCaptor<Consumer<ProfilingResult>>()
         verify(mockService).registerForAllProfilingResults(any(), triggerCallbackCaptor.capture())
         val anrResult = mock<ProfilingResult> {
@@ -185,7 +185,7 @@ internal class AnrProfilingTriggerRegistrarTest {
         @StringForgery fakePath: String
     ) {
         // Given
-        testedRegistrar.register(mockContext, mockAnrListener)
+        testedRegistrar.register(mockContext, mockListener)
         val triggerCallbackCaptor = argumentCaptor<Consumer<ProfilingResult>>()
         verify(mockService).registerForAllProfilingResults(any(), triggerCallbackCaptor.capture())
         val anrResult = mock<ProfilingResult> {
@@ -226,7 +226,7 @@ internal class AnrProfilingTriggerRegistrarTest {
             mainThreadProvider = { Thread.currentThread() },
             allStackTracesProvider = { throw RuntimeException("boom") }
         )
-        testedRegistrar.register(mockContext, mockAnrListener)
+        testedRegistrar.register(mockContext, mockListener)
         val triggerCallbackCaptor = argumentCaptor<Consumer<ProfilingResult>>()
         verify(mockService).registerForAllProfilingResults(any(), triggerCallbackCaptor.capture())
         val anrResult = mock<ProfilingResult> {
@@ -239,14 +239,14 @@ internal class AnrProfilingTriggerRegistrarTest {
 
         // Then
         val captor = argumentCaptor<ProfilingAnrDetectedEvent>()
-        verify(mockAnrListener).onAnrDetected(captor.capture())
+        verify(mockListener).onAnrDetected(captor.capture())
         assertThat(captor.firstValue.allThreads).isEmpty()
     }
 
     @Test
     fun `M remove system trigger W unregister()`() {
         // Given
-        testedRegistrar.register(mockContext, mockAnrListener)
+        testedRegistrar.register(mockContext, mockListener)
 
         // When
         testedRegistrar.unregister(mockContext)
@@ -271,11 +271,11 @@ internal class AnrProfilingTriggerRegistrarTest {
     @Test
     fun `M re-register after unregister W register() called again`() {
         // Given
-        testedRegistrar.register(mockContext, mockAnrListener)
+        testedRegistrar.register(mockContext, mockListener)
         testedRegistrar.unregister(mockContext)
 
         // When
-        testedRegistrar.register(mockContext, mockAnrListener)
+        testedRegistrar.register(mockContext, mockListener)
 
         // Then
         verify(mockService, times(2)).addProfilingTriggers(any())
@@ -288,7 +288,7 @@ internal class AnrProfilingTriggerRegistrarTest {
         whenever(mockContext.getSystemService(ProfilingManager::class.java)).doReturn(null)
 
         // When
-        testedRegistrar.register(mockContext, mockAnrListener)
+        testedRegistrar.register(mockContext, mockListener)
 
         // Then
         verify(mockService, never()).addProfilingTriggers(any())
@@ -306,7 +306,7 @@ internal class AnrProfilingTriggerRegistrarTest {
     @Test
     fun `M log warning and keep registered W unregister() {ProfilingManager service unavailable}`() {
         // Given
-        testedRegistrar.register(mockContext, mockAnrListener)
+        testedRegistrar.register(mockContext, mockListener)
         whenever(mockContext.getSystemService(ProfilingManager::class.java)).doReturn(null)
 
         // When
@@ -335,7 +335,7 @@ internal class AnrProfilingTriggerRegistrarTest {
     ) {
         // Given
         val tmpFile = File(tempDir, "result.trace").apply { writeText("placeholder") }
-        testedRegistrar.register(mockContext, mockAnrListener)
+        testedRegistrar.register(mockContext, mockListener)
         val triggerCallbackCaptor = argumentCaptor<Consumer<ProfilingResult>>()
         verify(mockService).registerForAllProfilingResults(any(), triggerCallbackCaptor.capture())
         val anrResult = mock<ProfilingResult> {
@@ -353,7 +353,7 @@ internal class AnrProfilingTriggerRegistrarTest {
     @Test
     fun `M drop ANR event and log warning W trigger callback fires {result file missing}`() {
         // Given
-        testedRegistrar.register(mockContext, mockAnrListener)
+        testedRegistrar.register(mockContext, mockListener)
         val triggerCallbackCaptor = argumentCaptor<Consumer<ProfilingResult>>()
         verify(mockService).registerForAllProfilingResults(any(), triggerCallbackCaptor.capture())
         val anrResult = mock<ProfilingResult> {
@@ -365,7 +365,7 @@ internal class AnrProfilingTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(anrResult)
 
         // Then
-        verify(mockAnrListener, never()).onAnrDetected(any())
+        verify(mockListener, never()).onAnrDetected(any())
         verify(mockInternalLogger).log(
             eq(InternalLogger.Level.WARN),
             eq(InternalLogger.Target.MAINTAINER),
@@ -401,7 +401,7 @@ internal class AnrProfilingTriggerRegistrarTest {
         ).creationTime().toMillis()
         val fakeNow = creationTimeMs + fakeDelayMs
         whenever(mockTimeProvider.getDeviceTimestampMillis()).doReturn(fakeNow)
-        testedRegistrar.register(mockContext, mockAnrListener)
+        testedRegistrar.register(mockContext, mockListener)
         val triggerCallbackCaptor = argumentCaptor<Consumer<ProfilingResult>>()
         verify(mockService).registerForAllProfilingResults(any(), triggerCallbackCaptor.capture())
         val anrResult = mock<ProfilingResult> {
@@ -416,7 +416,7 @@ internal class AnrProfilingTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(anrResult)
 
         // Then
-        verify(mockAnrListener).onAnrDetected(any())
+        verify(mockListener).onAnrDetected(any())
         verify(mockProfilingTelemetry).report(
             ProfilingTelemetryEvent.AnrTriggerResult(
                 errorCode = ProfilingResult.ERROR_NONE,
@@ -442,7 +442,7 @@ internal class AnrProfilingTriggerRegistrarTest {
         ).creationTime().toMillis()
         val fakeNow = creationTimeMs + fakeDelayMs
         whenever(mockTimeProvider.getDeviceTimestampMillis()).doReturn(fakeNow)
-        testedRegistrar.register(mockContext, mockAnrListener)
+        testedRegistrar.register(mockContext, mockListener)
         val triggerCallbackCaptor = argumentCaptor<Consumer<ProfilingResult>>()
         verify(mockService).registerForAllProfilingResults(any(), triggerCallbackCaptor.capture())
         val anrResult = mock<ProfilingResult> {
@@ -457,7 +457,7 @@ internal class AnrProfilingTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(anrResult)
 
         // Then
-        verify(mockAnrListener, never()).onAnrDetected(any())
+        verify(mockListener, never()).onAnrDetected(any())
         verify(mockProfilingTelemetry).report(
             ProfilingTelemetryEvent.AnrTriggerResult(
                 errorCode = ProfilingResult.ERROR_NONE,


### PR DESCRIPTION
### What does this PR do?

Renames ANR-specific profiling trigger classes to generic names so they can be reused for memory/other triggers:

- `AnrListener` → `ProfilingTriggerListener`
- `AnrTriggerRegistrar` → `ProfilingTriggerRegistrar`
- `AnrProfilingTriggerRegistrar` → `ProfilingManagerTriggerRegistrar`

Pure rename, no logic changes. Method `onAnrDetected` and event `ProfilingAnrDetectedEvent` kept as-is (cross-module, deferred).

### Motivation

RUM-18149

### Additional Notes

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)