### PR TITLE
RUM-18155: Emit ProfilingAnomalyDetectedEvent to RUM

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -183,6 +183,10 @@ sealed class com.datadog.android.internal.profiling.ProfilerEvent
   object TTIDNotTracked : ProfilerEvent
   data class RumAnrEvent : ProfilerEvent
     constructor(String, Long, Long, ProfilingRumContext)
+  data class RumOomErrorEvent : ProfilerEvent
+    constructor(String, Long, ProfilingRumContext)
+  data class RumAnomalyErrorEvent : ProfilerEvent
+    constructor(String, Long, ProfilingRumContext)
   data class RumLongTaskEvent : ProfilerEvent
     constructor(String, Long, Long, ProfilingRumContext)
   data class RumVitalEvent : ProfilerEvent
@@ -191,6 +195,8 @@ sealed class com.datadog.android.internal.profiling.ProfilerEvent
       - TTID
       - TTFD
       - OPERATION
+data class com.datadog.android.internal.profiling.ProfilingAnomalyDetectedEvent
+  constructor(Long)
 data class com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
   constructor(Long, List<StackTraceElement>, String, Thread.State, List<ProfilingThreadDump>)
 data class com.datadog.android.internal.profiling.ProfilingRumContext

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -347,6 +347,21 @@ public final class com/datadog/android/internal/profiler/GlobalBenchmark {
 public abstract class com/datadog/android/internal/profiling/ProfilerEvent {
 }
 
+public final class com/datadog/android/internal/profiling/ProfilerEvent$RumAnomalyErrorEvent : com/datadog/android/internal/profiling/ProfilerEvent {
+	public fun <init> (Ljava/lang/String;JLcom/datadog/android/internal/profiling/ProfilingRumContext;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()Lcom/datadog/android/internal/profiling/ProfilingRumContext;
+	public final fun copy (Ljava/lang/String;JLcom/datadog/android/internal/profiling/ProfilingRumContext;)Lcom/datadog/android/internal/profiling/ProfilerEvent$RumAnomalyErrorEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/ProfilerEvent$RumAnomalyErrorEvent;Ljava/lang/String;JLcom/datadog/android/internal/profiling/ProfilingRumContext;ILjava/lang/Object;)Lcom/datadog/android/internal/profiling/ProfilerEvent$RumAnomalyErrorEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getRumContext ()Lcom/datadog/android/internal/profiling/ProfilingRumContext;
+	public final fun getTimestamp ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/datadog/android/internal/profiling/ProfilerEvent$RumAnrEvent : com/datadog/android/internal/profiling/ProfilerEvent {
 	public fun <init> (Ljava/lang/String;JJLcom/datadog/android/internal/profiling/ProfilingRumContext;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -377,6 +392,21 @@ public final class com/datadog/android/internal/profiling/ProfilerEvent$RumLongT
 	public final fun getId ()Ljava/lang/String;
 	public final fun getRumContext ()Lcom/datadog/android/internal/profiling/ProfilingRumContext;
 	public final fun getStartMs ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/internal/profiling/ProfilerEvent$RumOomErrorEvent : com/datadog/android/internal/profiling/ProfilerEvent {
+	public fun <init> (Ljava/lang/String;JLcom/datadog/android/internal/profiling/ProfilingRumContext;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()Lcom/datadog/android/internal/profiling/ProfilingRumContext;
+	public final fun copy (Ljava/lang/String;JLcom/datadog/android/internal/profiling/ProfilingRumContext;)Lcom/datadog/android/internal/profiling/ProfilerEvent$RumOomErrorEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/ProfilerEvent$RumOomErrorEvent;Ljava/lang/String;JLcom/datadog/android/internal/profiling/ProfilingRumContext;ILjava/lang/Object;)Lcom/datadog/android/internal/profiling/ProfilerEvent$RumOomErrorEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getRumContext ()Lcom/datadog/android/internal/profiling/ProfilingRumContext;
+	public final fun getTimestamp ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -412,6 +442,17 @@ public final class com/datadog/android/internal/profiling/ProfilerEvent$RumVital
 
 public final class com/datadog/android/internal/profiling/ProfilerEvent$TTIDNotTracked : com/datadog/android/internal/profiling/ProfilerEvent {
 	public static final field INSTANCE Lcom/datadog/android/internal/profiling/ProfilerEvent$TTIDNotTracked;
+}
+
+public final class com/datadog/android/internal/profiling/ProfilingAnomalyDetectedEvent {
+	public fun <init> (J)V
+	public final fun component1 ()J
+	public final fun copy (J)Lcom/datadog/android/internal/profiling/ProfilingAnomalyDetectedEvent;
+	public static synthetic fun copy$default (Lcom/datadog/android/internal/profiling/ProfilingAnomalyDetectedEvent;JILjava/lang/Object;)Lcom/datadog/android/internal/profiling/ProfilingAnomalyDetectedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDetectedAtMs ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/datadog/android/internal/profiling/ProfilingAnrDetectedEvent {

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilerEvent.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilerEvent.kt
@@ -32,6 +32,36 @@ sealed class ProfilerEvent {
     ) : ProfilerEvent()
 
     /**
+     * Sent by the RUM feature to the profiling feature when an OOM error event
+     * has been successfully written. Allows the profiling feature to correlate
+     * the captured heap histogram with the RUM error event.
+     *
+     * @param id The ID of the corresponding RUM error event.
+     * @param timestamp Timestamp in milliseconds since epoch (server time-adjusted).
+     * @param rumContext RUM context at the time of the OOM.
+     */
+    data class RumOomErrorEvent(
+        val id: String,
+        val timestamp: Long,
+        val rumContext: ProfilingRumContext
+    ) : ProfilerEvent()
+
+    /**
+     * Sent by the RUM feature to the profiling feature when a memory anomaly
+     * error event has been successfully written. Allows the profiling feature
+     * to correlate the captured heap histogram with the RUM error event.
+     *
+     * @param id The ID of the corresponding RUM error event.
+     * @param timestamp Timestamp in milliseconds since epoch (server time-adjusted).
+     * @param rumContext RUM context at the time of the anomaly.
+     */
+    data class RumAnomalyErrorEvent(
+        val id: String,
+        val timestamp: Long,
+        val rumContext: ProfilingRumContext
+    ) : ProfilerEvent()
+
+    /**
      * Sent by the RUM feature to the profiling feature whenever a long task is detected.
      *
      * @param id The ID of the corresponding RUM long task event.

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilingAnomalyDetectedEvent.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiling/ProfilingAnomalyDetectedEvent.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.profiling
+
+/**
+ * Sent by the profiling feature to the RUM feature when ProfilingManager
+ * notifies us of an anomaly trigger via the trigger-based capture API.
+ *
+ * Not limited to memory anomalies. May originate from any anomaly-style
+ * system trigger, such as [ProfilingTrigger.TRIGGER_TYPE_ANOMALY]
+ * where anomalous behaviors span all areas and the artifact varies by anomaly.
+ *
+ * @param detectedAtMs Timestamp (device clock, millis since epoch) when the
+ *   profiling feature handled the anomaly trigger callback.
+ */
+data class ProfilingAnomalyDetectedEvent(
+    val detectedAtMs: Long
+)

--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilerEventRumAnomalyErrorEventForgeryFactory.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilerEventRumAnomalyErrorEventForgeryFactory.kt
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.tests.elmyr
+
+import com.datadog.android.internal.profiling.ProfilerEvent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.util.UUID
+
+class ProfilerEventRumAnomalyErrorEventForgeryFactory : ForgeryFactory<ProfilerEvent.RumAnomalyErrorEvent> {
+    override fun getForgery(forge: Forge): ProfilerEvent.RumAnomalyErrorEvent {
+        return ProfilerEvent.RumAnomalyErrorEvent(
+            id = forge.getForgery<UUID>().toString(),
+            // int instead of long to avoid overflow in call sites if timestamp is used
+            timestamp = forge.aPositiveInt().toLong(),
+            rumContext = forge.getForgery()
+        )
+    }
+}

--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilerEventRumOomErrorEventForgeryFactory.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilerEventRumOomErrorEventForgeryFactory.kt
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.tests.elmyr
+
+import com.datadog.android.internal.profiling.ProfilerEvent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.util.UUID
+
+class ProfilerEventRumOomErrorEventForgeryFactory : ForgeryFactory<ProfilerEvent.RumOomErrorEvent> {
+    override fun getForgery(forge: Forge): ProfilerEvent.RumOomErrorEvent {
+        return ProfilerEvent.RumOomErrorEvent(
+            id = forge.getForgery<UUID>().toString(),
+            // int instead of long to avoid overflow in call sites if timestamp is used
+            timestamp = forge.aPositiveInt().toLong(),
+            rumContext = forge.getForgery()
+        )
+    }
+}

--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilingAnomalyDetectedEventForgeryFactory.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/elmyr/ProfilingAnomalyDetectedEventForgeryFactory.kt
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.tests.elmyr
+
+import com.datadog.android.internal.profiling.ProfilingAnomalyDetectedEvent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+class ProfilingAnomalyDetectedEventForgeryFactory : ForgeryFactory<ProfilingAnomalyDetectedEvent> {
+    override fun getForgery(forge: Forge): ProfilingAnomalyDetectedEvent {
+        return ProfilingAnomalyDetectedEvent(
+            detectedAtMs = forge.aLong(min = 1L)
+        )
+    }
+}

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -21,6 +21,7 @@ import com.datadog.android.api.storage.FeatureStorageConfiguration
 import com.datadog.android.internal.FeatureContextKeys
 import com.datadog.android.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.internal.profiling.ProfilerEvent
+import com.datadog.android.internal.profiling.ProfilingAnomalyDetectedEvent
 import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 import com.datadog.android.internal.rum.RumSessionConstants
 import com.datadog.android.internal.time.DefaultTimeProvider
@@ -228,14 +229,19 @@ internal class ProfilingFeature(
         if (isLaunchProfilingActive || continuousProfilingScheduler?.isActive == true) {
             sdkCore.getFeature(Feature.RUM_FEATURE_NAME)?.sendEvent(event)
         }
+        // TODO RUM-18154: Wire resultFilePath with ProfilingDataWriter
     }
 
     override fun onOutOfMemoryDetected(detectedAtMs: Long, resultFilePath: String) {
-        // TODO RUM-18155: emit a ProfilingOomDetectedEvent to RUM.
+        // RUM already generates its own OOM error event, so the profiling feature
+        // does not forward a separate OOM event.
+        // TODO RUM-18154: Wire resultFilePath with ProfilingDataWriter
     }
 
     override fun onMemoryAnomalyDetected(detectedAtMs: Long, resultFilePath: String) {
-        // TODO RUM-18155: emit a ProfilingAnomalyDetectedEvent to RUM.
+        sdkCore.getFeature(Feature.RUM_FEATURE_NAME)?.sendEvent(
+            ProfilingAnomalyDetectedEvent(detectedAtMs)
+        )
     }
 
     private fun onTtidEvent() {

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/anr/ProfilingManagerTriggerRegistrar.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/anr/ProfilingManagerTriggerRegistrar.kt
@@ -165,6 +165,7 @@ internal class ProfilingManagerTriggerRegistrar(
                         currentListener.onOutOfMemoryDetected(detectedAtMs, resultPath)
 
                     ProfilingTrigger.TRIGGER_TYPE_ANOMALY ->
+                        // TODO RUM-18223: filter in only memory anomaly result by tag
                         currentListener.onMemoryAnomalyDetected(detectedAtMs, resultPath)
                 }
                 // We currently don't use the result profile, just delete it.

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -21,6 +21,7 @@ import com.datadog.android.core.sampling.DeterministicSampler
 import com.datadog.android.internal.FeatureContextKeys
 import com.datadog.android.internal.data.SharedPreferencesStorage
 import com.datadog.android.internal.profiling.ProfilerEvent
+import com.datadog.android.internal.profiling.ProfilingAnomalyDetectedEvent
 import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 import com.datadog.android.internal.rum.RumSessionConstants
 import com.datadog.android.internal.sampling.SessionSamplingIdProvider
@@ -1332,6 +1333,36 @@ internal class ProfilingFeatureTest {
 
         // Then
         verify(mockRumFeatureScope, never()).sendEvent(any())
+    }
+
+    @Test
+    fun `M not forward OOM event to RUM W onOutOfMemoryDetected()`(
+        @LongForgery(min = 0L) fakeDetectedAtMs: Long
+    ) {
+        // Given
+        testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
+        testedFeature.onInitialize(mockContext)
+
+        // When
+        testedFeature.onOutOfMemoryDetected(fakeDetectedAtMs, "")
+
+        // Then
+        verify(mockRumFeatureScope, never()).sendEvent(any())
+    }
+
+    @Test
+    fun `M forward anomaly event to RUM W onMemoryAnomalyDetected()`(
+        @LongForgery(min = 0L) fakeDetectedAtMs: Long
+    ) {
+        // Given
+        testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
+        testedFeature.onInitialize(mockContext)
+
+        // When
+        testedFeature.onMemoryAnomalyDetected(fakeDetectedAtMs, "")
+
+        // Then
+        verify(mockRumFeatureScope).sendEvent(ProfilingAnomalyDetectedEvent(fakeDetectedAtMs))
     }
 
     @Test

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/Configurator.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/Configurator.kt
@@ -6,9 +6,12 @@
 
 package com.datadog.android.profiling.forge
 
+import com.datadog.android.internal.tests.elmyr.ProfilerEventRumAnomalyErrorEventForgeryFactory
 import com.datadog.android.internal.tests.elmyr.ProfilerEventRumAnrEventForgeryFactory
 import com.datadog.android.internal.tests.elmyr.ProfilerEventRumLongTaskEventForgeryFactory
+import com.datadog.android.internal.tests.elmyr.ProfilerEventRumOomErrorEventForgeryFactory
 import com.datadog.android.internal.tests.elmyr.ProfilerEventRumVitalEventFactory
+import com.datadog.android.internal.tests.elmyr.ProfilingAnomalyDetectedEventForgeryFactory
 import com.datadog.android.internal.tests.elmyr.ProfilingAnrDetectedEventForgeryFactory
 import com.datadog.android.internal.tests.elmyr.ProfilingRumContextFactory
 import com.datadog.android.internal.tests.elmyr.ProfilingThreadDumpForgeryFactory
@@ -28,8 +31,11 @@ class Configurator : BaseConfigurator() {
         forge.addFactory(ProfilerEventRumVitalEventFactory())
         forge.addFactory(ProfilerEventRumLongTaskEventForgeryFactory())
         forge.addFactory(ProfilerEventRumAnrEventForgeryFactory())
+        forge.addFactory(ProfilerEventRumOomErrorEventForgeryFactory())
+        forge.addFactory(ProfilerEventRumAnomalyErrorEventForgeryFactory())
         forge.addFactory(ProfilingRumContextFactory())
         forge.addFactory(ProfilingAnrDetectedEventForgeryFactory())
+        forge.addFactory(ProfilingAnomalyDetectedEventForgeryFactory())
         forge.addFactory(StackTraceElementForgeryFactory())
         forge.addFactory(ProfilingThreadDumpForgeryFactory())
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
@@ -80,6 +80,12 @@ object RumAttributes {
     internal const val INTERNAL_ALL_THREADS: String = "_dd.error.threads"
 
     /**
+     * Private marker set on RUM error events that originate from the profiling
+     * feature (e.g. a memory anomaly trigger).
+     */
+    internal const val INTERNAL_PROFILING_ANOMALY: String = "_dd.profiling.anomaly"
+
+    /**
      * Overrides the default view instrumentation type with a custom one.
      * Used by cross-platform SDKs (Flutter, React Native, Unity, etc.) to report
      * their specific navigation patterns in telemetry.

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -37,6 +37,7 @@ import com.datadog.android.event.NoOpEventMapper
 import com.datadog.android.heatmaps.HeatmapIdentifierRegistryProvider
 import com.datadog.android.internal.flags.RumFlagEvaluationMessage
 import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
+import com.datadog.android.internal.profiling.ProfilingAnomalyDetectedEvent
 import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 import com.datadog.android.internal.profiling.ProfilingThreadDump
 import com.datadog.android.internal.system.BuildSdkVersionProvider
@@ -431,6 +432,7 @@ internal class RumFeature(
             is InternalTelemetryEvent -> handleTelemetryEvent(event)
             is RumFlagEvaluationMessage -> handleFlagEvaluationEvent(event)
             is ProfilingAnrDetectedEvent -> handleProfilingAnrDetectedEvent(event)
+            is ProfilingAnomalyDetectedEvent -> handleProfilingAnomalyDetectedEvent(event)
             else -> {
                 sdkCore.internalLogger.log(
                     InternalLogger.Level.WARN,
@@ -467,6 +469,18 @@ internal class RumFeature(
             mapOf(
                 RumAttributes.INTERNAL_TIMESTAMP to event.detectedAtMs,
                 RumAttributes.INTERNAL_ALL_THREADS to allThreads
+            )
+        )
+    }
+
+    private fun handleProfilingAnomalyDetectedEvent(event: ProfilingAnomalyDetectedEvent) {
+        GlobalRumMonitor.get(sdkCore).addError(
+            MEMORY_ANOMALY_MESSAGE,
+            RumErrorSource.SOURCE,
+            null,
+            mapOf(
+                RumAttributes.INTERNAL_TIMESTAMP to event.detectedAtMs,
+                RumAttributes.INTERNAL_PROFILING_ANOMALY to true
             )
         )
     }
@@ -813,6 +827,7 @@ internal class RumFeature(
         internal const val WEB_VIEW_INGESTED_NOTIFICATION_MESSAGE_TYPE = "web_view_ingested_notification"
         internal const val TELEMETRY_SESSION_REPLAY_SKIP_FRAME = "sr_skipped_frame"
         internal const val FLUSH_AND_STOP_MONITOR_MESSAGE_TYPE = "flush_and_stop_monitor"
+        internal const val MEMORY_ANOMALY_MESSAGE = "Memory Anomaly"
 
         internal val RUM_TTL_24H = TimeUnit.HOURS.toMillis(24)
         internal const val ALL_IN_SAMPLE_RATE: Float = 100f

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -746,6 +746,8 @@ internal open class RumViewScope(
         val isFatal = errorCustomAttributes.remove(RumAttributes.INTERNAL_ERROR_IS_CRASH) as? Boolean == true ||
             event.isFatal
         val errorFingerprint = errorCustomAttributes.remove(RumAttributes.ERROR_FINGERPRINT) as? String
+        val isProfilingAnomaly =
+            errorCustomAttributes.remove(RumAttributes.INTERNAL_PROFILING_ANOMALY) as? Boolean == true
         // if a cross-platform crash was already reported, do not send its native version
         if (crashCount > 0 && isFatal) return
 
@@ -810,7 +812,11 @@ internal open class RumViewScope(
                     fingerprint = errorFingerprint,
                     type = errorType,
                     sourceType = event.sourceType.toSchemaSourceType(),
-                    category = ErrorEvent.Category.tryFrom(event),
+                    category = if (isProfilingAnomaly) {
+                        ErrorEvent.Category.MEMORY_WARNING
+                    } else {
+                        ErrorEvent.Category.tryFrom(event)
+                    },
                     threads = event.threads.map {
                         ErrorEvent.Thread(
                             name = it.name,
@@ -923,6 +929,19 @@ internal open class RumViewScope(
                             // the next launch) can dedupe against an ANR the in-process watchdog/profiling
                             // trigger already reported. The storage key keeps the legacy "fatal" name.
                             sdkCore.writeLastFatalAnrSent(event.eventTime.timestamp)
+                        } else if (isProfilingAnomaly) {
+                            sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.sendEvent(
+                                ProfilerEvent.RumAnomalyErrorEvent(
+                                    id = errorId,
+                                    timestamp = event.eventTime.timestamp + serverTimeOffsetInMs,
+                                    rumContext = ProfilingRumContext(
+                                        applicationId = rumContext.applicationId,
+                                        sessionId = rumContext.sessionId,
+                                        viewId = rumContext.viewId,
+                                        viewName = rumContext.viewName
+                                    )
+                                )
+                            )
                         }
                     }
                 }
@@ -933,6 +952,23 @@ internal open class RumViewScope(
             errorCount++
             crashCount++
             sendViewUpdate(event, datadogContext, writeScope, writer, eventType)
+            // Best-effort signal: for fatal crashes there is no onSuccess callback
+            // (the app is crashing), so we send the signal immediately after
+            // submitting the write.
+            if (event.throwable is OutOfMemoryError) {
+                sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.sendEvent(
+                    ProfilerEvent.RumOomErrorEvent(
+                        id = errorId,
+                        timestamp = event.eventTime.timestamp + serverTimeOffsetInMs,
+                        rumContext = ProfilingRumContext(
+                            applicationId = rumContext.applicationId,
+                            sessionId = rumContext.sessionId,
+                            viewId = rumContext.viewId,
+                            viewName = rumContext.viewName
+                        )
+                    )
+                )
+            }
         } else {
             pendingErrorCount++
         }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -23,6 +23,7 @@ import com.datadog.android.core.feature.event.ThreadDump
 import com.datadog.android.event.EventMapper
 import com.datadog.android.event.MapperSerializer
 import com.datadog.android.internal.flags.RumFlagEvaluationMessage
+import com.datadog.android.internal.profiling.ProfilingAnomalyDetectedEvent
 import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
@@ -105,6 +106,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -1203,6 +1205,27 @@ internal class RumFeatureTest {
         assertThat(mainDump.state).isEqualTo(eventWithNoOtherThreads.anrThreadState.asString())
         assertThat(mainDump.stack).isEqualTo(throwable.loggableStackTrace())
         assertThat(mainDump.crashed).isFalse
+    }
+
+    @Test
+    fun `M call addError W onReceive(ProfilingAnomalyDetectedEvent)`(
+        @Forgery fakeEvent: ProfilingAnomalyDetectedEvent
+    ) {
+        // When
+        testedFeature.onReceive(fakeEvent)
+
+        // Then
+        val attributesCaptor = argumentCaptor<Map<String, Any?>>()
+        verify(mockRumMonitor).addError(
+            eq(RumFeature.MEMORY_ANOMALY_MESSAGE),
+            eq(RumErrorSource.SOURCE),
+            isNull(),
+            attributesCaptor.capture()
+        )
+        assertThat(attributesCaptor.firstValue[RumAttributes.INTERNAL_TIMESTAMP])
+            .isEqualTo(fakeEvent.detectedAtMs)
+        assertThat(attributesCaptor.firstValue[RumAttributes.INTERNAL_PROFILING_ANOMALY])
+            .isEqualTo(true)
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -41,6 +41,7 @@ import com.datadog.android.rum.assertj.VitalEventAssert
 import com.datadog.android.rum.assertj.VitalOperationPropertiesAssert
 import com.datadog.android.rum.internal.FeaturesContextResolver
 import com.datadog.android.rum.internal.RumErrorSourceType
+import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.anr.ANRDetectorRunnable
 import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.domain.InfoProvider
@@ -4287,6 +4288,151 @@ internal class RumViewScopeTest {
         // Then — the profile must not reference an ANR error id that RUM never ingested.
         verify(mockWriter).write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))
         verify(mockProfilingFeatureScope, never()).sendEvent(isA<ProfilerEvent.RumAnrEvent>())
+    }
+
+    @Test
+    fun `M send RumAnomalyErrorEvent to profiling W handleEvent(AddError) {profiling anomaly marker}`(
+        @StringForgery fakeMessage: String,
+        @Forgery fakeSource: RumErrorSource,
+        @StringForgery fakeStacktrace: String,
+        forge: Forge
+    ) {
+        // Given
+        testedScope.activeActionScope = mockActionScope
+        val fakeErrorAttributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        fakeErrorAttributes[RumAttributes.INTERNAL_PROFILING_ANOMALY] = true
+        fakeEvent = RumRawEvent.AddError(
+            fakeMessage,
+            fakeSource,
+            null,
+            fakeStacktrace,
+            isFatal = false,
+            threads = emptyList(),
+            attributes = fakeErrorAttributes,
+            eventTime = fakeEventTime
+        )
+        val expectedTimestamp = resolveExpectedTimestamp(fakeEvent.eventTime.timestamp)
+
+        // When
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        argumentCaptor<ErrorEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(firstValue).hasErrorCategory(ErrorEvent.Category.MEMORY_WARNING)
+        }
+        argumentCaptor<ProfilerEvent.RumAnomalyErrorEvent> {
+            verify(mockProfilingFeatureScope).sendEvent(capture())
+            assertThat(firstValue.id).isNotEmpty()
+            assertThat(firstValue.timestamp).isEqualTo(expectedTimestamp)
+            assertThat(firstValue.rumContext).isEqualTo(
+                ProfilingRumContext(
+                    applicationId = fakeParentContext.applicationId,
+                    sessionId = fakeParentContext.sessionId,
+                    viewId = testedScope.viewId,
+                    viewName = fakeKey.name
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `M not send RumAnomalyErrorEvent to profiling W handleEvent(AddError) {no profiling anomaly marker}`(
+        @Forgery fakeSource: RumErrorSource,
+        @StringForgery fakeStacktrace: String,
+        forge: Forge
+    ) {
+        // Given
+        val fakeThrowable = RuntimeException("not an anomaly")
+        testedScope.activeActionScope = mockActionScope
+        val fakeErrorAttributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        // Same message as the profiling anomaly but without the private marker — must not match.
+        fakeEvent = RumRawEvent.AddError(
+            RumFeature.MEMORY_ANOMALY_MESSAGE,
+            fakeSource,
+            fakeThrowable,
+            fakeStacktrace,
+            isFatal = false,
+            threads = emptyList(),
+            attributes = fakeErrorAttributes,
+            eventTime = fakeEventTime
+        )
+
+        // When
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        verify(mockProfilingFeatureScope, never()).sendEvent(isA<ProfilerEvent.RumAnomalyErrorEvent>())
+    }
+
+    @Test
+    fun `M send RumOomErrorEvent to profiling W handleEvent(AddError) {fatal OutOfMemoryError}`(
+        @Forgery fakeSource: RumErrorSource,
+        @StringForgery fakeStacktrace: String,
+        forge: Forge
+    ) {
+        // Given
+        val fakeThrowable = OutOfMemoryError()
+        testedScope.activeActionScope = mockActionScope
+        val fakeErrorAttributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        fakeEvent = RumRawEvent.AddError(
+            "OutOfMemoryError",
+            fakeSource,
+            fakeThrowable,
+            fakeStacktrace,
+            isFatal = true,
+            threads = emptyList(),
+            attributes = fakeErrorAttributes,
+            eventTime = fakeEventTime
+        )
+        val expectedTimestamp = resolveExpectedTimestamp(fakeEvent.eventTime.timestamp)
+
+        // When
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then — best-effort signal sent immediately (fatal crash has no onSuccess callback)
+        argumentCaptor<ProfilerEvent.RumOomErrorEvent> {
+            verify(mockProfilingFeatureScope).sendEvent(capture())
+            assertThat(firstValue.id).isNotEmpty()
+            assertThat(firstValue.timestamp).isEqualTo(expectedTimestamp)
+            assertThat(firstValue.rumContext).isEqualTo(
+                ProfilingRumContext(
+                    applicationId = fakeParentContext.applicationId,
+                    sessionId = fakeParentContext.sessionId,
+                    viewId = testedScope.viewId,
+                    viewName = fakeKey.name
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `M not send RumOomErrorEvent to profiling W handleEvent(AddError) {fatal but not OutOfMemoryError}`(
+        @StringForgery fakeMessage: String,
+        @Forgery fakeSource: RumErrorSource,
+        @StringForgery fakeStacktrace: String,
+        forge: Forge
+    ) {
+        // Given
+        val fakeThrowable = RuntimeException("not an OOM")
+        testedScope.activeActionScope = mockActionScope
+        val fakeErrorAttributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        fakeEvent = RumRawEvent.AddError(
+            fakeMessage,
+            fakeSource,
+            fakeThrowable,
+            fakeStacktrace,
+            isFatal = true,
+            threads = emptyList(),
+            attributes = fakeErrorAttributes,
+            eventTime = fakeEventTime
+        )
+
+        // When
+        testedScope.handleEvent(fakeEvent, fakeDatadogContext, mockEventWriteScope, mockWriter)
+
+        // Then
+        verify(mockProfilingFeatureScope, never()).sendEvent(isA<ProfilerEvent.RumOomErrorEvent>())
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
@@ -12,6 +12,7 @@ import com.datadog.android.internal.tests.elmyr.InternalTelemetryDebugLogForgery
 import com.datadog.android.internal.tests.elmyr.InternalTelemetryErrorLogForgeryFactory
 import com.datadog.android.internal.tests.elmyr.InternalTelemetryEventForgeryFactory
 import com.datadog.android.internal.tests.elmyr.InternalTelemetryMetricForgeryFactory
+import com.datadog.android.internal.tests.elmyr.ProfilingAnomalyDetectedEventForgeryFactory
 import com.datadog.android.internal.tests.elmyr.ProfilingAnrDetectedEventForgeryFactory
 import com.datadog.android.internal.tests.elmyr.ProfilingThreadDumpForgeryFactory
 import com.datadog.android.internal.tests.elmyr.TracingHeaderTypesSetForgeryFactory
@@ -76,6 +77,7 @@ internal class Configurator : BaseConfigurator() {
         forge.addFactory(TracingHeaderTypesSetForgeryFactory())
         forge.addFactory(ProfilingThreadDumpForgeryFactory())
         forge.addFactory(ProfilingAnrDetectedEventForgeryFactory())
+        forge.addFactory(ProfilingAnomalyDetectedEventForgeryFactory())
 
         // RumRawEvent
         forge.addFactory(ActionSentForgeryFactory())


### PR DESCRIPTION
### What does this PR do?

Emits a `ProfilingAnomalyDetectedEvent` from the profiling feature to RUM when a memory anomaly trigger fires, and wires the full round-trip: RUM generates an error event classified as MEMORY_WARNING, then sends a `RumAnomalyErrorEvent` correlation signal back to the profiling feature so the captured heap dump can be anchored to the RUM session.

OOM is intentionally not forwarded — RUM already generates its own OOM error event.

### Motivation

RUM-18155

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

