### PR TITLE
Migrate from `exoplayer2` to `media3` used in the sample apps

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -31,6 +31,7 @@ import,androidx.lifecycle,Apache-2.0,Copyright 2018 The Android Open Source Proj
 import,androidx.loader,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.localbroadcastmanager,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.media,Apache-2.0,Copyright 2018 The Android Open Source Project
+import,androidx.media3,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.metrics,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.multidex,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.navigation,Apache-2.0,Copyright 2018 The Android Open Source Project
@@ -62,7 +63,6 @@ import,com.github.spotbugs,"GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1","Cop
 import,com.github.TeamNewPipe,AGPL-3.0-only,"2017-2024 NewPipe contributors <https://newpipe.net>"
 import,com.github.TeamNewPipe.NewPipeExtractor,AGPL-3.0-only,"2017-2024 NewPipe contributors <https://newpipe.net>"
 import,com.google.accompanist,Apache-2.0,Copyright 2018 The Android Open Source Project
-import,com.google.android.exoplayer,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,com.google.android.gms,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,com.google.android.material,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,com.google.code.gson,Apache-2.0,Copyright 2008 Google Inc

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -96,7 +96,7 @@ room = "2.5.1"
 rxJava3 = "3.0.0"
 timber = "5.0.1"
 coroutines = "1.7.3"
-exoplayer = "2.19.1"
+media3 = "1.1.1"
 newPipeExtractor = "v0.24.6"
 navigation3 = "1.0.0-alpha01"
 kotlinxSerializationCore = "1.8.1"
@@ -257,9 +257,9 @@ openFeatureKotlinSdk = { module = "dev.openfeature:kotlin-sdk", version.ref = "o
 coroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 
-exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "exoplayer" }
-exoplayerDataSource = { module = "com.google.android.exoplayer:exoplayer-datasource", version.ref = "exoplayer" }
-exoplayerOkHttp = { module = "com.google.android.exoplayer:extension-okhttp", version.ref = "exoplayer" }
+media3Exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
+media3DataSourceOkHttp = { module = "androidx.media3:media3-datasource-okhttp", version.ref = "media3" }
+media3Ui = { module = "androidx.media3:media3-ui", version.ref = "media3" }
 newPipeExtractor = { module = "com.github.TeamNewPipe.NewPipeExtractor:extractor", version.ref = "newPipeExtractor" }
 
 # Core Navigation 3 libraries
@@ -350,10 +350,10 @@ glide = [
     "glideOkHttp3",
 ]
 
