### PR TITLE
RUM-18330: Add ViewEventMapper identity check to RumViewEventWriter

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriter.kt
@@ -90,24 +90,40 @@ internal class RumViewEventWriterImpl(
                     )
                     viewEvent
                 }
-                mappedViewEvent = mapped
+
+                // The ViewEventMapper contract requires the same instance to be returned;
+                // if a different reference comes back, ignore it and use the original event
+                // (matches the identity check historically enforced in
+                // RumEventMapper.resolveEvent() for the raw ViewEvent / crash-recovery path).
+                val safeMapped = if (mapped !== viewEvent) {
+                    sdkCore.internalLogger.log(
+                        level = InternalLogger.Level.ERROR,
+                        target = InternalLogger.Target.USER,
+                        messageBuilder = { VIEW_EVENT_MAPPER_NOT_SAME_INSTANCE_WARNING_MESSAGE }
+                    )
+                    viewEvent
+                } else {
+                    mapped
+                }
+
+                mappedViewEvent = safeMapped
                 val prev = prevViewEvent
 
                 when (config) {
-                    RumViewEventWriteConfig.AlwaysFullView -> MappedViewEvent(mapped)
+                    RumViewEventWriteConfig.AlwaysFullView -> MappedViewEvent(safeMapped)
                     RumViewEventWriteConfig.FullViewOnlyAtStart -> {
                         if (prev == null) {
-                            MappedViewEvent(mapped)
-                        } else if (shouldWriteFullView(mapped.dd.documentVersion, mapped.view.isActive)) {
+                            MappedViewEvent(safeMapped)
+                        } else if (shouldWriteFullView(safeMapped.dd.documentVersion, safeMapped.view.isActive)) {
                             // Send the last partial diff followed immediately by the full view checkpoint
                             DiffThenFullView(
-                                viewUpdate = diffViewEvent(prev, mapped),
-                                viewEvent = mapped
+                                viewUpdate = diffViewEvent(prev, safeMapped),
+                                viewEvent = safeMapped
                             )
                         } else {
                             RumViewUpdateData(
-                                viewUpdate = diffViewEvent(prev, mapped),
-                                viewEvent = mapped
+                                viewUpdate = diffViewEvent(prev, safeMapped),
+                                viewEvent = safeMapped
                             )
                         }
                     }
@@ -129,6 +145,9 @@ internal class RumViewEventWriterImpl(
     companion object {
         internal const val VIEW_EVENT_MAPPER_FALLBACK_WARNING_MESSAGE =
             "ViewEventMapper failed, using original ViewEvent."
+        internal const val VIEW_EVENT_MAPPER_NOT_SAME_INSTANCE_WARNING_MESSAGE =
+            "ViewEventMapper returned a different ViewEvent instance than the one passed in; " +
+                "the original ViewEvent will be used instead."
         internal const val FULL_VIEW_EVERY_N_UPDATES = 4L
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewEventWriterTest.kt
@@ -33,10 +33,12 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 
@@ -315,6 +317,45 @@ internal class RumViewEventWriterTest {
         // Then
         assertThat(writtenEvents).hasSize(1)
         assertThat(writtenEvents[0]).isEqualTo(MappedViewEvent(fakeViewEvent))
+    }
+
+    @Test
+    fun `M fallback to original view event W mapper returns different instance`(
+        @Forgery fakeViewEvent: ViewEvent
+    ) {
+        // Given
+        val differentInstance = fakeViewEvent.copy() // same field values, different reference
+        whenever(mockViewEventMapper.map(fakeViewEvent)) doReturn differentInstance
+        val writtenEvents = mutableListOf<Any>()
+        whenever(mockDataWriter.write(eq(mockEventBatchWriter), any(), eq(fakeEventType))) doAnswer {
+            writtenEvents += it.getArgument<Any>(1)
+            true
+        }
+
+        // When
+        testedWriter.writeViewEvent(
+            viewEvent = fakeViewEvent,
+            datadogContext = fakeDatadogContext,
+            writeScope = mockEventWriteScope,
+            writer = mockDataWriter,
+            eventType = fakeEventType
+        )
+
+        // Then
+        assertThat(writtenEvents).hasSize(1)
+        assertThat(writtenEvents[0]).isEqualTo(MappedViewEvent(fakeViewEvent))
+        argumentCaptor<() -> String> {
+            verify(mockInternalLogger).log(
+                level = eq(InternalLogger.Level.ERROR),
+                target = eq(InternalLogger.Target.USER),
+                messageBuilder = capture(),
+                throwable = eq(null),
+                onlyOnce = eq(false),
+                additionalProperties = eq(null)
+            )
+            assertThat(firstValue())
+                .isEqualTo(RumViewEventWriterImpl.VIEW_EVENT_MAPPER_NOT_SAME_INSTANCE_WARNING_MESSAGE)
+        }
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
Adds an identity check in `RumViewEventWriterImpl.writeViewEvent()`: if the configured `ViewEventMapper` returns a different `ViewEvent` instance than the one it was given, the mismatch is ignored and the original event is used instead (with an `ERROR` log). Every downstream use of the mapped event — full-view writes, diff computation, and checkpoint writes — now consistently uses this safe value.

### Motivation
`ViewEventMapper`'s documented contract requires the same instance to be returned (mutating "writable" fields/maps in place); a different reference must be ignored. This is already enforced in `RumEventMapper.resolveEvent()` for the raw `ViewEvent` / crash-recovery path, but `RumViewEventWriterImpl` — the primary path for all regular/live view event writes introduced by the Partial View Updates feature — never had the same protection. Flagged by Codex automated review on PR #3809; investigated and confirmed as an unintentional gap left over from PR #3299 (RUM-14814), not a deliberate design decision. Tracked in RUM-18330.

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)