### PR TITLE
Replace fixed pre-launch sleep in `SessionReplayTestRule` with a poll

### DIFF
--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/SessionReplayTestConstants.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/SessionReplayTestConstants.kt
@@ -28,12 +28,13 @@ internal const val UI_THREAD_DELAY_MS = 1000L
 internal const val DECOMPRESSION_BUFFER_SIZE = 1024
 
 /**
- * Delay before launching a new activity in tests.
- * This gives time to remove the previous activity to avoid issues where Espresso
- * tries to launch a new activity while the previous one is still being removed,
- * which can cause WindowInspector.getGlobalWindowViews() to return multiple windows.
+ * Maximum time to wait for the previous activity to be torn down before launching a new one.
+ * Espresso can otherwise try to launch a new activity while the previous one is still being
+ * removed, which makes WindowInspector.getGlobalWindowViews() return multiple windows and
+ * alters the SR recorder's snapshots. This is an upper bound: the wait is a poll and returns
+ * as soon as no activity is alive.
  */
-internal const val SLEEP_DELAY_BEFORE_ACTIVITY_LAUNCH_MS = 2000L
+internal const val ACTIVITY_TEARDOWN_TIMEOUT_MS = 2000L
 
 /**
  * Sample rate indicating no sessions should be recorded (0%).

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/SessionReplayTestRule.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/SessionReplayTestRule.kt
@@ -8,10 +8,15 @@ package com.datadog.android.sdk.rules
 
 import android.app.Activity
 import android.content.Intent
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
+import androidx.test.runner.lifecycle.Stage
 import com.datadog.android.privacy.TrackingConsent
-import com.datadog.android.sdk.integration.sessionreplay.SLEEP_DELAY_BEFORE_ACTIVITY_LAUNCH_MS
+import com.datadog.android.sdk.integration.sessionreplay.ACTIVITY_TEARDOWN_TIMEOUT_MS
 import com.datadog.android.sdk.integration.sessionreplay.overrideProcessImportance
 import com.datadog.android.sdk.utils.addExtras
+import com.datadog.tools.unit.ConditionWatcher
+import java.util.concurrent.atomic.AtomicBoolean
 
 internal open class SessionReplayTestRule<T : Activity>(
     activityClass: Class<T>,
@@ -23,12 +28,12 @@ internal open class SessionReplayTestRule<T : Activity>(
     // region ActivityTestRule
 
     override fun beforeActivityLaunched() {
-        // give time to remove the previous activity. Espresso seems to have moments
+        // wait for the previous activity to be removed. Espresso seems to have moments
         // when it tries to launch the new activity while the previous one is still somehow
         // in the process of being removed. This creates an issue with our SR recorder which
         // calls the WindowInspector.getGlobalWindowViews() which can return the previous window +
         // the current window and alters the tests.
-        Thread.sleep(SLEEP_DELAY_BEFORE_ACTIVITY_LAUNCH_MS)
+        waitForPreviousActivityTeardown()
         removeCallbacks(listOf(Class.forName(SESSION_REPLAY_LIFECYCLE_CALLBACK_CLASS_NAME)))
         super.beforeActivityLaunched()
         overrideProcessImportance()
@@ -45,8 +50,43 @@ internal open class SessionReplayTestRule<T : Activity>(
 
     // endregion
 
+    // region Internal
+
+    private fun waitForPreviousActivityTeardown() {
+        try {
+            ConditionWatcher(pollingIntervalMs = TEARDOWN_POLLING_INTERVAL_MS) {
+                noActivityAlive()
+            }.doWait(timeoutMs = ACTIVITY_TEARDOWN_TIMEOUT_MS)
+        } catch (@Suppress("SwallowedException") _: ConditionWatcher.TimeoutException) {
+            // an activity outliving the timeout is not necessarily fatal, and this wait used to
+            // be an unconditional sleep of the same duration, so keep going rather than failing
+            // a test that would previously have passed.
+        }
+        // the activity being destroyed does not guarantee its window is already gone: removal is
+        // posted to the main looper. Let it drain so WindowInspector.getGlobalWindowViews() does
+        // not still see the previous window.
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    }
+
+    private fun noActivityAlive(): Boolean {
+        val monitor = ActivityLifecycleMonitorRegistry.getInstance()
+        val noneAlive = AtomicBoolean(false)
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            noneAlive.set(
+                Stage.values()
+                    .filter { it != Stage.DESTROYED }
+                    .all { monitor.getActivitiesInStage(it).isEmpty() }
+            )
+        }
+        return noneAlive.get()
+    }
+
+    // endregion
+
     companion object {
         private const val SESSION_REPLAY_LIFECYCLE_CALLBACK_CLASS_NAME =
             "com.datadog.android.sessionreplay.internal.SessionReplayLifecycleCallback"
+
+        private const val TEARDOWN_POLLING_INTERVAL_MS = 50L
     }
 }


### PR DESCRIPTION
Every Session Replay instrumented test paid an unconditional `Thread.sleep(2000)` in `beforeActivityLaunched`, guarding against Espresso launching a new activity while the previous one was still being removed (which makes `WindowInspector.getGlobalWindowViews()` report both windows and alters the recorder's snapshots). Across 28 SR test methods that is ~56s of pure sleep per suite run, paid even when no previous activity exists.

Poll for the actual condition instead, reusing the existing `ConditionWatcher` from tools/unit: wait until no activity remains in a non-`DESTROYED` lifecycle stage, via `ActivityLifecycleMonitorRegistry` (public AndroidX Test API that works on `minSdk 23`, unlike `WindowInspector` which is API 29+). The 2000ms becomes an upper bound rather than a fixed cost, so the constant is renamed to `ACTIVITY_TEARDOWN_TIMEOUT_MS`.

Two safety choices preserve existing behaviour:
- on timeout the wait proceeds instead of failing, matching the old "sleep then carry on" semantics, so a slow-but-passing test cannot turn red;
- `waitForIdleSync()` drains the main looper afterwards, since an activity being destroyed does not guarantee its window is already gone (removal is posted to the main thread) and the window is what the guard is actually about.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

