### PR TITLE
Encapsulate OOM/Anomaly profiling results in PerfettoResult and rename package name

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilerCallback.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilerCallback.kt
@@ -16,7 +16,7 @@ internal interface ProfilerCallback {
 
     fun onAnrDetected(event: ProfilingAnrDetectedEvent)
 
-    fun onOutOfMemoryDetected(detectedAtMs: Long, resultFilePath: String)
+    fun onOutOfMemoryDetected(result: PerfettoResult)
 
-    fun onMemoryAnomalyDetected(detectedAtMs: Long, resultFilePath: String)
+    fun onMemoryAnomalyDetected(result: PerfettoResult)
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -233,15 +233,15 @@ internal class ProfilingFeature(
         // TODO RUM-18154: Wire resultFilePath with ProfilingDataWriter
     }
 
-    override fun onOutOfMemoryDetected(detectedAtMs: Long, resultFilePath: String) {
+    override fun onOutOfMemoryDetected(result: PerfettoResult) {
         // RUM already generates its own OOM error event, so the profiling feature
         // does not forward a separate OOM event.
         // TODO RUM-18154: Wire resultFilePath with ProfilingDataWriter
     }
 
-    override fun onMemoryAnomalyDetected(detectedAtMs: Long, resultFilePath: String) {
+    override fun onMemoryAnomalyDetected(result: PerfettoResult) {
         sdkCore.getFeature(Feature.RUM_FEATURE_NAME)?.sendEvent(
-            ProfilingAnomalyDetectedEvent(detectedAtMs)
+            ProfilingAnomalyDetectedEvent(result.start)
         )
     }
 

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingStartReason.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingStartReason.kt
@@ -14,5 +14,9 @@ internal enum class ProfilingStartReason(val value: String) {
 
     CONTINUOUS("continuous"),
 
+    OUT_OF_MEMORY("out_of_memory"),
+
+    MEMORY_ANOMALY("memory_anomaly"),
+
     UNKNOWN("unknown")
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
@@ -21,12 +21,12 @@ import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.profiling.internal.Profiler
 import com.datadog.android.profiling.internal.ProfilerCallback
 import com.datadog.android.profiling.internal.ProfilingStartReason
-import com.datadog.android.profiling.internal.anr.ProfilingManagerTriggerRegistrar
-import com.datadog.android.profiling.internal.anr.ProfilingTriggerListener
-import com.datadog.android.profiling.internal.anr.ProfilingTriggerRegistrar
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetry
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetryEvent
 import com.datadog.android.profiling.internal.time.MutableTimeProvider
+import com.datadog.android.profiling.internal.trigger.ProfilingManagerTriggerRegistrar
+import com.datadog.android.profiling.internal.trigger.ProfilingTriggerListener
+import com.datadog.android.profiling.internal.trigger.ProfilingTriggerRegistrar
 import com.datadog.android.profiling.internal.utils.fileSizeSafe
 import com.datadog.android.profiling.internal.utils.getProfilingModuleLongVersionCode
 import com.datadog.android.profiling.internal.utils.isProfilingModuleVersionBlocked
@@ -109,12 +109,12 @@ internal class PerfettoProfiler(
             callback?.onAnrDetected(event)
         }
 
-        override fun onOutOfMemoryDetected(detectedAtMs: Long, resultFilePath: String) {
-            callback?.onOutOfMemoryDetected(detectedAtMs, resultFilePath)
+        override fun onOutOfMemoryDetected(result: PerfettoResult) {
+            callback?.onOutOfMemoryDetected(result)
         }
 
-        override fun onMemoryAnomalyDetected(detectedAtMs: Long, resultFilePath: String) {
-            callback?.onMemoryAnomalyDetected(detectedAtMs, resultFilePath)
+        override fun onMemoryAnomalyDetected(result: PerfettoResult) {
+            callback?.onMemoryAnomalyDetected(result)
         }
     }
 

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/trigger/ProfilingManagerTriggerRegistrar.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/trigger/ProfilingManagerTriggerRegistrar.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.profiling.internal.anr
+package com.datadog.android.profiling.internal.trigger
 
 import android.content.Context
 import android.os.Build
@@ -15,6 +15,8 @@ import androidx.annotation.RequiresApi
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.profiling.internal.ProfilingStartReason
+import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetry
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetryEvent
 import com.datadog.android.profiling.internal.utils.ThreadDumper
@@ -157,17 +159,7 @@ internal class ProfilingManagerTriggerRegistrar(
                 droppedAsStale = delayMs > MAX_CALLBACK_DELAY_MS
             }
             if (callbackDelayMs != null && !droppedAsStale) {
-                when (triggerType) {
-                    ProfilingTrigger.TRIGGER_TYPE_ANR ->
-                        currentListener.onAnrDetected(threadDumper.dump(detectedAtMs))
-
-                    ProfilingTrigger.TRIGGER_TYPE_OOM ->
-                        currentListener.onOutOfMemoryDetected(detectedAtMs, resultPath)
-
-                    ProfilingTrigger.TRIGGER_TYPE_ANOMALY ->
-                        // TODO RUM-18223: filter in only memory anomaly result by tag
-                        currentListener.onMemoryAnomalyDetected(detectedAtMs, resultPath)
-                }
+                forwardTriggerResult(triggerType, currentListener, detectedAtMs, resultPath)
                 // We currently don't use the result profile, just delete it.
                 safeDelete(resultPath)
             } else {
@@ -186,6 +178,41 @@ internal class ProfilingManagerTriggerRegistrar(
                 droppedAsStale = droppedAsStale
             )
         )
+    }
+
+    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
+    private fun forwardTriggerResult(
+        triggerType: Int,
+        listener: ProfilingTriggerListener,
+        detectedAtMs: Long,
+        resultPath: String
+    ) {
+        when (triggerType) {
+            ProfilingTrigger.TRIGGER_TYPE_ANR ->
+                listener.onAnrDetected(threadDumper.dump(detectedAtMs))
+
+            ProfilingTrigger.TRIGGER_TYPE_OOM ->
+                listener.onOutOfMemoryDetected(
+                    PerfettoResult(
+                        start = detectedAtMs,
+                        startReason = ProfilingStartReason.OUT_OF_MEMORY,
+                        end = detectedAtMs,
+                        resultFilePath = resultPath
+                    )
+                )
+
+            ProfilingTrigger.TRIGGER_TYPE_ANOMALY ->
+                // TODO RUM-18223: filter in only memory anomaly result by tag
+                listener.onMemoryAnomalyDetected(
+                    PerfettoResult(
+                        start = detectedAtMs,
+                        startReason = ProfilingStartReason.MEMORY_ANOMALY,
+                        // end is same as start in point-in-time profile
+                        end = detectedAtMs,
+                        resultFilePath = resultPath
+                    )
+                )
+        }
     }
 
     private fun safeDelete(path: String) {

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/trigger/ProfilingTriggerListener.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/trigger/ProfilingTriggerListener.kt
@@ -4,14 +4,15 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.profiling.internal.anr
+package com.datadog.android.profiling.internal.trigger
 
 import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
+import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 
 internal interface ProfilingTriggerListener {
     fun onAnrDetected(event: ProfilingAnrDetectedEvent)
 
-    fun onOutOfMemoryDetected(detectedAtMs: Long, resultFilePath: String)
+    fun onOutOfMemoryDetected(result: PerfettoResult)
 
-    fun onMemoryAnomalyDetected(detectedAtMs: Long, resultFilePath: String)
+    fun onMemoryAnomalyDetected(result: PerfettoResult)
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/trigger/ProfilingTriggerRegistrar.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/trigger/ProfilingTriggerRegistrar.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.profiling.internal.anr
+package com.datadog.android.profiling.internal.trigger
 
 import android.content.Context
 import com.datadog.android.api.InternalLogger

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -35,7 +35,6 @@ import com.datadog.android.profiling.internal.ProfilingRequestFactory
 import com.datadog.android.profiling.internal.ProfilingStartReason
 import com.datadog.android.profiling.internal.ProfilingStorage
 import com.datadog.android.profiling.internal.ProfilingWriter
-import com.datadog.android.profiling.internal.anr.ProfilingTriggerRegistrar
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 import com.datadog.android.profiling.internal.quota.NoOpQuotaChecker
@@ -45,6 +44,7 @@ import com.datadog.android.profiling.internal.quota.QuotaResult
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetry
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetryEvent
 import com.datadog.android.profiling.internal.time.MutableTimeProvider
+import com.datadog.android.profiling.internal.trigger.ProfilingTriggerRegistrar
 import com.datadog.android.profiling.utils.config.MainLooperTestConfiguration
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -1448,14 +1448,14 @@ internal class ProfilingFeatureTest {
 
     @Test
     fun `M not forward OOM event to RUM W onOutOfMemoryDetected()`(
-        @LongForgery(min = 0L) fakeDetectedAtMs: Long
+        @Forgery fakeResult: PerfettoResult
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
         testedFeature.onInitialize(mockContext)
 
         // When
-        testedFeature.onOutOfMemoryDetected(fakeDetectedAtMs, "")
+        testedFeature.onOutOfMemoryDetected(fakeResult)
 
         // Then
         verify(mockRumFeatureScope, never()).sendEvent(any())
@@ -1463,17 +1463,17 @@ internal class ProfilingFeatureTest {
 
     @Test
     fun `M forward anomaly event to RUM W onMemoryAnomalyDetected()`(
-        @LongForgery(min = 0L) fakeDetectedAtMs: Long
+        @Forgery fakeResult: PerfettoResult
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
         testedFeature.onInitialize(mockContext)
 
         // When
-        testedFeature.onMemoryAnomalyDetected(fakeDetectedAtMs, "")
+        testedFeature.onMemoryAnomalyDetected(fakeResult)
 
         // Then
-        verify(mockRumFeatureScope).sendEvent(ProfilingAnomalyDetectedEvent(fakeDetectedAtMs))
+        verify(mockRumFeatureScope).sendEvent(ProfilingAnomalyDetectedEvent(fakeResult.start))
     }
 
     @Test

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/Configurator.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/Configurator.kt
@@ -27,7 +27,7 @@ class Configurator : BaseConfigurator() {
         super.configure(forge)
         forge.useCoreFactories()
         forge.addFactory(ProfilingConfigurationForgeryFactory())
-        forge.addFactory(PerfettoResultFactory())
+        forge.addFactory(PerfettoResultForgeryFactory())
         forge.addFactory(ProfilerEventRumVitalEventFactory())
         forge.addFactory(ProfilerEventRumLongTaskEventForgeryFactory())
         forge.addFactory(ProfilerEventRumAnrEventForgeryFactory())

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/PerfettoResultForgeryFactory.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/forge/PerfettoResultForgeryFactory.kt
@@ -10,7 +10,7 @@ import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
-internal class PerfettoResultFactory : ForgeryFactory<PerfettoResult> {
+internal class PerfettoResultForgeryFactory : ForgeryFactory<PerfettoResult> {
     override fun getForgery(forge: Forge): PerfettoResult {
         return PerfettoResult(
             start = forge.aLong(),

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -20,7 +20,6 @@ import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.time.DefaultTimeProvider
 import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.profiling.forge.Configurator
-import com.datadog.android.profiling.internal.anr.ProfilingTriggerRegistrar
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler.Companion.APP_LAUNCH_PROFILING_MAX_DURATION_MS
 import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler.Companion.PROFILING_SAMPLING_RATE_APP_LAUNCH
@@ -28,6 +27,7 @@ import com.datadog.android.profiling.internal.perfetto.PerfettoProfiler.Companio
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetry
 import com.datadog.android.profiling.internal.time.MutableTimeProvider
+import com.datadog.android.profiling.internal.trigger.ProfilingTriggerRegistrar
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
-import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mock
@@ -63,7 +62,6 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
-import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
@@ -75,7 +73,7 @@ import java.util.function.Consumer
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-class PerfettoProfilerTest {
+internal class PerfettoProfilerTest {
 
     @Mock
     private lateinit var mockContext: Context
@@ -1091,32 +1089,24 @@ class PerfettoProfilerTest {
 
     @Test
     fun `M dispatch OOM histogram to registered callback W triggerListener fires`(
-        @TempDir tempDir: File,
-        @LongForgery(min = 0L) fakeDetectedAtMs: Long
+        @Forgery fakeResult: PerfettoResult
     ) {
-        // Given
-        val fakeFile = File(tempDir, "heap.hprof").apply { writeText("hist") }
-
         // When
-        testedProfiler.triggerListener.onOutOfMemoryDetected(fakeDetectedAtMs, fakeFile.absolutePath)
+        testedProfiler.triggerListener.onOutOfMemoryDetected(fakeResult)
 
         // Then
-        verify(mockProfilerCallback).onOutOfMemoryDetected(fakeDetectedAtMs, fakeFile.absolutePath)
+        verify(mockProfilerCallback).onOutOfMemoryDetected(fakeResult)
     }
 
     @Test
     fun `M dispatch anomaly histogram to registered callback W triggerListener fires`(
-        @TempDir tempDir: File,
-        @LongForgery(min = 0L) fakeDetectedAtMs: Long
+        @Forgery fakeResult: PerfettoResult
     ) {
-        // Given
-        val fakeFile = File(tempDir, "heap.hprof").apply { writeText("hist") }
-
         // When
-        testedProfiler.triggerListener.onMemoryAnomalyDetected(fakeDetectedAtMs, fakeFile.absolutePath)
+        testedProfiler.triggerListener.onMemoryAnomalyDetected(fakeResult)
 
         // Then
-        verify(mockProfilerCallback).onMemoryAnomalyDetected(fakeDetectedAtMs, fakeFile.absolutePath)
+        verify(mockProfilerCallback).onMemoryAnomalyDetected(fakeResult)
     }
 
     @Test

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/trigger/ProfilingManagerTriggerRegistrarTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/trigger/ProfilingManagerTriggerRegistrarTest.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.profiling.internal.anr
+package com.datadog.android.profiling.internal.trigger
 
 import android.content.Context
 import android.os.ProfilingManager
@@ -14,6 +14,8 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 import com.datadog.android.internal.system.BuildSdkVersionProvider
 import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.profiling.internal.ProfilingStartReason
+import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetry
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetryEvent
 import com.datadog.android.profiling.internal.utils.ThreadDumper
@@ -542,7 +544,13 @@ internal class ProfilingManagerTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(oomResult)
 
         // Then
-        verify(mockListener).onOutOfMemoryDetected(eq(fakeNow), eq(tmpFile.absolutePath))
+        val forwardedResultCaptor = argumentCaptor<PerfettoResult>()
+        verify(mockListener).onOutOfMemoryDetected(forwardedResultCaptor.capture())
+        val forwardedResult = forwardedResultCaptor.firstValue
+        assertThat(forwardedResult.start).isEqualTo(fakeNow)
+        assertThat(forwardedResult.end).isEqualTo(fakeNow)
+        assertThat(forwardedResult.startReason).isEqualTo(ProfilingStartReason.OUT_OF_MEMORY)
+        assertThat(forwardedResult.resultFilePath).isEqualTo(tmpFile.absolutePath)
         assertThat(tmpFile.exists()).isFalse // registrar deletes the histogram file after forwarding
         verify(mockProfilingTelemetry).report(
             ProfilingTelemetryEvent.TriggerResult(
@@ -585,7 +593,7 @@ internal class ProfilingManagerTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(oomResult)
 
         // Then
-        verify(mockListener, never()).onOutOfMemoryDetected(any(), any())
+        verify(mockListener, never()).onOutOfMemoryDetected(any())
         assertThat(tmpFile.exists()).isFalse // registrar deletes the stale histogram file
         verify(mockProfilingTelemetry).report(
             ProfilingTelemetryEvent.TriggerResult(
@@ -628,7 +636,13 @@ internal class ProfilingManagerTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(anomalyResult)
 
         // Then
-        verify(mockListener).onMemoryAnomalyDetected(eq(fakeNow), eq(tmpFile.absolutePath))
+        val forwardedResultCaptor = argumentCaptor<PerfettoResult>()
+        verify(mockListener).onMemoryAnomalyDetected(forwardedResultCaptor.capture())
+        val forwardedResult = forwardedResultCaptor.firstValue
+        assertThat(forwardedResult.start).isEqualTo(fakeNow)
+        assertThat(forwardedResult.end).isEqualTo(fakeNow)
+        assertThat(forwardedResult.startReason).isEqualTo(ProfilingStartReason.MEMORY_ANOMALY)
+        assertThat(forwardedResult.resultFilePath).isEqualTo(tmpFile.absolutePath)
         assertThat(tmpFile.exists()).isFalse // registrar deletes the histogram file after forwarding
         verify(mockProfilingTelemetry).report(
             ProfilingTelemetryEvent.TriggerResult(
@@ -671,7 +685,7 @@ internal class ProfilingManagerTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(anomalyResult)
 
         // Then
-        verify(mockListener, never()).onMemoryAnomalyDetected(any(), any())
+        verify(mockListener, never()).onMemoryAnomalyDetected(any())
         assertThat(tmpFile.exists()).isFalse
         verify(mockProfilingTelemetry).report(
             ProfilingTelemetryEvent.TriggerResult(
@@ -707,8 +721,8 @@ internal class ProfilingManagerTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(oomResult)
 
         // Then
-        verify(mockListener, never()).onOutOfMemoryDetected(any(), any())
-        verify(mockListener, never()).onMemoryAnomalyDetected(any(), any())
+        verify(mockListener, never()).onOutOfMemoryDetected(any())
+        verify(mockListener, never()).onMemoryAnomalyDetected(any())
         verify(mockProfilingTelemetry).report(
             ProfilingTelemetryEvent.TriggerResult(
                 triggerType = ProfilingTrigger.TRIGGER_TYPE_OOM,


### PR DESCRIPTION
### What does this PR do?

Encapsulates the OOM/Anomaly profiling results in `PerfettoResult` (point-in-time: `start == end == detectedAtMs`), adds `OUT_OF_MEMORY` and `MEMORY_ANOMALY` cases to `ProfilingStartReason`, and renames the `anr` package to `trigger`.

### Motivation

Unify the profiling result representation so trigger-based profiles (OOM, memory anomaly) flow through the same `PerfettoResult` type as launch/continuous profiles.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)