### PR TITLE
Add `jitpack.io` repository back in the build-logic module

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -30,6 +30,7 @@ repositories {
     mavenCentral()
     google()
     gradlePluginPortal()
+    maven { setUrl("https://jitpack.io") }
 }
 
 dependencies {


### PR DESCRIPTION
### What does this PR do?

Revert the following change https://github.com/DataDog/dd-sdk-android/pull/3822/files#diff-f714fa5f754f0da54abb877f8cf4e3de6341ad321db5f4c697fa602a5da8e4b4L33

https://github.com/xgouchet/Elmyr is still hosted on Jitpack and used by the tests in `build-logic`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

