### PR TITLE
RUM-15605: Add comments to reduce confusion about double reporting

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -155,6 +155,12 @@ internal class RumResourceScope(
     ) {
         if (key != event.key) return
         timing = event.timing
+        // DatadogEventListener can dispatch AddResourceTiming more than once for the same
+        // resource (e.g. once from responseHeadersEnd for HTTP error status codes, again from
+        // callEnd/callFailed). This is not a double-report risk: as soon as sendResource() below
+        // runs, handleEvent() returns null and RumViewScope.delegateEventToResources removes this
+        // scope from activeResourceScopes in that same dispatch. Any later AddResourceTiming for
+        // this key finds no matching scope and is silently dropped before it ever reaches here.
         if (stopped && !sent) {
             sendResource(kind, statusCode, size, event.eventTime, datadogContext, writeScope, writer)
         }

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogEventListener.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogEventListener.kt
@@ -131,6 +131,11 @@ internal constructor(
     override fun responseHeadersEnd(call: Call, response: Response) {
         super.responseHeadersEnd(call, response)
         headersEnd = sdkCore.time.deviceTimeNs
+        // For error responses, report timing as soon as headers are in rather than waiting for
+        // callEnd, which can fire only after a much later body read. callEnd/callFailed below
+        // will still call sendTiming() again, but that's harmless: RumResourceScope discards
+        // any AddResourceTiming that arrives after the resource has already been sent (see
+        // RumResourceScope.onAddResourceTiming), so it never causes a double-report.
         if (response.code >= HttpURLConnection.HTTP_BAD_REQUEST) {
             sendTiming()
         }

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/RumInstrumentationTimingsCounter.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/RumInstrumentationTimingsCounter.kt
@@ -98,7 +98,11 @@ internal class RumInstrumentationTimingsCounter(
     override fun responseHeadersEnd(call: Call, response: Response) {
         super.responseHeadersEnd(call, response)
         headersEnd = sdkCore.time.deviceTimeNs
-        // TODO RUM-15605 - Check if we need this reporting logic
+        // For error responses, report timing as soon as headers are in rather than waiting for
+        // callEnd, which can fire only after a much later body read. callEnd/callFailed below
+        // will still call sendTiming() again, but that's harmless: RumResourceScope discards
+        // any AddResourceTiming that arrives after the resource has already been sent (see
+        // RumResourceScope.onAddResourceTiming), so it never causes a double-report.
         if (response.code >= HttpURLConnection.HTTP_BAD_REQUEST) {
             requestTracingStateRegistry.get(call)?.let(::sendTiming)
         }


### PR DESCRIPTION
### What does this PR do?

Adds comments to DatadogEventListener and RumResourceScope explaining why AddResourceTiming can fire more than once per resource (headers-end for error responses, plus callEnd/callFailed) and why that's safe — the sent/stopped guard in RumResourceScope.onAddResourceTiming ensures the resource event is only ever written once.

### Motivation

While investigating a suspicion that the timing-on-error fix from [#285](https://github.com/DataDog/dd-sdk-android/pull/285) causes double-reported RUM resource events, confirmed the multi-call behavior is real but harmless due to a pre-existing guard. No functional bug was found, but the mechanism was non-obvious, so documenting it should save the next person from re-investigating the same suspicion.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

