### PR TITLE
RUM-18188: Bump `cronetApi` version to `143.7445.0`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,12 +18,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 # Allows Kotlin with target JVM compat 17 to be built on JDK 21
 kotlin.jvm.target.validation.mode = IGNORE
 
-# TODO RUM-18188
-# Cronet ships cronet-api and its transitive cronet-shared with the same
-# `org.chromium.net` namespace. AGP 9 turned that from a warning into an error.
-# Remove once Cronet publishes distinct namespaces.
-android.uniquePackageNames=false
-
 # TODO RUM-18189
 # Kotlin 2.0 is not compatible with new DSL APIs enforced in AGP 9 by default. This option will
 # be removed in AGP 10 (2027-2028?)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Commons
 apollo = "4.3.3"
-cronetApi = "141.7340.3"
+cronetApi = "143.7445.0"
 cronetPlayServices = "18.1.1"
 gson = "2.10.1"
 kotlin = "2.0.21"

--- a/integrations/dd-sdk-android-cronet/README.md
+++ b/integrations/dd-sdk-android-cronet/README.md
@@ -16,7 +16,7 @@ dependencies {
 }
 ```
 
-**Note**: Datadog uses `cronet-api` version `141.7340.3` and has verified compatibility with the `play-services-cronet` implementation at version `17.0.1`.
+**Note**: Datadog uses `cronet-api` version `143.7445.0` and has verified compatibility with the `play-services-cronet` implementation at version `17.0.1`.
 
 ## Configuration
 

--- a/integrations/dd-sdk-android-cronet/transitiveDependencies
+++ b/integrations/dd-sdk-android-cronet/transitiveDependencies
@@ -1,10 +1,10 @@
 Dependencies List
 
 androidx.annotation:annotation-jvm:1.9.1                        :   59 Kb
-org.chromium.net:cronet-api:141.7340.3                          :   77 Kb
-org.chromium.net:cronet-shared:141.7340.3                       :   92 Kb
+org.chromium.net:cronet-api:143.7445.0                          :   82 Kb
+org.chromium.net:cronet-shared:143.7445.0                       :   97 Kb
 org.jetbrains.kotlin:kotlin-stdlib:2.0.21                       : 1706 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              : 1952 Kb
+Total transitive dependencies size                              : 1962 Kb
 


### PR DESCRIPTION
### What does this PR do?

Bumps `cronetApi` version to `143.7445.0`, which is the first version that publishes `cronet-api` and `cronet-shared` under distinct manifest namespaces (`org.chromium.cronet_api` / `org.chromium.net.cronet_shared`) instead of both declaring `org.chromium.net`.

### Motivation

Remove colliding namespaces so we can remove the `android.uniquePackageNames=false` flag.

### Additional notes

[Here](https://mvnrepository.com/artifact/org.chromium.net) are the cronet versions. The next thing would be dropping `cronet-api` and moving to `cronet 500.0` version, as the first one is deprecated. However, the new one has `minSdk 24`, so this is something we could only think about for v4.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

