### PR TITLE
RUMS-6221: use sleep-including clock for session timeout/inactivity

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -303,11 +303,13 @@ interface com.datadog.android.internal.time.TimeProvider
   fun getServerOffsetNanos(): Long
   fun getServerOffsetMillis(): Long
   fun getDeviceElapsedRealtimeMillis(): Long
+  fun getDeviceElapsedRealtimeNanos(): Long
   fun getDeviceUptimeMillis(): Long
 abstract class com.datadog.android.internal.time.BaseTimeProvider : TimeProvider
   override fun getDeviceTimestampMillis(): Long
   override fun getDeviceElapsedTimeNanos(): Long
   override fun getDeviceElapsedRealtimeMillis(): Long
+  override fun getDeviceElapsedRealtimeNanos(): Long
   override fun getDeviceUptimeMillis(): Long
 fun ByteArray.toHexString(): String
 fun <T> android.content.Context.getSystemServiceAs(String): T?

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -714,6 +714,7 @@ public final class com/datadog/android/internal/thread/ThreadUtilsKt {
 public abstract class com/datadog/android/internal/time/BaseTimeProvider : com/datadog/android/internal/time/TimeProvider {
 	public fun <init> ()V
 	public final fun getDeviceElapsedRealtimeMillis ()J
+	public final fun getDeviceElapsedRealtimeNanos ()J
 	public final fun getDeviceElapsedTimeNanos ()J
 	public final fun getDeviceTimestampMillis ()J
 	public final fun getDeviceUptimeMillis ()J
@@ -728,6 +729,7 @@ public final class com/datadog/android/internal/time/DefaultTimeProvider : com/d
 
 public abstract interface class com/datadog/android/internal/time/TimeProvider {
 	public abstract fun getDeviceElapsedRealtimeMillis ()J
+	public abstract fun getDeviceElapsedRealtimeNanos ()J
 	public abstract fun getDeviceElapsedTimeNanos ()J
 	public abstract fun getDeviceTimestampMillis ()J
 	public abstract fun getDeviceUptimeMillis ()J

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/time/TimeProvider.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/time/TimeProvider.kt
@@ -49,6 +49,18 @@ interface TimeProvider {
     fun getDeviceElapsedRealtimeMillis(): Long
 
     /**
+     * Returns the time since boot in nanoseconds, including time spent in sleep.
+     * This is implemented in [BaseTimeProvider] as [SystemClock.elapsedRealtimeNanos].
+     *
+     * Unlike [getDeviceElapsedTimeNanos] (which is backed by [System.nanoTime] /
+     * `CLOCK_MONOTONIC` and is frozen while the device is in deep sleep), this clock
+     * keeps advancing during deep sleep. It must be used for session timeout and
+     * inactivity computations so that a multi-hour idle gap spent mostly in deep
+     * sleep is actually observed as exceeding the threshold (see RUMS-6221).
+     */
+    fun getDeviceElapsedRealtimeNanos(): Long
+
+    /**
      * Returns the time since boot in milliseconds, NOT including time spent in sleep.
      * This is implemented in [BaseTimeProvider] as [SystemClock.uptimeMillis].
      * Uses [CLOCK_MONOTONIC] — the same clock domain as [System.nanoTime] and
@@ -65,5 +77,6 @@ abstract class BaseTimeProvider : TimeProvider {
     final override fun getDeviceTimestampMillis(): Long = System.currentTimeMillis()
     final override fun getDeviceElapsedTimeNanos(): Long = System.nanoTime()
     final override fun getDeviceElapsedRealtimeMillis(): Long = SystemClock.elapsedRealtime()
+    final override fun getDeviceElapsedRealtimeNanos(): Long = SystemClock.elapsedRealtimeNanos()
     final override fun getDeviceUptimeMillis(): Long = SystemClock.uptimeMillis()
 }

--- a/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/stub/StubTimeProvider.kt
+++ b/dd-sdk-android-internal/src/testFixtures/kotlin/com/datadog/android/internal/tests/stub/StubTimeProvider.kt
@@ -17,6 +17,7 @@ import com.datadog.android.internal.time.TimeProvider
  * @property serverOffsetNs The server time offset in nanoseconds. Defaults to `0`.
  * @property serverOffsetMs The server time offset in milliseconds. Defaults to `0`.
  * @property elapsedRealtimeMs The elapsed realtime in milliseconds (includes time in sleep). Defaults to `0`.
+ * @property elapsedRealtimeNs The elapsed realtime in nanoseconds (includes time in sleep). Defaults to `0`.
  * @property uptimeMs The uptime in milliseconds (excludes time in sleep). Defaults to `0`.
  */
 class StubTimeProvider(
@@ -26,6 +27,7 @@ class StubTimeProvider(
     var serverOffsetNs: Long = 0L,
     var serverOffsetMs: Long = 0L,
     var elapsedRealtimeMs: Long = 0L,
+    var elapsedRealtimeNs: Long = 0L,
     var uptimeMs: Long = 0L
 ) : TimeProvider {
 
@@ -40,6 +42,8 @@ class StubTimeProvider(
     override fun getServerOffsetMillis(): Long = serverOffsetMs
 
     override fun getDeviceElapsedRealtimeMillis(): Long = elapsedRealtimeMs
+
+    override fun getDeviceElapsedRealtimeNanos(): Long = elapsedRealtimeNs
 
     override fun getDeviceUptimeMillis(): Long = uptimeMs
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/time/MutableTimeProvider.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/time/MutableTimeProvider.kt
@@ -28,6 +28,8 @@ internal interface MutableTimeProvider : TimeProvider {
 
         override fun getDeviceElapsedRealtimeMillis(): Long = delegate.getDeviceElapsedRealtimeMillis()
 
+        override fun getDeviceElapsedRealtimeNanos(): Long = delegate.getDeviceElapsedRealtimeNanos()
+
         override fun getDeviceUptimeMillis(): Long = delegate.getDeviceUptimeMillis()
     }
 

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -1312,6 +1312,7 @@ class PerfettoProfilerTest {
         override fun getServerOffsetMillis(): Long = 0L
 
         override fun getDeviceElapsedRealtimeMillis(): Long = 0L
+        override fun getDeviceElapsedRealtimeNanos(): Long = 0L
         override fun getDeviceUptimeMillis(): Long = 0L
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -75,7 +75,7 @@ internal class RumSessionScope(
     internal val sessionSampleRate: Float = sessionSampler.getSampleRate() ?: RumContext.SAMPLE_ALL_RATE
     private var startReason: StartReason = StartReason.USER_APP_LAUNCH
     internal var isActive: Boolean = true
-    private val sessionStartNs = AtomicLong(sdkCore.timeProvider.getDeviceElapsedTimeNanos())
+    private val sessionStartNs = AtomicLong(sdkCore.timeProvider.getDeviceElapsedRealtimeNanos())
 
     private val lastUserInteractionNs = AtomicLong(0L)
 
@@ -263,7 +263,7 @@ internal class RumSessionScope(
 
     @Suppress("ComplexMethod")
     private fun updateSession(event: RumRawEvent) {
-        val nanoTime = sdkCore.timeProvider.getDeviceElapsedTimeNanos()
+        val nanoTime = sdkCore.timeProvider.getDeviceElapsedRealtimeNanos()
         val isNewSession = sessionId == RumContext.NULL_UUID
 
         val timeSinceLastInteractionNs = nanoTime - lastUserInteractionNs.get()
@@ -318,7 +318,7 @@ internal class RumSessionScope(
         startReason = reason
         sessionState = if (keepSession) State.TRACKED else State.NOT_TRACKED
         sessionId = newSessionId
-        sessionStartNs.set(time.nanoTime)
+        sessionStartNs.set(sdkCore.timeProvider.getDeviceElapsedRealtimeNanos())
         rumSessionScopeStartupManager = rumSessionScopeStartupManagerFactory()
         childScope?.renewViewScopes(time)
         if (keepSession) {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -204,7 +204,10 @@ internal class RumSessionScopeTest {
 
     @BeforeEach
     fun `set up`(forge: Forge) {
-        stubTimeProvider = StubTimeProvider(elapsedTimeNs = TEST_INACTIVITY_NS + 1)
+        stubTimeProvider = StubTimeProvider(
+            elapsedTimeNs = TEST_INACTIVITY_NS + 1,
+            elapsedRealtimeNs = TEST_INACTIVITY_NS + 1
+        )
         fakeInitialViewEvent = forge.startViewEvent()
         fakeParentContext = fakeParentContext.copy(viewType = RumViewType.NONE)
 
@@ -996,6 +999,96 @@ internal class RumSessionScopeTest {
             .isNotEqualTo(RumContext.NULL_UUID)
         assertThat(context.sessionState).isEqualTo(RumSessionScope.State.TRACKED)
         assertThat(context.sessionStartReason).isEqualTo(RumSessionScope.StartReason.MAX_DURATION)
+    }
+
+    @Test
+    fun `M start new session W max duration exceeded in wall-clock but monotonic frozen by deep sleep`(
+        forge: Forge
+    ) {
+        // Given — a tracked session is started
+        testedScope.handleEvent(
+            forge.startViewEvent(eventTime = currentFakeTime()),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+        val initialContext = testedScope.getRumContext()
+
+        // The session runs awake for almost the full max duration, with frequent
+        // interactions so that the inactivity threshold is NOT crossed during the
+        // awake period.
+        val awakeSteps = (TEST_MAX_DURATION_MS / TEST_SLEEP_MS).toInt() - 1
+        repeat(awakeSteps) {
+            advanceTimeByMs(TEST_SLEEP_MS)
+            testedScope.handleEvent(
+                forge.startActionEvent(continuous = false, eventTime = currentFakeTime()),
+                fakeDatadogContext,
+                mockEventWriteScope,
+                mockWriter
+            )
+        }
+
+        // When — the device then deep-sleeps past the max duration in wall-clock time,
+        //        but the monotonic clock the SDK previously read (getDeviceElapsedTimeNanos /
+        //        System.nanoTime / CLOCK_MONOTONIC) is frozen during deep sleep. The sleep is
+        //        short enough that the inactivity threshold is still NOT crossed (so the only
+        //        condition that should fire is the max-duration timeout).
+        //        See RUMS-6221: before the fix the SDK reused the old session id because the
+        //        frozen monotonic clock never crossed the 4h threshold.
+        simulateDeepSleepByMs(TEST_SLEEP_MS * 2)
+        val result = testedScope.handleEvent(
+            forge.startViewEvent(eventTime = currentFakeTime()),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+        val context = testedScope.getRumContext()
+
+        // Then — a new session must be started with the MAX_DURATION reason, because the
+        //         wall-clock (sleep-including) time exceeded the max duration while the
+        //         inactivity threshold was not crossed.
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId)
+            .isNotEqualTo(initialContext.sessionId)
+            .isNotEqualTo(RumContext.NULL_UUID)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.TRACKED)
+        assertThat(context.sessionStartReason).isEqualTo(RumSessionScope.StartReason.MAX_DURATION)
+    }
+
+    @Test
+    fun `M start new session W inactivity exceeded in wall-clock but monotonic frozen by deep sleep`(
+        forge: Forge
+    ) {
+        // Given — a tracked session is started
+        testedScope.handleEvent(
+            forge.startViewEvent(eventTime = currentFakeTime()),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+        val initialContext = testedScope.getRumContext()
+
+        // When — the device sleeps for longer than the inactivity threshold in wall-clock
+        //        time, but the monotonic clock the SDK reads is frozen during deep sleep.
+        simulateDeepSleepByMs(TEST_INACTIVITY_MS + TEST_SLEEP_MS)
+        val result = testedScope.handleEvent(
+            forge.startViewEvent(eventTime = currentFakeTime()),
+            fakeDatadogContext,
+            mockEventWriteScope,
+            mockWriter
+        )
+        val context = testedScope.getRumContext()
+
+        // Then — a new session must be started after the wall-clock inactivity exceeded
+        //         the inactivity threshold, regardless of the frozen monotonic clock.
+        //         See RUMS-6221: currently this assertion FAILS because the SDK reuses the
+        //         old session id (the defect under investigation).
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId)
+            .isNotEqualTo(initialContext.sessionId)
+            .isNotEqualTo(RumContext.NULL_UUID)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.TRACKED)
+        assertThat(context.sessionStartReason).isEqualTo(RumSessionScope.StartReason.INACTIVITY_TIMEOUT)
     }
 
     @Test
@@ -2096,6 +2189,25 @@ internal class RumSessionScopeTest {
 
     private fun advanceTimeByMs(ms: Long) {
         stubTimeProvider.elapsedTimeNs += TimeUnit.MILLISECONDS.toNanos(ms)
+        stubTimeProvider.elapsedRealtimeNs += TimeUnit.MILLISECONDS.toNanos(ms)
+    }
+
+    /**
+     * Simulates device deep sleep: the wall-clock (elapsedRealtime / device timestamp)
+     * advances by [ms], but the monotonic clock (System.nanoTime / CLOCK_MONOTONIC,
+     * exposed via [TimeProvider.getDeviceElapsedTimeNanos]) is frozen — exactly as it is
+     * on a real Android device in deep sleep.
+     *
+     * This is the scenario reported in RUMS-6221: the app stays inactive for several
+     * hours, mostly in deep sleep, so the monotonic clock the SDK currently uses for
+     * session timeout/inactivity never crosses the 4h / 15min thresholds even though
+     * wall-clock time has long passed them.
+     */
+    private fun simulateDeepSleepByMs(ms: Long) {
+        stubTimeProvider.elapsedRealtimeMs += ms
+        stubTimeProvider.elapsedRealtimeNs += TimeUnit.MILLISECONDS.toNanos(ms)
+        stubTimeProvider.deviceTimestampMs += ms
+        // elapsedTimeNs intentionally NOT advanced — mirrors CLOCK_MONOTONIC during sleep
     }
 
     private fun currentFakeTime(): Time {

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
@@ -184,6 +184,7 @@ class StubSDKCore(
         override fun getServerOffsetNanos(): Long = 0L
         override fun getServerOffsetMillis(): Long = 0L
         override fun getDeviceElapsedRealtimeMillis(): Long = SystemClock.elapsedRealtime()
+        override fun getDeviceElapsedRealtimeNanos(): Long = SystemClock.elapsedRealtimeNanos()
         override fun getDeviceUptimeMillis(): Long = SystemClock.uptimeMillis()
     }
 


### PR DESCRIPTION
### What does this PR do?

Switches the RUM session timeout (4h max duration) and inactivity (15min) computations from the sleep-excluding monotonic clock (`System.nanoTime()` / `CLOCK_MONOTONIC`) to the sleep-including realtime clock (`SystemClock.elapsedRealtimeNanos()`).

Adds `getDeviceElapsedRealtimeNanos()` to `TimeProvider` and uses it at the 3 call sites in `RumSessionScope` (session-start capture, the `updateSession()` timeout read, and `renewSession()` reset).

### Motivation

Fixes [RUMS-6221](https://datadoghq.atlassian.net/browse/RUMS-6221).

`CLOCK_MONOTONIC` (via `System.nanoTime()`) **freezes during device deep sleep**. When an app stays inactive for several hours (mostly in deep sleep), the monotonic clock barely advances and never crosses the 4h/15min thresholds, so the SDK reuses the stale `session.id` instead of starting a new session. This causes `session.resource.count` to undercount and Resources Explorer / Session detail views to diverge.

Using the sleep-including realtime clock means real wall-clock inactivity is observed regardless of device sleep state.

### Additional Notes

- **TDD:** Two new tests in `RumSessionScopeTest` prove the fix via a `simulateDeepSleepByMs()` helper that advances the wall-clock fields while freezing the monotonic field on `StubTimeProvider` — faithfully modeling real deep-sleep clock semantics without a device/emulator. These tests fail against the old code (red) and pass with the fix (green).
- All other `getDeviceElapsedTimeNanos` callsites were audited: they measure active execution durations (resource timing, long-task detection, debouncers, etc.) where `CLOCK_MONOTONIC` is the *correct* semantic and are intentionally left unchanged. Only wall-clock-elapsed checks (session timeout/inactivity) needed the switch.
- API surface (`dd-sdk-android-internal`) regenerated for the new `TimeProvider` method.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

[RUMS-6221]: https://datadoghq.atlassian.net/browse/RUMS-6221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