### PR TITLE
RUM-18249: Making view required back in rum events

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -401,7 +401,7 @@ class com.datadog.android.sqlite.DatadogDatabaseErrorHandler : android.database.
   constructor(String? = null, android.database.DatabaseErrorHandler = DefaultDatabaseErrorHandler())
   override fun onCorruption(android.database.sqlite.SQLiteDatabase)
 data class com.datadog.android.rum.model.ActionEvent
-  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ActionEventSession, ActionEventSource? = null, ActionEventView? = null, Usr? = null, Account? = null, Tab? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Stream? = null, Container? = null, ActionEventAction)
+  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ActionEventSession, ActionEventSource? = null, ActionEventView, Usr? = null, Account? = null, Tab? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Stream? = null, Container? = null, ActionEventAction)
   val type: kotlin.String
   fun toJson(): com.google.gson.JsonElement
   companion object 
@@ -714,7 +714,7 @@ data class com.datadog.android.rum.model.ActionEvent
     companion object 
       fun fromJson(kotlin.String): Type
 data class com.datadog.android.rum.model.ErrorEvent
-  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ErrorEventSession, ErrorEventSource? = null, ErrorEventView? = null, Usr? = null, Account? = null, Tab? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Stream? = null, Action? = null, Container? = null, Error, Freeze? = null, Context? = null)
+  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ErrorEventSession, ErrorEventSource? = null, ErrorEventView, Usr? = null, Account? = null, Tab? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Stream? = null, Action? = null, Container? = null, Error, Freeze? = null, Context? = null)
   val type: kotlin.String
   fun toJson(): com.google.gson.JsonElement
   companion object 
@@ -1107,7 +1107,7 @@ data class com.datadog.android.rum.model.ErrorEvent
     companion object 
       fun fromJson(kotlin.String): ProviderType
 data class com.datadog.android.rum.model.LongTaskEvent
-  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, LongTaskEventSession, LongTaskEventSource? = null, LongTaskEventView? = null, Usr? = null, Account? = null, Tab? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Stream? = null, Action? = null, Container? = null, LongTask)
+  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, LongTaskEventSession, LongTaskEventSource? = null, LongTaskEventView, Usr? = null, Account? = null, Tab? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Stream? = null, Action? = null, Container? = null, LongTask)
   val type: kotlin.String
   fun toJson(): com.google.gson.JsonElement
   companion object 
@@ -1387,7 +1387,7 @@ data class com.datadog.android.rum.model.LongTaskEvent
     companion object 
       fun fromJson(kotlin.String): InvokerType
 data class com.datadog.android.rum.model.ResourceEvent
-  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ResourceEventSession, ResourceEventSource? = null, ResourceEventView? = null, Usr? = null, Account? = null, Tab? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Stream? = null, Action? = null, Container? = null, Resource)
+  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, ResourceEventSession, ResourceEventSource? = null, ResourceEventView, Usr? = null, Account? = null, Tab? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Stream? = null, Action? = null, Container? = null, Resource)
   val type: kotlin.String
   fun toJson(): com.google.gson.JsonElement
   companion object 

