### PR TITLE
Delegate TrackingConsent to stub DatadogContext

### DIFF
--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
@@ -23,6 +23,7 @@ import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.privacy.TrackingConsent
 import fr.xgouchet.elmyr.Forge
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.doReturn
@@ -170,6 +171,9 @@ class StubSDKCore(
 
     override val networkInfo: NetworkInfo
         get() = datadogContext.networkInfo
+
+    override val trackingConsent: TrackingConsent
+        get() = datadogContext.trackingConsent
 
     // endregion
 


### PR DESCRIPTION
### What does this PR do?
Fixes possible NPE when running tests that rely on trackingConsent being set

This is backporting part of the change enable client-side-stats in dogfooding before the reset of `dogfooding`
https://github.com/DataDog/dd-sdk-android/pull/3710/changes/dfcbbc07792d6a7d52132fd30f58f54d0f9ac8a5

### Motivation
When client side stats gets enabled by default, it triggers a code path that reads this field which triggers a NPE in tests

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

