### PR TITLE
RUM-18192: Print AAR metadata

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -70,23 +70,21 @@ dependencies {
 gradlePlugin {
     plugins {
         register("datadogBuildConfig") {
-            id = "datadogBuildConfig" // the alias
             implementationClass = "com.datadog.gradle.plugin.config.DatadogBuildConfigPlugin"
         }
         register("apiSurface") {
-            id = "apiSurface" // the alias
             implementationClass = "com.datadog.gradle.plugin.apisurface.ApiSurfacePlugin"
         }
+        register("aarMetadata") {
+            implementationClass = "com.datadog.gradle.plugin.aarmetadata.AarMetadataPlugin"
+        }
         register("cloneDependencies") {
-            id = "cloneDependencies" // the alias
             implementationClass = "com.datadog.gradle.plugin.gitclone.GitCloneDependenciesPlugin"
         }
         register("transitiveDependencies") {
-            id = "transitiveDependencies" // the alias
             implementationClass = "com.datadog.gradle.plugin.transdeps.TransitiveDependenciesPlugin"
         }
         register("verificationXml") {
-            id = "verificationXml" // the alias
             implementationClass = "com.datadog.gradle.plugin.verification.VerificationXmlPlugin"
         }
     }

--- a/build-logic/src/main/kotlin/com/datadog/gradle/plugin/aarmetadata/AarMetadataPlugin.kt
+++ b/build-logic/src/main/kotlin/com/datadog/gradle/plugin/aarmetadata/AarMetadataPlugin.kt
@@ -1,0 +1,66 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.aarmetadata
+
+import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.register
+
+/**
+ * Extracts the AAR metadata properties (`META-INF/com/android/build/gradle/aar-metadata.properties`)
+ * from the produced debug AAR into a file checked into the repository, so that any change of the
+ * consumer constraints (min compile SDK, min AGP version, ...) is visible in the diff.
+ */
+class AarMetadataPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        target.pluginManager.withPlugin(ANDROID_LIBRARY_PLUGIN) {
+            registerTasks(target)
+        }
+    }
+
+    private fun registerTasks(target: Project) {
+        val aarMetadataFile = target.layout.projectDirectory
+            .dir("api")
+            .file(FILE_NAME)
+
+        val generateAarMetadataTask = target.tasks
+            .register<GenerateAarMetadataInfoTask>(TASK_GEN_AAR_METADATA) {
+                this.aarMetadataFile.set(aarMetadataFile)
+            }
+
+        target.tasks
+            .register<CheckAarMetadataInfoTask>(TASK_CHECK_AAR_METADATA) {
+                this.aarMetadataFile.set(aarMetadataFile)
+                dependsOn(generateAarMetadataTask)
+            }
+
+        target.extensions.configure<LibraryAndroidComponentsExtension>("androidComponents") {
+            onVariants(selector().withName(VARIANT_NAME)) { variant ->
+                generateAarMetadataTask.configure {
+                    this.aarFile.set(variant.artifacts.get(SingleArtifact.AAR))
+                }
+            }
+        }
+
+        target.tasks.matching { it.name == BUNDLE_AAR_TASK }.configureEach {
+            finalizedBy(generateAarMetadataTask)
+        }
+    }
+
+    companion object {
+        const val TASK_GEN_AAR_METADATA = "generateAarMetadataInfo"
+        const val TASK_CHECK_AAR_METADATA = "checkAarMetadataInfoChanges"
+        const val FILE_NAME = "aar-metadata.txt"
+        const val ANDROID_LIBRARY_PLUGIN = "com.android.library"
+        const val VARIANT_NAME = "debug"
+        const val BUNDLE_AAR_TASK = "bundleDebugAar"
+    }
+}

--- a/build-logic/src/main/kotlin/com/datadog/gradle/plugin/aarmetadata/CheckAarMetadataInfoTask.kt
+++ b/build-logic/src/main/kotlin/com/datadog/gradle/plugin/aarmetadata/CheckAarMetadataInfoTask.kt
@@ -1,0 +1,39 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.aarmetadata
+
+import com.datadog.gradle.plugin.CheckGeneratedFileTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
+
+abstract class CheckAarMetadataInfoTask @Inject constructor(
+    execOperations: ExecOperations
+) : CheckGeneratedFileTask(
+    genTaskName = AarMetadataPlugin.TASK_GEN_AAR_METADATA,
+    execOperations
+) {
+
+    @get:InputFile
+    abstract val aarMetadataFile: RegularFileProperty
+
+    init {
+        group = "datadog"
+        description = "Check the AAR metadata properties of the library"
+    }
+
+    // region Task
+
+    @TaskAction
+    fun applyTask() {
+        verifyGeneratedFileExists(aarMetadataFile.get().asFile)
+    }
+
+    // endregion
+}