--- a/features/dd-sdk-android-rum/src/main/json/rum/action-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/action-schema.json
@@ -12,7 +12,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "action"],
+      "required": ["type", "view", "action"],
       "properties": {
         "type": {
           "type": "string",

--- a/features/dd-sdk-android-rum/src/main/json/rum/error-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/error-schema.json
@@ -15,7 +15,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "error"],
+      "required": ["type", "view", "error"],
       "properties": {
         "type": {
           "type": "string",

--- a/features/dd-sdk-android-rum/src/main/json/rum/long_task-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/long_task-schema.json
@@ -16,7 +16,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "long_task"],
+      "required": ["type", "view", "long_task"],
       "properties": {
         "type": {
           "type": "string",

--- a/features/dd-sdk-android-rum/src/main/json/rum/resource-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/resource-schema.json
@@ -15,7 +15,7 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "resource"],
+      "required": ["type", "view", "resource"],
       "properties": {
         "type": {
           "type": "string",

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
@@ -157,19 +157,19 @@ internal class ActionEventAssert(actual: ActionEvent) :
         expectedName: String?,
         expectedUrl: String?
     ): ActionEventAssert {
-        assertThat(actual.view?.id)
+        assertThat(actual.view.id)
             .overridingErrorMessage(
-                "Expected event data to have view.id $expectedId but was ${actual.view?.id}"
+                "Expected event data to have view.id $expectedId but was ${actual.view.id}"
             )
             .isEqualTo(expectedId.orEmpty())
-        assertThat(actual.view?.name)
+        assertThat(actual.view.name)
             .overridingErrorMessage(
-                "Expected event data to have view.name $expectedName but was ${actual.view?.name}"
+                "Expected event data to have view.name $expectedName but was ${actual.view.name}"
             )
             .isEqualTo(expectedName)
-        assertThat(actual.view?.url)
+        assertThat(actual.view.url)
             .overridingErrorMessage(
-                "Expected event data to have view.url $expectedUrl but was ${actual.view?.url}"
+                "Expected event data to have view.url $expectedUrl but was ${actual.view.url}"
             )
             .isEqualTo(expectedUrl.orEmpty())
         return this
@@ -178,21 +178,21 @@ internal class ActionEventAssert(actual: ActionEvent) :
     fun hasView(
         expected: RumContext
     ): ActionEventAssert {
-        assertThat(actual.view?.id)
+        assertThat(actual.view.id)
             .overridingErrorMessage(
-                "Expected event data to have view.id ${expected.viewId} but was ${actual.view?.id}"
+                "Expected event data to have view.id ${expected.viewId} but was ${actual.view.id}"
             )
             .isEqualTo(expected.viewId.orEmpty())
-        assertThat(actual.view?.name)
+        assertThat(actual.view.name)
             .overridingErrorMessage(
                 "Expected event data to have view.name ${expected.viewName} " +
-                    "but was ${actual.view?.name}"
+                    "but was ${actual.view.name}"
             )
             .isEqualTo(expected.viewName)
-        assertThat(actual.view?.url)
+        assertThat(actual.view.url)
             .overridingErrorMessage(
                 "Expected event data to have view.url ${expected.viewUrl} " +
-                    "but was ${actual.view?.url}"
+                    "but was ${actual.view.url}"
             )
             .isEqualTo(expected.viewUrl.orEmpty())
         return this

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
@@ -252,41 +252,41 @@ internal class ErrorEventAssert(actual: ErrorEvent) :
         expectedName: String?,
         expectedUrl: String?
     ): ErrorEventAssert {
-        assertThat(actual.view?.id)
+        assertThat(actual.view.id)
             .overridingErrorMessage(
-                "Expected event data to have view.id $expectedId but was ${actual.view?.id}"
+                "Expected event data to have view.id $expectedId but was ${actual.view.id}"
             )
             .isEqualTo(expectedId.orEmpty())
-        assertThat(actual.view?.name)
+        assertThat(actual.view.name)
             .overridingErrorMessage(
-                "Expected event data to have view.name $expectedName but was ${actual.view?.name}"
+                "Expected event data to have view.name $expectedName but was ${actual.view.name}"
             )
             .isEqualTo(expectedName)
-        assertThat(actual.view?.url)
+        assertThat(actual.view.url)
             .overridingErrorMessage(
-                "Expected event data to have view.url $expectedUrl but was ${actual.view?.url}"
+                "Expected event data to have view.url $expectedUrl but was ${actual.view.url}"
             )
             .isEqualTo(expectedUrl.orEmpty())
         return this
     }
 
     fun hasView(expected: RumContext): ErrorEventAssert {
-        assertThat(actual.view?.id)
+        assertThat(actual.view.id)
             .overridingErrorMessage(
                 "Expected event data to have view.id ${expected.viewId} " +
-                    "but was ${actual.view?.id}"
+                    "but was ${actual.view.id}"
             )
             .isEqualTo(expected.viewId.orEmpty())
-        assertThat(actual.view?.name)
+        assertThat(actual.view.name)
             .overridingErrorMessage(
                 "Expected event data to have view.name ${expected.viewName} " +
-                    "but was ${actual.view?.name}"
+                    "but was ${actual.view.name}"
             )
             .isEqualTo(expected.viewName)
-        assertThat(actual.view?.url)
+        assertThat(actual.view.url)
             .overridingErrorMessage(
                 "Expected event data to have view.url ${expected.viewUrl} " +
-                    "but was ${actual.view?.url}"
+                    "but was ${actual.view.url}"
             )
             .isEqualTo(expected.viewUrl.orEmpty())
         return this

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/LongTaskEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/LongTaskEventAssert.kt
@@ -180,14 +180,14 @@ internal class LongTaskEventAssert(actual: LongTaskEvent) :
     }
 
     fun hasView(expectedId: String?, expectedUrl: String?): LongTaskEventAssert {
-        assertThat(actual.view?.id)
+        assertThat(actual.view.id)
             .overridingErrorMessage(
-                "Expected event data to have view.id $expectedId but was ${actual.view?.id}"
+                "Expected event data to have view.id $expectedId but was ${actual.view.id}"
             )
             .isEqualTo(expectedId.orEmpty())
-        assertThat(actual.view?.url)
+        assertThat(actual.view.url)
             .overridingErrorMessage(
-                "Expected event data to have view.id $expectedUrl but was ${actual.view?.url}"
+                "Expected event data to have view.id $expectedUrl but was ${actual.view.url}"
             )
             .isEqualTo(expectedUrl.orEmpty())
         return this

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
@@ -377,22 +377,22 @@ internal class ResourceEventAssert(actual: ResourceEvent) :
     }
 
     fun hasView(expected: RumContext): ResourceEventAssert {
-        assertThat(actual.view?.id)
+        assertThat(actual.view.id)
             .overridingErrorMessage(
                 "Expected event data to have view.id ${expected.viewId} " +
-                    "but was ${actual.view?.id}"
+                    "but was ${actual.view.id}"
             )
             .isEqualTo(expected.viewId.orEmpty())
-        assertThat(actual.view?.name)
+        assertThat(actual.view.name)
             .overridingErrorMessage(
                 "Expected event data to have view.name ${expected.viewName} " +
-                    "but was ${actual.view?.name}"
+                    "but was ${actual.view.name}"
             )
             .isEqualTo(expected.viewName)
-        assertThat(actual.view?.url)
+        assertThat(actual.view.url)
             .overridingErrorMessage(
                 "Expected event data to have view.url ${expected.viewUrl} " +
-                    "but was ${actual.view?.url}"
+                    "but was ${actual.view.url}"
             )
             .isEqualTo(expected.viewUrl.orEmpty())
         return this

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
@@ -94,8 +94,8 @@ internal class RumEventSerializerTest {
                 hasField("type", event.session.type.name.lowercase(Locale.US))
             }
             .hasField("view") {
-                hasNullableField("id", event.view?.id)
-                hasNullableField("url", event.view?.url)
+                hasNullableField("id", event.view.id)
+                hasNullableField("url", event.view.url)
             }
             .hasField("_dd") {
                 hasField("format_version", 2L)
@@ -211,8 +211,8 @@ internal class RumEventSerializerTest {
                 hasField("type", event.session.type.name.lowercase(Locale.US))
             }
             .hasField("view") {
-                hasNullableField("id", event.view?.id)
-                hasNullableField("url", event.view?.url)
+                hasNullableField("id", event.view.id)
+                hasNullableField("url", event.view.url)
             }
             .hasField("_dd") {
                 hasField("format_version", 2L)
@@ -403,8 +403,8 @@ internal class RumEventSerializerTest {
                 hasField("type", event.session.type.name.lowercase(Locale.US))
             }
             .hasField("view") {
-                hasNullableField("id", event.view?.id)
-                hasNullableField("url", event.view?.url)
+                hasNullableField("id", event.view.id)
+                hasNullableField("url", event.view.url)
             }
             .hasField("_dd") {
                 hasField("format_version", 2L)
@@ -490,8 +490,8 @@ internal class RumEventSerializerTest {
                 hasField("type", event.session.type.name.lowercase(Locale.US))
             }
             .hasField("view") {
-                hasNullableField("id", event.view?.id)
-                hasNullableField("url", event.view?.url)
+                hasNullableField("id", event.view.id)
+                hasNullableField("url", event.view.url)
             }
             .hasField("_dd") {
                 hasField("format_version", 2L)
@@ -669,7 +669,7 @@ internal class RumEventSerializerTest {
             }
             .hasNullableField("service", event.service)
 
-        event.view?.let {
+        event.view.let {
             assertThat(jsonObject).hasField("view") {
                 val view = checkNotNull(event.view)
                 hasField("id", view.id)


### PR DESCRIPTION
### What does this PR do?

Restores `view` to the local `required` array of ActionEvent/ErrorEvent/LongTaskEvent/ResourceEvent RUM schemas, making the generated `view` field non-nullable again for these events.

### Motivation

RUM-17613 ("Build timeseries events from the shared RUM schema") removed `view` from `_common-schema.json`'s shared `required` array so that new timeseries events (which don't have a view) could validate. This had the unintended side effect of making `view` nullable for ALL RUM events, including Action/Error/LongTask/Resource, which always have a view. This matches a regression already published in 3.13.0 and would break consumers (e.g. dd-sdk-flutter) that mutate `event.view.*` directly assuming non-null.

Fix: add `view` back to each individual event schema's own `required` block (matching the pattern used upstream in rum-events-format for non-timeseries events), instead of restoring it in the shared `_common-schema.json` (which would re-break timeseries events).

### Additional Notes

apiSurface regenerated (view fields now non-optional in ActionEvent/ErrorEvent/LongTaskEvent/ResourceEvent constructors). Unit tests updated to drop now-unnecessary safe calls on `.view`. Full `dd-sdk-android-rum` test suite passes (2659 tests). Targets `release/3.13.0` so the fix can ship in a patch release, since 3.13.0 is already published to Maven Central with the bug.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

Ref: RUM-18249