### PR TITLE
RUM-18338: Aligning `timeseries` api with iOS

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -90,6 +90,7 @@ data class com.datadog.android.rum.RumConfiguration
     fun setSlowFramesConfiguration(com.datadog.android.rum.configuration.SlowFramesConfiguration?): Builder
     fun trackAnonymousUser(Boolean): Builder
     fun setAppStartupActivityPredicate(com.datadog.android.rum.startup.AppStartupActivityPredicate): Builder
+    fun setTimeseriesConfiguration(com.datadog.android.rum.timeseries.TimeseriesConfiguration): Builder
     fun build(): RumConfiguration
 enum com.datadog.android.rum.RumErrorSource
   - NETWORK
@@ -314,9 +315,7 @@ class com.datadog.android.rum.resource.RumResourceInputStream : java.io.InputStr
 interface com.datadog.android.rum.startup.AppStartupActivityPredicate
   fun shouldTrackStartup(android.app.Activity): Boolean
 class com.datadog.android.rum.timeseries.TimeseriesConfiguration
-  class Builder
-    fun collectOnly(TimeseriesType): Builder
-    fun build(): TimeseriesConfiguration
+  constructor(Set<TimeseriesType>)
   companion object 
     val DEFAULT: TimeseriesConfiguration
 enum com.datadog.android.rum.timeseries.TimeseriesType

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -118,6 +118,7 @@ public final class com/datadog/android/rum/RumConfiguration$Builder {
 	public final fun setSessionSampleRate (F)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setSlowFramesConfiguration (Lcom/datadog/android/rum/configuration/SlowFramesConfiguration;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setTelemetrySampleRate (F)Lcom/datadog/android/rum/RumConfiguration$Builder;
+	public final fun setTimeseriesConfiguration (Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setViewEventMapper (Lcom/datadog/android/rum/event/ViewEventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setVitalEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setVitalEventMapper (Lcom/datadog/android/event/EventMapper;Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
@@ -11886,12 +11887,7 @@ public abstract interface class com/datadog/android/rum/startup/AppStartupActivi
 
 public final class com/datadog/android/rum/timeseries/TimeseriesConfiguration {
 	public static final field Companion Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration$Companion;
-}
-
-public final class com/datadog/android/rum/timeseries/TimeseriesConfiguration$Builder {
-	public fun <init> ()V
-	public final fun build ()Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration;
-	public final fun collectOnly ([Lcom/datadog/android/rum/timeseries/TimeseriesType;)Lcom/datadog/android/rum/timeseries/TimeseriesConfiguration$Builder;
+	public fun <init> (Ljava/util/Set;)V
 }
 
 public final class com/datadog/android/rum/timeseries/TimeseriesConfiguration$Companion {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
@@ -416,13 +416,10 @@ data class RumConfiguration internal constructor(
         /**
          * Enables device timeseries collection.
          *
-         * By default, all supported timeseries types are collected. Use
-         * [TimeseriesConfiguration.Builder.collectOnly] to restrict collection to specific types.
-         *
          * @param configuration configuration for timeseries collection.
          */
         @ExperimentalRumApi
-        internal fun setTimeseriesConfiguration(
+        fun setTimeseriesConfiguration(
             configuration: TimeseriesConfiguration
         ): Builder {
             rumConfig = rumConfig.copy(timeseriesConfiguration = configuration)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfiguration.kt
@@ -5,48 +5,20 @@
  */
 package com.datadog.android.rum.timeseries
 
-import com.datadog.android.rum.ExperimentalRumApi
-
 /**
  * Configuration for memory and CPU timeseries collection.
  *
- * Use [Builder] to create an instance.
+ * @param collectTypes the timeseries types to collect. Passing an empty set disables
+ * collection of every timeseries type.
  */
-class TimeseriesConfiguration internal constructor(
-    internal val enabledTypes: Set<TimeseriesType>
-) {
+class TimeseriesConfiguration(collectTypes: Set<TimeseriesType>) {
 
-    /**
-     * A Builder for [TimeseriesConfiguration].
-     */
-    @ExperimentalRumApi
-    class Builder {
-
-        private var enabledTypes: Set<TimeseriesType> = TimeseriesType.entries.toSet()
-
-        /**
-         * Restricts collection to the provided timeseries types.
-         *
-         * By default, all supported timeseries types are collected.
-         * Passing an empty array disables collection of every timeseries type.
-         *
-         * @param types the timeseries types to collect.
-         */
-        fun collectOnly(vararg types: TimeseriesType): Builder = apply {
-            enabledTypes = types.toSet()
-        }
-
-        /** Builds a [TimeseriesConfiguration] from the current builder state. */
-        fun build(): TimeseriesConfiguration = TimeseriesConfiguration(
-            enabledTypes = enabledTypes
-        )
-    }
+    internal val enabledTypes: Set<TimeseriesType> = collectTypes.toSet()
 
     companion object {
 
-        /** Default [TimeseriesConfiguration] built with all default settings. */
-        @ExperimentalRumApi
-        val DEFAULT: TimeseriesConfiguration = Builder().build()
+        /** Default [TimeseriesConfiguration] collecting CPU and MEMORY timeseries types. */
+        val DEFAULT: TimeseriesConfiguration = TimeseriesConfiguration(setOf(TimeseriesType.CPU, TimeseriesType.MEMORY))
 
         /** Default number of samples to accumulate before emitting a timeseries event. */
         internal const val DEFAULT_BUFFER_SIZE: Int = 120

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
@@ -745,9 +745,7 @@ internal class RumConfigurationBuilderTest {
     @Test
     fun `M store provided configuration W setTimeseriesConfiguration(config)`(forge: Forge) {
         // Given
-        val fakeConfig = TimeseriesConfiguration.Builder()
-            .collectOnly(forge.aValueFrom(TimeseriesType::class.java))
-            .build()
+        val fakeConfig = TimeseriesConfiguration(setOf(forge.aValueFrom(TimeseriesType::class.java)))
 
         // When
         val rumConfiguration = testedBuilder.setTimeseriesConfiguration(fakeConfig).build()

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
@@ -219,7 +219,7 @@ internal class RumTest {
         // Given
         stubFeatureInitialization(fakePackageName)
         val fakeType = forge.aValueFrom(TimeseriesType::class.java)
-        val timeseriesConfiguration = TimeseriesConfiguration.Builder().collectOnly(fakeType).build()
+        val timeseriesConfiguration = TimeseriesConfiguration(setOf(fakeType))
 
         // When
         Rum.enable(fakeRumConfiguration.withTimeseries(timeseriesConfiguration), mockSdkCore)
@@ -238,7 +238,7 @@ internal class RumTest {
     ) {
         // Given
         stubFeatureInitialization(fakePackageName)
-        val fakeTimeseriesConfiguration = TimeseriesConfiguration.Builder().collectOnly().build()
+        val fakeTimeseriesConfiguration = TimeseriesConfiguration(emptySet())
 
         // When
         Rum.enable(fakeRumConfiguration.withTimeseries(fakeTimeseriesConfiguration), mockSdkCore)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -878,7 +878,7 @@ internal class RumFeatureTest {
     ) {
         // Given
         fakeConfiguration = fakeConfiguration.copy(
-            timeseriesConfiguration = TimeseriesConfiguration.Builder().build()
+            timeseriesConfiguration = TimeseriesConfiguration.DEFAULT
         )
         testedFeature = RumFeature(
             mockSdkCore,
@@ -930,7 +930,7 @@ internal class RumFeatureTest {
         fakeConfiguration = fakeConfiguration.copy(
             vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.NEVER,
             slowFramesConfiguration = null,
-            timeseriesConfiguration = TimeseriesConfiguration.Builder().build()
+            timeseriesConfiguration = TimeseriesConfiguration.DEFAULT
         )
         testedFeature = RumFeature(
             mockSdkCore,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/DefaultTimeseriesCollectorFactoryTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/timeseries/DefaultTimeseriesCollectorFactoryTest.kt
@@ -91,7 +91,7 @@ internal class DefaultTimeseriesCollectorFactoryTest {
 
     private fun createFactory(
         totalRamBytes: Long,
-        configuration: TimeseriesConfiguration = TimeseriesConfiguration.Builder().build()
+        configuration: TimeseriesConfiguration = TimeseriesConfiguration.DEFAULT
     ) = DefaultTimeseriesCollectorFactory(
         sdkCore = mockSdkCore,
         configuration = configuration,
@@ -162,9 +162,7 @@ internal class DefaultTimeseriesCollectorFactoryTest {
     @Test
     fun `M build only cpu pipeline W create() { configuration collects only cpu }`() {
         // Given
-        val fakeConfiguration = TimeseriesConfiguration.Builder()
-            .collectOnly(TimeseriesType.CPU)
-            .build()
+        val fakeConfiguration = TimeseriesConfiguration(setOf(TimeseriesType.CPU))
         val testedFactory = createFactory(0L, fakeConfiguration)
 
         // When
@@ -184,9 +182,7 @@ internal class DefaultTimeseriesCollectorFactoryTest {
         @LongForgery(min = 1L) fakeTotalRamBytes: Long
     ) {
         // Given
-        val fakeConfiguration = TimeseriesConfiguration.Builder()
-            .collectOnly(TimeseriesType.MEMORY)
-            .build()
+        val fakeConfiguration = TimeseriesConfiguration(setOf(TimeseriesType.MEMORY))
         val testedFactory = createFactory(fakeTotalRamBytes, fakeConfiguration)
 
         // When
@@ -205,9 +201,7 @@ internal class DefaultTimeseriesCollectorFactoryTest {
         @LongForgery(min = 1L) fakeTotalRamBytes: Long
     ) {
         // Given
-        val fakeConfiguration = TimeseriesConfiguration.Builder()
-            .collectOnly(*emptyArray())
-            .build()
+        val fakeConfiguration = TimeseriesConfiguration(emptySet())
         val testedFactory = createFactory(fakeTotalRamBytes, fakeConfiguration)
 
         // When

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfigurationTests.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/timeseries/TimeseriesConfigurationTests.kt
@@ -16,9 +16,9 @@ import org.junit.jupiter.params.provider.EnumSource
 internal class TimeseriesConfigurationTests {
 
     @Test
-    fun `M collect all types W build() { collectOnly not called }`() {
+    fun `M collect all types W constructor() { all types passed }`() {
         // When
-        val config = TimeseriesConfiguration.Builder().build()
+        val config = TimeseriesConfiguration(TimeseriesType.entries.toSet())
 
         // Then
         assertThat(config.enabledTypes).containsExactlyInAnyOrderElementsOf(TimeseriesType.entries.toList())
@@ -26,22 +26,18 @@ internal class TimeseriesConfigurationTests {
 
     @ParameterizedTest
     @EnumSource(TimeseriesType::class)
-    fun `M collect selected type W collectOnly()`(fakeType: TimeseriesType) {
+    fun `M collect selected type W constructor()`(fakeType: TimeseriesType) {
         // When
-        val config = TimeseriesConfiguration.Builder()
-            .collectOnly(fakeType)
-            .build()
+        val config = TimeseriesConfiguration(setOf(fakeType))
 
         // Then
         assertThat(config.enabledTypes).containsExactly(fakeType)
     }
 
     @Test
-    fun `M collect no types W collectOnly() { empty array }`() {
+    fun `M collect no types W constructor() { empty set }`() {
         // When
-        val config = TimeseriesConfiguration.Builder()
-            .collectOnly(*emptyArray())
-            .build()
+        val config = TimeseriesConfiguration(emptySet())
 
         // Then
         assertThat(config.enabledTypes).isEmpty()

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
@@ -80,7 +80,7 @@ internal class ConfigurationRumForgeryFactory :
             insightsCollector = mock(),
             appStartupActivityPredicate = mock(),
             rumViewEventWriteConfig = RumViewEventWriteConfig.FullViewOnlyAtStart,
-            timeseriesConfiguration = forge.aNullable { TimeseriesConfiguration.Builder().build() }
+            timeseriesConfiguration = forge.aNullable { TimeseriesConfiguration.DEFAULT }
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?

1. Renames `collectOnly` to `collectTypes` in order to align with iOS
2. Removes `Builder` class from `TimeseriesConfiguration` as `collectTypes` parameter becomes mandatory in order to reduce confusion with the `timeseries` configuration.
3. Makes `setTimeseriesConfiguration` public, meanwhile keeping `@ExperimentalRumApi` annotation

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

