### PR TITLE
RUM-18154: Rename profiling writer methods to distinguish manual vs trigger profile writes

### DIFF
--- a/detekt_custom_safe_calls_third_party.yml
+++ b/detekt_custom_safe_calls_third_party.yml
@@ -797,6 +797,7 @@ datadog:
       - "kotlin.collections.listOf(kotlin.String)"
       - "kotlin.collections.listOf(okhttp3.ConnectionSpec)"
       - "kotlin.collections.listOfNotNull(com.datadog.android.sessionreplay.model.MobileSegment.Wireframe?)"
+      - "kotlin.collections.listOfNotNull(com.datadog.android.profiling.model.RumMetadataEvent?)"
       - "kotlin.collections.listOfNotNull(kotlin.Array)"
       - "kotlin.collections.listOfNotNull(kotlin.String?)"
       - "kotlin.collections.mapOf()"

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingDataWriter.kt
@@ -30,7 +30,7 @@ import kotlin.math.abs
 internal class ProfilingDataWriter(
     private val sdkCore: FeatureSdkCore
 ) : ProfilingWriter {
-    override fun write(
+    override fun writeManualProfile(
         profilingResult: PerfettoResult,
         longTasks: List<ProfilerEvent.RumLongTaskEvent>,
         anrEvents: List<ProfilerEvent.RumAnrEvent>,
@@ -57,11 +57,6 @@ internal class ProfilingDataWriter(
                             eventType = EventType.DEFAULT
                         )
                     }
-                    // TODO RUM-17263: when multiple SDK instances share the same resultFilePath,
-                    // the first writer to reach here deletes the file out from under the others,
-                    // so their reads fail and their profiles are dropped as perfetto_unreadable.
-                    // Deletion ownership needs to move to a single coordinator (read-once-and-fan-out
-                    // bytes, or reference-count across instances) before multi-instance is supported.
                     safeDelete(profilingResult.resultFilePath)
                 }
             }
