### PR TITLE
Migrate Json Schema Validator to new Maven Coords

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -30,7 +30,6 @@ repositories {
     mavenCentral()
     google()
     gradlePluginPortal()
-    maven { setUrl("https://jitpack.io") }
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -79,7 +79,7 @@ nexusPublishGradlePlugin = "2.0.0"
 datadogPlugin = "1.27.0"
 
 kotlinPoet = "1.14.2"
-jsonSchemaValidator = "1.12.1"
+jsonSchemaValidator = "1.14.6"
 binaryCompatibility = "0.18.1"
 dependencyLicense = "0.7.0"
 kotlinXmlBuilder = "1.9.3"
@@ -227,7 +227,7 @@ kotlinPoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinPoet" }
 kotlinPoetKsp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinPoet" }
 kotlinSP = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "kotlinSP" }
 kotlinCompilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
-jsonSchemaValidator = { module = "com.github.everit-org.json-schema:org.everit.json.schema", version.ref = "jsonSchemaValidator" }
+jsonSchemaValidator = { module = "com.github.erosb:everit-json-schema", version.ref = "jsonSchemaValidator" }
 kotlinXmlBuilder = { module = "org.redundent:kotlin-xml-builder", version.ref = "kotlinXmlBuilder" }
 
 # Integrations

--- a/sample/tv/build.gradle.kts
+++ b/sample/tv/build.gradle.kts
@@ -66,9 +66,7 @@ android {
     }
 }
 
-repositories.depotProxied(providers) {
-    maven { setUrl("https://jitpack.io") }
-}
+repositories.depotProxied(providers) {}
 
 dependencies {
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,14 +13,6 @@ pluginManagement {
         gradlePluginPortal()
         google()
         mavenCentral()
-        // `build-logic` pulls the Kotlin grammar parser from Jitpack; its transitive
-        // dependencies are resolved against these repositories when its plugins are applied.
-        maven {
-            setUrl("https://jitpack.io")
-            mavenContent {
-                includeGroupByRegex("com\\.github\\..*")
-            }
-        }
     }
 
     // Build logic (convention plugins + build-time code generators) lives in its own build so that


### PR DESCRIPTION
### What does this PR do?
* Json schema validator updated its group/artifact coordinates and moved it to maven central.
* Remove jitpack since it is not used anymore

### Motivation
Upgrading to up to date coordinates that are hosted on maven central to improve CI stability

### Additional Notes
The library is being replaced with 
```
<dependency>
    <groupId>com.github.erosb</groupId>
    <artifactId>json-sKema</artifactId>
    <version>0.25.0</version>
</dependency>
```
but the cheaper solution at the moment is to switch to the newer coordinates of the legacy library
https://github.com/everit-org/json-schema/issues/532

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

