### PR TITLE
Fix `dogfood.py` version regex to allow uppercase and build-metadata chars

### DIFF
--- a/ci/scripts/dogfood.py
+++ b/ci/scripts/dogfood.py
@@ -81,7 +81,7 @@ def generate_target_code(target: str, temp_dir_path: str, version: str):
     file_path = FILE_PATH[target]
     target_file = os.path.join(temp_dir_path, file_path)
     prefix = PREFIX[target]
-    regex = prefix + " = \"[0-9a-z\\.-]+\""
+    regex = prefix + " = \"[0-9a-zA-Z\\.\\-+]+\""
 
     previous_version = None
 


### PR DESCRIPTION
### What does this PR do?

Widens the version-matching regex in `ci/scripts/dogfood.py`'s `generate_target_code()` from `[0-9a-z.-]+` to `[0-9a-zA-Z.\-+]+`, so it can match and replace version strings containing uppercase letters or `+` build metadata.

### Motivation

`shopist-android` and `datadog-android` both currently have their `datadogSdk`/`datadog` version pinned to `3.13.0-dogfooding-SNAPSHOT`. The uppercase `SNAPSHOT` isn't in the old character class, so the substitution regex silently fails to match that line — the file is left unchanged, `repo.is_dirty()` returns `False`, and the dogfood job exits 0 having done nothing. Confirmed against `datadog-android`'s dogfood PR history: PRs #8620, #8721, #8727 (titled "Update Datadog SDK to version X", opened by the dogfood bot) all have `headRefOid == baseRefOid` — i.e. empty PRs with zero commits, consistent with the regex never matching.
