### PR TITLE
RUM-18218: Harden JVM crash exception handler

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
@@ -15,6 +15,7 @@ internal class CrashReportsFeature(private val sdkCore: FeatureSdkCore) : Featur
 
     internal val initialized = AtomicBoolean(false)
     internal var originalUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
+    private var ourUncaughtExceptionHandler: Thread.UncaughtExceptionHandler? = null
 
     // region Feature
 
@@ -34,18 +35,19 @@ internal class CrashReportsFeature(private val sdkCore: FeatureSdkCore) : Featur
 
     // region Internal
 
-    private fun setupExceptionHandler(
-        appContext: Context
-    ) {
+    private fun setupExceptionHandler(appContext: Context) {
         originalUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
-        DatadogExceptionHandler(
+        ourUncaughtExceptionHandler = DatadogExceptionHandler(
             sdkCore = sdkCore,
             appContext = appContext
-        ).register()
+        ).apply { register() }
     }
 
     private fun resetOriginalExceptionHandler() {
-        Thread.setDefaultUncaughtExceptionHandler(originalUncaughtExceptionHandler)
+        if (Thread.getDefaultUncaughtExceptionHandler() === ourUncaughtExceptionHandler) {
+            Thread.setDefaultUncaughtExceptionHandler(originalUncaughtExceptionHandler)
+        }
+        ourUncaughtExceptionHandler = null
     }
 
     // endregion

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
@@ -18,20 +18,52 @@ import com.datadog.android.core.internal.thread.waitToIdle
 import com.datadog.android.core.internal.utils.triggerUploadWorker
 import com.datadog.android.internal.utils.asString
 import com.datadog.android.internal.utils.loggableStackTrace
-import java.lang.ref.WeakReference
 import java.util.concurrent.ThreadPoolExecutor
 
 internal class DatadogExceptionHandler(
     private val sdkCore: FeatureSdkCore,
-    appContext: Context
+    private val appContext: Context
 ) : Thread.UncaughtExceptionHandler {
 
-    private val contextRef = WeakReference(appContext)
+    @Volatile
     private var previousHandler: Thread.UncaughtExceptionHandler? = null
 
     // region Thread.UncaughtExceptionHandler
 
     override fun uncaughtException(t: Thread, e: Throwable) {
+        try {
+            ingestUncaughtException(t, e)
+        } catch (@Suppress("TooGenericExceptionCaught") fatal: Throwable) {
+            try {
+                sdkCore.internalLogger.log(
+                    InternalLogger.Level.ERROR,
+                    listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+                    { PROCESSING_FAILURE_MESSAGE },
+                    fatal
+                )
+            } catch (@Suppress("TooGenericExceptionCaught, SwallowedException") _: Throwable) {
+                // do nothing, we did our best
+            }
+        } finally {
+            // Always do this one last; this will shut down the VM
+            previousHandler?.uncaughtException(t, e)
+        }
+    }
+
+    // endregion
+
+    // region DatadogExceptionHandler
+
+    fun register() {
+        previousHandler = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler(this)
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun ingestUncaughtException(t: Thread, e: Throwable) {
         val threads = getThreadDumps(t, e)
 
         // write a RUM Error too
@@ -68,28 +100,10 @@ internal class DatadogExceptionHandler(
         }
 
         // trigger a task to send the logs ASAP
-        contextRef.get()?.let {
-            if (WorkManager.isInitialized()) {
-                triggerUploadWorker(it, sdkCore.name, sdkCore.internalLogger)
-            }
+        if (WorkManager.isInitialized()) {
+            triggerUploadWorker(appContext, sdkCore.name, sdkCore.internalLogger)
         }
-
-        // Always do this one last; this will shut down the VM
-        previousHandler?.uncaughtException(t, e)
     }
-
-    // endregion
-
-    // region DatadogExceptionHandler
-
-    fun register() {
-        previousHandler = Thread.getDefaultUncaughtExceptionHandler()
-        Thread.setDefaultUncaughtExceptionHandler(this)
-    }
-
-    // endregion
-
-    // region Internal
 
     private fun createCrashMessage(throwable: Throwable): String {
         val rawMessage = throwable.message
@@ -147,5 +161,6 @@ internal class DatadogExceptionHandler(
                 "Some events could be lost."
         internal const val MISSING_RUM_FEATURE_INFO =
             "RUM feature is not registered, won't report crash as RUM event."
+        internal const val PROCESSING_FAILURE_MESSAGE = "Failed to process uncaught exception."
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
@@ -81,6 +81,52 @@ internal class CrashReportsFeatureTest {
         assertThat(finalHandler).isSameAs(mockOriginalHandler)
     }
 
+    @Test
+    fun `M keep foreign handler W onStop() { another handler registered after us }`() {
+        // Given
+        val mockOriginalHandler: Thread.UncaughtExceptionHandler = mock()
+        Thread.setDefaultUncaughtExceptionHandler(mockOriginalHandler)
+        testedFeature.onInitialize(appContext.mockInstance)
+        val mockForeignHandler: Thread.UncaughtExceptionHandler = mock()
+        Thread.setDefaultUncaughtExceptionHandler(mockForeignHandler)
+
+        // When
+        testedFeature.onStop()
+
+        // Then
+        assertThat(Thread.getDefaultUncaughtExceptionHandler()).isSameAs(mockForeignHandler)
+    }
+
+    @Test
+    fun `M keep current handler W onStop() { feature was never initialized }`() {
+        // Given
+        val mockForeignHandler: Thread.UncaughtExceptionHandler = mock()
+        Thread.setDefaultUncaughtExceptionHandler(mockForeignHandler)
+
+        // When
+        testedFeature.onStop()
+
+        // Then
+        assertThat(Thread.getDefaultUncaughtExceptionHandler()).isSameAs(mockForeignHandler)
+    }
+
+    @Test
+    fun `M keep current handler W onStop() twice`() {
+        // Given
+        val mockOriginalHandler: Thread.UncaughtExceptionHandler = mock()
+        Thread.setDefaultUncaughtExceptionHandler(mockOriginalHandler)
+        testedFeature.onInitialize(appContext.mockInstance)
+        testedFeature.onStop()
+        val mockForeignHandler: Thread.UncaughtExceptionHandler = mock()
+        Thread.setDefaultUncaughtExceptionHandler(mockForeignHandler)
+
+        // When
+        testedFeature.onStop()
+
+        // Then
+        assertThat(Thread.getDefaultUncaughtExceptionHandler()).isSameAs(mockForeignHandler)
+    }
+
     companion object {
         val appContext = ApplicationContextTestConfiguration(Application::class.java)
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -30,6 +30,7 @@ import com.datadog.android.utils.verifyLog
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
+import com.datadog.tools.unit.forge.aThrowable
 import com.datadog.tools.unit.setStaticValue
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.ArgumentMatchers
@@ -51,6 +53,7 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -370,6 +373,48 @@ internal class DatadogExceptionHandlerTest {
             }
         }
         verify(mockPreviousHandler).uncaughtException(currentThread, throwable)
+    }
+
+    // endregion
+
+    // region Resilience
+
+    @Test
+    fun `M call previous handler W uncaughtException() { exception ingestion throws }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeFailure = forge.aThrowable()
+        whenever(mockRumFeatureScope.sendEvent(any())) doThrow fakeFailure
+        val currentThread = Thread.currentThread()
+
+        // When
+        testedHandler.uncaughtException(currentThread, fakeThrowable)
+
+        // Then
+        verify(mockPreviousHandler).uncaughtException(currentThread, fakeThrowable)
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            DatadogExceptionHandler.PROCESSING_FAILURE_MESSAGE,
+            fakeFailure
+        )
+    }
+
+    @Test
+    fun `M not throw W uncaughtException() { ingestion throws and no previous handler }`(
+        @StringForgery fakeErrorMessage: String
+    ) {
+        // Given
+        whenever(mockRumFeatureScope.sendEvent(any())) doThrow RuntimeException(fakeErrorMessage)
+        Thread.setDefaultUncaughtExceptionHandler(null)
+        testedHandler.register()
+        val currentThread = Thread.currentThread()
+
+        // When + Then
+        assertDoesNotThrow {
+            testedHandler.uncaughtException(currentThread, fakeThrowable)
+        }
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

- Wrap `DatadogExceptionHandler.uncaughtException()` ingestion in try/catch/finally so a failure while processing the crash cannot prevent the previous handler from running. Skipping it means `RuntimeInit.KillApplicationHandler` never runs: no FATAL EXCEPTION in logcat, no system crash report, and no process kill.
- Mark `previousHandler` as `@Volatile`: it is written on the init thread and read on whichever thread crashed, and `Thread.defaultUncaughtExceptionHandler` is itself non-volatile.
- Track our own registered handler and only restore the original on stop if no other handler took over in the meantime, so stopping one SDK instance no longer silently unregisters another instance's or the host app's handler.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

