### PR TITLE
RUM-18325: Restore accessibility-change dedup for full ViewEvent writes

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
@@ -47,6 +47,7 @@ internal class RumDataWriter(
 ) : DataWriter<Any> {
 
     private var currentViewId: String? = null
+    private val lastWrittenAccessibilityByViewId = mutableMapOf<String, ViewEvent.Accessibility?>()
 
     @WorkerThread
     override fun write(writer: EventBatchWriter, element: Any, eventType: EventType): Boolean {
@@ -108,12 +109,39 @@ internal class RumDataWriter(
         val eventMeta = RumEventMeta.View(
             viewId = event.view.id,
             documentVersion = event.dd.documentVersion,
-            hasAccessibility = event.view.accessibility != null
+            hasAccessibility = resolveHasAccessibility(event)
         )
         val serializedEventMeta = eventMetaSerializer.serializeToByteArray(eventMeta, sdkCore.internalLogger)
             ?: EMPTY_BYTE_ARRAY
 
         return byteArray to serializedEventMeta
+    }
+
+    /**
+     * Returns true when this full [ViewEvent]'s accessibility snapshot differs from the last
+     * full ViewEvent written for this exact viewId. This signals [RumViewEventFilter] to retain
+     * this event even if a later documentVersion supersedes it for batch dedup purposes — since
+     * accessibility settings can change mid-view (e.g. screen reader toggled) and later,
+     * otherwise-superseding full view writes would not preserve that intermediate state.
+     *
+     * Tracked per viewId (not a single "current view") because RumViewManagerScope can hold
+     * multiple concurrently active RumViewScope instances (e.g. a background or app-launch view
+     * scope alongside a newly started foreground view), so writes for different views can be
+     * interleaved rather than strictly sequential for a single view.
+     */
+    @WorkerThread
+    private fun resolveHasAccessibility(event: ViewEvent): Boolean {
+        synchronized(this) {
+            val viewId = event.view.id
+            val changed = event.view.accessibility != lastWrittenAccessibilityByViewId[viewId]
+            if (event.view.isActive == false) {
+                // Last write for this view — evict to avoid unbounded growth across a long session.
+                lastWrittenAccessibilityByViewId.remove(viewId)
+            } else {
+                lastWrittenAccessibilityByViewId[viewId] = event.view.accessibility
+            }
+            return changed
+        }
     }
 
     @WorkerThread

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
@@ -1305,6 +1305,145 @@ internal class RumDataWriterTest {
         assertThat(metaData.hasAccessibility).isTrue
     }
 
+    @Test
+    fun `M hasAccessibility false W write() { second write, same accessibility }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeAccessibility = forge.getForgery<ViewEvent.Accessibility>()
+        val baseViewEvent = forge.getForgery<ViewEvent>()
+        val firstWrite = baseViewEvent.copy(
+            view = baseViewEvent.view.copy(accessibility = fakeAccessibility, isActive = true)
+        )
+        val secondWrite = firstWrite.copy(
+            dd = firstWrite.dd.copy(documentVersion = firstWrite.dd.documentVersion + 1)
+        )
+        listOf(firstWrite, secondWrite).forEach {
+            whenever(mockEventMapper.map(it)) doReturn it
+            whenever(mockEventSerializer.serialize(it)) doReturn fakeSerializedEvent
+        }
+
+        // When
+        testedWriter.write(mockEventBatchWriter, firstWrite, fakeEventType)
+        testedWriter.write(mockEventBatchWriter, secondWrite, fakeEventType)
+
+        // Then
+        val captor = argumentCaptor<RumEventMeta.View>()
+        verify(mockEventMetaSerializer, times(2)).serialize(captor.capture())
+        assertThat(captor.allValues[0].hasAccessibility).isTrue // no prior write for this view yet
+        assertThat(captor.allValues[1].hasAccessibility).isFalse // unchanged since the first write
+    }
+
+    @Test
+    fun `M hasAccessibility true W write() { second write, different accessibility }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeAccessibility1 = forge.getForgery<ViewEvent.Accessibility>().copy(screenReaderEnabled = true)
+        val fakeAccessibility2 = fakeAccessibility1.copy(screenReaderEnabled = false)
+        val baseViewEvent = forge.getForgery<ViewEvent>()
+        val firstWrite = baseViewEvent.copy(
+            view = baseViewEvent.view.copy(accessibility = fakeAccessibility1, isActive = true)
+        )
+        val secondWrite = firstWrite.copy(
+            view = firstWrite.view.copy(accessibility = fakeAccessibility2),
+            dd = firstWrite.dd.copy(documentVersion = firstWrite.dd.documentVersion + 1)
+        )
+        listOf(firstWrite, secondWrite).forEach {
+            whenever(mockEventMapper.map(it)) doReturn it
+            whenever(mockEventSerializer.serialize(it)) doReturn fakeSerializedEvent
+        }
+
+        // When
+        testedWriter.write(mockEventBatchWriter, firstWrite, fakeEventType)
+        testedWriter.write(mockEventBatchWriter, secondWrite, fakeEventType)
+
+        // Then
+        val captor = argumentCaptor<RumEventMeta.View>()
+        verify(mockEventMetaSerializer, times(2)).serialize(captor.capture())
+        assertThat(captor.allValues[0].hasAccessibility).isTrue
+        assertThat(captor.allValues[1].hasAccessibility).isTrue // accessibility changed between writes
+    }
+
+    @Test
+    fun `M track accessibility independently per view W write() { interleaved views }`(
+        forge: Forge
+    ) {
+        // Given — two distinct views, A and B, with different accessibility snapshots
+        val fakeAccessibilityA = forge.getForgery<ViewEvent.Accessibility>().copy(screenReaderEnabled = true)
+        val fakeAccessibilityB = fakeAccessibilityA.copy(screenReaderEnabled = false)
+
+        val baseViewEventA = forge.getForgery<ViewEvent>()
+        val viewEventA1 = baseViewEventA.copy(
+            view = baseViewEventA.view.copy(accessibility = fakeAccessibilityA, isActive = true)
+        )
+        val viewEventA2 = viewEventA1.copy(
+            dd = viewEventA1.dd.copy(documentVersion = viewEventA1.dd.documentVersion + 1)
+        )
+
+        val baseViewEventB = forge.getForgery<ViewEvent>()
+        val viewEventB1 = baseViewEventB.copy(
+            view = baseViewEventB.view.copy(accessibility = fakeAccessibilityB, isActive = true)
+        )
+
+        listOf(viewEventA1, viewEventB1, viewEventA2).forEach {
+            whenever(mockEventMapper.map(it)) doReturn it
+            whenever(mockEventSerializer.serialize(it)) doReturn fakeSerializedEvent
+        }
+
+        // When — view A's first update, then an interleaved write for a completely different
+        // view B, then view A's second update (same accessibility as its own first write)
+        testedWriter.write(mockEventBatchWriter, viewEventA1, fakeEventType)
+        testedWriter.write(mockEventBatchWriter, viewEventB1, fakeEventType)
+        testedWriter.write(mockEventBatchWriter, viewEventA2, fakeEventType)
+
+        // Then
+        val captor = argumentCaptor<RumEventMeta.View>()
+        verify(mockEventMetaSerializer, times(3)).serialize(captor.capture())
+        assertThat(captor.allValues[0].hasAccessibility).isTrue // A1: first write for view A
+        assertThat(captor.allValues[1].hasAccessibility).isTrue // B1: first write for view B
+        // A2 must be compared against A1's own accessibility, not B1's — proves per-viewId tracking
+        assertThat(captor.allValues[2].hasAccessibility).isFalse
+    }
+
+    @Test
+    fun `M reset accessibility tracking W write() { view closes, isActive false }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeAccessibility = forge.getForgery<ViewEvent.Accessibility>()
+        val baseViewEvent = forge.getForgery<ViewEvent>()
+        val firstWrite = baseViewEvent.copy(
+            view = baseViewEvent.view.copy(accessibility = fakeAccessibility, isActive = true)
+        )
+        val closingWrite = firstWrite.copy(
+            view = firstWrite.view.copy(isActive = false),
+            dd = firstWrite.dd.copy(documentVersion = firstWrite.dd.documentVersion + 1)
+        )
+        // A late write for the same viewId after it was closed (e.g. crash-recovery raw ViewEvent),
+        // with the same accessibility snapshot as before
+        val lateWrite = closingWrite.copy(
+            dd = closingWrite.dd.copy(documentVersion = closingWrite.dd.documentVersion + 1)
+        )
+        listOf(firstWrite, closingWrite, lateWrite).forEach {
+            whenever(mockEventMapper.map(it)) doReturn it
+            whenever(mockEventSerializer.serialize(it)) doReturn fakeSerializedEvent
+        }
+
+        // When
+        testedWriter.write(mockEventBatchWriter, firstWrite, fakeEventType)
+        testedWriter.write(mockEventBatchWriter, closingWrite, fakeEventType)
+        testedWriter.write(mockEventBatchWriter, lateWrite, fakeEventType)
+
+        // Then
+        val captor = argumentCaptor<RumEventMeta.View>()
+        verify(mockEventMetaSerializer, times(3)).serialize(captor.capture())
+        assertThat(captor.allValues[0].hasAccessibility).isTrue // first write for this view
+        assertThat(captor.allValues[1].hasAccessibility).isFalse // unchanged, but this write closes the view
+        // tracking was evicted when the view closed, so this is treated as unseen again
+        assertThat(captor.allValues[2].hasAccessibility).isTrue
+    }
+
     // endregion
 
     companion object {


### PR DESCRIPTION
### What does this PR do?
Restores `RumViewEventFilter`'s batch-level dedup for full `ViewEvent` writes, which was unintentionally disabled when `RumDataWriter.hasAccessibility` started always evaluating to `true`. Tracks the last-written accessibility snapshot per `viewId` in `RumDataWriter`, so `hasAccessibility` correctly reflects whether accessibility actually changed since the last full-view write for that specific view.

### Motivation
Flagged by Codex's automated review on PR #3809: `RumViewScope` now always populates `ViewEvent.view.accessibility` (superseded `AccessibilitySnapshotManager`'s null-unless-changed approach with diff-level dedup for `ViewUpdateEvent`, which works correctly). However, `RumDataWriter` still computed `hasAccessibility = event.view.accessibility != null`, which is now always `true`. Since `RumViewEventFilter` treats `hasAccessibility == true` as "always retain this event," dedup for redundant full `ViewEvent`s never triggers anymore — every full view write is persisted/uploaded, even when a later document version fully supersedes it. Data volume only, not data loss (see RUM-18325 for full analysis).

### Additional Notes
- We expect to remove this once partial view updates (and the periodic full-view checkpoint mechanism) become the only way full ViewEvents are written — at that point each view will only ever produce an initial and a closing full ViewEvent, and RumViewEventFilter's existing max-documentVersion dedup already covers that case without needing this exemption.

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the CONTRIBUTING doc)