### PR TITLE
RUM-18204: Migrate from KotlinX AST to Kotlin PSI model for API surface generation

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -45,8 +45,8 @@ dependencies {
     compileOnly(libs.detektGradlePlugin)
     compileOnly(libs.ktlintGradlePlugin)
 
-    // check api surface
-    implementation(libs.kotlinGrammarParser)
+    // Bundled with Gradle buildscript path
+    compileOnly(libs.kotlinCompilerEmbeddable)
 
     // JsonSchema 2 Poko
     implementation(libs.gson)
@@ -56,6 +56,9 @@ dependencies {
     implementation(libs.kotlinXmlBuilder)
 
     // Tests
+    // Not inherited from `compileOnly`, and the test JVM has no buildscript classpath to
+    // borrow it from, so the API surface tests need their own copy.
+    testImplementation(libs.kotlinCompilerEmbeddable)
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.mockitoKotlin)
     testImplementation(libs.assertJ)

--- a/build-logic/src/main/kotlin/com/datadog/gradle/plugin/apisurface/KotlinFileVisitor.kt
+++ b/build-logic/src/main/kotlin/com/datadog/gradle/plugin/apisurface/KotlinFileVisitor.kt
@@ -6,32 +6,65 @@
 
 package com.datadog.gradle.plugin.apisurface
 
-import kotlinx.ast.common.AstSource
-import kotlinx.ast.common.ast.Ast
-import kotlinx.ast.common.ast.AstNode
-import kotlinx.ast.common.ast.AstTerminal
-import kotlinx.ast.common.print
-import kotlinx.ast.grammar.kotlin.target.antlr.kotlin.KotlinGrammarAntlrKotlinParser
+import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.com.intellij.psi.PsiComment
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassBody
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtEnumEntry
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtFunctionType
+import org.jetbrains.kotlin.psi.KtModifierListOwner
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtNullableType
+import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtPrimaryConstructor
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.KtSecondaryConstructor
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.KtTypeAlias
+import org.jetbrains.kotlin.psi.KtTypeElement
+import org.jetbrains.kotlin.psi.KtTypeParameter
+import org.jetbrains.kotlin.psi.KtTypeProjection
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.KtUserType
 import java.io.File
 
+/**
+ * Builds the API surface description of a set of Kotlin files.
+ *
+ * This uses the Kotlin compiler's own PSI parser, which holds no state between files, so the
+ * memory used is proportional to the file being parsed rather than to everything parsed so far.
+ *
+ * Note that types are rendered the way they are written in the source, with only the file's
+ * own import list applied — no symbol resolution happens, and none is wanted: the surface
+ * file records the API as it is declared.
+ */
 class KotlinFileVisitor {
 
     val description = StringBuilder()
-    private lateinit var pkg: String
+
+    private var pkg: String = ""
     private val imports = mutableMapOf<String, String>()
 
     // region KotlinFileVisitor
 
     @Suppress("TooGenericExceptionCaught")
-    fun visitFile(file: File, printAst: Boolean = false) {
-        val code = file.readText()
-        val source = AstSource.String(description = "Content of file ${file.path}", content = code)
-        val ast = KotlinGrammarAntlrKotlinParser.parseKotlinFile(source)
-
-        if (printAst) ast.print()
+    fun visitFile(file: File) {
+        val ktFile = PSI_FACTORY.createFile(file.name, file.readText())
         imports.clear()
         try {
-            visitAst(ast, level = 0)
+            visitKtFile(ktFile)
         } catch (e: Exception) {
             throw IllegalStateException("Error generating API surface for $file", e)
         }
@@ -41,155 +74,138 @@ class KotlinFileVisitor {
 
     // region Internal/Visitor
 
-    private fun visitAst(ast: Ast, level: Int) {
-        when (ast) {
-            is AstNode -> visitAstNode(ast, level)
-            is AstTerminal -> ignoreNode()
-            else -> error("Unable to handle $ast")
+    private fun visitKtFile(ktFile: KtFile) {
+        val packageName = ktFile.packageDirective?.qualifiedName.orEmpty()
+        pkg = if (packageName.isEmpty()) "" else "$packageName."
+
+        ktFile.importDirectives.forEach { directive ->
+            val imported = directive.importedFqName?.asString() ?: return@forEach
+            val alias = directive.aliasName
+            imports[alias ?: imported.substringAfterLast(".")] = imported
+        }
+
+        ktFile.declarations.forEach { visitDeclaration(it, level = 0) }
+    }
+
+    private fun visitDeclaration(declaration: KtDeclaration, level: Int) {
+        when (declaration) {
+            is KtEnumEntry -> visitEnumEntry(declaration, level)
+            is KtClass -> visitTypeDeclaration(declaration, level, "class")
+            is KtObjectDeclaration -> visitTypeDeclaration(
+                declaration,
+                level,
+                if (declaration.isCompanion()) "companion object" else "object"
+            )
+
+            is KtSecondaryConstructor -> visitSecondaryConstructor(declaration, level)
+            is KtNamedFunction -> visitFunctionDeclaration(declaration, level)
+            is KtProperty -> visitProperty(declaration, level)
+            is KtTypeAlias -> visitTypeAlias(declaration, level)
+            else -> ignoreDeclaration()
         }
     }
 
-    private fun visitAstNode(node: AstNode, level: Int) {
-        when (node.description) {
-            "kotlinFile",
-            "importList",
-            "topLevelObject",
-            "declaration",
-            "classMemberDeclarations",
-            "classMemberDeclaration",
-            "enumEntries",
-            "kamoulox" -> node.children.forEach {
-                visitAst(it, level)
-            }
-            "packageHeader" -> visitPackage(node)
-            "importHeader" -> visitImport(node)
-            "classDeclaration" -> visitTypeDeclaration(node, level, "class")
-            "objectDeclaration" -> visitTypeDeclaration(node, level, "object")
-            "companionObject" -> visitTypeDeclaration(node, level, "companion object")
-            "secondaryConstructor" -> visitSecondaryConstructor(node, level)
-            "functionDeclaration" -> visitFunctionDeclaration(node, level)
-            "propertyDeclaration" -> visitProperty(node, level)
-            "typeAlias" -> visitTypeAlias(node, level)
-            "enumEntry" -> visitEnumEntry(node, level)
-            "semis" -> ignoreNode()
-            else -> println("??? ${node.description}")
-        }
-    }
-
-    private fun visitTypeDeclaration(node: AstNode, level: Int, type: String) {
-        if (node.isInternal() || node.isPrivate()) return
+    private fun visitTypeDeclaration(declaration: KtClassOrObject, level: Int, type: String) {
+        if (declaration.isInternal() || declaration.isPrivate()) return
 
         description.append(INDENT.repeat(level))
 
         // Modifiers
-        if (node.isDeprecated()) description.append("DEPRECATED ")
-        if (node.isDataClass()) description.append("data ")
-        if (node.isSealed()) description.append("sealed ")
-        if (node.isProtected()) description.append("protected ")
-        if (node.isOpen()) description.append("open ")
-        if (node.isAbstract()) description.append("abstract ")
+        if (declaration.isDeprecated()) description.append("DEPRECATED ")
+        if (declaration.isData()) description.append("data ")
+        if (declaration.isSealed()) description.append("sealed ")
+        if (declaration.isProtected()) description.append("protected ")
+        if (declaration.isOpen()) description.append("open ")
+        if (declaration.isAbstract()) description.append("abstract ")
 
         when {
-            node.hasChildTerminal("INTERFACE") -> description.append("interface ")
-            node.isEnum() -> description.append("enum ")
-            node.isAnnotation() -> description.append("annotation ")
+            declaration.isInterface() -> description.append("interface ")
+            declaration.isEnum() -> description.append("enum ")
+            declaration.isAnnotation() -> description.append("annotation ")
             else -> description.append("$type ")
         }
 
         // Canonical name
         if (level == 0) description.append(pkg)
-        description.append(node.identifierName())
+        description.append(declaration.declaredName())
 
         // Generics
-        visitTypeParameters(node)
+        visitTypeParameters(declaration)
 
         // Parent types
-        visitParentTypes(node)
+        visitParentTypes(declaration)
 
         // EOL
         description.append("\n")
 
         // Primary constructor
-        val primaryConstructor = node.firstChildNodeOrNull("primaryConstructor")
-        if (primaryConstructor != null) {
-            visitPrimaryConstructor(primaryConstructor, level + 1)
-        }
+        declaration.primaryConstructor?.let { visitPrimaryConstructor(it, level + 1) }
 
         // Content
-        node.firstChildNodeOrNull("classBody")?.children?.forEach {
-            visitAst(it, level + 1)
-        }
-        node.firstChildNodeOrNull("enumClassBody")?.children?.forEach {
-            visitAst(it, level + 1)
-        }
+        declaration.body?.let { visitClassBody(it, level + 1) }
     }
 
-    private fun visitPrimaryConstructor(node: AstNode, level: Int) {
-        if (node.isInternal() || node.isPrivate()) return
+    private fun visitClassBody(body: KtClassBody, level: Int) {
+        body.declarations.forEach { visitDeclaration(it, level) }
+    }
+
+    private fun visitPrimaryConstructor(constructor: KtPrimaryConstructor, level: Int) {
+        if (constructor.isInternal() || constructor.isPrivate()) return
 
         description.append(INDENT.repeat(level))
-
         description.append("constructor")
-
-        // Parameters
-        visitConstructorParameters(node)
-
-        // EOL
+        visitParameters(constructor.valueParameters)
         description.append("\n")
     }
 
-    private fun visitSecondaryConstructor(node: AstNode, level: Int) {
-        if (node.isInternal() || node.isPrivate()) return
+    private fun visitSecondaryConstructor(constructor: KtSecondaryConstructor, level: Int) {
+        if (constructor.isInternal() || constructor.isPrivate()) return
 
         description.append(INDENT.repeat(level))
 
         // Modifiers
-        if (node.isDeprecated()) description.append("DEPRECATED ")
-        if (node.isProtected()) description.append("protected ")
+        if (constructor.isDeprecated()) description.append("DEPRECATED ")
+        if (constructor.isProtected()) description.append("protected ")
 
         description.append("constructor")
-
-        // Parameters
-        visitFunctionParameters(node)
-
-        // EOL
+        visitParameters(constructor.valueParameters)
         description.append("\n")
     }
 
-    private fun visitFunctionDeclaration(node: AstNode, level: Int) {
-        if (node.isInternal() || node.isPrivate()) return
+    private fun visitFunctionDeclaration(function: KtNamedFunction, level: Int) {
+        if (function.isInternal() || function.isPrivate()) return
 
         description.append(INDENT.repeat(level))
 
         // Modifiers
-        if (node.isDeprecated()) description.append("DEPRECATED ")
-        if (node.isOverride()) description.append("override ")
-        if (node.isProtected()) description.append("protected ")
-        if (node.isOpen()) description.append("open ")
-        if (node.isAbstract()) description.append("abstract ")
+        if (function.isDeprecated()) description.append("DEPRECATED ")
+        if (function.isOverride()) description.append("override ")
+        if (function.isProtected()) description.append("protected ")
+        if (function.isOpen()) description.append("open ")
+        if (function.isAbstract()) description.append("abstract ")
 
         description.append("fun ")
 
         // Generics
-        visitTypeParameters(node)
-        if (node.hasChildNode("typeParameters")) {
+        visitTypeParameters(function)
+        if (function.typeParameters.isNotEmpty()) {
             description.append(" ")
         }
 
-        visitReceiver(node)
-        if (node.hasChildNode("receiverType")) {
+        // Receiver
+        function.receiverTypeReference?.let {
+            description.append(it.typeName())
             description.append(".")
         }
 
         // Name
-        description.append(node.identifierName())
+        description.append(function.declaredName())
 
         // Parameters
-        visitFunctionParameters(node)
+        visitParameters(function.valueParameters)
 
         // Return type
-        val type = node.firstChildNodeOrNull("type")
-        type?.let {
+        function.typeReference?.let {
             description.append(": ")
             description.append(it.typeName())
         }
@@ -198,35 +214,34 @@ class KotlinFileVisitor {
         description.append("\n")
     }
 
-    private fun visitProperty(node: AstNode, level: Int) {
-        if (node.isInternal() || node.isPrivate()) return
+    private fun visitProperty(property: KtProperty, level: Int) {
+        if (property.isInternal() || property.isPrivate()) return
 
         description.append(INDENT.repeat(level))
 
         // Modifiers
-        if (node.isDeprecated()) description.append("DEPRECATED ")
-        if (node.isOverride()) description.append("override ")
-        if (node.isProtected()) description.append("protected ")
-        if (node.isOpen()) description.append("open ")
-        if (node.isAbstract()) description.append("abstract ")
-        if (node.isConst()) description.append("const ")
+        if (property.isDeprecated()) description.append("DEPRECATED ")
+        if (property.isOverride()) description.append("override ")
+        if (property.isProtected()) description.append("protected ")
+        if (property.isOpen()) description.append("open ")
+        if (property.isAbstract()) description.append("abstract ")
+        if (property.isConst()) description.append("const ")
 
         // Property type
-        if (node.hasChildTerminal("VAL")) {
-            description.append("val ")
-        } else if (node.hasChildTerminal("VAR")) {
+        if (property.isVar) {
             description.append("var ")
+        } else {
+            description.append("val ")
         }
 
-        val variableDeclaration = node.firstChildNode("variableDeclaration")
-        description.append(variableDeclaration.identifierName())
+        description.append(property.declaredName())
 
         // Type
         description.append(": ")
-        val propertyType = variableDeclaration.firstChildNodeOrNull("type")
+        val propertyType = property.typeReference
         checkNotNull(propertyType) {
             "Public properties should use an explicit type. " +
-                "Error on property ${variableDeclaration.identifierName()}"
+                "Error on property ${property.name}"
         }
         description.append(propertyType.typeName())
 
@@ -234,101 +249,50 @@ class KotlinFileVisitor {
         description.append("\n")
     }
 
-    private fun visitEnumEntry(node: AstNode, level: Int) {
+    private fun visitEnumEntry(entry: KtEnumEntry, level: Int) {
         description.append(INDENT.repeat(level))
         description.append("- ")
-        description.append(node.identifierName())
+        description.append(entry.declaredName())
         description.append("\n")
     }
 
-    private fun visitParentTypes(node: AstNode) {
-        val parentSpecifiers = node.firstChildNodeOrNull("delegationSpecifiers")
-            ?.childrenNodes("annotatedDelegationSpecifier")
-            ?.map {
-                val delegation = it.firstChildNode("delegationSpecifier")
-                val typeRef = delegation.firstChildNodeOrNull("constructorInvocation")
-                    ?: delegation.firstChildNodeOrNull("explicitDelegation")
-                    ?: delegation
-                typeRef.typeReferenceName()
-            }
-        if (!parentSpecifiers.isNullOrEmpty()) {
+    private fun visitParentTypes(declaration: KtClassOrObject) {
+        val parentSpecifiers = declaration.superTypeListEntries
+            .mapNotNull { it.typeReference?.typeName() }
+        if (parentSpecifiers.isNotEmpty()) {
             description.append(" : ")
             description.append(parentSpecifiers.joinToString(", "))
         }
     }
 
-    private fun visitTypeParameters(node: AstNode) {
-        val typeParameters = node.firstChildNodeOrNull("typeParameters") ?: return
-        val generics = typeParameters.childrenNodes("typeParameter")
-            .map {
-                val name = it.identifierName()
-                val type = it.firstChildNodeOrNull("type")?.typeName()
-                name + (if (type == null) "" else ": $type")
-            }
-        description.append(
-            generics.joinToString(", ", prefix = "<", postfix = ">")
-        )
-    }
-
-    private fun visitReceiver(node: AstNode) {
-        val receiverType = node.firstChildNodeOrNull("receiverType") ?: return
-        description.append(receiverType.typeName())
-    }
-
-    private fun visitFunctionParameters(node: AstNode) {
-        description.append("(")
-        description.append(
-            node.firstChildNode("functionValueParameters")
-                .childrenNodes("functionValueParameter")
-                .joinToString(", ") { it.parameterType() }
-        )
-        description.append(")")
-    }
-
-    private fun visitConstructorParameters(node: AstNode) {
-        description.append("(")
-        description.append(
-            node.firstChildNode("classParameters")
-                .childrenNodes("classParameter")
-                .joinToString(", ") { it.constructorParameterType() }
-        )
-        description.append(")")
-    }
-
-    private fun visitPackage(node: AstNode) {
-        val identifier = node.firstChildNodeOrNull("identifier")
-        pkg = if (identifier != null) {
-            identifier.identifierName() + "."
-        } else {
-            ""
+    private fun visitTypeParameters(declaration: KtDeclaration) {
+        val typeParameters = declaration.typeParametersOrNull() ?: return
+        if (typeParameters.isEmpty()) return
+        val generics = typeParameters.map { parameter ->
+            val name = parameter.name.orEmpty()
+            val bound = parameter.extendsBound?.typeName()
+            name + (if (bound == null) "" else ": $bound")
         }
+        description.append(generics.joinToString(", ", prefix = "<", postfix = ">"))
     }
 
-    private fun visitImport(node: AstNode) {
-        val import = node.firstChildNode("identifier").identifierName()
-
-        val importAlias = node.firstChildNodeOrNull("importAlias")?.identifierName()
-
-        imports[importAlias ?: import.substringAfterLast(".")] = import
+    private fun visitParameters(parameters: List<KtParameter>) {
+        description.append("(")
+        description.append(parameters.joinToString(", ") { it.parameterType() })
+        description.append(")")
     }
 
-    private fun visitTypeAlias(node: AstNode, level: Int) {
-        if (node.isInternal() || node.isPrivate()) return
+    private fun visitTypeAlias(typeAlias: KtTypeAlias, level: Int) {
+        if (typeAlias.isInternal() || typeAlias.isPrivate()) return
 
-        val name = node.identifierName()
-
-        val type = node.firstChildNode("type")
+        val name = typeAlias.declaredName()
+        val type = typeAlias.getTypeReference()
 
         description.append(INDENT.repeat(level))
-        val rootTypeName = if (type.hasChildNode("functionType")) {
-            type.lambdaName()
-        } else {
-            type.typeName()
-        }
-        description.append("typealias $name = $rootTypeName\n")
+        description.append("typealias $name = ${type?.typeName()}\n")
     }
 
-    private fun ignoreNode() {
+    private fun ignoreDeclaration() {
         // Do Nothing
     }
 
@@ -336,161 +300,94 @@ class KotlinFileVisitor {
 
     // region Internal/Ext/Modifiers
 
-    private fun AstNode.isSealed(): Boolean {
-        return hasModifier("classModifier", "SEALED")
-    }
+    private fun KtClassOrObject.isSealed(): Boolean = this is KtClass && isSealed()
 
-    private fun AstNode.isDataClass(): Boolean {
-        return hasModifier("classModifier", "DATA")
-    }
+    private fun KtClassOrObject.isEnum(): Boolean = this is KtClass && isEnum()
 
-    private fun AstNode.isEnum(): Boolean {
-        return hasModifier("classModifier", "ENUM")
-    }
+    private fun KtClassOrObject.isInterface(): Boolean = this is KtClass && isInterface()
 
-    private fun AstNode.isAnnotation(): Boolean {
-        return hasModifier("classModifier", "ANNOTATION")
-    }
+    private fun KtModifierListOwner.isProtected(): Boolean = hasModifier(KtTokens.PROTECTED_KEYWORD)
 
-    private fun AstNode.isProtected(): Boolean {
-        return hasModifier("visibilityModifier", "PROTECTED")
-    }
+    private fun KtModifierListOwner.isPrivate(): Boolean = hasModifier(KtTokens.PRIVATE_KEYWORD)
 
-    private fun AstNode.isPrivate(): Boolean {
-        return hasModifier("visibilityModifier", "PRIVATE")
-    }
+    private fun KtModifierListOwner.isInternal(): Boolean = hasModifier(KtTokens.INTERNAL_KEYWORD)
 
-    private fun AstNode.isInternal(): Boolean {
-        return hasModifier("visibilityModifier", "INTERNAL")
-    }
+    private fun KtModifierListOwner.isOpen(): Boolean = hasModifier(KtTokens.OPEN_KEYWORD)
 
-    private fun AstNode.isOpen(): Boolean {
-        return hasModifier("inheritanceModifier", "OPEN")
-    }
+    private fun KtModifierListOwner.isAbstract(): Boolean = hasModifier(KtTokens.ABSTRACT_KEYWORD)
 
-    private fun AstNode.isAbstract(): Boolean {
-        return hasModifier("inheritanceModifier", "ABSTRACT")
-    }
+    private fun KtModifierListOwner.isOverride(): Boolean = hasModifier(KtTokens.OVERRIDE_KEYWORD)
 
-    private fun AstNode.isOverride(): Boolean {
-        return hasModifier("memberModifier", "OVERRIDE")
-    }
+    private fun KtModifierListOwner.isConst(): Boolean = hasModifier(KtTokens.CONST_KEYWORD)
 
-    private fun AstNode.isConst(): Boolean {
-        return hasModifier("propertyModifier", "CONST")
-    }
-
-    private fun AstNode.hasModifier(group: String, modifier: String): Boolean {
-        val modifiers = firstChildNodeOrNull("modifiers") ?: return false
-        return modifiers.childrenNodes("modifier")
-            .mapNotNull { it.firstChildNodeOrNull(group) }
-            .any { it.firstChildTerminalOrNull(modifier) != null }
-    }
-
-    private fun AstNode.isDeprecated(): Boolean {
-        val modifiers = firstChildNodeOrNull("modifiers") ?: return false
-        return modifiers.childrenNodes("annotation")
-            .mapNotNull { it.firstChildNodeOrNull("singleAnnotation") }
-            .mapNotNull { it.firstChildNodeOrNull("unescapedAnnotation") }
-            .map { it.firstChildNodeOrNull("constructorInvocation") ?: it }
-            .filter { it.hasChildNode("userType") }
-            .any { it.typeReferenceName() in DEPRECATED_ANNOTATIONS }
-    }
-
-    // endregion
-
-    // region Internal/Ext/Node
-
-    private fun Ast.isNode(description: String): Boolean {
-        return this is AstNode && this.description == description
-    }
-
-    private fun AstNode.firstChildNode(description: String): AstNode {
-        val first = firstChildNodeOrNull(description)
-        checkNotNull(first) { "Unable to find a child with description $description in \n$this" }
-        return first
-    }
-
-    private fun AstNode.firstChildNodeOrNull(description: String): AstNode? {
-        return children.firstOrNull { it.isNode(description) } as? AstNode
-    }
-
-    private fun AstNode.hasChildNode(description: String): Boolean {
-        return children.any { it.isNode(description) }
-    }
-
-    private fun AstNode.childrenNodes(description: String): List<AstNode> {
-        return children.filterIsInstance<AstNode>()
-            .filter { it.description == description }
-    }
-
-    // endregion
-
-    // region Internal/Ext/Terminal
-
-    private fun Ast.isTerminal(description: String): Boolean {
-        return this is AstTerminal && this.description == description
-    }
-
-    private fun AstNode.firstChildTerminalOrNull(description: String): AstTerminal? {
-        return children.firstOrNull { it.isTerminal(description) } as? AstTerminal
-    }
-
-    private fun AstNode.hasChildTerminal(description: String): Boolean {
-        return children.any { it.isTerminal(description) }
+    private fun KtModifierListOwner.isDeprecated(): Boolean {
+        val annotations = modifierList?.annotationEntries.orEmpty()
+        return annotations.any { entry ->
+            val typeElement = entry.typeReference?.typeElement
+            typeElement is KtUserType && typeElement.userTypeName() in DEPRECATED_ANNOTATIONS
+        }
     }
 
     // endregion
 
     // region Internal/Ext/Names
 
-    private fun AstNode.identifierName(): String {
-        return childrenNodes("simpleIdentifier")
-            .joinToString(".") {
-                it.firstChildTerminalOrNull("Identifier")?.text ?: it.children.first()
-                    .expressionValue()
-            }
+    /**
+     * The name exactly as written: backticks are kept, and a companion object declared without
+     * a name stays nameless rather than picking up the implicit `Companion`.
+     */
+    private fun KtNamedDeclaration.declaredName(): String = nameIdentifier?.text.orEmpty()
+
+    private fun KtDeclaration.typeParametersOrNull(): List<KtTypeParameter>? = when (this) {
+        is KtClassOrObject -> typeParameterList?.parameters
+        is KtNamedFunction -> typeParameterList?.parameters
+        else -> null
     }
 
-    private fun AstNode.typeName(): String {
-        val nullableType = firstChildNodeOrNull("nullableType")
-        return when {
-            nullableType != null -> nullableType.typeName() + "?"
-            hasChildNode("functionType") -> lambdaName()
-            else -> firstChildNode("typeReference").typeReferenceName()
+    private fun KtTypeReference.typeName(): String {
+        val element = typeElement ?: return ""
+        return element.typeElementName()
+    }
+
+    private fun KtTypeElement.typeElementName(): String = when (this) {
+        is KtNullableType -> (innerType?.typeElementName() ?: "") + "?"
+        is KtFunctionType -> lambdaName()
+        is KtUserType -> userTypeName()
+        else -> text
+    }
+
+    /**
+     * Renders a user type the way the surface file records it: the qualifier chain as written,
+     * with only the first segment expanded through the file's imports.
+     */
+    private fun KtUserType.userTypeName(): String {
+        val segments = mutableListOf<KtUserType>()
+        var current: KtUserType? = this
+        while (current != null) {
+            segments.add(0, current)
+            current = current.qualifier
         }
-    }
 
-    private fun AstNode.typeReferenceName(): String {
-        val simpleUserTypes = firstChildNode("userType")
-            .childrenNodes("simpleUserType")
-
-        return simpleUserTypes.fold("") { aggr, userType ->
-            val typeName = userType.identifierName()
-            val generics = userType.firstChildNodeOrNull("typeArguments")
-                ?.childrenNodes("typeProjection")
-                ?.joinToString(", ", prefix = "<", postfix = ">") {
-                    it.firstChildNodeOrNull("type")?.typeName()
-                        ?: it.firstChildTerminalOrNull("MULT")?.text.toString()
-                } ?: ""
-            if (aggr.isEmpty()) {
+        return segments.foldIndexed("") { index, aggregate, segment ->
+            val typeName = segment.referencedName.orEmpty()
+            val generics = segment.typeArgumentList?.arguments
+                ?.joinToString(", ", prefix = "<", postfix = ">") { it.projectionName() }
+                ?: ""
+            if (index == 0) {
                 (imports[typeName] ?: typeName) + generics
             } else {
-                "$aggr.$typeName$generics"
+                "$aggregate.$typeName$generics"
             }
         }
     }
 
-    private fun AstNode.lambdaName(): String {
-        val functionType = firstChildNode("functionType")
+    private fun KtTypeProjection.projectionName(): String =
+        typeReference?.typeName() ?: "*"
 
-        val receiver = functionType.firstChildNodeOrNull("receiverType")?.typeName()
-        val functionTypeParamsNode = functionType.firstChildNode("functionTypeParameters")
-        val params =
-            (functionTypeParamsNode.firstChildNodeOrNull("parameter") ?: functionTypeParamsNode)
-                .childrenNodes("type")
-                .joinToString(", ") { it.typeName() }
-        val returns = functionType.firstChildNode("type").typeName()
+    private fun KtFunctionType.lambdaName(): String {
+        val receiver = receiverTypeReference?.typeName()
+        val params = parameters.joinToString(", ") { it.typeReference?.typeName().orEmpty() }
+        val returns = returnTypeReference?.typeName().orEmpty()
 
         return if (receiver == null) {
             "($params) -> $returns"
@@ -499,46 +396,104 @@ class KotlinFileVisitor {
         }
     }
 
-    private fun AstNode.parameterType(): String {
-        val typeName = firstChildNode("parameter")
-            .firstChildNode("type")
-            .typeName()
+    private fun KtParameter.parameterType(): String {
+        val typeName = typeReference?.typeName().orEmpty()
+        val default = defaultValue ?: return typeName
+        return "$typeName = ${default.normalizedText()}"
+    }
 
-        return if (hasChildNode("expression")) {
-            val defaultValue = firstChildNode("expression").expressionValue()
-            "$typeName = $defaultValue"
-        } else {
-            typeName
+    /**
+     * The expression rendered from its tokens alone, with all whitespace and comments dropped.
+     *
+     * The surface file records default values so reviewers can see them, but it should only
+     * change when the API does. Rendering the source verbatim lets a reformat, or a comment
+     * added inside a default value, mark the checked-in surface stale, and a default written
+     * across several lines breaks the one-declaration-per-line layout.
+     *
+     * Spacing is therefore derived from the tokens themselves rather than from the trivia
+     * between them: a space goes in only where leaving it out would run two tokens together
+     * into a different one (`to 1` must not become `to1`). That makes the rendering canonical
+     * — `foo(1,2)`, `foo(1, 2)` and `foo(1,/* note */2)` all come out as `foo(1,2)`.
+     *
+     * Tokens are walked rather than the text rewritten, so whitespace *inside* string literals
+     * is left alone.
+     */
+    private fun PsiElement.normalizedText(): String {
+        val builder = StringBuilder()
+        appendTokens(this, builder)
+        return builder.toString()
+    }
+
+    private fun appendTokens(element: PsiElement, builder: StringBuilder) {
+        when {
+            element is PsiComment || element is PsiWhiteSpace -> return
+
+            // A string literal is several tokens (quote, content, quote) but has to stay
+            // exactly as written, spaces included, so it is emitted as one unit.
+            element is KtStringTemplateExpression -> appendToken(element.text, builder)
+
+            element.firstChild == null -> appendToken(element.text, builder)
+
+            else -> {
+                var child = element.firstChild
+                while (child != null) {
+                    appendTokens(child, builder)
+                    child = child.nextSibling
+                }
+            }
         }
     }
 
-    private fun AstNode.constructorParameterType(): String {
-        val typeName = firstChildNode("type")
-            .typeName()
+    private fun appendToken(token: String, builder: StringBuilder) {
+        if (token.isEmpty()) return
+        if (builder.isNotEmpty() && builder.needsSeparatorBefore(token)) {
+            builder.append(" ")
+        }
+        builder.append(token)
+    }
 
-        return if (hasChildNode("expression")) {
-            val defaultValue = firstChildNode("expression").expressionValue()
-            "$typeName = $defaultValue"
-        } else {
-            typeName
+    /**
+     * Whether a space belongs between what has been written so far and [token].
+     *
+     * This looks only at the two tokens, never at the source, which is what keeps the
+     * rendering independent of formatting and comments.
+     */
+    private fun StringBuilder.needsSeparatorBefore(token: String): Boolean {
+        val previous = last()
+        return when {
+            // An empty lambda stays tight: `{}`, never `{ }`.
+            previous == '{' && token == "}" -> false
+            // Lambdas are padded, so `remember{emptyMap()}` and `remember { emptyMap() }`
+            // both render as the latter.
+            previous == '{' || token == "{" || token == "}" -> true
+            // Otherwise a space only where the tokens would otherwise merge into one.
+            else -> previous.isIdentifierChar() && token.first().isIdentifierChar()
         }
     }
 
-    private fun Ast.expressionValue(): String {
-        return if (this is AstNode) {
-            children.map { it.expressionValue() }.joinToString("")
-        } else if (this is AstTerminal) {
-            text
-        } else {
-            println("EXPR ?? $this")
-            "…"
-        }
-    }
+    /** Quotes count, so `"a" to 1` keeps its spaces instead of collapsing to `"a"to 1`. */
+
+    private fun Char.isIdentifierChar(): Boolean =
+        isLetterOrDigit() || this == '_' || this == '`' || this == '"' || this == '\''
 
     // endregion
 
     companion object {
         private const val INDENT = "  "
+
+        /**
+         * The compiler environment sets up an IntelliJ application, which is a per-process
+         * singleton, so it is built once and kept for the life of the JVM. It holds no
+         * per-file state: every parsed file becomes garbage as soon as we are done with it.
+         */
+        private val PSI_FACTORY: KtPsiFactory by lazy {
+            val environment = KotlinCoreEnvironment.createForProduction(
+                Disposer.newDisposable("KotlinFileVisitor"),
+                CompilerConfiguration(),
+                EnvironmentConfigFiles.JVM_CONFIG_FILES
+            )
+            KtPsiFactory(environment.project, markGenerated = false)
+        }
 
         private val DEPRECATED_ANNOTATIONS = arrayOf(
             "java.lang.Deprecated",

--- a/build-logic/src/test/kotlin/com/datadog/gradle/plugin/apisurface/KotlinFileVisitorTest.kt
+++ b/build-logic/src/test/kotlin/com/datadog/gradle/plugin/apisurface/KotlinFileVisitorTest.kt
@@ -999,6 +999,86 @@ internal class KotlinFileVisitorTest {
         ).isEqualTo("fun String.withFooBar(): String\n")
     }
 
+    @Test
+    fun `renders default parameters the same however they are formatted`() {
+        val variants = listOf(
+            "foo(1,2)",
+            "foo(1, 2)",
+            "foo(1,/* note */2)",
+            "foo(1, /* note */ 2)",
+            "foo(\n    1,\n    2\n)"
+        )
+
+        val descriptions = variants.map { default ->
+            val visitor = KotlinFileVisitor()
+            tempFile.writeText("fun doSomething(i: Int = $default) {}")
+            visitor.visitFile(tempFile)
+            visitor.description.toString()
+        }
+
+        assertThat(descriptions).containsOnly("fun doSomething(Int = foo(1,2))\n")
+    }
+
+    @Test
+    fun `renders lambda defaults with canonical brace spacing`() {
+        val variants = listOf("remember{emptyMap()}", "remember { emptyMap() }")
+
+        val descriptions = variants.map { default ->
+            val visitor = KotlinFileVisitor()
+            tempFile.writeText("fun doSomething(m: Map<String, Any?> = $default) {}")
+            visitor.visitFile(tempFile)
+            visitor.description.toString()
+        }
+
+        assertThat(descriptions)
+            .containsOnly("fun doSomething(Map<String, Any?> = remember { emptyMap() })\n")
+    }
+
+    @Test
+    fun `renders empty lambda defaults without padding`() {
+        tempFile.writeText(
+            """
+            fun doSomething(a: () -> Unit = {}, b: () -> Unit = {   }) {}
+            """.trimIndent()
+        )
+
+        testedVisitor.visitFile(tempFile)
+
+        assertThat(
+            testedVisitor.description.toString()
+        ).isEqualTo("fun doSomething(() -> Unit = {}, () -> Unit = {})\n")
+    }
+
+    @Test
+    fun `keeps spacing needed to separate default parameter tokens`() {
+        tempFile.writeText(
+            """
+            fun doSomething(m: Map<String, Int> = mapOf("x" to 1), a: Any = o as String) {}
+            """.trimIndent()
+        )
+
+        testedVisitor.visitFile(tempFile)
+
+        assertThat(
+            testedVisitor.description.toString()
+        ).isEqualTo("fun doSomething(Map<String, Int> = mapOf(\"x\" to 1), Any = o as String)\n")
+    }
+
+    @Test
+    fun `keeps whitespace inside default parameter string literals`() {
+        tempFile.writeText(
+            """
+            fun doSomething(s: String = "a  b", c: String = "not /* a */ comment") {}
+            """.trimIndent()
+        )
+
+        testedVisitor.visitFile(tempFile)
+
+        assertThat(
+            testedVisitor.description.toString()
+        ).isEqualTo("fun doSomething(String = \"a  b\", String = \"not /* a */ comment\")\n")
+    }
+
     companion object {
         const val FILE_NAME = "file.kt"
     }

--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -128,9 +128,9 @@ interface com.datadog.android.api.feature.FeatureEventReceiver
   fun onReceive(Any)
 interface com.datadog.android.api.feature.FeatureScope
   val dataStore: com.datadog.android.api.storage.datastore.DataStoreHandler
-  fun withWriteContext(Set<String> = emptySet(), (com.datadog.android.api.context.DatadogContext) -> Unit)
+  fun withWriteContext(Set<String> = emptySet(), (com.datadog.android.api.context.DatadogContext, EventWriteScope) -> Unit)
   fun withContext(Set<String> = emptySet(), (com.datadog.android.api.context.DatadogContext) -> Unit)
-  fun withWriteContextSync(Set<String> = emptySet(), (com.datadog.android.api.context.DatadogContext) -> Unit): Boolean
+  fun withWriteContextSync(Set<String> = emptySet(), (com.datadog.android.api.context.DatadogContext, EventWriteScope) -> Unit): Boolean
   fun sendEvent(Any)
   fun <T: Feature> unwrap(): T
 typealias EventWriteScope = ((com.datadog.android.api.storage.EventBatchWriter) -> Unit) -> Unit

--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -285,8 +285,10 @@ interface com.datadog.android.internal.thread.NamedExecutionUnit
   val name: String
 class com.datadog.android.internal.thread.NamedRunnable : NamedExecutionUnit, Runnable
   constructor(String, Runnable)
+  override val name: String
 class com.datadog.android.internal.thread.NamedCallable<V> : NamedExecutionUnit, java.util.concurrent.Callable<V>
   constructor(String, java.util.concurrent.Callable<V>)
+  override val name: String
 fun isMainThread(): Boolean
 class com.datadog.android.internal.time.DefaultTimeProvider : BaseTimeProvider
   override fun getServerTimestampMillis(): Long

--- a/features/dd-sdk-android-trace-api/api/apiSurface
+++ b/features/dd-sdk-android-trace-api/api/apiSurface
@@ -51,11 +51,11 @@ interface com.datadog.android.trace.api.propagation.DatadogHttpHeadersPropagatio
   fun handleSampledHeaders(com.datadog.android.api.instrumentation.network.HttpRequestInfoBuilder, com.datadog.android.trace.api.tracer.DatadogTracer, com.datadog.android.trace.api.span.DatadogSpan): com.datadog.android.api.instrumentation.network.HttpRequestInfoBuilder
   fun handleNotSampledHeaders(com.datadog.android.api.instrumentation.network.HttpRequestInfoBuilder, com.datadog.android.trace.api.tracer.DatadogTracer, com.datadog.android.trace.api.span.DatadogSpan): com.datadog.android.api.instrumentation.network.HttpRequestInfoBuilder
 interface com.datadog.android.trace.api.propagation.DatadogPropagation
-  fun <C> inject(com.datadog.android.trace.api.span.DatadogSpanContext, C, (C) -> Unit)
-  fun <C> extract(C, (C) -> Unit): com.datadog.android.trace.api.span.DatadogSpanContext?
+  fun <C> inject(com.datadog.android.trace.api.span.DatadogSpanContext, C, (C, String, String) -> Unit)
+  fun <C> extract(C, (C, (String, String) -> Boolean) -> Unit): com.datadog.android.trace.api.span.DatadogSpanContext?
 class com.datadog.android.trace.api.propagation.NoOpDatadogPropagation : DatadogPropagation
-  override fun <C> inject(com.datadog.android.trace.api.span.DatadogSpanContext, C, (C) -> Unit)
-  override fun <C> extract(C, (C) -> Unit): com.datadog.android.trace.api.span.DatadogSpanContext?
+  override fun <C> inject(com.datadog.android.trace.api.span.DatadogSpanContext, C, (C, String, String) -> Unit)
+  override fun <C> extract(C, (C, (String, String) -> Boolean) -> Unit): com.datadog.android.trace.api.span.DatadogSpanContext?
 interface com.datadog.android.trace.api.scope.DatadogScope : java.io.Closeable
   override fun close()
 interface com.datadog.android.trace.api.span.DatadogSpan

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,7 +71,6 @@ nexusPublishGradlePlugin = "2.0.0"
 datadogPlugin = "1.27.0"
 
 kotlinPoet = "1.14.2"
-kotlinGrammarParser = "41b00c0"
 jsonSchemaValidator = "1.12.1"
 binaryCompatibility = "0.18.1"
 dependencyLicense = "0.7.0"
@@ -220,7 +219,7 @@ androidLintChecks = { module = "com.android.tools.lint:lint-checks", version.ref
 kotlinPoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinPoet" }
 kotlinPoetKsp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinPoet" }
 kotlinSP = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "kotlinSP" }
-kotlinGrammarParser = { module = "com.github.kotlinx.ast:grammar-kotlin-parser-antlr-kotlin-jvm", version.ref = "kotlinGrammarParser" }
+kotlinCompilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 jsonSchemaValidator = { module = "com.github.everit-org.json-schema:org.everit.json.schema", version.ref = "jsonSchemaValidator" }
 kotlinXmlBuilder = { module = "org.redundent:kotlin-xml-builder", version.ref = "kotlinXmlBuilder" }
 


### PR DESCRIPTION
### What does this PR do?

Reasons to do migration:

* https://github.com/kotlinx/ast seems to be abandoned and doesn't receive any development.
* Since it is using static caches, sometimes we can get `OutOfMemoryError`. Overall, using it leads to the high memory usage.
* It is published on the JitPack -> JCenter. JCenter is in the read-only mode after sunsetting, so we would like to reduce the number of dependencies hosted there.

I would skip reviewing precisely changes in `KotlinFileVisitor`, because `apiSurface` stays the same after migration (plus it got some fixes) and test suite is passing.

#### Performance gains

Headline A/B — 32 generateApiSurface tasks, warm daemon, `--rerun-tasks --no-build-cache`, run back-to-back in the same script:

```
┌─────────────────────┬────────────────────┬───────────────────────────┐
│                     │ wall time (2 runs) │ daemon heap after full GC │
├─────────────────────┼────────────────────┼───────────────────────────┤
│ kotlinx-ast (ANTLR) │ 10666 ms, 10056 ms │ 1692 MB                   │
├─────────────────────┼────────────────────┼───────────────────────────┤
│ Kotlin PSI          │ 1054 ms, 707 ms    │ 64 MB                     │
└─────────────────────┴────────────────────┴───────────────────────────┘
```

~14× faster, ~26× less retained heap.

#### Why the speed

ANTLR's adaptive LL(*) prediction is expensive on a grammar the size of Kotlin's — it learns the grammar at runtime, building DFA states as it goes. The Kotlin compiler's PSI parser is hand-written recursive descent: no prediction, no learning. Per-module, the RUM module (194 sources + 11 generated files, one of them 4327 lines) went from ~10.3 s of parse time to a ~470 ms end-to-end task including all Gradle overhead.

#### Why the memory

This was the actual bug. `KotlinParser`/`KotlinLexer` hold `DECISION_TO_DFA` and `SHARED_CONTEXT_CACHE` in JVM-static fields with no eviction — `PredictionContextCache` has no clear() at all. Parsing RUM alone accumulated 92,592 DFA states and 2,240,384 prediction contexts = 555 MB live; across the whole repo it reached ~2 GB, growing linearly at ~1.2 MB/file with no sign of saturating. Because Gradle caches the build-logic plugin classloader, that memory was pinned for the daemon's entire life — surviving every subsequent build.

PSI keeps no cross-file state. Each parsed file becomes garbage immediately, so the retained set is now flat regardless of how many modules or builds run.

#### On the OOM specifically

`generateApiSurface` is wired `finalizedBy` every Kotlin compilation, so all 32 modules paid this on any build that compiled Kotlin. CI caps the daemon at 4096m (overriding the local 6144m), runs the Kotlin compiler in-process, and loads the `dd-java-agent` — ~1.7 GB of dead cache in a 4 GB heap is what made it tip over intermittently, depending on task scheduling. That memory is simply gone now.

Worth noting `org.gradle.jvmargs` has been raised four times historically (2560m → 3072 → 4096 → 6144). There may now be room to walk that back — I haven't tested lowering it, so I'd measure before changing it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

