### PR TITLE
RUM-18168: Make DataUploadScheduler.stopScheduling() work as intended

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadScheduler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadScheduler.kt
@@ -6,14 +6,17 @@
 
 package com.datadog.android.core.internal.data.upload
 
+import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.configuration.UploadSchedulerStrategy
 import com.datadog.android.core.internal.ContextProvider
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.persistence.Storage
 import com.datadog.android.core.internal.system.SystemInfoProvider
-import com.datadog.android.core.internal.utils.executeSafe
+import com.datadog.android.core.internal.utils.scheduleSafe
+import java.util.concurrent.Callable
 import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
 
 internal class DataUploadScheduler(
     private val featureName: String,
@@ -25,31 +28,59 @@ internal class DataUploadScheduler(
     uploadSchedulerStrategy: UploadSchedulerStrategy,
     maxBatchesPerJob: Int,
     private val scheduledThreadPoolExecutor: ScheduledThreadPoolExecutor,
-    private val internalLogger: InternalLogger
-) : UploadScheduler {
-
-    internal val runnable = DataUploadRunnable(
+    private val internalLogger: InternalLogger,
+    internal val runnable: Callable<Long> = DataUploadTask(
         featureName = featureName,
-        threadPoolExecutor = scheduledThreadPoolExecutor,
         storage = storage,
         dataUploader = dataUploader,
         contextProvider = contextProvider,
         networkInfoProvider = networkInfoProvider,
         systemInfoProvider = systemInfoProvider,
         uploadSchedulerStrategy = uploadSchedulerStrategy,
-        maxBatchesPerJob = maxBatchesPerJob,
-        internalLogger = internalLogger
+        maxBatchesPerJob = maxBatchesPerJob
     )
+) : UploadScheduler {
+
+    private val scheduleLock = Any()
+    private var stopped = false
+
+    @Suppress("ObjectLiteralToLambda") // a lambda can't carry the @WorkerThread annotation run() needs
+    private val uploadTask = object : Runnable {
+        @WorkerThread
+        @Suppress("UnsafeThirdPartyFunctionCall") // called inside a dedicated executor
+        override fun run() {
+            synchronized(scheduleLock) {
+                if (stopped) return
+            }
+            scheduleNext(runnable.call())
+        }
+    }
 
     override fun startScheduling() {
-        scheduledThreadPoolExecutor.executeSafe(
-            "$featureName: data upload",
-            internalLogger,
-            runnable
-        )
+        scheduleNext(0)
     }
 
     override fun stopScheduling() {
-        scheduledThreadPoolExecutor.remove(runnable)
+        // Fire and forget: the current or queued cycle is left to run, not canceled. Cancelling a
+        // future that's already executing only poisons its terminal state to CANCELLED, which
+        // LoggingScheduledThreadPoolExecutor then logs as a false ERROR, and there's no safe way
+        // to tell "queued" from "running" from here. The stopped flag below makes any cycle that
+        // does fire a no-op instead.
+        synchronized(scheduleLock) {
+            stopped = true
+        }
+    }
+
+    private fun scheduleNext(delayMs: Long) {
+        synchronized(scheduleLock) {
+            if (stopped) return
+            scheduledThreadPoolExecutor.scheduleSafe(
+                "$featureName: data upload",
+                delayMs,
+                TimeUnit.MILLISECONDS,
+                internalLogger,
+                uploadTask
+            )
+        }
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadTask.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadTask.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.core.internal.data.upload
 
 import androidx.annotation.WorkerThread
-import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.api.storage.RawBatchEvent
@@ -19,13 +18,10 @@ import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.persistence.BatchId
 import com.datadog.android.core.internal.persistence.Storage
 import com.datadog.android.core.internal.system.SystemInfoProvider
-import com.datadog.android.core.internal.utils.scheduleSafe
-import java.util.concurrent.ScheduledThreadPoolExecutor
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.Callable
 
-internal class DataUploadRunnable(
+internal class DataUploadTask(
     private val featureName: String,
-    private val threadPoolExecutor: ScheduledThreadPoolExecutor,
     private val storage: Storage,
     private val dataUploader: DataUploader,
     private val contextProvider: ContextProvider,
@@ -33,14 +29,18 @@ internal class DataUploadRunnable(
     private val systemInfoProvider: SystemInfoProvider,
     internal val uploadSchedulerStrategy: UploadSchedulerStrategy,
     internal val maxBatchesPerJob: Int,
-    private val internalLogger: InternalLogger,
     private val benchmarkUploads: BenchmarkUploads = BenchmarkUploads()
-) : UploadRunnable {
+) : Callable<Long> {
 
-    //  region Runnable
+    //  region Callable
 
+    /**
+     * Runs one upload cycle.
+     *
+     * @return the delay in ms before the next cycle should run.
+     */
     @WorkerThread
-    override fun run() {
+    override fun call(): Long {
         var uploadAttempts = 0
         var lastBatchUploadStatus: UploadStatus? = null
         if (isNetworkAvailable() && isSystemReady()) {
@@ -60,13 +60,12 @@ internal class DataUploadRunnable(
             )
         }
 
-        val delayMs = uploadSchedulerStrategy.getMsDelayUntilNextUpload(
+        return uploadSchedulerStrategy.getMsDelayUntilNextUpload(
             featureName,
             uploadAttempts,
             lastBatchUploadStatus?.code,
             lastBatchUploadStatus?.throwable
         )
-        scheduleNextUpload(delayMs)
     }
 
     // endregion
@@ -100,17 +99,6 @@ internal class DataUploadRunnable(
             systemInfo.onExternalPowerSource ||
             systemInfo.batteryLevel > LOW_BATTERY_THRESHOLD
         return hasEnoughPower && !systemInfo.powerSaveMode
-    }
-
-    private fun scheduleNextUpload(delayMs: Long) {
-        threadPoolExecutor.remove(this)
-        threadPoolExecutor.scheduleSafe(
-            "$featureName: data upload",
-            delayMs,
-            TimeUnit.MILLISECONDS,
-            internalLogger,
-            this
-        )
     }
 
     @WorkerThread

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadRunnable.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadRunnable.kt
@@ -1,9 +1,0 @@
-/*
- * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
- * This product includes software developed at Datadog (https://www.datadoghq.com/).
- * Copyright 2016-Present Datadog, Inc.
- */
-
-package com.datadog.android.core.internal.data.upload
-
-internal interface UploadRunnable : Runnable

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -23,8 +23,8 @@ import com.datadog.android.core.internal.SdkFeature.Companion.BATCH_COUNT_METRIC
 import com.datadog.android.core.internal.SdkFeature.Companion.METER_NAME
 import com.datadog.android.core.internal.configuration.DataUploadConfiguration
 import com.datadog.android.core.internal.data.upload.DataOkHttpUploader
-import com.datadog.android.core.internal.data.upload.DataUploadRunnable
 import com.datadog.android.core.internal.data.upload.DataUploadScheduler
+import com.datadog.android.core.internal.data.upload.DataUploadTask
 import com.datadog.android.core.internal.data.upload.DefaultUploadSchedulerStrategy
 import com.datadog.android.core.internal.data.upload.NoOpDataUploader
 import com.datadog.android.core.internal.data.upload.NoOpUploadScheduler
@@ -87,6 +87,7 @@ import java.util.concurrent.CancellationException
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Future
 import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 @Extensions(
@@ -205,15 +206,11 @@ internal class SdkFeatureTest {
 
         // Then
         assertThat(testedFeature.uploadScheduler).isInstanceOf(DataUploadScheduler::class.java)
-        val dataUploadRunnable = (testedFeature.uploadScheduler as DataUploadScheduler).runnable
-        val uploadSchedulerStrategy = (dataUploadRunnable.uploadSchedulerStrategy as? DefaultUploadSchedulerStrategy)
+        val dataUploadTask = (testedFeature.uploadScheduler as DataUploadScheduler).runnable as DataUploadTask
+        val uploadSchedulerStrategy = (dataUploadTask.uploadSchedulerStrategy as? DefaultUploadSchedulerStrategy)
         assertThat(uploadSchedulerStrategy?.uploadConfiguration).isEqualTo(expectedUploadConfiguration)
-        assertThat(dataUploadRunnable.maxBatchesPerJob).isEqualTo(fakeCoreBatchProcessingLevel.maxBatchesPerUploadJob)
-        argumentCaptor<Runnable> {
-            verify(coreFeature.mockUploadExecutor).execute(
-                argThat { this is DataUploadRunnable }
-            )
-        }
+        assertThat(dataUploadTask.maxBatchesPerJob).isEqualTo(fakeCoreBatchProcessingLevel.maxBatchesPerUploadJob)
+        verify(coreFeature.mockUploadExecutor).schedule(any(), eq(0L), eq(TimeUnit.MILLISECONDS))
         assertThat(testedFeature.uploader).isInstanceOf(DataOkHttpUploader::class.java)
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadSchedulerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadSchedulerTest.kt
@@ -6,12 +6,19 @@
 
 package com.datadog.android.core.internal.data.upload
 
+import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.core.configuration.UploadSchedulerStrategy
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
+import com.datadog.android.core.internal.persistence.Storage
+import com.datadog.android.core.internal.system.SystemInfo
+import com.datadog.android.core.internal.system.SystemInfoProvider
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -19,12 +26,25 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
-import org.mockito.kotlin.argThat
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -70,24 +90,217 @@ internal class DataUploadSchedulerTest {
         testedScheduler.startScheduling()
 
         // Then
-        verify(mockExecutor).execute(
-            argThat { this is DataUploadRunnable }
-        )
+        verify(mockExecutor).schedule(any(), eq(0L), eq(TimeUnit.MILLISECONDS))
     }
 
     @Test
-    fun `when stop it will try to remove the executed runnable`() {
-        // Given
+    fun `M not cancel the pending upload W stopScheduling()`() {
+        // Given - a local scheduler so the collaborators the upload task exercises can be stubbed
+        val mockStorage: Storage = mock()
+        val mockNetworkInfoProvider: NetworkInfoProvider = mock()
+        val mockSystemInfoProvider: SystemInfoProvider = mock()
+        whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn NetworkInfo(
+            connectivity = NetworkInfo.Connectivity.NETWORK_WIFI
+        )
+        whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn SystemInfo(
+            batteryFullOrCharging = true,
+            batteryLevel = 100,
+            powerSaveMode = false,
+            onExternalPowerSource = true
+        )
+        whenever(mockStorage.readNextBatch()) doReturn null
+        whenever(
+            mockUploadSchedulerStrategy.getMsDelayUntilNextUpload(any(), any(), anyOrNull(), anyOrNull())
+        ) doReturn RESCHEDULE_DELAY_MS
+        val mockFuture: ScheduledFuture<Any> = mock()
+        whenever(mockExecutor.schedule(any(), any(), any())) doReturn mockFuture
+
+        testedScheduler = DataUploadScheduler(
+            featureName = fakeFeatureName,
+            storage = mockStorage,
+            dataUploader = mock(),
+            contextProvider = mock(),
+            networkInfoProvider = mockNetworkInfoProvider,
+            systemInfoProvider = mockSystemInfoProvider,
+            uploadSchedulerStrategy = mockUploadSchedulerStrategy,
+            maxBatchesPerJob = fakeMaxBatchesPerJob,
+            scheduledThreadPoolExecutor = mockExecutor,
+            internalLogger = mock()
+        )
+        val runnableCaptor = argumentCaptor<Runnable>()
         testedScheduler.startScheduling()
+        verify(mockExecutor).schedule(runnableCaptor.capture(), eq(0L), eq(TimeUnit.MILLISECONDS))
+        // run the captured task once, so a next cycle gets scheduled via scheduleNext()
+        runnableCaptor.firstValue.run()
 
         // When
         testedScheduler.stopScheduling()
 
-        // Then
-        val argumentCaptor = argumentCaptor<Runnable>()
-        verify(mockExecutor).execute(
-            argumentCaptor.capture()
+        // Then - cancel(false) on an already-executing future would only poison its terminal
+        // state without actually stopping it, so we never call it; the stopped flag alone is
+        // what prevents further work
+        verify(mockFuture, never()).cancel(any())
+    }
+
+    @Test
+    fun `M not run the upload again W stopScheduling()`() {
+        // Given - a real executor and real DataUploadTask; stopScheduling() never cancels
+        // the queued future, so this proves the stopped flag alone is enough to stop the loop.
+        val realExecutor = ScheduledThreadPoolExecutor(1)
+        try {
+            val mockStorage: Storage = mock()
+            val mockNetworkInfoProvider: NetworkInfoProvider = mock()
+            val mockSystemInfoProvider: SystemInfoProvider = mock()
+            whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn NetworkInfo(
+                connectivity = NetworkInfo.Connectivity.NETWORK_WIFI
+            )
+            whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn SystemInfo(
+                batteryFullOrCharging = true,
+                batteryLevel = 100,
+                powerSaveMode = false,
+                onExternalPowerSource = true
+            )
+            whenever(
+                mockUploadSchedulerStrategy.getMsDelayUntilNextUpload(any(), any(), anyOrNull(), anyOrNull())
+            ) doReturn RESCHEDULE_DELAY_MS
+            // The reschedule delay is short, so cycles fire in quick succession - a fixed-time
+            // window can't tell "exactly one ran" from "many ran". Count them instead.
+            val firstCycle = CountDownLatch(1)
+            val cycleCount = AtomicInteger(0)
+            whenever(mockStorage.readNextBatch()) doAnswer {
+                cycleCount.incrementAndGet()
+                firstCycle.countDown()
+                null
+            }
+
+            val realScheduler = DataUploadScheduler(
+                featureName = fakeFeatureName,
+                storage = mockStorage,
+                dataUploader = mock(),
+                contextProvider = mock(),
+                networkInfoProvider = mockNetworkInfoProvider,
+                systemInfoProvider = mockSystemInfoProvider,
+                uploadSchedulerStrategy = mockUploadSchedulerStrategy,
+                maxBatchesPerJob = 1,
+                scheduledThreadPoolExecutor = realExecutor,
+                internalLogger = mock()
+            )
+
+            // When
+            realScheduler.startScheduling()
+            assertThat(firstCycle.await(1, TimeUnit.SECONDS)).isTrue()
+            realScheduler.stopScheduling()
+            val countAtStop = cycleCount.get()
+
+            // Then - scheduleNext() re-checks `stopped` before arming, so at most one already
+            // in-flight cycle can still complete; nothing new is ever scheduled after that.
+            val noFurtherCycle = CountDownLatch(1)
+            assertThat(noFurtherCycle.await(500, TimeUnit.MILLISECONDS)).isFalse()
+            assertThat(cycleCount.get()).isLessThanOrEqualTo(countAtStop + 1)
+        } finally {
+            realExecutor.shutdownNow()
+            realExecutor.awaitTermination(1, TimeUnit.SECONDS)
+        }
+    }
+
+    @Test
+    fun `M reschedule with the returned delay W the upload task runs`(
+        @LongForgery(min = 1) fakeDelayMs: Long
+    ) {
+        // Given
+        val stubTask: Callable<Long> = mock()
+        whenever(stubTask.call()) doReturn fakeDelayMs
+        testedScheduler = DataUploadScheduler(
+            featureName = fakeFeatureName,
+            storage = mock(),
+            dataUploader = mock(),
+            contextProvider = mock(),
+            networkInfoProvider = mock(),
+            systemInfoProvider = mock(),
+            uploadSchedulerStrategy = mockUploadSchedulerStrategy,
+            maxBatchesPerJob = fakeMaxBatchesPerJob,
+            scheduledThreadPoolExecutor = mockExecutor,
+            internalLogger = mock(),
+            runnable = stubTask
         )
-        verify(mockExecutor).remove(argumentCaptor.firstValue)
+        val runnableCaptor = argumentCaptor<Runnable>()
+        testedScheduler.startScheduling()
+        verify(mockExecutor).schedule(runnableCaptor.capture(), eq(0L), eq(TimeUnit.MILLISECONDS))
+
+        // When
+        runnableCaptor.firstValue.run()
+
+        // Then
+        verify(mockExecutor).schedule(any(), eq(fakeDelayMs), eq(TimeUnit.MILLISECONDS))
+    }
+
+    @Test
+    fun `M does not run nor reschedule W the task runs {stopped}`() {
+        // Given
+        val mockTask: Callable<Long> = mock()
+        testedScheduler = DataUploadScheduler(
+            featureName = fakeFeatureName,
+            storage = mock(),
+            dataUploader = mock(),
+            contextProvider = mock(),
+            networkInfoProvider = mock(),
+            systemInfoProvider = mock(),
+            uploadSchedulerStrategy = mockUploadSchedulerStrategy,
+            maxBatchesPerJob = fakeMaxBatchesPerJob,
+            scheduledThreadPoolExecutor = mockExecutor,
+            internalLogger = mock(),
+            runnable = mockTask
+        )
+        val runnableCaptor = argumentCaptor<Runnable>()
+        testedScheduler.startScheduling()
+        verify(mockExecutor).schedule(runnableCaptor.capture(), eq(0L), eq(TimeUnit.MILLISECONDS))
+        testedScheduler.stopScheduling()
+
+        // When
+        runnableCaptor.firstValue.run()
+
+        // Then - only the initial schedule() from startScheduling() happened, no reschedule
+        verifyNoInteractions(mockTask)
+        verify(mockExecutor, times(1)).schedule(any(), any(), any())
+    }
+
+    @Test
+    fun `M does not reschedule W stopScheduling() during an upload`(
+        @LongForgery(min = 1) fakeDelayMs: Long
+    ) {
+        // Given - call() is the long-running call that occupies the window a concurrent
+        // stopScheduling() could land in; stubbing it to call stopScheduling() itself
+        // deterministically simulates that race landing mid-cycle, without real threads/timing
+        val stubTask: Callable<Long> = mock()
+        testedScheduler = DataUploadScheduler(
+            featureName = fakeFeatureName,
+            storage = mock(),
+            dataUploader = mock(),
+            contextProvider = mock(),
+            networkInfoProvider = mock(),
+            systemInfoProvider = mock(),
+            uploadSchedulerStrategy = mockUploadSchedulerStrategy,
+            maxBatchesPerJob = fakeMaxBatchesPerJob,
+            scheduledThreadPoolExecutor = mockExecutor,
+            internalLogger = mock(),
+            runnable = stubTask
+        )
+        whenever(stubTask.call()) doAnswer {
+            testedScheduler.stopScheduling()
+            fakeDelayMs
+        }
+        val runnableCaptor = argumentCaptor<Runnable>()
+        testedScheduler.startScheduling()
+        verify(mockExecutor).schedule(runnableCaptor.capture(), eq(0L), eq(TimeUnit.MILLISECONDS))
+
+        // When
+        runnableCaptor.firstValue.run()
+
+        // Then - only the initial schedule() from startScheduling() happened, no reschedule
+        verify(mockExecutor, times(1)).schedule(any(), any(), any())
+    }
+
+    companion object {
+        private const val RESCHEDULE_DELAY_MS = 10L
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadTaskTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadTaskTest.kt
@@ -27,6 +27,7 @@ import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -52,8 +53,6 @@ import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import org.mockito.stubbing.Answer
-import java.util.concurrent.ScheduledThreadPoolExecutor
-import java.util.concurrent.TimeUnit
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -61,10 +60,7 @@ import java.util.concurrent.TimeUnit
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal class DataUploadRunnableTest {
-
-    @Mock
-    lateinit var mockThreadPoolExecutor: ScheduledThreadPoolExecutor
+internal class DataUploadTaskTest {
 
     @Mock
     lateinit var mockStorage: Storage
@@ -102,7 +98,7 @@ internal class DataUploadRunnableTest {
     @StringForgery
     lateinit var fakeFeatureName: String
 
-    private lateinit var testedRunnable: DataUploadRunnable
+    private lateinit var testedTask: DataUploadTask
 
     @BeforeEach
     fun `set up`(forge: Forge) {
@@ -125,17 +121,15 @@ internal class DataUploadRunnableTest {
 
         whenever(mockContextProvider.getContext(emptySet())) doReturn fakeContext
 
-        testedRunnable = DataUploadRunnable(
+        testedTask = DataUploadTask(
             featureName = fakeFeatureName,
-            threadPoolExecutor = mockThreadPoolExecutor,
             storage = mockStorage,
             dataUploader = mockDataUploader,
             contextProvider = mockContextProvider,
             networkInfoProvider = mockNetworkInfoProvider,
             systemInfoProvider = mockSystemInfoProvider,
             uploadSchedulerStrategy = mockUploadSchedulerStrategy,
-            maxBatchesPerJob = fakeMaxBatchesPerJob,
-            internalLogger = mockInternalLogger
+            maxBatchesPerJob = fakeMaxBatchesPerJob
         )
     }
 
@@ -148,19 +142,19 @@ internal class DataUploadRunnableTest {
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn networkInfo
 
         // When
-        testedRunnable.run()
+        val delayMs = testedTask.call()
 
         // Then
         verifyNoInteractions(mockDataUploader, mockStorage)
         verify(mockUploadSchedulerStrategy).getMsDelayUntilNextUpload(fakeFeatureName, 0, null, null)
-        verify(mockThreadPoolExecutor).schedule(testedRunnable, fakeDelayUntilNextUploadMs, TimeUnit.MILLISECONDS)
+        assertThat(delayMs).isEqualTo(fakeDelayUntilNextUploadMs)
     }
 
     @Test
     fun `M send batch W run() { batteryFullOrCharging }`(
         @Forgery batch: List<RawBatchEvent>,
         @StringForgery batchMeta: String,
-        @IntForgery(min = 0, max = DataUploadRunnable.LOW_BATTERY_THRESHOLD) batteryLevel: Int,
+        @IntForgery(min = 0, max = DataUploadTask.LOW_BATTERY_THRESHOLD) batteryLevel: Int,
         forge: Forge
     ) {
         // Given
@@ -188,7 +182,7 @@ internal class DataUploadRunnableTest {
         ) doReturn fakeUploadStatus
 
         // When
-        testedRunnable.run()
+        val delayMs = testedTask.call()
 
         // Then
         verify(mockStorage, times(fakeMaxBatchesPerJob)).confirmBatchRead(
@@ -203,14 +197,14 @@ internal class DataUploadRunnableTest {
             fakeUploadStatus.code,
             null
         )
-        verify(mockThreadPoolExecutor).schedule(testedRunnable, fakeDelayUntilNextUploadMs, TimeUnit.MILLISECONDS)
+        assertThat(delayMs).isEqualTo(fakeDelayUntilNextUploadMs)
     }
 
     @Test
     fun `M send batch W run() { battery level high }`(
         @Forgery batch: List<RawBatchEvent>,
         @StringForgery batchMeta: String,
-        @IntForgery(min = DataUploadRunnable.LOW_BATTERY_THRESHOLD + 1) batteryLevel: Int,
+        @IntForgery(min = DataUploadTask.LOW_BATTERY_THRESHOLD + 1) batteryLevel: Int,
         forge: Forge
     ) {
         // Given
@@ -237,7 +231,7 @@ internal class DataUploadRunnableTest {
         ) doReturn fakeUploadStatus
 
         // When
-        testedRunnable.run()
+        val delayMs = testedTask.call()
 
         // Then
         verify(mockStorage, times(fakeMaxBatchesPerJob)).confirmBatchRead(
@@ -252,14 +246,14 @@ internal class DataUploadRunnableTest {
             fakeUploadStatus.code,
             null
         )
-        verify(mockThreadPoolExecutor).schedule(testedRunnable, fakeDelayUntilNextUploadMs, TimeUnit.MILLISECONDS)
+        assertThat(delayMs).isEqualTo(fakeDelayUntilNextUploadMs)
     }
 
     @Test
     fun `M send batch W run() { onExternalPower }`(
         @Forgery batch: List<RawBatchEvent>,
         @StringForgery batchMeta: String,
-        @IntForgery(min = 0, max = DataUploadRunnable.LOW_BATTERY_THRESHOLD) batteryLevel: Int,
+        @IntForgery(min = 0, max = DataUploadTask.LOW_BATTERY_THRESHOLD) batteryLevel: Int,
         forge: Forge
     ) {
         val fakeSystemInfo = SystemInfo(
@@ -285,7 +279,7 @@ internal class DataUploadRunnableTest {
         ) doReturn fakeUploadStatus
 
         // When
-        testedRunnable.run()
+        val delayMs = testedTask.call()
 
         // Then
         verify(mockStorage, times(fakeMaxBatchesPerJob)).confirmBatchRead(
@@ -300,12 +294,12 @@ internal class DataUploadRunnableTest {
             fakeUploadStatus.code,
             null
         )
-        verify(mockThreadPoolExecutor).schedule(testedRunnable, fakeDelayUntilNextUploadMs, TimeUnit.MILLISECONDS)
+        assertThat(delayMs).isEqualTo(fakeDelayUntilNextUploadMs)
     }
 
     @Test
     fun `M not send batch W run() { not enough battery }`(
-        @IntForgery(min = 0, max = DataUploadRunnable.LOW_BATTERY_THRESHOLD) batteryLevel: Int
+        @IntForgery(min = 0, max = DataUploadTask.LOW_BATTERY_THRESHOLD) batteryLevel: Int
     ) {
         // Given
         val fakeSystemInfo = SystemInfo(
@@ -317,12 +311,12 @@ internal class DataUploadRunnableTest {
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
 
         // When
-        testedRunnable.run()
+        val delayMs = testedTask.call()
 
         // Then
         verifyNoInteractions(mockStorage, mockDataUploader)
         verify(mockUploadSchedulerStrategy).getMsDelayUntilNextUpload(fakeFeatureName, 0, null, null)
-        verify(mockThreadPoolExecutor).schedule(testedRunnable, fakeDelayUntilNextUploadMs, TimeUnit.MILLISECONDS)
+        assertThat(delayMs).isEqualTo(fakeDelayUntilNextUploadMs)
     }
 
     @Test
@@ -339,17 +333,17 @@ internal class DataUploadRunnableTest {
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
 
         // When
-        testedRunnable.run()
+        val delayMs = testedTask.call()
 
         // Then
         verifyNoInteractions(mockStorage, mockDataUploader)
         verify(mockUploadSchedulerStrategy).getMsDelayUntilNextUpload(fakeFeatureName, 0, null, null)
-        verify(mockThreadPoolExecutor).schedule(testedRunnable, fakeDelayUntilNextUploadMs, TimeUnit.MILLISECONDS)
+        assertThat(delayMs).isEqualTo(fakeDelayUntilNextUploadMs)
     }
 
     @Test
     fun `M not send batch W run() { batteryLeveHigh, powerSaveMode }`(
-        @IntForgery(min = DataUploadRunnable.LOW_BATTERY_THRESHOLD + 1) batteryLevel: Int
+        @IntForgery(min = DataUploadTask.LOW_BATTERY_THRESHOLD + 1) batteryLevel: Int
     ) {
         // Given
         val fakeSystemInfo = SystemInfo(
@@ -361,17 +355,17 @@ internal class DataUploadRunnableTest {
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
 
         // When
-        testedRunnable.run()
+        val delayMs = testedTask.call()
 
         // Then
         verifyNoInteractions(mockStorage, mockDataUploader)
         verify(mockUploadSchedulerStrategy).getMsDelayUntilNextUpload(fakeFeatureName, 0, null, null)
-        verify(mockThreadPoolExecutor).schedule(testedRunnable, fakeDelayUntilNextUploadMs, TimeUnit.MILLISECONDS)
+        assertThat(delayMs).isEqualTo(fakeDelayUntilNextUploadMs)
     }
 
     @Test
     fun `M not send batch W run() { onExternalPower, powerSaveMode }`(
-        @IntForgery(min = 0, max = DataUploadRunnable.LOW_BATTERY_THRESHOLD) batteryLevel: Int
+        @IntForgery(min = 0, max = DataUploadTask.LOW_BATTERY_THRESHOLD) batteryLevel: Int
     ) {
         // Given
         val fakeSystemInfo = SystemInfo(
@@ -383,12 +377,12 @@ internal class DataUploadRunnableTest {
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
 
         // When
-        testedRunnable.run()
+        val delayMs = testedTask.call()
 
         // Then
         verifyNoInteractions(mockStorage, mockDataUploader)
         verify(mockUploadSchedulerStrategy).getMsDelayUntilNextUpload(fakeFeatureName, 0, null, null)
-        verify(mockThreadPoolExecutor).schedule(testedRunnable, fakeDelayUntilNextUploadMs, TimeUnit.MILLISECONDS)
+        assertThat(delayMs).isEqualTo(fakeDelayUntilNextUploadMs)
     }
 
     @Test
@@ -397,14 +391,14 @@ internal class DataUploadRunnableTest {
         whenever(mockStorage.readNextBatch()).thenReturn(null)
 
         // When
-        testedRunnable.run()
+        val delayMs = testedTask.call()
 
         // Then
         verify(mockStorage).readNextBatch()
         verifyNoMoreInteractions(mockStorage)
         verifyNoInteractions(mockDataUploader)
         verify(mockUploadSchedulerStrategy).getMsDelayUntilNextUpload(fakeFeatureName, 0, null, null)
-        verify(mockThreadPoolExecutor).schedule(testedRunnable, fakeDelayUntilNextUploadMs, TimeUnit.MILLISECONDS)
+        assertThat(delayMs).isEqualTo(fakeDelayUntilNextUploadMs)
     }
 
     @Test
@@ -429,7 +423,7 @@ internal class DataUploadRunnableTest {
         ) doReturn fakeUploadStatus
 
         // When
-        testedRunnable.run()
+        val delayMs = testedTask.call()
 
         // Then
         verify(mockStorage, times(fakeMaxBatchesPerJob)).confirmBatchRead(any(), any(), eq(true))
@@ -440,8 +434,7 @@ internal class DataUploadRunnableTest {
             fakeUploadStatus.code,
             null
         )
-        verify(mockThreadPoolExecutor).remove(testedRunnable)
-        verify(mockThreadPoolExecutor).schedule(testedRunnable, fakeDelayUntilNextUploadMs, TimeUnit.MILLISECONDS)
+        assertThat(delayMs).isEqualTo(fakeDelayUntilNextUploadMs)
     }
 
     @ParameterizedTest
@@ -467,7 +460,7 @@ internal class DataUploadRunnableTest {
         ) doReturn uploadStatus
 
         // When
-        testedRunnable.run()
+        val delayMs = testedTask.call()
 
         // Then
         verify(mockStorage).confirmBatchRead(eq(batchId), any(), eq(false))
@@ -478,7 +471,7 @@ internal class DataUploadRunnableTest {
             uploadStatus.code,
             uploadStatus.throwable
         )
-        verify(mockThreadPoolExecutor).schedule(testedRunnable, fakeDelayUntilNextUploadMs, TimeUnit.MILLISECONDS)
+        assertThat(delayMs).isEqualTo(fakeDelayUntilNextUploadMs)
     }
 
     @ParameterizedTest
@@ -506,7 +499,7 @@ internal class DataUploadRunnableTest {
 
         // WHen
         repeat(runCount) {
-            testedRunnable.run()
+            assertThat(testedTask.call()).isEqualTo(fakeDelayUntilNextUploadMs)
         }
 
         // Then
@@ -518,8 +511,6 @@ internal class DataUploadRunnableTest {
             uploadStatus.code,
             uploadStatus.throwable
         )
-        verify(mockThreadPoolExecutor, times(runCount))
-            .schedule(testedRunnable, fakeDelayUntilNextUploadMs, TimeUnit.MILLISECONDS)
     }
 
     @ParameterizedTest
@@ -545,7 +536,7 @@ internal class DataUploadRunnableTest {
         ) doReturn uploadStatus
 
         // When
-        testedRunnable.run()
+        val delayMs = testedTask.call()
 
         // Then
         verify(mockStorage).confirmBatchRead(eq(batchId), any(), eq(true))
@@ -556,7 +547,7 @@ internal class DataUploadRunnableTest {
             uploadStatus.code,
             uploadStatus.throwable
         )
-        verify(mockThreadPoolExecutor).schedule(testedRunnable, fakeDelayUntilNextUploadMs, TimeUnit.MILLISECONDS)
+        assertThat(delayMs).isEqualTo(fakeDelayUntilNextUploadMs)
     }
 
     // region maxBatchesPerJob
@@ -566,17 +557,15 @@ internal class DataUploadRunnableTest {
         forge: Forge
     ) {
         // Given
-        testedRunnable = DataUploadRunnable(
+        testedTask = DataUploadTask(
             featureName = fakeFeatureName,
-            threadPoolExecutor = mockThreadPoolExecutor,
             storage = mockStorage,
             dataUploader = mockDataUploader,
             contextProvider = mockContextProvider,
             networkInfoProvider = mockNetworkInfoProvider,
             systemInfoProvider = mockSystemInfoProvider,
             uploadSchedulerStrategy = mockUploadSchedulerStrategy,
-            maxBatchesPerJob = fakeMaxBatchesPerJob,
-            internalLogger = mockInternalLogger
+            maxBatchesPerJob = fakeMaxBatchesPerJob
         )
         val batches = forge.aList(
             size = forge.anInt(
@@ -601,7 +590,7 @@ internal class DataUploadRunnableTest {
         }
 
         // When
-        testedRunnable.run()
+        val delayMs = testedTask.call()
 
         // Then
         repeat(fakeMaxBatchesPerJob) { index ->
@@ -614,7 +603,7 @@ internal class DataUploadRunnableTest {
             )
         }
         verifyNoMoreInteractions(mockDataUploader)
-        verify(mockThreadPoolExecutor).schedule(testedRunnable, fakeDelayUntilNextUploadMs, TimeUnit.MILLISECONDS)
+        assertThat(delayMs).isEqualTo(fakeDelayUntilNextUploadMs)
     }
 
     @Test
@@ -622,17 +611,15 @@ internal class DataUploadRunnableTest {
         forge: Forge
     ) {
         // Given
-        testedRunnable = DataUploadRunnable(
+        testedTask = DataUploadTask(
             featureName = fakeFeatureName,
-            threadPoolExecutor = mockThreadPoolExecutor,
             storage = mockStorage,
             dataUploader = mockDataUploader,
             contextProvider = mockContextProvider,
             networkInfoProvider = mockNetworkInfoProvider,
             systemInfoProvider = mockSystemInfoProvider,
             uploadSchedulerStrategy = mockUploadSchedulerStrategy,
-            maxBatchesPerJob = fakeMaxBatchesPerJob,
-            internalLogger = mockInternalLogger
+            maxBatchesPerJob = fakeMaxBatchesPerJob
         )
         val fakeBatchesCount = forge.anInt(
             min = 1,
@@ -656,7 +643,7 @@ internal class DataUploadRunnableTest {
         }
 
         // When
-        testedRunnable.run()
+        val delayMs = testedTask.call()
 
         // Then
         batches.forEachIndexed { index, batch ->
@@ -668,7 +655,7 @@ internal class DataUploadRunnableTest {
             )
         }
         verifyNoMoreInteractions(mockDataUploader)
-        verify(mockThreadPoolExecutor).schedule(testedRunnable, fakeDelayUntilNextUploadMs, TimeUnit.MILLISECONDS)
+        assertThat(delayMs).isEqualTo(fakeDelayUntilNextUploadMs)
     }
 
     // region Internal
@@ -702,9 +689,8 @@ internal class DataUploadRunnableTest {
     @Test
     fun `M send upload benchmark telemetry W run { online }`() {
         // Given
-        testedRunnable = DataUploadRunnable(
+        testedTask = DataUploadTask(
             featureName = fakeFeatureName,
-            threadPoolExecutor = mockThreadPoolExecutor,
             storage = mockStorage,
             dataUploader = mockDataUploader,
             contextProvider = mockContextProvider,
@@ -712,12 +698,11 @@ internal class DataUploadRunnableTest {
             systemInfoProvider = mockSystemInfoProvider,
             uploadSchedulerStrategy = mockUploadSchedulerStrategy,
             maxBatchesPerJob = fakeMaxBatchesPerJob,
-            internalLogger = mockInternalLogger,
             benchmarkUploads = mockBenchmarkUploads
         )
 
         // When
-        testedRunnable.run()
+        testedTask.call()
 
         // Then
         verify(mockBenchmarkUploads).incrementBenchmarkUploadsCount(any())
@@ -728,9 +713,8 @@ internal class DataUploadRunnableTest {
         @Mock mockNetworkInfo: NetworkInfo
     ) {
         // Given
-        testedRunnable = DataUploadRunnable(
+        testedTask = DataUploadTask(
             featureName = fakeFeatureName,
-            threadPoolExecutor = mockThreadPoolExecutor,
             storage = mockStorage,
             dataUploader = mockDataUploader,
             contextProvider = mockContextProvider,
@@ -738,7 +722,6 @@ internal class DataUploadRunnableTest {
             systemInfoProvider = mockSystemInfoProvider,
             uploadSchedulerStrategy = mockUploadSchedulerStrategy,
             maxBatchesPerJob = fakeMaxBatchesPerJob,
-            internalLogger = mockInternalLogger,
             benchmarkUploads = mockBenchmarkUploads
         )
 
@@ -749,7 +732,7 @@ internal class DataUploadRunnableTest {
             .thenReturn(NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED)
 
         // When
-        testedRunnable.run()
+        testedTask.call()
 
         // Then
         verify(mockBenchmarkUploads, never()).incrementBenchmarkUploadsCount(any())
@@ -760,9 +743,8 @@ internal class DataUploadRunnableTest {
         forge: Forge
     ) {
         // Given
-        testedRunnable = DataUploadRunnable(
+        testedTask = DataUploadTask(
             featureName = fakeFeatureName,
-            threadPoolExecutor = mockThreadPoolExecutor,
             storage = mockStorage,
             dataUploader = mockDataUploader,
             contextProvider = mockContextProvider,
@@ -770,7 +752,6 @@ internal class DataUploadRunnableTest {
             systemInfoProvider = mockSystemInfoProvider,
             uploadSchedulerStrategy = mockUploadSchedulerStrategy,
             maxBatchesPerJob = fakeMaxBatchesPerJob,
-            internalLogger = mockInternalLogger,
             benchmarkUploads = mockBenchmarkUploads
         )
 
@@ -791,7 +772,7 @@ internal class DataUploadRunnableTest {
         ).thenReturn(UploadStatus.Success(202))
 
         // When
-        testedRunnable.run()
+        testedTask.call()
 
         // Then
         verify(mockBenchmarkUploads).sendBenchmarkBytesUploaded(any(), any())
@@ -802,9 +783,8 @@ internal class DataUploadRunnableTest {
         forge: Forge
     ) {
         // Given
-        testedRunnable = DataUploadRunnable(
+        testedTask = DataUploadTask(
             featureName = fakeFeatureName,
-            threadPoolExecutor = mockThreadPoolExecutor,
             storage = mockStorage,
             dataUploader = mockDataUploader,
             contextProvider = mockContextProvider,
@@ -812,7 +792,6 @@ internal class DataUploadRunnableTest {
             systemInfoProvider = mockSystemInfoProvider,
             uploadSchedulerStrategy = mockUploadSchedulerStrategy,
             maxBatchesPerJob = fakeMaxBatchesPerJob,
-            internalLogger = mockInternalLogger,
             benchmarkUploads = mockBenchmarkUploads
         )
 
@@ -833,7 +812,7 @@ internal class DataUploadRunnableTest {
         ).thenReturn(UploadStatus.RequestCreationError(mock()))
 
         // When
-        testedRunnable.run()
+        testedTask.call()
 
         // Then
         verify(mockBenchmarkUploads, never()).sendBenchmarkBytesUploaded(any(), any())


### PR DESCRIPTION
### What does this PR do?
stopScheduling() called executor.remove(runnable), which can never match the ScheduledFutureTask wrapper that schedule enqueues internally, so it was a silent no-op: the periodic upload loop kept running regardless of stop calls.

The scheduler now owns the schedule/stop state directly (scheduleLock, a one-way stopped flag, and a cancellable nextUpload future), so stopScheduling() really cancels the next cycle. This required moving self-rescheduling out of DataUploadRunnable (now UploadRunnable.uploadNextBatches(): Long, no longer a Runnable) and into the scheduler's own task.

### Motivation
Trying to reduce the likelihood of multiple batches being sent via the `Datadog.flushAndShutdownExecutors()` system that RUM FIT triggers, should stablize the MAUI tests

Replaces #3739 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