@@ -70,6 +65,69 @@ internal class ProfilingDataWriter(
 
     override fun discard(profilingResult: PerfettoResult) {
         safeDelete(profilingResult.resultFilePath)
+    }
+
+    override fun writeTriggerProfile(
+        perfettoResult: PerfettoResult,
+        rumErrorId: String,
+        rumContext: ProfilingRumContext
+    ) {
+        val resultFilePath = perfettoResult.resultFilePath
+        val operation = perfettoResult.startReason.value
+        val detectedAtMs = perfettoResult.start
+        val feature = sdkCore.getFeature(Feature.PROFILING_FEATURE_NAME)
+        if (feature == null) {
+            safeDelete(resultFilePath)
+            return
+        }
+        feature.withWriteContext { context, writeScope ->
+            writeScope { writer ->
+                synchronized(this) {
+                    val profileBytes = readProfilingData(resultFilePath)
+                    if (profileBytes == null || profileBytes.isEmpty()) {
+                        logWriteResultMetric(
+                            dropped = true,
+                            dropReason = DROP_REASON_PERFETTO_UNREADABLE,
+                            startReason = operation,
+                            hasRumErrorId = rumErrorId.isNotEmpty()
+                        )
+                        safeDelete(resultFilePath)
+                        return@synchronized
+                    }
+                    val profileEvent = ProfileEvent(
+                        start = formatIsoUtc(detectedAtMs),
+                        end = formatIsoUtc(perfettoResult.end),
+                        attachments = listOf(PERFETTO_ATTACHMENT_NAME, RUM_MOBILE_EVENTS_ATTACHMENT_NAME),
+                        family = ProfileEvent.Family.ANDROID,
+                        runtime = ProfileEvent.Family.ANDROID,
+                        version = VERSION_NUMBER,
+                        tagsProfiler = buildTags(context, operation),
+                        application = ProfileEvent.Application(id = rumContext.applicationId),
+                        session = ProfileEvent.Session(id = rumContext.sessionId),
+                        view = ProfileEvent.View(
+                            id = listOfNotNull(rumContext.viewId),
+                            name = listOfNotNull(rumContext.viewName)
+                        ),
+                        error = ProfileEvent.Error(id = listOfNotNull(rumErrorId.ifEmpty { null }))
+                    )
+                    val serialized = profileEvent.toJson().toString().toByteArray(Charsets.UTF_8)
+                    val rumMobileEventsJson = buildTriggerRumMobileEventsJson(rumErrorId, detectedAtMs)
+                    val metadata = ProfilingBatchMetadata(profileBytes, rumMobileEventsJson).toBytes()
+                    logWriteResultMetric(
+                        dropped = false,
+                        dropReason = null,
+                        startReason = operation,
+                        hasRumErrorId = rumErrorId.isNotEmpty()
+                    )
+                    writer.write(
+                        event = RawBatchEvent(data = serialized, metadata = metadata),
+                        batchMetadata = null,
+                        eventType = EventType.DEFAULT
+                    )
+                    safeDelete(resultFilePath)
+                }
+            }
+        }
     }
 
     private fun buildRawBatchEvent(
@@ -172,25 +230,28 @@ internal class ProfilingDataWriter(
     private fun logWriteResultMetric(
         dropped: Boolean,
         dropReason: String?,
-        driftMs: Long,
+        driftMs: Long? = null,
         startReason: String,
-        longTaskEvents: List<ProfilerEvent.RumLongTaskEvent>,
-        anrEvents: List<ProfilerEvent.RumAnrEvent>,
-        vitalEvents: List<ProfilerEvent.RumVitalEvent>
+        longTaskEvents: List<ProfilerEvent.RumLongTaskEvent>? = null,
+        anrEvents: List<ProfilerEvent.RumAnrEvent>? = null,
+        vitalEvents: List<ProfilerEvent.RumVitalEvent>? = null,
+        hasRumErrorId: Boolean? = null
     ) {
+        val writeResult = buildMap {
+            put(KEY_DROPPED, dropped)
+            put(KEY_DROP_REASON, dropReason)
+            put(ProfilingTelemetry.KEY_START_REASON, startReason)
+            driftMs?.let { put(KEY_CLIENT_CLOCK_DRIFT, it) }
+            longTaskEvents?.let { put(KEY_LONG_TASK_COUNT, it.size) }
+            anrEvents?.let { put(KEY_ANR_COUNT, it.size) }
+            vitalEvents?.let { put(KEY_VITAL_COUNT, it.size) }
+            hasRumErrorId?.let { put(KEY_HAS_RUM_ERROR_ID, it) }
+        }
         sdkCore.internalLogger.logMetric(
             messageBuilder = { ProfilingTelemetry.TELEMETRY_MSG_PROFILING_SESSION },
             additionalProperties = mapOf(
                 ProfilingTelemetry.KEY_METRIC_TYPE to METRIC_TYPE_PROFILING_WRITE,
-                KEY_PROFILING_WRITE to mapOf(
-                    KEY_DROPPED to dropped,
-                    KEY_DROP_REASON to dropReason,
-                    KEY_CLIENT_CLOCK_DRIFT to driftMs,
-                    ProfilingTelemetry.KEY_START_REASON to startReason,
-                    KEY_LONG_TASK_COUNT to longTaskEvents.size,
-                    KEY_ANR_COUNT to anrEvents.size,
-                    KEY_VITAL_COUNT to vitalEvents.size
-                )
+                KEY_PROFILING_WRITE to writeResult
             ),
             samplingRate = MethodCallSamplingRate.ALL.rate
         )
@@ -282,6 +343,24 @@ internal class ProfilingDataWriter(
                 durationNs = it.durationNs
             )
         }
+        return serializeRumMobileEvents(rumMobileEvents)
+    }
+
+    private fun buildTriggerRumMobileEventsJson(rumErrorId: String, detectedAtMs: Long): ByteArray {
+        val rumMobileEvents = listOfNotNull(
+            rumErrorId.ifEmpty { null }?.let {
+                RumMetadataEvent(
+                    id = it,
+                    type = RumMetadataEvent.Type.ERROR,
+                    startNs = TimeUnit.MILLISECONDS.toNanos(detectedAtMs),
+                    durationNs = 0L
+                )
+            }
+        )
+        return serializeRumMobileEvents(rumMobileEvents)
+    }
+
+    private fun serializeRumMobileEvents(rumMobileEvents: List<RumMetadataEvent>): ByteArray {
         return JsonArray(rumMobileEvents.size).apply {
             rumMobileEvents.forEach {
                 add(it.toJson())
@@ -352,6 +431,7 @@ internal class ProfilingDataWriter(
         internal const val DROP_REASON_CLOCK_DRIFT = "clock_drift_exceeded"
         internal const val DROP_REASON_PERFETTO_UNREADABLE = "perfetto_unreadable"
         internal const val DROP_REASON_NO_RUM_CONTEXT = "no_rum_context"
+        internal const val KEY_HAS_RUM_ERROR_ID = "has_rum_error_id"
 
         private const val TAG_KEY_SERVICE = "service"
         private const val TAG_KEY_VERSION = "version"

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -323,7 +323,7 @@ internal class ProfilingFeature(
                         pendingRumEvents.clear()
                     } else {
                         val (longTasks, anrEvents, vitalEvents) = pendingRumEvents.drain()
-                        dataWriter.write(
+                        dataWriter.writeManualProfile(
                             profilingResult = result,
                             longTasks = longTasks,
                             anrEvents = anrEvents,
@@ -340,7 +340,7 @@ internal class ProfilingFeature(
                 val scheduler = continuousProfilingScheduler ?: return
                 scheduler.onActiveWindowEnded()
                 val (longTasks, anrEvents, vitalEvents) = pendingRumEvents.drain()
-                dataWriter.write(
+                dataWriter.writeManualProfile(
                     profilingResult = result,
                     longTasks = longTasks,
                     anrEvents = anrEvents,

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingWriter.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingWriter.kt
@@ -7,17 +7,24 @@
 package com.datadog.android.profiling.internal
 
 import com.datadog.android.internal.profiling.ProfilerEvent
+import com.datadog.android.internal.profiling.ProfilingRumContext
 import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 import com.datadog.tools.annotation.NoOpImplementation
 
 @NoOpImplementation
 internal interface ProfilingWriter {
 
-    fun write(
+    fun writeManualProfile(
         profilingResult: PerfettoResult,
         longTasks: List<ProfilerEvent.RumLongTaskEvent>,
         anrEvents: List<ProfilerEvent.RumAnrEvent>,
         vitalEvents: List<ProfilerEvent.RumVitalEvent>
+    )
+
+    fun writeTriggerProfile(
+        perfettoResult: PerfettoResult,
+        rumErrorId: String,
+        rumContext: ProfilingRumContext
     )
 
     /**

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -823,7 +823,7 @@ internal class ProfilingFeatureTest {
         )
 
         // Then
-        verify(mockDataWriter).write(
+        verify(mockDataWriter).writeManualProfile(
             profilingResult = fakePerfettoResult.copy(startReason = ProfilingStartReason.CONTINUOUS),
             longTasks = emptyList(),
             anrEvents = emptyList(),
@@ -875,7 +875,7 @@ internal class ProfilingFeatureTest {
         )
 
         // Then
-        verify(mockDataWriter).write(
+        verify(mockDataWriter).writeManualProfile(
             profilingResult = fakePerfettoResult.copy(startReason = ProfilingStartReason.CONTINUOUS),
             longTasks = listOf(fakeRumLongTaskEvent),
             anrEvents = emptyList(),
@@ -916,7 +916,7 @@ internal class ProfilingFeatureTest {
         )
 
         // Then
-        verify(mockDataWriter).write(
+        verify(mockDataWriter).writeManualProfile(
             profilingResult = fakePerfettoResult.copy(startReason = ProfilingStartReason.CONTINUOUS),
             longTasks = emptyList(),
             anrEvents = listOf(fakeRumAnrEvent),
@@ -1258,7 +1258,7 @@ internal class ProfilingFeatureTest {
         )
 
         // Then
-        verify(mockDataWriter).write(
+        verify(mockDataWriter).writeManualProfile(
             profilingResult = fakePerfettoResult.copy(startReason = ProfilingStartReason.APPLICATION_LAUNCH),
             longTasks = listOf(fakeRumLongTaskEvent),
             anrEvents = emptyList(),
@@ -1290,7 +1290,7 @@ internal class ProfilingFeatureTest {
 
         // Then
         verify(mockDataWriter).discard(launchResult)
-        verify(mockDataWriter, never()).write(any(), any(), any(), any())
+        verify(mockDataWriter, never()).writeManualProfile(any(), any(), any(), any())
     }
 
     @Test
@@ -1317,7 +1317,7 @@ internal class ProfilingFeatureTest {
         )
 
         // Then
-        verify(mockDataWriter).write(
+        verify(mockDataWriter).writeManualProfile(
             profilingResult = fakePerfettoResult.copy(startReason = ProfilingStartReason.APPLICATION_LAUNCH),
             longTasks = emptyList(),
             anrEvents = listOf(fakeRumAnrEvent),
@@ -1619,7 +1619,7 @@ internal class ProfilingFeatureTest {
         )
 
         // Then
-        verify(mockDataWriter, never()).write(
+        verify(mockDataWriter, never()).writeManualProfile(
             profilingResult = any(),
             longTasks = any(),
             anrEvents = any(),
@@ -1651,7 +1651,7 @@ internal class ProfilingFeatureTest {
         )
 
         // Then
-        verify(mockDataWriter).write(
+        verify(mockDataWriter).writeManualProfile(
             profilingResult = fakePerfettoResult.copy(startReason = ProfilingStartReason.APPLICATION_LAUNCH),
             longTasks = listOf(fakeRumLongTaskEvent),
             anrEvents = emptyList(),
@@ -1681,7 +1681,7 @@ internal class ProfilingFeatureTest {
         )
 
         // Then — nothing is written while the quota decision is still pending
-        verify(mockDataWriter, never()).write(
+        verify(mockDataWriter, never()).writeManualProfile(
             profilingResult = any(),
             longTasks = any(),
             anrEvents = any(),
@@ -1692,7 +1692,7 @@ internal class ProfilingFeatureTest {
         testedFeature.simulateQuotaAllowed()
 
         // Then — the buffered launch event is now written
-        verify(mockDataWriter).write(
+        verify(mockDataWriter).writeManualProfile(
             profilingResult = fakePerfettoResult.copy(startReason = ProfilingStartReason.APPLICATION_LAUNCH),
             longTasks = listOf(fakeRumLongTaskEvent),
             anrEvents = emptyList(),

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingDataWriterTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/ProfilingDataWriterTest.kt
@@ -17,6 +17,7 @@ import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.internal.profiling.ProfilerEvent
+import com.datadog.android.internal.profiling.ProfilingRumContext
 import com.datadog.android.internal.utils.formatIsoUtc
 import com.datadog.android.profiling.assertj.ProfileEventAssert.Companion.assertThat
 import com.datadog.android.profiling.assertj.RumMetadataEventsAssert.Companion.assertThat
@@ -29,6 +30,7 @@ import com.datadog.android.profiling.model.RumMetadataEvent
 import com.google.gson.JsonParser
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -111,7 +113,7 @@ internal class ProfilingDataWriterTest {
     }
 
     @Test
-    fun `M write the result in a batch W write`(
+    fun `M write the result in a batch W writeManualProfile()`(
         @Forgery fakeResult: PerfettoResult,
         @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
         @Forgery fakeLongTasks: List<ProfilerEvent.RumLongTaskEvent>,
@@ -125,7 +127,7 @@ internal class ProfilingDataWriterTest {
         val rumContext = fakeVitals.first().rumContext
 
         // When
-        testedDataWriterTest.write(
+        testedDataWriterTest.writeManualProfile(
             profilingResult = fakeResult.copy(resultFilePath = file.absolutePath),
             vitalEvents = fakeVitals.map {
                 it.copy(
@@ -246,7 +248,7 @@ internal class ProfilingDataWriterTest {
     }
 
     @Test
-    fun `M skip writing and log warn on delete W write {perfetto file not found}`(
+    fun `M skip writing and log warn on delete W writeManualProfile() {perfetto file not found}`(
         @Forgery fakeResult: PerfettoResult,
         @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
         @Forgery fakeLongTasks: List<ProfilerEvent.RumLongTaskEvent>,
@@ -256,7 +258,7 @@ internal class ProfilingDataWriterTest {
         val nonExistentFile = File(tmp, "nonexistent.perfetto-stack-sample")
 
         // When
-        testedDataWriterTest.write(
+        testedDataWriterTest.writeManualProfile(
             profilingResult = fakeResult.copy(resultFilePath = nonExistentFile.absolutePath),
             vitalEvents = fakeVitals,
             anrEvents = fakeAnrs,
@@ -294,7 +296,7 @@ internal class ProfilingDataWriterTest {
     }
 
     @Test
-    fun `M skip writing and report drop metric W write {file is empty}`(
+    fun `M skip writing and report drop metric W writeManualProfile() {file is empty}`(
         @Forgery fakeResult: PerfettoResult,
         @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
         @Forgery fakeLongTasks: List<ProfilerEvent.RumLongTaskEvent>,
@@ -305,7 +307,7 @@ internal class ProfilingDataWriterTest {
         file.writeBytes(ByteArray(0))
 
         // When
-        testedDataWriterTest.write(
+        testedDataWriterTest.writeManualProfile(
             profilingResult = fakeResult.copy(resultFilePath = file.absolutePath),
             vitalEvents = fakeVitals,
             anrEvents = fakeAnrs,
@@ -336,7 +338,7 @@ internal class ProfilingDataWriterTest {
     }
 
     @Test
-    fun `M skip writing and report metric W write {no rum events}`(
+    fun `M skip writing and report metric W writeManualProfile() {no rum events}`(
         @Forgery fakeResult: PerfettoResult,
         forge: Forge
     ) {
@@ -345,7 +347,7 @@ internal class ProfilingDataWriterTest {
         file.writeBytes(forge.aString().toByteArray())
 
         // When
-        testedDataWriterTest.write(
+        testedDataWriterTest.writeManualProfile(
             profilingResult = fakeResult.copy(resultFilePath = file.absolutePath),
             vitalEvents = emptyList(),
             anrEvents = emptyList(),
@@ -376,7 +378,7 @@ internal class ProfilingDataWriterTest {
     }
 
     @Test
-    fun `M write the result in a batch W write {only vital events present}`(
+    fun `M write the result in a batch W writeManualProfile() {only vital events present}`(
         @Forgery fakeResult: PerfettoResult,
         @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
         forge: Forge
@@ -396,7 +398,7 @@ internal class ProfilingDataWriterTest {
         }
 
         // When
-        testedDataWriterTest.write(
+        testedDataWriterTest.writeManualProfile(
             profilingResult = fakeResult.copy(resultFilePath = file.absolutePath),
             vitalEvents = alignedVitals,
             anrEvents = emptyList(),
@@ -441,7 +443,7 @@ internal class ProfilingDataWriterTest {
     }
 
     @Test
-    fun `M delete result file W write {feature not initialized}`(
+    fun `M delete result file W writeManualProfile() {feature not initialized}`(
         @Forgery fakeResult: PerfettoResult,
         forge: Forge
     ) {
@@ -451,7 +453,7 @@ internal class ProfilingDataWriterTest {
         file.writeBytes(forge.aString().toByteArray())
 
         // When
-        testedDataWriterTest.write(
+        testedDataWriterTest.writeManualProfile(
             profilingResult = fakeResult.copy(resultFilePath = file.absolutePath),
             vitalEvents = emptyList(),
             anrEvents = emptyList(),
@@ -464,7 +466,7 @@ internal class ProfilingDataWriterTest {
     }
 
     @Test
-    fun `M delete result file W write {events present}`(
+    fun `M delete result file W writeManualProfile() {events present}`(
         @Forgery fakeResult: PerfettoResult,
         @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
         forge: Forge
@@ -483,7 +485,7 @@ internal class ProfilingDataWriterTest {
         }
 
         // When
-        testedDataWriterTest.write(
+        testedDataWriterTest.writeManualProfile(
             profilingResult = fakeResult.copy(resultFilePath = file.absolutePath),
             vitalEvents = alignedVitals,
             anrEvents = emptyList(),
@@ -496,7 +498,7 @@ internal class ProfilingDataWriterTest {
     }
 
     @Test
-    fun `M drop and report write metric with clock drift reason W write {continuous, drift over threshold positive}`(
+    fun `M drop write metric on clock drift W writeManualProfile() {continuous, drift over threshold positive}`(
         @Forgery fakeResult: PerfettoResult,
         @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
         forge: Forge
@@ -510,7 +512,7 @@ internal class ProfilingDataWriterTest {
         file.writeBytes(forge.aString().toByteArray())
 
         // When
-        testedDataWriterTest.write(
+        testedDataWriterTest.writeManualProfile(
             profilingResult = fakeResult.copy(
                 resultFilePath = file.absolutePath,
                 startReason = ProfilingStartReason.CONTINUOUS
@@ -544,7 +546,7 @@ internal class ProfilingDataWriterTest {
     }
 
     @Test
-    fun `M drop and report write metric with clock drift reason W write {continuous, drift over threshold negative}`(
+    fun `M drop write metric on clock drift W writeManualProfile() {continuous, drift over threshold negative}`(
         @Forgery fakeResult: PerfettoResult,
         @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
         forge: Forge
@@ -558,7 +560,7 @@ internal class ProfilingDataWriterTest {
         file.writeBytes(forge.aString().toByteArray())
 
         // When
-        testedDataWriterTest.write(
+        testedDataWriterTest.writeManualProfile(
             profilingResult = fakeResult.copy(
                 resultFilePath = file.absolutePath,
                 startReason = ProfilingStartReason.CONTINUOUS
@@ -592,7 +594,7 @@ internal class ProfilingDataWriterTest {
     }
 
     @Test
-    fun `M write profile despite clock drift W write {app launch, drift over threshold positive}`(
+    fun `M write profile despite clock drift W writeManualProfile() {app launch, drift over threshold positive}`(
         @Forgery fakeResult: PerfettoResult,
         @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
         forge: Forge
@@ -606,7 +608,7 @@ internal class ProfilingDataWriterTest {
         file.writeBytes(forge.aString().toByteArray())
 
         // When
-        testedDataWriterTest.write(
+        testedDataWriterTest.writeManualProfile(
             profilingResult = fakeResult.copy(
                 resultFilePath = file.absolutePath,
                 startReason = ProfilingStartReason.APPLICATION_LAUNCH
@@ -640,7 +642,7 @@ internal class ProfilingDataWriterTest {
     }
 
     @Test
-    fun `M write profile despite clock drift W write {app launch, drift over threshold negative}`(
+    fun `M write profile despite clock drift W writeManualProfile() {app launch, drift over threshold negative}`(
         @Forgery fakeResult: PerfettoResult,
         @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
         forge: Forge
@@ -654,7 +656,7 @@ internal class ProfilingDataWriterTest {
         file.writeBytes(forge.aString().toByteArray())
 
         // When
-        testedDataWriterTest.write(
+        testedDataWriterTest.writeManualProfile(
             profilingResult = fakeResult.copy(
                 resultFilePath = file.absolutePath,
                 startReason = ProfilingStartReason.APPLICATION_LAUNCH
@@ -688,7 +690,7 @@ internal class ProfilingDataWriterTest {
     }
 
     @Test
-    fun `M report write metric with event counts W write {write successful}`(
+    fun `M report write metric with event counts W writeManualProfile() {write successful}`(
         @Forgery fakeResult: PerfettoResult,
         @Forgery fakeVitals: List<ProfilerEvent.RumVitalEvent>,
         @Forgery fakeLongTasks: List<ProfilerEvent.RumLongTaskEvent>,
@@ -700,7 +702,7 @@ internal class ProfilingDataWriterTest {
         file.writeBytes(forge.aString().toByteArray())
 
         // When
-        testedDataWriterTest.write(
+        testedDataWriterTest.writeManualProfile(
             profilingResult = fakeResult.copy(resultFilePath = file.absolutePath),
             vitalEvents = fakeVitals,
             anrEvents = fakeAnrs,
@@ -765,5 +767,103 @@ internal class ProfilingDataWriterTest {
             isNull()
         )
         verifyNoInteractions(mockEventBatchWriter)
+    }
+
+    @Test
+    fun `M write ProfileEvent with error id and oom operation W writeTriggerProfile() {valid file}`(
+        @StringForgery rumErrorId: String,
+        @Forgery rumContext: ProfilingRumContext,
+        forge: Forge
+    ) {
+        // Given
+        val profileFile = File(tmp, "trigger.proto").apply { writeBytes(forge.aString().toByteArray()) }
+        val detectedAtMs = 1_000L
+
+        // When
+        testedDataWriterTest.writeTriggerProfile(
+            perfettoResult = PerfettoResult(
+                start = detectedAtMs,
+                startReason = ProfilingStartReason.OUT_OF_MEMORY,
+                end = detectedAtMs,
+                resultFilePath = profileFile.absolutePath
+            ),
+            rumErrorId = rumErrorId,
+            rumContext = rumContext
+        )
+
+        // Then
+        val argumentCaptor = argumentCaptor<RawBatchEvent>()
+        verify(mockEventBatchWriter).write(
+            event = argumentCaptor.capture(),
+            batchMetadata = isNull(),
+            eventType = eq(EventType.DEFAULT)
+        )
+        val actualEvent = ProfileEvent.fromJson(String(argumentCaptor.firstValue.data))
+        val expectedTagList = arrayListOf(
+            "service:${fakeDatadogContext.service}",
+            "env:${fakeDatadogContext.env}",
+            "version:${fakeDatadogContext.version}",
+            "sdk_version:${fakeDatadogContext.sdkVersion}",
+            "profiler_version:${fakeDatadogContext.sdkVersion}",
+            "runtime_version:${fakeDatadogContext.deviceInfo.osVersion}",
+            "operation:out_of_memory"
+        )
+        fakeDatadogContext.appBuildId?.let {
+            expectedTagList.add("build_id:${fakeDatadogContext.appBuildId}")
+        }
+        assertThat(actualEvent)
+            .hasStart(formatIsoUtc(detectedAtMs))
+            .hasEnd(formatIsoUtc(detectedAtMs))
+            .hasAttachments(listOf("perfetto.proto", "rum-mobile-events.json"))
+            .hasFamily(ProfileEvent.Family.ANDROID)
+            .hasRuntime(ProfileEvent.Family.ANDROID)
+            .hasVersion(4)
+            .hasTags(expectedTagList)
+            .hasApplicationId(rumContext.applicationId)
+            .hasSessionId(rumContext.sessionId)
+            .hasErrorIds(listOf(rumErrorId))
+        assertThat(profileFile.exists()).isFalse()
+
+        val actualMetadata = ProfilingBatchMetadata
+            .fromBytesOrNull(argumentCaptor.firstValue.metadata, mock<InternalLogger>())
+        checkNotNull(actualMetadata)
+        val actualMetadataEvents = JsonParser.parseString(String(actualMetadata.rumMobileEventsBytes))
+            .asJsonArray
+            .map {
+                RumMetadataEvent.fromJsonObject(it.asJsonObject)
+            }
+        assertThat(actualMetadataEvents).containsExactly(
+            RumMetadataEvent(
+                id = rumErrorId,
+                type = RumMetadataEvent.Type.ERROR,
+                startNs = TimeUnit.MILLISECONDS.toNanos(detectedAtMs),
+                durationNs = 0L
+            )
+        )
+    }
+
+    @Test
+    fun `M not write and delete file W writeTriggerProfile() {empty file}`(
+        @StringForgery rumErrorId: String,
+        @Forgery rumContext: ProfilingRumContext
+    ) {
+        // Given
+        val profileFile = File(tmp, "empty.proto").apply { writeBytes(ByteArray(0)) }
+
+        // When
+        testedDataWriterTest.writeTriggerProfile(
+            perfettoResult = PerfettoResult(
+                start = 1_000L,
+                startReason = ProfilingStartReason.MEMORY_ANOMALY,
+                end = 1_000L,
+                resultFilePath = profileFile.absolutePath
+            ),
+            rumErrorId = rumErrorId,
+            rumContext = rumContext
+        )
+
+        // Then
+        verifyNoInteractions(mockEventBatchWriter)
+        assertThat(profileFile.exists()).isFalse()
     }
 }


### PR DESCRIPTION
### What does this PR do?

Renames `ProfilingWriter.write` to `writeManualProfile` and adds `writeTriggerProfile` (the OOM/anomaly trigger write path), unifying their telemetry into a single `logWriteResultMetric`. Also fixes `writeTriggerProfile` reporting a zero-duration event and a bogus empty error id, and removes the stale RUM-17263 multi-instance TODO (no longer applicable).

### Motivation

Clean up naming and telemetry ahead of generalizing trigger-based profile writes beyond heap histograms.

### Additional Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)
