### PR TITLE
RUM-18340: Define PendingTriggerProfiles interface and wire up trigger result + writer

### DIFF
--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilerCallback.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilerCallback.kt
@@ -14,5 +14,5 @@ internal interface ProfilerCallback {
 
     fun onFailure(startReason: ProfilingStartReason)
 
-    fun onAnrDetected(event: ProfilingAnrDetectedEvent)
+    fun onAnrDetected(event: ProfilingAnrDetectedEvent, result: PerfettoResult)
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingFeature.kt
@@ -31,8 +31,11 @@ import com.datadog.android.profiling.internal.quota.NoOpQuotaChecker
 import com.datadog.android.profiling.internal.quota.ProfilingQuotaChecker
 import com.datadog.android.profiling.internal.quota.QuotaChecker
 import com.datadog.android.profiling.internal.quota.QuotaResult
+import com.datadog.android.profiling.internal.trigger.NoOpPendingTriggerProfiles
+import com.datadog.android.profiling.internal.trigger.PendingTriggerProfiles
 import java.util.Locale
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -50,6 +53,9 @@ internal class ProfilingFeature(
     internal var dataWriter: ProfilingWriter = NoOpProfilingWriter()
 
     internal val pendingRumEvents = PendingRumEventsBuffer()
+
+    @Volatile
+    internal var pendingTriggerProfiles: PendingTriggerProfiles = NoOpPendingTriggerProfiles()
 
     @Volatile
     private var isLaunchProfilingActive: Boolean = false
@@ -105,7 +111,7 @@ internal class ProfilingFeature(
         sdkCore.updateFeatureContext(Feature.PROFILING_FEATURE_NAME) { context ->
             context[FeatureContextKeys.PROFILER_IS_RUNNING] = profiler.isRunning()
         }
-        dataWriter = createDataWriter(sdkCore)
+        dataWriter = ProfilingDataWriter(sdkCore)
 
         val quotaCallFactory = sdkCore.createOkHttpCallFactory {
             callTimeout(QUOTA_CHECK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
@@ -130,6 +136,10 @@ internal class ProfilingFeature(
             start(launchProfilingActive = profiler.isRunning())
         }
         continuousProfilingScheduler = scheduler
+
+        pendingTriggerProfiles = createPendingTriggerProfiles(
+            executor = profiler.scheduledExecutorService
+        )
 
         sdkCore.setContextUpdateReceiver(this)
 
@@ -156,6 +166,8 @@ internal class ProfilingFeature(
         quotaChecker = NoOpQuotaChecker()
         quotaExecutor?.shutdownNow()
         quotaExecutor = null
+        pendingTriggerProfiles.stop()
+        pendingTriggerProfiles = NoOpPendingTriggerProfiles()
         lastQuotaResult = null
         lastSeenRumSessionId = null
         pendingRumEvents.clear()
@@ -185,6 +197,7 @@ internal class ProfilingFeature(
                 if (isRecordingProfile()) {
                     pendingRumEvents.add(event)
                 }
+                pendingTriggerProfiles.addRumGatingEvent(event)
             }
 
             else -> sdkCore.internalLogger.log(
@@ -223,11 +236,12 @@ internal class ProfilingFeature(
         }
     }
 
-    override fun onAnrDetected(event: ProfilingAnrDetectedEvent) {
+    override fun onAnrDetected(event: ProfilingAnrDetectedEvent, result: PerfettoResult) {
         // The ANR event should be forwarded to RUM only when profiling is actually running.
         if (isLaunchProfilingActive || continuousProfilingScheduler?.isActive == true) {
             sdkCore.getFeature(Feature.RUM_FEATURE_NAME)?.sendEvent(event)
         }
+        pendingTriggerProfiles.addProfilingResult(result)
     }
 
     private fun onTtidEvent() {
@@ -345,8 +359,18 @@ internal class ProfilingFeature(
         )
     }
 
-    private fun createDataWriter(sdkCore: FeatureSdkCore): ProfilingDataWriter {
-        return ProfilingDataWriter(sdkCore)
+    /**
+     * Builds a [PendingTriggerProfiles] wired to dispatch matched pairs to [dataWriter].
+     * [executor] is null before [onInitialize] runs and after [onStop] — the sweep simply
+     * never runs in that case.
+     */
+    @Suppress("UnusedParameter")
+    private fun createPendingTriggerProfiles(
+        executor: ScheduledExecutorService?
+    ): PendingTriggerProfiles {
+        // TODO RUM-18341: replace with PendingTriggerProfilesImpl once the buffer
+        // and matching logic is implemented.
+        return NoOpPendingTriggerProfiles()
     }
 
     internal fun propagateQuotaResult(result: QuotaResult) {

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingStartReason.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/ProfilingStartReason.kt
@@ -14,5 +14,7 @@ internal enum class ProfilingStartReason(val value: String) {
 
     CONTINUOUS("continuous"),
 
+    ANR("anr"),
+
     UNKNOWN("unknown")
 }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/perfetto/PerfettoProfiler.kt
@@ -96,8 +96,8 @@ internal class PerfettoProfiler(
             profilingTelemetry.internalLogger = value
         }
 
-    internal val triggerListener = ProfilingTriggerListener { event ->
-        callback?.onAnrDetected(event)
+    internal val triggerListener = ProfilingTriggerListener { event, result ->
+        callback?.onAnrDetected(event, result)
     }
 
     @Volatile

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/trigger/PendingTriggerProfiles.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/trigger/PendingTriggerProfiles.kt
@@ -1,0 +1,47 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.profiling.internal.trigger
+
+import com.datadog.android.internal.profiling.ProfilerEvent
+import com.datadog.android.profiling.internal.perfetto.PerfettoResult
+import com.datadog.tools.annotation.NoOpImplementation
+
+/**
+ * Thread-safe buffer pairing a trigger-captured profiling artifact with the gating RUM error
+ * event that promotes it to an upload.
+ */
+@NoOpImplementation
+internal interface PendingTriggerProfiles {
+
+    /**
+     * Buffers a trigger-captured [PerfettoResult]. If a matching RUM gating event is already
+     * pending, the pair is dispatched immediately via the on-match callback; otherwise the
+     * result self-cleans after [EXPIRY_TIMEOUT_MS].
+     */
+    fun addProfilingResult(result: PerfettoResult)
+
+    /**
+     * Buffers a RUM gating [ProfilerEvent]. If a matching profiling result is already pending,
+     * the pair is dispatched immediately via the on-match callback; otherwise the event
+     * self-cleans after [EXPIRY_TIMEOUT_MS]. Non-ANR events are silently rejected.
+     */
+    fun addRumGatingEvent(event: ProfilerEvent)
+
+    /**
+     * Cancels any pending cleanup tasks and deletes any still-pending profiling result's
+     * artifact file in place. Safe to call once.
+     */
+    fun stop()
+
+    companion object {
+        /**
+         * How long a profiling result or RUM gating event may wait for its counterpart
+         * before it is considered stale and dropped.
+         */
+        internal const val EXPIRY_TIMEOUT_MS = 5_000L
+    }
+}

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/trigger/ProfilingManagerTriggerRegistrar.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/trigger/ProfilingManagerTriggerRegistrar.kt
@@ -14,6 +14,8 @@ import android.os.ProfilingTrigger
 import androidx.annotation.RequiresApi
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.profiling.internal.ProfilingStartReason
+import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetry
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetryEvent
 import com.datadog.android.profiling.internal.utils.ThreadDumper
@@ -123,14 +125,14 @@ internal class ProfilingManagerTriggerRegistrar(
             if (creationTimeMs != null) {
                 val delayMs = detectedAtMs - creationTimeMs
                 callbackDelayMs = delayMs
-                if (delayMs > MAX_CALLBACK_DELAY_MS) {
-                    droppedAsStale = true
-                } else {
-                    currentListener.onAnrDetected(threadDumper.dump(detectedAtMs))
-                }
+                droppedAsStale = delayMs > MAX_CALLBACK_DELAY_MS
             }
-            // We currently don't use the result profile, just delete it.
-            safeDelete(resultPath)
+            if (callbackDelayMs != null && !droppedAsStale) {
+                forwardTriggerResult(currentListener, detectedAtMs, resultPath)
+            } else {
+                // Not forwarded (stale, or could not compute staleness): delete to avoid leaking.
+                safeDelete(resultPath)
+            }
         }
         profilingTelemetry.report(
             ProfilingTelemetryEvent.AnrTriggerResult(
@@ -140,6 +142,23 @@ internal class ProfilingManagerTriggerRegistrar(
                 callbackDelayMs = callbackDelayMs,
                 clientClockDriftMs = timeProvider.getServerOffsetMillis(),
                 droppedAsStale = droppedAsStale
+            )
+        )
+    }
+
+    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
+    private fun forwardTriggerResult(
+        listener: ProfilingTriggerListener,
+        detectedAtMs: Long,
+        resultPath: String
+    ) {
+        listener.onAnrDetected(
+            event = threadDumper.dump(detectedAtMs),
+            result = PerfettoResult(
+                start = detectedAtMs,
+                startReason = ProfilingStartReason.ANR,
+                end = detectedAtMs,
+                resultFilePath = resultPath
             )
         )
     }

--- a/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/trigger/ProfilingTriggerListener.kt
+++ b/features/dd-sdk-android-profiling/src/main/java/com/datadog/android/profiling/internal/trigger/ProfilingTriggerListener.kt
@@ -7,7 +7,8 @@
 package com.datadog.android.profiling.internal.trigger
 
 import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
+import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 
 internal fun interface ProfilingTriggerListener {
-    fun onAnrDetected(event: ProfilingAnrDetectedEvent)
+    fun onAnrDetected(event: ProfilingAnrDetectedEvent, result: PerfettoResult)
 }

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingFeatureTest.kt
@@ -43,6 +43,8 @@ import com.datadog.android.profiling.internal.quota.QuotaResult
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetry
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetryEvent
 import com.datadog.android.profiling.internal.time.MutableTimeProvider
+import com.datadog.android.profiling.internal.trigger.NoOpPendingTriggerProfiles
+import com.datadog.android.profiling.internal.trigger.PendingTriggerProfiles
 import com.datadog.android.profiling.internal.trigger.ProfilingTriggerRegistrar
 import com.datadog.android.profiling.utils.config.MainLooperTestConfiguration
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
@@ -155,6 +157,9 @@ internal class ProfilingFeatureTest {
 
     @Mock
     private lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
+
+    @Mock
+    private lateinit var mockPendingTriggerProfiles: PendingTriggerProfiles
 
     @Forgery
     private lateinit var fakeConfiguration: ProfilingConfiguration
@@ -594,6 +599,20 @@ internal class ProfilingFeatureTest {
     }
 
     @Test
+    fun `M stop and reset pendingTriggerProfiles W onStop()`() {
+        // Given
+        testedFeature.onInitialize(mockContext)
+        testedFeature.pendingTriggerProfiles = mockPendingTriggerProfiles
+
+        // When
+        testedFeature.onStop()
+
+        // Then
+        verify(mockPendingTriggerProfiles).stop()
+        assertThat(testedFeature.pendingTriggerProfiles).isInstanceOf(NoOpPendingTriggerProfiles::class.java)
+    }
+
+    @Test
     fun `M start continuous cycle W profiler result received {TTID session unsampled}`() {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
@@ -872,6 +891,19 @@ internal class ProfilingFeatureTest {
         // Then
         assertThat(testedFeature.pendingRumEvents.pendingLongTasks).isEmpty()
         assertThat(testedFeature.pendingRumEvents.pendingAnrEvents).isEmpty()
+    }
+
+    @Test
+    fun `M forward gating event to pendingTriggerProfiles W onReceive() {RumAnrEvent}`() {
+        // Given
+        testedFeature.onInitialize(mockContext)
+        testedFeature.pendingTriggerProfiles = mockPendingTriggerProfiles
+
+        // When
+        testedFeature.onReceive(fakeRumAnrEvent)
+
+        // Then
+        verify(mockPendingTriggerProfiles).addRumGatingEvent(fakeRumAnrEvent)
     }
 
     @Test
@@ -1304,7 +1336,8 @@ internal class ProfilingFeatureTest {
 
     @Test
     fun `M forward ProfilingAnrDetectedEvent to RUM W onAnrDetected() {launch profiling active}`(
-        @Forgery fakeEvent: ProfilingAnrDetectedEvent
+        @Forgery fakeEvent: ProfilingAnrDetectedEvent,
+        @Forgery fakeResult: PerfettoResult
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
@@ -1312,7 +1345,7 @@ internal class ProfilingFeatureTest {
         testedFeature.onInitialize(mockContext)
 
         // When
-        testedFeature.onAnrDetected(fakeEvent)
+        testedFeature.onAnrDetected(fakeEvent, fakeResult)
 
         // Then
         verify(mockRumFeatureScope).sendEvent(fakeEvent)
@@ -1320,7 +1353,8 @@ internal class ProfilingFeatureTest {
 
     @Test
     fun `M drop ProfilingAnrDetectedEvent W onAnrDetected() {profiling inactive}`(
-        @Forgery fakeEvent: ProfilingAnrDetectedEvent
+        @Forgery fakeEvent: ProfilingAnrDetectedEvent,
+        @Forgery fakeResult: PerfettoResult
     ) {
         // Given
         testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
@@ -1328,10 +1362,28 @@ internal class ProfilingFeatureTest {
         testedFeature.onInitialize(mockContext)
 
         // When
-        testedFeature.onAnrDetected(fakeEvent)
+        testedFeature.onAnrDetected(fakeEvent, fakeResult)
 
         // Then
         verify(mockRumFeatureScope, never()).sendEvent(any())
+    }
+
+    @Test
+    fun `M forward profiling result to pendingTriggerProfiles W onAnrDetected()`(
+        @Forgery fakeEvent: ProfilingAnrDetectedEvent,
+        @Forgery fakeResult: PerfettoResult
+    ) {
+        // Given
+        testedFeature = ProfilingFeature(mockSdkCore, fakeAllSampledConfiguration, mockProfiler)
+        whenever(mockProfiler.isRunning()) doReturn false
+        testedFeature.onInitialize(mockContext)
+        testedFeature.pendingTriggerProfiles = mockPendingTriggerProfiles
+
+        // When
+        testedFeature.onAnrDetected(fakeEvent, fakeResult)
+
+        // Then
+        verify(mockPendingTriggerProfiles).addProfilingResult(fakeResult)
     }
 
     @Test

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/ProfilingTest.kt
@@ -14,6 +14,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.remote.model.RemoteConfiguration
 import com.datadog.android.internal.data.SharedPreferencesStorage
+import com.datadog.android.internal.time.TimeProvider
 import com.datadog.android.profiling.Profiling.UNEXPECTED_SDK_CORE_TYPE
 import com.datadog.android.profiling.forge.Configurator
 import com.datadog.android.profiling.internal.NoOpProfiler
@@ -76,6 +77,9 @@ class ProfilingTest {
     private lateinit var mockProfilingExecutor: ExecutorService
 
     @Mock
+    private lateinit var mockTimeProvider: TimeProvider
+
+    @Mock
     private lateinit var mockProfilingManager: ProfilingManager
 
     @Mock
@@ -91,6 +95,7 @@ class ProfilingTest {
     fun `set up`() {
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockSdkCore.name) doReturn fakeInstanceName
+        whenever(mockSdkCore.timeProvider) doReturn mockTimeProvider
         whenever(mockSdkCore.createSingleThreadExecutorService(any())) doReturn mockProfilingExecutor
         whenever(mockSdkCore.remoteConfiguration) doReturn null
         whenever(mockContext.getSystemService(ProfilingManager::class.java)) doReturn mockProfilingManager
@@ -198,7 +203,9 @@ class ProfilingTest {
         whenever(mockCore1.isCoreActive()) doReturn true
         whenever(mockCore1.name) doReturn fakeCore1Name
         whenever(mockCore1.internalLogger) doReturn mockInternalLogger
+        whenever(mockCore1.timeProvider) doReturn mockTimeProvider
         whenever(mockCore2.internalLogger) doReturn mockInternalLogger
+        whenever(mockCore2.timeProvider) doReturn mockTimeProvider
         Profiling.enable(fakeConfiguration, mockCore1)
 
         // When
@@ -226,7 +233,9 @@ class ProfilingTest {
         val mockCore1 = mock<InternalSdkCore>()
         val mockCore2 = mock<InternalSdkCore>()
         whenever(mockCore1.internalLogger) doReturn mockInternalLogger
+        whenever(mockCore1.timeProvider) doReturn mockTimeProvider
         whenever(mockCore2.internalLogger) doReturn mockInternalLogger
+        whenever(mockCore2.timeProvider) doReturn mockTimeProvider
         whenever(mockCore1.isCoreActive()) doReturn true
         Profiling.enable(fakeConfiguration, mockCore1)
         assertThat(Profiling.currentRegisteredCore?.get()).isEqualTo(mockCore1)

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/PerfettoProfilerTest.kt
@@ -73,7 +73,7 @@ import java.util.function.Consumer
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-class PerfettoProfilerTest {
+internal class PerfettoProfilerTest {
 
     @Mock
     private lateinit var mockContext: Context
@@ -725,7 +725,7 @@ class PerfettoProfilerTest {
 
     @ParameterizedTest(name = "startReason: {0}")
     @EnumSource(ProfilingStartReason::class)
-    internal fun `M include start_reason in telemetry W profiling finishes { startReason }`(
+    fun `M include start_reason in telemetry W profiling finishes { startReason }`(
         startReason: ProfilingStartReason,
         @LongForgery(min = 0L) fakeStartTime: Long,
         @LongForgery(min = 0L) fakeDuration: Long
@@ -1048,13 +1048,14 @@ class PerfettoProfilerTest {
 
     @Test
     fun `M dispatch to registered callback W triggerListener fires`(
-        @Forgery fakeEvent: ProfilingAnrDetectedEvent
+        @Forgery fakeEvent: ProfilingAnrDetectedEvent,
+        @Forgery fakeResult: PerfettoResult
     ) {
         // When
-        testedProfiler.triggerListener.onAnrDetected(fakeEvent)
+        testedProfiler.triggerListener.onAnrDetected(fakeEvent, fakeResult)
 
         // Then
-        verify(mockProfilerCallback).onAnrDetected(fakeEvent)
+        verify(mockProfilerCallback).onAnrDetected(fakeEvent, fakeResult)
     }
 
     @Test

--- a/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/anr/ProfilingManagerTriggerRegistrarTest.kt
+++ b/features/dd-sdk-android-profiling/src/test/kotlin/com/datadog/android/profiling/internal/anr/ProfilingManagerTriggerRegistrarTest.kt
@@ -13,6 +13,8 @@ import android.os.ProfilingTrigger
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.internal.profiling.ProfilingAnrDetectedEvent
 import com.datadog.android.internal.time.TimeProvider
+import com.datadog.android.profiling.internal.ProfilingStartReason
+import com.datadog.android.profiling.internal.perfetto.PerfettoResult
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetry
 import com.datadog.android.profiling.internal.telemetry.ProfilingTelemetryEvent
 import com.datadog.android.profiling.internal.trigger.ProfilingManagerTriggerRegistrar
@@ -145,7 +147,7 @@ internal class ProfilingManagerTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(nonAnrResult)
 
         // Then
-        verify(mockListener, never()).onAnrDetected(any())
+        verify(mockListener, never()).onAnrDetected(any(), any())
     }
 
     @Test
@@ -241,7 +243,7 @@ internal class ProfilingManagerTriggerRegistrarTest {
 
         // Then
         val captor = argumentCaptor<ProfilingAnrDetectedEvent>()
-        verify(mockListener).onAnrDetected(captor.capture())
+        verify(mockListener).onAnrDetected(captor.capture(), any())
         assertThat(captor.firstValue.allThreads).isEmpty()
     }
 
@@ -332,7 +334,7 @@ internal class ProfilingManagerTriggerRegistrarTest {
     }
 
     @Test
-    fun `M delete result file W trigger callback fires {ANR result has filePath}`(
+    fun `M keep result file W trigger callback fires {ANR result has filePath}`(
         @TempDir tempDir: File
     ) {
         // Given
@@ -348,8 +350,8 @@ internal class ProfilingManagerTriggerRegistrarTest {
         // When
         triggerCallbackCaptor.firstValue.accept(anrResult)
 
-        // Then
-        assertThat(tmpFile.exists()).isFalse
+        // Then — the listener owns the file lifetime now; registrar must not delete it.
+        assertThat(tmpFile.exists()).isTrue
     }
 
     @Test
@@ -367,7 +369,7 @@ internal class ProfilingManagerTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(anrResult)
 
         // Then
-        verify(mockListener, never()).onAnrDetected(any())
+        verify(mockListener, never()).onAnrDetected(any(), any())
         verify(mockInternalLogger).log(
             eq(InternalLogger.Level.WARN),
             eq(InternalLogger.Target.MAINTAINER),
@@ -418,7 +420,14 @@ internal class ProfilingManagerTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(anrResult)
 
         // Then
-        verify(mockListener).onAnrDetected(any())
+        val resultCaptor = argumentCaptor<PerfettoResult>()
+        verify(mockListener).onAnrDetected(any(), resultCaptor.capture())
+        val forwardedResult = resultCaptor.firstValue
+        assertThat(forwardedResult.start).isEqualTo(fakeNow)
+        assertThat(forwardedResult.end).isEqualTo(fakeNow)
+        assertThat(forwardedResult.startReason).isEqualTo(ProfilingStartReason.ANR)
+        assertThat(forwardedResult.resultFilePath).isEqualTo(tmpFile.absolutePath)
+        assertThat(tmpFile.exists()).isTrue // registrar keeps the file; the listener owns its lifetime
         verify(mockProfilingTelemetry).report(
             ProfilingTelemetryEvent.AnrTriggerResult(
                 errorCode = ProfilingResult.ERROR_NONE,
@@ -459,7 +468,7 @@ internal class ProfilingManagerTriggerRegistrarTest {
         triggerCallbackCaptor.firstValue.accept(anrResult)
 
         // Then
-        verify(mockListener, never()).onAnrDetected(any())
+        verify(mockListener, never()).onAnrDetected(any(), any())
         verify(mockProfilingTelemetry).report(
             ProfilingTelemetryEvent.AnrTriggerResult(
                 errorCode = ProfilingResult.ERROR_NONE,


### PR DESCRIPTION
### What does this PR do?

Defines the `PendingTriggerProfiles` interface (`@NoOpImplementation`) and wires it into the profiling feature so ANR trigger-captured `PerfettoResult`s and `RumAnrEvent` gating events flow through it to `writeTriggerProfile`. The implementation is a no-op stub for now (TODO RUM-18341).

Also adds `ProfilingStartReason.ANR`, updates `onAnrDetected` to carry the `PerfettoResult`, and makes `ProfilingManagerTriggerRegistrar` keep the trace file when forwarding (listener owns the lifetime).

### Motivation

First part of ANR trigger profile upload (RUM-15779). Establishes the interface and wiring so the buffer/matching implementation (RUM-18341) can be added without further structural changes.

### Additional Notes

No behavioral change — the no-op stub discards all results silently.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)