### PR TITLE
Make OutOfMemory simulation in sample app crash again

### DIFF
--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/crash/CrashFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/crash/CrashFragment.kt
@@ -98,8 +98,8 @@ internal class CrashFragment :
 
     private fun triggerOOM() {
         Thread {
-            for (i in 0..128) {
-                bitmapList.add(Bitmap.createBitmap(3840, 2160, Bitmap.Config.ARGB_8888))
+            while (true) {
+                bitmapList.add(Bitmap.createBitmap(38400, 21600, Bitmap.Config.ARGB_8888))
                 Log.i("OOM", "Allocated ${bitmapList.size} bitmaps")
                 Thread.sleep(10)
             }


### PR DESCRIPTION
### What does this PR do?

The previous simulation of OOM is not enough to trigger a crash anymore in nowadays device with big RAM.

Increasing the allocation by 100 times until it crashes.

### Motivation

Make OOM crash again!

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

