### PR TITLE
[FFL-2929] Add assignment request timeout

### DIFF
--- a/features/dd-sdk-android-flags/api/apiSurface
+++ b/features/dd-sdk-android-flags/api/apiSurface
@@ -19,6 +19,7 @@ interface com.datadog.android.flags.FlagsClient
   companion object 
     fun get(String = DEFAULT_CLIENT_NAME, com.datadog.android.api.SdkCore = Datadog.getInstance()): FlagsClient
 data class com.datadog.android.flags.FlagsConfiguration
+  fun copy(Boolean = this.trackExposures, Boolean = this.trackEvaluations, String? = this.customExposureEndpoint, String? = this.customEvaluationEndpoint, String? = this.customFlagEndpoint, Long = this.evaluationFlushIntervalMs, Boolean = this.rumIntegrationEnabled, Boolean = this.gracefulModeEnabled): FlagsConfiguration
   class Builder
     fun trackExposures(Boolean): Builder
     fun trackEvaluations(Boolean): Builder
@@ -26,6 +27,8 @@ data class com.datadog.android.flags.FlagsConfiguration
     fun useCustomEvaluationEndpoint(String): Builder
     fun evaluationFlushInterval(Long): Builder
     fun useCustomFlagEndpoint(String): Builder
+    fun assignmentRequestCallFactory(okhttp3.Call.Factory): Builder
+    fun assignmentRequestTimeout(Long): Builder
     fun rumIntegrationEnabled(Boolean): Builder
     fun gracefulModeEnabled(Boolean): Builder
     fun build(): FlagsConfiguration

