### PR TITLE
Remove `dd-` prefix from profiling quota thread pool context name

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -380,7 +380,7 @@ internal class ProfilingFeature(
         private const val LOG_CONTINUOUS_PROFILING_WRITTEN =
             "Continuous profiling result written: %d long task(s), %d ANR event(s)."
         internal const val QUOTA_CHECK_TIMEOUT_MS = 5_000L
-        private const val QUOTA_EXECUTOR_CONTEXT = "dd-profiling-quota"
+        private const val QUOTA_EXECUTOR_CONTEXT = "profiling-quota"
         internal const val LOG_LAUNCH_PROFILING_DROPPED_QUOTA_DENIED =
             "Launch profiling dropped: quota denied (reason=%s)."
     }


### PR DESCRIPTION
### What does this PR do?

Very tiny change, `DatadogThreadFactory` already [adds](https://github.com/DataDog/dd-sdk-android/blob/ce8737ba70a8ce6eb605c9ef66512cc101bd773d/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/thread/DatadogThreadFactory.kt#L20) `datadog-` prefix, so with `dd-` prefix thread name is like `datadog-dd-profiling-quota-thread-1`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

