### PR TITLE
RUM-18249: Fix missing view requirement in _vital-common-schema.json

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -2685,7 +2685,7 @@ data class com.datadog.android.rum.model.ViewEvent
     companion object 
       fun fromJson(kotlin.String): ErrorReason
 data class com.datadog.android.rum.model.VitalAppLaunchEvent
-  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, VitalAppLaunchEventSession, VitalAppLaunchEventSource? = null, VitalAppLaunchEventView? = null, Usr? = null, Account? = null, Tab? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Stream? = null, Container? = null, Vital)
+  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, VitalAppLaunchEventSession, VitalAppLaunchEventSource? = null, VitalAppLaunchEventView, Usr? = null, Account? = null, Tab? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Stream? = null, Container? = null, Vital)
   val type: kotlin.String
   fun toJson(): com.google.gson.JsonElement
   companion object 
@@ -2950,7 +2950,7 @@ data class com.datadog.android.rum.model.VitalAppLaunchEvent
     companion object 
       fun fromJson(kotlin.String): ErrorReason
 data class com.datadog.android.rum.model.VitalOperationStepEvent
-  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, VitalOperationStepEventSession, VitalOperationStepEventSource? = null, VitalOperationStepEventView? = null, Usr? = null, Account? = null, Tab? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Stream? = null, Container? = null, Vital)
+  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, VitalOperationStepEventSession, VitalOperationStepEventSource? = null, VitalOperationStepEventView, Usr? = null, Account? = null, Tab? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Stream? = null, Container? = null, Vital)
   val type: kotlin.String
   fun toJson(): com.google.gson.JsonElement
   companion object 

--- a/features/dd-sdk-android-rum/src/main/json/rum/_vital-common-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/_vital-common-schema.json
@@ -12,12 +12,16 @@
       "$ref": "_view-container-schema.json"
     },
     {
-      "required": ["type", "vital"],
+      "required": ["type", "view", "vital"],
       "properties": {
         "type": {
           "type": "string",
           "description": "RUM event type",
           "const": "vital",
+          "readOnly": true
+        },
+        "view": {
+          "type": "object",
           "readOnly": true
         },
         "vital": {

--- a/features/dd-sdk-android-rum/src/main/json/rum/long_task-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/long_task-schema.json
@@ -24,6 +24,10 @@
           "const": "long_task",
           "readOnly": true
         },
+        "view": {
+          "type": "object",
+          "readOnly": true
+        },
         "long_task": {
           "type": "object",
           "description": "Long Task properties",

--- a/features/dd-sdk-android-rum/src/main/json/rum/resource-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/resource-schema.json
@@ -23,6 +23,10 @@
           "const": "resource",
           "readOnly": true
         },
+        "view": {
+          "type": "object",
+          "readOnly": true
+        },
         "resource": {
           "type": "object",
           "description": "Resource properties",

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/VitalAppLaunchEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/VitalAppLaunchEventAssert.kt
@@ -98,25 +98,25 @@ internal class VitalAppLaunchEventAssert(
     }
 
     fun hasViewId(expectedId: String) = apply {
-        assertThat(actual.view?.id)
+        assertThat(actual.view.id)
             .overridingErrorMessage(
-                "Expected event data to have view.id $expectedId but was ${actual.view?.id}"
+                "Expected event data to have view.id $expectedId but was ${actual.view.id}"
             )
             .isEqualTo(expectedId)
     }
 
     fun hasName(expected: String?) = apply {
-        assertThat(actual.view?.name)
+        assertThat(actual.view.name)
             .overridingErrorMessage(
-                "Expected event data to have view.name $expected but was ${actual.view?.name}"
+                "Expected event data to have view.name $expected but was ${actual.view.name}"
             )
             .isEqualTo(expected)
     }
 
     fun hasUrl(expected: String) = apply {
-        assertThat(actual.view?.url)
+        assertThat(actual.view.url)
             .overridingErrorMessage(
-                "Expected event data to have view.url $expected but was ${actual.view?.url}"
+                "Expected event data to have view.url $expected but was ${actual.view.url}"
             )
             .isEqualTo(expected)
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/VitalEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/VitalEventAssert.kt
@@ -98,34 +98,26 @@ internal class VitalEventAssert(
             .isEqualTo(hasReplay)
     }
 
-    fun hasNullView() = apply {
-        assertThat(actual.view)
-            .overridingErrorMessage(
-                "Expected event data to have view equal to null"
-            )
-            .isNull()
-    }
-
     fun hasViewId(expectedId: String) = apply {
-        assertThat(actual.view?.id)
+        assertThat(actual.view.id)
             .overridingErrorMessage(
-                "Expected event data to have view.id $expectedId but was ${actual.view?.id}"
+                "Expected event data to have view.id $expectedId but was ${actual.view.id}"
             )
             .isEqualTo(expectedId)
     }
 
     fun hasName(expected: String) = apply {
-        assertThat(actual.view?.name)
+        assertThat(actual.view.name)
             .overridingErrorMessage(
-                "Expected event data to have view.name $expected but was ${actual.view?.name}"
+                "Expected event data to have view.name $expected but was ${actual.view.name}"
             )
             .isEqualTo(expected)
     }
 
     fun hasUrl(expected: String) = apply {
-        assertThat(actual.view?.url)
+        assertThat(actual.view.url)
             .overridingErrorMessage(
-                "Expected event data to have view.url $expected but was ${actual.view?.url}"
+                "Expected event data to have view.url $expected but was ${actual.view.url}"
             )
             .isEqualTo(expected)
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -10604,8 +10604,8 @@ internal class RumViewScopeTest {
 
         assertThat(profilerEvent.rumContext.applicationId).isEqualTo(writtenVital.application.id)
         assertThat(profilerEvent.rumContext.sessionId).isEqualTo(writtenVital.session.id)
-        assertThat(profilerEvent.rumContext.viewId).isEqualTo(writtenVital.view?.id)
-        assertThat(profilerEvent.rumContext.viewName).isEqualTo(writtenVital.view?.name)
+        assertThat(profilerEvent.rumContext.viewId).isEqualTo(writtenVital.view.id)
+        assertThat(profilerEvent.rumContext.viewName).isEqualTo(writtenVital.view.name)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

Follow-up to #3783. That PR made `view` required again on `action`, `error`, `long_task` and `resource` events, but missed `_vital-common-schema.json` — the shared base schema for `VitalOperationStepEvent` and `VitalAppLaunchEvent`. This PR adds `view` to that schema's `required` array and declares the `view` property explicitly (matching the same pattern applied upstream in `rum-events-format` commit `7cd262a`, and to `long_task-schema.json` / `resource-schema.json` here for consistency).

### Motivation

Found while testing the #3783 fix against `dd-sdk-flutter`'s `DatadogRumEventMapper.kt`: compiling it against a locally-published `dd-sdk-android-rum` snapshot still failed with a nullable-receiver error on `VitalOperationStepEvent.view`, since `_vital-common-schema.json` still allowed `view` to be null.

### Additional Notes

- Regenerated `apiSurface`; `VitalOperationStepEvent.view` and `VitalAppLaunchEvent.view` are now non-null.
- Removed now-redundant `?.` safe calls in `VitalEventAssert.kt`, `VitalAppLaunchEventAssert.kt`, `RumViewScopeTest.kt`.
- Verified against the real `dd-sdk-flutter` example app: builds and runs successfully on an Android API 28 emulator using this fix.

Ref: RUM-18249