### PR TITLE
[FFL-2929] Add FFE ownership for Android Flags

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,5 +9,6 @@
 
 ## Feature Flags
 
+/features/dd-sdk-android-flags/ @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk
 /features/dd-sdk-android-flags-openfeature/ @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk
 /features/dd-sdk-android-flags-openfeature/README.md @DataDog/documentation @DataDog/rum-mobile @DataDog/rum-mobile-android @DataDog/feature-flagging-and-experimentation-sdk


### PR DESCRIPTION
## Motivation

Changes to the Android Flags SDK do not request review from the FFE SDK team. Only the OpenFeature integration has explicit FFE ownership.

## Changes and Decisions

- Add the FFE SDK team as an owner of `dd-sdk-android-flags`.
- Preserve the existing RUM Mobile and Android owners.