-exoplayer = [
-    "exoplayer",
-    "exoplayerDataSource",
-    "exoplayerOkHttp"
+media3 = [
+    "media3Exoplayer",
+    "media3DataSourceOkHttp",
+    "media3Ui"
 ]
 
 ktor = [

--- a/sample/automotive/build.gradle.kts
+++ b/sample/automotive/build.gradle.kts
@@ -84,7 +84,7 @@ dependencies {
 }
 
 datadogBuild {
-    applyKotlinConfig(evaluateWarningsAsErrors = false)
+    applyKotlinConfig()
     applyJunitConfig()
 }
 

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -11,6 +11,7 @@ import com.datadog.gradle.config.configureFlavorForSampleApp
 import com.datadog.gradle.config.java17
 import com.datadog.gradle.config.taskConfig
 import com.datadog.gradle.plugin.InstrumentationMode
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     // Build
@@ -239,11 +240,11 @@ dependencies {
 }
 
 datadogBuild {
-    applyKotlinConfig(evaluateWarningsAsErrors = false)
+    applyKotlinConfig()
     applyJunitConfig()
 }
 
-taskConfig<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+taskConfig<KotlinCompile> {
     compilerOptions {
         optIn.add("kotlin.RequiresOptIn")
     }

--- a/sample/tv/build.gradle.kts
+++ b/sample/tv/build.gradle.kts
@@ -9,6 +9,7 @@ import com.datadog.gradle.config.configureFlavorForTvApp
 import com.datadog.gradle.config.depotProxied
 import com.datadog.gradle.config.java17
 import com.datadog.gradle.config.taskConfig
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     // Build
@@ -102,16 +103,16 @@ dependencies {
     implementation(libs.timber)
 
     // Video
-    implementation(libs.bundles.exoplayer)
+    implementation(libs.bundles.media3)
     implementation(libs.newPipeExtractor)
 }
 
 datadogBuild {
-    applyKotlinConfig(evaluateWarningsAsErrors = false)
+    applyKotlinConfig()
     applyJunitConfig()
 }
 
-taskConfig<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+taskConfig<KotlinCompile> {
     compilerOptions {
         optIn.add("kotlin.RequiresOptIn")
     }

--- a/sample/tv/src/main/java/com/datadog/android/tv/sample/PlayerActivity.kt
+++ b/sample/tv/src/main/java/com/datadog/android/tv/sample/PlayerActivity.kt
@@ -9,26 +9,26 @@ package com.datadog.android.tv.sample
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.media3.common.MediaItem
+import androidx.media3.datasource.okhttp.OkHttpDataSource
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.ui.PlayerView
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumErrorSource
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.ext.okhttp.OkHttpDataSource
-import com.google.android.exoplayer2.source.ProgressiveMediaSource
-import com.google.android.exoplayer2.ui.StyledPlayerView
 import org.schabi.newpipe.extractor.services.youtube.YoutubeService
 import org.schabi.newpipe.extractor.stream.StreamExtractor
 import timber.log.Timber
 import kotlin.random.Random
 
 /**
- * An activity playing a video stream from a Youtube URL.
+ * An activity playing a video stream from a YouTube URL.
  *
  * This activity looks for the URL in the `Intent`'s `data` property.
  */
 class PlayerActivity : AppCompatActivity() {
 
-    private lateinit var videoPlayerView: StyledPlayerView
+    private lateinit var videoPlayerView: PlayerView
     private lateinit var videoPlayer: ExoPlayer
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -37,8 +37,10 @@ class PlayerActivity : AppCompatActivity() {
 
         val okHttpClient = (applicationContext as TvSampleApplication).okHttpClient
         videoPlayerView = findViewById(R.id.video_player_view)
+        val mediaSourceFactory = DefaultMediaSourceFactory(this)
+            .setDataSourceFactory(OkHttpDataSource.Factory(okHttpClient))
         videoPlayer = ExoPlayer.Builder(this)
-            .setMediaSourceFactory(ProgressiveMediaSource.Factory(OkHttpDataSource.Factory(okHttpClient)))
+            .setMediaSourceFactory(mediaSourceFactory)
             .build()
         videoPlayer.addListener(RumPlayerListener())
     }
@@ -65,10 +67,10 @@ class PlayerActivity : AppCompatActivity() {
         try {
             val extractor = extractStreamingInformation(intentUri)
             val videoStreams = extractor.videoStreams
-            val streamIdx = Random.Default.nextInt(videoStreams.size)
+            val streamIdx = Random.nextInt(videoStreams.size)
             val videoStream = videoStreams[streamIdx]
             val mediaItem = MediaItem.Builder()
-                .setUri(videoStream.getUrl())
+                .setUri(videoStream.content)
                 .setMediaId(intentUri)
                 .build()
             runOnUiThread {

--- a/sample/tv/src/main/java/com/datadog/android/tv/sample/RumPlayerListener.kt
+++ b/sample/tv/src/main/java/com/datadog/android/tv/sample/RumPlayerListener.kt
@@ -6,10 +6,10 @@
 
 package com.datadog.android.tv.sample
 
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumActionType
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.Player
 
 internal class RumPlayerListener : Player.Listener {
 
@@ -52,7 +52,7 @@ internal class RumPlayerListener : Player.Listener {
 
     override fun onIsPlayingChanged(isPlaying: Boolean) {
         super.onIsPlayingChanged(isPlaying)
-        currentMediaItem?.let { mediaItem ->
+        currentMediaItem?.let { _ ->
             val name = if (isPlaying) "play" else "pause"
 
             GlobalRumMonitor.get().addAction(
@@ -69,7 +69,7 @@ internal class RumPlayerListener : Player.Listener {
         reason: Int
     ) {
         super.onPositionDiscontinuity(oldPosition, newPosition, reason)
-        currentMediaItem?.let { mediaItem ->
+        currentMediaItem?.let { _ ->
             GlobalRumMonitor.get().addAction(
                 type = RumActionType.CUSTOM,
                 name = "media-seek",
@@ -91,7 +91,7 @@ internal class RumPlayerListener : Player.Listener {
     }
 
     private fun stopMedia(mediaEnded: Boolean) {
-        currentMediaItem?.let { mediaItem ->
+        currentMediaItem?.let { _ ->
             attributes["media.ended"] = mediaEnded
             GlobalRumMonitor.get().addAction(
                 type = RumActionType.CUSTOM,

--- a/sample/tv/src/main/res/layout/activity_player.xml
+++ b/sample/tv/src/main/res/layout/activity_player.xml
@@ -11,7 +11,7 @@
     android:layout_height="match_parent"
     android:layout_margin="16dp">
 
-    <com.google.android.exoplayer2.ui.StyledPlayerView
+    <androidx.media3.ui.PlayerView
         android:id="@+id/video_player_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"/>

--- a/sample/vendor-lib/build.gradle.kts
+++ b/sample/vendor-lib/build.gradle.kts
@@ -85,7 +85,7 @@ dependencies {
 }
 
 datadogBuild {
-    applyKotlinConfig(evaluateWarningsAsErrors = false)
+    applyKotlinConfig()
     applyJunitConfig()
 }
 

--- a/tools/noopfactory/build.gradle.kts
+++ b/tools/noopfactory/build.gradle.kts
@@ -5,6 +5,7 @@
  */
 
 import com.datadog.gradle.config.taskConfig
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     // Build
@@ -32,7 +33,7 @@ datadogBuild {
     applyJunitConfig()
 }
 
-taskConfig<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+taskConfig<KotlinCompile> {
     compilerOptions {
         optIn.add("kotlin.RequiresOptIn")
     }


### PR DESCRIPTION
### What does this PR do?

Cleanup of `exoplayer2` deprecation warnings which come up during compilation. Changes only affect sample apps.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

