### PR TITLE
Explicitly declare generated models directory using AGP API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ Filename matches the flavor: `config/us1.json`, `config/staging.json`, etc. Get 
 
 # Generated Models
 
-Some modules generate Kotlin data classes from JSON schemas at build time (e.g. `features/dd-sdk-android-rum/src/main/json/`). The generated Kotlin files land in `build/generated/json2kotlin/` — **do not edit them directly**. Edit the JSON schemas instead and rebuild.
+Some modules generate Kotlin data classes from JSON schemas at build time (e.g. `features/dd-sdk-android-rum/src/main/json/`). The generated Kotlin files land in `build/generated/<generationTaskName>/` — **do not edit them directly**. Edit the JSON schemas instead and rebuild.
 
 # Commits
 

--- a/build-logic/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
+++ b/build-logic/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
@@ -49,9 +49,6 @@ internal fun Project.androidLibraryConfig() {
         sourceSets.all {
             java.srcDir("src/$name/kotlin")
         }
-        sourceSets.named("main") {
-            java.srcDir("build/generated/json2kotlin/main/kotlin")
-        }
 
         testOptions {
             unitTests.isReturnDefaultValues = true

--- a/build-logic/src/main/kotlin/com/datadog/gradle/plugin/apisurface/ApiSurfacePlugin.kt
+++ b/build-logic/src/main/kotlin/com/datadog/gradle/plugin/apisurface/ApiSurfacePlugin.kt
@@ -32,7 +32,7 @@ class ApiSurfacePlugin : Plugin<Project> {
         val generateApiSurfaceTask = target.tasks
             .register<GenerateApiSurfaceTask>(TASK_GEN_KOTLIN_API_SURFACE) {
                 this.srcDir.set(srcDir)
-                this.genDir.from(jsonToModelGenerations.map { it.destinationPackageDirectory })
+                this.genDir.from(jsonToModelGenerations.map { it.destinationGenDirectory })
                 this.surfaceFile.set(kotlinSurfaceFile)
             }
         target.tasks

--- a/build-logic/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/GenerateJsonSchemaTask.kt
+++ b/build-logic/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/GenerateJsonSchemaTask.kt
@@ -24,7 +24,6 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import java.io.File
 
 // TODO test all from https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/master/tests/draft2019-09
 
@@ -95,16 +94,15 @@ abstract class GenerateJsonSchemaTask : DefaultTask() {
     abstract val inputNameMapping: MapProperty<String, String>
 
     /**
-     * The directory to package-agnostic directory write the generated files.
-     */
-    @get:Input
-    abstract val destinationGenDirectoryPath: Property<String>
-
-    /**
-     * The [OutputDirectory] (`src/main/kotlin/{out_package}`).
+     * The [OutputDirectory] where the generated files are written, in a package-agnostic way
+     * (the `{out_package}` subdirectories are created by the generator itself).
+     *
+     * Note that this is wired to the Android variant sources through
+     * `SourceDirectories.addGeneratedSourceDirectory`, which sets a *convention* on this property,
+     * hence the location set by the caller always wins.
      */
     @get:OutputDirectory
-    abstract val destinationPackageDirectory: DirectoryProperty
+    abstract val destinationGenDirectory: DirectoryProperty
 
     // endregion
 
@@ -116,7 +114,7 @@ abstract class GenerateJsonSchemaTask : DefaultTask() {
     @TaskAction
     fun performTask() {
         val inputDir = inputDir.get().asFile
-        val outputDir = File(destinationGenDirectoryPath.get())
+        val outputDir = destinationGenDirectory.get().asFile
         val files = inputFiles
             .filter {
                 it.name !in ignoredFiles.get() && it.parentFile == inputDir

--- a/build-logic/src/main/kotlin/com/datadog/gradle/utils/JsonSchemaGenerationTasks.kt
+++ b/build-logic/src/main/kotlin/com/datadog/gradle/utils/JsonSchemaGenerationTasks.kt
@@ -6,16 +6,13 @@
 
 package com.datadog.gradle.utils
 
-import com.datadog.gradle.config.taskConfig
-import com.datadog.gradle.plugin.apisurface.GenerateApiSurfaceTask
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.datadog.gradle.plugin.gitclone.GitCloneDependenciesExtension
 import com.datadog.gradle.plugin.gitclone.GitCloneDependenciesTask
 import com.datadog.gradle.plugin.jsonschema.GenerateJsonSchemaTask
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.register
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-import java.io.File
 import java.nio.file.Paths
 
 private const val RUM_EVENTS_FORMAT_REPO = "https://github.com/DataDog/rum-events-format.git"
@@ -66,19 +63,9 @@ fun Project.createJsonModelsGenerationTask(
 
         action()
 
-        val rootPath = Paths.get("generated", "json2kotlin", "main", "kotlin")
-        val rootGenDirectory = layout.buildDirectory
-            .dir(rootPath.toString())
-            .get()
-            .asFile
-        destinationGenDirectoryPath.set(rootGenDirectory.absolutePath)
-        val outputPackageDir = File(
-            rootGenDirectory,
-            targetPackageName.get().replace(".", File.separator)
-        ).apply {
-            if (!exists()) mkdirs()
-        }
-        destinationPackageDirectory.set(outputPackageDir)
+        destinationGenDirectory.set(
+            layout.buildDirectory.dir(Paths.get("generated", taskName).toString())
+        )
         inputDir.set(layout.projectDirectory.dir(inputDirPath))
         inputFiles.from(
             inputDir.map {
@@ -91,15 +78,15 @@ fun Project.createJsonModelsGenerationTask(
 
     rootTask.dependsOn(task)
 
-    taskConfig<GenerateApiSurfaceTask> {
-        dependsOn(task)
-    }
-
-    taskConfig<KotlinCompilationTask<KotlinJvmCompilerOptions>> {
-        dependsOn(task)
-    }
-
-    tasks.matching { it.name.startsWith("ksp") && it.name.endsWith("Kotlin") }.configureEach {
-        dependsOn(task)
+    val androidComponents = extensions.findByType<LibraryAndroidComponentsExtension>()
+        ?: error(
+            "Project $path applies the JSON models generation without the Android library plugin," +
+                " the generated sources cannot be wired to any variant."
+        )
+    androidComponents.onVariants { variant ->
+        variant.sources.java?.addGeneratedSourceDirectory(
+            task,
+            GenerateJsonSchemaTask::destinationGenDirectory
+        )
     }
 }


### PR DESCRIPTION
Fix to the following error:

```
FAILURE: Build failed with an exception.
* What went wrong:
A problem was found with the configuration of task ':tools:benchmark:sourceReleaseJar' (type 'SourceJarTask').
  - Gradle detected a problem with the following location: '/go/src/github.com/DataDog/dd-sdk-android/tools/benchmark/build/generated/json2kotlin/main/kotlin'.
    
    Reason: Task ':tools:benchmark:sourceReleaseJar' uses this output of task ':tools:benchmark:generateTraceModelsFromJson' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':tools:benchmark:generateTraceModelsFromJson' as an input of ':tools:benchmark:sourceReleaseJar'.
      2. Declare an explicit dependency on ':tools:benchmark:generateTraceModelsFromJson' from ':tools:benchmark:sourceReleaseJar' using Task#dependsOn.
      3. Declare an explicit dependency on ':tools:benchmark:generateTraceModelsFromJson' from ':tools:benchmark:sourceReleaseJar' using Task#mustRunAfter.
```

caused by the [following change ](https://github.com/DataDog/dd-sdk-android/pull/3751/files#diff-69796662a59a24b67b3c0f33299883ccdb25427b53997a873ab9442bdd75e0f0)

The generated models directory used to be registered as a plain source directory path (`java.srcDir("build/generated/json2kotlin/main/kotlin")`), which carries no information about the task producing it. Every consumer therefore needed an explicit `dependsOn` on the generation task, and any consumer we forgot about failed Gradle's validation with an implicit dependency error, as `source<Variant>Jar` recently did.

The directory is now declared as the `@OutputDirectory` of GenerateJsonSchemaTask and wired to the variant sources through `SourceDirectories.addGeneratedSourceDirectory`, so Kotlin compilation, KSP, lint and the source jars all get the dependency implicitly and the manual `dependsOn` wiring is gone.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

