### PR TITLE
RUM-18191: Re-enable warnings-as-errors on the Compose modules

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-compose/build.gradle.kts
@@ -4,7 +4,9 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
+import com.datadog.gradle.config.taskConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     // Build
@@ -78,17 +80,18 @@ unMock {
 }
 
 datadogBuild {
-    applyKotlinConfig(
-        // TODO RUM-18191
-        // Suppress -> generateFunctionKeyMetaClasses is deprecated. It was replaced by emitting annotations on functions
-        // instead. Use generateFunctionKeyMetaAnnotations instead. Seems to Compose <-> Kotlin mismatch.
-        evaluateWarningsAsErrors = false,
-        jvmBytecodeTarget = JvmTarget.JVM_11
-    )
+    applyKotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
     applyAndroidLibraryConfig()
     applyJunitConfig()
     applyJavadocConfig()
     applyPublishingConfig(
         "Session Replay Extension Support for Jetpack Compose."
     )
+}
+
+taskConfig<KotlinCompile> {
+    compilerOptions {
+        // TODO RUM-18190
+        freeCompilerArgs.add("-Xwarning-level=ERROR_SUPPRESSION:disabled")
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,15 @@ cronetApi = "141.7340.3"
 cronetPlayServices = "18.1.1"
 gson = "2.10.1"
 kotlin = "2.0.21"
+# Deliberately not `version.ref = "kotlin"`: this must match the Kotlin Gradle Plugin that is actually
+# loaded, which is AGP's. `androidToolsPlugin` (below) depends on KGP 2.2.10, and that outranks the
+# `kotlin` version above in conflict resolution (`kotlin-gradle-plugin:2.0.21 -> 2.2.10`).
+# The Compose *compiler* is always resolved at the loaded KGP's version and never at this one, so the
+# two drift apart silently. An older plugin against a newer compiler passes options the compiler has
+# since deprecated (RUM-18191, `generateFunctionKeyMetaClasses`), and the version also decides which
+# options are sent at all — 2.2.10 turns on `sourceInformation`, which changes generated Compose code.
+# Re-check this whenever `androidToolsPlugin` moves.
+composeCompilerPlugin = "2.2.10"
 kotlinSP = "2.0.21-1.0.28"
 kronosNTP = "0.0.1-alpha11"
 kotlinxSerialization = "1.6.3"
@@ -371,7 +380,7 @@ traceCore = [
 [plugins]
 nexusPublishGradlePlugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublishGradlePlugin" }
 datadogGradlePlugin = { id = "com.datadoghq.dd-sdk-android-gradle-plugin", version.ref = "datadogPlugin" }
-composeCompilerPlugin = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+composeCompilerPlugin = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "composeCompilerPlugin" }
 apolloPlugin = { id = "com.apollographql.apollo", version.ref = "apollo" }
 dependencyLicenseGradlePlugin = { id = "com.datadoghq.dependency-license", version.ref = "dependencyLicense" }
 kotlinAndroidPlugin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/instrumented/integration/build.gradle.kts
+++ b/instrumented/integration/build.gradle.kts
@@ -7,6 +7,8 @@
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.depotProxied
 import com.datadog.gradle.config.java17
+import com.datadog.gradle.config.taskConfig
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     // Build
@@ -145,10 +147,12 @@ dependencies {
 }
 
 datadogBuild {
-    applyKotlinConfig(
-        // TODO RUM-18191
-        // Suppress -> generateFunctionKeyMetaClasses is deprecated. It was replaced by emitting annotations on functions
-        // instead. Use generateFunctionKeyMetaAnnotations instead. Seems to Compose <-> Kotlin mismatch.
-        evaluateWarningsAsErrors = false
-    )
+    applyKotlinConfig()
+}
+
+taskConfig<KotlinCompile> {
+    compilerOptions {
+        // TODO RUM-18190
+        freeCompilerArgs.add("-Xwarning-level=ERROR_SUPPRESSION:disabled")
+    }
 }

--- a/integrations/dd-sdk-android-compose/build.gradle.kts
+++ b/integrations/dd-sdk-android-compose/build.gradle.kts
@@ -6,6 +6,7 @@
 
 import com.datadog.gradle.config.taskConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     // Build
@@ -79,13 +80,7 @@ unMock {
 }
 
 datadogBuild {
-    applyKotlinConfig(
-        // TODO RUM-18191
-        // Suppress -> generateFunctionKeyMetaClasses is deprecated. It was replaced by emitting annotations on functions
-        // instead. Use generateFunctionKeyMetaAnnotations instead. Seems to Compose <-> Kotlin mismatch.
-        evaluateWarningsAsErrors = false,
-        jvmBytecodeTarget = JvmTarget.JVM_11
-    )
+    applyKotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
     applyAndroidLibraryConfig()
     applyJunitConfig()
     applyJavadocConfig()
@@ -95,8 +90,10 @@ datadogBuild {
     )
 }
 
-taskConfig<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+taskConfig<KotlinCompile> {
     compilerOptions {
         optIn.add("kotlin.RequiresOptIn")
+        // TODO RUM-18190
+        freeCompilerArgs.add("-Xwarning-level=ERROR_SUPPRESSION:disabled")
     }
 }

--- a/sample/benchmark/build.gradle.kts
+++ b/sample/benchmark/build.gradle.kts
@@ -132,11 +132,6 @@ dependencies {
 }
 
 datadogBuild {
-    applyKotlinConfig(
-        // TODO RUM-18191
-        // Suppress -> generateFunctionKeyMetaClasses is deprecated. It was replaced by emitting annotations on functions
-        // instead. Use generateFunctionKeyMetaAnnotations instead. Seems to Compose <-> Kotlin mismatch.
-        evaluateWarningsAsErrors = false
-    )
+    applyKotlinConfig()
     applyJunitConfig()
 }


### PR DESCRIPTION
### What does this PR do?

Removes the `evaluateWarningsAsErrors = false` from 4 modules and fix the warnings that made these necessary:

- `generateFunctionKeyMetaClasses is deprecated`. This was a version skew between the Compose Compiler Gradle Plugin and the Compose Compiler.  The Compose compiler is always resolved at the loaded KGP's version. AGP 9.1.1 dependes on KGP 2.2.10 and wins conflict resolution (`kotlin-gradle-plugin:2.0.21 -> 2.2.10`). The 2.0.21 subplugin passes `generateFunctionKeyMetaClasses` unconditionally, and the 2.2.10 compiler deprecates it. Fixed by pinning to the version KGP actually runs.

- `This code uses error suppression for INVISIBLE_REFERENCE`. This is necessary in the modules that access Compose internals. Adding `freeCompilerArgs.add("-Xwarning-level=ERROR_SUPPRESSION:disabled")` in these modules' `compilerOptions` is more self-contained than setting `warningsAsErrors = false`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

