### PR TITLE
RUM-18220: Gate profiling trigger registration on RUM session sampling

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -7,6 +7,7 @@ object com.datadog.android.internal.FeatureContextKeys
   const val PROFILER_IS_RUNNING: String
   const val RUM_SESSION_ID: String
   const val RUM_SESSION_SAMPLE_RATE: String
+  const val RUM_SESSION_STATE: String
   const val PROFILING_QUOTA_REASON: String
   const val PROFILING_QUOTA_SESSION_ID: String
 interface com.datadog.android.internal.attributes.LocalAttribute
@@ -205,6 +206,9 @@ data class com.datadog.android.internal.profiling.ProfilingThreadDump
   constructor(String, Thread.State, String)
 object com.datadog.android.internal.rum.RumSessionConstants
   const val EMPTY_RUM_SESSION_ID: String
+  const val SESSION_STATE_TRACKED: String
+  const val SESSION_STATE_NOT_TRACKED: String
+  const val SESSION_STATE_EXPIRED: String
 object com.datadog.android.internal.sampling.DeterministicSampling
   fun combinedSampleRate(Float, Float): Float
 object com.datadog.android.internal.sampling.SessionSamplingIdProvider

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -34,6 +34,7 @@ public final class com/datadog/android/internal/FeatureContextKeys {
 	public static final field PROFILING_QUOTA_SESSION_ID Ljava/lang/String;
 	public static final field RUM_SESSION_ID Ljava/lang/String;
 	public static final field RUM_SESSION_SAMPLE_RATE Ljava/lang/String;
+	public static final field RUM_SESSION_STATE Ljava/lang/String;
 }
 
 public abstract interface class com/datadog/android/internal/attributes/LocalAttribute {
@@ -509,6 +510,9 @@ public final class com/datadog/android/internal/profiling/ProfilingThreadDump {
 public final class com/datadog/android/internal/rum/RumSessionConstants {
 	public static final field EMPTY_RUM_SESSION_ID Ljava/lang/String;
 	public static final field INSTANCE Lcom/datadog/android/internal/rum/RumSessionConstants;
+	public static final field SESSION_STATE_EXPIRED Ljava/lang/String;
+	public static final field SESSION_STATE_NOT_TRACKED Ljava/lang/String;
+	public static final field SESSION_STATE_TRACKED Ljava/lang/String;
 }
 
 public final class com/datadog/android/internal/sampling/DeterministicSampling {

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/FeatureContextKeys.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/FeatureContextKeys.kt
@@ -31,6 +31,14 @@ object FeatureContextKeys {
     const val RUM_SESSION_SAMPLE_RATE: String = "session_sample_rate"
 
     /**
+     * State of the current RUM session, as one of [RumSessionConstants.SESSION_STATE_*].
+     * Written by the RUM feature into its own feature context; read by other features that
+     * need to know whether the session is being tracked (i.e. sampled in) without
+     * recomputing the sampling decision themselves.
+     */
+    const val RUM_SESSION_STATE: String = "session_state"
+
+    /**
      * Reason profiling was denied by the quota API for the current RUM session.
      * Written by the profiling feature; read by RUM to include in event attributes.
      * Absent when profiling is allowed or no quota check has been performed.

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/rum/RumSessionConstants.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/rum/RumSessionConstants.kt
@@ -6,6 +6,8 @@
 
 package com.datadog.android.internal.rum
 
+import com.datadog.android.internal.FeatureContextKeys
+
 /**
  * Shared sentinel values for the RUM session state exposed via the features context.
  */
@@ -16,4 +18,22 @@ object RumSessionConstants {
      * ID equals this value.
      */
     const val EMPTY_RUM_SESSION_ID: String = "00000000-0000-0000-0000-000000000000"
+
+    /**
+     * The RUM session is being tracked (i.e. it was sampled in). Exposed via the features
+     * context under [FeatureContextKeys.RUM_SESSION_STATE].
+     */
+    const val SESSION_STATE_TRACKED: String = "TRACKED"
+
+    /**
+     * The RUM session is not being tracked (i.e. it was sampled out). Exposed via the
+     * features context under [FeatureContextKeys.RUM_SESSION_STATE].
+     */
+    const val SESSION_STATE_NOT_TRACKED: String = "NOT_TRACKED"
+
+    /**
+     * The RUM session has expired and is awaiting renewal. Exposed via the features context
+     * under [FeatureContextKeys.RUM_SESSION_STATE].
+     */
+    const val SESSION_STATE_EXPIRED: String = "EXPIRED"
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/NoOpProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/NoOpProfiler.kt
@@ -39,6 +39,8 @@ internal class NoOpProfiler : Profiler {
 
     override fun unregisterProfilingCallback(appContext: Context) = Unit
 
+    override fun setTriggersEnabled(appContext: Context, enabled: Boolean) = Unit
+
     override fun setExtendLaunchSession(extend: Boolean) = Unit
 
     override fun resolveProfilingPackageVersionCode(appContext: Context) = Unit

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/Profiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/Profiler.kt
@@ -35,6 +35,11 @@ internal interface Profiler {
     fun unregisterProfilingCallback(appContext: Context)
 
     /**
+     * Enables or disables system profiling triggers for the current RUM session.
+     */
+    fun setTriggersEnabled(appContext: Context, enabled: Boolean)
+
+    /**
      * Controls whether an app launch profiling session should extend past the 10-second
      * TTID threshold. Set to `true` when continuous profiling is enabled for the session
      * so the launch window merges into the first continuous cycle.

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -149,6 +149,7 @@ internal class ProfilingFeature(
         continuousProfilingScheduler?.stop()
         profiler.apply {
             stop()
+            setTriggersEnabled(appContext, false)
             unregisterProfilingCallback(appContext)
         }
         sdkCore.removeEventReceiver(name)
@@ -261,17 +262,33 @@ internal class ProfilingFeature(
     override fun onContextUpdate(featureName: String, context: Map<String, Any?>) {
         if (featureName != Feature.RUM_FEATURE_NAME) return
         val sessionId = context[FeatureContextKeys.RUM_SESSION_ID] as? String
-        if (sessionId == null ||
-            sessionId == RumSessionConstants.EMPTY_RUM_SESSION_ID ||
-            sessionId == lastSeenRumSessionId
-        ) {
-            return
+        when {
+            sessionId == null || sessionId == RumSessionConstants.EMPTY_RUM_SESSION_ID -> {
+                profiler.setTriggersEnabled(appContext, false)
+            }
+
+            sessionId == lastSeenRumSessionId -> {
+                profiler.setTriggersEnabled(appContext, isRumSessionTracked(context))
+            }
+
+            else -> {
+                onNewRumSession(sessionId, context)
+            }
         }
+    }
+
+    private fun isRumSessionTracked(context: Map<String, Any?>): Boolean {
+        return context[FeatureContextKeys.RUM_SESSION_STATE] ==
+            RumSessionConstants.SESSION_STATE_TRACKED
+    }
+
+    private fun onNewRumSession(sessionId: String, context: Map<String, Any?>) {
         this.lastQuotaResult = null
         continuousProfilingScheduler?.lastQuotaResult = null
         val sampleRate = (context[FeatureContextKeys.RUM_SESSION_SAMPLE_RATE] as? Number)?.toFloat()
             ?: DEFAULT_RUM_SESSION_SAMPLE_RATE
         lastSeenRumSessionId = sessionId
+        profiler.setTriggersEnabled(appContext, isRumSessionTracked(context))
         sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)?.withContext { datadogContext ->
             quotaChecker.checkAsync(sessionId, datadogContext)
         }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
@@ -271,17 +271,23 @@ internal class PerfettoProfiler(
     ) {
         synchronized(this) {
             this.callback = callback
-            if (buildSdkVersionProvider.isAtLeastBaklava) {
-                triggerRegistrar.register(appContext, triggerListener)
-            }
         }
     }
 
     override fun unregisterProfilingCallback(appContext: Context) {
         synchronized(this) {
             callback = null
+        }
+    }
+
+    override fun setTriggersEnabled(appContext: Context, enabled: Boolean) {
+        synchronized(this) {
             if (buildSdkVersionProvider.isAtLeastBaklava) {
-                triggerRegistrar.unregister(appContext)
+                if (enabled) {
+                    triggerRegistrar.register(appContext, triggerListener)
+                } else {
+                    triggerRegistrar.unregister(appContext)
+                }
             }
         }
     }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -500,7 +500,7 @@ internal class ProfilingFeatureTest {
     }
 
     @Test
-    fun `M ignore context update W onContextUpdate {session id is NULL_UUID sentinel}`(
+    fun `M disable triggers W onContextUpdate {session id is NULL_UUID sentinel}`(
         @FloatForgery(min = 0f, max = 100f) fakeSessionRate: Float
     ) {
         // Given — RUM has been initialised but no session has been created yet
@@ -517,6 +517,7 @@ internal class ProfilingFeatureTest {
 
         // Then
         assertThat(testedFeature.lastSeenRumSessionId).isNull()
+        verify(mockProfiler).setTriggersEnabled(mockContext, false)
     }
 
     @Test
@@ -563,6 +564,116 @@ internal class ProfilingFeatureTest {
         // Then
         assertThat(scheduler.currentSessionSampled).isEqualTo(sampledAfterFirst)
     }
+
+    // region trigger gating
+
+    @Test
+    fun `M enable triggers W onContextUpdate {RUM session sampled in}`() {
+        // Given
+        testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
+        whenever(mockProfiler.isRunning()) doReturn false
+        testedFeature.onInitialize(mockContext)
+        val sessionId = sampledInSessionId()
+
+        // When
+        testedFeature.dispatchRumSession(sessionId, 100f)
+
+        // Then
+        verify(mockProfiler).setTriggersEnabled(mockContext, true)
+    }
+
+    @Test
+    fun `M disable triggers W onContextUpdate {RUM session sampled out}`() {
+        // Given
+        testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
+        whenever(mockProfiler.isRunning()) doReturn false
+        testedFeature.onInitialize(mockContext)
+
+        // When
+        testedFeature.dispatchRumSession(
+            UUID.randomUUID().toString(),
+            0f,
+            RumSessionConstants.SESSION_STATE_NOT_TRACKED
+        )
+
+        // Then
+        verify(mockProfiler).setTriggersEnabled(mockContext, false)
+    }
+
+    @Test
+    fun `M disable triggers W onStop {after sampled-in session}`() {
+        // Given
+        testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
+        whenever(mockProfiler.isRunning()) doReturn false
+        testedFeature.onInitialize(mockContext)
+        testedFeature.dispatchRumSession(sampledInSessionId(), 100f)
+
+        // When
+        testedFeature.onStop()
+
+        // Then
+        verify(mockProfiler).setTriggersEnabled(mockContext, false)
+    }
+
+    @Test
+    fun `M disable triggers W onContextUpdate {sampled-in session then expired, same id}`() {
+        // Given — a sampled-in session registered the triggers
+        testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
+        whenever(mockProfiler.isRunning()) doReturn false
+        testedFeature.onInitialize(mockContext)
+        val sessionId = sampledInSessionId()
+        testedFeature.dispatchRumSession(sessionId, 100f)
+
+        // When — the session expires on a non-interaction event: RUM keeps the same id
+        // but transitions the state to EXPIRED.
+        testedFeature.dispatchRumSession(
+            sessionId,
+            100f,
+            RumSessionConstants.SESSION_STATE_EXPIRED
+        )
+
+        // Then
+        verify(mockProfiler).setTriggersEnabled(mockContext, false)
+    }
+
+    @Test
+    fun `M keep triggers enabled W onContextUpdate {same session id, still tracked}`() {
+        // Given — a sampled-in session registered the triggers
+        testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
+        whenever(mockProfiler.isRunning()) doReturn false
+        testedFeature.onInitialize(mockContext)
+        val sessionId = sampledInSessionId()
+        testedFeature.dispatchRumSession(sessionId, 100f)
+
+        // When — a spurious context update re-emits the same id still in TRACKED state
+        testedFeature.dispatchRumSession(sessionId, 100f)
+
+        // Then — triggers are never disabled for the tracked session
+        verify(mockProfiler, never()).setTriggersEnabled(mockContext, false)
+    }
+
+    @Test
+    fun `M disable triggers W onContextUpdate {sampled-in session then cleared}`() {
+        // Given — a sampled-in session registered the triggers
+        testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
+        whenever(mockProfiler.isRunning()) doReturn false
+        testedFeature.onInitialize(mockContext)
+        testedFeature.dispatchRumSession(sampledInSessionId(), 100f)
+
+        // When — the session ends and RUM clears its feature context (no session id)
+        testedFeature.onContextUpdate(
+            Feature.RUM_FEATURE_NAME,
+            mapOf(
+                FeatureContextKeys.RUM_SESSION_ID to RumSessionConstants.EMPTY_RUM_SESSION_ID,
+                FeatureContextKeys.RUM_SESSION_SAMPLE_RATE to 100f
+            )
+        )
+
+        // Then
+        verify(mockProfiler).setTriggersEnabled(mockContext, false)
+    }
+
+    // endregion
 
     @Test
     fun `M unregister context receiver and clear last session W onStop()`(
@@ -1401,6 +1512,7 @@ internal class ProfilingFeatureTest {
     fun `M fire quota check W onContextUpdate { new session id }`(forge: Forge) {
         // Given
         val fakeNewSessionId = forge.aString()
+        testedFeature.onInitialize(mockContext)
         testedFeature.quotaChecker = mockQuotaChecker
 
         // When
@@ -1596,15 +1708,24 @@ internal class ProfilingFeatureTest {
         propagateQuotaResult(QuotaResult(QuotaResult.Decision.ALLOWED, QuotaReason.QUOTA_OK))
     }
 
-    private fun ProfilingFeature.dispatchRumSession(sessionId: String, sampleRate: Float) {
+    private fun ProfilingFeature.dispatchRumSession(
+        sessionId: String,
+        sampleRate: Float,
+        sessionState: String = RumSessionConstants.SESSION_STATE_TRACKED
+    ) {
         onContextUpdate(
             Feature.RUM_FEATURE_NAME,
             mapOf(
                 FeatureContextKeys.RUM_SESSION_ID to sessionId,
-                FeatureContextKeys.RUM_SESSION_SAMPLE_RATE to sampleRate
+                FeatureContextKeys.RUM_SESSION_SAMPLE_RATE to sampleRate,
+                FeatureContextKeys.RUM_SESSION_STATE to sessionState
             )
         )
     }
+
+    // dispatchRumSession defaults the session state to TRACKED, so any UUID dispatched
+    // through it is treated as a sampled-in RUM session.
+    private fun sampledInSessionId(): String = UUID.randomUUID().toString()
 
     companion object {
         private val mainLooper = MainLooperTestConfiguration()

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -1033,19 +1033,49 @@ class PerfettoProfilerTest {
     // region ANR trigger registration
 
     @Test
-    fun `M delegate to registrar W registerProfilingCallback`() {
-        // Set-up performs 1 registerProfilingCallback call, which delegates to the registrar,
-        // passing the profiler's listener.
-        verify(mockRegistrar).register(mockContext, testedProfiler.triggerListener)
+    fun `M not delegate to registrar W registerProfilingCallback`() {
+        // Set-up performs 1 registerProfilingCallback call, which no longer registers triggers;
+        // trigger registration is now driven by setTriggersEnabled.
+        verify(mockRegistrar, never()).register(any(), any())
     }
 
     @Test
-    fun `M call registrar unregister W callback removed`() {
+    fun `M not call registrar unregister W unregisterProfilingCallback`() {
         // When
         testedProfiler.unregisterProfilingCallback(mockContext)
 
         // Then
+        verify(mockRegistrar, never()).unregister(any())
+    }
+
+    @Test
+    fun `M delegate to registrar register W setTriggersEnabled {enabled=true}`() {
+        // When
+        testedProfiler.setTriggersEnabled(mockContext, true)
+
+        // Then
+        verify(mockRegistrar).register(mockContext, testedProfiler.triggerListener)
+    }
+
+    @Test
+    fun `M delegate to registrar unregister W setTriggersEnabled {enabled=false}`() {
+        // When
+        testedProfiler.setTriggersEnabled(mockContext, false)
+
+        // Then
         verify(mockRegistrar).unregister(mockContext)
+    }
+
+    @Test
+    fun `M not delegate to registrar W setTriggersEnabled {SDK below BAKLAVA}`() {
+        // Given
+        whenever(mockBuildSdkVersionProvider.isAtLeastBaklava) doReturn false
+
+        // When
+        testedProfiler.setTriggersEnabled(mockContext, true)
+
+        // Then
+        verify(mockRegistrar, never()).register(any(), any())
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumContext.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumContext.kt
@@ -60,7 +60,7 @@ internal data class RumContext(
         const val APPLICATION_ID = "application_id"
         const val SESSION_ID = FeatureContextKeys.RUM_SESSION_ID
         const val SESSION_ACTIVE = "session_active"
-        const val SESSION_STATE = "session_state"
+        const val SESSION_STATE = FeatureContextKeys.RUM_SESSION_STATE
         const val SESSION_START_REASON = "session_start_reason"
         const val VIEW_ID = "view_id"
         const val VIEW_NAME = "view_name"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -16,6 +16,7 @@ import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.internal.heatmaps.HeatmapIdentifierRegistry
+import com.datadog.android.internal.rum.RumSessionConstants
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.RumSessionType
 import com.datadog.android.rum.internal.domain.InfoProvider
@@ -110,9 +111,9 @@ internal class RumSessionScope(
         }
 
     enum class State(val asString: String) {
-        NOT_TRACKED("NOT_TRACKED"),
-        TRACKED("TRACKED"),
-        EXPIRED("EXPIRED");
+        NOT_TRACKED(RumSessionConstants.SESSION_STATE_NOT_TRACKED),
+        TRACKED(RumSessionConstants.SESSION_STATE_TRACKED),
+        EXPIRED(RumSessionConstants.SESSION_STATE_EXPIRED);
 
         companion object {
             fun fromString(string: String?): State? {


### PR DESCRIPTION
### What does this PR do?

Gates system profiling-trigger registration (ANR / OOM / Anomaly) on the RUM session sampling decision. Triggers now register only when the current RUM session is sampled in, and unregister when a renewal is sampled out — instead of registering unconditionally at feature init.

- Add `Profiler.setTriggersEnabled(appContext, enabled)`; `PerfettoProfiler` moves trigger register/unregister out of the callback lifecycle into this seam.
- `ProfilingFeature.onContextUpdate` computes a RUM-session-rate-only sampling decision and calls `setTriggersEnabled(true/false)`; `onStop` disables triggers.

### Motivation

ANR/OOM/Anomaly detection should align with the RUM session lifecycle instead of running unconditionally for every process.

### Additional Notes

- Gate uses the RUM session sample rate only (continuous profiling combined rate is unchanged).
- `setTriggersEnabled` is `internal`; public API surface unchanged. `PerfettoProfilerTest` 45/45, `ProfilingFeatureTest` 58/58 passing.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)
