### PR TITLE
Enable profiling feature tests on CI and fix `StubSDKCore` call factory

### DIFF
--- a/ci/pipelines/default-pipeline.yml
+++ b/ci/pipelines/default-pipeline.yml
@@ -409,6 +409,23 @@ test-pyramid:single-fit-okhttp:
     reports:
       junit: "**/build/test-results/testReleaseUnitTest/*.xml"
 
+test-pyramid:single-fit-profiling:
+  extends:
+    - .base-cache-pull-job
+  tags: [ "arch:amd64" ]
+  image: $CI_IMAGE_DOCKER
+  stage: test-pyramid
+  timeout: 1h
+  script:
+    - !reference [ .snippets, setup-gradle ]
+    - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
+    - DD_TAGS="test.configuration.variant:release" ./gradlew :reliability:single-fit:profiling:testReleaseUnitTest
+  artifacts:
+    when: always
+    expire_in: 1 week
+    reports:
+      junit: "**/build/test-results/testReleaseUnitTest/*.xml"
+
 # RUN INSTRUMENTED TESTS ON MIN API (23), LATEST API (34) and MEDIAN API (28)
 
 test-pyramid:legacy-integration-instrumented-min-api:

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubCallFactory.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubCallFactory.kt
@@ -1,0 +1,59 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.stub
+
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Request
+import okhttp3.Response
+import okio.Timeout
+import java.io.IOException
+
+/**
+ * Stubbed version of a [Call.Factory], which never performs any real network call.
+ *
+ * Every [Call] it creates fails with an [IOException], letting the calling code exercise its
+ * error handling path without reaching out to any host.
+ */
+class StubCallFactory : Call.Factory {
+
+    override fun newCall(request: Request): Call = StubCall(request)
+
+    private class StubCall(private val request: Request) : Call {
+
+        private var isExecuted = false
+        private var isCanceled = false
+
+        override fun request(): Request = request
+
+        override fun execute(): Response {
+            isExecuted = true
+            throw IOException(ERROR_MESSAGE)
+        }
+
+        override fun enqueue(responseCallback: Callback) {
+            isExecuted = true
+            responseCallback.onFailure(this, IOException(ERROR_MESSAGE))
+        }
+
+        override fun cancel() {
+            isCanceled = true
+        }
+
+        override fun isExecuted(): Boolean = isExecuted
+
+        override fun isCanceled(): Boolean = isCanceled
+
+        override fun timeout(): Timeout = Timeout.NONE
+
+        override fun clone(): Call = StubCall(request)
+    }
+
+    private companion object {
+        const val ERROR_MESSAGE = "StubCallFactory does not perform any real network call"
+    }
+}

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
@@ -24,6 +24,8 @@ import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.internal.time.TimeProvider
 import fr.xgouchet.elmyr.Forge
+import okhttp3.Call
+import okhttp3.OkHttpClient
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.whenever
@@ -240,6 +242,10 @@ class StubSDKCore(
 
     override fun createSingleThreadExecutorService(executorContext: String): ExecutorService {
         return StubExecutorService(executorContext)
+    }
+
+    override fun createOkHttpCallFactory(block: OkHttpClient.Builder.() -> Unit): Call.Factory {
+        return StubCallFactory()
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

Add a `test-pyramid:single-fit-profiling` job running `:reliability:single-fit:profiling:testReleaseUnitTest`.

Those tests were failing with a `NullPointerException`: `StubSDKCore` implements `InternalSdkCore` by delegation to a `Mockito` mock and never overrode `createOkHttpCallFactory`, so the mock returned null and `ProfilingFeature.onInitialize` passed it into `ProfilingQuotaChecker`'s non-null `callFactory` parameter.

Add `StubCallFactory`, an offline `Call.Factory` whose calls always fail with an `IOException`, and return it from `StubSDKCore`. It has to stay offline because `StubExecutorService` runs submitted tasks inline, so a real `OkHttpClient` would issue an actual request to the forged intake host during the quota check.

During the feature tests we don't reach upload stage anyway.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