--- a/build-logic/src/main/kotlin/com/datadog/gradle/plugin/aarmetadata/GenerateAarMetadataInfoTask.kt
+++ b/build-logic/src/main/kotlin/com/datadog/gradle/plugin/aarmetadata/GenerateAarMetadataInfoTask.kt
@@ -1,0 +1,61 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.aarmetadata
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import java.util.zip.ZipFile
+
+abstract class GenerateAarMetadataInfoTask : DefaultTask() {
+
+    @get:InputFile
+    abstract val aarFile: RegularFileProperty
+
+    @get:OutputFile
+    abstract val aarMetadataFile: RegularFileProperty
+
+    init {
+        group = "datadog"
+        description = "List the AAR metadata properties of the produced AAR"
+    }
+
+    // region Task
+
+    @TaskAction
+    fun applyTask() {
+        val aar = aarFile.get().asFile
+
+        val properties = ZipFile(aar).use { zip ->
+            val entry = zip.getEntry(AAR_METADATA_ENTRY)
+            checkNotNull(entry) {
+                "Couldn't find $AAR_METADATA_ENTRY entry in the ${aar.absolutePath}"
+            }
+            zip.getInputStream(entry)
+                .bufferedReader()
+                .readLines()
+        }
+            // comment lines are holding generation time, which is not stable
+            .filterNot { it.isBlank() || it.trimStart().startsWith("#") }
+            .sorted()
+
+        logger.lifecycle(
+            "AAR metadata of ${aar.name}:\n" + properties.joinToString("\n")
+        )
+
+        aarMetadataFile.get().asFile
+            .writeText(properties.joinToString(separator = "\n", postfix = "\n"))
+    }
+
+    // endregion
+
+    companion object {
+        private const val AAR_METADATA_ENTRY = "META-INF/com/android/build/gradle/aar-metadata.properties"
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -164,12 +164,15 @@ registerSubModuleAggregationTask("checkApiSurfaceChangesAll", "checkApiSurfaceCh
 
 registerSubModuleAggregationTask("checkCompilerMetadataChangesAll", "checkCompilerMetadataChanges")
 
+registerSubModuleAggregationTask("checkAarMetadataInfoChangesAll", "checkAarMetadataInfoChanges")
+
 registerSubModuleAggregationTask("checkTransitiveDependenciesListAll", "checkTransitiveDependenciesList")
 
 tasks.register("checkGeneratedFiles") {
     dependsOn("checkDependencyLicensesAll")
     dependsOn("checkApiSurfaceChangesAll")
     dependsOn("checkCompilerMetadataChangesAll")
+    dependsOn("checkAarMetadataInfoChangesAll")
     dependsOn("checkTransitiveDependenciesListAll")
 }
 

--- a/dd-sdk-android-core/api/aar-metadata.txt
+++ b/dd-sdk-android-core/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/dd-sdk-android-core/build.gradle.kts
+++ b/dd-sdk-android-core/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/dd-sdk-android-internal/api/aar-metadata.txt
+++ b/dd-sdk-android-internal/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/dd-sdk-android-internal/build.gradle.kts
+++ b/dd-sdk-android-internal/build.gradle.kts
@@ -32,6 +32,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/features/dd-sdk-android-flags-openfeature/api/aar-metadata.txt
+++ b/features/dd-sdk-android-flags-openfeature/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/features/dd-sdk-android-flags-openfeature/build.gradle.kts
+++ b/features/dd-sdk-android-flags-openfeature/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/features/dd-sdk-android-flags/api/aar-metadata.txt
+++ b/features/dd-sdk-android-flags/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/features/dd-sdk-android-flags/build.gradle.kts
+++ b/features/dd-sdk-android-flags/build.gradle.kts
@@ -32,6 +32,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/features/dd-sdk-android-logs/api/aar-metadata.txt
+++ b/features/dd-sdk-android-logs/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/features/dd-sdk-android-logs/build.gradle.kts
+++ b/features/dd-sdk-android-logs/build.gradle.kts
@@ -34,6 +34,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/features/dd-sdk-android-ndk/api/aar-metadata.txt
+++ b/features/dd-sdk-android-ndk/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/features/dd-sdk-android-ndk/build.gradle.kts
+++ b/features/dd-sdk-android-ndk/build.gradle.kts
@@ -31,6 +31,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/features/dd-sdk-android-profiling/api/aar-metadata.txt
+++ b/features/dd-sdk-android-profiling/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/features/dd-sdk-android-profiling/build.gradle.kts
+++ b/features/dd-sdk-android-profiling/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/features/dd-sdk-android-rum-debug-widget/api/aar-metadata.txt
+++ b/features/dd-sdk-android-rum-debug-widget/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/features/dd-sdk-android-rum-debug-widget/build.gradle.kts
+++ b/features/dd-sdk-android-rum-debug-widget/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/features/dd-sdk-android-rum/api/aar-metadata.txt
+++ b/features/dd-sdk-android-rum/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/features/dd-sdk-android-rum/build.gradle.kts
+++ b/features/dd-sdk-android-rum/build.gradle.kts
@@ -36,6 +36,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/features/dd-sdk-android-session-replay-compose/api/aar-metadata.txt
+++ b/features/dd-sdk-android-session-replay-compose/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/features/dd-sdk-android-session-replay-compose/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-compose/build.gradle.kts
@@ -31,6 +31,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/features/dd-sdk-android-session-replay-material/api/aar-metadata.txt
+++ b/features/dd-sdk-android-session-replay-material/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/features/dd-sdk-android-session-replay-material/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-material/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("detekt-conventions")

--- a/features/dd-sdk-android-session-replay/api/aar-metadata.txt
+++ b/features/dd-sdk-android-session-replay/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/features/dd-sdk-android-session-replay/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/features/dd-sdk-android-trace-api/api/aar-metadata.txt
+++ b/features/dd-sdk-android-trace-api/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/features/dd-sdk-android-trace-api/build.gradle.kts
+++ b/features/dd-sdk-android-trace-api/build.gradle.kts
@@ -32,6 +32,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("binary-compatibility-validator")
     id("test-pyramid-api-surface")

--- a/features/dd-sdk-android-trace-internal/api/aar-metadata.txt
+++ b/features/dd-sdk-android-trace-internal/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/features/dd-sdk-android-trace-internal/build.gradle.kts
+++ b/features/dd-sdk-android-trace-internal/build.gradle.kts
@@ -32,6 +32,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("binary-compatibility-validator")
     id("test-pyramid-api-surface")

--- a/features/dd-sdk-android-trace-otel/api/aar-metadata.txt
+++ b/features/dd-sdk-android-trace-otel/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/features/dd-sdk-android-trace-otel/build.gradle.kts
+++ b/features/dd-sdk-android-trace-otel/build.gradle.kts
@@ -31,6 +31,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/features/dd-sdk-android-trace/api/aar-metadata.txt
+++ b/features/dd-sdk-android-trace/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/features/dd-sdk-android-trace/build.gradle.kts
+++ b/features/dd-sdk-android-trace/build.gradle.kts
@@ -34,6 +34,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/features/dd-sdk-android-webview/api/aar-metadata.txt
+++ b/features/dd-sdk-android-webview/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/features/dd-sdk-android-webview/build.gradle.kts
+++ b/features/dd-sdk-android-webview/build.gradle.kts
@@ -31,6 +31,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/integrations/dd-sdk-android-apollo/api/aar-metadata.txt
+++ b/integrations/dd-sdk-android-apollo/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/integrations/dd-sdk-android-apollo/build.gradle.kts
+++ b/integrations/dd-sdk-android-apollo/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("test-pyramid-api-surface")

--- a/integrations/dd-sdk-android-coil/api/aar-metadata.txt
+++ b/integrations/dd-sdk-android-coil/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/integrations/dd-sdk-android-coil/build.gradle.kts
+++ b/integrations/dd-sdk-android-coil/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/integrations/dd-sdk-android-coil3/api/aar-metadata.txt
+++ b/integrations/dd-sdk-android-coil3/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/integrations/dd-sdk-android-coil3/build.gradle.kts
+++ b/integrations/dd-sdk-android-coil3/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/integrations/dd-sdk-android-compose/api/aar-metadata.txt
+++ b/integrations/dd-sdk-android-compose/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/integrations/dd-sdk-android-compose/build.gradle.kts
+++ b/integrations/dd-sdk-android-compose/build.gradle.kts
@@ -32,6 +32,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("test-pyramid-api-surface")

--- a/integrations/dd-sdk-android-cronet/api/aar-metadata.txt
+++ b/integrations/dd-sdk-android-cronet/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/integrations/dd-sdk-android-cronet/build.gradle.kts
+++ b/integrations/dd-sdk-android-cronet/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/integrations/dd-sdk-android-fresco/api/aar-metadata.txt
+++ b/integrations/dd-sdk-android-fresco/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/integrations/dd-sdk-android-fresco/build.gradle.kts
+++ b/integrations/dd-sdk-android-fresco/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/integrations/dd-sdk-android-glide/api/aar-metadata.txt
+++ b/integrations/dd-sdk-android-glide/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/integrations/dd-sdk-android-glide/build.gradle.kts
+++ b/integrations/dd-sdk-android-glide/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/integrations/dd-sdk-android-okhttp-otel/api/aar-metadata.txt
+++ b/integrations/dd-sdk-android-okhttp-otel/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/integrations/dd-sdk-android-okhttp-otel/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp-otel/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/integrations/dd-sdk-android-okhttp/api/aar-metadata.txt
+++ b/integrations/dd-sdk-android-okhttp/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/integrations/dd-sdk-android-okhttp/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp/build.gradle.kts
@@ -33,6 +33,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/integrations/dd-sdk-android-rum-coroutines/api/aar-metadata.txt
+++ b/integrations/dd-sdk-android-rum-coroutines/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("test-pyramid-api-surface")

--- a/integrations/dd-sdk-android-rx/api/aar-metadata.txt
+++ b/integrations/dd-sdk-android-rx/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/integrations/dd-sdk-android-rx/build.gradle.kts
+++ b/integrations/dd-sdk-android-rx/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/integrations/dd-sdk-android-sqldelight/api/aar-metadata.txt
+++ b/integrations/dd-sdk-android-sqldelight/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/integrations/dd-sdk-android-sqldelight/build.gradle.kts
+++ b/integrations/dd-sdk-android-sqldelight/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/integrations/dd-sdk-android-timber/api/aar-metadata.txt
+++ b/integrations/dd-sdk-android-timber/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/integrations/dd-sdk-android-timber/build.gradle.kts
+++ b/integrations/dd-sdk-android-timber/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")

--- a/integrations/dd-sdk-android-trace-coroutines/api/aar-metadata.txt
+++ b/integrations/dd-sdk-android-trace-coroutines/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("test-pyramid-api-surface")

--- a/integrations/dd-sdk-android-tv/api/aar-metadata.txt
+++ b/integrations/dd-sdk-android-tv/api/aar-metadata.txt
@@ -1,0 +1,6 @@
+aarFormatVersion=1.0
+aarMetadataVersion=1.0
+coreLibraryDesugaringEnabled=false
+minAndroidGradlePluginVersion=1.0.0
+minCompileSdk=1
+minCompileSdkExtension=0

--- a/integrations/dd-sdk-android-tv/build.gradle.kts
+++ b/integrations/dd-sdk-android-tv/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
 
     // Internal Generation
     id("apiSurface")
+    id("aarMetadata")
     id("transitiveDependencies")
     id("verificationXml")
     id("binary-compatibility-validator")


### PR DESCRIPTION
### Motivation

AGP may add some restrictions to the AAR metadata of the published library, which are then imposed on consumers. It is worth to show it.

### Implementation

Add an `aarMetadata` convention plugin which extracts the AAR metadata properties (`META-INF/com/android/build/gradle/aar-metadata.properties`) from the produced debug AAR and stores them in `api/aar-metadata.txt`, so that any change in the consumer constraints (min compile SDK, min AGP version, core library desugaring, ...) becomes visible in the diff.

Following the same layout as the `apiSurface` plugin, it provides:
* `generateAarMetadataInfo` - reads the metadata entry from the debug AAR, prints it and writes it to `api/aar-metadata.txt`. It is wired as a `finalizedBy` of `bundleDebugAar`, so the file is refreshed on a regular local build.
* `checkAarMetadataInfoChanges` - fails if the checked-in file drifts from the generated one, aggregated by the root `checkAarMetadataInfoChangesAll` task and included in `checkGeneratedFiles`.

The plugin registers its tasks only for the modules applying the `com.android.library` plugin.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

