### PR TITLE
Fix compilation warnings on `sample/kotlin` module

### DIFF
--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -187,6 +187,7 @@ dependencies {
     implementation(libs.bundles.androidXNavigation)
     implementation(libs.androidXAppCompat)
     implementation(libs.bundles.androidXCompose)
+    implementation(libs.androidXLifecycleCompose)
     implementation(libs.material3Android)
     implementation(libs.googleAccompanistAppCompatTheme)
     implementation(libs.googleAccompanistPager)
@@ -240,7 +241,7 @@ dependencies {
 }
 
 datadogBuild {
-    applyKotlinConfig()
+    applyKotlinConfig(evaluateWarningsAsErrors = false)
     applyJunitConfig()
 }
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/about/AboutFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/about/AboutFragment.kt
@@ -12,7 +12,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import com.datadog.android.sample.R
 
 internal class AboutFragment :
@@ -37,9 +37,9 @@ internal class AboutFragment :
         return rootView
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        viewModel = ViewModelProviders.of(this).get(AboutViewModel::class.java)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel = ViewModelProvider(this)[AboutViewModel::class.java]
     }
 
     override fun onResume() {

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/LegacyComposeActivity.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/LegacyComposeActivity.kt
@@ -31,9 +31,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.datadog.android.rum.GlobalRumMonitor
 import com.google.accompanist.appcompattheme.AppCompatTheme
 import com.google.accompanist.pager.ExperimentalPagerApi

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/Navigation3Activity.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/Navigation3Activity.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.ui.NavDisplay
 import com.datadog.android.compose.AttributesResolver
+import com.datadog.android.compose.ExperimentalTrackingApi
 import com.datadog.android.compose.Navigation3TrackingEffect
 
 internal class Navigation3Activity : ComponentActivity() {
@@ -26,6 +27,7 @@ internal class Navigation3Activity : ComponentActivity() {
         }
     }
 
+    @OptIn(ExperimentalTrackingApi::class)
     @Composable
     @Suppress("StringLiteralDuplication")
     private fun NavDisplaySample() {
@@ -41,11 +43,11 @@ internal class Navigation3Activity : ComponentActivity() {
         Navigation3TrackingEffect(
             backStack = backStack,
             attributesResolver = object : AttributesResolver<Nav3Page> {
-                override fun resolveAttributes(destination: Nav3Page): Map<String, Any?>? {
-                    return when (destination) {
+                override fun resolveAttributes(key: Nav3Page): Map<String, Any?>? {
+                    return when (key) {
                         is Nav3Page.Home -> mapOf("userId" to "defaultUser")
-                        is Nav3Page.Discovery -> mapOf("userId" to destination.userId)
-                        is Nav3Page.Settings -> mapOf("userId" to destination.userId)
+                        is Nav3Page.Discovery -> mapOf("userId" to key.userId)
+                        is Nav3Page.Settings -> mapOf("userId" to key.userId)
                     }
                 }
             }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/TabsSample.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/TabsSample.kt
@@ -27,9 +27,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.datadog.android.rum.GlobalRumMonitor
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/crash/CrashFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/crash/CrashFragment.kt
@@ -16,7 +16,7 @@ import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import androidx.appcompat.widget.AppCompatSpinner
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import com.datadog.android.sample.R
 import java.util.Locale
 
@@ -59,9 +59,9 @@ internal class CrashFragment :
         return rootView
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        viewModel = ViewModelProviders.of(this).get(CrashViewModel::class.java)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel = ViewModelProvider(this)[CrashViewModel::class.java]
     }
 
     // endregion

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/flags/OpenFeatureFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/flags/OpenFeatureFragment.kt
@@ -67,10 +67,6 @@ internal class OpenFeatureFragment :
 
     private fun observeProviderState() {
         val provider = OpenFeatureAPI.getProvider()
-        if (provider == null) {
-            updateProviderState(STATE_NOT_SET)
-            return
-        }
 
         // Display initial state
         updateProviderState(STATE_INITIALIZING)
@@ -231,7 +227,6 @@ internal class OpenFeatureFragment :
         private const val FLAG_TYPE_INTEGER = 2
         private const val FLAG_TYPE_DOUBLE = 3
 
-        private const val STATE_NOT_SET = "NOT_SET"
         private const val STATE_INITIALIZING = "INITIALIZING"
         private const val STATE_READY = "READY"
         private const val STATE_STALE = "STALE"

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/home/HomeFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/home/HomeFragment.kt
@@ -13,7 +13,7 @@ import android.widget.Button
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.children
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment.Companion.findNavController
 import com.datadog.android.sample.R
@@ -42,9 +42,9 @@ internal class HomeFragment :
         return rootView
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        viewModel = ViewModelProviders.of(this).get(HomeViewModel::class.java)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel = ViewModelProvider(this)[HomeViewModel::class.java]
         navController = findNavController(this)
     }
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/logs/LogsFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/logs/LogsFragment.kt
@@ -14,12 +14,11 @@ import android.widget.ArrayAdapter
 import android.widget.EditText
 import android.widget.Spinner
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import com.datadog.android.log.Logger
 import com.datadog.android.sample.BuildConfig
 import com.datadog.android.sample.R
 
-@Suppress("DEPRECATION")
 internal class LogsFragment :
     Fragment(),
     View.OnClickListener {
@@ -66,10 +65,9 @@ internal class LogsFragment :
         return rootView
     }
 
-    @Deprecated("Deprecated in parent Java class")
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        viewModel = ViewModelProviders.of(this).get(LogsViewModel::class.java)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel = ViewModelProvider(this)[LogsViewModel::class.java]
     }
 
     // endregion

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/sessionreplay/SessionReplayFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/sessionreplay/SessionReplayFragment.kt
@@ -40,8 +40,8 @@ internal class SessionReplayFragment :
         return rootView
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         navController = findNavController(this)
     }
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/OtelTracesFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/OtelTracesFragment.kt
@@ -13,7 +13,7 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ProgressBar
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import com.datadog.android.sample.R
 import com.datadog.android.sample.SampleApplication
 
@@ -47,11 +47,10 @@ internal class OtelTracesFragment : Fragment(), View.OnClickListener {
         super.onPause()
     }
 
-    @Suppress("UnsafeCallOnNullableType") // not an issue in the sample
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         val factory = SampleApplication.getViewModelFactory(requireContext())
-        viewModel = ViewModelProviders.of(this, factory).get(OtelTracesViewModel::class.java)
+        viewModel = ViewModelProvider(this, factory)[OtelTracesViewModel::class.java]
     }
 
     override fun onDetach() {

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/TracesFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/TracesFragment.kt
@@ -15,7 +15,7 @@ import android.widget.ImageView
 import android.widget.ProgressBar
 import androidx.annotation.DrawableRes
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import com.datadog.android.sample.R
 import com.datadog.android.sample.SampleApplication
 import com.datadog.android.trace.withinSpan
@@ -49,11 +49,10 @@ internal class TracesFragment : Fragment(), View.OnClickListener {
         return rootView
     }
 
-    @Suppress("UnsafeCallOnNullableType") // not an issue in the sample
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         val factory = SampleApplication.getViewModelFactory(requireContext())
-        viewModel = ViewModelProviders.of(this, factory).get(TracesViewModel::class.java)
+        viewModel = ViewModelProvider(this, factory)[TracesViewModel::class.java]
     }
 
     override fun onDetach() {

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/vitals/VitalsFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/vitals/VitalsFragment.kt
@@ -14,7 +14,7 @@ import android.widget.CheckBox
 import android.widget.CompoundButton
 import android.widget.ProgressBar
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import com.datadog.android.rum.operations.FailureReason
 import com.datadog.android.sample.R
 import com.google.android.material.textfield.TextInputEditText
@@ -57,9 +57,9 @@ internal class VitalsFragment :
         return rootView
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        viewModel = ViewModelProviders.of(this).get(VitalsViewModel::class.java)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel = ViewModelProvider(this)[VitalsViewModel::class.java]
     }
 
     override fun onResume() {

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/webview/WebFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/webview/WebFragment.kt
@@ -13,7 +13,7 @@ import android.view.ViewGroup
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import com.datadog.android.rum.ExperimentalRumApi
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.sample.R
@@ -54,7 +54,7 @@ internal class WebFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val factory = SampleApplication.getViewModelFactory(requireContext())
-        viewModel = ViewModelProviders.of(this, factory).get(WebViewModel::class.java)
+        viewModel = ViewModelProvider(this, factory)[WebViewModel::class.java]
     }
 
     override fun onResume() {


### PR DESCRIPTION
### What does this PR do?

Re-adds the `evaluateWarningsAsErrors = false` flag inside `sample/kotlin` app's `build.gradle.kts`. 
Some deprecation warnings were addressed, but there are more complex ones including migrating from `AsyncTask` to coroutines, so let's keep this flag to fix the pipeline quickly for now.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

