### PR TITLE
fix: Add MAUI as RumErrorSourceType

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumErrorSourceType.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumErrorSourceType.kt
@@ -16,5 +16,6 @@ internal enum class RumErrorSourceType {
     REACT_NATIVE,
     FLUTTER,
     NDK,
-    NDK_IL2CPP
+    NDK_IL2CPP,
+    MAUI
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
@@ -118,6 +118,7 @@ internal fun RumErrorSourceType.toSchemaSourceType(): ErrorEvent.SourceType {
         RumErrorSourceType.FLUTTER -> ErrorEvent.SourceType.FLUTTER
         RumErrorSourceType.NDK -> ErrorEvent.SourceType.NDK
         RumErrorSourceType.NDK_IL2CPP -> ErrorEvent.SourceType.NDK_IL2CPP
+        RumErrorSourceType.MAUI -> ErrorEvent.SourceType.MAUI
     }
 }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -1098,6 +1098,7 @@ internal class DatadogRumMonitor(
             "flutter" -> RumErrorSourceType.FLUTTER
             "ndk" -> RumErrorSourceType.NDK
             "ndk+il2cpp" -> RumErrorSourceType.NDK_IL2CPP
+            "maui" -> RumErrorSourceType.MAUI
             else -> RumErrorSourceType.ANDROID
         }
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -1963,6 +1963,7 @@ internal class DatadogRumMonitorTest {
             "flutter" to RumErrorSourceType.FLUTTER,
             "ndk" to RumErrorSourceType.NDK,
             "ndk+il2cpp" to RumErrorSourceType.NDK_IL2CPP,
+            "maui" to RumErrorSourceType.MAUI,
             nonSupportedValue to RumErrorSourceType.ANDROID,
             null to RumErrorSourceType.ANDROID
         )


### PR DESCRIPTION
### What does this PR do?

It adds MAUI as a valid RumErrorSourceType.

### Motivation

I missed this when adding MAUI as a valid source for the SDK on https://github.com/DataDog/dd-sdk-android/pull/3423

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](../CONTRIBUTING.md) doc)

