### PR TITLE
RUM-18187: Update AGP to version 9.1.1

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -209,10 +209,11 @@ build,commons-codec,Apache-2.0,Copyright 2002-2024 The Apache Software Foundatio
 build,commons-io,Apache-2.0,Copyright 2002-2024 The Apache Software Foundation
 build,commons-logging,Apache-2.0,Copyright 2002-2024 The Apache Software Foundation
 build,io.github.aakira,Apache-2.0,"Copyright (C) 2019 A.Akira"
+build,io.gitlab.arturbosch.detekt,Apache-2.0,Copyright 2016-2019 the original author or authors
 build,io.github.classgraph,MIT,"Copyright (c) 2019 Luke Hutchison"
+build,io.github.java-diff-utils,Apache-2.0,"Copyright 2009-2017 java-diff-utils."
 build,io.github.microutils,Apache-2.0,Copyright (c) 2016-2018 Ohad Shai
 build,io.github.oshai,Apache-2.0,"Copyright oshai authors"
-build,io.gitlab.arturbosch.detekt,Apache-2.0,Copyright 2016-2019 the original author or authors
 build,io.grpc,Apache-2.0,Copyright 2014 The gRPC Authors
 build,io.netty,Apache-2.0,Copyright 2014 The Netty Project
 build,io.opencensus,Apache-2.0,"Copyright 2017, OpenCensus Authors"

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -45,7 +45,10 @@ dependencies {
     compileOnly(libs.detektGradlePlugin)
     compileOnly(libs.ktlintGradlePlugin)
 
-    // Bundled with Gradle buildscript path
+    // Kotlin PSI, used by the API surface generator to parse sources. Kept off the plugin runtime
+    // classpath on purpose: KGP warns (and misbehaves) when a second `kotlin-compiler-embeddable`
+    // sits next to it on the buildscript classpath. `GenerateApiSurfaceTask` loads it at execution
+    // time from an isolated worker classpath instead.
     compileOnly(libs.kotlinCompilerEmbeddable)
 
     // JsonSchema 2 Poko
@@ -56,8 +59,8 @@ dependencies {
     implementation(libs.kotlinXmlBuilder)
 
     // Tests
-    // Not inherited from `compileOnly`, and the test JVM has no buildscript classpath to
-    // borrow it from, so the API surface tests need their own copy.
+    // Not inherited from `compileOnly`, and the test JVM has no worker classpath to borrow it
+    // from, so the API surface tests need their own copy.
     testImplementation(libs.kotlinCompilerEmbeddable)
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.mockitoKotlin)

--- a/build-logic/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
+++ b/build-logic/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
@@ -40,6 +40,14 @@ internal fun Project.androidLibraryConfig() {
 
         defaultConfig {
             minSdk = AndroidConfig.MIN_SDK
+            aarMetadata {
+                // TODO RUM-18201
+                // AGP 9 now sets it to the compileSdk value, imposing consumers
+                // to use this compile SDK or above. This will force consumers of the library to
+                // migrate to the latest API level once we bump it on our side.
+                // Set it compatible with AGP 8.x behavior for now.
+                minCompileSdk = 1
+            }
         }
 
         compileOptions {
@@ -47,7 +55,7 @@ internal fun Project.androidLibraryConfig() {
         }
 
         sourceSets.all {
-            java.srcDir("src/$name/kotlin")
+            java.directories += "src/$name/kotlin"
         }
 
         testOptions {

--- a/build-logic/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
+++ b/build-logic/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
@@ -8,21 +8,20 @@ package com.datadog.gradle.config
 
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 internal fun Project.kotlinConfig(
     evaluateWarningsAsErrors: Boolean = true,
     jvmBytecodeTarget: JvmTarget = JvmTarget.JVM_17
 ) {
-    taskConfig<KotlinCompilationTask<KotlinJvmCompilerOptions>> {
+    taskConfig<KotlinJvmCompile> {
         compilerOptions {
             jvmTarget.set(jvmBytecodeTarget)
             val isCI = System.getenv("CI").toBoolean()
             allWarningsAsErrors.set(evaluateWarningsAsErrors && isCI)
-            apiVersion.set(KotlinVersion.KOTLIN_1_8)
-            languageVersion.set(KotlinVersion.KOTLIN_1_8)
+            apiVersion.set(KotlinVersion.KOTLIN_2_0)
+            languageVersion.set(KotlinVersion.KOTLIN_2_0)
         }
     }
 }

--- a/build-logic/src/main/kotlin/com/datadog/gradle/plugin/apisurface/ApiSurfacePlugin.kt
+++ b/build-logic/src/main/kotlin/com/datadog/gradle/plugin/apisurface/ApiSurfacePlugin.kt
@@ -10,6 +10,9 @@ import com.datadog.gradle.config.taskConfig
 import com.datadog.gradle.plugin.jsonschema.GenerateJsonSchemaTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
@@ -29,10 +32,12 @@ class ApiSurfacePlugin : Plugin<Project> {
         val compilerMetaFile = apiDir.file("compiler-meta.txt")
 
         val jsonToModelGenerations = target.tasks.withType<GenerateJsonSchemaTask>()
+        val parserClasspath = target.createParserConfiguration()
         val generateApiSurfaceTask = target.tasks
             .register<GenerateApiSurfaceTask>(TASK_GEN_KOTLIN_API_SURFACE) {
                 this.srcDir.set(srcDir)
                 this.genDir.from(jsonToModelGenerations.map { it.destinationGenDirectory })
+                this.parserClasspath.from(parserClasspath)
                 this.surfaceFile.set(kotlinSurfaceFile)
             }
         target.tasks
@@ -87,7 +92,30 @@ class ApiSurfacePlugin : Plugin<Project> {
         }
     }
 
+    /**
+     * Classpath the API surface generator parses sources with. It is resolved as a project
+     * dependency rather than shipped with this plugin, to keep a second copy of
+     * `kotlin-compiler-embeddable` off the buildscript classpath, where it would clash with the
+     * one bundled with the Kotlin Gradle plugin.
+     */
+    private fun Project.createParserConfiguration(): Configuration {
+        val kotlinVersion = extensions.getByType<VersionCatalogsExtension>()
+            .named("libs")
+            .findVersion("kotlin")
+            .orElseThrow { IllegalStateException("No `kotlin` version found in the version catalog") }
+        return configurations.create(CONFIGURATION_PARSER) {
+            isCanBeConsumed = false
+            isCanBeResolved = true
+            isVisible = false
+            dependencies.add(
+                this@createParserConfiguration.dependencies
+                    .create("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinVersion")
+            )
+        }
+    }
+
     companion object {
+        const val CONFIGURATION_PARSER = "apiSurfaceParser"
         const val TASK_GEN_KOTLIN_API_SURFACE = "generateApiSurface"
         const val TASK_GEN_COMPILER_METADATA = "generateCompilerMetadata"
         const val TASK_GEN_JAVA_API_SURFACE = "apiDump"

--- a/build-logic/src/main/kotlin/com/datadog/gradle/plugin/apisurface/GenerateApiSurfaceTask.kt
+++ b/build-logic/src/main/kotlin/com/datadog/gradle/plugin/apisurface/GenerateApiSurfaceTask.kt
@@ -11,13 +11,15 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import java.io.File
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
 
 @CacheableTask
 abstract class GenerateApiSurfaceTask : DefaultTask() {
@@ -30,10 +32,19 @@ abstract class GenerateApiSurfaceTask : DefaultTask() {
     @get:InputFiles
     abstract val genDir: ConfigurableFileCollection
 
+    /**
+     * Kotlin compiler jars holding the PSI parser. They are deliberately absent from the plugin
+     * runtime classpath (see `build-logic/build.gradle.kts`) and only loaded here, inside the
+     * worker's isolated classloader.
+     */
+    @get:Classpath
+    abstract val parserClasspath: ConfigurableFileCollection
+
     @get:OutputFile
     abstract val surfaceFile: RegularFileProperty
 
-    private lateinit var visitor: KotlinFileVisitor
+    @get:Inject
+    abstract val workerExecutor: WorkerExecutor
 
     init {
         group = "datadog"
@@ -44,43 +55,15 @@ abstract class GenerateApiSurfaceTask : DefaultTask() {
 
     @TaskAction
     fun applyTask() {
-        visitor = KotlinFileVisitor()
-        visitDirectoryRecursively(srcDir.get().asFile)
-        genDir.forEach {
-            visitDirectoryRecursively(it)
+        val queue = workerExecutor.classLoaderIsolation {
+            classpath.from(parserClasspath)
         }
-
-        surfaceFile.get().asFile.printWriter().use {
-            it.print(visitor.description.toString())
+        queue.submit(GenerateApiSurfaceWorkAction::class.java) {
+            srcDir.set(this@GenerateApiSurfaceTask.srcDir)
+            genDir.setFrom(this@GenerateApiSurfaceTask.genDir)
+            surfaceFile.set(this@GenerateApiSurfaceTask.surfaceFile)
         }
     }
 
     // endregion
-
-    private fun visitDirectoryRecursively(file: File) {
-        when {
-            !file.exists() -> logger.info("File $file doesn't exist, ignoring")
-            file.isDirectory ->
-                file.listFiles().orEmpty()
-                    .sortedBy { it.absolutePath }
-                    .forEach { visitDirectoryRecursively(it) }
-
-            file.isFile -> visitFile(file)
-            else -> logger.error("${file.path} is neither file nor directory")
-        }
-    }
-
-    private fun visitFile(file: File) {
-        if (file.canRead()) {
-            if (file.extension == EXT_KT) {
-                visitor.visitFile(file)
-            }
-        } else {
-            logger.error("${file.path} is not readable")
-        }
-    }
-
-    companion object {
-        const val EXT_KT = "kt"
-    }
 }

--- a/build-logic/src/main/kotlin/com/datadog/gradle/plugin/apisurface/GenerateApiSurfaceWorkAction.kt
+++ b/build-logic/src/main/kotlin/com/datadog/gradle/plugin/apisurface/GenerateApiSurfaceWorkAction.kt
@@ -1,0 +1,71 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.apisurface
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.slf4j.LoggerFactory
+import java.io.File
+
+/**
+ * Walks the source directories and writes the API surface description.
+ *
+ * Runs in a worker with an isolated classloader, which is where the Kotlin PSI classes used by
+ * [KotlinFileVisitor] come from.
+ */
+abstract class GenerateApiSurfaceWorkAction : WorkAction<GenerateApiSurfaceWorkAction.Params> {
+
+    interface Params : WorkParameters {
+        val srcDir: DirectoryProperty
+        val genDir: ConfigurableFileCollection
+        val surfaceFile: RegularFileProperty
+    }
+
+    private val visitor = KotlinFileVisitor()
+
+    override fun execute() {
+        visitDirectoryRecursively(parameters.srcDir.get().asFile)
+        parameters.genDir.forEach {
+            visitDirectoryRecursively(it)
+        }
+
+        parameters.surfaceFile.get().asFile.printWriter().use {
+            it.print(visitor.description.toString())
+        }
+    }
+
+    private fun visitDirectoryRecursively(file: File) {
+        when {
+            !file.exists() -> LOGGER.info("File {} doesn't exist, ignoring", file)
+            file.isDirectory ->
+                file.listFiles().orEmpty()
+                    .sortedBy { it.absolutePath }
+                    .forEach { visitDirectoryRecursively(it) }
+
+            file.isFile -> visitFile(file)
+            else -> LOGGER.error("{} is neither file nor directory", file.path)
+        }
+    }
+
+    private fun visitFile(file: File) {
+        if (file.canRead()) {
+            if (file.extension == EXT_KT) {
+                visitor.visitFile(file)
+            }
+        } else {
+            LOGGER.error("{} is not readable", file.path)
+        }
+    }
+
+    companion object {
+        const val EXT_KT = "kt"
+        private val LOGGER = LoggerFactory.getLogger(GenerateApiSurfaceWorkAction::class.java)
+    }
+}

--- a/build-logic/src/main/kotlin/com/datadog/gradle/plugin/config/DatadogBuildExtension.kt
+++ b/build-logic/src/main/kotlin/com/datadog/gradle/plugin/config/DatadogBuildExtension.kt
@@ -27,7 +27,6 @@ abstract class DatadogBuildExtension @Inject constructor(
 ) {
 
     /** Aligns Kotlin compilation: bytecode target, API/language version and warning strictness. */
-    @JvmOverloads
     fun applyKotlinConfig(
         evaluateWarningsAsErrors: Boolean = true,
         jvmBytecodeTarget: JvmTarget = JvmTarget.JVM_17
@@ -51,7 +50,6 @@ abstract class DatadogBuildExtension @Inject constructor(
     }
 
     /** Declares the Maven publication (POM metadata, sources/javadoc jars) and its signing. */
-    @JvmOverloads
     fun applyPublishingConfig(
         projectDescription: String,
         customArtifactId: String = project.name

--- a/dd-sdk-android-core/api/compiler-meta.txt
+++ b/dd-sdk-android-core/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -68,6 +68,7 @@ public final class com/datadog/android/DatadogSite : java/lang/Enum {
 	public static final field US2_FED Lcom/datadog/android/DatadogSite;
 	public static final field US3 Lcom/datadog/android/DatadogSite;
 	public static final field US5 Lcom/datadog/android/DatadogSite;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getIntakeEndpoint ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/DatadogSite;
 	public static fun values ()[Lcom/datadog/android/DatadogSite;
@@ -118,6 +119,7 @@ public final class com/datadog/android/api/InternalLogger$Level : java/lang/Enum
 	public static final field INFO Lcom/datadog/android/api/InternalLogger$Level;
 	public static final field VERBOSE Lcom/datadog/android/api/InternalLogger$Level;
 	public static final field WARN Lcom/datadog/android/api/InternalLogger$Level;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/api/InternalLogger$Level;
 	public static fun values ()[Lcom/datadog/android/api/InternalLogger$Level;
 }
@@ -126,6 +128,7 @@ public final class com/datadog/android/api/InternalLogger$Target : java/lang/Enu
 	public static final field MAINTAINER Lcom/datadog/android/api/InternalLogger$Target;
 	public static final field TELEMETRY Lcom/datadog/android/api/InternalLogger$Target;
 	public static final field USER Lcom/datadog/android/api/InternalLogger$Target;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/api/InternalLogger$Target;
 	public static fun values ()[Lcom/datadog/android/api/InternalLogger$Target;
 }
@@ -261,6 +264,7 @@ public final class com/datadog/android/api/context/DeviceType : java/lang/Enum {
 	public static final field OTHER Lcom/datadog/android/api/context/DeviceType;
 	public static final field TABLET Lcom/datadog/android/api/context/DeviceType;
 	public static final field TV Lcom/datadog/android/api/context/DeviceType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/api/context/DeviceType;
 	public static fun values ()[Lcom/datadog/android/api/context/DeviceType;
 }
@@ -321,6 +325,7 @@ public final class com/datadog/android/api/context/NetworkInfo$Connectivity : ja
 	public static final field NETWORK_WIFI Lcom/datadog/android/api/context/NetworkInfo$Connectivity;
 	public static final field NETWORK_WIMAX Lcom/datadog/android/api/context/NetworkInfo$Connectivity;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/api/context/NetworkInfo$Connectivity;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/api/context/NetworkInfo$Connectivity;
 	public static fun values ()[Lcom/datadog/android/api/context/NetworkInfo$Connectivity;
 }
@@ -588,6 +593,7 @@ public final class com/datadog/android/api/storage/EventType : java/lang/Enum {
 	public static final field CRASH Lcom/datadog/android/api/storage/EventType;
 	public static final field DEFAULT Lcom/datadog/android/api/storage/EventType;
 	public static final field TELEMETRY Lcom/datadog/android/api/storage/EventType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/api/storage/EventType;
 	public static fun values ()[Lcom/datadog/android/api/storage/EventType;
 }
@@ -704,6 +710,7 @@ public final class com/datadog/android/core/UploadWorker$Companion {
 public final class com/datadog/android/core/configuration/BackPressureMitigation : java/lang/Enum {
 	public static final field DROP_OLDEST Lcom/datadog/android/core/configuration/BackPressureMitigation;
 	public static final field IGNORE_NEWEST Lcom/datadog/android/core/configuration/BackPressureMitigation;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/configuration/BackPressureMitigation;
 	public static fun values ()[Lcom/datadog/android/core/configuration/BackPressureMitigation;
 }
@@ -729,6 +736,7 @@ public final class com/datadog/android/core/configuration/BatchProcessingLevel :
 	public static final field HIGH Lcom/datadog/android/core/configuration/BatchProcessingLevel;
 	public static final field LOW Lcom/datadog/android/core/configuration/BatchProcessingLevel;
 	public static final field MEDIUM Lcom/datadog/android/core/configuration/BatchProcessingLevel;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getMaxBatchesPerUploadJob ()I
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/configuration/BatchProcessingLevel;
 	public static fun values ()[Lcom/datadog/android/core/configuration/BatchProcessingLevel;
@@ -738,6 +746,7 @@ public final class com/datadog/android/core/configuration/BatchSize : java/lang/
 	public static final field LARGE Lcom/datadog/android/core/configuration/BatchSize;
 	public static final field MEDIUM Lcom/datadog/android/core/configuration/BatchSize;
 	public static final field SMALL Lcom/datadog/android/core/configuration/BatchSize;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/configuration/BatchSize;
 	public static fun values ()[Lcom/datadog/android/core/configuration/BatchSize;
 }
@@ -793,6 +802,7 @@ public final class com/datadog/android/core/configuration/UploadFrequency : java
 	public static final field AVERAGE Lcom/datadog/android/core/configuration/UploadFrequency;
 	public static final field FREQUENT Lcom/datadog/android/core/configuration/UploadFrequency;
 	public static final field RARE Lcom/datadog/android/core/configuration/UploadFrequency;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/configuration/UploadFrequency;
 	public static fun values ()[Lcom/datadog/android/core/configuration/UploadFrequency;
 }
@@ -929,6 +939,7 @@ public final class com/datadog/android/core/metrics/MethodCallSamplingRate : jav
 	public static final field MEDIUM Lcom/datadog/android/core/metrics/MethodCallSamplingRate;
 	public static final field RARE Lcom/datadog/android/core/metrics/MethodCallSamplingRate;
 	public static final field REDUCED Lcom/datadog/android/core/metrics/MethodCallSamplingRate;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getRate ()F
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/metrics/MethodCallSamplingRate;
 	public static fun values ()[Lcom/datadog/android/core/metrics/MethodCallSamplingRate;
@@ -946,6 +957,7 @@ public final class com/datadog/android/core/metrics/PerformanceMetric$Companion 
 
 public final class com/datadog/android/core/metrics/TelemetryMetricType : java/lang/Enum {
 	public static final field MethodCalled Lcom/datadog/android/core/metrics/TelemetryMetricType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/metrics/TelemetryMetricType;
 	public static fun values ()[Lcom/datadog/android/core/metrics/TelemetryMetricType;
 }
@@ -1124,6 +1136,7 @@ public final class com/datadog/android/privacy/TrackingConsent : java/lang/Enum 
 	public static final field GRANTED Lcom/datadog/android/privacy/TrackingConsent;
 	public static final field NOT_GRANTED Lcom/datadog/android/privacy/TrackingConsent;
 	public static final field PENDING Lcom/datadog/android/privacy/TrackingConsent;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/privacy/TrackingConsent;
 	public static fun values ()[Lcom/datadog/android/privacy/TrackingConsent;
 }
@@ -1142,6 +1155,7 @@ public final class com/datadog/android/trace/TracingHeaderType : java/lang/Enum 
 	public static final field B3MULTI Lcom/datadog/android/trace/TracingHeaderType;
 	public static final field DATADOG Lcom/datadog/android/trace/TracingHeaderType;
 	public static final field TRACECONTEXT Lcom/datadog/android/trace/TracingHeaderType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getHeaderType ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/trace/TracingHeaderType;
 	public static fun values ()[Lcom/datadog/android/trace/TracingHeaderType;

--- a/dd-sdk-android-core/build.gradle.kts
+++ b/dd-sdk-android-core/build.gradle.kts
@@ -50,6 +50,8 @@ fun isLogEnabledInRelease(): String {
     return project.findProperty(GradlePropertiesKeys.FORCE_ENABLE_LOGCAT) as? String ?: "false"
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     defaultConfig {
         consumerProguardFiles("consumer-rules.pro")

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -19,6 +19,7 @@ import java.net.Proxy
  *
  * This is necessary to initialize the SDK with the [Datadog.initialize] method.
  */
+@ExposedCopyVisibility
 data class Configuration
 internal constructor(
     internal val coreConfig: Core,

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallbackTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallbackTest.kt
@@ -127,6 +127,7 @@ internal class ProcessLifecycleCallbackTest {
     fun `when process started cancel existing workers`() {
         // Given
         WorkManagerImpl::class.java.setStaticValue("sDefaultInstance", mockWorkManager)
+        whenever(mockWorkManager.cancelAllWorkByTag(any())) doReturn mock()
 
         // When
         testedCallback.onStarted()

--- a/dd-sdk-android-core/transitiveDependencies
+++ b/dd-sdk-android-core/transitiveDependencies
@@ -1,6 +1,6 @@
 Dependencies List
 
-androidx.annotation:annotation-experimental:1.1.0               :   16 Kb
+androidx.annotation:annotation-experimental:1.0.0               :   11 Kb
 androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
 androidx.arch.core:core-common:2.1.0                            :   10 Kb
 androidx.arch.core:core-runtime:2.1.0                           :    5 Kb

--- a/dd-sdk-android-internal/api/compiler-meta.txt
+++ b/dd-sdk-android-internal/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -47,6 +47,7 @@ public final class com/datadog/android/internal/attributes/LocalAttribute$Key : 
 	public static final field CREATION_SAMPLING_RATE Lcom/datadog/android/internal/attributes/LocalAttribute$Key;
 	public static final field REPORTING_SAMPLING_RATE Lcom/datadog/android/internal/attributes/LocalAttribute$Key;
 	public static final field VIEW_SCOPE_INSTRUMENTATION_TYPE Lcom/datadog/android/internal/attributes/LocalAttribute$Key;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/internal/attributes/LocalAttribute$Key;
 	public static fun values ()[Lcom/datadog/android/internal/attributes/LocalAttribute$Key;
@@ -77,6 +78,7 @@ public final class com/datadog/android/internal/attributes/ViewScopeInstrumentat
 	public static final field COMPOSE Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType$Native;
 	public static final field FRAGMENT Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType$Native;
 	public static final field MANUAL Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType$Native;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public fun getKey ()Lcom/datadog/android/internal/attributes/LocalAttribute$Key;
 	public fun getValue ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/internal/attributes/ViewScopeInstrumentationType$Native;
@@ -222,6 +224,7 @@ public final class com/datadog/android/internal/network/GraphQLHeaders : java/la
 	public static final field DD_GRAPHQL_PAYLOAD_HEADER Lcom/datadog/android/internal/network/GraphQLHeaders;
 	public static final field DD_GRAPHQL_TYPE_HEADER Lcom/datadog/android/internal/network/GraphQLHeaders;
 	public static final field DD_GRAPHQL_VARIABLES_HEADER Lcom/datadog/android/internal/network/GraphQLHeaders;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getHeaderValue ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/internal/network/GraphQLHeaders;
 	public static fun values ()[Lcom/datadog/android/internal/network/GraphQLHeaders;
@@ -406,6 +409,7 @@ public final class com/datadog/android/internal/profiling/ProfilerEvent$RumVital
 	public static final field OPERATION Lcom/datadog/android/internal/profiling/ProfilerEvent$RumVitalEvent$Type;
 	public static final field TTFD Lcom/datadog/android/internal/profiling/ProfilerEvent$RumVitalEvent$Type;
 	public static final field TTID Lcom/datadog/android/internal/profiling/ProfilerEvent$RumVitalEvent$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/internal/profiling/ProfilerEvent$RumVitalEvent$Type;
 	public static fun values ()[Lcom/datadog/android/internal/profiling/ProfilerEvent$RumVitalEvent$Type;
 }
@@ -517,6 +521,7 @@ public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent
 	public static final field FAIL Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$AddOperationStepVital$ActionType;
 	public static final field START Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$AddOperationStepVital$ActionType;
 	public static final field SUCCEED Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$AddOperationStepVital$ActionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$AddOperationStepVital$ActionType;
 	public static fun values ()[Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$AddOperationStepVital$ActionType;
 }
@@ -539,6 +544,7 @@ public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent
 	public static final field CRONET Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$NetworkInstrumentation$LibraryType;
 	public static final field LEGACY_OKHTTP Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$NetworkInstrumentation$LibraryType;
 	public static final field OKHTTP Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$NetworkInstrumentation$LibraryType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$NetworkInstrumentation$LibraryType;
 	public static fun values ()[Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage$NetworkInstrumentation$LibraryType;
 }
@@ -621,6 +627,7 @@ public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent
 public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent$ResourceHeadersTrackingConfigured$Mode : java/lang/Enum {
 	public static final field CUSTOM Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ResourceHeadersTrackingConfigured$Mode;
 	public static final field DEFAULT_HEADERS Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ResourceHeadersTrackingConfigured$Mode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ResourceHeadersTrackingConfigured$Mode;
 	public static fun values ()[Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ResourceHeadersTrackingConfigured$Mode;
 }
@@ -668,6 +675,7 @@ public final class com/datadog/android/internal/telemetry/TracingHeaderType : ja
 	public static final field B3MULTI Lcom/datadog/android/internal/telemetry/TracingHeaderType;
 	public static final field DATADOG Lcom/datadog/android/internal/telemetry/TracingHeaderType;
 	public static final field TRACECONTEXT Lcom/datadog/android/internal/telemetry/TracingHeaderType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/internal/telemetry/TracingHeaderType;
 	public static fun values ()[Lcom/datadog/android/internal/telemetry/TracingHeaderType;
 }

--- a/dd-sdk-android-internal/build.gradle.kts
+++ b/dd-sdk-android-internal/build.gradle.kts
@@ -38,6 +38,8 @@ plugins {
     id("binary-compatibility-validator")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.internal"
     compileOptions {

--- a/detekt_custom_safe_calls_third_party.yml
+++ b/detekt_custom_safe_calls_third_party.yml
@@ -140,6 +140,7 @@ datadog:
       - "java.util.LinkedList.clear()"
       - "java.util.LinkedList.constructor()"
       - "java.util.LinkedList.constructor(kotlin.collections.MutableCollection?)"
+      - "java.util.LinkedList.firstOrNull()"
       - "java.util.LinkedList.firstOrNull(kotlin.Function1)"
       - "java.util.LinkedList.forEach(kotlin.Function1)"
       - "java.util.LinkedList.isEmpty()"

--- a/features/dd-sdk-android-flags-openfeature/api/compiler-meta.txt
+++ b/features/dd-sdk-android-flags-openfeature/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/features/dd-sdk-android-flags-openfeature/build.gradle.kts
+++ b/features/dd-sdk-android-flags-openfeature/build.gradle.kts
@@ -37,6 +37,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.flags.openfeature"
 }

--- a/features/dd-sdk-android-flags-openfeature/transitiveDependencies
+++ b/features/dd-sdk-android-flags-openfeature/transitiveDependencies
@@ -2,8 +2,8 @@ Dependencies List
 
 androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
 dev.openfeature:kotlin-sdk-android:0.6.2                        :  118 Kb
-org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
-org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
+org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.20                  :  963 b 
+org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20                  :  969 b 
 org.jetbrains.kotlin:kotlin-stdlib:2.1.21                       : 1683 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3         : 1514 Kb
 org.jetbrains:annotations:23.0.0                                :   28 Kb

--- a/features/dd-sdk-android-flags/api/compiler-meta.txt
+++ b/features/dd-sdk-android-flags/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/features/dd-sdk-android-flags/api/dd-sdk-android-flags.api
+++ b/features/dd-sdk-android-flags/api/dd-sdk-android-flags.api
@@ -86,6 +86,7 @@ public final class com/datadog/android/flags/model/ErrorCode : java/lang/Enum {
 	public static final field PARSE_ERROR Lcom/datadog/android/flags/model/ErrorCode;
 	public static final field PROVIDER_NOT_READY Lcom/datadog/android/flags/model/ErrorCode;
 	public static final field TYPE_MISMATCH Lcom/datadog/android/flags/model/ErrorCode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/flags/model/ErrorCode;
 	public static fun values ()[Lcom/datadog/android/flags/model/ErrorCode;
 }
@@ -489,6 +490,7 @@ public final class com/datadog/android/flags/model/ResolutionReason : java/lang/
 	public static final field SPLIT Lcom/datadog/android/flags/model/ResolutionReason;
 	public static final field STATIC Lcom/datadog/android/flags/model/ResolutionReason;
 	public static final field TARGETING_MATCH Lcom/datadog/android/flags/model/ResolutionReason;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/flags/model/ResolutionReason;
 	public static fun values ()[Lcom/datadog/android/flags/model/ResolutionReason;
 }

--- a/features/dd-sdk-android-flags/build.gradle.kts
+++ b/features/dd-sdk-android-flags/build.gradle.kts
@@ -44,6 +44,8 @@ createJsonModelsGenerationTask("generateFlagsModelsFromJson") {
     targetPackageName = "com.datadog.android.flags.model"
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.flags"
 }

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsConfiguration.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsConfiguration.kt
@@ -9,6 +9,7 @@ package com.datadog.android.flags
 /**
  * Describes configuration to be used for the Flags feature.
  */
+@ExposedCopyVisibility
 data class FlagsConfiguration internal constructor(
     internal val trackExposures: Boolean,
     internal val trackEvaluations: Boolean,

--- a/features/dd-sdk-android-logs/api/compiler-meta.txt
+++ b/features/dd-sdk-android-logs/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/features/dd-sdk-android-logs/api/dd-sdk-android-logs.api
+++ b/features/dd-sdk-android-logs/api/dd-sdk-android-logs.api
@@ -425,6 +425,7 @@ public final class com/datadog/android/log/model/LogEvent$Status : java/lang/Enu
 	public static final field TRACE Lcom/datadog/android/log/model/LogEvent$Status;
 	public static final field WARN Lcom/datadog/android/log/model/LogEvent$Status;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/log/model/LogEvent$Status;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/log/model/LogEvent$Status;
 	public static fun values ()[Lcom/datadog/android/log/model/LogEvent$Status;
@@ -471,6 +472,7 @@ public final class com/datadog/android/log/model/LogEvent$Type : java/lang/Enum 
 	public static final field TABLET Lcom/datadog/android/log/model/LogEvent$Type;
 	public static final field TV Lcom/datadog/android/log/model/LogEvent$Type;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/log/model/LogEvent$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/log/model/LogEvent$Type;
 	public static fun values ()[Lcom/datadog/android/log/model/LogEvent$Type;

--- a/features/dd-sdk-android-logs/build.gradle.kts
+++ b/features/dd-sdk-android-logs/build.gradle.kts
@@ -41,6 +41,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     defaultConfig {
         consumerProguardFiles(Paths.get(rootDir.path, "consumer-rules.pro").toString())

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/LogsConfiguration.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/LogsConfiguration.kt
@@ -13,6 +13,7 @@ import com.datadog.android.log.model.LogEvent
 /**
  * Describes configuration to be used for the Logs feature.
  */
+@ExposedCopyVisibility
 data class LogsConfiguration internal constructor(
     internal val customEndpointUrl: String?,
     internal val eventMapper: EventMapper<LogEvent>

--- a/features/dd-sdk-android-ndk/api/compiler-meta.txt
+++ b/features/dd-sdk-android-ndk/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/features/dd-sdk-android-ndk/build.gradle.kts
+++ b/features/dd-sdk-android-ndk/build.gradle.kts
@@ -38,10 +38,11 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
 
     defaultConfig {
-        multiDexEnabled = true
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {
@@ -71,7 +72,6 @@ dependencies {
     api(project(":dd-sdk-android-core"))
     implementation(libs.kotlin)
     implementation(libs.okHttp)
-    implementation(libs.androidXMultidex)
 
     testImplementation(project(":tools:unit")) {
         attributes {

--- a/features/dd-sdk-android-ndk/transitiveDependencies
+++ b/features/dd-sdk-android-ndk/transitiveDependencies
@@ -1,6 +1,5 @@
 Dependencies List
 
-androidx.multidex:multidex:2.0.1                                :   26 Kb
 com.squareup.okhttp3:okhttp:4.12.0                              :  771 Kb
 com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 

--- a/features/dd-sdk-android-profiling/api/compiler-meta.txt
+++ b/features/dd-sdk-android-profiling/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/features/dd-sdk-android-profiling/api/dd-sdk-android-profiling.api
+++ b/features/dd-sdk-android-profiling/api/dd-sdk-android-profiling.api
@@ -133,6 +133,7 @@ public final class com/datadog/android/profiling/model/ProfileEvent$Family : jav
 	public static final field Companion Lcom/datadog/android/profiling/model/ProfileEvent$Family$Companion;
 	public static final field IOS Lcom/datadog/android/profiling/model/ProfileEvent$Family;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/profiling/model/ProfileEvent$Family;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/profiling/model/ProfileEvent$Family;
 	public static fun values ()[Lcom/datadog/android/profiling/model/ProfileEvent$Family;
@@ -261,6 +262,7 @@ public final class com/datadog/android/profiling/model/RumMetadataEvent$Type : j
 	public static final field LONG_TASK Lcom/datadog/android/profiling/model/RumMetadataEvent$Type;
 	public static final field VITAL Lcom/datadog/android/profiling/model/RumMetadataEvent$Type;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/profiling/model/RumMetadataEvent$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/profiling/model/RumMetadataEvent$Type;
 	public static fun values ()[Lcom/datadog/android/profiling/model/RumMetadataEvent$Type;

--- a/features/dd-sdk-android-profiling/build.gradle.kts
+++ b/features/dd-sdk-android-profiling/build.gradle.kts
@@ -42,6 +42,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.profiling"
 

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/ProfilingConfiguration.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/ProfilingConfiguration.kt
@@ -11,6 +11,7 @@ import androidx.annotation.FloatRange
 /**
  * Describes configuration to be used for the Profiling feature.
  */
+@ExposedCopyVisibility
 @ExperimentalProfilingApi
 data class ProfilingConfiguration internal constructor(
     internal val customEndpointUrl: String?,

--- a/features/dd-sdk-android-profiling/transitiveDependencies
+++ b/features/dd-sdk-android-profiling/transitiveDependencies
@@ -1,9 +1,9 @@
 Dependencies List
 
 androidx.annotation:annotation-experimental:1.4.1               :   38 Kb
-androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
+androidx.annotation:annotation-jvm:1.8.1                        :   54 Kb
 androidx.arch.core:core-common:2.2.0                            :   11 Kb
-androidx.collection:collection-jvm:1.4.5                        :  770 Kb
+androidx.collection:collection:1.0.0                            :   40 Kb
 androidx.core:core-ktx:1.15.0                                   :  171 Kb
 androidx.core:core:1.15.0                                       : 1304 Kb
 androidx.lifecycle:lifecycle-common:2.6.2                       :   51 Kb

--- a/features/dd-sdk-android-rum-debug-widget/api/compiler-meta.txt
+++ b/features/dd-sdk-android-rum-debug-widget/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/features/dd-sdk-android-rum-debug-widget/build.gradle.kts
+++ b/features/dd-sdk-android-rum-debug-widget/build.gradle.kts
@@ -37,6 +37,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.rumdebugwidget"
 }
@@ -48,6 +50,7 @@ dependencies {
 
     // Android Instrumentation
     implementation(libs.androidXFragment)
+    implementation(libs.androidXCoreKtx)
 
     testImplementation(project(":tools:unit")) {
         attributes {

--- a/features/dd-sdk-android-rum-debug-widget/transitiveDependencies
+++ b/features/dd-sdk-android-rum-debug-widget/transitiveDependencies
@@ -1,15 +1,15 @@
 Dependencies List
 
-androidx.activity:activity:1.7.2                                :  139 Kb
+androidx.activity:activity:1.1.0                                :   13 Kb
 androidx.annotation:annotation-experimental:1.4.1               :   38 Kb
-androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
+androidx.annotation:annotation-jvm:1.8.1                        :   54 Kb
 androidx.arch.core:core-common:2.2.0                            :   11 Kb
-androidx.arch.core:core-runtime:2.2.0                           :    7 Kb
-androidx.collection:collection-jvm:1.4.5                        :  770 Kb
+androidx.arch.core:core-runtime:2.1.0                           :    5 Kb
+androidx.collection:collection:1.1.0                            :   41 Kb
 androidx.core:core-ktx:1.15.0                                   :  171 Kb
 androidx.core:core:1.15.0                                       : 1304 Kb
-androidx.customview:customview:1.1.0                            :   32 Kb
-androidx.fragment:fragment:1.6.2                                :  345 Kb
+androidx.customview:customview:1.0.0                            :   32 Kb
+androidx.fragment:fragment:1.2.4                                :  221 Kb
 androidx.lifecycle:lifecycle-common:2.6.2                       :   51 Kb
 androidx.lifecycle:lifecycle-livedata-core:2.6.2                :   11 Kb
 androidx.lifecycle:lifecycle-livedata:2.6.2                     :   18 Kb
@@ -20,12 +20,12 @@ androidx.loader:loader:1.0.0                                    :   32 Kb
 androidx.savedstate:savedstate:1.2.1                            :   19 Kb
 androidx.versionedparcelable:versionedparcelable:1.1.1          :   30 Kb
 androidx.viewpager:viewpager:1.0.0                              :   52 Kb
-org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
-org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
+org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0                   :  963 b 
+org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0                   :  968 b 
 org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4          :   19 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4         : 1442 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              :    6 Mb
+Total transitive dependencies size                              :    5 Mb
 

--- a/features/dd-sdk-android-rum/api/compiler-meta.txt
+++ b/features/dd-sdk-android-rum/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -36,6 +36,7 @@ public final class com/datadog/android/rum/RumActionType : java/lang/Enum {
 	public static final field SCROLL Lcom/datadog/android/rum/RumActionType;
 	public static final field SWIPE Lcom/datadog/android/rum/RumActionType;
 	public static final field TAP Lcom/datadog/android/rum/RumActionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/RumActionType;
 	public static fun values ()[Lcom/datadog/android/rum/RumActionType;
 }
@@ -147,6 +148,7 @@ public final class com/datadog/android/rum/RumErrorSource : java/lang/Enum {
 	public static final field REPORT Lcom/datadog/android/rum/RumErrorSource;
 	public static final field SOURCE Lcom/datadog/android/rum/RumErrorSource;
 	public static final field WEBVIEW Lcom/datadog/android/rum/RumErrorSource;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/RumErrorSource;
 	public static fun values ()[Lcom/datadog/android/rum/RumErrorSource;
 }
@@ -211,6 +213,7 @@ public final class com/datadog/android/rum/RumPerformanceMetric : java/lang/Enum
 	public static final field FLUTTER_BUILD_TIME Lcom/datadog/android/rum/RumPerformanceMetric;
 	public static final field FLUTTER_RASTER_TIME Lcom/datadog/android/rum/RumPerformanceMetric;
 	public static final field JS_FRAME_TIME Lcom/datadog/android/rum/RumPerformanceMetric;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/RumPerformanceMetric;
 	public static fun values ()[Lcom/datadog/android/rum/RumPerformanceMetric;
 }
@@ -238,6 +241,7 @@ public final class com/datadog/android/rum/RumResourceKind : java/lang/Enum {
 	public static final field OTHER Lcom/datadog/android/rum/RumResourceKind;
 	public static final field UNKNOWN Lcom/datadog/android/rum/RumResourceKind;
 	public static final field XHR Lcom/datadog/android/rum/RumResourceKind;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/RumResourceKind;
 	public static fun values ()[Lcom/datadog/android/rum/RumResourceKind;
 }
@@ -256,6 +260,7 @@ public final class com/datadog/android/rum/RumResourceMethod : java/lang/Enum {
 	public static final field POST Lcom/datadog/android/rum/RumResourceMethod;
 	public static final field PUT Lcom/datadog/android/rum/RumResourceMethod;
 	public static final field TRACE Lcom/datadog/android/rum/RumResourceMethod;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/RumResourceMethod;
 	public static fun values ()[Lcom/datadog/android/rum/RumResourceMethod;
 }
@@ -267,6 +272,7 @@ public abstract interface class com/datadog/android/rum/RumSessionListener {
 public final class com/datadog/android/rum/RumSessionType : java/lang/Enum {
 	public static final field SYNTHETICS Lcom/datadog/android/rum/RumSessionType;
 	public static final field USER Lcom/datadog/android/rum/RumSessionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/RumSessionType;
 	public static fun values ()[Lcom/datadog/android/rum/RumSessionType;
 }
@@ -324,6 +330,7 @@ public final class com/datadog/android/rum/configuration/VitalsUpdateFrequency :
 	public static final field FREQUENT Lcom/datadog/android/rum/configuration/VitalsUpdateFrequency;
 	public static final field NEVER Lcom/datadog/android/rum/configuration/VitalsUpdateFrequency;
 	public static final field RARE Lcom/datadog/android/rum/configuration/VitalsUpdateFrequency;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/configuration/VitalsUpdateFrequency;
 	public static fun values ()[Lcom/datadog/android/rum/configuration/VitalsUpdateFrequency;
 }
@@ -336,6 +343,7 @@ public final class com/datadog/android/rum/featureoperations/FailureReason : jav
 	public static final field ABANDONED Lcom/datadog/android/rum/featureoperations/FailureReason;
 	public static final field ERROR Lcom/datadog/android/rum/featureoperations/FailureReason;
 	public static final field OTHER Lcom/datadog/android/rum/featureoperations/FailureReason;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/featureoperations/FailureReason;
 	public static fun values ()[Lcom/datadog/android/rum/featureoperations/FailureReason;
 }
@@ -671,6 +679,7 @@ public final class com/datadog/android/rum/model/ActionEvent$ActionEventActionTy
 	public static final field SWIPE Lcom/datadog/android/rum/model/ActionEvent$ActionEventActionType;
 	public static final field TAP Lcom/datadog/android/rum/model/ActionEvent$ActionEventActionType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$ActionEventActionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$ActionEventActionType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ActionEvent$ActionEventActionType;
@@ -711,6 +720,7 @@ public final class com/datadog/android/rum/model/ActionEvent$ActionEventSessionT
 	public static final field SYNTHETICS Lcom/datadog/android/rum/model/ActionEvent$ActionEventSessionType;
 	public static final field USER Lcom/datadog/android/rum/model/ActionEvent$ActionEventSessionType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$ActionEventSessionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$ActionEventSessionType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ActionEvent$ActionEventSessionType;
@@ -734,6 +744,7 @@ public final class com/datadog/android/rum/model/ActionEvent$ActionEventSource :
 	public static final field ROKU Lcom/datadog/android/rum/model/ActionEvent$ActionEventSource;
 	public static final field UNITY Lcom/datadog/android/rum/model/ActionEvent$ActionEventSource;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$ActionEventSource;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$ActionEventSource;
 	public static fun values ()[Lcom/datadog/android/rum/model/ActionEvent$ActionEventSource;
@@ -1157,6 +1168,7 @@ public final class com/datadog/android/rum/model/ActionEvent$DeviceType : java/l
 	public static final field TABLET Lcom/datadog/android/rum/model/ActionEvent$DeviceType;
 	public static final field TV Lcom/datadog/android/rum/model/ActionEvent$DeviceType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$DeviceType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$DeviceType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ActionEvent$DeviceType;
@@ -1195,6 +1207,7 @@ public final class com/datadog/android/rum/model/ActionEvent$EffectiveType : jav
 	public static final field Companion Lcom/datadog/android/rum/model/ActionEvent$EffectiveType$Companion;
 	public static final field SLOW_2G Lcom/datadog/android/rum/model/ActionEvent$EffectiveType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$EffectiveType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$EffectiveType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ActionEvent$EffectiveType;
@@ -1256,6 +1269,7 @@ public final class com/datadog/android/rum/model/ActionEvent$Interface : java/la
 	public static final field WIFI Lcom/datadog/android/rum/model/ActionEvent$Interface;
 	public static final field WIMAX Lcom/datadog/android/rum/model/ActionEvent$Interface;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$Interface;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$Interface;
 	public static fun values ()[Lcom/datadog/android/rum/model/ActionEvent$Interface;
@@ -1294,6 +1308,7 @@ public final class com/datadog/android/rum/model/ActionEvent$NameSource : java/l
 	public static final field STANDARD_ATTRIBUTE Lcom/datadog/android/rum/model/ActionEvent$NameSource;
 	public static final field TEXT_CONTENT Lcom/datadog/android/rum/model/ActionEvent$NameSource;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$NameSource;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$NameSource;
 	public static fun values ()[Lcom/datadog/android/rum/model/ActionEvent$NameSource;
@@ -1335,6 +1350,7 @@ public final class com/datadog/android/rum/model/ActionEvent$Plan : java/lang/En
 	public static final field PLAN_1 Lcom/datadog/android/rum/model/ActionEvent$Plan;
 	public static final field PLAN_2 Lcom/datadog/android/rum/model/ActionEvent$Plan;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$Plan;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$Plan;
 	public static fun values ()[Lcom/datadog/android/rum/model/ActionEvent$Plan;
@@ -1396,6 +1412,7 @@ public final class com/datadog/android/rum/model/ActionEvent$SessionPrecondition
 	public static final field PREWARM Lcom/datadog/android/rum/model/ActionEvent$SessionPrecondition;
 	public static final field USER_APP_LAUNCH Lcom/datadog/android/rum/model/ActionEvent$SessionPrecondition;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$SessionPrecondition;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$SessionPrecondition;
 	public static fun values ()[Lcom/datadog/android/rum/model/ActionEvent$SessionPrecondition;
@@ -1411,6 +1428,7 @@ public final class com/datadog/android/rum/model/ActionEvent$Status : java/lang/
 	public static final field MAYBE Lcom/datadog/android/rum/model/ActionEvent$Status;
 	public static final field NOT_CONNECTED Lcom/datadog/android/rum/model/ActionEvent$Status;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$Status;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$Status;
 	public static fun values ()[Lcom/datadog/android/rum/model/ActionEvent$Status;
@@ -1495,6 +1513,7 @@ public final class com/datadog/android/rum/model/ActionEvent$Type : java/lang/En
 	public static final field RAGE_CLICK Lcom/datadog/android/rum/model/ActionEvent$Type;
 	public static final field RAGE_TAP Lcom/datadog/android/rum/model/ActionEvent$Type;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ActionEvent$Type;
 	public static fun values ()[Lcom/datadog/android/rum/model/ActionEvent$Type;
@@ -1733,6 +1752,7 @@ public final class com/datadog/android/rum/model/ErrorEvent$Category : java/lang
 	public static final field NETWORK Lcom/datadog/android/rum/model/ErrorEvent$Category;
 	public static final field WATCHDOG_TERMINATION Lcom/datadog/android/rum/model/ErrorEvent$Category;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Category;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Category;
 	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$Category;
@@ -1882,6 +1902,7 @@ public final class com/datadog/android/rum/model/ErrorEvent$ConnectivityStatus :
 	public static final field MAYBE Lcom/datadog/android/rum/model/ErrorEvent$ConnectivityStatus;
 	public static final field NOT_CONNECTED Lcom/datadog/android/rum/model/ErrorEvent$ConnectivityStatus;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$ConnectivityStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$ConnectivityStatus;
 	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$ConnectivityStatus;
@@ -2090,6 +2111,7 @@ public final class com/datadog/android/rum/model/ErrorEvent$DeviceType : java/la
 	public static final field TABLET Lcom/datadog/android/rum/model/ErrorEvent$DeviceType;
 	public static final field TV Lcom/datadog/android/rum/model/ErrorEvent$DeviceType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$DeviceType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$DeviceType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$DeviceType;
@@ -2126,6 +2148,7 @@ public final class com/datadog/android/rum/model/ErrorEvent$Disposition : java/l
 	public static final field ENFORCE Lcom/datadog/android/rum/model/ErrorEvent$Disposition;
 	public static final field REPORT Lcom/datadog/android/rum/model/ErrorEvent$Disposition;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Disposition;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Disposition;
 	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$Disposition;
@@ -2142,6 +2165,7 @@ public final class com/datadog/android/rum/model/ErrorEvent$EffectiveType : java
 	public static final field Companion Lcom/datadog/android/rum/model/ErrorEvent$EffectiveType$Companion;
 	public static final field SLOW_2G Lcom/datadog/android/rum/model/ErrorEvent$EffectiveType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$EffectiveType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$EffectiveType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$EffectiveType;
@@ -2244,6 +2268,7 @@ public final class com/datadog/android/rum/model/ErrorEvent$ErrorEventSessionTyp
 	public static final field SYNTHETICS Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSessionType;
 	public static final field USER Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSessionType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSessionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSessionType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSessionType;
@@ -2267,6 +2292,7 @@ public final class com/datadog/android/rum/model/ErrorEvent$ErrorEventSource : j
 	public static final field ROKU Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSource;
 	public static final field UNITY Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSource;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSource;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSource;
 	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$ErrorEventSource;
@@ -2315,6 +2341,7 @@ public final class com/datadog/android/rum/model/ErrorEvent$ErrorReason : java/l
 	public static final field NOT_SUPPORTED_BY_BROWSER Lcom/datadog/android/rum/model/ErrorEvent$ErrorReason;
 	public static final field UNEXPECTED_EXCEPTION Lcom/datadog/android/rum/model/ErrorEvent$ErrorReason;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$ErrorReason;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$ErrorReason;
 	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$ErrorReason;
@@ -2335,6 +2362,7 @@ public final class com/datadog/android/rum/model/ErrorEvent$ErrorSource : java/l
 	public static final field SOURCE Lcom/datadog/android/rum/model/ErrorEvent$ErrorSource;
 	public static final field WEBVIEW Lcom/datadog/android/rum/model/ErrorEvent$ErrorSource;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$ErrorSource;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$ErrorSource;
 	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$ErrorSource;
@@ -2369,6 +2397,7 @@ public final class com/datadog/android/rum/model/ErrorEvent$Handling : java/lang
 	public static final field HANDLED Lcom/datadog/android/rum/model/ErrorEvent$Handling;
 	public static final field UNHANDLED Lcom/datadog/android/rum/model/ErrorEvent$Handling;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Handling;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Handling;
 	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$Handling;
@@ -2390,6 +2419,7 @@ public final class com/datadog/android/rum/model/ErrorEvent$Interface : java/lan
 	public static final field WIFI Lcom/datadog/android/rum/model/ErrorEvent$Interface;
 	public static final field WIMAX Lcom/datadog/android/rum/model/ErrorEvent$Interface;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Interface;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Interface;
 	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$Interface;
@@ -2445,6 +2475,7 @@ public final class com/datadog/android/rum/model/ErrorEvent$Method : java/lang/E
 	public static final field PUT Lcom/datadog/android/rum/model/ErrorEvent$Method;
 	public static final field TRACE Lcom/datadog/android/rum/model/ErrorEvent$Method;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Method;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Method;
 	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$Method;
@@ -2486,6 +2517,7 @@ public final class com/datadog/android/rum/model/ErrorEvent$Plan : java/lang/Enu
 	public static final field PLAN_1 Lcom/datadog/android/rum/model/ErrorEvent$Plan;
 	public static final field PLAN_2 Lcom/datadog/android/rum/model/ErrorEvent$Plan;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Plan;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Plan;
 	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$Plan;
@@ -2530,6 +2562,7 @@ public final class com/datadog/android/rum/model/ErrorEvent$ProfilingStatus : ja
 	public static final field STARTING Lcom/datadog/android/rum/model/ErrorEvent$ProfilingStatus;
 	public static final field STOPPED Lcom/datadog/android/rum/model/ErrorEvent$ProfilingStatus;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$ProfilingStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$ProfilingStatus;
 	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$ProfilingStatus;
@@ -2582,6 +2615,7 @@ public final class com/datadog/android/rum/model/ErrorEvent$ProviderType : java/
 	public static final field UTILITY Lcom/datadog/android/rum/model/ErrorEvent$ProviderType;
 	public static final field VIDEO Lcom/datadog/android/rum/model/ErrorEvent$ProviderType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$ProviderType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$ProviderType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$ProviderType;
@@ -2629,6 +2663,7 @@ public final class com/datadog/android/rum/model/ErrorEvent$SessionPrecondition 
 	public static final field PREWARM Lcom/datadog/android/rum/model/ErrorEvent$SessionPrecondition;
 	public static final field USER_APP_LAUNCH Lcom/datadog/android/rum/model/ErrorEvent$SessionPrecondition;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$SessionPrecondition;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$SessionPrecondition;
 	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$SessionPrecondition;
@@ -2654,6 +2689,7 @@ public final class com/datadog/android/rum/model/ErrorEvent$SourceType : java/la
 	public static final field ROKU Lcom/datadog/android/rum/model/ErrorEvent$SourceType;
 	public static final field WINDOWS Lcom/datadog/android/rum/model/ErrorEvent$SourceType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$SourceType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$SourceType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ErrorEvent$SourceType;
@@ -3053,6 +3089,7 @@ public final class com/datadog/android/rum/model/LongTaskEvent$ConnectivityStatu
 	public static final field MAYBE Lcom/datadog/android/rum/model/LongTaskEvent$ConnectivityStatus;
 	public static final field NOT_CONNECTED Lcom/datadog/android/rum/model/LongTaskEvent$ConnectivityStatus;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$ConnectivityStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$ConnectivityStatus;
 	public static fun values ()[Lcom/datadog/android/rum/model/LongTaskEvent$ConnectivityStatus;
@@ -3241,6 +3278,7 @@ public final class com/datadog/android/rum/model/LongTaskEvent$DeviceType : java
 	public static final field TABLET Lcom/datadog/android/rum/model/LongTaskEvent$DeviceType;
 	public static final field TV Lcom/datadog/android/rum/model/LongTaskEvent$DeviceType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$DeviceType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$DeviceType;
 	public static fun values ()[Lcom/datadog/android/rum/model/LongTaskEvent$DeviceType;
@@ -3279,6 +3317,7 @@ public final class com/datadog/android/rum/model/LongTaskEvent$EffectiveType : j
 	public static final field Companion Lcom/datadog/android/rum/model/LongTaskEvent$EffectiveType$Companion;
 	public static final field SLOW_2G Lcom/datadog/android/rum/model/LongTaskEvent$EffectiveType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$EffectiveType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$EffectiveType;
 	public static fun values ()[Lcom/datadog/android/rum/model/LongTaskEvent$EffectiveType;
@@ -3293,6 +3332,7 @@ public final class com/datadog/android/rum/model/LongTaskEvent$EntryType : java/
 	public static final field LONG_ANIMATION_FRAME Lcom/datadog/android/rum/model/LongTaskEvent$EntryType;
 	public static final field LONG_TASK Lcom/datadog/android/rum/model/LongTaskEvent$EntryType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$EntryType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$EntryType;
 	public static fun values ()[Lcom/datadog/android/rum/model/LongTaskEvent$EntryType;
@@ -3309,6 +3349,7 @@ public final class com/datadog/android/rum/model/LongTaskEvent$ErrorReason : jav
 	public static final field NOT_SUPPORTED_BY_BROWSER Lcom/datadog/android/rum/model/LongTaskEvent$ErrorReason;
 	public static final field UNEXPECTED_EXCEPTION Lcom/datadog/android/rum/model/LongTaskEvent$ErrorReason;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$ErrorReason;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$ErrorReason;
 	public static fun values ()[Lcom/datadog/android/rum/model/LongTaskEvent$ErrorReason;
@@ -3330,6 +3371,7 @@ public final class com/datadog/android/rum/model/LongTaskEvent$Interface : java/
 	public static final field WIFI Lcom/datadog/android/rum/model/LongTaskEvent$Interface;
 	public static final field WIMAX Lcom/datadog/android/rum/model/LongTaskEvent$Interface;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$Interface;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$Interface;
 	public static fun values ()[Lcom/datadog/android/rum/model/LongTaskEvent$Interface;
@@ -3348,6 +3390,7 @@ public final class com/datadog/android/rum/model/LongTaskEvent$InvokerType : jav
 	public static final field RESOLVE_PROMISE Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;
 	public static final field USER_CALLBACK Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;
 	public static fun values ()[Lcom/datadog/android/rum/model/LongTaskEvent$InvokerType;
@@ -3427,6 +3470,7 @@ public final class com/datadog/android/rum/model/LongTaskEvent$LongTaskEventSess
 	public static final field SYNTHETICS Lcom/datadog/android/rum/model/LongTaskEvent$LongTaskEventSessionType;
 	public static final field USER Lcom/datadog/android/rum/model/LongTaskEvent$LongTaskEventSessionType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$LongTaskEventSessionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$LongTaskEventSessionType;
 	public static fun values ()[Lcom/datadog/android/rum/model/LongTaskEvent$LongTaskEventSessionType;
@@ -3450,6 +3494,7 @@ public final class com/datadog/android/rum/model/LongTaskEvent$LongTaskEventSour
 	public static final field ROKU Lcom/datadog/android/rum/model/LongTaskEvent$LongTaskEventSource;
 	public static final field UNITY Lcom/datadog/android/rum/model/LongTaskEvent$LongTaskEventSource;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$LongTaskEventSource;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$LongTaskEventSource;
 	public static fun values ()[Lcom/datadog/android/rum/model/LongTaskEvent$LongTaskEventSource;
@@ -3521,6 +3566,7 @@ public final class com/datadog/android/rum/model/LongTaskEvent$Plan : java/lang/
 	public static final field PLAN_1 Lcom/datadog/android/rum/model/LongTaskEvent$Plan;
 	public static final field PLAN_2 Lcom/datadog/android/rum/model/LongTaskEvent$Plan;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$Plan;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$Plan;
 	public static fun values ()[Lcom/datadog/android/rum/model/LongTaskEvent$Plan;
@@ -3565,6 +3611,7 @@ public final class com/datadog/android/rum/model/LongTaskEvent$ProfilingStatus :
 	public static final field STARTING Lcom/datadog/android/rum/model/LongTaskEvent$ProfilingStatus;
 	public static final field STOPPED Lcom/datadog/android/rum/model/LongTaskEvent$ProfilingStatus;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$ProfilingStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$ProfilingStatus;
 	public static fun values ()[Lcom/datadog/android/rum/model/LongTaskEvent$ProfilingStatus;
@@ -3626,6 +3673,7 @@ public final class com/datadog/android/rum/model/LongTaskEvent$SessionPreconditi
 	public static final field PREWARM Lcom/datadog/android/rum/model/LongTaskEvent$SessionPrecondition;
 	public static final field USER_APP_LAUNCH Lcom/datadog/android/rum/model/LongTaskEvent$SessionPrecondition;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$SessionPrecondition;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/LongTaskEvent$SessionPrecondition;
 	public static fun values ()[Lcom/datadog/android/rum/model/LongTaskEvent$SessionPrecondition;
@@ -4147,6 +4195,7 @@ public final class com/datadog/android/rum/model/ResourceEvent$DeliveryType : ja
 	public static final field NAVIGATIONAL_PREFETCH Lcom/datadog/android/rum/model/ResourceEvent$DeliveryType;
 	public static final field OTHER Lcom/datadog/android/rum/model/ResourceEvent$DeliveryType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$DeliveryType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$DeliveryType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ResourceEvent$DeliveryType;
@@ -4214,6 +4263,7 @@ public final class com/datadog/android/rum/model/ResourceEvent$DeviceType : java
 	public static final field TABLET Lcom/datadog/android/rum/model/ResourceEvent$DeviceType;
 	public static final field TV Lcom/datadog/android/rum/model/ResourceEvent$DeviceType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$DeviceType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$DeviceType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ResourceEvent$DeviceType;
@@ -4296,6 +4346,7 @@ public final class com/datadog/android/rum/model/ResourceEvent$EffectiveType : j
 	public static final field Companion Lcom/datadog/android/rum/model/ResourceEvent$EffectiveType$Companion;
 	public static final field SLOW_2G Lcom/datadog/android/rum/model/ResourceEvent$EffectiveType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$EffectiveType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$EffectiveType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ResourceEvent$EffectiveType;
@@ -4400,6 +4451,7 @@ public final class com/datadog/android/rum/model/ResourceEvent$Interface : java/
 	public static final field WIFI Lcom/datadog/android/rum/model/ResourceEvent$Interface;
 	public static final field WIMAX Lcom/datadog/android/rum/model/ResourceEvent$Interface;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$Interface;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$Interface;
 	public static fun values ()[Lcom/datadog/android/rum/model/ResourceEvent$Interface;
@@ -4443,6 +4495,7 @@ public final class com/datadog/android/rum/model/ResourceEvent$Method : java/lan
 	public static final field PUT Lcom/datadog/android/rum/model/ResourceEvent$Method;
 	public static final field TRACE Lcom/datadog/android/rum/model/ResourceEvent$Method;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$Method;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$Method;
 	public static fun values ()[Lcom/datadog/android/rum/model/ResourceEvent$Method;
@@ -4458,6 +4511,7 @@ public final class com/datadog/android/rum/model/ResourceEvent$OperationType : j
 	public static final field QUERY Lcom/datadog/android/rum/model/ResourceEvent$OperationType;
 	public static final field SUBSCRIPTION Lcom/datadog/android/rum/model/ResourceEvent$OperationType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$OperationType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$OperationType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ResourceEvent$OperationType;
@@ -4551,6 +4605,7 @@ public final class com/datadog/android/rum/model/ResourceEvent$Plan : java/lang/
 	public static final field PLAN_1 Lcom/datadog/android/rum/model/ResourceEvent$Plan;
 	public static final field PLAN_2 Lcom/datadog/android/rum/model/ResourceEvent$Plan;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$Plan;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$Plan;
 	public static fun values ()[Lcom/datadog/android/rum/model/ResourceEvent$Plan;
@@ -4603,6 +4658,7 @@ public final class com/datadog/android/rum/model/ResourceEvent$ProviderType : ja
 	public static final field UTILITY Lcom/datadog/android/rum/model/ResourceEvent$ProviderType;
 	public static final field VIDEO Lcom/datadog/android/rum/model/ResourceEvent$ProviderType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$ProviderType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$ProviderType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ResourceEvent$ProviderType;
@@ -4639,6 +4695,7 @@ public final class com/datadog/android/rum/model/ResourceEvent$RenderBlockingSta
 	public static final field Companion Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus$Companion;
 	public static final field NON_BLOCKING Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus;
 	public static fun values ()[Lcom/datadog/android/rum/model/ResourceEvent$RenderBlockingStatus;
@@ -4795,6 +4852,7 @@ public final class com/datadog/android/rum/model/ResourceEvent$ResourceEventSess
 	public static final field SYNTHETICS Lcom/datadog/android/rum/model/ResourceEvent$ResourceEventSessionType;
 	public static final field USER Lcom/datadog/android/rum/model/ResourceEvent$ResourceEventSessionType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$ResourceEventSessionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$ResourceEventSessionType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ResourceEvent$ResourceEventSessionType;
@@ -4818,6 +4876,7 @@ public final class com/datadog/android/rum/model/ResourceEvent$ResourceEventSour
 	public static final field ROKU Lcom/datadog/android/rum/model/ResourceEvent$ResourceEventSource;
 	public static final field UNITY Lcom/datadog/android/rum/model/ResourceEvent$ResourceEventSource;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$ResourceEventSource;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$ResourceEventSource;
 	public static fun values ()[Lcom/datadog/android/rum/model/ResourceEvent$ResourceEventSource;
@@ -4871,6 +4930,7 @@ public final class com/datadog/android/rum/model/ResourceEvent$ResourceType : ja
 	public static final field OTHER Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;
 	public static final field XHR Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;
@@ -4912,6 +4972,7 @@ public final class com/datadog/android/rum/model/ResourceEvent$SessionPreconditi
 	public static final field PREWARM Lcom/datadog/android/rum/model/ResourceEvent$SessionPrecondition;
 	public static final field USER_APP_LAUNCH Lcom/datadog/android/rum/model/ResourceEvent$SessionPrecondition;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$SessionPrecondition;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$SessionPrecondition;
 	public static fun values ()[Lcom/datadog/android/rum/model/ResourceEvent$SessionPrecondition;
@@ -4949,6 +5010,7 @@ public final class com/datadog/android/rum/model/ResourceEvent$Status : java/lan
 	public static final field MAYBE Lcom/datadog/android/rum/model/ResourceEvent$Status;
 	public static final field NOT_CONNECTED Lcom/datadog/android/rum/model/ResourceEvent$Status;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$Status;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$Status;
 	public static fun values ()[Lcom/datadog/android/rum/model/ResourceEvent$Status;
@@ -5468,6 +5530,7 @@ public final class com/datadog/android/rum/model/TimeseriesCpuEvent$DeviceType :
 	public static final field TABLET Lcom/datadog/android/rum/model/TimeseriesCpuEvent$DeviceType;
 	public static final field TV Lcom/datadog/android/rum/model/TimeseriesCpuEvent$DeviceType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$DeviceType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$DeviceType;
 	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesCpuEvent$DeviceType;
@@ -5506,6 +5569,7 @@ public final class com/datadog/android/rum/model/TimeseriesCpuEvent$EffectiveTyp
 	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesCpuEvent$EffectiveType$Companion;
 	public static final field SLOW_2G Lcom/datadog/android/rum/model/TimeseriesCpuEvent$EffectiveType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$EffectiveType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$EffectiveType;
 	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesCpuEvent$EffectiveType;
@@ -5527,6 +5591,7 @@ public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Interface : 
 	public static final field WIFI Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Interface;
 	public static final field WIMAX Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Interface;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Interface;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Interface;
 	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Interface;
@@ -5568,6 +5633,7 @@ public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Plan : java/
 	public static final field PLAN_1 Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Plan;
 	public static final field PLAN_2 Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Plan;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Plan;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Plan;
 	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Plan;
@@ -5587,6 +5653,7 @@ public final class com/datadog/android/rum/model/TimeseriesCpuEvent$SessionPreco
 	public static final field PREWARM Lcom/datadog/android/rum/model/TimeseriesCpuEvent$SessionPrecondition;
 	public static final field USER_APP_LAUNCH Lcom/datadog/android/rum/model/TimeseriesCpuEvent$SessionPrecondition;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$SessionPrecondition;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$SessionPrecondition;
 	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesCpuEvent$SessionPrecondition;
@@ -5610,6 +5677,7 @@ public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Source : jav
 	public static final field ROKU Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
 	public static final field UNITY Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
 	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Source;
@@ -5625,6 +5693,7 @@ public final class com/datadog/android/rum/model/TimeseriesCpuEvent$Status : jav
 	public static final field MAYBE Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Status;
 	public static final field NOT_CONNECTED Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Status;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Status;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Status;
 	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesCpuEvent$Status;
@@ -5760,6 +5829,7 @@ public final class com/datadog/android/rum/model/TimeseriesCpuEvent$TimeseriesCp
 	public static final field SYNTHETICS Lcom/datadog/android/rum/model/TimeseriesCpuEvent$TimeseriesCpuEventSessionType;
 	public static final field USER Lcom/datadog/android/rum/model/TimeseriesCpuEvent$TimeseriesCpuEventSessionType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$TimeseriesCpuEventSessionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesCpuEvent$TimeseriesCpuEventSessionType;
 	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesCpuEvent$TimeseriesCpuEventSessionType;
@@ -6240,6 +6310,7 @@ public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$DeviceTyp
 	public static final field TABLET Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$DeviceType;
 	public static final field TV Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$DeviceType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$DeviceType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$DeviceType;
 	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$DeviceType;
@@ -6278,6 +6349,7 @@ public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Effective
 	public static final field Companion Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$EffectiveType$Companion;
 	public static final field SLOW_2G Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$EffectiveType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$EffectiveType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$EffectiveType;
 	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$EffectiveType;
@@ -6299,6 +6371,7 @@ public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Interface
 	public static final field WIFI Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Interface;
 	public static final field WIMAX Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Interface;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Interface;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Interface;
 	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Interface;
@@ -6340,6 +6413,7 @@ public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Plan : ja
 	public static final field PLAN_1 Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Plan;
 	public static final field PLAN_2 Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Plan;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Plan;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Plan;
 	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Plan;
@@ -6359,6 +6433,7 @@ public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$SessionPr
 	public static final field PREWARM Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$SessionPrecondition;
 	public static final field USER_APP_LAUNCH Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$SessionPrecondition;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$SessionPrecondition;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$SessionPrecondition;
 	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$SessionPrecondition;
@@ -6382,6 +6457,7 @@ public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Source : 
 	public static final field ROKU Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
 	public static final field UNITY Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
 	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Source;
@@ -6397,6 +6473,7 @@ public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Status : 
 	public static final field MAYBE Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Status;
 	public static final field NOT_CONNECTED Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Status;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Status;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Status;
 	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$Status;
@@ -6532,6 +6609,7 @@ public final class com/datadog/android/rum/model/TimeseriesMemoryEvent$Timeserie
 	public static final field SYNTHETICS Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$TimeseriesMemoryEventSessionType;
 	public static final field USER Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$TimeseriesMemoryEventSessionType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$TimeseriesMemoryEventSessionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$TimeseriesMemoryEventSessionType;
 	public static fun values ()[Lcom/datadog/android/rum/model/TimeseriesMemoryEvent$TimeseriesMemoryEventSessionType;
@@ -6955,6 +7033,7 @@ public final class com/datadog/android/rum/model/ViewEvent$ConnectivityStatus : 
 	public static final field MAYBE Lcom/datadog/android/rum/model/ViewEvent$ConnectivityStatus;
 	public static final field NOT_CONNECTED Lcom/datadog/android/rum/model/ViewEvent$ConnectivityStatus;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$ConnectivityStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$ConnectivityStatus;
 	public static fun values ()[Lcom/datadog/android/rum/model/ViewEvent$ConnectivityStatus;
@@ -7212,6 +7291,7 @@ public final class com/datadog/android/rum/model/ViewEvent$DeviceType : java/lan
 	public static final field TABLET Lcom/datadog/android/rum/model/ViewEvent$DeviceType;
 	public static final field TV Lcom/datadog/android/rum/model/ViewEvent$DeviceType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$DeviceType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$DeviceType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ViewEvent$DeviceType;
@@ -7252,6 +7332,7 @@ public final class com/datadog/android/rum/model/ViewEvent$EffectiveType : java/
 	public static final field Companion Lcom/datadog/android/rum/model/ViewEvent$EffectiveType$Companion;
 	public static final field SLOW_2G Lcom/datadog/android/rum/model/ViewEvent$EffectiveType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$EffectiveType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$EffectiveType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ViewEvent$EffectiveType;
@@ -7288,6 +7369,7 @@ public final class com/datadog/android/rum/model/ViewEvent$ErrorReason : java/la
 	public static final field NOT_SUPPORTED_BY_BROWSER Lcom/datadog/android/rum/model/ViewEvent$ErrorReason;
 	public static final field UNEXPECTED_EXCEPTION Lcom/datadog/android/rum/model/ViewEvent$ErrorReason;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$ErrorReason;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$ErrorReason;
 	public static fun values ()[Lcom/datadog/android/rum/model/ViewEvent$ErrorReason;
@@ -7514,6 +7596,7 @@ public final class com/datadog/android/rum/model/ViewEvent$Interface : java/lang
 	public static final field WIFI Lcom/datadog/android/rum/model/ViewEvent$Interface;
 	public static final field WIMAX Lcom/datadog/android/rum/model/ViewEvent$Interface;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$Interface;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$Interface;
 	public static fun values ()[Lcom/datadog/android/rum/model/ViewEvent$Interface;
@@ -7586,6 +7669,7 @@ public final class com/datadog/android/rum/model/ViewEvent$LoadingType : java/la
 	public static final field VIEW_CONTROLLER_DISPLAY Lcom/datadog/android/rum/model/ViewEvent$LoadingType;
 	public static final field VIEW_CONTROLLER_REDISPLAY Lcom/datadog/android/rum/model/ViewEvent$LoadingType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$LoadingType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$LoadingType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ViewEvent$LoadingType;
@@ -7730,6 +7814,7 @@ public final class com/datadog/android/rum/model/ViewEvent$Plan : java/lang/Enum
 	public static final field PLAN_1 Lcom/datadog/android/rum/model/ViewEvent$Plan;
 	public static final field PLAN_2 Lcom/datadog/android/rum/model/ViewEvent$Plan;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$Plan;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$Plan;
 	public static fun values ()[Lcom/datadog/android/rum/model/ViewEvent$Plan;
@@ -7820,6 +7905,7 @@ public final class com/datadog/android/rum/model/ViewEvent$ProfilingStatus : jav
 	public static final field STARTING Lcom/datadog/android/rum/model/ViewEvent$ProfilingStatus;
 	public static final field STOPPED Lcom/datadog/android/rum/model/ViewEvent$ProfilingStatus;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$ProfilingStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$ProfilingStatus;
 	public static fun values ()[Lcom/datadog/android/rum/model/ViewEvent$ProfilingStatus;
@@ -7835,6 +7921,7 @@ public final class com/datadog/android/rum/model/ViewEvent$ReplayLevel : java/la
 	public static final field MASK Lcom/datadog/android/rum/model/ViewEvent$ReplayLevel;
 	public static final field MASK_USER_INPUT Lcom/datadog/android/rum/model/ViewEvent$ReplayLevel;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$ReplayLevel;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$ReplayLevel;
 	public static fun values ()[Lcom/datadog/android/rum/model/ViewEvent$ReplayLevel;
@@ -7926,6 +8013,7 @@ public final class com/datadog/android/rum/model/ViewEvent$SessionPrecondition :
 	public static final field PREWARM Lcom/datadog/android/rum/model/ViewEvent$SessionPrecondition;
 	public static final field USER_APP_LAUNCH Lcom/datadog/android/rum/model/ViewEvent$SessionPrecondition;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$SessionPrecondition;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$SessionPrecondition;
 	public static fun values ()[Lcom/datadog/android/rum/model/ViewEvent$SessionPrecondition;
@@ -7965,6 +8053,7 @@ public final class com/datadog/android/rum/model/ViewEvent$State : java/lang/Enu
 	public static final field PASSIVE Lcom/datadog/android/rum/model/ViewEvent$State;
 	public static final field TERMINATED Lcom/datadog/android/rum/model/ViewEvent$State;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$State;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$State;
 	public static fun values ()[Lcom/datadog/android/rum/model/ViewEvent$State;
@@ -8106,6 +8195,7 @@ public final class com/datadog/android/rum/model/ViewEvent$ViewEventSessionType 
 	public static final field SYNTHETICS Lcom/datadog/android/rum/model/ViewEvent$ViewEventSessionType;
 	public static final field USER Lcom/datadog/android/rum/model/ViewEvent$ViewEventSessionType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$ViewEventSessionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$ViewEventSessionType;
 	public static fun values ()[Lcom/datadog/android/rum/model/ViewEvent$ViewEventSessionType;
@@ -8129,6 +8219,7 @@ public final class com/datadog/android/rum/model/ViewEvent$ViewEventSource : jav
 	public static final field ROKU Lcom/datadog/android/rum/model/ViewEvent$ViewEventSource;
 	public static final field UNITY Lcom/datadog/android/rum/model/ViewEvent$ViewEventSource;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$ViewEventSource;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ViewEvent$ViewEventSource;
 	public static fun values ()[Lcom/datadog/android/rum/model/ViewEvent$ViewEventSource;
@@ -8377,6 +8468,7 @@ public final class com/datadog/android/rum/model/VitalAppLaunchEvent$AppLaunchMe
 	public static final field TTFD Lcom/datadog/android/rum/model/VitalAppLaunchEvent$AppLaunchMetric;
 	public static final field TTID Lcom/datadog/android/rum/model/VitalAppLaunchEvent$AppLaunchMetric;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$AppLaunchMetric;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$AppLaunchMetric;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalAppLaunchEvent$AppLaunchMetric;
@@ -8520,6 +8612,7 @@ public final class com/datadog/android/rum/model/VitalAppLaunchEvent$Connectivit
 	public static final field MAYBE Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ConnectivityStatus;
 	public static final field NOT_CONNECTED Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ConnectivityStatus;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ConnectivityStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ConnectivityStatus;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ConnectivityStatus;
@@ -8706,6 +8799,7 @@ public final class com/datadog/android/rum/model/VitalAppLaunchEvent$DeviceType 
 	public static final field TABLET Lcom/datadog/android/rum/model/VitalAppLaunchEvent$DeviceType;
 	public static final field TV Lcom/datadog/android/rum/model/VitalAppLaunchEvent$DeviceType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$DeviceType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$DeviceType;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalAppLaunchEvent$DeviceType;
@@ -8744,6 +8838,7 @@ public final class com/datadog/android/rum/model/VitalAppLaunchEvent$EffectiveTy
 	public static final field Companion Lcom/datadog/android/rum/model/VitalAppLaunchEvent$EffectiveType$Companion;
 	public static final field SLOW_2G Lcom/datadog/android/rum/model/VitalAppLaunchEvent$EffectiveType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$EffectiveType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$EffectiveType;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalAppLaunchEvent$EffectiveType;
@@ -8760,6 +8855,7 @@ public final class com/datadog/android/rum/model/VitalAppLaunchEvent$ErrorReason
 	public static final field NOT_SUPPORTED_BY_BROWSER Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ErrorReason;
 	public static final field UNEXPECTED_EXCEPTION Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ErrorReason;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ErrorReason;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ErrorReason;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ErrorReason;
@@ -8781,6 +8877,7 @@ public final class com/datadog/android/rum/model/VitalAppLaunchEvent$Interface :
 	public static final field WIFI Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Interface;
 	public static final field WIMAX Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Interface;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Interface;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Interface;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Interface;
@@ -8822,6 +8919,7 @@ public final class com/datadog/android/rum/model/VitalAppLaunchEvent$Plan : java
 	public static final field PLAN_1 Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Plan;
 	public static final field PLAN_2 Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Plan;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Plan;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Plan;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalAppLaunchEvent$Plan;
@@ -8866,6 +8964,7 @@ public final class com/datadog/android/rum/model/VitalAppLaunchEvent$ProfilingSt
 	public static final field STARTING Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ProfilingStatus;
 	public static final field STOPPED Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ProfilingStatus;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ProfilingStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ProfilingStatus;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalAppLaunchEvent$ProfilingStatus;
@@ -8885,6 +8984,7 @@ public final class com/datadog/android/rum/model/VitalAppLaunchEvent$SessionPrec
 	public static final field PREWARM Lcom/datadog/android/rum/model/VitalAppLaunchEvent$SessionPrecondition;
 	public static final field USER_APP_LAUNCH Lcom/datadog/android/rum/model/VitalAppLaunchEvent$SessionPrecondition;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$SessionPrecondition;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$SessionPrecondition;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalAppLaunchEvent$SessionPrecondition;
@@ -8899,6 +8999,7 @@ public final class com/datadog/android/rum/model/VitalAppLaunchEvent$StartupType
 	public static final field Companion Lcom/datadog/android/rum/model/VitalAppLaunchEvent$StartupType$Companion;
 	public static final field WARM_START Lcom/datadog/android/rum/model/VitalAppLaunchEvent$StartupType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$StartupType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$StartupType;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalAppLaunchEvent$StartupType;
@@ -9094,6 +9195,7 @@ public final class com/datadog/android/rum/model/VitalAppLaunchEvent$VitalAppLau
 	public static final field SYNTHETICS Lcom/datadog/android/rum/model/VitalAppLaunchEvent$VitalAppLaunchEventSessionType;
 	public static final field USER Lcom/datadog/android/rum/model/VitalAppLaunchEvent$VitalAppLaunchEventSessionType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$VitalAppLaunchEventSessionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$VitalAppLaunchEventSessionType;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalAppLaunchEvent$VitalAppLaunchEventSessionType;
@@ -9117,6 +9219,7 @@ public final class com/datadog/android/rum/model/VitalAppLaunchEvent$VitalAppLau
 	public static final field ROKU Lcom/datadog/android/rum/model/VitalAppLaunchEvent$VitalAppLaunchEventSource;
 	public static final field UNITY Lcom/datadog/android/rum/model/VitalAppLaunchEvent$VitalAppLaunchEventSource;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$VitalAppLaunchEventSource;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalAppLaunchEvent$VitalAppLaunchEventSource;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalAppLaunchEvent$VitalAppLaunchEventSource;
@@ -9378,6 +9481,7 @@ public final class com/datadog/android/rum/model/VitalOperationStepEvent$Connect
 	public static final field MAYBE Lcom/datadog/android/rum/model/VitalOperationStepEvent$ConnectivityStatus;
 	public static final field NOT_CONNECTED Lcom/datadog/android/rum/model/VitalOperationStepEvent$ConnectivityStatus;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$ConnectivityStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$ConnectivityStatus;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalOperationStepEvent$ConnectivityStatus;
@@ -9564,6 +9668,7 @@ public final class com/datadog/android/rum/model/VitalOperationStepEvent$DeviceT
 	public static final field TABLET Lcom/datadog/android/rum/model/VitalOperationStepEvent$DeviceType;
 	public static final field TV Lcom/datadog/android/rum/model/VitalOperationStepEvent$DeviceType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$DeviceType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$DeviceType;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalOperationStepEvent$DeviceType;
@@ -9602,6 +9707,7 @@ public final class com/datadog/android/rum/model/VitalOperationStepEvent$Effecti
 	public static final field Companion Lcom/datadog/android/rum/model/VitalOperationStepEvent$EffectiveType$Companion;
 	public static final field SLOW_2G Lcom/datadog/android/rum/model/VitalOperationStepEvent$EffectiveType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$EffectiveType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$EffectiveType;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalOperationStepEvent$EffectiveType;
@@ -9618,6 +9724,7 @@ public final class com/datadog/android/rum/model/VitalOperationStepEvent$ErrorRe
 	public static final field NOT_SUPPORTED_BY_BROWSER Lcom/datadog/android/rum/model/VitalOperationStepEvent$ErrorReason;
 	public static final field UNEXPECTED_EXCEPTION Lcom/datadog/android/rum/model/VitalOperationStepEvent$ErrorReason;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$ErrorReason;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$ErrorReason;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalOperationStepEvent$ErrorReason;
@@ -9633,6 +9740,7 @@ public final class com/datadog/android/rum/model/VitalOperationStepEvent$Failure
 	public static final field ERROR Lcom/datadog/android/rum/model/VitalOperationStepEvent$FailureReason;
 	public static final field OTHER Lcom/datadog/android/rum/model/VitalOperationStepEvent$FailureReason;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$FailureReason;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$FailureReason;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalOperationStepEvent$FailureReason;
@@ -9654,6 +9762,7 @@ public final class com/datadog/android/rum/model/VitalOperationStepEvent$Interfa
 	public static final field WIFI Lcom/datadog/android/rum/model/VitalOperationStepEvent$Interface;
 	public static final field WIMAX Lcom/datadog/android/rum/model/VitalOperationStepEvent$Interface;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$Interface;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$Interface;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalOperationStepEvent$Interface;
@@ -9695,6 +9804,7 @@ public final class com/datadog/android/rum/model/VitalOperationStepEvent$Plan : 
 	public static final field PLAN_1 Lcom/datadog/android/rum/model/VitalOperationStepEvent$Plan;
 	public static final field PLAN_2 Lcom/datadog/android/rum/model/VitalOperationStepEvent$Plan;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$Plan;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$Plan;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalOperationStepEvent$Plan;
@@ -9739,6 +9849,7 @@ public final class com/datadog/android/rum/model/VitalOperationStepEvent$Profili
 	public static final field STARTING Lcom/datadog/android/rum/model/VitalOperationStepEvent$ProfilingStatus;
 	public static final field STOPPED Lcom/datadog/android/rum/model/VitalOperationStepEvent$ProfilingStatus;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$ProfilingStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$ProfilingStatus;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalOperationStepEvent$ProfilingStatus;
@@ -9758,6 +9869,7 @@ public final class com/datadog/android/rum/model/VitalOperationStepEvent$Session
 	public static final field PREWARM Lcom/datadog/android/rum/model/VitalOperationStepEvent$SessionPrecondition;
 	public static final field USER_APP_LAUNCH Lcom/datadog/android/rum/model/VitalOperationStepEvent$SessionPrecondition;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$SessionPrecondition;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$SessionPrecondition;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalOperationStepEvent$SessionPrecondition;
@@ -9774,6 +9886,7 @@ public final class com/datadog/android/rum/model/VitalOperationStepEvent$StepTyp
 	public static final field START Lcom/datadog/android/rum/model/VitalOperationStepEvent$StepType;
 	public static final field UPDATE Lcom/datadog/android/rum/model/VitalOperationStepEvent$StepType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$StepType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$StepType;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalOperationStepEvent$StepType;
@@ -9965,6 +10078,7 @@ public final class com/datadog/android/rum/model/VitalOperationStepEvent$VitalOp
 	public static final field SYNTHETICS Lcom/datadog/android/rum/model/VitalOperationStepEvent$VitalOperationStepEventSessionType;
 	public static final field USER Lcom/datadog/android/rum/model/VitalOperationStepEvent$VitalOperationStepEventSessionType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$VitalOperationStepEventSessionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$VitalOperationStepEventSessionType;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalOperationStepEvent$VitalOperationStepEventSessionType;
@@ -9988,6 +10102,7 @@ public final class com/datadog/android/rum/model/VitalOperationStepEvent$VitalOp
 	public static final field ROKU Lcom/datadog/android/rum/model/VitalOperationStepEvent$VitalOperationStepEventSource;
 	public static final field UNITY Lcom/datadog/android/rum/model/VitalOperationStepEvent$VitalOperationStepEventSource;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$VitalOperationStepEventSource;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/VitalOperationStepEvent$VitalOperationStepEventSource;
 	public static fun values ()[Lcom/datadog/android/rum/model/VitalOperationStepEvent$VitalOperationStepEventSource;
@@ -10031,6 +10146,7 @@ public final class com/datadog/android/rum/operations/FailureReason : java/lang/
 	public static final field ABANDONED Lcom/datadog/android/rum/operations/FailureReason;
 	public static final field ERROR Lcom/datadog/android/rum/operations/FailureReason;
 	public static final field OTHER Lcom/datadog/android/rum/operations/FailureReason;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/operations/FailureReason;
 	public static fun values ()[Lcom/datadog/android/rum/operations/FailureReason;
 }
@@ -10118,6 +10234,7 @@ public final class com/datadog/android/rum/timeseries/TimeseriesConfiguration$Co
 public final class com/datadog/android/rum/timeseries/TimeseriesType : java/lang/Enum {
 	public static final field CPU Lcom/datadog/android/rum/timeseries/TimeseriesType;
 	public static final field MEMORY Lcom/datadog/android/rum/timeseries/TimeseriesType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/timeseries/TimeseriesType;
 	public static fun values ()[Lcom/datadog/android/rum/timeseries/TimeseriesType;
 }
@@ -10733,6 +10850,7 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public static final field DATADOG Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SelectedTracingPropagator;
 	public static final field TRACECONTEXT Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SelectedTracingPropagator;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SelectedTracingPropagator;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SelectedTracingPropagator;
 	public static fun values ()[Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SelectedTracingPropagator;
@@ -10768,6 +10886,7 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public static final field LOCAL_STORAGE Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SessionPersistence;
 	public static final field MEMORY Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SessionPersistence;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SessionPersistence;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SessionPersistence;
 	public static fun values ()[Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$SessionPersistence;
@@ -10790,6 +10909,7 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public static final field RUM_CPP Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Source;
 	public static final field UNITY Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Source;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Source;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Source;
 	public static fun values ()[Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Source;
@@ -10832,6 +10952,7 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public static final field Companion Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection$Companion;
 	public static final field SAMPLED Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;
 	public static fun values ()[Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;
@@ -10848,6 +10969,7 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public static final field RESOURCE Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackFeatureFlagsForEvent;
 	public static final field VITAL Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackFeatureFlagsForEvent;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackFeatureFlagsForEvent;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackFeatureFlagsForEvent;
 	public static fun values ()[Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackFeatureFlagsForEvent;
@@ -10862,6 +10984,7 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public static final field Companion Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackResourceHeaders$Companion;
 	public static final field DEFAULT_HEADERS Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackResourceHeaders;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackResourceHeaders;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackResourceHeaders;
 	public static fun values ()[Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackResourceHeaders;
@@ -10877,6 +11000,7 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public static final field NOT_GRANTED Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;
 	public static final field PENDING Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;
 	public static fun values ()[Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;
@@ -10913,6 +11037,7 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public static final field MIXEDVIEWTRACKINGSTRATEGY Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;
 	public static final field NAVIGATIONVIEWTRACKINGSTRATEGY Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;
 	public static fun values ()[Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;
@@ -11111,6 +11236,7 @@ public final class com/datadog/android/telemetry/model/TelemetryDebugEvent$Sourc
 	public static final field RUM_CPP Lcom/datadog/android/telemetry/model/TelemetryDebugEvent$Source;
 	public static final field UNITY Lcom/datadog/android/telemetry/model/TelemetryDebugEvent$Source;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryDebugEvent$Source;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryDebugEvent$Source;
 	public static fun values ()[Lcom/datadog/android/telemetry/model/TelemetryDebugEvent$Source;
@@ -11382,6 +11508,7 @@ public final class com/datadog/android/telemetry/model/TelemetryErrorEvent$Sourc
 	public static final field RUM_CPP Lcom/datadog/android/telemetry/model/TelemetryErrorEvent$Source;
 	public static final field UNITY Lcom/datadog/android/telemetry/model/TelemetryErrorEvent$Source;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryErrorEvent$Source;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryErrorEvent$Source;
 	public static fun values ()[Lcom/datadog/android/telemetry/model/TelemetryErrorEvent$Source;
@@ -11507,6 +11634,7 @@ public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Actio
 	public static final field START Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$ActionType;
 	public static final field SUCCEED Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$ActionType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$ActionType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$ActionType;
 	public static fun values ()[Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$ActionType;
@@ -11646,6 +11774,7 @@ public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Sourc
 	public static final field RUM_CPP Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Source;
 	public static final field UNITY Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Source;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Source;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Source;
 	public static fun values ()[Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Source;
@@ -11689,6 +11818,7 @@ public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Track
 	public static final field NOT_GRANTED Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$TrackingConsent;
 	public static final field PENDING Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$TrackingConsent;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$TrackingConsent;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$TrackingConsent;
 	public static fun values ()[Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$TrackingConsent;
@@ -11704,6 +11834,7 @@ public final class com/datadog/android/telemetry/model/TelemetryUsageEvent$Type 
 	public static final field LEGACY_OKHTTP Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Type;
 	public static final field OKHTTP Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Type;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Type;
 	public static fun values ()[Lcom/datadog/android/telemetry/model/TelemetryUsageEvent$Type;

--- a/features/dd-sdk-android-rum/build.gradle.kts
+++ b/features/dd-sdk-android-rum/build.gradle.kts
@@ -43,6 +43,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     defaultConfig {
         consumerProguardFiles(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
@@ -39,6 +39,7 @@ import com.datadog.android.telemetry.model.TelemetryConfigurationEvent
 /**
  * Describes configuration to be used for the RUM feature.
  */
+@ExposedCopyVisibility
 data class RumConfiguration internal constructor(
     internal val applicationId: String,
     internal val featureConfiguration: RumFeature.Configuration

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumScopeKeyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumScopeKeyTest.kt
@@ -256,6 +256,7 @@ internal class RumScopeKeyTest {
     }
 
     class StubLegacyFragment : LegacyFragment() {
+        @Suppress("POTENTIALLY_NON_REPORTED_ANNOTATION")
         @Deprecated("Deprecated in Java")
         override fun toString(): String {
             return "StubLegacyFragment{${System.identityHashCode(this)}}"

--- a/features/dd-sdk-android-rum/transitiveDependencies
+++ b/features/dd-sdk-android-rum/transitiveDependencies
@@ -3,12 +3,12 @@ Dependencies List
 androidx.activity:activity-ktx:1.7.2                            :   25 Kb
 androidx.activity:activity:1.7.2                                :  139 Kb
 androidx.annotation:annotation-experimental:1.4.1               :   38 Kb
-androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
+androidx.annotation:annotation-jvm:1.8.1                        :   54 Kb
 androidx.arch.core:core-common:2.2.0                            :   11 Kb
-androidx.arch.core:core-runtime:2.2.0                           :    7 Kb
-androidx.collection:collection-jvm:1.4.5                        :  770 Kb
-androidx.collection:collection-ktx:1.4.5                        :  261 b 
-androidx.core:core-ktx:1.15.0                                   :  171 Kb
+androidx.arch.core:core-runtime:2.1.0                           :    5 Kb
+androidx.collection:collection-ktx:1.1.0                        :   18 Kb
+androidx.collection:collection:1.1.0                            :   41 Kb
+androidx.core:core-ktx:1.2.0                                    :  155 Kb
 androidx.core:core:1.15.0                                       : 1304 Kb
 androidx.customview:customview:1.1.0                            :   32 Kb
 androidx.fragment:fragment-ktx:1.6.2                            :   29 Kb
@@ -43,5 +43,5 @@ org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4          :   19 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4         : 1442 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              :    8 Mb
+Total transitive dependencies size                              :    7 Mb
 

--- a/features/dd-sdk-android-session-replay-compose/api/compiler-meta.txt
+++ b/features/dd-sdk-android-session-replay-compose/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/features/dd-sdk-android-session-replay-compose/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-compose/build.gradle.kts
@@ -38,6 +38,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.sessionreplay.compose"
 
@@ -76,7 +78,13 @@ unMock {
 }
 
 datadogBuild {
-    applyKotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+    applyKotlinConfig(
+        // TODO RUM-18191
+        // Suppress -> generateFunctionKeyMetaClasses is deprecated. It was replaced by emitting annotations on functions
+        // instead. Use generateFunctionKeyMetaAnnotations instead. Seems to Compose <-> Kotlin mismatch.
+        evaluateWarningsAsErrors = false,
+        jvmBytecodeTarget = JvmTarget.JVM_11
+    )
     applyAndroidLibraryConfig()
     applyJunitConfig()
     applyJavadocConfig()

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapperTest.kt
@@ -241,7 +241,7 @@ internal open class AbstractSemanticsNodeMapperTest {
     }
 
     protected fun mockSemanticsNodeWithBound(additionalMock: SemanticsNode.() -> Unit = {}): SemanticsNode {
-        return mock<SemanticsNode?>().apply {
+        return mock<SemanticsNode>().apply {
             whenever(id) doReturn fakeSemanticsId
             whenever(boundsInRoot) doReturn fakeBounds
             whenever(layoutInfo) doReturn mockLayoutInfo
@@ -277,7 +277,6 @@ internal open class AbstractSemanticsNodeMapperTest {
     companion object {
         private const val MAX_ALPHA = 255
         private const val DEFAULT_FONT_FAMILY = "Roboto, sans-serif"
-        protected const val DEFAULT_TEXT_COLOR = "#000000FF"
     }
 }
 

--- a/features/dd-sdk-android-session-replay-compose/transitiveDependencies
+++ b/features/dd-sdk-android-session-replay-compose/transitiveDependencies
@@ -3,10 +3,10 @@ Dependencies List
 androidx.activity:activity-compose:1.7.0                        : 1082 Kb
 androidx.activity:activity-ktx:1.7.0                            :   25 Kb
 androidx.activity:activity:1.7.0                                :  139 Kb
-androidx.annotation:annotation-experimental:1.3.0               :   35 Kb
-androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
+androidx.annotation:annotation-experimental:1.1.0               :   16 Kb
+androidx.annotation:annotation:1.5.0                            :   52 Kb
 androidx.arch.core:core-common:2.2.0                            :   11 Kb
-androidx.collection:collection-jvm:1.4.5                        :  770 Kb
+androidx.collection:collection:1.0.0                            :   40 Kb
 androidx.compose.animation:animation-android:1.5.4              : 1309 Kb
 androidx.compose.animation:animation-core-android:1.5.4         : 1338 Kb
 androidx.compose.foundation:foundation-android:1.5.4            :    3 Mb
@@ -24,8 +24,8 @@ androidx.compose.ui:ui-tooling-android:1.5.4                    :  222 Kb
 androidx.compose.ui:ui-tooling-data-android:1.5.4               :   36 Kb
 androidx.compose.ui:ui-tooling-preview-android:1.5.4            :   13 Kb
 androidx.compose.ui:ui-unit-android:1.5.4                       :   64 Kb
-androidx.core:core-ktx:1.10.0                                   :  178 Kb
-androidx.core:core:1.10.0                                       : 1219 Kb
+androidx.core:core-ktx:1.2.0                                    :  155 Kb
+androidx.core:core:1.8.0                                        : 1052 Kb
 androidx.lifecycle:lifecycle-common-java8:2.6.1                 :  261 b 
 androidx.lifecycle:lifecycle-common:2.6.1                       :   51 Kb
 androidx.lifecycle:lifecycle-livedata-core:2.6.1                :   11 Kb
@@ -44,12 +44,12 @@ androidx.savedstate:savedstate-ktx:1.2.1                        :    3 Kb
 androidx.savedstate:savedstate:1.2.1                            :   19 Kb
 androidx.versionedparcelable:versionedparcelable:1.1.1          :   30 Kb
 com.google.code.gson:gson:2.10.1                                :  276 Kb
-org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
-org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
+org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0                   :  963 b 
+org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0                   :  968 b 
 org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4          :   19 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4         : 1442 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              :   28 Mb
+Total transitive dependencies size                              :   27 Mb
 

--- a/features/dd-sdk-android-session-replay-material/api/compiler-meta.txt
+++ b/features/dd-sdk-android-session-replay-material/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/features/dd-sdk-android-session-replay-material/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-material/build.gradle.kts
@@ -36,6 +36,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     defaultConfig {
         consumerProguardFiles("consumer-rules.pro")

--- a/features/dd-sdk-android-session-replay-material/transitiveDependencies
+++ b/features/dd-sdk-android-session-replay-material/transitiveDependencies
@@ -1,41 +1,40 @@
 Dependencies List
 
-androidx.activity:activity:1.2.4                                :   67 Kb
-androidx.annotation:annotation-experimental:1.1.0               :   16 Kb
-androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
-androidx.appcompat:appcompat-resources:1.4.2                    :   65 Kb
-androidx.appcompat:appcompat:1.4.2                              : 1092 Kb
+androidx.activity:activity:1.0.0                                :   13 Kb
+androidx.annotation:annotation-experimental:1.0.0               :   11 Kb
+androidx.annotation:annotation:1.1.0                            :   27 Kb
+androidx.appcompat:appcompat-resources:1.2.0                    :   61 Kb
+androidx.appcompat:appcompat:1.2.0                              : 1083 Kb
 androidx.arch.core:core-common:2.1.0                            :   10 Kb
-androidx.arch.core:core-runtime:2.1.0                           :    5 Kb
+androidx.arch.core:core-runtime:2.0.0                           :    5 Kb
 androidx.cardview:cardview:1.0.0                                :   21 Kb
-androidx.collection:collection-jvm:1.4.5                        :  770 Kb
+androidx.collection:collection:1.1.0                            :   41 Kb
 androidx.constraintlayout:constraintlayout-solver:2.0.1         :  197 Kb
 androidx.constraintlayout:constraintlayout:2.0.1                :  373 Kb
 androidx.coordinatorlayout:coordinatorlayout:1.1.0              :   43 Kb
-androidx.core:core:1.7.0                                        :  957 Kb
+androidx.core:core:1.3.1                                        :  710 Kb
 androidx.cursoradapter:cursoradapter:1.0.0                      :   10 Kb
 androidx.customview:customview:1.0.0                            :   32 Kb
 androidx.documentfile:documentfile:1.0.0                        :   10 Kb
 androidx.drawerlayout:drawerlayout:1.0.0                        :   31 Kb
 androidx.dynamicanimation:dynamicanimation:1.0.0                :   31 Kb
-androidx.fragment:fragment:1.3.6                                :  291 Kb
+androidx.fragment:fragment:1.1.0                                :  162 Kb
 androidx.interpolator:interpolator:1.0.0                        :    7 Kb
 androidx.legacy:legacy-support-core-utils:1.0.0                 :    4 Kb
-androidx.lifecycle:lifecycle-common:2.4.0                       :   23 Kb
-androidx.lifecycle:lifecycle-livedata-core:2.3.1                :    8 Kb
-androidx.lifecycle:lifecycle-livedata:2.1.0                     :   10 Kb
-androidx.lifecycle:lifecycle-runtime:2.4.0                      :   11 Kb
-androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.1         :   15 Kb
-androidx.lifecycle:lifecycle-viewmodel:2.3.1                    :   10 Kb
+androidx.lifecycle:lifecycle-common:2.1.0                       :   21 Kb
+androidx.lifecycle:lifecycle-livedata-core:2.0.0                :    8 Kb
+androidx.lifecycle:lifecycle-livedata:2.0.0                     :    9 Kb
+androidx.lifecycle:lifecycle-runtime:2.1.0                      :    8 Kb
+androidx.lifecycle:lifecycle-viewmodel:2.1.0                    :    8 Kb
 androidx.loader:loader:1.0.0                                    :   32 Kb
 androidx.localbroadcastmanager:localbroadcastmanager:1.0.0      :    6 Kb
 androidx.print:print:1.0.0                                      :   15 Kb
 androidx.recyclerview:recyclerview:1.1.0                        :  349 Kb
-androidx.savedstate:savedstate:1.1.0                            :   10 Kb
+androidx.savedstate:savedstate:1.0.0                            :    9 Kb
 androidx.transition:transition:1.2.0                            :  166 Kb
 androidx.vectordrawable:vectordrawable-animated:1.1.0           :   33 Kb
 androidx.vectordrawable:vectordrawable:1.1.0                    :   32 Kb
-androidx.versionedparcelable:versionedparcelable:1.1.1          :   30 Kb
+androidx.versionedparcelable:versionedparcelable:1.1.0          :   30 Kb
 androidx.viewpager:viewpager:1.0.0                              :   52 Kb
 androidx.viewpager2:viewpager2:1.0.0                            :   60 Kb
 com.google.android.material:material:1.3.0                      : 1535 Kb
@@ -43,5 +42,5 @@ com.google.code.gson:gson:2.10.1                                :  276 Kb
 org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              :    8 Mb
+Total transitive dependencies size                              :    7 Mb
 

--- a/features/dd-sdk-android-session-replay/api/compiler-meta.txt
+++ b/features/dd-sdk-android-session-replay/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -9,6 +9,7 @@ public final class com/datadog/android/sessionreplay/ImagePrivacy : java/lang/En
 	public static final field MASK_ALL Lcom/datadog/android/sessionreplay/ImagePrivacy;
 	public static final field MASK_LARGE_ONLY Lcom/datadog/android/sessionreplay/ImagePrivacy;
 	public static final field MASK_NONE Lcom/datadog/android/sessionreplay/ImagePrivacy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/ImagePrivacy;
 	public static fun values ()[Lcom/datadog/android/sessionreplay/ImagePrivacy;
 }
@@ -111,6 +112,7 @@ public final class com/datadog/android/sessionreplay/SessionReplayPrivacy : java
 	public static final field ALLOW Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
 	public static final field MASK Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
 	public static final field MASK_USER_INPUT Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
 	public static fun values ()[Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
 }
@@ -135,6 +137,7 @@ public final class com/datadog/android/sessionreplay/TextAndInputPrivacy : java/
 	public static final field MASK_ALL Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
 	public static final field MASK_ALL_INPUTS Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
 	public static final field MASK_SENSITIVE_INPUTS Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
 	public static fun values ()[Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
 }
@@ -142,6 +145,7 @@ public final class com/datadog/android/sessionreplay/TextAndInputPrivacy : java/
 public final class com/datadog/android/sessionreplay/TouchPrivacy : java/lang/Enum, com/datadog/android/sessionreplay/PrivacyLevel {
 	public static final field HIDE Lcom/datadog/android/sessionreplay/TouchPrivacy;
 	public static final field SHOW Lcom/datadog/android/sessionreplay/TouchPrivacy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/TouchPrivacy;
 	public static fun values ()[Lcom/datadog/android/sessionreplay/TouchPrivacy;
 }
@@ -383,6 +387,7 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$Horizon
 	public static final field LEFT Lcom/datadog/android/sessionreplay/model/MobileSegment$Horizontal;
 	public static final field RIGHT Lcom/datadog/android/sessionreplay/model/MobileSegment$Horizontal;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Horizontal;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Horizontal;
 	public static fun values ()[Lcom/datadog/android/sessionreplay/model/MobileSegment$Horizontal;
@@ -704,6 +709,7 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$Pointer
 	public static final field MOVE Lcom/datadog/android/sessionreplay/model/MobileSegment$PointerEventType;
 	public static final field UP Lcom/datadog/android/sessionreplay/model/MobileSegment$PointerEventType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$PointerEventType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$PointerEventType;
 	public static fun values ()[Lcom/datadog/android/sessionreplay/model/MobileSegment$PointerEventType;
@@ -719,6 +725,7 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$Pointer
 	public static final field PEN Lcom/datadog/android/sessionreplay/model/MobileSegment$PointerType;
 	public static final field TOUCH Lcom/datadog/android/sessionreplay/model/MobileSegment$PointerType;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$PointerType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$PointerType;
 	public static fun values ()[Lcom/datadog/android/sessionreplay/model/MobileSegment$PointerType;
@@ -851,6 +858,7 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$Source 
 	public static final field MAUI Lcom/datadog/android/sessionreplay/model/MobileSegment$Source;
 	public static final field REACT_NATIVE Lcom/datadog/android/sessionreplay/model/MobileSegment$Source;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Source;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Source;
 	public static fun values ()[Lcom/datadog/android/sessionreplay/model/MobileSegment$Source;
@@ -918,6 +926,7 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$Truncat
 	public static final field MIDDLE Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;
 	public static final field TAIL Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;
 	public static fun values ()[Lcom/datadog/android/sessionreplay/model/MobileSegment$TruncationMode;
@@ -933,6 +942,7 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$Vertica
 	public static final field Companion Lcom/datadog/android/sessionreplay/model/MobileSegment$Vertical$Companion;
 	public static final field TOP Lcom/datadog/android/sessionreplay/model/MobileSegment$Vertical;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Vertical;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Vertical;
 	public static fun values ()[Lcom/datadog/android/sessionreplay/model/MobileSegment$Vertical;

--- a/features/dd-sdk-android-session-replay/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay/build.gradle.kts
@@ -42,6 +42,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     defaultConfig {
         consumerProguardFiles("consumer-rules.pro")

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
@@ -16,6 +16,7 @@ import java.util.Locale
 /**
  * Describes configuration to be used for the Session Replay feature.
  */
+@ExposedCopyVisibility
 data class SessionReplayConfiguration internal constructor(
     internal val customEndpointUrl: String?,
     internal val privacy: SessionReplayPrivacy,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AndroidMDrawableToColorMapper.kt
@@ -259,6 +259,7 @@ internal open class AndroidMDrawableToColorMapper(
         @Suppress("PrivateAPI", "SwallowedException", "TooGenericExceptionCaught")
         internal val mColorField = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
             try {
+                @Suppress("SoonBlockedPrivateApi")
                 PorterDuffColorFilter::class.java.getDeclaredField("mColor").apply {
                     this.isAccessible = true
                 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/BitmapPool.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/BitmapPool.kt
@@ -106,6 +106,7 @@ internal class BitmapPool(
 
     override fun onConfigurationChanged(newConfig: Configuration) {}
 
+    @Deprecated("Deprecated in Java")
     @Synchronized
     override fun onLowMemory() {
         bitmapPoolHelper.safeCall {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourcesLRUCache.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourcesLRUCache.kt
@@ -30,6 +30,7 @@ internal class ResourcesLRUCache(
 
     override fun onConfigurationChanged(newConfig: Configuration) {}
 
+    @Deprecated("Deprecated in Java")
     override fun onLowMemory() {
         @Suppress("UnsafeThirdPartyFunctionCall") // Called within a try/catch block
         invocationUtils.safeCallWithErrorLogging(

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/BitmapPoolTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/BitmapPoolTest.kt
@@ -348,6 +348,7 @@ internal class BitmapPoolTest {
         testedCache.put(mockBitmap)
 
         // When
+        @Suppress("DEPRECATION")
         testedCache.onLowMemory()
 
         // Then
@@ -388,6 +389,7 @@ internal class BitmapPoolTest {
                 if (forge.aBool()) {
                     testedCache.get(bitmapKey)
                 } else {
+                    @Suppress("DEPRECATION")
                     testedCache.onLowMemory()
                 }
             }

--- a/features/dd-sdk-android-session-replay/transitiveDependencies
+++ b/features/dd-sdk-android-session-replay/transitiveDependencies
@@ -2,22 +2,22 @@ Dependencies List
 
 androidx.activity:activity:1.2.4                                :   67 Kb
 androidx.annotation:annotation-experimental:1.1.0               :   16 Kb
-androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
+androidx.annotation:annotation:1.3.0                            :   30 Kb
 androidx.appcompat:appcompat-resources:1.4.2                    :   65 Kb
 androidx.appcompat:appcompat:1.4.2                              : 1092 Kb
 androidx.arch.core:core-common:2.1.0                            :   10 Kb
-androidx.arch.core:core-runtime:2.1.0                           :    5 Kb
-androidx.collection:collection-jvm:1.4.5                        :  770 Kb
+androidx.arch.core:core-runtime:2.0.0                           :    5 Kb
+androidx.collection:collection:1.1.0                            :   41 Kb
 androidx.core:core:1.7.0                                        :  957 Kb
 androidx.cursoradapter:cursoradapter:1.0.0                      :   10 Kb
 androidx.customview:customview:1.0.0                            :   32 Kb
 androidx.drawerlayout:drawerlayout:1.0.0                        :   31 Kb
 androidx.fragment:fragment:1.3.6                                :  291 Kb
 androidx.interpolator:interpolator:1.0.0                        :    7 Kb
-androidx.lifecycle:lifecycle-common:2.4.0                       :   23 Kb
+androidx.lifecycle:lifecycle-common:2.3.1                       :   22 Kb
 androidx.lifecycle:lifecycle-livedata-core:2.3.1                :    8 Kb
-androidx.lifecycle:lifecycle-livedata:2.1.0                     :   10 Kb
-androidx.lifecycle:lifecycle-runtime:2.4.0                      :   11 Kb
+androidx.lifecycle:lifecycle-livedata:2.0.0                     :    9 Kb
+androidx.lifecycle:lifecycle-runtime:2.3.1                      :   10 Kb
 androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.1         :   15 Kb
 androidx.lifecycle:lifecycle-viewmodel:2.3.1                    :   10 Kb
 androidx.loader:loader:1.0.0                                    :   32 Kb
@@ -34,5 +34,5 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b
 org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              :    6 Mb
+Total transitive dependencies size                              :    5 Mb
 

--- a/features/dd-sdk-android-trace-api/api/compiler-meta.txt
+++ b/features/dd-sdk-android-trace-api/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/features/dd-sdk-android-trace-api/build.gradle.kts
+++ b/features/dd-sdk-android-trace-api/build.gradle.kts
@@ -38,6 +38,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.trace.api"
 }
@@ -45,6 +47,7 @@ android {
 dependencies {
     api(project(":dd-sdk-android-core"))
     implementation(project(":dd-sdk-android-internal"))
+    implementation(libs.kotlin)
     implementation(libs.gson)
     implementation(libs.androidXAnnotation)
     implementation(libs.bundles.traceCore)

--- a/features/dd-sdk-android-trace-internal/api/compiler-meta.txt
+++ b/features/dd-sdk-android-trace-internal/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/features/dd-sdk-android-trace-internal/build.gradle.kts
+++ b/features/dd-sdk-android-trace-internal/build.gradle.kts
@@ -38,6 +38,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.trace.internal"
 }
@@ -45,6 +47,7 @@ android {
 dependencies {
     api(project(":dd-sdk-android-core"))
     implementation(project(":dd-sdk-android-internal"))
+    implementation(libs.kotlin)
     implementation(libs.gson)
     implementation(libs.androidXAnnotation)
     implementation(libs.bundles.traceCore)

--- a/features/dd-sdk-android-trace-otel/api/compiler-meta.txt
+++ b/features/dd-sdk-android-trace-otel/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/features/dd-sdk-android-trace-otel/build.gradle.kts
+++ b/features/dd-sdk-android-trace-otel/build.gradle.kts
@@ -38,6 +38,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     defaultConfig {
         buildFeatures {

--- a/features/dd-sdk-android-trace-otel/src/main/kotlin/com/datadog/android/trace/opentelemetry/internal/OtelContext.kt
+++ b/features/dd-sdk-android-trace-otel/src/main/kotlin/com/datadog/android/trace/opentelemetry/internal/OtelContext.kt
@@ -29,7 +29,7 @@ internal class OtelContext(
     }
 
     @Suppress("ReturnCount")
-    override fun <V> with(k1: ContextKey<V>, v1: V): Context {
+    override fun <V : Any> with(k1: ContextKey<V>, v1: V): Context {
         if (OTEL_CONTEXT_SPAN_KEY == k1.toString()) {
             return OtelContext(wrapped, v1 as Span, rootSpan)
         } else if (OTEL_CONTEXT_ROOT_SPAN_KEY == k1.toString()) {

--- a/features/dd-sdk-android-trace/api/compiler-meta.txt
+++ b/features/dd-sdk-android-trace/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -20,6 +20,7 @@ public final class com/datadog/android/trace/ApmNetworkInstrumentationConfigurat
 public final class com/datadog/android/trace/ApmNetworkTracingScope : java/lang/Enum {
 	public static final field ALL Lcom/datadog/android/trace/ApmNetworkTracingScope;
 	public static final field EXCLUDE_INTERNAL_REDIRECTS Lcom/datadog/android/trace/ApmNetworkTracingScope;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/trace/ApmNetworkTracingScope;
 	public static fun values ()[Lcom/datadog/android/trace/ApmNetworkTracingScope;
 }
@@ -86,6 +87,7 @@ public final class com/datadog/android/trace/TraceConfiguration$Builder {
 public final class com/datadog/android/trace/TraceContextInjection : java/lang/Enum {
 	public static final field ALL Lcom/datadog/android/trace/TraceContextInjection;
 	public static final field SAMPLED Lcom/datadog/android/trace/TraceContextInjection;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/trace/TraceContextInjection;
 	public static fun values ()[Lcom/datadog/android/trace/TraceContextInjection;
 }
@@ -627,6 +629,7 @@ public final class com/datadog/android/trace/model/SpanEvent$Type : java/lang/En
 	public static final field TABLET Lcom/datadog/android/trace/model/SpanEvent$Type;
 	public static final field TV Lcom/datadog/android/trace/model/SpanEvent$Type;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/trace/model/SpanEvent$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/trace/model/SpanEvent$Type;
 	public static fun values ()[Lcom/datadog/android/trace/model/SpanEvent$Type;

--- a/features/dd-sdk-android-trace/build.gradle.kts
+++ b/features/dd-sdk-android-trace/build.gradle.kts
@@ -41,6 +41,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     defaultConfig {
         consumerProguardFiles("consumer-rules.pro")

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/TraceConfiguration.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/TraceConfiguration.kt
@@ -12,6 +12,7 @@ import com.datadog.android.trace.event.SpanEventMapper
 /**
  * Describes configuration to be used for the Traces feature.
  */
+@ExposedCopyVisibility
 data class TraceConfiguration internal constructor(
     internal val customEndpointUrl: String?,
     internal val eventMapper: SpanEventMapper,

--- a/features/dd-sdk-android-webview/api/compiler-meta.txt
+++ b/features/dd-sdk-android-webview/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/features/dd-sdk-android-webview/build.gradle.kts
+++ b/features/dd-sdk-android-webview/build.gradle.kts
@@ -38,6 +38,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.webview"
 }

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/domain/WebViewNativeRumViewsCache.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/domain/WebViewNativeRumViewsCache.kt
@@ -59,19 +59,15 @@ internal class WebViewNativeRumViewsCache(
     private fun addToCache(
         entry: ViewEntry
     ) {
-        if (parentViewsHistoryQueue.isEmpty() ||
-            (
-                parentViewsHistoryQueue.first.viewId != entry.viewId &&
-                    parentViewsHistoryQueue.first.timestamp <= entry.timestamp
-                )
-        ) {
+        val first = parentViewsHistoryQueue.firstOrNull()
+        if (first == null || (first.viewId != entry.viewId && first.timestamp <= entry.timestamp)) {
             // add(index, element) instead of addFirst here is on purpose, to prevent issues
             // with old AGP being used when compiling with Android API 35.
             // Index 0 is always safe
             @Suppress("UnsafeThirdPartyFunctionCall")
             parentViewsHistoryQueue.add(0, entry)
-        } else if (parentViewsHistoryQueue.first.viewId == entry.viewId) {
-            // the function is synchronized and we are checking the size before
+        } else if (first.viewId == entry.viewId) {
+            // the function is synchronized, and we are checking the size before
             if (parentViewsHistoryQueue.isNotEmpty()) {
                 // removeAt(index) instead of removeFirst here is on purpose, to prevent issues
                 // with old AGP being used when compiling with Android API 35.

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,19 @@ org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 # Allows Kotlin with target JVM compat 17 to be built on JDK 21
 kotlin.jvm.target.validation.mode = IGNORE
 
+# TODO RUM-18188
+# Cronet ships cronet-api and its transitive cronet-shared with the same
+# `org.chromium.net` namespace. AGP 9 turned that from a warning into an error.
+# Remove once Cronet publishes distinct namespaces.
+android.uniquePackageNames=false
+
+# TODO RUM-18189
+# Kotlin 2.0 is not compatible with new DSL APIs enforced in AGP 9 by default. This option will
+# be removed in AGP 10 (2027-2028?)
+android.newDsl=false
+android.builtInKotlin=false
+
+# Changed from false to true by default on AGP 8 -> AGP 9, putting the old behavior
+android.onlyEnableUnitTestForTheTestedBuildType=false
+
 # Leave the next line blank for CI

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ okHttp = "4.12.0"
 # Android
 adapterDelegates = "4.3.2"
 androidDesugaringSdk = "2.0.4"
-androidToolsPlugin = "8.13.2"
+androidToolsPlugin = "9.1.1"
 androidXAnnotations = "1.9.1"
 androidXAppCompat = "1.4.2" # Next version will bring coroutines
 androidXCar = "1.4.0"
@@ -28,7 +28,6 @@ androidXLeanback = "1.0.0"
 androidXLifecycle = "2.8.7"
 androidXLegacy = "1.0.0"
 androidXMetrics = "1.0.0-beta03"
-androidXMultidex = "2.0.1"
 androidXNavigation = "2.7.7"
 androidXRecyclerView = "1.3.2"
 androidXWorkManager = "2.8.1" # Next version will bring coroutines
@@ -87,7 +86,7 @@ picasso = "2.8"
 room = "2.5.1"
 rxJava3 = "3.0.0"
 timber = "5.0.1"
-coroutines = "1.4.2"
+coroutines = "1.7.3"
 exoplayer = "2.19.1"
 newPipeExtractor = "v0.24.6"
 navigation3 = "1.0.0-alpha01"
@@ -147,7 +146,6 @@ androidXCoreKtx = { module = "androidx.core:core-ktx", version.ref = "androidXCo
 androidXFragment = { module = "androidx.fragment:fragment", version.ref = "androidXFragment" }
 androidXLeanback = { module = "androidx.leanback:leanback", version.ref = "androidXLeanback" }
 androidXMetrics = { module = "androidx.metrics:metrics-performance", version.ref = "androidXMetrics" }
-androidXMultidex = { module = "androidx.multidex:multidex", version.ref = "androidXMultidex" }
 androidXNavigationFragment = { module = "androidx.navigation:navigation-fragment", version.ref = "androidXNavigation" }
 androidXNavigationRuntime = { module = "androidx.navigation:navigation-runtime", version.ref = "androidXNavigation" }
 androidXNavigationUIKtx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidXNavigation" }

--- a/instrumented/integration/build.gradle.kts
+++ b/instrumented/integration/build.gradle.kts
@@ -19,6 +19,8 @@ plugins {
     id("datadogBuildConfig")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
 
     compileSdk = AndroidConfig.TARGET_SDK
@@ -36,7 +38,6 @@ android {
             compose = true
         }
 
-        multiDexEnabled = true
         vectorDrawables.useSupportLibrary = true
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -114,7 +115,6 @@ dependencies {
     implementation(libs.gson)
     implementation(libs.kotlin)
     implementation(libs.bundles.androidXSupportBase)
-    implementation(libs.androidXMultidex)
     implementation(libs.elmyr)
     implementation(libs.leakCanaryAndroid)
 
@@ -145,5 +145,10 @@ dependencies {
 }
 
 datadogBuild {
-    applyKotlinConfig()
+    applyKotlinConfig(
+        // TODO RUM-18191
+        // Suppress -> generateFunctionKeyMetaClasses is deprecated. It was replaced by emitting annotations on functions
+        // instead. Use generateFunctionKeyMetaAnnotations instead. Seems to Compose <-> Kotlin mismatch.
+        evaluateWarningsAsErrors = false
+    )
 }

--- a/integrations/dd-sdk-android-apollo/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-apollo/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-apollo/build.gradle.kts
+++ b/integrations/dd-sdk-android-apollo/build.gradle.kts
@@ -36,6 +36,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.apollo"
 }

--- a/integrations/dd-sdk-android-coil/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-coil/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-coil/build.gradle.kts
+++ b/integrations/dd-sdk-android-coil/build.gradle.kts
@@ -36,6 +36,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.coil"
 }

--- a/integrations/dd-sdk-android-coil/transitiveDependencies
+++ b/integrations/dd-sdk-android-coil/transitiveDependencies
@@ -1,8 +1,8 @@
 Dependencies List
 
-androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
-androidx.lifecycle:lifecycle-common-java8:2.6.2                 :  261 b 
-androidx.lifecycle:lifecycle-common:2.6.2                       :   51 Kb
+androidx.annotation:annotation:1.1.0                            :   27 Kb
+androidx.lifecycle:lifecycle-common-java8:2.2.0                 : 1015 b 
+androidx.lifecycle:lifecycle-common:2.2.0                       :   21 Kb
 com.squareup.okhttp3:okhttp:4.12.0                              :  771 Kb
 com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
 io.coil-kt:coil-base:1.0.0                                      :  395 Kb
@@ -10,8 +10,8 @@ io.coil-kt:coil:1.0.0                                           :   15 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
 org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
-org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4          :   19 Kb
-org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4         : 1442 Kb
+org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9          :   19 Kb
+org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.3.9         : 1629 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    4 Mb

--- a/integrations/dd-sdk-android-coil3/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-coil3/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-coil3/api/dd-sdk-android-coil3.api
+++ b/integrations/dd-sdk-android-coil3/api/dd-sdk-android-coil3.api
@@ -2,6 +2,9 @@ public final class com/datadog/android/coil3/DatadogCoilRequestListener : coil3/
 	public fun <init> ()V
 	public fun <init> (Lcom/datadog/android/api/SdkCore;)V
 	public synthetic fun <init> (Lcom/datadog/android/api/SdkCore;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun onCancel (Lcoil3/request/ImageRequest;)V
 	public fun onError (Lcoil3/request/ImageRequest;Lcoil3/request/ErrorResult;)V
+	public fun onStart (Lcoil3/request/ImageRequest;)V
+	public fun onSuccess (Lcoil3/request/ImageRequest;Lcoil3/request/SuccessResult;)V
 }
 

--- a/integrations/dd-sdk-android-coil3/build.gradle.kts
+++ b/integrations/dd-sdk-android-coil3/build.gradle.kts
@@ -36,6 +36,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.coil3"
 }

--- a/integrations/dd-sdk-android-coil3/transitiveDependencies
+++ b/integrations/dd-sdk-android-coil3/transitiveDependencies
@@ -1,6 +1,6 @@
 Dependencies List
 
-androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
+androidx.annotation:annotation-jvm:1.8.1                        :   54 Kb
 androidx.arch.core:core-common:2.2.0                            :   11 Kb
 androidx.lifecycle:lifecycle-common-jvm:2.8.7                   :   55 Kb
 androidx.lifecycle:lifecycle-runtime-android:2.8.7              :   80 Kb

--- a/integrations/dd-sdk-android-compose/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-compose/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-compose/build.gradle.kts
+++ b/integrations/dd-sdk-android-compose/build.gradle.kts
@@ -38,6 +38,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.compose"
     defaultConfig {
@@ -77,7 +79,13 @@ unMock {
 }
 
 datadogBuild {
-    applyKotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+    applyKotlinConfig(
+        // TODO RUM-18191
+        // Suppress -> generateFunctionKeyMetaClasses is deprecated. It was replaced by emitting annotations on functions
+        // instead. Use generateFunctionKeyMetaAnnotations instead. Seems to Compose <-> Kotlin mismatch.
+        evaluateWarningsAsErrors = false,
+        jvmBytecodeTarget = JvmTarget.JVM_11
+    )
     applyAndroidLibraryConfig()
     applyJunitConfig()
     applyJavadocConfig()

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/ComposeActionTrackingStrategyTest.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/ComposeActionTrackingStrategyTest.kt
@@ -293,11 +293,11 @@ class ComposeActionTrackingStrategyTest {
                 )
             )
         }
-        whenever(nodeList[0].zSortedChildren) doReturn mutableVectorOf(nodeList[1], nodeList[2])
-        whenever(nodeList[1].zSortedChildren) doReturn mutableVectorOf(nodeList[3], nodeList[4])
-        whenever(nodeList[2].zSortedChildren) doReturn mutableVectorOf()
-        whenever(nodeList[3].zSortedChildren) doReturn mutableVectorOf()
-        whenever(nodeList[4].zSortedChildren) doReturn mutableVectorOf()
+        whenever(nodeList[0].zSortedChildren) doReturn mutableVectorOf<LayoutNode>(nodeList[1], nodeList[2])
+        whenever(nodeList[1].zSortedChildren) doReturn mutableVectorOf<LayoutNode>(nodeList[3], nodeList[4])
+        whenever(nodeList[2].zSortedChildren) doReturn mutableVectorOf<LayoutNode>()
+        whenever(nodeList[3].zSortedChildren) doReturn mutableVectorOf<LayoutNode>()
+        whenever(nodeList[4].zSortedChildren) doReturn mutableVectorOf<LayoutNode>()
         whenever(mockAndroidComposeView.root) doReturn nodeList[0]
     }
 

--- a/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeUtilsTest.kt
+++ b/integrations/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/internal/utils/LayoutNodeUtilsTest.kt
@@ -40,6 +40,7 @@ import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
@@ -96,6 +97,8 @@ class LayoutNodeUtilsTest {
 
     // region Legacy Compose (SemanticsModifier)
 
+    // TODO RUM-18190 Access to the internal classes
+    @Disabled
     @Test
     fun `M return correct target node W call resolveLayoutNode {legacy compose}`(
         forge: Forge
@@ -127,6 +130,8 @@ class LayoutNodeUtilsTest {
 
     // region Clickable Modifier Elements
 
+    // TODO RUM-18190 Access to the internal classes
+    @Disabled
     @ParameterizedTest
     @MethodSource("clickableModifierElements")
     fun `M return clickable target node W resolveLayoutNode {clickable modifier element}`(
@@ -150,6 +155,8 @@ class LayoutNodeUtilsTest {
 
     // region Scrollable Modifier Elements
 
+    // TODO RUM-18190 Access to the internal classes
+    @Disabled
     @ParameterizedTest
     @MethodSource("scrollableModifierElements")
     fun `M return scrollable target node W resolveLayoutNode {scrollable modifier element}`(
@@ -227,6 +234,8 @@ class LayoutNodeUtilsTest {
 
     // region Reflection Fallback State Machine
 
+    // TODO RUM-18190 Access to the internal classes
+    @Disabled
     @Test
     fun `M keep skipping reflection path W getLayoutNodeBoundsInWindow() {repeated, internal succeeds}`() {
         // Given
@@ -274,6 +283,8 @@ class LayoutNodeUtilsTest {
             .doesNotContainValue(null)
     }
 
+    // TODO RUM-18190 Access to the internal classes
+    @Disabled
     @Test
     fun `M not grow suffix cache W getLayoutNodeBoundsInWindow() {repeated reflection calls}`() {
         // Given
@@ -322,6 +333,8 @@ class LayoutNodeUtilsTest {
         verify(testedLayoutNodeUtils, never()).getLayoutNodeBoundsInWindowReflection(any<LayoutNode>())
     }
 
+    // TODO RUM-18190 Access to the internal classes
+    @Disabled
     @Test
     fun `M stay on internal W getLayoutNodeBoundsInWindow() {first call resolved via internal, repeated}`() {
         // Given
@@ -394,6 +407,8 @@ class LayoutNodeUtilsTest {
             .isEqualTo(LayoutNodeUtils.MethodResolver.State.MANGLING_FAILED)
     }
 
+    // TODO RUM-18190 Access to the internal classes
+    @Disabled
     @Test
     fun `M keep state UNKNOWN W getLayoutNodeBoundsInWindow() {internal path succeeds}`() {
         // Given

--- a/integrations/dd-sdk-android-compose/transitiveDependencies
+++ b/integrations/dd-sdk-android-compose/transitiveDependencies
@@ -1,12 +1,12 @@
 Dependencies List
 
-androidx.activity:activity-compose:1.7.2                        : 1082 Kb
-androidx.activity:activity-ktx:1.7.2                            :   25 Kb
-androidx.activity:activity:1.7.2                                :  139 Kb
-androidx.annotation:annotation-experimental:1.4.1               :   38 Kb
-androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
+androidx.activity:activity-compose:1.7.0                        : 1082 Kb
+androidx.activity:activity-ktx:1.7.0                            :   25 Kb
+androidx.activity:activity:1.7.0                                :  139 Kb
+androidx.annotation:annotation-experimental:1.1.0               :   16 Kb
+androidx.annotation:annotation:1.5.0                            :   52 Kb
 androidx.arch.core:core-common:2.2.0                            :   11 Kb
-androidx.collection:collection-jvm:1.4.5                        :  770 Kb
+androidx.collection:collection:1.0.0                            :   40 Kb
 androidx.compose.animation:animation-android:1.5.4              : 1309 Kb
 androidx.compose.animation:animation-core-android:1.5.4         : 1338 Kb
 androidx.compose.foundation:foundation-android:1.5.4            :    3 Mb
@@ -21,31 +21,31 @@ androidx.compose.ui:ui-geometry-android:1.5.4                   :   36 Kb
 androidx.compose.ui:ui-graphics-android:1.5.4                   : 1422 Kb
 androidx.compose.ui:ui-text-android:1.5.4                       :  770 Kb
 androidx.compose.ui:ui-unit-android:1.5.4                       :   64 Kb
-androidx.core:core-ktx:1.15.0                                   :  171 Kb
-androidx.core:core:1.15.0                                       : 1304 Kb
-androidx.lifecycle:lifecycle-common-java8:2.6.2                 :  261 b 
-androidx.lifecycle:lifecycle-common:2.6.2                       :   51 Kb
-androidx.lifecycle:lifecycle-livedata-core:2.6.2                :   11 Kb
-androidx.lifecycle:lifecycle-runtime-ktx:2.6.2                  :   60 Kb
-androidx.lifecycle:lifecycle-runtime:2.6.2                      :   21 Kb
-androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2            :   21 Kb
-androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2                :    4 Kb
-androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.2         :   38 Kb
-androidx.lifecycle:lifecycle-viewmodel:2.6.2                    :   38 Kb
-androidx.navigation:navigation-common-ktx:2.7.7                 :    2 Kb
-androidx.navigation:navigation-common:2.7.7                     :  180 Kb
-androidx.navigation:navigation-compose:2.7.7                    : 1139 Kb
-androidx.navigation:navigation-runtime-ktx:2.7.7                :    2 Kb
-androidx.navigation:navigation-runtime:2.7.7                    :  126 Kb
+androidx.core:core-ktx:1.2.0                                    :  155 Kb
+androidx.core:core:1.8.0                                        : 1052 Kb
+androidx.lifecycle:lifecycle-common-java8:2.6.1                 :  261 b 
+androidx.lifecycle:lifecycle-common:2.6.1                       :   51 Kb
+androidx.lifecycle:lifecycle-livedata-core:2.6.1                :   11 Kb
+androidx.lifecycle:lifecycle-runtime-ktx:2.6.1                  :   60 Kb
+androidx.lifecycle:lifecycle-runtime:2.6.1                      :   21 Kb
+androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1            :   21 Kb
+androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1                :    4 Kb
+androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1         :   38 Kb
+androidx.lifecycle:lifecycle-viewmodel:2.6.1                    :   38 Kb
+androidx.navigation:navigation-common-ktx:2.6.0                 :    2 Kb
+androidx.navigation:navigation-common:2.6.0                     :  178 Kb
+androidx.navigation:navigation-compose:2.6.0                    : 1110 Kb
+androidx.navigation:navigation-runtime-ktx:2.6.0                :    2 Kb
+androidx.navigation:navigation-runtime:2.6.0                    :  125 Kb
 androidx.savedstate:savedstate-ktx:1.2.1                        :    3 Kb
 androidx.savedstate:savedstate:1.2.1                            :   19 Kb
 androidx.versionedparcelable:versionedparcelable:1.1.1          :   30 Kb
-org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
-org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
+org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0                   :  963 b 
+org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0                   :  968 b 
 org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4          :   19 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4         : 1442 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              :   28 Mb
+Total transitive dependencies size                              :   27 Mb
 

--- a/integrations/dd-sdk-android-cronet/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-cronet/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-cronet/build.gradle.kts
+++ b/integrations/dd-sdk-android-cronet/build.gradle.kts
@@ -37,6 +37,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.cronet"
     lint {

--- a/integrations/dd-sdk-android-fresco/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-fresco/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-fresco/build.gradle.kts
+++ b/integrations/dd-sdk-android-fresco/build.gradle.kts
@@ -36,6 +36,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.fresco"
 }

--- a/integrations/dd-sdk-android-glide/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-glide/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-glide/build.gradle.kts
+++ b/integrations/dd-sdk-android-glide/build.gradle.kts
@@ -36,6 +36,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.glide"
 }

--- a/integrations/dd-sdk-android-glide/transitiveDependencies
+++ b/integrations/dd-sdk-android-glide/transitiveDependencies
@@ -1,26 +1,26 @@
 Dependencies List
 
 androidx.activity:activity:1.7.2                                :  139 Kb
-androidx.annotation:annotation-experimental:1.4.1               :   38 Kb
-androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
+androidx.annotation:annotation-experimental:1.1.0               :   16 Kb
+androidx.annotation:annotation-jvm:1.7.1                        :   53 Kb
 androidx.arch.core:core-common:2.2.0                            :   11 Kb
-androidx.arch.core:core-runtime:2.2.0                           :    7 Kb
-androidx.collection:collection-jvm:1.4.5                        :  770 Kb
-androidx.core:core-ktx:1.15.0                                   :  171 Kb
-androidx.core:core:1.15.0                                       : 1304 Kb
-androidx.customview:customview:1.1.0                            :   32 Kb
+androidx.arch.core:core-runtime:2.1.0                           :    5 Kb
+androidx.collection:collection:1.1.0                            :   41 Kb
+androidx.core:core-ktx:1.2.0                                    :  155 Kb
+androidx.core:core:1.8.0                                        : 1052 Kb
+androidx.customview:customview:1.0.0                            :   32 Kb
 androidx.exifinterface:exifinterface:1.3.6                      :   62 Kb
-androidx.fragment:fragment:1.6.2                                :  345 Kb
+androidx.fragment:fragment:1.6.1                                :  345 Kb
 androidx.interpolator:interpolator:1.0.0                        :    7 Kb
-androidx.lifecycle:lifecycle-common:2.6.2                       :   51 Kb
-androidx.lifecycle:lifecycle-livedata-core:2.6.2                :   11 Kb
-androidx.lifecycle:lifecycle-livedata:2.6.2                     :   18 Kb
-androidx.lifecycle:lifecycle-runtime:2.6.2                      :   21 Kb
-androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.2         :   38 Kb
-androidx.lifecycle:lifecycle-viewmodel:2.6.2                    :   38 Kb
+androidx.lifecycle:lifecycle-common:2.6.1                       :   51 Kb
+androidx.lifecycle:lifecycle-livedata-core:2.6.1                :   11 Kb
+androidx.lifecycle:lifecycle-livedata:2.6.1                     :   18 Kb
+androidx.lifecycle:lifecycle-runtime:2.6.1                      :   21 Kb
+androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.1         :   38 Kb
+androidx.lifecycle:lifecycle-viewmodel:2.6.1                    :   38 Kb
 androidx.loader:loader:1.0.0                                    :   32 Kb
 androidx.savedstate:savedstate:1.2.1                            :   19 Kb
-androidx.tracing:tracing:1.2.0                                  :    5 Kb
+androidx.tracing:tracing:1.0.0                                  :    4 Kb
 androidx.vectordrawable:vectordrawable-animated:1.1.0           :   33 Kb
 androidx.vectordrawable:vectordrawable:1.1.0                    :   32 Kb
 androidx.versionedparcelable:versionedparcelable:1.1.1          :   30 Kb
@@ -39,5 +39,5 @@ org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4          :   19 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4         : 1442 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              :    8 Mb
+Total transitive dependencies size                              :    7 Mb
 

--- a/integrations/dd-sdk-android-okhttp-otel/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-okhttp-otel/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-okhttp-otel/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp-otel/build.gradle.kts
@@ -36,6 +36,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.okhttp.otel"
 }

--- a/integrations/dd-sdk-android-okhttp/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-okhttp/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-okhttp/api/dd-sdk-android-okhttp.api
+++ b/integrations/dd-sdk-android-okhttp/api/dd-sdk-android-okhttp.api
@@ -59,6 +59,7 @@ public final class com/datadog/android/okhttp/TraceContext {
 public final class com/datadog/android/okhttp/TraceContextInjection : java/lang/Enum {
 	public static final field ALL Lcom/datadog/android/okhttp/TraceContextInjection;
 	public static final field SAMPLED Lcom/datadog/android/okhttp/TraceContextInjection;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/okhttp/TraceContextInjection;
 	public static fun values ()[Lcom/datadog/android/okhttp/TraceContextInjection;
 }

--- a/integrations/dd-sdk-android-okhttp/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp/build.gradle.kts
@@ -40,6 +40,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.okhttp"
 }

--- a/integrations/dd-sdk-android-rum-coroutines/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-rum-coroutines/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
@@ -35,6 +35,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.rum.coroutines"
 }

--- a/integrations/dd-sdk-android-rum-coroutines/transitiveDependencies
+++ b/integrations/dd-sdk-android-rum-coroutines/transitiveDependencies
@@ -1,10 +1,10 @@
 Dependencies List
 
-org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
-org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
+org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.20                  :  963 b 
+org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20                  :  969 b 
 org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
-org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4         : 1442 Kb
-org.jetbrains:annotations:13.0                                  :   17 Kb
+org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3         : 1514 Kb
+org.jetbrains:annotations:23.0.0                                :   28 Kb
 
 Total transitive dependencies size                              :    3 Mb
 

--- a/integrations/dd-sdk-android-rx/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-rx/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-rx/build.gradle.kts
+++ b/integrations/dd-sdk-android-rx/build.gradle.kts
@@ -36,6 +36,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.rx"
 }

--- a/integrations/dd-sdk-android-sqldelight/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-sqldelight/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-sqldelight/build.gradle.kts
+++ b/integrations/dd-sdk-android-sqldelight/build.gradle.kts
@@ -36,6 +36,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.sqldelight"
 }

--- a/integrations/dd-sdk-android-sqldelight/transitiveDependencies
+++ b/integrations/dd-sdk-android-sqldelight/transitiveDependencies
@@ -1,7 +1,7 @@
 Dependencies List
 
-androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
-androidx.sqlite:sqlite:2.3.0                                    :   29 Kb
+androidx.annotation:annotation:1.0.0                            :   24 Kb
+androidx.sqlite:sqlite:2.1.0                                    :   10 Kb
 com.squareup.okhttp3:okhttp:4.12.0                              :  771 Kb
 com.squareup.okio:okio-jvm:3.6.0                                :  351 Kb
 com.squareup.sqldelight:android-driver:1.5.5                    :   23 Kb

--- a/integrations/dd-sdk-android-timber/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-timber/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-timber/build.gradle.kts
+++ b/integrations/dd-sdk-android-timber/build.gradle.kts
@@ -36,6 +36,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.timber"
 }

--- a/integrations/dd-sdk-android-timber/transitiveDependencies
+++ b/integrations/dd-sdk-android-timber/transitiveDependencies
@@ -2,7 +2,7 @@ Dependencies List
 
 com.jakewharton.timber:timber:5.0.1                             :   31 Kb
 org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
-org.jetbrains:annotations:20.1.0                                :   25 Kb
+org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              : 1763 Kb
+Total transitive dependencies size                              : 1755 Kb
 

--- a/integrations/dd-sdk-android-trace-coroutines/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-trace-coroutines/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
@@ -35,6 +35,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.trace.coroutines"
 }

--- a/integrations/dd-sdk-android-trace-coroutines/transitiveDependencies
+++ b/integrations/dd-sdk-android-trace-coroutines/transitiveDependencies
@@ -1,8 +1,10 @@
 Dependencies List
 
+org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.20                  :  963 b 
+org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20                  :  969 b 
 org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
-org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.4.2         : 1635 Kb
-org.jetbrains:annotations:13.0                                  :   17 Kb
+org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.7.3         : 1514 Kb
+org.jetbrains:annotations:23.0.0                                :   28 Kb
 
 Total transitive dependencies size                              :    3 Mb
 

--- a/integrations/dd-sdk-android-tv/api/compiler-meta.txt
+++ b/integrations/dd-sdk-android-tv/api/compiler-meta.txt
@@ -1,2 +1,2 @@
-kotlin_abi_version=1.8.0
+kotlin_abi_version=2.0.0
 jvm_bytecode_version=11

--- a/integrations/dd-sdk-android-tv/build.gradle.kts
+++ b/integrations/dd-sdk-android-tv/build.gradle.kts
@@ -36,6 +36,8 @@ plugins {
     id("test-pyramid-api-surface")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.tv"
 }

--- a/integrations/dd-sdk-android-tv/transitiveDependencies
+++ b/integrations/dd-sdk-android-tv/transitiveDependencies
@@ -1,46 +1,37 @@
 Dependencies List
 
-androidx.activity:activity:1.7.2                                :  139 Kb
-androidx.annotation:annotation-experimental:1.4.1               :   38 Kb
-androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
-androidx.arch.core:core-common:2.2.0                            :   11 Kb
-androidx.arch.core:core-runtime:2.2.0                           :    7 Kb
+androidx.annotation:annotation:1.0.0                            :   24 Kb
+androidx.arch.core:core-common:2.0.0                            :   10 Kb
+androidx.arch.core:core-runtime:2.0.0                           :    5 Kb
 androidx.asynclayoutinflater:asynclayoutinflater:1.0.0          :    7 Kb
-androidx.collection:collection-jvm:1.4.5                        :  770 Kb
+androidx.collection:collection:1.0.0                            :   40 Kb
 androidx.coordinatorlayout:coordinatorlayout:1.0.0              :   43 Kb
-androidx.core:core-ktx:1.15.0                                   :  171 Kb
-androidx.core:core:1.15.0                                       : 1304 Kb
+androidx.core:core:1.0.0                                        :  618 Kb
 androidx.cursoradapter:cursoradapter:1.0.0                      :   10 Kb
-androidx.customview:customview:1.1.0                            :   32 Kb
+androidx.customview:customview:1.0.0                            :   32 Kb
 androidx.documentfile:documentfile:1.0.0                        :   10 Kb
 androidx.drawerlayout:drawerlayout:1.0.0                        :   31 Kb
-androidx.fragment:fragment:1.6.2                                :  345 Kb
+androidx.fragment:fragment:1.0.0                                :  152 Kb
 androidx.interpolator:interpolator:1.0.0                        :    7 Kb
 androidx.leanback:leanback:1.0.0                                : 1329 Kb
 androidx.legacy:legacy-support-core-ui:1.0.0                    :   11 Kb
 androidx.legacy:legacy-support-core-utils:1.0.0                 :    4 Kb
-androidx.lifecycle:lifecycle-common:2.6.2                       :   51 Kb
-androidx.lifecycle:lifecycle-livedata-core:2.6.2                :   11 Kb
-androidx.lifecycle:lifecycle-livedata:2.6.2                     :   18 Kb
-androidx.lifecycle:lifecycle-runtime:2.6.2                      :   21 Kb
-androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.2         :   38 Kb
-androidx.lifecycle:lifecycle-viewmodel:2.6.2                    :   38 Kb
+androidx.lifecycle:lifecycle-common:2.0.0                       :   19 Kb
+androidx.lifecycle:lifecycle-livedata-core:2.0.0                :    8 Kb
+androidx.lifecycle:lifecycle-livedata:2.0.0                     :    9 Kb
+androidx.lifecycle:lifecycle-runtime:2.0.0                      :    8 Kb
+androidx.lifecycle:lifecycle-viewmodel:2.0.0                    :    6 Kb
 androidx.loader:loader:1.0.0                                    :   32 Kb
 androidx.localbroadcastmanager:localbroadcastmanager:1.0.0      :    6 Kb
 androidx.media:media:1.0.0                                      :  330 Kb
 androidx.print:print:1.0.0                                      :   15 Kb
-androidx.recyclerview:recyclerview:1.3.2                        :  399 Kb
-androidx.savedstate:savedstate:1.2.1                            :   19 Kb
-androidx.slidingpanelayout:slidingpanelayout:1.2.0              :   37 Kb
+androidx.recyclerview:recyclerview:1.0.0                        :  344 Kb
+androidx.slidingpanelayout:slidingpanelayout:1.0.0              :   22 Kb
 androidx.swiperefreshlayout:swiperefreshlayout:1.0.0            :   32 Kb
-androidx.versionedparcelable:versionedparcelable:1.1.1          :   30 Kb
+androidx.versionedparcelable:versionedparcelable:1.0.0          :   26 Kb
 androidx.viewpager:viewpager:1.0.0                              :   52 Kb
-org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.10                  :  959 b 
-org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.10                  :  965 b 
 org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
-org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4          :   19 Kb
-org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4         : 1442 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              :    8 Mb
+Total transitive dependencies size                              :    4 Mb
 

--- a/reliability/core-it/build.gradle.kts
+++ b/reliability/core-it/build.gradle.kts
@@ -21,6 +21,8 @@ plugins {
     id("test-pyramid-api-usage")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
 
     compileSdk = AndroidConfig.TARGET_SDK
@@ -30,7 +32,6 @@ android {
     defaultConfig {
         minSdk = AndroidConfig.MIN_SDK
         targetSdk = AndroidConfig.TARGET_SDK
-        multiDexEnabled = true
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/FeatureSdkCoreTest.kt
+++ b/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/FeatureSdkCoreTest.kt
@@ -103,6 +103,7 @@ class FeatureSdkCoreTest : MockServerTest() {
     @Test
     fun mustReturnTheCrashReportFeature_when_getFeature_crashReportEnabled() {
         // Given
+        @Suppress("DATA_CLASS_INVISIBLE_COPY_USAGE_WARNING")
         val fakeConfigCrashReportsEnabled = fakeConfiguration.copy(crashReportsEnabled = true)
 
         // When
@@ -124,6 +125,7 @@ class FeatureSdkCoreTest : MockServerTest() {
     @Test
     fun mustReturnEmptyFeatures_when_getFeature_crashReportNotEnabled() {
         // Given
+        @Suppress("DATA_CLASS_INVISIBLE_COPY_USAGE_WARNING")
         val fakeConfigCrashReportsNotEnabled = fakeConfiguration.copy(crashReportsEnabled = false)
 
         // When

--- a/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/InternalSdkCoreTest.kt
+++ b/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/InternalSdkCoreTest.kt
@@ -537,6 +537,7 @@ class InternalSdkCoreTest : MockServerTest() {
     @Test
     fun mustReturnTheCrashReportFeature_when_getAllFeatures_crashReportEnabled() {
         // Given
+        @Suppress("DATA_CLASS_INVISIBLE_COPY_USAGE_WARNING")
         val fakeConfigCrashReportsEnabled = fakeConfiguration.copy(crashReportsEnabled = true)
 
         // When
@@ -559,6 +560,7 @@ class InternalSdkCoreTest : MockServerTest() {
     @Test
     fun mustReturnEmptyFeatures_when_getAllFeatures_crashReportNotEnabled() {
         // Given
+        @Suppress("DATA_CLASS_INVISIBLE_COPY_USAGE_WARNING")
         val fakeConfigCrashReportsNotEnabled = fakeConfiguration.copy(crashReportsEnabled = false)
 
         // When

--- a/reliability/single-fit/logs/build.gradle.kts
+++ b/reliability/single-fit/logs/build.gradle.kts
@@ -22,6 +22,8 @@ plugins {
     id("de.mobilej.unmock")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.logs.integration"
 }

--- a/reliability/single-fit/okhttp/build.gradle.kts
+++ b/reliability/single-fit/okhttp/build.gradle.kts
@@ -23,6 +23,8 @@ plugins {
     alias(libs.plugins.apolloPlugin)
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.okhttp.integration"
 }
@@ -82,6 +84,11 @@ unMock {
 
 datadogBuild {
     applyAndroidLibraryConfig()
-    applyKotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+    applyKotlinConfig(
+        // TODO RUM-18200 We access internal members of another module in this module
+        // This should be addressed properly, temporarily disable treating warnings as errors
+        evaluateWarningsAsErrors = false,
+        jvmBytecodeTarget = JvmTarget.JVM_11
+    )
     applyJunitConfig()
 }

--- a/reliability/single-fit/profiling/build.gradle.kts
+++ b/reliability/single-fit/profiling/build.gradle.kts
@@ -22,6 +22,8 @@ plugins {
     id("de.mobilej.unmock")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.profiling.integration"
 }

--- a/reliability/single-fit/rum/build.gradle.kts
+++ b/reliability/single-fit/rum/build.gradle.kts
@@ -22,6 +22,8 @@ plugins {
     id("de.mobilej.unmock")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.rum.integration"
 }

--- a/reliability/single-fit/trace/build.gradle.kts
+++ b/reliability/single-fit/trace/build.gradle.kts
@@ -22,6 +22,8 @@ plugins {
     id("de.mobilej.unmock")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.trace.integration"
 

--- a/reliability/stub-core/build.gradle.kts
+++ b/reliability/stub-core/build.gradle.kts
@@ -22,6 +22,8 @@ plugins {
     id("de.mobilej.unmock")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.core.stub"
 }

--- a/reliability/stub-feature/build.gradle.kts
+++ b/reliability/stub-feature/build.gradle.kts
@@ -19,6 +19,8 @@ plugins {
     id("test-pyramid-api-usage")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.api.feature.stub"
 }

--- a/sample/automotive/build.gradle.kts
+++ b/sample/automotive/build.gradle.kts
@@ -21,6 +21,8 @@ plugins {
     alias(libs.plugins.datadogGradlePlugin)
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     compileSdk = AndroidConfig.TARGET_SDK
     buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
@@ -30,7 +32,6 @@ android {
         targetSdk = AndroidConfig.TARGET_SDK
         versionCode = AndroidConfig.VERSION.code
         versionName = AndroidConfig.VERSION.name
-        multiDexEnabled = true
 
         buildFeatures {
             buildConfig = true
@@ -72,7 +73,6 @@ dependencies {
     implementation(libs.kotlin)
 
     // Android dependencies
-    implementation(libs.androidXMultidex)
     implementation(libs.androidXCoreKtx)
     implementation(libs.androidXAppCompat)
     implementation(libs.androidXLegacySupportV4)

--- a/sample/benchmark/build.gradle.kts
+++ b/sample/benchmark/build.gradle.kts
@@ -24,7 +24,8 @@ plugins {
     alias(libs.plugins.datadogGradlePlugin)
 }
 
-@Suppress("StringLiteralDuplication")
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION", "StringLiteralDuplication")
 android {
     namespace = "com.datadog.sample.benchmark"
     compileSdk = AndroidConfig.TARGET_SDK
@@ -35,7 +36,6 @@ android {
         targetSdk = AndroidConfig.TARGET_SDK
         versionCode = AndroidConfig.VERSION.code
         versionName = AndroidConfig.VERSION.name
-        multiDexEnabled = true
 
         buildFeatures {
             buildConfig = true
@@ -93,7 +93,6 @@ dependencies {
 
     // Android dependencies
     implementation(libs.adapterDelegatesViewBinding)
-    implementation(libs.androidXMultidex)
     implementation(libs.bundles.androidXNavigation)
     implementation(libs.androidXAppCompat)
     implementation(libs.androidXConstraintLayout)
@@ -133,6 +132,11 @@ dependencies {
 }
 
 datadogBuild {
-    applyKotlinConfig()
+    applyKotlinConfig(
+        // TODO RUM-18191
+        // Suppress -> generateFunctionKeyMetaClasses is deprecated. It was replaced by emitting annotations on functions
+        // instead. Use generateFunctionKeyMetaAnnotations instead. Seems to Compose <-> Kotlin mismatch.
+        evaluateWarningsAsErrors = false
+    )
     applyJunitConfig()
 }

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -34,7 +34,8 @@ sqldelight {
     }
 }
 
-@Suppress("StringLiteralDuplication")
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION", "StringLiteralDuplication")
 android {
     compileSdk = AndroidConfig.TARGET_SDK
     buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
@@ -44,7 +45,6 @@ android {
         targetSdk = AndroidConfig.TARGET_SDK
         versionCode = AndroidConfig.VERSION.code
         versionName = AndroidConfig.VERSION.name
-        multiDexEnabled = true
 
         buildFeatures {
             buildConfig = true
@@ -182,7 +182,6 @@ dependencies {
     implementation(libs.kotlin)
 
     // Android dependencies
-    implementation(libs.androidXMultidex)
     implementation(libs.cronetPlayServices)
     implementation(libs.bundles.androidXNavigation)
     implementation(libs.androidXAppCompat)

--- a/sample/tv/build.gradle.kts
+++ b/sample/tv/build.gradle.kts
@@ -21,6 +21,8 @@ plugins {
     alias(libs.plugins.datadogGradlePlugin)
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     namespace = "com.datadog.android.tv.sample"
     compileSdk = AndroidConfig.TARGET_SDK
@@ -31,7 +33,6 @@ android {
         targetSdk = AndroidConfig.TARGET_SDK
         versionCode = AndroidConfig.VERSION.code
         versionName = AndroidConfig.VERSION.name
-        multiDexEnabled = true
 
         vectorDrawables.useSupportLibrary = true
 

--- a/sample/vendor-lib/build.gradle.kts
+++ b/sample/vendor-lib/build.gradle.kts
@@ -20,13 +20,14 @@ plugins {
     id("datadogBuildConfig")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     compileSdk = AndroidConfig.TARGET_SDK
     buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
 
     defaultConfig {
         minSdk = AndroidConfig.MIN_SDK
-        multiDexEnabled = true
 
         buildFeatures {
             buildConfig = true

--- a/sample/wear/build.gradle.kts
+++ b/sample/wear/build.gradle.kts
@@ -18,6 +18,8 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     compileSdk = AndroidConfig.TARGET_SDK
     buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION

--- a/tools/benchmark/build.gradle.kts
+++ b/tools/benchmark/build.gradle.kts
@@ -22,6 +22,8 @@ plugins {
     signing
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     defaultConfig {
         compileSdk = AndroidConfig.TARGET_SDK

--- a/tools/benchmark/src/main/java/com/datadog/benchmark/DatadogExporterConfiguration.kt
+++ b/tools/benchmark/src/main/java/com/datadog/benchmark/DatadogExporterConfiguration.kt
@@ -19,6 +19,7 @@ package com.datadog.benchmark
  * @param endPoint the endpoint to submit the metrics.
  * @param intervalInSeconds the interval of seconds of sampling and uploading vital data.
  */
+@ConsistentCopyVisibility
 data class DatadogExporterConfiguration internal constructor(
     val serviceName: String? = null,
     val resource: String? = null,

--- a/tools/noopfactory/src/main/kotlin/com/datadog/tools/noopfactory/NoOpFactorySymbolProcessor.kt
+++ b/tools/noopfactory/src/main/kotlin/com/datadog/tools/noopfactory/NoOpFactorySymbolProcessor.kt
@@ -563,7 +563,7 @@ class NoOpFactorySymbolProcessor(
                 }
             }
 
-            returnClassKind == ClassKind.INTERFACE && !returnType.isFunctionType -> {
+            returnClassKind == ClassKind.INTERFACE && !returnType.isFunctionTypeOrAlias -> {
                 // NoOp implementations are always generated at the package root, never nested.
                 // The name concatenates all enclosing class names to avoid collisions
                 // (e.g. Outer.Inner → NoOpOuterInner, not Outer.NoOpInner).
@@ -574,7 +574,7 @@ class NoOpFactorySymbolProcessor(
                 funSpecBuilder.addStatement("return %T()", noOpReturnType)
             }
 
-            returnType.isFunctionType -> {
+            returnType.isFunctionTypeOrAlias -> {
                 val funcReturnTypeName = returnType.returnTypeNameOfFunctionType(typeParamResolver)
                 if (funcReturnTypeName == UNIT) {
                     funSpecBuilder.addStatement("return {}")
@@ -682,6 +682,14 @@ class NoOpFactorySymbolProcessor(
             }
         }
     }
+
+    /**
+     * KSP1 expanded typealiases when resolving a [KSType], so a `typealias Foo = (A) -> Unit`
+     * reported `isFunctionType == true`. KSP2 keeps the alias, so the check has to look through it.
+     */
+    private val KSType.isFunctionTypeOrAlias: Boolean
+        get() = isFunctionType ||
+            (declaration as? KSTypeAlias)?.type?.resolve()?.isFunctionTypeOrAlias == true
 
     /**
      * @return the identifier name of the [KSFunctionDeclaration]

--- a/tools/unit/build.gradle.kts
+++ b/tools/unit/build.gradle.kts
@@ -19,6 +19,8 @@ plugins {
     id("datadogBuildConfig")
 }
 
+// TODO RUM-18189 Support new AGP DSL
+@Suppress("DEPRECATION")
 android {
     compileSdk = AndroidConfig.TARGET_SDK
     buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION


### PR DESCRIPTION
### What does this PR do?

This PR updates AGP to version 9.1.1 - first version which [supports compilation against Android API 37](https://developer.android.com/build/releases/agp-9-1-0-release-notes).

As a part of this migration the following was done:

* Added `ExposedCopyVisibility` to the public data classes with `internal` constructor: although we don't want `copy` method to be exposed, we will keep binary API compatibility for now. We may move away from data classes in public API in SDK v4. The only exception is `:tools:benchmark` module, because it is published only for the internal needs.
* Bumped `apiVersion` and `languageVersion` of Kotlin to 2.0., this is acknowledged ABI change. `1.8` could still live, but there is warning that it is deprecated by the build tooling (Kotlin 2.2 imposed by AGP 9) and it is time to bump it. We can afford this without major SDK release.
* AGP 9 strictly pins the version of KSP unlike AGP 8, so now KSP is for Kotlin 2.2, that change caused the issue in code generated by NoOp plugin.
* AGP 9 flips the value of `android.useConstraints` from `true` to `false` compared to AGP 8, this caused some transitive versions shaking. See [docs](https://developer.android.com/build/releases/agp-9-0-0-release-notes) for more details.
* Removed multi-DEX support. It is not needed since our `minSdk` is 21.
* Bumped Kotlin Coroutines version: it was resolved to 1.7.3 by the OpenFeature SDK anyway.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