--- a/features/dd-sdk-android-flags/api/dd-sdk-android-flags.api
+++ b/features/dd-sdk-android-flags/api/dd-sdk-android-flags.api
@@ -46,7 +46,9 @@ public final class com/datadog/android/flags/FlagsClient$DefaultImpls {
 
 public final class com/datadog/android/flags/FlagsConfiguration {
 	public final fun copy (ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;JZZ)Lcom/datadog/android/flags/FlagsConfiguration;
+	public final fun copy (ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;JZZLokhttp3/Call$Factory;J)Lcom/datadog/android/flags/FlagsConfiguration;
 	public static synthetic fun copy$default (Lcom/datadog/android/flags/FlagsConfiguration;ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;JZZILjava/lang/Object;)Lcom/datadog/android/flags/FlagsConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/flags/FlagsConfiguration;ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;JZZLokhttp3/Call$Factory;JILjava/lang/Object;)Lcom/datadog/android/flags/FlagsConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -54,6 +56,8 @@ public final class com/datadog/android/flags/FlagsConfiguration {
 
 public final class com/datadog/android/flags/FlagsConfiguration$Builder {
 	public fun <init> ()V
+	public final fun assignmentRequestCallFactory (Lokhttp3/Call$Factory;)Lcom/datadog/android/flags/FlagsConfiguration$Builder;
+	public final fun assignmentRequestTimeout (J)Lcom/datadog/android/flags/FlagsConfiguration$Builder;
 	public final fun build ()Lcom/datadog/android/flags/FlagsConfiguration;
 	public final fun evaluationFlushInterval (J)Lcom/datadog/android/flags/FlagsConfiguration$Builder;
 	public final fun gracefulModeEnabled (Z)Lcom/datadog/android/flags/FlagsConfiguration$Builder;

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsClient.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsClient.kt
@@ -31,6 +31,7 @@ import com.datadog.android.flags.model.EvaluationContext
 import com.datadog.android.flags.model.FlagsClientState
 import com.datadog.android.flags.model.ResolutionDetails
 import com.datadog.android.internal.utils.DDCoreStateHolder
+import okhttp3.Call
 import org.json.JSONObject
 
 /**
@@ -408,11 +409,13 @@ interface FlagsClient {
                 NoOpFlagsRepository()
             }
 
-            val callFactory = featureSdkCore.createOkHttpCallFactory()
+            val callFactory: Call.Factory = configuration.assignmentRequestCallFactory
+                ?: featureSdkCore.createOkHttpCallFactory()
             val assignmentsDownloader = PrecomputedAssignmentsDownloader(
                 internalLogger = featureSdkCore.internalLogger,
                 callFactory = callFactory,
-                requestFactory = flagsFeature.precomputedRequestFactory
+                requestFactory = flagsFeature.precomputedRequestFactory,
+                requestTimeoutMs = configuration.assignmentRequestTimeoutMs
             )
 
             val precomputeMapper = PrecomputeMapper(featureSdkCore.internalLogger)

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsConfiguration.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/FlagsConfiguration.kt
@@ -6,6 +6,10 @@
 
 package com.datadog.android.flags
 
+import okhttp3.Call
+
+private const val DEFAULT_ASSIGNMENT_REQUEST_TIMEOUT_MS = 0L
+
 /**
  * Describes configuration to be used for the Flags feature.
  */
@@ -18,17 +22,56 @@ data class FlagsConfiguration internal constructor(
     internal val customFlagEndpoint: String?,
     internal val evaluationFlushIntervalMs: Long,
     internal val rumIntegrationEnabled: Boolean,
-    internal val gracefulModeEnabled: Boolean
+    internal val gracefulModeEnabled: Boolean,
+    internal val assignmentRequestCallFactory: Call.Factory?,
+    internal val assignmentRequestTimeoutMs: Long
 ) {
+    init {
+        @Suppress("UnsafeThirdPartyFunctionCall") // Enforce the public copy invariant.
+        require(assignmentRequestTimeoutMs >= 0) {
+            "assignmentRequestTimeoutMs must be greater than or equal to 0"
+        }
+    }
+
+    /**
+     * Copies this configuration while preserving assignment request settings.
+     *
+     * This overload retains the public JVM signature generated before assignment request settings were added.
+     */
+    fun copy(
+        trackExposures: Boolean = this.trackExposures,
+        trackEvaluations: Boolean = this.trackEvaluations,
+        customExposureEndpoint: String? = this.customExposureEndpoint,
+        customEvaluationEndpoint: String? = this.customEvaluationEndpoint,
+        customFlagEndpoint: String? = this.customFlagEndpoint,
+        evaluationFlushIntervalMs: Long = this.evaluationFlushIntervalMs,
+        rumIntegrationEnabled: Boolean = this.rumIntegrationEnabled,
+        gracefulModeEnabled: Boolean = this.gracefulModeEnabled
+    ): FlagsConfiguration = FlagsConfiguration(
+        trackExposures = trackExposures,
+        trackEvaluations = trackEvaluations,
+        customExposureEndpoint = customExposureEndpoint,
+        customEvaluationEndpoint = customEvaluationEndpoint,
+        customFlagEndpoint = customFlagEndpoint,
+        evaluationFlushIntervalMs = evaluationFlushIntervalMs,
+        rumIntegrationEnabled = rumIntegrationEnabled,
+        gracefulModeEnabled = gracefulModeEnabled,
+        assignmentRequestCallFactory = assignmentRequestCallFactory,
+        assignmentRequestTimeoutMs = assignmentRequestTimeoutMs
+    )
+
     /**
      * A Builder class for a [FlagsConfiguration].
      */
+    @Suppress("TooManyFunctions")
     class Builder {
         private var trackExposures: Boolean = true
         private var trackEvaluations: Boolean = true
         private var customExposureEndpoint: String? = null
         private var customEvaluationEndpoint: String? = null
         private var customFlagEndpoint: String? = null
+        private var assignmentRequestCallFactory: Call.Factory? = null
+        private var assignmentRequestTimeoutMs: Long = DEFAULT_ASSIGNMENT_REQUEST_TIMEOUT_MS
         private var evaluationFlushIntervalMs: Long = DEFAULT_EVALUATION_FLUSH_INTERVAL_MS
         private var rumIntegrationEnabled: Boolean = true
         private var gracefulModeEnabled: Boolean = true
@@ -117,6 +160,36 @@ data class FlagsConfiguration internal constructor(
         }
 
         /**
+         * Sets the HTTP call factory used only for precomputed assignment requests.
+         *
+         * The SDK constructs the request before it calls [Call.Factory.newCall]. Exposure and evaluation uploads
+         * continue to use the SDK transport. The application retains ownership of the factory and its resources.
+         * The assignment request timeout applies to calls from this factory.
+         *
+         * @param callFactory Factory used to create precomputed assignment calls.
+         * @return this [Builder] instance for method chaining.
+         */
+        fun assignmentRequestCallFactory(callFactory: Call.Factory): Builder {
+            assignmentRequestCallFactory = callFactory
+            return this
+        }
+
+        /**
+         * Sets the timeout for a precomputed assignment request.
+         *
+         * The timeout includes the complete response-body download. A value of zero disables the SDK timeout and
+         * preserves any timeout already configured on the HTTP call. If the call already has a nonzero timeout, the
+         * shorter timeout applies. Negative values are coerced to zero.
+         *
+         * @param timeoutMs Request timeout in milliseconds.
+         * @return this [Builder] instance for method chaining.
+         */
+        fun assignmentRequestTimeout(timeoutMs: Long): Builder {
+            assignmentRequestTimeoutMs = timeoutMs.coerceAtLeast(0)
+            return this
+        }
+
+        /**
          * Sets whether RUM evaluation logging is enabled.
          * This adds the result of evaluating a feature flag to the view.
          * Enabled by default.
@@ -160,7 +233,9 @@ data class FlagsConfiguration internal constructor(
             customFlagEndpoint = customFlagEndpoint,
             evaluationFlushIntervalMs = evaluationFlushIntervalMs,
             rumIntegrationEnabled = rumIntegrationEnabled,
-            gracefulModeEnabled = gracefulModeEnabled
+            gracefulModeEnabled = gracefulModeEnabled,
+            assignmentRequestCallFactory = assignmentRequestCallFactory,
+            assignmentRequestTimeoutMs = assignmentRequestTimeoutMs
         )
 
         internal companion object {

--- a/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsDownloader.kt
+++ b/features/dd-sdk-android-flags/src/main/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsDownloader.kt
@@ -13,6 +13,8 @@ import com.datadog.android.flags.model.EvaluationContext
 import okhttp3.Call
 import okhttp3.Request
 import okhttp3.Response
+import okio.Timeout
+import java.util.concurrent.TimeUnit
 
 /**
  * Downloads precomputed flag assignments from Datadog Feature Flags service.
@@ -20,11 +22,13 @@ import okhttp3.Response
  * @param callFactory Factory for creating HTTP calls
  * @param internalLogger Logger for error and debug messages
  * @param requestFactory Factory for creating precomputed assignments requests
+ * @param requestTimeoutMs SDK timeout for the request, in milliseconds. Zero preserves the call timeout
  */
 internal class PrecomputedAssignmentsDownloader(
     private val callFactory: Call.Factory,
     private val internalLogger: InternalLogger,
-    private val requestFactory: PrecomputedAssignmentsRequestFactory
+    private val requestFactory: PrecomputedAssignmentsRequestFactory,
+    private val requestTimeoutMs: Long = 0
 ) : PrecomputedAssignmentsReader {
 
     @WorkerThread
@@ -36,7 +40,11 @@ internal class PrecomputedAssignmentsDownloader(
 
     @Suppress("TooGenericExceptionCaught")
     private fun executeDownloadRequest(request: Request): String? = try {
-        val response = callFactory.newCall(request).execute()
+        val call = callFactory.newCall(request)
+        if (requestTimeoutMs > 0) {
+            applyRequestTimeout(call)
+        }
+        val response = call.execute()
         handleResponse(response)
     } catch (e: Throwable) {
         internalLogger.log(
@@ -46,6 +54,23 @@ internal class PrecomputedAssignmentsDownloader(
             e
         )
         null
+    }
+
+    @Suppress(
+        "CheckInternal", // Reject an invalid custom Call before an unbounded request starts.
+        "UnsafeThirdPartyFunctionCall" // The caller catches custom Call failures.
+    )
+    private fun applyRequestTimeout(call: Call) {
+        val timeout = call.timeout()
+        check(timeout !== Timeout.NONE) {
+            "The assignment request Call.Factory must provide a configurable Call.timeout()"
+        }
+
+        val requestTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(requestTimeoutMs)
+        val callTimeoutNanos = timeout.timeoutNanos()
+        if (callTimeoutNanos == 0L || requestTimeoutNanos < callTimeoutNanos) {
+            timeout.timeout(requestTimeoutMs, TimeUnit.MILLISECONDS)
+        }
     }
 
     private fun handleResponse(response: Response): String? = if (response.isSuccessful) {

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/FlagsClientAssignmentTimeoutTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/FlagsClientAssignmentTimeoutTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.flags
+
+import com.datadog.android.DatadogSite
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.Feature.Companion.FLAGS_FEATURE_NAME
+import com.datadog.android.api.feature.FeatureScope
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.api.storage.datastore.DataStoreHandler
+import com.datadog.android.flags.internal.FlagsFeature
+import com.datadog.android.flags.model.EvaluationContext
+import okhttp3.Call
+import okhttp3.Request
+import okio.Timeout
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.io.IOException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.TimeUnit
+
+@ExtendWith(MockitoExtension::class)
+internal class FlagsClientAssignmentTimeoutTest {
+
+    @Mock
+    lateinit var mockSdkCore: FeatureSdkCore
+
+    @Mock
+    lateinit var mockFeatureScope: FeatureScope
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @Mock
+    lateinit var mockExecutorService: ExecutorService
+
+    @Mock
+    lateinit var mockDatadogContext: DatadogContext
+
+    @Mock
+    lateinit var mockDataStore: DataStoreHandler
+
+    @Test
+    fun `M apply timeout to custom assignment transport W setEvaluationContext`() {
+        // Given
+        val callFactory = mock<Call.Factory>()
+        val call = mock<Call>()
+        val timeout = mock<Timeout>()
+        val configuration = FlagsConfiguration.Builder()
+            .trackEvaluations(false)
+            .assignmentRequestCallFactory(callFactory)
+            .assignmentRequestTimeout(REQUEST_TIMEOUT_MS)
+            .build()
+        whenever(callFactory.newCall(any())).thenReturn(call)
+        whenever(call.timeout()).thenReturn(timeout)
+        whenever(timeout.timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)).thenReturn(timeout)
+        whenever(call.execute()).thenThrow(IOException("network failure"))
+        whenever(mockDatadogContext.site).thenReturn(DatadogSite.US1)
+        whenever(mockDatadogContext.clientToken).thenReturn(CLIENT_TOKEN)
+        whenever(mockDatadogContext.env).thenReturn(ENVIRONMENT)
+        whenever(mockDatadogContext.sdkVersion).thenReturn(SDK_VERSION)
+        whenever(mockDatadogContext.featuresContext).thenReturn(emptyMap())
+
+        // When
+        val client = buildClient(configuration)
+        client.setEvaluationContext(EvaluationContext("target"))
+
+        // Then
+        val requestCaptor = argumentCaptor<Request>()
+        verify(callFactory).newCall(requestCaptor.capture())
+        assertThat(requestCaptor.firstValue.method).isEqualTo("POST")
+        assertThat(requestCaptor.firstValue.header("dd-client-token")).isEqualTo(CLIENT_TOKEN)
+        assertThat(requestCaptor.firstValue.header("Content-Type")).isEqualTo("application/vnd.api+json")
+        verify(timeout).timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        verify(call).execute()
+        verify(mockSdkCore, never()).createOkHttpCallFactory()
+    }
+
+    @Test
+    fun `M preserve custom assignment transport timeout W assignment timeout disabled`() {
+        // Given
+        val callFactory = mock<Call.Factory>()
+        val call = mock<Call>()
+        val configuration = FlagsConfiguration.Builder()
+            .trackEvaluations(false)
+            .assignmentRequestCallFactory(callFactory)
+            .build()
+        whenever(callFactory.newCall(any())).thenReturn(call)
+        whenever(call.execute()).thenThrow(IOException("network failure"))
+        whenever(mockDatadogContext.site).thenReturn(DatadogSite.US1)
+        whenever(mockDatadogContext.clientToken).thenReturn(CLIENT_TOKEN)
+        whenever(mockDatadogContext.env).thenReturn(ENVIRONMENT)
+        whenever(mockDatadogContext.sdkVersion).thenReturn(SDK_VERSION)
+        whenever(mockDatadogContext.featuresContext).thenReturn(emptyMap())
+
+        // When
+        val client = buildClient(configuration)
+        client.setEvaluationContext(EvaluationContext("target"))
+
+        // Then
+        verify(callFactory, times(1)).newCall(any())
+        verify(call, times(1)).execute()
+        verify(call, never()).timeout()
+        verify(mockSdkCore, never()).createOkHttpCallFactory()
+    }
+
+    private fun buildClient(configuration: FlagsConfiguration): FlagsClient {
+        whenever(mockSdkCore.internalLogger).thenReturn(mockInternalLogger)
+        val flagsFeature = FlagsFeature(mockSdkCore, configuration)
+        whenever(mockSdkCore.createSingleThreadExecutorService(any())).thenReturn(mockExecutorService)
+        whenever(mockSdkCore.getFeature(FLAGS_FEATURE_NAME)).thenReturn(mockFeatureScope)
+        whenever(mockFeatureScope.dataStore).thenReturn(mockDataStore)
+        whenever(mockFeatureScope.unwrap<FlagsFeature>()).thenReturn(flagsFeature)
+        doAnswer { invocation -> invocation.getArgument<Runnable>(0).run() }
+            .whenever(mockExecutorService).execute(any())
+        doAnswer { invocation ->
+            invocation.getArgument<(DatadogContext) -> Unit>(1).invoke(mockDatadogContext)
+        }.whenever(mockFeatureScope).withContext(any(), any())
+        return FlagsClient.Builder(sdkCore = mockSdkCore).build()
+    }
+
+    private companion object {
+        const val REQUEST_TIMEOUT_MS = 1_500L
+        const val CLIENT_TOKEN = "client-token"
+        const val ENVIRONMENT = "test"
+        const val SDK_VERSION = "1.0.0"
+    }
+}

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/FlagsConfigurationTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/FlagsConfigurationTest.kt
@@ -9,9 +9,12 @@ package com.datadog.android.flags
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import okhttp3.Call
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.mock
 
 @ExtendWith(ForgeExtension::class)
 internal class FlagsConfigurationTest {
@@ -29,6 +32,86 @@ internal class FlagsConfigurationTest {
         assertThat(configuration.customExposureEndpoint).isNull()
         assertThat(configuration.customFlagEndpoint).isNull()
         assertThat(configuration.gracefulModeEnabled).isTrue()
+        assertThat(configuration.assignmentRequestCallFactory).isNull()
+        assertThat(configuration.assignmentRequestTimeoutMs).isZero()
+    }
+
+    @Test
+    fun `M set assignment request timeout and factory W Builder`() {
+        // Given
+        val callFactory = mock<Call.Factory>()
+
+        // When
+        val configuration = FlagsConfiguration.Builder()
+            .assignmentRequestCallFactory(callFactory)
+            .assignmentRequestTimeout(2_500)
+            .build()
+
+        // Then
+        assertThat(configuration.assignmentRequestCallFactory).isSameAs(callFactory)
+        assertThat(configuration.assignmentRequestTimeoutMs).isEqualTo(2_500)
+    }
+
+    @Test
+    fun `M coerce assignment request timeout to zero W Builder { negative value }`() {
+        // When
+        val configuration = FlagsConfiguration.Builder()
+            .assignmentRequestTimeout(-1)
+            .build()
+
+        // Then
+        assertThat(configuration.assignmentRequestTimeoutMs).isZero()
+    }
+
+    @Test
+    fun `M preserve assignment request settings W copy { legacy overload }`() {
+        // Given
+        val callFactory = mock<Call.Factory>()
+        val configuration = FlagsConfiguration.Builder()
+            .assignmentRequestCallFactory(callFactory)
+            .assignmentRequestTimeout(2_500)
+            .build()
+
+        // When
+        val copy = configuration.copy(trackExposures = false)
+        val defaultCopy = configuration.copy()
+        val configurationWithDifferentTimeout = FlagsConfiguration.Builder()
+            .assignmentRequestTimeout(5_000)
+            .build()
+
+        // Then
+        assertThat(copy.trackExposures).isFalse()
+        assertThat(copy.assignmentRequestCallFactory).isSameAs(callFactory)
+        assertThat(copy.assignmentRequestTimeoutMs).isEqualTo(2_500)
+        assertThat(defaultCopy).isEqualTo(configuration)
+        assertThat(defaultCopy.assignmentRequestCallFactory).isSameAs(callFactory)
+        assertThat(configurationWithDifferentTimeout).isNotEqualTo(configuration)
+    }
+
+    @Test
+    fun `M reject negative assignment request timeout W copy { generated overload }`() {
+        // Given
+        val configuration = FlagsConfiguration.Builder().build()
+
+        // When / Then
+        assertThatThrownBy {
+            configuration.copy(assignmentRequestTimeoutMs = -1)
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessage("assignmentRequestTimeoutMs must be greater than or equal to 0")
+    }
+
+    @Test
+    fun `M accept assignment request timeout boundary W copy { generated overload }`() {
+        // Given
+        val configuration = FlagsConfiguration.Builder()
+            .assignmentRequestTimeout(2_500)
+            .build()
+
+        // When
+        val copy = configuration.copy(assignmentRequestTimeoutMs = 0)
+
+        // Then
+        assertThat(copy.assignmentRequestTimeoutMs).isZero()
     }
 
     @Test

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsDownloaderNetworkTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsDownloaderNetworkTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.flags.internal.net
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.flags.model.EvaluationContext
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import java.util.concurrent.TimeUnit
+
+@ExtendWith(MockitoExtension::class)
+internal class PrecomputedAssignmentsDownloaderNetworkTest {
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @Mock
+    lateinit var mockRequestFactory: PrecomputedAssignmentsRequestFactory
+
+    @Mock
+    lateinit var mockDatadogContext: DatadogContext
+
+    private lateinit var mockWebServer: MockWebServer
+    private val evaluationContext = EvaluationContext("target")
+
+    @BeforeEach
+    fun `set up`() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+        val request = Request.Builder()
+            .url(
+                mockWebServer.url("/precompute-assignments")
+                    .newBuilder()
+                    .host("127.0.0.1")
+                    .build()
+            )
+            .build()
+        whenever(mockRequestFactory.create(evaluationContext, mockDatadogContext)).thenReturn(request)
+    }
+
+    @AfterEach
+    fun `tear down`() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `M time out while reading response body W explicit SDK timeout`() {
+        // Given
+        mockWebServer.enqueue(slowBodyResponse())
+        val callFactory = OkHttpClient.Builder()
+            .callTimeout(LONG_CLIENT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .retryOnConnectionFailure(false)
+            .build()
+        val downloader = createDownloader(callFactory, EXPLICIT_SDK_TIMEOUT_MS)
+
+        // When
+        val result = downloader.readPrecomputedFlags(evaluationContext, mockDatadogContext)
+
+        // Then
+        assertThat(result).isNull()
+        assertThat(mockWebServer.requestCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `M preserve client timeout while reading response body W SDK timeout disabled`() {
+        // Given
+        mockWebServer.enqueue(slowBodyResponse())
+        val callFactory = OkHttpClient.Builder()
+            .callTimeout(CUSTOM_CLIENT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .retryOnConnectionFailure(false)
+            .build()
+        val downloader = createDownloader(callFactory, requestTimeoutMs = 0L)
+
+        // When
+        val result = downloader.readPrecomputedFlags(evaluationContext, mockDatadogContext)
+
+        // Then
+        assertThat(result).isNull()
+        assertThat(mockWebServer.requestCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `M allow delayed response body W SDK timeout disabled and client timeout permits it`() {
+        // Given
+        mockWebServer.enqueue(delayedBodyResponse(NO_SDK_TIMEOUT_BODY_DELAY_MS))
+        val callFactory = OkHttpClient.Builder()
+            .callTimeout(LONG_CLIENT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            .retryOnConnectionFailure(false)
+            .build()
+        val downloader = createDownloader(callFactory, requestTimeoutMs = 0L)
+
+        // When
+        val result = downloader.readPrecomputedFlags(evaluationContext, mockDatadogContext)
+
+        // Then
+        assertThat(result).isEqualTo(RESPONSE_BODY)
+        assertThat(mockWebServer.requestCount).isEqualTo(1)
+    }
+
+    private fun delayedBodyResponse(bodyDelayMs: Long): MockResponse = MockResponse()
+        .setResponseCode(200)
+        .setBody(RESPONSE_BODY)
+        .setBodyDelay(bodyDelayMs, TimeUnit.MILLISECONDS)
+
+    private fun slowBodyResponse(): MockResponse = MockResponse()
+        .setResponseCode(200)
+        .setBody(RESPONSE_BODY)
+        .throttleBody(SLOW_BODY_BYTES_PER_PERIOD, SLOW_BODY_PERIOD_MS, TimeUnit.MILLISECONDS)
+
+    private fun createDownloader(
+        callFactory: Call.Factory,
+        requestTimeoutMs: Long
+    ) = PrecomputedAssignmentsDownloader(
+        callFactory = callFactory,
+        internalLogger = mockInternalLogger,
+        requestFactory = mockRequestFactory,
+        requestTimeoutMs = requestTimeoutMs
+    )
+
+    private companion object {
+        const val RESPONSE_BODY = "{\"flags\":{}}"
+        const val EXPLICIT_SDK_TIMEOUT_MS = 1_000L
+        const val CUSTOM_CLIENT_TIMEOUT_MS = 200L
+        const val LONG_CLIENT_TIMEOUT_MS = 5_000L
+        const val NO_SDK_TIMEOUT_BODY_DELAY_MS = 500L
+        const val SLOW_BODY_BYTES_PER_PERIOD = 1L
+        const val SLOW_BODY_PERIOD_MS = 1_000L
+    }
+}

--- a/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsDownloaderTest.kt
+++ b/features/dd-sdk-android-flags/src/test/kotlin/com/datadog/android/flags/internal/net/PrecomputedAssignmentsDownloaderTest.kt
@@ -24,6 +24,7 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody
 import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Timeout
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,14 +37,17 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.isA
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.io.IOException
 import java.net.UnknownHostException
 import java.util.UUID
+import java.util.concurrent.TimeUnit
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -140,6 +144,154 @@ internal class PrecomputedAssignmentsDownloaderTest {
 
         // Then
         verify(mockRequestFactory).create(fakeEvaluationContext, fakeDatadogContext)
+    }
+
+    // endregion
+
+    // region readPrecomputedFlags() - Request timeout
+
+    @Test
+    fun `M apply request timeout W readPrecomputedFlags() { no existing timeout }`(
+        @StringForgery fakeResponseBody: String,
+        @StringForgery(regex = "https://[a-z]+\\.(com|net)/[a-z]+") fakeUrl: String
+    ) {
+        // Given
+        val requestTimeout = mock<Timeout>()
+        val fakeRequest = Request.Builder().url(fakeUrl).build()
+        val fakeResponse = createSuccessfulResponse(fakeResponseBody, fakeUrl)
+        testedDownloader = PrecomputedAssignmentsDownloader(
+            callFactory = mockCallFactory,
+            internalLogger = mockInternalLogger,
+            requestFactory = mockRequestFactory,
+            requestTimeoutMs = 1_500
+        )
+        whenever(mockRequestFactory.create(fakeEvaluationContext, fakeDatadogContext)).doReturn(fakeRequest)
+        whenever(mockCallFactory.newCall(fakeRequest)).doReturn(mockCall)
+        whenever(mockCall.timeout()).doReturn(requestTimeout)
+        whenever(requestTimeout.timeout(1_500, TimeUnit.MILLISECONDS)).doReturn(requestTimeout)
+        whenever(mockCall.execute()).doReturn(fakeResponse)
+
+        // When
+        val result = testedDownloader.readPrecomputedFlags(fakeEvaluationContext, fakeDatadogContext)
+
+        // Then
+        assertThat(result).isEqualTo(fakeResponseBody)
+        verify(requestTimeout).timeout(1_500, TimeUnit.MILLISECONDS)
+    }
+
+    @Test
+    fun `M preserve shorter call timeout W readPrecomputedFlags()`(
+        @StringForgery fakeResponseBody: String,
+        @StringForgery(regex = "https://[a-z]+\\.(com|net)/[a-z]+") fakeUrl: String
+    ) {
+        // Given
+        val requestTimeout = mock<Timeout>()
+        val fakeRequest = Request.Builder().url(fakeUrl).build()
+        val fakeResponse = createSuccessfulResponse(fakeResponseBody, fakeUrl)
+        testedDownloader = PrecomputedAssignmentsDownloader(
+            callFactory = mockCallFactory,
+            internalLogger = mockInternalLogger,
+            requestFactory = mockRequestFactory,
+            requestTimeoutMs = 1_500
+        )
+        whenever(mockRequestFactory.create(fakeEvaluationContext, fakeDatadogContext)).doReturn(fakeRequest)
+        whenever(mockCallFactory.newCall(fakeRequest)).doReturn(mockCall)
+        whenever(mockCall.timeout()).doReturn(requestTimeout)
+        whenever(requestTimeout.timeoutNanos()).doReturn(TimeUnit.MILLISECONDS.toNanos(500))
+        whenever(mockCall.execute()).doReturn(fakeResponse)
+
+        // When
+        val result = testedDownloader.readPrecomputedFlags(fakeEvaluationContext, fakeDatadogContext)
+
+        // Then
+        assertThat(result).isEqualTo(fakeResponseBody)
+        verify(requestTimeout, never()).timeout(1_500, TimeUnit.MILLISECONDS)
+    }
+
+    @Test
+    fun `M preserve call timeout W readPrecomputedFlags() { SDK timeout disabled }`(
+        @StringForgery fakeResponseBody: String,
+        @StringForgery(regex = "https://[a-z]+\\.(com|net)/[a-z]+") fakeUrl: String
+    ) {
+        // Given
+        val fakeRequest = Request.Builder().url(fakeUrl).build()
+        val fakeResponse = createSuccessfulResponse(fakeResponseBody, fakeUrl)
+        whenever(mockRequestFactory.create(fakeEvaluationContext, fakeDatadogContext)).doReturn(fakeRequest)
+        whenever(mockCallFactory.newCall(fakeRequest)).doReturn(mockCall)
+        whenever(mockCall.execute()).doReturn(fakeResponse)
+
+        // When
+        val result = testedDownloader.readPrecomputedFlags(fakeEvaluationContext, fakeDatadogContext)
+
+        // Then
+        assertThat(result).isEqualTo(fakeResponseBody)
+        verify(mockCall, never()).timeout()
+    }
+
+    @Test
+    fun `M reject unbounded custom call W readPrecomputedFlags() { timeout enabled }`(
+        @StringForgery(regex = "https://[a-z]+\\.(com|net)/[a-z]+") fakeUrl: String
+    ) {
+        // Given
+        val fakeRequest = Request.Builder().url(fakeUrl).build()
+        testedDownloader = PrecomputedAssignmentsDownloader(
+            callFactory = mockCallFactory,
+            internalLogger = mockInternalLogger,
+            requestFactory = mockRequestFactory,
+            requestTimeoutMs = 1_500
+        )
+        whenever(mockRequestFactory.create(fakeEvaluationContext, fakeDatadogContext)).doReturn(fakeRequest)
+        whenever(mockCallFactory.newCall(fakeRequest)).doReturn(mockCall)
+        whenever(mockCall.timeout()).doReturn(Timeout.NONE)
+
+        // When
+        val result = testedDownloader.readPrecomputedFlags(fakeEvaluationContext, fakeDatadogContext)
+
+        // Then
+        assertThat(result).isNull()
+        verify(mockCall, never()).execute()
+    }
+
+    @Test
+    fun `M include response body in call timeout W readPrecomputedFlags()`(
+        @StringForgery fakeResponseBody: String,
+        @StringForgery(regex = "https://[a-z]+\\.(com|net)/[a-z]+") fakeUrl: String
+    ) {
+        // Given
+        val requestTimeout = mock<Timeout>()
+        val responseBody = mock<ResponseBody>()
+        val fakeRequest = Request.Builder().url(fakeUrl).build()
+        val fakeResponse = Response.Builder()
+            .request(fakeRequest)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("OK")
+            .body(responseBody)
+            .build()
+        testedDownloader = PrecomputedAssignmentsDownloader(
+            callFactory = mockCallFactory,
+            internalLogger = mockInternalLogger,
+            requestFactory = mockRequestFactory,
+            requestTimeoutMs = 1_500
+        )
+        whenever(mockRequestFactory.create(fakeEvaluationContext, fakeDatadogContext)).doReturn(fakeRequest)
+        whenever(mockCallFactory.newCall(fakeRequest)).doReturn(mockCall)
+        whenever(mockCall.timeout()).doReturn(requestTimeout)
+        whenever(requestTimeout.timeout(1_500, TimeUnit.MILLISECONDS)).doReturn(requestTimeout)
+        whenever(mockCall.execute()).doReturn(fakeResponse)
+        whenever(responseBody.string()).doReturn(fakeResponseBody)
+
+        // When
+        val result = testedDownloader.readPrecomputedFlags(fakeEvaluationContext, fakeDatadogContext)
+
+        // Then
+        assertThat(result).isEqualTo(fakeResponseBody)
+        inOrder(requestTimeout, mockCall, responseBody) {
+            verify(requestTimeout).timeout(1_500, TimeUnit.MILLISECONDS)
+            verify(mockCall).execute()
+            verify(responseBody).string()
+            verify(responseBody).close()
+        }
     }
 
     // endregion


### PR DESCRIPTION
## Motivation

Flag assignment requests can wait on a slow or incomplete response without an SDK-level bound.

## Changes and Decisions

- Add an opt-in timeout for each assignment request. Zero preserves current behavior.
- Include the complete response-body download in the timeout.
- Preserve a shorter timeout from the HTTP transport.
- Support an assignment-only custom `Call.Factory`. The SDK timeout composes with its calls.

## Usage

Set a five-second timeout before you enable Flags:

```kotlin
val flagsConfiguration = FlagsConfiguration.Builder()
    .assignmentRequestTimeout(5_000)
    .build()

Flags.enable(flagsConfiguration)
```

## Validation

Validated commit `bcc78b10c` on an Android 16 / API 36 emulator. A deterministic local HTTPS server supplied delayed bodies and HTTP errors. Each case ran three times through public Flags APIs. Telemetry uploads were disabled.

| Validation | Expected behavior | Observed result |
| --- | --- | --- |
| Timeout disabled | A 1.2-second response succeeds without an SDK timeout. | 3/3 passed; one request and one completion; `ready` in 1,212–1,256 ms. |
| Full-body timeout | A stalled response body stops near 500 ms. | 3/3 passed; one request and one completion; `error` in 506–507 ms. |
| Initial request only | HTTP 500 ends after the initial assignment request. | 3/3 passed; one request and one completion; `error` in 11–48 ms. |
| Custom `Call.Factory` | The public 500 ms timeout applies to a custom factory. | 3/3 passed; one factory call; each call received 500 ms; `error` in 502–507 ms. |
| Shorter transport timeout | The custom 250 ms timeout stays active under the 500 ms SDK timeout. | 3/3 passed; one factory call; timeout remained 250 ms; `error` in 252–254 ms. |

Result: **15/15 fresh timeout-only emulator cases passed**.